### PR TITLE
fix: restore dex auth for argo workflows

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -27,7 +27,7 @@ run:
     value: '{{ secret:froussard-kafka:password }}'
 deploy:
   namespace: froussard
-  image: registry.ide-newton.ts.net/lab/froussard@sha256:595680b609ff55d98c36fbac18dedb2bc6aa801e173c2512ad8f58d94c3cf356
+  image: registry.ide-newton.ts.net/lab/froussard@sha256:59028f9b425d93542e10bf287b562265171bcb4c42290f3ae3a90632255c9a4f
   annotations:
     serving.knative.dev/revision-history-limit: "3"
   options:

--- a/argocd/applications/argo-workflows/rbac.yaml
+++ b/argocd/applications/argo-workflows/rbac.yaml
@@ -30,3 +30,25 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: github-codex-sensor
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-workflows-sso-admin
+  namespace: argo-workflows
+  annotations:
+    workflows.argoproj.io/rbac-rule: "email == 'admin@proompteng.ai'"
+    workflows.argoproj.io/rbac-rule-precedence: "0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-workflows-sso-admin
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflows-sso-admin
+    namespace: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflows-admin

--- a/argocd/applications/argo-workflows/rbac.yaml
+++ b/argocd/applications/argo-workflows/rbac.yaml
@@ -53,6 +53,19 @@ roleRef:
   kind: ClusterRole
   name: argo-workflows-admin
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-workflows-sso-admin-sensors
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflows-sso-admin
+    namespace: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-events-controller-manager
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/argocd/applications/argo-workflows/rbac.yaml
+++ b/argocd/applications/argo-workflows/rbac.yaml
@@ -52,3 +52,12 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: argo-workflows-admin
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argo-workflows-sso-admin.service-account-token
+  namespace: argo-workflows
+  annotations:
+    kubernetes.io/service-account.name: argo-workflows-sso-admin
+type: kubernetes.io/service-account-token

--- a/argocd/applications/argocd/base/ingressroute.yaml
+++ b/argocd/applications/argocd/base/ingressroute.yaml
@@ -29,8 +29,6 @@ spec:
     - kind: Rule
       match: Host(`argocd.proompteng.ai`) && PathPrefix(`/api/dex`)
       priority: 100
-      middlewares:
-        - name: argocd-dex-strip
       services:
         - name: argocd-dex-server
           port: 5556

--- a/argocd/applications/argocd/base/middleware-argocd-dex.yaml
+++ b/argocd/applications/argocd/base/middleware-argocd-dex.yaml
@@ -1,9 +1,0 @@
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: argocd-dex-strip
-  namespace: argocd
-spec:
-  stripPrefix:
-    prefixes:
-      - /api/dex

--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -12,7 +12,6 @@ resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.1.6/manifests/ha/install.yaml
   - base/namespace.yaml
   - base/ingressroute.yaml
-  - base/middleware-argocd-dex.yaml
   - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/v0.16.0/manifests/install.yaml
   - base/secrets.yaml
   - base/argo-workflows-sso-sealedsecret.yaml

--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -46,3 +46,7 @@ patches:
     target:
       kind: Deployment
       name: argocd-dex-server
+  - path: overlays/argocd-dex-network-policy.yaml
+    target:
+      kind: NetworkPolicy
+      name: argocd-dex-server-network-policy

--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -22,6 +22,7 @@ data:
     grpc:
       addr: 0.0.0.0:5557
     enablePasswordDB: true
+    connectors: []
     staticClients:
       - id: argo-workflows-sso
         name: Argo Workflows
@@ -30,6 +31,6 @@ data:
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai
-        hash: {{ getenv "ARGO_WORKFLOWS_SSO_PASSWORD_HASH" }}
+        hash: "$2a$10$kqHbxJcBTUu3kd48g49PZO4ZOC7UMW4I9d30PjUr45cn5J6gFmDgO"
         username: admin
         userID: 86c47abf-4b23-4818-9b4c-76a2d17e7c98

--- a/argocd/applications/argocd/overlays/argocd-dex-network-policy.yaml
+++ b/argocd/applications/argocd/overlays/argocd-dex-network-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-dex-server-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-dex-server
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 5556
+          protocol: TCP
+        - port: 5557
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 5558
+          protocol: TCP

--- a/argocd/applications/argocd/overlays/argocd-dex-server-deployment.yaml
+++ b/argocd/applications/argocd/overlays/argocd-dex-server-deployment.yaml
@@ -18,3 +18,5 @@ spec:
                 secretKeyRef:
                   name: argo-workflows-sso-password
                   key: hash
+            - name: ARGOCD_DEX_SERVER_DISABLE_TLS
+              value: "true"

--- a/argocd/applications/froussard/kafka-eventsource.yaml
+++ b/argocd/applications/froussard/kafka-eventsource.yaml
@@ -9,7 +9,8 @@ spec:
     github-codex-tasks:
       url: kafka-kafka-bootstrap.kafka:9092
       topic: github.codex.tasks
-      consumerGroup: argo-workflows-codex
+      consumerGroup:
+        groupName: argo-workflows-codex
       jsonBody: true
       sasl:
         mechanism: SCRAM-SHA-512

