### PR TITLE
feat(argocd): update istio-ingress chart name to gateway

### DIFF
--- a/argocd/applications/istio-ingress/kustomization.yaml
+++ b/argocd/applications/istio-ingress/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: istio-ingress
 helmCharts:
-  - name: istio-ingress
+  - name: gateway
     repo: https://istio-release.storage.googleapis.com/charts
     version: 1.25.1
     releaseName: gateway


### PR DESCRIPTION
## Description

- Updated the Istio ingress chart name from `istio-ingress` to `gateway` in the ArgoCD configuration
- This change aligns the chart name with the latest Istio terminology and naming conventions
- The purpose of this update is to ensure the ArgoCD configuration matches the Istio deployment and provides a more accurate representation of the deployed components