### PR TITLE
Update docker-build-push.yaml to use linux/arm64 platform

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -24,10 +24,10 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64
+          platforms: linux/arm64
           context: ./apps/ecran
           file: ./apps/ecran/Dockerfile
           push: true
           tags: gitea.proompteng.ai/gitbot/lab/ecran:latest
           cache-from: type=registry,ref=gitea.proompteng.ai/gitbot/lab/ecran:latest
-          cache-to: type=inline
+          cache-to: type=registry,ref=gitea.proompteng.ai/gitbot/lab/ecran:latest,mode=max


### PR DESCRIPTION
This pull request updates the docker-build-push.yaml file to use the linux/arm64 platform instead of the linux/amd64 platform. This change is necessary to support ARM64 architecture.