### PR TITLE
✨ feat: Disable HTTPS on Istio ingress gateway

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -15,4 +15,4 @@ run:
     value: '{{ secret:github-secret:webhook-secret }}'
 deploy:
   namespace: froussard
-  image: xleb.duckdns.org/froussard@sha256:82fc3123fda55bb74948395420fcd796af3e2c88da4bd373eb59391eea67b794
+  image: xleb.duckdns.org/froussard@sha256:4738ff9c2af83161b6411d6d48e83b772857c0f7d66ca5638f1183ad69c8b194

--- a/argocd/applications/istio-ingress/external-gateway.yaml
+++ b/argocd/applications/istio-ingress/external-gateway.yaml
@@ -13,9 +13,3 @@ spec:
         name: http
       hosts:
         - "*"
-    - port:
-        number: 443
-        protocol: HTTPS
-        name: https
-      hosts:
-        - "*"


### PR DESCRIPTION
- Disabled HTTPS on the Istio ingress gateway
- This change allows HTTP traffic to be routed through the ingress gateway
- Simplifies the configuration and setup of the ingress gateway