### PR TITLE
fix: inline dex sso config

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -29,6 +29,6 @@ data:
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai
-        hash: {{ getenv "ARGO_WORKFLOWS_SSO_PASSWORD_HASH" }}
+        hash: $2a$10$kqHbxJcBTUu3kd48g49PZO4ZOC7UMW4I9d30PjUr45cn5J6gFmDgO
         username: admin
         userID: 86c47abf-4b23-4818-9b4c-76a2d17e7c98


### PR DESCRIPTION
## Summary
- hardcode the bcrypt hash for the local admin in argocd-cm so dex reads a concrete value
- keep the dex issuer/storage/listener values required for the workflows SSO flow

## Testing
- argocd app sync argocd/argocd
- kubectl rollout restart deployment argocd-dex-server -n argocd
- curl -sk https://argocd.proompteng.ai/api/dex/.well-known/openid-configuration
