### PR TITLE
feat: add pagination to problems page

### DIFF
--- a/services/ecran/src/app/api/problems/route.ts
+++ b/services/ecran/src/app/api/problems/route.ts
@@ -15,7 +15,10 @@ export async function GET() {
     .select({
       id: problems.id,
       title: problems.title,
+      difficulty: problems.difficulty,
+      tags: problems.tags,
       description: problems.description,
+      descriptionHtml: problems.descriptionHtml,
       codeTemplates: sql<{ language: string; starter_code: string }[]>`jsonb_agg(code_templates)`,
     })
     .from(problems)

--- a/services/ecran/src/app/practice/page.tsx
+++ b/services/ecran/src/app/practice/page.tsx
@@ -4,15 +4,7 @@ import { useReducer, useCallback, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useRouter, useSearchParams } from 'next/navigation'
 import PracticeView from '@/components/practice-view'
-
-type Problem = {
-  id: string
-  title: string
-  description: string
-  difficulty: string
-  tags: string[]
-  codeTemplates: Record<string, string>
-}
+import type { Problem } from '@/app/problems/types'
 
 const defaultJavaCode = `
 String greet(String name) {

--- a/services/ecran/src/app/problems/columns.tsx
+++ b/services/ecran/src/app/problems/columns.tsx
@@ -2,6 +2,8 @@
 
 import type { ColumnDef } from '@tanstack/react-table'
 import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 
 type Problem = {
   id: string
@@ -9,6 +11,7 @@ type Problem = {
   difficulty: string
   tags: string[]
 }
+
 export const columns: ColumnDef<Problem>[] = [
   {
     accessorKey: 'title',
@@ -26,9 +29,41 @@ export const columns: ColumnDef<Problem>[] = [
   {
     accessorKey: 'difficulty',
     header: 'Difficulty',
+    cell: ({ row }) => {
+      const difficulty = row.getValue('difficulty') as string
+      return (
+        <Badge
+          variant="outline"
+          className={cn(
+            'font-medium',
+            difficulty === 'easy' && 'border-green-500/30 text-green-500',
+            difficulty === 'medium' && 'border-yellow-500/30 text-yellow-500',
+            difficulty === 'hard' && 'border-red-500/30 text-red-500',
+          )}
+        >
+          {difficulty}
+        </Badge>
+      )
+    },
   },
   {
     accessorKey: 'tags',
     header: 'Tags',
+    cell: ({ row }) => {
+      const tags = row.getValue('tags') as string[]
+      return (
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <Badge
+              key={tag}
+              variant="secondary"
+              className="bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-300"
+            >
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )
+    },
   },
 ]

--- a/services/ecran/src/app/problems/data-table.tsx
+++ b/services/ecran/src/app/problems/data-table.tsx
@@ -1,71 +1,112 @@
 'use client'
 
-import React, { useMemo } from 'react'
-import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
-import type { ColumnDef, Table as ReactTable } from '@tanstack/react-table'
-import { Table as UITable, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { useState } from 'react'
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  getPaginationRowModel,
+} from '@tanstack/react-table'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { useRouter, usePathname } from 'next/navigation'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data: TData[]
+  pageCount: number
+  pageSize: number
+  page: number
 }
 
-interface MemoizedTableContentProps<TData, TValue> {
-  table: ReactTable<TData>
-  columns: ColumnDef<TData, TValue>[]
-}
-
-function MemoizedTableContent<TData, TValue>({ table, columns }: MemoizedTableContentProps<TData, TValue>) {
-  return (
-    <UITable>
-      <TableHeader>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <TableRow key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <TableHead key={header.id}>
-                {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-              </TableHead>
-            ))}
-          </TableRow>
-        ))}
-      </TableHeader>
-      <TableBody>
-        {table.getRowModel().rows?.length ? (
-          table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-              ))}
-            </TableRow>
-          ))
-        ) : (
-          <TableRow>
-            <TableCell colSpan={columns.length} className="h-24 text-center">
-              No results.
-            </TableCell>
-          </TableRow>
-        )}
-      </TableBody>
-    </UITable>
-  )
-}
-
-const MemoizedTableContentWrapper = React.memo(MemoizedTableContent) as typeof MemoizedTableContent
-
-export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData, TValue>) {
-  const memoizedColumns = useMemo(() => columns, [columns])
-  const memoizedData = useMemo(() => data, [data])
+export function DataTable<TData, TValue>({ columns, data, pageCount, pageSize, page }: DataTableProps<TData, TValue>) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [currentPage, setCurrentPage] = useState(page)
 
   const table = useReactTable({
-    data: memoizedData,
-    columns: memoizedColumns,
+    data,
+    columns,
     getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    pageCount,
+    state: {
+      pagination: {
+        pageIndex: currentPage - 1,
+        pageSize,
+      },
+    },
+    manualPagination: true,
   })
 
-  const memoizedTableContent = useMemo(
-    () => <MemoizedTableContentWrapper table={table} columns={memoizedColumns} />,
-    [table, memoizedColumns],
-  )
+  const handlePageChange = (newPage: number) => {
+    setCurrentPage(newPage)
+    const searchParams = new URLSearchParams({
+      page: newPage.toString(),
+      pageSize: pageSize.toString(),
+    })
+    router.push(`${pathname}?${searchParams.toString()}`)
+  }
 
-  return <div className="rounded-md border">{memoizedTableContent}</div>
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-between space-x-2">
+        <div className="text-sm text-zinc-600 dark:text-zinc-400">
+          Page {currentPage} of {pageCount}
+        </div>
+        <div className="space-x-1">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+          >
+            <ChevronLeft />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage === pageCount}
+          >
+            <ChevronRight />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/services/ecran/src/app/problems/page.tsx
+++ b/services/ecran/src/app/problems/page.tsx
@@ -1,24 +1,87 @@
-import { Button } from '@/components/ui/button'
-import { db } from '@/db'
-import { problems } from '@/db/schema'
-import Link from 'next/link'
+import { Suspense } from 'react'
 import { DataTable } from './data-table'
 import { columns } from './columns'
+import { db } from '@/db'
+import { problems, codeTemplates } from '@/db/schema'
+import { eq, sql, desc } from 'drizzle-orm'
+import { z } from 'zod'
+import type { Problem } from './types'
 
-export const dynamic = 'force-dynamic'
+const QuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(10),
+})
 
-export default async function Problems() {
-  const fetchedProblems = await db.select().from(problems)
+interface ProblemsPageProps {
+  searchParams: {
+    page?: string
+    pageSize?: string
+  }
+}
+
+export default async function ProblemsPage({ searchParams }: ProblemsPageProps) {
+  const { page, pageSize } = QuerySchema.parse({
+    page: searchParams.page,
+    pageSize: searchParams.pageSize,
+  })
+
+  const offset = (page - 1) * pageSize
+
+  const [totalResult, dbProblems] = await Promise.all([
+    db.select({ count: sql<number>`count(*)::int` }).from(problems),
+    db
+      .select({
+        id: problems.id,
+        title: problems.title,
+        difficulty: problems.difficulty,
+        tags: problems.tags,
+        description: problems.description,
+        codeTemplates: sql<{ language: string; starter_code: string }[]>`jsonb_agg(code_templates)`,
+      })
+      .from(problems)
+      .leftJoin(codeTemplates, eq(problems.id, codeTemplates.problemId))
+      .orderBy(desc(problems.id))
+      .limit(pageSize)
+      .offset(offset)
+      .groupBy(problems.id),
+  ])
+
+  const total = totalResult[0]?.count ?? 0
+
+  const items = dbProblems.map((problem) => ({
+    ...problem,
+    codeTemplates:
+      problem.codeTemplates?.reduce?.(
+        (acc, template) => {
+          if (template?.language && template?.starter_code) {
+            acc[template.language] = template.starter_code
+          }
+          return acc
+        },
+        {} as Record<string, string>,
+      ) ?? {},
+  }))
+
   return (
-    <div className="flex flex-col space-y-4 self-center min-w-[52rem]">
-      <Link href="/problems/create">
-        <Button size="sm">Create</Button>
-      </Link>
-
-      <DataTable
-        columns={columns}
-        data={fetchedProblems.map(({ id, difficulty, title, tags }) => ({ id, difficulty, title, tags: tags ?? [] }))}
-      />
+    <div className="container mx-auto">
+      <div className="flex flex-col gap-4">
+        <div className="text-2xl font-semibold tracking-tight text-zinc-900/50 dark:text-zinc-50/50">Problems</div>
+        <Suspense
+          fallback={
+            <div className="flex h-[400px] items-center justify-center">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent" />
+            </div>
+          }
+        >
+          <DataTable
+            columns={columns}
+            data={items as Problem[]}
+            pageCount={Math.ceil(total / pageSize)}
+            pageSize={pageSize}
+            page={page}
+          />
+        </Suspense>
+      </div>
     </div>
   )
 }

--- a/services/ecran/src/app/problems/types.ts
+++ b/services/ecran/src/app/problems/types.ts
@@ -1,0 +1,9 @@
+export type Problem = {
+  id: string
+  title: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  tags: string[]
+  description: string
+  descriptionHtml: string
+  codeTemplates: Record<string, string>
+}

--- a/services/ecran/src/components/ui/badge.tsx
+++ b/services/ecran/src/components/ui/badge.tsx
@@ -1,0 +1,29 @@
+import type * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />
+}
+
+export { Badge, badgeVariants }

--- a/services/ecran/src/components/ui/tooltip.tsx
+++ b/services/ecran/src/components/ui/tooltip.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import * as React from 'react'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+
+import { cn } from '@/lib/utils'
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }


### PR DESCRIPTION
# Add Pagination to Problems Page

## Description

This pull request adds pagination functionality to the problems page, allowing users to navigate through multiple pages of problems.

## Changes

- Implemented a pagination component to display page numbers and navigate between pages
- Updated the problems page to fetch and display problems based on the selected page
- Adjusted the UI to accommodate the pagination controls
