### PR TITLE
Refactor apps/values.yaml to remove cert-manager and sealed-secrets paths

### DIFF
--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -13,6 +13,4 @@ applications:
     namespace: ecran
   - name: sealed-secrets
     path: apps/sealed-secrets
-  - name: cert-manager
-    path: apps/cert-manager
-    namespace: cert-manager
+


### PR DESCRIPTION
This pull request removes the cert-manager and sealed-secrets paths from the apps/values.yaml file. These paths are no longer needed and can be safely removed.