### PR TITLE
fix: configure dex issuer for workflows sso

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -9,6 +9,18 @@ data:
   application.resourceTrackingMethod: annotation
   timeout.reconciliation: 180s
   dex.config: |
+    issuer: https://argocd.proompteng.ai/api/dex
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+    web:
+      http: 0.0.0.0:5556
+    telemetry:
+      http: 0.0.0.0:5558
+    grpc:
+      addr: 0.0.0.0:5557
+    enablePasswordDB: true
     staticClients:
       - id: argo-workflows-sso
         name: Argo Workflows


### PR DESCRIPTION
## Summary
- add the missing Dex issuer/storage/listener settings so Argo CD actually serves /api/dex for workflows SSO
- keep the existing static client/password wiring but enable Dex's password DB so the static entry works

## Testing
- kubectl apply -f /tmp/argocd-cm.yaml
- kubectl rollout restart deployment argocd-dex-server -n argocd
- curl -sk https://argocd.proompteng.ai/api/dex/.well-known/openid-configuration
