### PR TITLE
✨ Add Traefik IngressRoute for ecran app

### DIFF
--- a/apps/ecran/kustomize/ingress.yaml
+++ b/apps/ecran/kustomize/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: ecran
+  namespace: ecran
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`ecran.lan`)
+      priority: 10
+      services:
+        - name: ecran
+          port: 80
+    - kind: Rule
+      match: Host(`proompteng.ai`)
+      priority: 10
+      services:
+        - name: ecran
+          port: 80
+  tls:
+    certResolver: default


### PR DESCRIPTION
Added Traefik IngressRoute for ecran app to route traffic based on
Host header and enforce TLS termination.