### PR TITLE
feat: add certificate and ingress

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -14,5 +14,5 @@ build:
     value: build
 deploy:
   namespace: froussard
-  image: xleb.duckdns.org/froussard@sha256:ceca9c1cf3912aa3948143a57dfcc4b52e2c15e48fa043c4c5df60ae242ce796
+  image: xleb.duckdns.org/froussard@sha256:02373735d9ac656451db9c5a3782e0519701c207fb644ad6be0e7e2f0b3f6c3c
   serviceAccountName: froussard-sa

--- a/argocd/applications/froussard/certificate.yaml
+++ b/argocd/applications/froussard/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: froussard-cert
+  namespace: froussard
+spec:
+  secretName: froussard-tls
+  dnsNames:
+    - "froussard.froussard.proompteng.ai"
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/argocd/applications/froussard/kustomization.yaml
+++ b/argocd/applications/froussard/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: froussard
 resources:
   - serviceaccount.yaml
   - secrets.yaml
+  - certificate.yaml

--- a/argocd/applications/istio-ingress/kustomization.yaml
+++ b/argocd/applications/istio-ingress/kustomization.yaml
@@ -9,4 +9,11 @@ helmCharts:
     namespace: istio-ingress
     valuesInline:
       service:
-        type: None
+        type: ClusterIP
+        ports:
+          - name: http2
+            port: 80
+            targetPort: 8080
+          - name: https
+            port: 443
+            targetPort: 8443


### PR DESCRIPTION
## Description

- Added a new SSL/TLS certificate to the application
- Configured an ingress to handle incoming traffic and route it to the appropriate services
- The certificate and ingress setup will improve the security and reliability of the application by providing HTTPS support and load balancing capabilities