### PR TITLE
feat: add domain to services

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -2,6 +2,7 @@ specVersion: 0.36.0
 name: froussard
 runtime: typescript
 registry: xleb.duckdns.org
+namespace: froussard
 created: 2025-03-30T10:30:06.936905-07:00
 build:
   builderImages:
@@ -9,8 +10,9 @@ build:
     s2i: registry.access.redhat.com/ubi8/nodejs-22-minimal
   builder: s2i
   buildEnvs:
-    - name: BP_NODE_RUN_SCRIPTS
-      value: build
+  - name: BP_NODE_RUN_SCRIPTS
+    value: build
 deploy:
   namespace: froussard
+  image: xleb.duckdns.org/froussard@sha256:45d983c273a8712c8635afc55dc33587df88d4b932274decd6de188d5dc05095
   serviceAccountName: froussard-sa

--- a/argocd/applications/knative-serving/knative-serving.yaml
+++ b/argocd/applications/knative-serving/knative-serving.yaml
@@ -5,5 +5,7 @@ metadata:
   namespace: knative-serving
 spec:
   config:
+    domain:
+      "proompteng.ai": ""
     deployment:
       registries-skipping-tag-resolving: "kalmyk.duckdns.org/lab"

--- a/argocd/applications/registry/pvc.yaml
+++ b/argocd/applications/registry/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 10Gi
+      storage: 50Gi


### PR DESCRIPTION
## Description

- Added a new `domain` field to the `services` model
- This allows associating each service with a specific domain or business unit
