### PR TITLE
feat(argocd): migrate ingress to ingressroute

### DIFF
--- a/argocd/applications/argocd/base/ingressroute.yaml
+++ b/argocd/applications/argocd/base/ingressroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: argocd-server

--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v2.14.5/manifests/ha/install.yaml
   - base/namespace.yaml
-  - base/ingress.yaml
+  - base/ingressroute.yaml
   - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/manifests/install.yaml
   - base/secrets.yaml
 

--- a/argocd/applications/backstage/ingressroute.yaml
+++ b/argocd/applications/backstage/ingressroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: backstage

--- a/argocd/applications/ecran/ingress.yaml
+++ b/argocd/applications/ecran/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: ecran

--- a/argocd/applications/findbobastore/ingressroute.yaml
+++ b/argocd/applications/findbobastore/ingressroute.yaml
@@ -1,17 +1,17 @@
-apiVersion: traefik.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: proompteng
-  namespace: proompteng
+  name: findbobastore
+  namespace: findbobastore
 spec:
   entryPoints:
     - web
     - websecure
   routes:
     - kind: Rule
-      match: Host(`proompteng.ai`)
+      match: Host(`findboba.store`)
       services:
-        - name: proompteng
+        - name: findbobastore
           port: 80
   tls:
     certResolver: default

--- a/argocd/applications/findbobastore/kustomization.yaml
+++ b/argocd/applications/findbobastore/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - secrets.yaml
   - deployment.yaml
   - service.yaml
-  - ingress.yaml
+  - ingressroute.yaml
 images:
   - name: kalmyk.duckdns.org/lab/findbobastore
     newTag: 0.164.0

--- a/argocd/applications/proompteng/ingressroute.yaml
+++ b/argocd/applications/proompteng/ingressroute.yaml
@@ -1,17 +1,17 @@
-apiVersion: traefik.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: findbobastore
-  namespace: findbobastore
+  name: proompteng
+  namespace: proompteng
 spec:
   entryPoints:
     - web
     - websecure
   routes:
     - kind: Rule
-      match: Host(`findboba.store`)
+      match: Host(`proompteng.ai`)
       services:
-        - name: findbobastore
+        - name: proompteng
           port: 80
   tls:
     certResolver: default

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - secrets.yaml
 - deployment.yaml
 - service.yaml
-- ingress.yaml
+- ingressroute.yaml
 images:
 - name: kalmyk.duckdns.org/lab/proompteng
   newTag: 0.164.0

--- a/argocd/applications/reviseur/overlays/dev/ingressroute.yaml
+++ b/argocd/applications/reviseur/overlays/dev/ingressroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: reviseur-ingress

--- a/argocd/applications/reviseur/overlays/dev/kustomization.yaml
+++ b/argocd/applications/reviseur/overlays/dev/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - secrets.yaml
-  - ingress.yaml
+  - ingressroute.yaml


### PR DESCRIPTION
## Description

- Migrated the ingress configuration to use IngressRoute instead of Ingress
- This change allows for more advanced routing capabilities provided by IngressRoute