### PR TITLE
feat(gitea): Bump Gitea chart version to 11.0.1

### DIFF
--- a/argocd/applications/gitea/Chart.yaml
+++ b/argocd/applications/gitea/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 appVersion: 0.0.3
 description: Gitea is a painless self-hosted Git service
 name: gitea
-version: 11.0.0
+version: 11.0.1
 type: application
 dependencies:
   - name: gitea
-    version: 11.0.0
+    version: 11.0.1
     repository: https://dl.gitea.com/charts


### PR DESCRIPTION
The changes update the Gitea chart version from 11.0.0 to 11.0.1 in the
ArgoCD application manifest. This is to ensure the latest version of the
Gitea chart is deployed.