### PR TITLE
Remove cert-manager helm chart and namespace from values.yaml

### DIFF
--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -13,6 +13,3 @@ applications:
     namespace: ecran
   - name: sealed-secrets
     path: apps/sealed-secrets
-  - name: cert-manager
-    path: apps/cert-manager
-    namespace: cert-manager


### PR DESCRIPTION
This pull request removes the cert-manager helm chart and namespace from the values.yaml file. This change is necessary because we no longer need cert-manager in our application.