### PR TITLE
feat(istio-ingress): set gateway service type to None

### DIFF
--- a/argocd/applications/istio-ingress/kustomization.yaml
+++ b/argocd/applications/istio-ingress/kustomization.yaml
@@ -7,3 +7,6 @@ helmCharts:
     version: 1.25.1
     releaseName: gateway
     namespace: istio-ingress
+    valuesInline:
+      service:
+        type: None


### PR DESCRIPTION
## Description

- Set the Istio ingress gateway service type to `None`
- This change ensures that the ingress gateway is not exposed as a Kubernetes service, which is the desired configuration for this deployment
- Keeping the gateway service type as `None` prevents the creation of an external load balancer, which is not needed in this setup