### PR TITLE
feat(pod): update creationTimestamp schema to use date type

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -99,6 +99,14 @@ jobs:
         working-directory: apps/kitty-krew
         run: bun install --frozen-lockfile
 
+      - name: Lint
+        working-directory: apps/kitty-krew
+        run: bun biome lint
+
+      - name: Format check
+        working-directory: apps/kitty-krew
+        run: bun biome format
+
       - name: Build kitty-krew app
         working-directory: apps/kitty-krew
         run: bun run build

--- a/apps/kitty-krew/src/app/routes/index.tsx
+++ b/apps/kitty-krew/src/app/routes/index.tsx
@@ -13,10 +13,9 @@ interface PodTableProps {
 // Memoized PodTable component
 const PodTable = React.memo(({ pods, isLoading, error }: PodTableProps) => {
   // Safely format the creation time
-  const formatCreationTime = React.useCallback((dateString?: string): string => {
-    if (!dateString) return 'N/A'
-    // Format to match the screenshot (MM/DD/YYYY, hh:mm:ss AM/PM)
-    const date = new Date(dateString)
+  const formatCreationTime = React.useCallback((dateInput?: Date | string): string => {
+    if (!dateInput) return 'N/A'
+    const date = dateInput instanceof Date ? dateInput : new Date(dateInput)
     return `${date.toLocaleDateString()}, ${date.toLocaleTimeString()}`
   }, [])
 

--- a/apps/kitty-krew/src/common/schemas/pod.ts
+++ b/apps/kitty-krew/src/common/schemas/pod.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 export const podMetadataSchema = z.object({
   name: z.string().optional(),
   namespace: z.string().optional(),
-  creationTimestamp: z.string().optional(),
+  creationTimestamp: z.date().optional(),
   uid: z.string().optional(),
 })
 

--- a/apps/kitty-krew/src/common/schemas/pod.ts
+++ b/apps/kitty-krew/src/common/schemas/pod.ts
@@ -10,9 +10,16 @@ export const podMetadataSchema = z.object({
       .refine((date) => !Number.isNaN(date.getTime()), {
         message: 'Invalid date format for creationTimestamp',
       })
-      .refine((date) => date <= new Date(), {
-        message: 'creationTimestamp cannot be in the future',
-      })
+      .refine(
+        (date) => {
+          const now = new Date()
+          const allowedSkew = 60 * 1000 // Allow 1 minute of clock skew
+          return date <= new Date(now.getTime() + allowedSkew)
+        },
+        {
+          message: 'creationTimestamp cannot be too far in the future',
+        },
+      )
       .optional(),
   ),
   uid: z.string().optional(),

--- a/apps/kitty-krew/src/common/schemas/pod.ts
+++ b/apps/kitty-krew/src/common/schemas/pod.ts
@@ -3,7 +3,18 @@ import { z } from 'zod'
 export const podMetadataSchema = z.object({
   name: z.string().optional(),
   namespace: z.string().optional(),
-  creationTimestamp: z.date().optional(),
+  creationTimestamp: z.preprocess(
+    (val) => (val instanceof Date ? val : new Date(String(val))),
+    z
+      .date()
+      .refine((date) => !Number.isNaN(date.getTime()), {
+        message: 'Invalid date format for creationTimestamp',
+      })
+      .refine((date) => date <= new Date(), {
+        message: 'creationTimestamp cannot be in the future',
+      })
+      .optional(),
+  ),
   uid: z.string().optional(),
 })
 


### PR DESCRIPTION
## Description

- Updated the `creationTimestamp` schema for the `Pod` resource to use the `date` type instead of the default `string` type.
- This change ensures that the `creationTimestamp` field is properly parsed and displayed as a date, providing a more accurate representation of the pod's creation time.