### PR TITLE
fix: skip husky during bonjour docker build

### DIFF
--- a/packages/bonjour/Dockerfile
+++ b/packages/bonjour/Dockerfile
@@ -3,6 +3,7 @@
 FROM node:22.19.0-bullseye-slim AS builder
 ENV PNPM_HOME=/root/.local/share/pnpm
 ENV PATH=$PNPM_HOME:$PATH
+ENV HUSKY=0
 RUN corepack enable
 WORKDIR /workspace
 
@@ -22,6 +23,7 @@ RUN pnpm --filter @proompteng/bonjour build
 FROM node:22.19.0-bullseye-slim AS prod-deps
 ENV PNPM_HOME=/root/.local/share/pnpm
 ENV PATH=$PNPM_HOME:$PATH
+ENV HUSKY=0
 RUN corepack enable
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary
- set HUSKY=0 in the builder and prod dependency stages so Docker installs no longer run husky

## Testing
- docker build --target prod-deps -f packages/bonjour/Dockerfile .