### PR TITLE
✨ Add Terraform Harvester provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# lab
-Experimentation Lab
+# Experimentation Lab
+
+## Home Cloud
+
+### Terraform Harvester provider
+
+> [Docs](https://github.com/harvester/terraform-provider-harvester/blob/master/docs/index.md)

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,14 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/harvester/harvester" {
+  version     = "0.6.4"
+  constraints = "0.6.4"
+  hashes = [
+    "h1:UHghgGU7GUP5ljLeP1gI3F5nIcw9URAi9kIgEwdViI0=",
+    "zh:2b249034120f20629f57e2afdb44368fd1ec4b984f894b4dfd49aa8abff742d4",
+    "zh:2c557ab60bc824033258efd00189e4759cda8beef8a19d89fe0679caaee894ba",
+    "zh:2d25f0ccbfb348d96e6d82729451337b96d7c7e65eff96cc72ce7d0b139193d4",
+    "zh:a1bb9d05770dc991f83408b7cac77af7877da3ca7ae3ed1df76cb0a6d93d8934",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    harvester = {
+      source  = "harvester/harvester"
+      version = "0.6.4"
+    }
+  }
+  backend "pg" {
+    conn_str = "postgres://localhost:5433/altra?sslmode=disable"
+  }
+}
+
+provider "harvester" {
+  kubeconfig = "~/.kube/altra.yaml"
+}
+
+resource "harvester_image" "ubuntu" {
+  name         = "ubuntu"
+  display_name = "Ubuntu Server Image"
+  source_type  = "download"
+  namespace    = "harvester-public"
+  url          = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
+}


### PR DESCRIPTION
- Updated Terraform provider "harvester/harvester" to version 0.6.4 with specific
  constraints and hashes for secure installation.
- Enhanced documentation links for the "Experimentation Lab" to be more
  descriptive and accessible.
- Introduced configuration for Home Cloud environment, including backend
  connection details and resource definitions for Harvester images.