### PR TITLE
fix: stabilize argocd dex config

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -22,10 +22,6 @@ data:
     grpc:
       addr: 0.0.0.0:5557
     enablePasswordDB: true
-    connectors:
-      - type: local
-        id: local
-        name: Local
     staticClients:
       - id: argo-workflows-sso
         name: Argo Workflows
@@ -34,6 +30,6 @@ data:
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai
-        hash: {{ getenv "ARGO_WORKFLOWS_SSO_PASSWORD_HASH" }}
+        hash: $$2a$10$kqHbxJcBTUu3kd48g49PZO4ZOC7UMW4I9d30PjUr45cn5J6gFmDgO
         username: admin
         userID: 86c47abf-4b23-4818-9b4c-76a2d17e7c98

--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -30,6 +30,6 @@ data:
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai
-        hash: $$2a$10$kqHbxJcBTUu3kd48g49PZO4ZOC7UMW4I9d30PjUr45cn5J6gFmDgO
+        hash: {{ getenv "ARGO_WORKFLOWS_SSO_PASSWORD_HASH" }}
         username: admin
         userID: 86c47abf-4b23-4818-9b4c-76a2d17e7c98

--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -34,6 +34,6 @@ data:
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai
-        hash: "$2a$10$kqHbxJcBTUu3kd48g49PZO4ZOC7UMW4I9d30PjUr45cn5J6gFmDgO"
+        hash: {{ getenv "ARGO_WORKFLOWS_SSO_PASSWORD_HASH" }}
         username: admin
         userID: 86c47abf-4b23-4818-9b4c-76a2d17e7c98


### PR DESCRIPTION
## Summary
- set the Argo CD base URL in `argocd-cm` so the server advertises https://argocd.proompteng.ai
- keep Dex reading the shared secret for the admin password instead of an inline literal
- drop the unsupported `local` connector so Dex starts cleanly

## Testing
- kubectl apply -k argocd/applications/argocd
- kubectl rollout restart deployment argocd-dex-server -n argocd
- curl -sk https://argocd.proompteng.ai/api/dex/.well-known/openid-configuration
