### PR TITLE
feat(argocd): add froussard gateway and virtualservice

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -14,5 +14,5 @@ build:
     value: build
 deploy:
   namespace: froussard
-  image: xleb.duckdns.org/froussard@sha256:02373735d9ac656451db9c5a3782e0519701c207fb644ad6be0e7e2f0b3f6c3c
+  image: xleb.duckdns.org/froussard@sha256:8643e20725a0b2278100eabc5b069025b1ee577f1cc0083fe600f9d5303544d0
   serviceAccountName: froussard-sa

--- a/argocd/applications/froussard/gateway.yaml
+++ b/argocd/applications/froussard/gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: froussard-gateway
+  namespace: froussard
+spec:
+  selector:
+    app: gateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "froussard.froussard.proompteng.ai"

--- a/argocd/applications/froussard/kustomization.yaml
+++ b/argocd/applications/froussard/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - serviceaccount.yaml
   - secrets.yaml
   - certificate.yaml
+  - gateway.yaml
+  - virtualservice.yaml

--- a/argocd/applications/froussard/virtualservice.yaml
+++ b/argocd/applications/froussard/virtualservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: froussard-vs
+  namespace: froussard
+spec:
+  hosts:
+    - "froussard.froussard.proompteng.ai"
+  gateways:
+    - froussard-gateway
+  http:
+    - match:
+        - uri:
+            prefix: "/"
+      route:
+        - destination:
+            host: froussard.froussard.svc.cluster.local
+            port:
+              number: 80

--- a/argocd/applications/knative-serving/knative-serving.yaml
+++ b/argocd/applications/knative-serving/knative-serving.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: knative-serving
 spec:
   config:
+    istio:
+      local-gateways: |
+        - name: knative-local-gateway
+          namespace: istio-system
+          service: knative-local-gateway.istio-system.svc.cluster.local
     domain:
       "proompteng.ai": ""
     deployment:


### PR DESCRIPTION
- Added a new gateway and virtualservice for the froussard service in ArgoCD
- This allows the froussard service to be exposed and accessed through the cluster
- Improves the overall service mesh and routing configuration in the application