### PR TITLE
✨feat(argocd): add SASL authentication to Kafka cluster

### DIFF
--- a/argocd/applications/kafka/application.yaml
+++ b/argocd/applications/kafka/application.yaml
@@ -22,3 +22,5 @@ spec:
     helm:
       releaseName: kafka
       skipCrds: false
+      valuesObject:
+        advertisedListeners: CLIENT://kafka.kafka.svc.cluster.local:9092

--- a/argocd/applications/kafka/kustomization.yaml
+++ b/argocd/applications/kafka/kustomization.yaml
@@ -16,6 +16,13 @@ helmCharts:
           clusters:
             - name: kafka
               bootstrapServers: kafka:9092
+              properties:
+                security.protocol: SASL_PLAINTEXT
+                sasl.mechanism: PLAIN
+              sasl:
+                mechanism: PLAIN
+                username: user1
+                password: "SHVUB9nR5B"
         auth:
           type: disabled
         management:


### PR DESCRIPTION
- Added SASL authentication to the Kafka cluster in the ArgoCD deployment
- Implemented support for SASL authentication to enable secure communication with the Kafka cluster
- Configured the necessary settings and configurations to enable SASL authentication in the ArgoCD deployment