### PR TITLE
feat(tailscale): update Tailscale operator to v1.82.5

### DIFF
--- a/argocd/applications/tailscale/kustomization.yaml
+++ b/argocd/applications/tailscale/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tailscale
 resources:
-  - https://raw.githubusercontent.com/tailscale/tailscale/refs/tags/v1.80.3/cmd/k8s-operator/deploy/manifests/operator.yaml
+  - https://raw.githubusercontent.com/tailscale/tailscale/refs/tags/v1.82.5/cmd/k8s-operator/deploy/manifests/operator.yaml
   - base/secrets.yaml
 
 patches:


### PR DESCRIPTION
Updates the Tailscale Kubernetes operator to version 1.82.5. This
version includes bug fixes and improvements to the operator, ensuring
better reliability and functionality for the Tailscale deployment.