### PR TITLE
chore: set git identity for image updater

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-image-updater-config.yaml
+++ b/argocd/applications/argocd/overlays/argocd-image-updater-config.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: argocd-image-updater-config
 data:
+  git.email: noreply@proompteng.ai
+  git.user: Proompt Eng
   log.level: debug
   registries.conf: |
     registries:


### PR DESCRIPTION
## Summary
- configure the argocd-image-updater ConfigMap with the Proompt Eng git identity

## Testing
- not run (infra change)

------
https://chatgpt.com/codex/tasks/task_e_68db67cc52448324a73b6cbc24caaa45