### PR TITLE
feat: Upgrade ArgoCD to version 2.14.5

### DIFF
--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.1/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.14.5/manifests/ha/install.yaml
   - base/namespace.yaml
   - base/ingress.yaml
   - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/manifests/install.yaml


### PR DESCRIPTION
## Description

- Upgraded ArgoCD to version 2.14.5
- This upgrade includes bug fixes and performance improvements for the ArgoCD application
- The new version provides enhanced stability and reliability for our ArgoCD deployment
- Upgrading to the latest version ensures we have access to the latest features and security updates