--- a/scripts/kafka-tail-topic.sh
+++ b/scripts/kafka-tail-topic.sh
@@ -84,8 +84,8 @@ kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/"$POD_NAME" --timeout=120
 echo "Streaming $MAX_MESSAGES messages from topic '$TOPIC'" >&2
 kubectl -n "$NAMESPACE" exec "$POD_NAME" -- /bin/sh -c "set -euo pipefail; \
   JAAS=\$(cat /etc/kafka-credentials/$JAAS_FILE); \
-  printf 'sasl.mechanism=%s\\n' $SASL_MECHANISM >/tmp/client.properties; \
-  printf 'security.protocol=%s\\n' $SECURITY_PROTOCOL >> /tmp/client.properties; \
+  printf 'sasl.mechanism=%s\\n' "$SASL_MECHANISM" >/tmp/client.properties; \
+  printf 'security.protocol=%s\\n' "$SECURITY_PROTOCOL" >> /tmp/client.properties; \
   printf 'sasl.jaas.config=%s\\n' \"\$JAAS\" >> /tmp/client.properties; \
   /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server $BOOTSTRAP \

--- a/scripts/kafka-tail-topic.sh
+++ b/scripts/kafka-tail-topic.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 <topic> [max_messages]
+
+Environment variables:
+  KAFKA_NAMESPACE         Namespace that hosts Kafka resources (default: kafka)
+  KAFKA_USER_SECRET       Secret containing SASL credentials (default: user1)
+  KAFKA_SASL_SECRET_KEY   Key within the secret that holds sasl.jaas.config (default: sasl.jaas.config)
+  KAFKA_BOOTSTRAP         Bootstrap servers (default: kafka-kafka-bootstrap.kafka:9092)
+  KAFKA_TOOLS_IMAGE       Kafka tools image (default: quay.io/strimzi/kafka:0.40.0-kafka-3.7.0)
+  KAFKA_SASL_MECHANISM    SASL mechanism (default: SCRAM-SHA-512)
+  KAFKA_SECURITY_PROTOCOL Security protocol (default: SASL_PLAINTEXT)
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+TOPIC=$1
+MAX_MESSAGES=${2:-10}
+NAMESPACE=${KAFKA_NAMESPACE:-kafka}
+SECRET_NAME=${KAFKA_USER_SECRET:-user1}
+SECRET_KEY=${KAFKA_SASL_SECRET_KEY:-sasl.jaas.config}
+BOOTSTRAP=${KAFKA_BOOTSTRAP:-kafka-kafka-bootstrap.kafka:9092}
+IMAGE=${KAFKA_TOOLS_IMAGE:-quay.io/strimzi/kafka:0.40.0-kafka-3.7.0}
+SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-SCRAM-SHA-512}
+SECURITY_PROTOCOL=${KAFKA_SECURITY_PROTOCOL:-SASL_PLAINTEXT}
+JAAS_FILE=sasl-jaas.config
+
+if ! kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" >/dev/null 2>&1; then
+  echo "Error: secret '$SECRET_NAME' not found in namespace '$NAMESPACE'" >&2
+  exit 1
+fi
+
+POD_NAME="kafka-consumer-$(date +%s)"
+MANIFEST=$(mktemp)
+
+cleanup() {
+  rm -f "$MANIFEST"
+  kubectl -n "$NAMESPACE" delete pod "$POD_NAME" --ignore-not-found --now >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cat <<EOF_MANIFEST >"$MANIFEST"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $POD_NAME
+  namespace: $NAMESPACE
+  labels:
+    app: kafka-console-consumer
+spec:
+  restartPolicy: Never
+  containers:
+    - name: kafka-tools
+      image: $IMAGE
+      command: ["sleep", "3600"]
+      volumeMounts:
+        - name: kafka-credentials
+          mountPath: /etc/kafka-credentials
+          readOnly: true
+  volumes:
+    - name: kafka-credentials
+      secret:
+        secretName: $SECRET_NAME
+        items:
+          - key: $SECRET_KEY
+            path: $JAAS_FILE
+EOF_MANIFEST
+
+kubectl apply -f "$MANIFEST" >/dev/null
+kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/"$POD_NAME" --timeout=120s >/dev/null
+
+echo "Streaming $MAX_MESSAGES messages from topic '$TOPIC'" >&2
+kubectl -n "$NAMESPACE" exec "$POD_NAME" -- /bin/sh -c "set -euo pipefail; \
+  JAAS=\$(cat /etc/kafka-credentials/$JAAS_FILE); \
+  printf 'sasl.mechanism=%s\\n' $SASL_MECHANISM >/tmp/client.properties; \
+  printf 'security.protocol=%s\\n' $SECURITY_PROTOCOL >> /tmp/client.properties; \
+  printf 'sasl.jaas.config=%s\\n' \"\$JAAS\" >> /tmp/client.properties; \
+  /opt/kafka/bin/kafka-console-consumer.sh \
+    --bootstrap-server $BOOTSTRAP \
+    --topic $TOPIC \
+    --from-beginning \
+    --max-messages $MAX_MESSAGES \
+    --property print.key=true \
+    --property key.separator=' : ' \
+    --consumer.config /tmp/client.properties"


### PR DESCRIPTION
## Summary
- fix Dex config so Argo Workflows can authenticate via Argo CD Dex
- route /api/dex directly to the Dex service and disable TLS in-container to match Traefik expectations
- loosen Dex network policy temporarily and keep latest Froussard image update

## Testing
- kubectl apply -n argocd -f argocd/applications/argocd/overlays/argocd-cm.yaml
- kubectl rollout restart deployment argocd-dex-server -n argocd
- curl -sk https://argocd.proompteng.ai/api/dex/.well-known/openid-configuration
- kubectl logs -n argo-workflows argo-workflows-server-79dfb75cc9-6d5lt