### PR TITLE
Make argocd insecure for traefik

### DIFF
--- a/bootstrap/argo-cd/kustomization.yaml
+++ b/bootstrap/argo-cd/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 configMapGenerator:
-  - behavior: merge
+  - name: argocd-cm
+    behavior: merge
     literals:
       - |
         repository.credentials=- passwordSecret:
@@ -10,7 +11,12 @@ configMapGenerator:
           usernameSecret:
             key: git_username
             name: autopilot-secret
-    name: argocd-cm
+
+  - name: argocd-cmd-params-cm
+    behavior: merge
+    literals:
+      - "server.insecure=true"
+
 kind: Kustomization
 namespace: argocd
 resources:


### PR DESCRIPTION
Make argocd insecure, grabbed from https://github.com/argoproj-labs/argocd-autopilot/blob/main/manifests/insecure/kustomization.yaml

<img width="569" alt="image" src="https://github.com/gregkonush/lab/assets/12027037/ef8ce9b8-68bf-4b21-ab78-c0052c7a02d7">
