### PR TITLE
Update cache-to value in docker-build-push.yaml

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -30,4 +30,4 @@ jobs:
           push: true
           tags: gitea.proompteng.ai/gitbot/lab/ecran:latest
           cache-from: type=registry,ref=gitea.proompteng.ai/gitbot/lab/ecran:latest
-          cache-to: type=registry,ref=gitea.proompteng.ai/gitbot/lab/ecran:latest,mode=max
+          cache-to: type=inline


### PR DESCRIPTION
This pull request updates the cache-to value in the docker-build-push.yaml file to use the "inline" mode instead of the "max" mode. This change ensures that the cache is properly updated during the build and push process.