### PR TITLE
fix: narrow lgtm pvc diff ignore

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -195,29 +195,8 @@ spec:
           group: apps
           namespace: lgtm
           jqPathExpressions:
-            - .spec.persistentVolumeClaimRetentionPolicy
-            - .spec.podManagementPolicy
-            - .spec.updateStrategy.type
-            - .spec.updateStrategy.rollingUpdate.partition
-            - .spec.template.metadata.creationTimestamp
-            - .spec.template.spec.serviceAccount
-            - .spec.template.spec.dnsPolicy
-            - .spec.template.spec.restartPolicy
-            - .spec.template.spec.schedulerName
-            - .spec.template.spec.volumes[].configMap.defaultMode
-            - .spec.template.spec.containers[].terminationMessagePath
-            - .spec.template.spec.containers[].terminationMessagePolicy
-            - .spec.template.spec.containers[].readinessProbe.failureThreshold
-            - .spec.template.spec.containers[].readinessProbe.periodSeconds
-            - .spec.template.spec.containers[].readinessProbe.successThreshold
-            - .spec.template.spec.containers[].readinessProbe.timeoutSeconds
-            - .spec.template.spec.containers[].livenessProbe.failureThreshold
-            - .spec.template.spec.containers[].livenessProbe.periodSeconds
-            - .spec.template.spec.containers[].livenessProbe.successThreshold
-            - .spec.template.spec.containers[].livenessProbe.timeoutSeconds
-            - .spec.volumeClaimTemplates[].metadata.creationTimestamp
-            - .spec.volumeClaimTemplates[].spec.volumeMode
-            - .spec.volumeClaimTemplates[].status
+            - .spec.volumeClaimTemplates[].apiVersion
+            - .spec.volumeClaimTemplates[].kind
         - kind: Deployment
           group: apps
           namespace: istio-system


### PR DESCRIPTION
## Summary
- drop the broad Argo CD diff ignore entries for the lgtm StatefulSet
- keep only the Helm-generated pvc template apiVersion/kind churn ignored

## Testing
- not run (not requested)
