### PR TITLE
feat: add redis operator argocd app

### DIFF
--- a/argocd/applications/redis-operator/README.md
+++ b/argocd/applications/redis-operator/README.md
@@ -1,0 +1,12 @@
+# Redis Operator
+
+- Managed via Argo CD from `argocd/applications/redis-operator`.
+- Installs the [OT-Container-Kit Redis Operator](https://github.com/OT-CONTAINER-KIT/redis-operator) Helm chart (v0.22.1).
+- Controller namespace: `redis-operator` (auto-created by Argo CD sync).
+
+Check status:
+
+```bash
+kubectl -n argocd get application redis-operator
+kubectl -n redis-operator get deploy,pod
+```

--- a/argocd/applications/redis-operator/application.yaml
+++ b/argocd/applications/redis-operator/application.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: redis-operator
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: redis-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+  source:
+    repoURL: https://ot-container-kit.github.io/helm-charts
+    chart: redis-operator
+    targetRevision: 0.22.1
+    helm:
+      releaseName: redis-operator
+      skipCrds: false

--- a/argocd/applications/redis-operator/kustomization.yaml
+++ b/argocd/applications/redis-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - application.yaml

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -16,6 +16,13 @@ spec:
               argocd.argoproj.io/sync-wave: "-1"
             automation: manual
             enabled: "true"
+          - name: redis-operator
+            path: argocd/applications/redis-operator
+            namespace: redis-operator
+            annotations:
+              argocd.argoproj.io/sync-wave: "-1"
+            automation: manual
+            enabled: "true"
           - name: external-dns
             path: argocd/applications/external-dns
             namespace: external-dns


### PR DESCRIPTION
## Summary
- add an Argo CD application that tracks the ot-container-kit redis-operator Helm chart v0.22.1
- document the redis-operator app location and basic status checks
- enable the redis-operator entry in the platform ApplicationSet for reconciliation

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e0f2788adc8324b770d48d3f206e2f