### PR TITLE
Update cert-manager leader election configuration in kustomization.yaml

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -14,4 +14,4 @@ helmCharts:
       global:
         leaderElection:
           # https://github.com/cert-manager/cert-manager/issues/6716
-          namespace: cert-manager
+          namespace: "cert-manager"


### PR DESCRIPTION
This pull request updates the cert-manager leader election configuration in the kustomization.yaml file. The namespace for the leader election has been changed from "cert-manager" to "cert-manager".