### PR TITLE
fix: update proompteng image tag to 0.209.0

### DIFF
--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  newTag: 0.203.0
+  newTag: 0.209.0


### PR DESCRIPTION
## Summary
- update the Proompteng Argo CD kustomization to reference the 0.209.0 image tag so deployments pick up the latest build

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9b2e9260883249be6f6f751e7d1a4