### PR TITLE
fix: auto-sync docs and proompteng applications

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -21,7 +21,7 @@ spec:
               argocd-image-updater.argoproj.io/git-repository: git@github.com:gregkonush/lab.git
               argocd-image-updater.argoproj.io/git-branch: release/proompteng
               argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/proompteng
-            automation: manual
+            automation: auto
             enabled: true
           - name: docs
             path: argocd/applications/docs
@@ -35,7 +35,7 @@ spec:
               argocd-image-updater.argoproj.io/git-repository: git@github.com:gregkonush/lab.git
               argocd-image-updater.argoproj.io/git-branch: release/docs
               argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/docs
-            automation: manual
+            automation: auto
             enabled: true
           - name: kitty-krew
             path: argocd/applications/kitty-krew


### PR DESCRIPTION
## Summary
- configure only the proompteng and docs applications in the product ApplicationSet to auto sync
- restore manual sync mode for the remaining product applications

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9b8a7a6c48324bed224fc20ae2183