### PR TITLE
fix: expose dex via traefik

### DIFF
--- a/argocd/applications/argocd/base/ingressroute.yaml
+++ b/argocd/applications/argocd/base/ingressroute.yaml
@@ -27,6 +27,14 @@ spec:
         - name: argocd-server
           port: 80
     - kind: Rule
+      match: Host(`argocd.proompteng.ai`) && PathPrefix(`/api/dex`)
+      priority: 100
+      middlewares:
+        - name: argocd-dex-strip
+      services:
+        - name: argocd-dex-server
+          port: 5556
+    - kind: Rule
       match: Host(`argocd.proompteng.ai`) && Header(`Content-Type`, `application/grpc`)
       priority: 11
       services:

--- a/argocd/applications/argocd/base/middleware-argocd-dex.yaml
+++ b/argocd/applications/argocd/base/middleware-argocd-dex.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: argocd-dex-strip
+  namespace: argocd
+spec:
+  stripPrefix:
+    prefixes:
+      - /api/dex

--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.1.6/manifests/ha/install.yaml
   - base/namespace.yaml
   - base/ingressroute.yaml
+  - base/middleware-argocd-dex.yaml
   - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/v0.16.0/manifests/install.yaml
   - base/secrets.yaml
   - base/argo-workflows-sso-sealedsecret.yaml

--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -9,6 +9,18 @@ data:
   application.resourceTrackingMethod: annotation
   timeout.reconciliation: 180s
   dex.config: |
+    issuer: https://argocd.proompteng.ai/api/dex
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+    web:
+      http: 0.0.0.0:5556
+    telemetry:
+      http: 0.0.0.0:5558
+    grpc:
+      addr: 0.0.0.0:5557
+    enablePasswordDB: true
     staticClients:
       - id: argo-workflows-sso
         name: Argo Workflows


### PR DESCRIPTION
## Summary
- add a dedicated Traefik rule for Host=argocd.proompteng.ai PathPrefix /api/dex so requests hit the dex service
- strip the /api/dex prefix before forwarding to port 5556 to satisfy workflows’ issuer URL

## Testing
- kubectl apply -k argocd/applications/argocd
- curl -sk https://argocd.proompteng.ai/api/dex/.well-known/openid-configuration
