### PR TITLE
feat: Add Istio 1.25.1 deployment configuration

### DIFF
--- a/argocd/applications/istio-system/kustomization.yaml
+++ b/argocd/applications/istio-system/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: istio-system
+helmCharts:
+  - name: base
+    repo: https://istio-release.storage.googleapis.com/charts
+    version: 1.25.1
+    releaseName: istio-base
+    namespace: istio-system
+    includeCRDs: true
+  - name: istiod
+    repo: https://istio-release.storage.googleapis.com/charts
+    version: 1.25.1
+    releaseName: istiod
+    namespace: istio-system
+    valuesInline:
+      profile: ambient
+  - name: cni
+    repo: https://istio-release.storage.googleapis.com/charts
+    version: 1.25.1
+    releaseName: istio-cni
+    namespace: istio-system
+    valuesInline:
+      profile: ambient
+  - name: ztunnel
+    repo: https://istio-release.storage.googleapis.com/charts
+    version: 1.25.1
+    releaseName: ztunnel
+    namespace: istio-system
+  - name: gateway
+    repo: https://istio-release.storage.googleapis.com/charts
+    version: 1.25.1
+    releaseName: istio-ingress
+    namespace: istio-ingress


### PR DESCRIPTION
## Description

- Added Istio 1.25.1 deployment configuration files
- This allows deploying the latest version of Istio to the Kubernetes cluster
- Includes configuration for the Istio control plane, sidecar injector, and various Istio components
- Enables advanced traffic management, security, and observability features provided by Istio