### PR TITLE
fix: enable certmanager in knative, setup istio to recommended setup

### DIFF
--- a/argocd/applications/istio-ingress/external-gateway.yaml
+++ b/argocd/applications/istio-ingress/external-gateway.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: istio-ingress
 spec:
   selector:
-    istio: ingressgateway
+    istio: gateway
   servers:
     - port:
         number: 80

--- a/argocd/applications/istio-system/ingress-class.yaml
+++ b/argocd/applications/istio-system/ingress-class.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: istio
+spec:
+  controller: istio.io/ingress-controller

--- a/argocd/applications/istio-system/kustomization.yaml
+++ b/argocd/applications/istio-system/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: istio-system
+resources:
+  - ingress-class.yaml
 helmCharts:
   - name: base
     repo: https://istio-release.storage.googleapis.com/charts

--- a/argocd/applications/knative-serving/README.md
+++ b/argocd/applications/knative-serving/README.md
@@ -11,6 +11,7 @@ The integration uses the Let's Encrypt production issuer with HTTP01 challenges 
 **Important settings:**
 
 - External Domain TLS: `Enabled` - Automatically provisions certificates for external domains via cert-manager
+- HTTP-01 Challenges: `httpProtocol` stays `Enabled` so Let's Encrypt can complete callbacks before Knative enforces HTTPS
 - Ingress: `Istio` - Knative net-istio is the only enabled ingress implementation
 - ClusterIssuer: `letsencrypt-prod` - Uses Let's Encrypt production with HTTP01 challenges through Istio
 - Domain Template: `{{.Name}}.{{.Domain}}` - Routes render as single-level subdomains (e.g., `froussard.proompteng.ai`)

--- a/argocd/applications/knative-serving/knative-serving.yaml
+++ b/argocd/applications/knative-serving/knative-serving.yaml
@@ -23,7 +23,7 @@ spec:
       domainTemplate: "{{.Name}}.{{.Domain}}"
       autoTLS: Enabled
       defaultExternalScheme: https
-      httpProtocol: Redirected
+      httpProtocol: Enabled
       ingress.class: istio.ingress.networking.knative.dev
     istio:
       external-gateways: |


### PR DESCRIPTION
## Description

- Enabled cert-manager in Knative
- Set up Istio to the recommended configuration