### PR TITLE
feat: install tailscale on ubuntu nodes

### DIFF
--- a/ansible/INSTALL.md
+++ b/ansible/INSTALL.md
@@ -1,0 +1,41 @@
+# Installing Ansible
+
+## On macOS
+
+```bash
+# Using Homebrew
+brew install ansible
+
+# Using pip
+pip install ansible
+```
+
+## On Ubuntu/Debian
+
+```bash
+# Add repository and install
+sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
+sudo apt install ansible
+
+# Or using pip
+sudo apt update
+sudo apt install python3-pip
+pip3 install ansible
+```
+
+## Verifying Installation
+
+```bash
+ansible --version
+```
+
+## Running the Tailscale Playbook
+
+Once Ansible is installed:
+
+```bash
+cd ansible
+ansible-playbook -i inventory/hosts.ini playbooks/install_tailscale.yml
+```

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory = inventory/hosts.ini
+host_key_checking = False
+remote_user = kalmyk

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -1,2 +1,74 @@
-[rancher_bootstrap]
-rancher2 ansible_host=192.168.1.150
+[all]
+# Masters
+kube-master-00 ansible_host=192.168.1.150
+kube-master-01 ansible_host=192.168.1.151
+kube-master-02 ansible_host=192.168.1.152
+
+# Workers
+kube-worker-00 ansible_host=192.168.1.160
+kube-worker-01 ansible_host=192.168.1.161
+kube-worker-02 ansible_host=192.168.1.162
+kube-worker-03 ansible_host=192.168.1.163
+kube-worker-04 ansible_host=192.168.1.164
+kube-worker-05 ansible_host=192.168.1.165
+kube-worker-06 ansible_host=192.168.1.166
+kube-worker-07 ansible_host=192.168.1.167
+kube-worker-08 ansible_host=192.168.1.168
+kube-worker-09 ansible_host=192.168.1.169
+kube-worker-10 ansible_host=192.168.1.170
+kube-worker-11 ansible_host=192.168.1.171
+kube-worker-12 ansible_host=192.168.1.172
+kube-worker-13 ansible_host=192.168.1.173
+kube-worker-14 ansible_host=192.168.1.174
+kube-worker-15 ansible_host=192.168.1.175
+kube-worker-16 ansible_host=192.168.1.176
+kube-worker-17 ansible_host=192.168.1.177
+kube-worker-18 ansible_host=192.168.1.178
+kube-worker-19 ansible_host=192.168.1.179
+kube-worker-20 ansible_host=192.168.1.180
+kube-worker-21 ansible_host=192.168.1.181
+kube-worker-22 ansible_host=192.168.1.182
+kube-worker-23 ansible_host=192.168.1.183
+kube-worker-24 ansible_host=192.168.1.184
+kube-worker-25 ansible_host=192.168.1.185
+kube-worker-26 ansible_host=192.168.1.186
+kube-worker-27 ansible_host=192.168.1.187
+kube-worker-28 ansible_host=192.168.1.188
+kube-worker-29 ansible_host=192.168.1.189
+
+[kube_masters]
+kube-master-00
+kube-master-01
+kube-master-02
+
+[kube_workers]
+kube-worker-00
+kube-worker-01
+kube-worker-02
+kube-worker-03
+kube-worker-04
+kube-worker-05
+kube-worker-06
+kube-worker-07
+kube-worker-08
+kube-worker-09
+kube-worker-10
+kube-worker-11
+kube-worker-12
+kube-worker-13
+kube-worker-14
+kube-worker-15
+kube-worker-16
+kube-worker-17
+kube-worker-18
+kube-worker-19
+kube-worker-20
+kube-worker-21
+kube-worker-22
+kube-worker-23
+kube-worker-24
+kube-worker-25
+kube-worker-26
+kube-worker-27
+kube-worker-28
+kube-worker-29

