### PR TITLE
feat(argocd): add reviseur application

### DIFF
--- a/argocd/applications/reviseur/base/deployment.yaml
+++ b/argocd/applications/reviseur/base/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviseur
+spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
+  replicas: 1
+  selector:
+    matchLabels:
+      cdk8s.io/metadata.addr: base-base-deployment-base-deployment-deployment-c8e0bde8
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        cdk8s.io/metadata.addr: base-base-deployment-base-deployment-deployment-c8e0bde8
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - image: kalmyk.duckdns.org/lab/reviseur
+          imagePullPolicy: Always
+          name: reviseur
+          ports:
+            - containerPort: 3000
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          startupProbe:
+            failureThreshold: 3
+            tcpSocket:
+              port: 3000
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+      restartPolicy: Always
+      securityContext:
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        runAsUser: 1000
+      setHostnameAsFQDN: false
+      shareProcessNamespace: false
+      terminationGracePeriodSeconds: 30

--- a/argocd/applications/reviseur/base/kustomization.yaml
+++ b/argocd/applications/reviseur/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: reviseur
+commonLabels:
+  app: reviseur
+  app.kubernetes.io/name: reviseur
+  app.kubernetes.io/part-of: reviseur
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/argocd/applications/reviseur/base/service.yaml
+++ b/argocd/applications/reviseur/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviseur
+spec:
+  externalIPs: []
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: reviseur
+  type: ClusterIP

--- a/argocd/applications/reviseur/kustomization.yaml
+++ b/argocd/applications/reviseur/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: reviseur
+resources:
+  - overlays/dev

--- a/argocd/applications/reviseur/overlays/dev/deployment.yaml
+++ b/argocd/applications/reviseur/overlays/dev/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviseur
+spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
+  replicas: 1
+  selector:
+    matchLabels:
+      cdk8s.io/metadata.addr: dev-dev-deployment-dev-deployment-deployment-c8e90e90
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        cdk8s.io/metadata.addr: dev-dev-deployment-dev-deployment-deployment-c8e90e90
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - image: kalmyk.duckdns.org/lab/reviseur
+          imagePullPolicy: Always
+          name: reviseur
+          ports:
+            - containerPort: 3000
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          startupProbe:
+            failureThreshold: 3
+            tcpSocket:
+              port: 3000
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+      restartPolicy: Always
+      securityContext:
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        runAsUser: 1000
+      setHostnameAsFQDN: false
+      shareProcessNamespace: false
+      terminationGracePeriodSeconds: 30

--- a/argocd/applications/reviseur/overlays/dev/kustomization.yaml
+++ b/argocd/applications/reviseur/overlays/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: reviseur
+commonLabels:
+  app: reviseur
+  app.kubernetes.io/name: reviseur
+  app.kubernetes.io/part-of: reviseur
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/argocd/applications/reviseur/overlays/dev/service.yaml
+++ b/argocd/applications/reviseur/overlays/dev/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviseur
+spec:
+  externalIPs: []
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: reviseur
+  type: ClusterIP

--- a/packages/cloutt/kustomization/common/kustomization.ts
+++ b/packages/cloutt/kustomization/common/kustomization.ts
@@ -4,7 +4,10 @@ import { ApiObject } from 'cdk8s'
 import { z } from 'zod'
 
 const kustomizationSchema = z.object({
+  name: z.string(),
   resources: z.array(z.string()),
+  namespace: z.string().optional(),
+  commonLabels: z.record(z.string(), z.string()).optional(),
 })
 
 export class Kustomization extends Chart {
@@ -16,10 +19,16 @@ export class Kustomization extends Chart {
   }
 
   #createKustomization(id: string, props: z.infer<typeof kustomizationSchema>) {
+    const { resources, namespace, commonLabels, name } = props
     new ApiObject(this, `${id}-kustomization`, {
       apiVersion: 'kustomize.config.k8s.io/v1beta1',
       kind: 'Kustomization',
-      resources: props.resources,
+      metadata: {
+        name,
+      },
+      resources,
+      ...(namespace && { namespace }),
+      ...(commonLabels && { commonLabels }),
     })
   }
 }

