### PR TITLE
✨ Remove unnecessary files from Argo CD bootstrap

### DIFF
--- a/bootstrap/argo-cd/argo-cd.yaml
+++ b/bootstrap/argo-cd/argo-cd.yaml
@@ -14,10 +14,6 @@ spec:
     path: bootstrap/argo-cd
     repoURL: https://github.com/gregkonush/lab
     targetRevision: HEAD
-    kustomize:
-      components:
-        - namespace.yaml
-        - ingress.yaml
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/argo-cd/kustomization.yaml
+++ b/bootstrap/argo-cd/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v2.8.16/manifests/install.yaml
   - ingress.yaml
   - argo-cd.yaml
-  - root.yaml
 configMapGenerator:
   - name: argocd-cmd-params-cm
     behavior: merge


### PR DESCRIPTION
Removed root.yaml file from kustomization.yaml and
removed namespace.yaml and ingress.yaml from argo-cd.yaml
as they are no longer needed.