### PR TITLE
fix: stabilize dex sso config

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -30,6 +30,6 @@ data:
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai
-        hash: $2a$10$kqHbxJcBTUu3kd48g49PZO4ZOC7UMW4I9d30PjUr45cn5J6gFmDgO
+        hash: "$2a$10$kqHbxJcBTUu3kd48g49PZO4ZOC7UMW4I9d30PjUr45cn5J6gFmDgO"
         username: admin
         userID: 86c47abf-4b23-4818-9b4c-76a2d17e7c98

--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -22,6 +22,10 @@ data:
     grpc:
       addr: 0.0.0.0:5557
     enablePasswordDB: true
+    connectors:
+      - type: local
+        id: local
+        name: Local
     staticClients:
       - id: argo-workflows-sso
         name: Argo Workflows

--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: argocd
 data:
+  url: https://argocd.proompteng.ai
   kustomize.buildOptions: --enable-helm
   application.resourceTrackingMethod: annotation
   timeout.reconciliation: 180s


### PR DESCRIPTION
## Summary
- add the Argo CD base URL to argocd-cm so the server advertises `https://argocd.proompteng.ai`
- inline and quote the bcrypt hash Dex uses for the local admin user
- register the built-in `local` connector so Dex has a valid configuration before external IdPs are wired

## Testing
- kubectl apply -k argocd/applications/argocd
- kubectl rollout restart deployment argocd-dex-server -n argocd
- curl -sk https://argocd.proompteng.ai/api/dex/.well-known/openid-configuration
