### PR TITLE
fix: ensure docs public directory exists for docker build

### DIFF
--- a/apps/docs/public/.gitkeep
+++ b/apps/docs/public/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder file to keep public directory in version control.


### PR DESCRIPTION
## Summary
- add a placeholder file so the docs app's public directory is persisted in the build context and available to Docker

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68da2506bef08324a5cec9eec2efe61c