### PR TITLE
Argocd autopilot

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,27 @@
+# Apps
+This directory contains all of the applications you installed by using:
+```bash
+argocd-autopilot app create <APP_NAME> --app <APP_SPECIFIER> -p <PROJECT_NAME>
+```
+
+## Application Types
+> If you don't specify the application `--type` argocd-autopilot will try to clone the source repository and infer the application type [automatically](https://argoproj.github.io/argo-cd/user-guide/tool_detection/#tool-detection)
+
+* ### Directory application
+  Such an application references a specific directory at a given repo URL, path and revision. It will be persisted in the GitOps Repository as a single file at `apps/<APP_NAME>/<PROJECT_NAME>/config.json`.  
+  #### Example:  
+  ```bash
+  argocd-autopilot app create dir-example --app github.com/argoproj-labs/argocd-autopilot/examples/demo-dir/ -p <PROJECT_NAME> --type dir
+  ```
+
+* ### Kustomize application
+  A Kustomize application will have <u>exactly one</u>: `apps/<APP_NAME>/base/kustomization.yaml` file, and one or more `apps/<APP_NAME>/overlays/<PROJECT_NAME>/` folders.
+
+  The `apps/<APP_NAME>/base/kustomization.yaml` file is created the first time you create the application. The `apps/<APP_NAME>/overlays/<PROJECT_NAME>/` folder is created for each project you install this application on. So all overlays of the same application are using the same base `kustomization.yaml`.
+  #### Example:
+  Try running the following command:
+  ```bash
+  argocd-autopilot app create hello-world --app github.com/argoproj-labs/argocd-autopilot/examples/demo-app/ -p <PROJECT_NAME> --type kustomize
+  ```
+
+###### * If you did not create a project yet take a look at: [creating a project](https://argocd-autopilot.readthedocs.io/en/stable/Getting-Started/#add-a-project-and-an-application).

--- a/bootstrap/argo-cd.yaml
+++ b/bootstrap/argo-cd.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: argocd-autopilot
+    app.kubernetes.io/name: argo-cd
+  name: argo-cd
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  ignoreDifferences:
+  - group: argoproj.io
+    jsonPointers:
+    - /status
+    kind: Application
+  project: default
+  source:
+    path: bootstrap/argo-cd
+    repoURL: https://github.com/gregkonush/lab.git
+    targetRevision: argocd-autopilot
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - allowEmpty=true
+status:
+  health: {}
+  summary: {}
+  sync:
+    comparedTo:
+      destination: {}
+      source:
+        repoURL: ""
+    status: ""

--- a/bootstrap/argo-cd/kustomization.yaml
+++ b/bootstrap/argo-cd/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+configMapGenerator:
+- behavior: merge
+  literals:
+  - |
+    repository.credentials=- passwordSecret:
+        key: git_token
+        name: autopilot-secret
+      url: https://github.com/
+      usernameSecret:
+        key: git_username
+        name: autopilot-secret
+  name: argocd-cm
+kind: Kustomization
+namespace: argocd
+resources:
+- github.com/argoproj-labs/argocd-autopilot/manifests/base?ref=v0.4.17

--- a/bootstrap/cluster-resources.yaml
+++ b/bootstrap/cluster-resources.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  creationTimestamp: null
+  name: cluster-resources
+  namespace: argocd
+spec:
+  generators:
+  - git:
+      files:
+      - path: bootstrap/cluster-resources/*.json
+      repoURL: https://github.com/gregkonush/lab.git
+      requeueAfterSeconds: 20
+      revision: argocd-autopilot
+      template:
+        metadata: {}
+        spec:
+          destination: {}
+          project: ""
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: argocd-autopilot
+        app.kubernetes.io/name: cluster-resources-{{name}}
+      name: cluster-resources-{{name}}
+      namespace: argocd
+    spec:
+      destination:
+        server: '{{server}}'
+      ignoreDifferences:
+      - group: argoproj.io
+        jsonPointers:
+        - /status
+        kind: Application
+      project: default
+      source:
+        path: bootstrap/cluster-resources/{{name}}
+        repoURL: https://github.com/gregkonush/lab.git
+        targetRevision: argocd-autopilot
+      syncPolicy:
+        automated:
+          allowEmpty: true
+          selfHeal: true
+status: {}

--- a/bootstrap/cluster-resources/in-cluster.json
+++ b/bootstrap/cluster-resources/in-cluster.json
@@ -1,0 +1,1 @@
+{"name":"in-cluster","server":"https://kubernetes.default.svc"}

--- a/bootstrap/cluster-resources/in-cluster/README.md
+++ b/bootstrap/cluster-resources/in-cluster/README.md
@@ -1,0 +1,3 @@
+# Cluster Resources
+This directory contains all cluster resources that should be applied to cluster: `in-cluster`.
+For example `Namespace` resources that are shared by multiple applications on the same namespace.

--- a/bootstrap/cluster-resources/in-cluster/argocd-ns.yaml
+++ b/bootstrap/cluster-resources/in-cluster/argocd-ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  creationTimestamp: null
+  name: argocd
+spec: {}
+status: {}

--- a/bootstrap/root.yaml
+++ b/bootstrap/root.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  labels:
+    app.kubernetes.io/managed-by: argocd-autopilot
+    app.kubernetes.io/name: root
+  name: root
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  ignoreDifferences:
+  - group: argoproj.io
+    jsonPointers:
+    - /status
+    kind: Application
+  project: default
+  source:
+    path: projects
+    repoURL: https://github.com/gregkonush/lab.git
+    targetRevision: argocd-autopilot
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - allowEmpty=true
+status:
+  health: {}
+  summary: {}
+  sync:
+    comparedTo:
+      destination: {}
+      source:
+        repoURL: ""
+    status: ""

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,21 @@
+# Projects
+This directory contains all of your `argocd-autopilot` projects. Projects provide a way to logically group applications and easily control things such as defaults and restrictions.
+
+### Creating a new project
+To create a new project run:
+```bash
+export GIT_TOKEN=<YOUR_TOKEN>
+export GIT_REPO=<REPO_URL>
+
+argocd-autopilot project create <PROJECT_NAME>
+```
+
+### Creating a new project on different cluster
+You can create a project that deploys applications to a different cluster, instead of the cluster where Argo-CD is installed. To do that run:
+```bash
+export GIT_TOKEN=<YOUR_TOKEN>
+export GIT_REPO=<REPO_URL>
+
+argocd-autopilot project create <PROJECT_NAME> --dest-kube-context <CONTEXT_NAME>
+```
+Now all applications in this project that do not explicitly specify a different `--dest-server` will be created on the project's destination server.


### PR DESCRIPTION
Argocd bootstrap from [docs](https://argocd-autopilot.readthedocs.io/en/stable/Getting-Started/)

```bash
brew install argocd-autopilot
```

Follow docs afterwards