### PR TITLE
feat(argocd): Add image update annotations for reviseur application

### DIFF
--- a/argocd/applicationsets/lovely-apps.yaml
+++ b/argocd/applicationsets/lovely-apps.yaml
@@ -68,6 +68,14 @@ spec:
         argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/git-creds
         argocd-image-updater.argoproj.io/git-branch: main
         argocd-image-updater.argoproj.io/write-back-target: "kustomization:/argocd/applications/kitty-krew"
+    {{- else if eq .path.basename "reviseur" }}
+    metadata:
+      annotations:
+        argocd-image-updater.argoproj.io/image-list: reviseur=kalmyk.duckdns.org/lab/reviseur
+        argocd-image-updater.argoproj.io/reviseur: semver
+        argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/git-creds
+        argocd-image-updater.argoproj.io/git-branch: main
+        argocd-image-updater.argoproj.io/write-back-target: "kustomization:/argocd/applications/reviseur"
     {{- else }}
     spec:
       source:


### PR DESCRIPTION
## Description

- Added image update annotations to the Reviseur application's Argo CD manifests
- This will enable automatic image updates when a new version of the application is deployed
