### PR TITLE
fix: add ignore diff, adjust healthchecks

### DIFF
--- a/argocd/applications/lgtm/lgtm-values.yaml
+++ b/argocd/applications/lgtm/lgtm-values.yaml
@@ -63,6 +63,31 @@ loki:
       shared_store: filesystem
     filesystem:
       directory: /var/loki/chunks
+  readinessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /ready
+      port: http
+      scheme: HTTP
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  livenessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /ready
+      port: http
+      scheme: HTTP
+    initialDelaySeconds: 300
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  structuredConfig:
+    ruler:
+      storage:
+        local:
+          directory: /var/loki/rules
   compactor:
     replicas: 1
     persistence:

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -191,6 +191,21 @@ spec:
           namespace: dagster
           jqPathExpressions:
             - .spec.volumeClaimTemplates
+        - kind: StatefulSet
+          group: apps
+          namespace: lgtm
+          jqPathExpressions:
+            - .spec.persistentVolumeClaimRetentionPolicy
+            - .spec.podManagementPolicy
+            - .spec.updateStrategy
+            - .spec.template.metadata.creationTimestamp
+            - .spec.template.spec.serviceAccount
+            - .spec.template.spec.volumes[].configMap.defaultMode
+            - .spec.template.spec.containers[].terminationMessagePath
+            - .spec.template.spec.containers[].terminationMessagePolicy
+            - .spec.volumeClaimTemplates[].metadata.creationTimestamp
+            - .spec.volumeClaimTemplates[].spec.volumeMode
+            - .spec.volumeClaimTemplates[].status
         - kind: Deployment
           group: apps
           namespace: istio-system


### PR DESCRIPTION
## Description

* add ignore statements for argocd
* update lokiconfiguration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Loki readiness/liveness probes and ruler local storage config; expands Argo CD ignoreDifferences for `lgtm` StatefulSets.
> 
> - **LGTM — Loki**:
>   - Add `readinessProbe` and `livenessProbe` endpoints (`/ready`).
>   - Configure `structuredConfig.ruler.storage.local.directory` to `/var/loki/rules`.
> - **Argo CD ApplicationSet (`argocd/applicationsets/platform.yaml`)**:
>   - Extend `ignoreDifferences` for `StatefulSet` in namespace `lgtm` to ignore fields like `persistentVolumeClaimRetentionPolicy`, `podManagementPolicy`, `updateStrategy`, various `template` and `volumeClaimTemplates` metadata/spec paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caa122ee1b3f82def34b0f345730916c497bb1ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->