### PR TITLE
Remove cert-manager and sealed-secrets from apps/values.yaml

### DIFF
--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -13,6 +13,3 @@ applications:
     namespace: ecran
   - name: sealed-secrets
     path: apps/sealed-secrets
-  - name: cert-manager
-    path: apps/cert-manager
-    namespace: cert-manager


### PR DESCRIPTION
This pull request removes the cert-manager and sealed-secrets paths from the apps/values.yaml file. This change is necessary to streamline the code and remove unnecessary dependencies.