### PR TITLE
feat(metallb): add L2Advertisement and IPAddressPool resources

### DIFF
--- a/argocd/applications/metallb-system/ipaddresspool.yaml
+++ b/argocd/applications/metallb-system/ipaddresspool.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: metallb-ip-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.1.100-192.168.1.150

--- a/argocd/applications/metallb-system/l2advertisement.yaml
+++ b/argocd/applications/metallb-system/l2advertisement.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: metallb-l2-advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - metallb-ip-pool


### PR DESCRIPTION
- Added `L2Advertisement` and `IPAddressPool` resources for MetalLB
- Implemented functionality to manage L2 advertisements and IP address pools
- Improved resource management for MetalLB deployment