### PR TITLE
Add cert-manager to apps/values.yaml and set namespace to cert-manager

### DIFF
--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -13,3 +13,6 @@ applications:
     namespace: ecran
   - name: sealed-secrets
     path: apps/sealed-secrets
+  - name: cert-manager
+    path: apps/cert-manager
+    namespace: cert-manager


### PR DESCRIPTION
This pull request adds the cert-manager application to the apps/values.yaml file and sets its namespace to cert-manager.