### PR TITLE
Update cert-manager helm chart values in kustomization.yaml

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -7,4 +7,7 @@ helmCharts:
     repo: https://charts.jetstack.io
     releaseName: cert-manager
     version: v1.14.5
-    includeCRDs: true
+    valuesMerge: merge
+    # https://artifacthub.io/packages/helm/cert-manager/cert-manager#installcrds-~-bool
+    valuesInline:
+      installCRDs: true


### PR DESCRIPTION
This pull request updates the cert-manager helm chart values in the kustomization.yaml file. Specifically, it sets the valuesMerge to merge and adds the valuesInline for installCRDs to true. This ensures that the CRDs are installed during the helm chart deployment.