--- a/packages/cloutt/kustomization/root.ts
+++ b/packages/cloutt/kustomization/root.ts
@@ -3,10 +3,12 @@ import { Kustomization } from './common/kustomization'
 import { Chart } from 'cdk8s'
 
 export class RootKustomization extends Chart {
-  constructor(scope: Construct, id: string, props: { overlays: string[] }) {
+  constructor(scope: Construct, id: string, props: { overlays: string[]; name: string }) {
     super(scope, id)
+    const { overlays, name } = props
     new Kustomization(this, id, {
-      resources: props.overlays,
+      name,
+      resources: overlays,
     })
   }
 }

--- a/packages/cloutt/main.ts
+++ b/packages/cloutt/main.ts
@@ -1,30 +1,108 @@
 import { App, YamlOutputType } from 'cdk8s'
 import { RootKustomization } from './kustomization/root'
 import { KustomizationBase } from './kustomization/base'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/**
+ * Removes the dist directory if it exists
+ */
+function cleanupDist(directory: string): void {
+  if (fs.existsSync(directory)) {
+    console.log(`Cleaning up ${directory}...`)
+    // Remove directory recursively
+    fs.rmSync(directory, { recursive: true, force: true })
+    console.log(`Removed ${directory}`)
+  }
+}
+
+/**
+ * Renames files to lowercase and removes "reviseur" from the names
+ */
+function renameFiles(directory: string): void {
+  // Read all files and directories in the given directory
+  const items = fs.readdirSync(directory)
+
+  for (const item of items) {
+    const fullPath = path.join(directory, item)
+    const stats = fs.statSync(fullPath)
+
+    if (stats.isDirectory()) {
+      // Recursively process subdirectories
+      renameFiles(fullPath)
+    } else if (stats.isFile() && item.endsWith('.yaml')) {
+      // Process only YAML files
+      const newName = item
+        .replace(/\.reviseur\.yaml$/i, '.yaml') // Remove 'reviseur' from the name
+        .toLowerCase() // Convert to lowercase
+
+      if (newName !== item) {
+        const newPath = path.join(directory, newName)
+        fs.renameSync(fullPath, newPath)
+        console.log(`Renamed: ${fullPath} -> ${newPath}`)
+      }
+    }
+  }
+}
 
 if (require.main === module) {
+  const distDir = path.resolve(__dirname, 'dist')
+
+  // Clean up dist directory before generating new files
+  cleanupDist(distDir)
+
   const kustomizationManifest = new App({
     outputFileExtension: '.yaml',
     yamlOutputType: YamlOutputType.FILE_PER_RESOURCE,
   })
-  new RootKustomization(kustomizationManifest, 'kustomization', { overlays: ['overlays/dev'] })
+
+  const appName = 'reviseur'
+
+  // Create root kustomization file, include overlays
+  new RootKustomization(kustomizationManifest, 'root-kustomization', {
+    overlays: ['overlays/dev'],
+    name: appName,
+  })
   kustomizationManifest.synth()
 
-  const appName = 'reviewer'
+  // Add base overlay with its own kustomization file
   const overlays = new App({
     outdir: 'dist/base',
     outputFileExtension: '.yaml',
     yamlOutputType: YamlOutputType.FILE_PER_RESOURCE,
   })
-  new KustomizationBase(overlays, 'kustomization', {
-    name: 'kitty-krew',
+  new KustomizationBase(overlays, 'base', {
+    name: appName,
     replicas: 1,
-    image: 'kalmyk.duckdns.org/lab/kitty-krew',
+    image: 'kalmyk.duckdns.org/lab/reviseur',
     containerPort: 3000,
     cpuRequest: 100,
-    cpuLimit: 500,
-    memoryRequest: 128,
-    memoryLimit: 512,
+    cpuLimit: 1000,
+    memoryRequest: 512,
+    memoryLimit: 1024,
   })
   overlays.synth()
+
+  // Create dev overlay in the separate directory
+  const devOverlay = new App({
+    outdir: 'dist/overlays/dev',
+    outputFileExtension: '.yaml',
+    yamlOutputType: YamlOutputType.FILE_PER_RESOURCE,
+  })
+  new KustomizationBase(devOverlay, 'dev', {
+    name: appName,
+    replicas: 1,
+    image: 'kalmyk.duckdns.org/lab/reviseur',
+    containerPort: 3000,
+    cpuRequest: 100,
+    cpuLimit: 1000,
+    memoryRequest: 512,
+    memoryLimit: 1024,
+  })
+  devOverlay.synth()
+
+  // Rename files in all generated directories
+  console.log('Renaming manifest files...')
+  renameFiles(distDir)
+  console.log('File renaming complete')
 }

--- a/packages/cloutt/package.json
+++ b/packages/cloutt/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "scripts": {
     "import": "cdk8s import",
-    "synth": "cdk8s synth"
+    "synth": "cdk8s synth",
+    "build": "bun main.ts"
   },
   "dependencies": {
     "cdk8s": "^2.69.48",


### PR DESCRIPTION
## Description

- Added a new ArgoCD application for the "reviseur" service
- This allows the "reviseur" application to be deployed and managed through ArgoCD
- Provides a centralized and declarative way to deploy and manage the "reviseur" application