### PR TITLE
🔧 feat(kafka): Add network policy for Kafka UI to access Kafka

### DIFF
--- a/argocd/applications/kafka/kafbat-ui-access-kafka.yaml
+++ b/argocd/applications/kafka/kafbat-ui-access-kafka.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kafbat-ui-access-kafka
+  namespace: kafka
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: kafka
+      app.kubernetes.io/name: kafka
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kafka-ui
+      ports:
+        - port: 9092
+          protocol: TCP

--- a/argocd/applications/kafka/kustomization.yaml
+++ b/argocd/applications/kafka/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - application.yaml
   - load-balancer.yaml
+  - kafbat-ui-access-kafka.yaml
 helmCharts:
   - name: kafka-ui
     repo: https://kafbat.github.io/helm-charts
@@ -13,7 +14,7 @@ helmCharts:
       yamlApplicationConfig:
         kafka:
           clusters:
-            - name: yaml
+            - name: kafka
               bootstrapServers: kafka:9092
         auth:
           type: disabled


### PR DESCRIPTION
- Added a network policy to allow the Kafka UI to access the Kafka cluster
- Enables the Kafka UI to communicate with the Kafka brokers
- Improves the overall accessibility and functionality of the Kafka UI