### PR TITLE
feat(argocd): add sealed secret and ingress for reviseur

### DIFF
--- a/argocd/applications/reviseur/overlays/dev/ingress.yaml
+++ b/argocd/applications/reviseur/overlays/dev/ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: reviseur-ingress
+  namespace: reviseur
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`reviseur.lan`)
+      kind: Rule
+      services:
+        - name: reviseur
+          port: 80

--- a/argocd/applications/reviseur/overlays/dev/kustomization.yaml
+++ b/argocd/applications/reviseur/overlays/dev/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - secrets.yaml
+  - ingress.yaml

--- a/argocd/applications/reviseur/overlays/dev/secrets.yaml
+++ b/argocd/applications/reviseur/overlays/dev/secrets.yaml
@@ -14,3 +14,19 @@ spec:
       name: registry
       namespace: reviseur
     type: kubernetes.io/dockerconfigjson
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: reviseur
+  namespace: reviseur
+spec:
+  encryptedData:
+    token: AgAyVVqVAtDg5DL33qGLsqDmA6C+q4m8/2mysJ+K23984uJbicphslKUJ1AhmGSay0zA3N7wGC2Y2Toph+ANdiZqvJ8xxe7hacEbe9jx1yCb/C5i8lUftQeMOAlHsEUdY9I34fSRdcwCr7IeIXwCe0Yr/IemQe2pfmaOoqUzYyQYfpp7S0/DjBhM+yeQELUlkgvsAUZFqSyeiDxWHlCDQ5/Rm+leYv9HtbN3PU9MU48iBJKyl5Zquf7Ir1tReHHT8SqD9ZlxGZFooUTyU59j1Bg+uO7PPihfzlqflzTGyiMD3ilf6IbGQzvE1VzATV3Sa/aguESDOKEi6V28idlWVQe1eDX7sJQzHMEo0yib9QIe0FBNwt4MRcQPik4HN7dinrROGDlZile/C8TQTIStlAhOMFM15P05pQQ9Kw5qXV5TXlAYmAKARjXPQk/TLpeTq+SpDFknJPgpR9nghM1haSSQcbIp6TvBFX/OBFU5wK1hswh2HBWl44jOh9yl5Cak303xzNjPToKbdx9E+qWP4MO8vXg/GMeBq40blZvXKUV/0+GKJEWPWm2XUvv1y4xW6BN3ipzYZp6kx+QKW2xHs+uUHyJuMncoxJIYg0hROPv5Wsq647LjH+1VTL66LEqFlJ7n1MTU+yQgf+El7gVX4P+lxLvow6dOO9FsoYMJ7rYJBJi6h1B7T6q5lXdxYny9Fge8ISBc6nBXu83J1sOL11HFRGhpTAkU47zuGPrM/xOB8e85q06wKJogGfiFngA/f08cPO0SugBvKXfafxqVu6hgq7fr2HDEe6DiphGJ/hWJWadQzWaQCiyRiEnlqILndY+x/3ujpto+qOx5V9E=
+  template:
+    metadata:
+      creationTimestamp: null
+      name: reviseur
+      namespace: reviseur
+    type: Opaque


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#8BpUSPJIV`](https://gitbutler.com/gregkonush/lab/reviews/8BpUSPJIV)

**feat(argocd): add sealed secret and ingress for reviseur**


## Description

- Added a sealed secret and ingress configuration for the Reviseur application in the ArgoCD deployment
- The ingress configuration provides a public-facing endpoint for accessing the Reviseur application


1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [feat(argocd): add sealed secret and ingress for reviseur](https://gitbutler.com/gregkonush/lab/reviews/8BpUSPJIV/commit/766ad240-8842-4c66-9dff-122b70f574a8) | ✅ | <img width="20" height="20" src="https://avatars.githubusercontent.com/u/12027037?v=4"> |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/gregkonush/lab/reviews/8BpUSPJIV)_
<!-- GitButler Review Footer Boundary Bottom -->
