### PR TITLE
🔧 feat: enable kafka-ui ingress

### DIFF
--- a/argocd/applications/kafka/kustomization.yaml
+++ b/argocd/applications/kafka/kustomization.yaml
@@ -8,3 +8,9 @@ helmCharts:
     version: 1.5.0
     releaseName: kafka-ui
     namespace: kafka
+    valuesInline:
+      ingress:
+        enabled: true
+        ingressClassName: tailscale
+        hosts:
+          - kafka-ui


### PR DESCRIPTION
- Enabled Kafka UI ingress to allow access to the Kafka UI
- Configured the necessary ingress rules and settings to expose the Kafka UI
- Integrated the Kafka UI with the existing infrastructure