### PR TITLE
Remove namespace.yaml from ecran/kustomize/kustomization.yaml and gitea/kustomization.yaml

### DIFF
--- a/apps/ecran/kustomize/kustomization.yaml
+++ b/apps/ecran/kustomize/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ecran
 resources:
-  - namespace.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml

--- a/apps/gitea/kustomization.yaml
+++ b/apps/gitea/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: gitea
 resources:
-  - namespace.yaml
   - ingress.yaml
 helmCharts:
   - name: gitea


### PR DESCRIPTION
This pull request removes the "namespace.yaml" file from the "ecran/kustomize/kustomization.yaml" and "gitea/kustomization.yaml" files. This change ensures that the namespace file is no longer included in the deployment process.