### PR TITLE
feat(knative): Update Knative Operator to v1.18.0

### DIFF
--- a/argocd/applications/knative/kustomization.yaml
+++ b/argocd/applications/knative/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: knative
 resources:
-  - https://github.com/knative/operator/releases/download/knative-v1.17.5/operator.yaml
+  - https://github.com/knative/operator/releases/download/knative-v1.18.0/operator.yaml


### PR DESCRIPTION
Upgrade the Knative Operator from v1.17.5 to v1.18.0 to
take advantage of the latest features and bug fixes in the
Knative project.