### PR TITLE
Update arc helm chart version to v0.9.1 in kustomization.yaml

### DIFF
--- a/apps/arc/kustomization.yaml
+++ b/apps/arc/kustomization.yaml
@@ -5,9 +5,9 @@ resources:
 helmCharts:
   - name: arc
     namespace: arc
-    repo: https://actions-runner-controller.github.io/actions-runner-controller
+    repo: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
     releaseName: arc
-    version: v0.27.6
+    version: v0.9.1
     valuesMerge: merge
     includeCRDs: true
     valuesInline:


### PR DESCRIPTION
This pull request updates the arc helm chart version in the kustomization.yaml file to v0.9.1. This update ensures that the latest version of the chart is used in the deployment.