### PR TITLE
feat(knative-serving): remove local-gateways config and update gateway selector

### DIFF
--- a/argocd/applications/froussard/gateway.yaml
+++ b/argocd/applications/froussard/gateway.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: froussard
 spec:
   selector:
-    app: gateway
+    istio: ingressgateway
   servers:
     - port:
         number: 80

--- a/argocd/applications/knative-serving/knative-serving.yaml
+++ b/argocd/applications/knative-serving/knative-serving.yaml
@@ -5,11 +5,6 @@ metadata:
   namespace: knative-serving
 spec:
   config:
-    istio:
-      local-gateways: |
-        - name: knative-local-gateway
-          namespace: istio-system
-          service: knative-local-gateway.istio-system.svc.cluster.local
     domain:
       "proompteng.ai": ""
     deployment:


### PR DESCRIPTION
- Removed the `local-gateways` configuration from Knative Serving
- Updated the gateway selector to use a different configuration
- This change simplifies the Knative Serving deployment and improves the overall stability and performance of the system