### PR TITLE
feat: Add Cert-Manager ClusterIssuers for Istio and Traefik

### DIFF
--- a/argocd/applications/cert-manager/cluster-issuer-production-istio.yaml
+++ b/argocd/applications/cert-manager/cluster-issuer-production-istio.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production-istio
+spec:
+  acme:
+    email: greg.konush@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-production-istio-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: istio

--- a/argocd/applications/cert-manager/cluster-issuer-production-traefik.yaml
+++ b/argocd/applications/cert-manager/cluster-issuer-production-traefik.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production-traefik
+spec:
+  acme:
+    email: greg.konush@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-production-traefik-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: traefik

--- a/argocd/applications/cert-manager/cluster-issuer-staging-istio.yaml
+++ b/argocd/applications/cert-manager/cluster-issuer-staging-istio.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging-istio
+spec:
+  acme:
+    email: greg.konush@gmail.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging-istio-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: istio

--- a/argocd/applications/cert-manager/cluster-issuer-staging-traefik.yaml
+++ b/argocd/applications/cert-manager/cluster-issuer-staging-traefik.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging-traefik
+spec:
+  acme:
+    email: greg.konush@gmail.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging-traefik-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: traefik

--- a/argocd/applications/cert-manager/kustomization.yaml
+++ b/argocd/applications/cert-manager/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 namespace: cert-manager
 resources:
   - https://github.com/cert-manager/cert-manager/releases/download/v1.17.0/cert-manager.yaml
-
-
+  - cluster-issuer-production-istio.yaml
+  - cluster-issuer-production-traefik.yaml
+  - cluster-issuer-staging-istio.yaml
+  - cluster-issuer-staging-traefik.yaml


### PR DESCRIPTION
## Description

- Added Cert-Manager ClusterIssuers for Istio and Traefik
- This allows the Istio and Traefik components to automatically request and renew SSL/TLS certificates for secure communication
- The ClusterIssuers are configured to use the Let's Encrypt ACME server for certificate provisioning
- This improves the overall security and reliability of the Istio and Traefik deployments