### PR TITLE
feat(kubernetes): Load Kubernetes config from cluster and use self-signed certificate

### DIFF
--- a/apps/kitty-krew/src/services/kubernetes.ts
+++ b/apps/kitty-krew/src/services/kubernetes.ts
@@ -72,8 +72,6 @@ export async function createK8sClient(): Promise<k8s.CoreV1Api> {
     // Check environment to use appropriate config loading
     if (process.env.NODE_ENV === 'production') {
       logger.info('Loading Kubernetes config from cluster')
-      // Configure the Kubernetes client to use the specified certificate
-      // instead of disabling TLS validation globally
       kc.loadFromCluster()
 
       // Configure self-signed certificate if available

--- a/argocd/applications/kitty-krew/overlays/dev/deployment.yaml
+++ b/argocd/applications/kitty-krew/overlays/dev/deployment.yaml
@@ -27,3 +27,5 @@ spec:
           env:
             - name: NODE_ENV
               value: "development"
+            - name: NODE_EXTRA_CA_CERTS
+              value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"


### PR DESCRIPTION
## Description

- Added support for using self-signed certificates when connecting to the Kubernetes API, enabling the application to work in environments where the cluster uses a self-signed certificate.