### PR TITLE
Update imagePullSecrets and add gitea-registry-credentials sealed secret

### DIFF
--- a/apps/ecran/kustomize/deployment.yaml
+++ b/apps/ecran/kustomize/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         - name: ecran
           image: gitea.proompteng.ai/gitbot/lab/ecran:latest
           imagePullPolicy: Always
+          imagePullSecrets:
+            - name: gitea-registry-credentials
           ports:
             - containerPort: 3000
           env:
@@ -28,8 +30,8 @@ spec:
                   key: resend-api-key
           resources:
             limits:
-              cpu: "1"
-              memory: "1Gi"
+              cpu: '1'
+              memory: '1Gi'
             requests:
-              cpu: "100m"
-              memory: "100Mi"
+              cpu: '100m'
+              memory: '100Mi'

--- a/apps/ecran/kustomize/sealed-secret.yaml
+++ b/apps/ecran/kustomize/sealed-secret.yaml
@@ -2,7 +2,6 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  creationTimestamp: null
   name: ecran-secrets
   namespace: ecran
 spec:
@@ -10,7 +9,20 @@ spec:
     resend-api-key: AgBC5BagWRPQKxLaXjW6FNOXusXpZ0jiDc2dQx/Pg6YDJyNZ70VGIq9eAUjWWuBSQl4/C7L0SoZuvKiTHwOJ5bu2GmNVChka4vIORPhrEUxohFrf+zcgMVskSdN9oUlAHLSAXjyHNTjIwnKR+MM0arm+346NO93cbZaZRHP4SZczhqbpw7dPIp8PYcJ1uscdQlY/lt/Kf8JuRIpvFgWDZpKri9cWORDyzfl9qIHrtvXdpzVgTupWiad5O4hoYIcqItqVGo43yf65Escl01L3sEUlDLMxyh1e/2H1aGTSbCY70QwP0cn0UTULwgZZQkRQm36hS/VK5tSgfNnjeA31F30JZUGfA9oUqUP18qO2yqBFwJ1jVVwaeDEHAppf8OJSLnM7Dl+bZdQCZ85LpRGJY7AjxK5BqkZwLcVuL4F64wseEoLiEyIRrcnqqQOvzfXECIkZ8XRuPlQGsdZeSqNWStankvknyaJY3Hc2tLGXcYh849qXBi6Dobdk9shFSWmK/W7R+DzptN16wCYDiau+uiw0z/OrMG6/2TTEJgfrCSfIKqSjWZbxrrLm/zez8z0cXXwefTKeVOlQILawPUk7v/roFdE5ih3JufmB+U3Rrkex5NEjD77CWjy0hQ0YHoN+ZqfAJSQaSP9Ymo21JEl/UUJ0lAw92PRf/nTTrOLhtfxJYWuMKYaJE8Y23PkYWMQM+Ldi/S9nVuTnb1SlaUGZPORlruYtj+YM9uWzcHq+uFeEHnGH8X0=
   template:
     metadata:
-      creationTimestamp: null
       name: ecran-secrets
       namespace: ecran
     type: Opaque
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: gitea-registry-credentials
+  namespace: ecran
+spec:
+  encryptedData:
+    .dockerconfigjson: AgA8jbKO/pd8WZLNhRPACVm2SiWaHxQgsHvRksNw1XD9Lhii7SKQZgHl1rvh66W0b35AU8K90uuSqxRP5KGJ/4VALfz21SIg8i46/3CDixnI4iCR1JKzdnm2QY+20btOohmT04Gi7x3eCD3M4WE8RMonz7tGhvyoIdkZxeRqC53K5Rzjy6LKqPJ3HG/HSGMrAZrsccD/yqntI6t+VcqHYx3QRPAJgqnjfgtQ0W7tz+yxOFmrGr2Tx1cheY15SIRZ71gmtuoT5E0BjtdnrVXDpjO3RdUWTnSdErT69CPlS84bFgyWF3RzWvkFJif28mjdiT/5bRb/n4566LNFHQd3e4ELcQ65xaJuM2TPEfnMY540LCglVQ2gr3EviZ4E3M0HgqgSqPrBwjMbS1JLcUZyzMq7wyEcrmHYL+B75bgHUGu8NxbxrNZiCLk/iwS0S7EyVqn/kC/OzwPo2P8uxiFk+6IfqroT3pmGPEcHKPDRVpfM1XXMkY8+deE4WuXp4eBLB1ioIpO7457GjqJeydl2nO2S4svt+aOlPCXCZHM5oUhbI50rvEzdRt8+QUEO8cN1T3gaUjksCKr7XwJG5pVYspfRW43Cmwse/tOX6PUNg8YE+gw1cQCSqchtWnds/QaRjFNrZCt9NXUtzNZ8EHyn86iHsRRXMZ5MhT+ImPjViYs+i2CXiY4Gw0mgXZvx+am5lvxGxmUElE1pwuc4646wf4rzuHYdQGdBQ9HwF3K2A6oZQfYadnIs912Yn5+HjnqWDc/Kuc1kgwxsYao5rcIKNPYJTLcBTLAKYJHoeK32HZpXIAI=
+  template:
+    metadata:
+      name: gitea-registry-credentials
+      namespace: ecran
+    type: kubernetes.io/dockerconfigjson

--- a/apps/sealed-secrets/README.md
+++ b/apps/sealed-secrets/README.md
@@ -42,3 +42,42 @@ kubectl get pods -n kube-system | grep sealed-secrets
 kubectl get sealedsecrets
 kubectl logs deployments/sealed-secrets -n kube-system
 ````
+
+### Create dockerconfig.json
+
+Create `auth`
+
+```bash
+echo -n 'user:password' | base64
+```
+
+Create `dockerconfig.json`
+
+```json
+{ "auths": { "gitea.proompteng.ai": { "auth": "dXNlcjpwYXNzd29yZA==" } } }
+```
+
+Encode json with `base64`
+
+```bash
+echo -n '{"auths":{"gitea.proompteng.ai":{"auth":"dXNlcjpwYXNzd29yZA=="}}}' | base64
+```
+
+Place output into secret yaml
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: kubernetes.io.dockerconfigjson
+metadata:
+  name: gitea-registry
+  namespace: ecran
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJnaXRlYS5wcm9vbXB0ZW5nLmFpIjp7ImF1dGgiOiJkWE5sY2pwd1lYTnpkMjl5WkE9PSJ9fX0=
+```
+
+Finally create a sealed-secret from plain text secret
+
+```bash
+kubeseal --controller-name sealed-secrets -f secret.yaml -w registry.yaml
+```


### PR DESCRIPTION
This pull request includes the following changes:

- Update imagePullSecrets in deployment.yaml to include the gitea-registry-credentials secret for pulling images from the Gitea registry.

- Add the gitea-registry-credentials sealed secret in sealed-secret.yaml to securely store the credentials for accessing the Gitea registry.