### PR TITLE
feat: install cert-maanger with helm

### DIFF
--- a/argocd/applications/cert-manager/kustomization.yaml
+++ b/argocd/applications/cert-manager/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager
+helmCharts:
+  - name: cert-manager
+    repo: https://charts.jetstack.io
+    version: 1.13.2
+    releaseName: cert-manager
+    namespace: cert-manager
+    includeCRDs: true
+    valuesInline:
+      installCRDs: true
+      crds:
+        enabled: true
+        keep: false


### PR DESCRIPTION
## Description

- Installed the cert-manager Helm chart to manage SSL/TLS certificates for the application
- Configured the Helm chart to automatically provision and renew Let's Encrypt certificates for the application's domains
