### PR TITLE
feat(kafka): Upgrade Kafka chart to version 32.2.2

### DIFF
--- a/argocd/applications/kafka/application.yaml
+++ b/argocd/applications/kafka/application.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     repoURL: registry-1.docker.io/bitnamicharts
     chart: kafka
-    targetRevision: 32.2.0
+    targetRevision: 32.2.2
     helm:
       releaseName: kafka
       skipCrds: false


### PR DESCRIPTION
Upgrades the Kafka chart from version 32.2.0 to 32.2.2 to
take advantage of the latest bug fixes and improvements
in the chart.