--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -1,0 +1,45 @@
+# Tailscale Installation Playbook for Ubuntu
+
+This playbook installs Tailscale on Ubuntu hosts defined in the inventory file, following the official Tailscale installation method for Ubuntu.
+
+## Prerequisites
+
+- Ansible installed on the control node
+- SSH access to all target hosts
+- Sudo privileges on target hosts
+- All hosts running Ubuntu
+
+## Usage
+
+Run the playbook with:
+
+```bash
+# Run with interactive authentication (will provide login URLs)
+ansible-playbook -i ../inventory/hosts.ini install_tailscale.yml
+
+# Run with automatic authentication using an authkey
+export TAILSCALE_AUTHKEY=tskey-auth-xxxxxxxxxxxx
+ansible-playbook -i ../inventory/hosts.ini install_tailscale.yml
+```
+
+You can get an auth key from the [Tailscale Admin Console](https://login.tailscale.com/admin/settings/keys).
+
+## Playbook Details
+
+The playbook:
+
+1. Adds the official Tailscale package signing key
+2. Adds the Tailscale repository for Ubuntu
+3. Installs the Tailscale package
+4. Starts and enables the Tailscale service
+5. Runs `tailscale up` with the authkey from TAILSCALE_AUTHKEY environment variable (if set)
+   or without an authkey (interactive authentication) if not set
+
+## Post-Installation
+
+If not using an authkey, after installation, you'll need to authenticate each node to your Tailscale network:
+
+1. Check the logs on each node to find the authentication URL
+2. Complete the authentication in a web browser using the URL
+
+The official Tailscale installation documentation used: https://tailscale.com/kb/1187/install-ubuntu-2204

--- a/ansible/playbooks/install_tailscale.yml
+++ b/ansible/playbooks/install_tailscale.yml
@@ -1,0 +1,40 @@
+---
+- name: Install Tailscale on Ubuntu
+  hosts: all
+  become: true
+  tasks:
+    - name: Add Tailscale package signing key
+      ansible.builtin.shell: curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+      args:
+        creates: /usr/share/keyrings/tailscale-archive-keyring.gpg
+
+    - name: Add Tailscale repository for Ubuntu
+      ansible.builtin.shell: curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list
+      args:
+        creates: /etc/apt/sources.list.d/tailscale.list
+
+    - name: Install Tailscale package on Ubuntu
+      ansible.builtin.apt:
+        name: tailscale
+        state: present
+        update_cache: yes
+
+    - name: Start and enable Tailscale service
+      ansible.builtin.systemd:
+        name: tailscaled
+        state: started
+        enabled: yes
+
+    - name: Run Tailscale UP with authkey from environment variable
+      ansible.builtin.command: "tailscale up --authkey={{ lookup('env', 'TAILSCALE_AUTHKEY') }} --accept-dns=true --accept-routes=true"
+      register: tailscale_up
+      changed_when: "'is running' not in tailscale_up.stdout"
+      failed_when: false
+      when: lookup('env', 'TAILSCALE_AUTHKEY') != ""
+
+    - name: Run Tailscale UP without authkey (interactive authentication)
+      ansible.builtin.command: "tailscale up --accept-dns=true --accept-routes=true"
+      register: tailscale_up_no_key
+      changed_when: "'is running' not in tailscale_up_no_key.stdout"
+      failed_when: false
+      when: lookup('env', 'TAILSCALE_AUTHKEY') == ""

--- a/argocd/applications/tailscale/kustomization.yaml
+++ b/argocd/applications/tailscale/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: tailscale
+resources:
+  - overlays/dev

--- a/tofu/harvester/main.tf
+++ b/tofu/harvester/main.tf
@@ -307,6 +307,7 @@ bootcmd:
   - update-grub
 packages:
   - qemu-guest-agent
+  - curl
 write-files:
   - path: /etc/sysctl.d/60-nvme-optimizations.conf
     content: |
@@ -334,6 +335,12 @@ runcmd:
   - sysctl -p /etc/sysctl.d/60-nvme-optimizations.conf
   - udevadm control --reload-rules
   - udevadm trigger
+  # Install Tailscale
+  - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+  - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list
+  - apt-get update
+  - apt-get install -y tailscale
+  - systemctl enable --now tailscaled
 bootcmd:
   - systemctl daemon-reload
 users:
@@ -363,6 +370,7 @@ package_upgrade: true
 package_reboot_if_required: true
 packages:
   - qemu-guest-agent
+  - curl
 runcmd:
   - systemctl enable --now qemu-guest-agent
   - install -m 0755 -d /etc/apt/keyrings
@@ -376,6 +384,12 @@ runcmd:
   - apt-get update
   - apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
   - systemctl enable --now docker
+  # Install Tailscale
+  - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+  - curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list
+  - apt-get update
+  - apt-get install -y tailscale
+  - systemctl enable --now tailscaled
   - echo 'alias k=kubectl' >> /home/kalmyk/.bashrc
   - mkdir -p /home/kalmyk/.ssh && chmod 700 /home/kalmyk/.ssh
   - touch /home/kalmyk/.ssh/authorized_keys && chmod 600 /home/kalmyk/.ssh/authorized_keys


### PR DESCRIPTION
## Description

- Installed Tailscale on Ubuntu nodes to enable secure and private connectivity between the nodes
- Tailscale provides a simple and easy-to-use VPN solution that allows the nodes to communicate securely over the internet
- This change will improve the overall security and reliability of the network infrastructure