### PR TITLE
✨ Update ROOT_URL to use HTTPS protocol

### DIFF
--- a/apps/gitea/kustomization.yaml
+++ b/apps/gitea/kustomization.yaml
@@ -16,7 +16,7 @@ helmCharts:
         config:
           server:
             DOMAIN: gitea.proompteng.ai
-            ROOT_URL: http://gitea.proompteng.ai
+            ROOT_URL: https://gitea.proompteng.ai
             SSH_DOMAIN: gitea.proompteng.ai
       ingress:
         apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Changed ROOT_URL in gitea config to use HTTPS protocol for secure connections.