### PR TITLE
Add cache configuration to Docker build and push workflow

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -29,3 +29,5 @@ jobs:
           file: ./apps/ecran/Dockerfile
           push: true
           tags: gitea.proompteng.ai/gitbot/lab/ecran:latest
+          cache-from: type=registry,ref=gitea.proompteng.ai/gitbot/lab/ecran:latest
+          cache-to: type=inline


### PR DESCRIPTION
This pull request adds cache configuration to the Docker build and push workflow. The cache configuration allows for faster builds by caching previously built images.