### PR TITLE
Update ecran service definition to include ports for http and https

### DIFF
--- a/apps/ecran/kustomize/service.yaml
+++ b/apps/ecran/kustomize/service.yaml
@@ -1,12 +1,19 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app.kubernetes.io/name: ecran
   name: ecran
   namespace: ecran
 spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 3000
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 3000
   selector:
     app.kubernetes.io/name: ecran
-  ports:
-  - name: http
-    port: 80
-    targetPort: 3000


### PR DESCRIPTION
This pull request updates the ecran service definition to include ports for http and https. This allows the service to properly handle incoming requests on these ports.