### PR TITLE
🔧 feat(metallb): add ipaddresspool and l2advertisement resources

### DIFF
--- a/argocd/applications/metallb-system/kustomization.yaml
+++ b/argocd/applications/metallb-system/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: metallb-system
 resources:
   - github.com/metallb/metallb/config/frr?ref=v0.14.9
+  - ipaddresspool.yaml
+  - l2advertisement.yaml


### PR DESCRIPTION
- Added `ipaddresspool` and `l2advertisement` resources for the MetalLB load balancer
- Implemented support for configuring IP address pools and Layer 2 advertisements
- Improved the overall functionality and flexibility of the MetalLB integration