### PR TITLE
feat(argocd): update ArgoCD to v2.14.11

### DIFF
--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.14.5/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.14.11/manifests/ha/install.yaml
   - base/namespace.yaml
   - base/ingressroute.yaml
   - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/manifests/install.yaml


### PR DESCRIPTION
Update the ArgoCD installation manifest from v2.14.5 to v2.14.11 to
take advantage of the latest bug fixes and improvements in the ArgoCD
project.