### PR TITLE
fix: include husky prepare script in docker builds

### DIFF
--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -2,9 +2,11 @@ FROM node:lts-alpine AS deps
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY apps/docs ./apps/docs
 
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+ENV HUSKY=0
 RUN corepack enable && pnpm install --frozen-lockfile
 
 FROM node:lts-alpine AS builder

--- a/packages/bonjour/Dockerfile
+++ b/packages/bonjour/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /workspace
 # Copy workspace manifests required for dependency installation
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY tsconfig.json ./
+COPY scripts/run-husky-install.mjs scripts/run-husky-install.mjs
 COPY packages/bonjour/package.json packages/bonjour/package.json
 COPY packages/bonjour/tsconfig.json packages/bonjour/tsconfig.json
 
@@ -28,6 +29,7 @@ RUN corepack enable
 WORKDIR /workspace
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY scripts/run-husky-install.mjs scripts/run-husky-install.mjs
 COPY packages/bonjour/package.json packages/bonjour/package.json
 
 RUN pnpm install --prod --frozen-lockfile --filter @proompteng/bonjour...


### PR DESCRIPTION
## Summary
- copy the shared husky prepare script into the bonjour Docker build context so filtered pnpm installs keep working
- include the same script for docs and set HUSKY=0 to let the prepare step exit cleanly during CI installs

## Testing
- docker build -t bonjour-test -f packages/bonjour/Dockerfile .
- docker build -t docs-test -f apps/docs/Dockerfile .