### PR TITLE
✨ feat(knative-serving): Remove Traefik ingress class

### DIFF
--- a/argocd/applications/knative-serving/knative-serving.yaml
+++ b/argocd/applications/knative-serving/knative-serving.yaml
@@ -18,4 +18,3 @@ spec:
         kind: ClusterIssuer
         name: letsencrypt-prod
     network:
-      ingress-class: traefik


### PR DESCRIPTION
- Removed the Traefik ingress class from Knative Serving
- This change simplifies the ingress configuration and removes a dependency on Traefik