### PR TITLE
Add cert-manager to apps/values.yaml and set namespace to cert-manager

### DIFF
--- a/apps/cert-manager/README.md
+++ b/apps/cert-manager/README.md
@@ -1,0 +1,9 @@
+# Cert Manager
+
+## Delete cert-manager resources
+
+[docs](https://cert-manager.io/docs/installation/kubectl/#uninstalling)
+
+```bash
+kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.yaml
+```

--- a/apps/values.yaml
+++ b/apps/values.yaml
@@ -13,3 +13,6 @@ applications:
     namespace: ecran
   - name: sealed-secrets
     path: apps/sealed-secrets
+  - name: cert-manager
+    path: apps/cert-manager
+    namespace: cert-manager


### PR DESCRIPTION
This pull request adds the cert-manager application to the apps/values.yaml file and sets its namespace to cert-manager.