### PR TITLE
feat(coder): use cluster type instead of default load balancer

### DIFF
--- a/argocd/applications/coder/values.yaml
+++ b/argocd/applications/coder/values.yaml
@@ -12,3 +12,5 @@ coder:
       enable: true
       className: traefik
       host: coder.proompteng.ai
+    service:
+      type: ClusterIP


### PR DESCRIPTION
## Description

- Changed the coder to use a cluster type instead of the default load balancer
