### PR TITLE
✨ Update helm chart versions and paths

### DIFF
--- a/apps/gitea/kustomization.yaml
+++ b/apps/gitea/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
   - ingress.yaml
 helmCharts:
   - name: gitea
-    repo: https://dl.gitea.com/charts/
+    repo: https://dl.gitea.com/charts
+    version: 10.1.4
     releaseName: gitea
     namespace: gitea
     valuesMerge: merge

--- a/apps/sealed-secrets/kustomization.yaml
+++ b/apps/sealed-secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+helmCharts:
+  - name: sealed-secrets
+    namespace: kube-system
+    repo: https://bitnami-labs.github.io/sealed-secrets
+    version: 2.15.3
+    releaseName: sealed-secrets

--- a/apps/templates/_application.yaml
+++ b/apps/templates/_application.yaml
@@ -16,7 +16,7 @@ spec:
   source:
     repoURL: {{ $root.Values.spec.source.repoURL }}
     targetRevision: {{ $root.Values.spec.source.targetRevision }}
-    path: apps/{{  $application.path }}
+    path: {{  $application.path }}
   syncPolicy:
     automated:
       prune: true

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -6,6 +6,8 @@ spec:
     targetRevision: main
 applications:
   - name: gitea
-    path: gitea
+    path: apps/gitea
   - name: ecran
-    path: ecran/kustomize
+    path: apps/ecran/kustomize
+  - name: sealed-secrets
+    path: apps/sealed-secrets


### PR DESCRIPTION
- Update Gitea helm chart to version 10.1.4
- Update Sealed Secrets helm chart to version 2.15.3
- Adjust application paths for Gitea, Ecran, and Sealed Secrets to match new
  directory structure.