### PR TITLE
fix: remove duplicate dex env valueFrom

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-dex-server-deployment.yaml
+++ b/argocd/applications/argocd/overlays/argocd-dex-server-deployment.yaml
@@ -20,3 +20,4 @@ spec:
                   key: hash
             - name: ARGOCD_DEX_SERVER_DISABLE_TLS
               value: "true"
+              valueFrom: null


### PR DESCRIPTION
## Summary
- drop the leftover valueFrom reference on ARGOCD_DEX_SERVER_DISABLE_TLS so Kustomize no longer renders value+valueFrom
- this unblocks Argo CD sync for the dex deployment

## Testing
- kubectl kustomize argocd/applications/argocd | grep -n "ARGOCD_DEX_SERVER_DISABLE_TLS"
- kubectl apply -n argocd -f argocd/applications/argocd/overlays/argocd-dex-server-deployment.yaml