### PR TITLE
Update ecran deployment and add service definition

### DIFF
--- a/apps/ecran/kustomize/deployment.yaml
+++ b/apps/ecran/kustomize/deployment.yaml
@@ -4,19 +4,26 @@ metadata:
   name: ecran-deployment
   namespace: ecran
   labels:
-    app: ecran
+    app.kubernetes.io/name: ecran
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ecran
+      app.kubernetes.io/name: ecran
   template:
     metadata:
       labels:
-        app: ecran
+        app.kubernetes.io/name: ecran
     spec:
       containers:
-      - name: ecran
-        image: gitea.proompteng.ai/gitbot/lab/ecran:latest
-        ports:
-        - containerPort: 3000
+        - name: ecran
+          image: gitea.proompteng.ai/gitbot/lab/ecran:latest
+          ports:
+            - containerPort: 3000
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+            requests:
+              cpu: "100m"
+              memory: "100Mi"

--- a/apps/ecran/kustomize/kustomization.yaml
+++ b/apps/ecran/kustomize/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: ecran
 resources:
   - namespace.yaml
   - deployment.yaml
+  - service.yaml

--- a/apps/ecran/kustomize/service.yaml
+++ b/apps/ecran/kustomize/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ecran
+  namespace: ecran
+spec:
+  selector:
+    app.kubernetes.io/name: ecran
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000


### PR DESCRIPTION
This pull request updates the ecran deployment and adds a service definition for the ecran application. The deployment.yaml file is modified to include resource limits and requests for the ecran container. Additionally, a new service.yaml file is added to define the service for the ecran application, with a target port of 3000 and a port of 80.