### PR TITLE
Update imagePullPolicy and imagePullSecrets in deployment.yaml

### DIFF
--- a/apps/ecran/kustomize/deployment.yaml
+++ b/apps/ecran/kustomize/deployment.yaml
@@ -14,12 +14,12 @@ spec:
       labels:
         app.kubernetes.io/name: ecran
     spec:
-      imagePullPolicy: Always
       imagePullSecrets:
         - name: gitea-registry-credentials
       containers:
         - name: ecran
           image: gitea.proompteng.ai/gitbot/lab/ecran:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
This pull request updates the imagePullPolicy and imagePullSecrets in the deployment.yaml file for the ecran application. The imagePullPolicy is set to "Always" and the imagePullSecrets is configured to use the "gitea-registry-credentials" secret. This ensures that the latest version of the ecran image is always pulled and the necessary credentials are provided for pulling the image from the registry.