### PR TITLE
feat(minio): Upgrade Minio Operator to v7.1.1

### DIFF
--- a/argocd/applications/minio/kustomization.yaml
+++ b/argocd/applications/minio/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 namespace: minio
 
 resources:
-  - github.com/minio/operator?ref=v6.0.4
+  - github.com/minio/operator?ref=v7.1.1


### PR DESCRIPTION
The Minio Operator version has been upgraded from v6.0.4 to v7.1.1.
This upgrade brings in the latest features and bug fixes from the
Minio Operator, improving the overall stability and functionality
of the Minio deployment.