### PR TITLE
ci: harden semantic pr workflow permissions

### DIFF
--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -1,0 +1,24 @@
+name: Semantic Commits
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+
+jobs:
+  lint:
+    name: Lint commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.cjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,38 @@
+name: Semantic Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        with:
+          # Keep aligned with commitlint.config.cjs
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+          subjectPattern: ^[a-z].+
+          subjectPatternError: >-
+            The subject must start with a lowercase letter and describe the change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,14 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 - `apps/<app>` contains Next.js/Turbo UIs; keep UI fixtures and tests alongside components.
 - Shared TS utilities stay in `packages/backend`; CDK8s blueprints sit in `packages/cloutt`.
 - Go services live in `services/<service>` with `main.go` and adjacent `*_test.go` files.
 - Infra-as-code spans `tofu/harvester` (OpenTofu), `kubernetes/` manifests, `argocd/` app specs, plus automation in `scripts/` and Ansible plays in `ansible/`.
 
 ## Build, Test & Development Commands
+
 - Install dependencies with `pnpm install` (Node 22.19.0) and run `go mod tidy` inside each Go service.
 - Start UIs with `pnpm run dev:proompteng`; swap the suffix for sibling apps.
 - Build and smoke test via `pnpm run build:<app>` then `pnpm run start:<app>`.
@@ -15,6 +17,7 @@
 - Infra flow: `pnpm run tf:plan` (review), `pnpm run tf:apply` (approved), and `pnpm run ansible` for playbooks.
 
 ## Coding Style & Naming Conventions
+
 - Run Biome before commits; it enforces two-space indentation, single quotes, trailing commas, and 120-character lines.
 - Name files in kebab-case (`dialog-panel.tsx`, `cron-worker.go`).
 - Order imports standard → third-party → internal with blank lines between groups.
@@ -22,16 +25,20 @@
 - Wrap Go errors as `fmt.Errorf("operation failed: %w", err)`.
 
 ## Testing Guidelines
+
 - Keep Go tests as `*_test.go` next to implementation; narrow runs with `go test ./services/prt -run TestHandleRoot`.
 - Write TypeScript tests as `*.test.ts`; trigger scoped runs with `pnpm --filter cloutt exec jest` or the appropriate workspace filter.
 - Target fast unit coverage first, then log manual QA steps in PR descriptions.
 
 ## Commit & Pull Request Guidelines
+
 - Adopt Conventional Commits (e.g. `feat: add prix cache`); use bodies for extra context or breaking notes.
+- Commits and PR titles MUST use the approved types (`build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`).
 - PRs should summarize the change, link issues, list verification (`go test`, `pnpm run lint:<app>`), and attach UI screenshots when visuals shift.
 - Keep scope tight, track follow-ups with TODOs, and document rollout or operational impacts.
 
 ## Security & Operations Notes
+
 - ArgoCD reconciles desired state; edit manifests in `argocd/` or `kubernetes/` and let automation deploy.
 - Pair Terraform plans from `pnpm run tf:plan` with review before `pnpm run tf:apply`; note outcomes after applies.
 - Prefer read-only `kubectl -n <namespace> get ...` for production checks and capture findings in runbooks.
@@ -46,7 +53,7 @@
   - MUST: Hit target ≥24px (mobile ≥44px) If visual <24px, expand hit area
   - MUST: Mobile `<input>` font-size ≥16px or set:
     ```html
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
     ```
   - NEVER: Disable browser zoom
   - MUST: `touch-action: manipulation` to prevent double-tap zoom; set `-webkit-tap-highlight-color` to match design
@@ -100,7 +107,7 @@
 - MUST: Deliberate alignment to grid/baseline/edges/optical centers—no accidental placement
 - SHOULD: Balance icon/text lockups (stroke/weight/size/spacing/color)
 - MUST: Verify mobile, laptop, ultra-wide (simulate ultra-wide at 50% zoom)
-- MUST: Respect safe areas (use env(safe-area-inset-*))
+- MUST: Respect safe areas (use env(safe-area-inset-\*))
 - MUST: Avoid unwanted scrollbars; fix overflows
 
 ## Content & Accessibility

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- switch the semantic pull request workflow to run on pull_request events
- restrict the workflow token to read-only pull request access to avoid unnecessary writes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da02a03f448324bc884b1afa903a85