### PR TITLE
fix: route argo workflows ingress to server svc

### DIFF
--- a/argocd/applications/argo-workflows/ingressroute.yaml
+++ b/argocd/applications/argo-workflows/ingressroute.yaml
@@ -12,7 +12,7 @@ spec:
     - match: Host(`workflows.proompteng.ai`)
       kind: Rule
       services:
-        - name: argo-server
+        - name: argo-workflows-server
           port: 2746
   tls:
     secretName: wildcard-proompteng-ai-tls


### PR DESCRIPTION
## Summary
- point the Traefik ingressroute at the existing argo-workflows-server service to restore traffic

## Testing
- kubectl describe ingressroute argo-workflows -n argo-workflows