### PR TITLE
fix: fix ingress path in airbyte

### DIFF
--- a/argocd/applications/airbyte/airbyte-values.yaml
+++ b/argocd/applications/airbyte/airbyte-values.yaml
@@ -5,4 +5,7 @@ webapp:
     enabled: true
     className: traefik
     hosts:
-      - airbyte.lan
+      - host: airbyte.lan
+        paths:
+          - path: /
+            pathType: Prefix


### PR DESCRIPTION
## Description

- Fixed the ingress path for the Airbyte service
- The previous path was incorrect, causing issues with accessing the Airbyte UI
