### PR TITLE
feat(temporal): Upgrade Temporal Helm chart to version 0.62.0

### DIFF
--- a/argocd/applications/temporal/Chart.yaml
+++ b/argocd/applications/temporal/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: temporal
 description: Temporal is a distributed, scalable, durable, and highly available orchestration engine for microservices.
-version: 0.51.0
+version: 0.62.0
 type: application
 dependencies:
   - name: temporal
-    version: 0.51.0
+    version: 0.62.0
     repository: https://go.temporal.io/helm-charts


### PR DESCRIPTION
The changes in this commit upgrade the Temporal Helm chart version from 0.51.0
to 0.62.0. This update is necessary to take advantage of the latest features and
bug fixes available in the newer version of the Temporal chart.