### PR TITLE
feat: expose lgtm grafana via tailscale

### DIFF
--- a/argocd/applications/lgtm/README.md
+++ b/argocd/applications/lgtm/README.md
@@ -1,0 +1,18 @@
+# LGTM Observability Stack
+
+This Argo CD application deploys the Grafana LGTM (Loki, Grafana, Tempo, Mimir) stack
+with the upstream `lgtm-distributed` Helm chart. The provided `lgtm-values.yaml`
+tunes the chart for the lab cluster by:
+
+- enabling persistent volumes with the `longhorn` storage class for all
+  stateful components (Grafana dashboards, Loki ingesters, Mimir stores, Tempo
+  trace blocks, and the backing MinIO bucket),
+- exposing the Grafana dashboard through a Tailscale load balancer for
+  secure remote access,
+- reducing replica counts to a single instance where safe to conserve
+  resources, and
+- pre-provisioning Grafana datasources that point at the in-cluster Loki,
+  Tempo, and Mimir services so dashboards work out of the box.
+
+The application is discovered by the `platform` ApplicationSet and is
+synchronized into the `lgtm` namespace.

--- a/argocd/applications/lgtm/kustomization.yaml
+++ b/argocd/applications/lgtm/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: lgtm
+
+helmCharts:
+  - name: lgtm-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 2.1.0
+    releaseName: lgtm
+    namespace: lgtm
+    includeCRDs: true
+    valuesFile: lgtm-values.yaml

--- a/argocd/applications/lgtm/lgtm-values.yaml
+++ b/argocd/applications/lgtm/lgtm-values.yaml
@@ -1,0 +1,168 @@
+---
+# Values tuned for the lab environment to run the LGTM (Loki, Grafana, Tempo, Mimir) stack
+# with modest resource usage and persistent Longhorn storage.
+grafana:
+  enabled: true
+  adminUser: admin
+  adminPassword: changeme
+  service:
+    type: LoadBalancer
+    annotations:
+      tailscale.com/hostname: lgtm
+    loadBalancerClass: tailscale
+  persistence:
+    enabled: true
+    storageClassName: longhorn
+    size: 10Gi
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Loki
+          uid: loki
+          type: loki
+          access: proxy
+          url: http://lgtm-loki-gateway
+          isDefault: false
+        - name: Mimir
+          uid: prom
+          type: prometheus
+          access: proxy
+          url: http://lgtm-mimir-nginx/prometheus
+          isDefault: true
+        - name: Tempo
+          uid: tempo
+          type: tempo
+          access: proxy
+          url: http://lgtm-tempo-query-frontend:3100
+          isDefault: false
+          jsonData:
+            tracesToLogsV2:
+              datasourceUid: loki
+            lokiSearch:
+              datasourceUid: loki
+            tracesToMetrics:
+              datasourceUid: prom
+            serviceMap:
+              datasourceUid: prom
+
+loki:
+  enabled: true
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: boltdb-shipper
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+  storageConfig:
+    boltdb_shipper:
+      cache_location: /var/loki/index
+      shared_store: filesystem
+    filesystem:
+      directory: /var/loki/chunks
+  compactor:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  ingester:
+    replicas: 1
+    persistence:
+      enabled: true
+      claims:
+        - name: data
+          size: 20Gi
+          storageClass: longhorn
+    zoneAwareReplication:
+      enabled: false
+  querier:
+    persistence:
+      enabled: true
+      size: 10Gi
+      storageClass: longhorn
+  ruler:
+    enabled: true
+    kind: StatefulSet
+    persistence:
+      enabled: true
+      size: 5Gi
+      storageClass: longhorn
+
+mimir:
+  enabled: true
+  admin_api:
+    replicas: 1
+  distributor:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  ingester:
+    replicas: 1
+    persistentVolume:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  querier:
+    replicas: 1
+  query_frontend:
+    replicas: 1
+  query_scheduler:
+    replicas: 1
+  ruler:
+    replicas: 1
+  store_gateway:
+    replicas: 1
+    persistentVolume:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  compactor:
+    replicas: 1
+    persistentVolume:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  alertmanager:
+    replicas: 1
+    persistence:
+      enabled: true
+      storageClass: longhorn
+      size: 5Gi
+  minio:
+    enabled: true
+    persistence:
+      enabled: true
+      size: 50Gi
+      storageClass: longhorn
+
+tempo:
+  enabled: true
+  ingester:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  compactor:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  querier:
+    replicas: 1
+  queryFrontend:
+    replicas: 1
+  distributor:
+    replicas: 1
+  storage:
+    trace:
+      backend: local
+      block:
+        version: vParquet3

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -79,6 +79,13 @@ spec:
               argocd.argoproj.io/sync-wave: "2"
             automation: manual
             enabled: "true"
+          - name: lgtm
+            path: argocd/applications/lgtm
+            namespace: lgtm
+            annotations:
+              argocd.argoproj.io/sync-wave: "3"
+            automation: manual
+            enabled: "true"
           - name: minio
             path: argocd/applications/minio
             namespace: minio
@@ -163,7 +170,7 @@ spec:
             values: ["false", "False", "0"]
   template:
     metadata:
-      name: '{{ .name }}'
+      name: "{{ .name }}"
     spec:
       project: '{{ if hasKey . "project" }}{{ .project }}{{ else }}default{{ end }}'
       destination:
@@ -172,7 +179,7 @@ spec:
       source:
         repoURL: https://github.com/gregkonush/lab.git
         targetRevision: main
-        path: '{{ .path }}'
+        path: "{{ .path }}"
       syncPolicy:
         syncOptions:
           - CreateNamespace=true


### PR DESCRIPTION
## Summary
- expose the LGTM Grafana service through a Tailscale-managed load balancer for remote access
- document the Tailscale dashboard availability in the LGTM stack README

## Testing
- not run (configuration only)

------
https://chatgpt.com/codex/tasks/task_e_68dcbc76ab60832496b08ec505d3e470

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an Argo CD app to deploy the LGTM stack with Longhorn-backed persistence and Tailscale-exposed Grafana, and registers it in the platform ApplicationSet.
> 
> - **Argo CD Application (`argocd/applications/lgtm`)**:
>   - **Helm**: Deploy `lgtm-distributed` (v2.1.0) via `kustomization.yaml` with `lgtm-values.yaml`.
>   - **Grafana**: Tailscale `LoadBalancer` (`tailscale.com/hostname: lgtm`), persistent storage (`longhorn`), pre-provisioned datasources (`Loki`, `Mimir` as default, `Tempo`).
>   - **Persistence/Replicas**: Enable Longhorn-backed PVCs and reduce replicas (mostly 1) for `loki`, `mimir`, `tempo`, and `minio` with specified sizes.
>   - **README**: Documents LGTM stack purpose and deployment details.
> - **ApplicationSet (`argocd/applicationsets/platform.yaml`)**:
>   - Register new `lgtm` app (path `argocd/applications/lgtm`, namespace `lgtm`) with sync-wave "3", manual automation, enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd7e0232f3d9b076939bcb742b5fd734b7831bd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->