### PR TITLE
feat: add codex automation container

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.6
+FROM ghcr.io/openai/codex-universal:latest
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    WORKSPACE=/workspace \
+    GIT_TERMINAL_PROMPT=0 \
+    BUN_INSTALL=/usr/local
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git gh jq python3 curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash \
+    && mkdir -p /opt/homebrew/bin \
+    && ln -s /usr/local/bin/bun /opt/homebrew/bin/bun
+
+RUN bash -lc 'source /root/.nvm/nvm.sh && npm install -g @openai/codex@latest && ln -sf "$(command -v codex)" /usr/local/bin/codex'
+
+RUN mkdir -p "$WORKSPACE" /root/.codex
+
+# Copy Codex auth secret during build (requires BuildKit secret)
+RUN --mount=type=secret,id=codex_auth,target=/tmp/codex_auth.json \
+    cp /tmp/codex_auth.json /root/.codex/auth.json
+
+COPY apps/froussard/scripts/codex-config-container.toml /root/.codex/config.toml
+
+# Authenticate gh using provided token
+RUN --mount=type=secret,id=github_token,target=/tmp/gh_token \
+    gh auth login --with-token < /tmp/gh_token
+
+RUN git config --global user.name "codex-automation" \
+    && git config --global user.email "codex-automation@users.noreply.github.com"
+
+COPY apps/froussard/scripts/codex-bootstrap.sh /usr/local/bin/codex-bootstrap.sh
+COPY apps/froussard/scripts/codex-plan.sh /usr/local/bin/codex-plan.sh
+RUN chmod +x /usr/local/bin/codex-bootstrap.sh /usr/local/bin/codex-plan.sh
+
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/codex-bootstrap.sh"]
+CMD ["bash"]

--- a/apps/froussard/README.md
+++ b/apps/froussard/README.md
@@ -54,3 +54,21 @@ The local runtime exposes:
 2. Ensure Argo Events produces a Workflow named `github-codex-echo-*` in
    `argo-workflows` namespace.
 3. Inspect pod logs to confirm the payload mirrors the Kafka message.
+
+## Codex Automation Image
+
+The Codex planning/implementation workflows use a derived container built from
+`apps/froussard/Dockerfile.codex`. The helper script below copies the local
+Codex auth (`~/.codex/auth.json`), Codex configuration (`~/.codex/config.toml`),
+and your GitHub CLI token into the image before pushing it to the shared
+registry.
+
+```bash
+apps/froussard/scripts/build-codex-image.sh
+```
+
+- Override `IMAGE_TAG` to publish a different tag or registry.
+- Provide `GH_TOKEN` explicitly if `gh auth token` is unavailable.
+- The resulting image defaults to cloning `gregkonush/lab` into
+  `/workspace/lab`; override `REPO_URL`, `BASE_BRANCH`, or `TARGET_DIR` at
+  runtime as needed.

--- a/apps/froussard/scripts/build-codex-image.sh
+++ b/apps/froussard/scripts/build-codex-image.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DOCKERFILE="$ROOT_DIR/apps/froussard/Dockerfile.codex"
+IMAGE_TAG=${IMAGE_TAG:-registry.ide-newton.ts.net/lab/codex-universal:latest}
+CONTEXT_DIR=${CONTEXT_DIR:-$ROOT_DIR}
+CODEX_AUTH=${CODEX_AUTH:-$HOME/.codex/auth.json}
+CODEX_CONFIG=${CODEX_CONFIG:-$HOME/.codex/config.toml}
+
+if [[ ! -f "$DOCKERFILE" ]]; then
+  echo "Dockerfile not found at $DOCKERFILE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CODEX_AUTH" ]]; then
+  echo "Missing Codex auth file: $CODEX_AUTH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CODEX_CONFIG" ]]; then
+  echo "Missing Codex config file: $CODEX_CONFIG" >&2
+  exit 1
+fi
+
+GH_TOKEN_FILE=""
+cleanup() {
+  if [[ -n "$GH_TOKEN_FILE" && -f "$GH_TOKEN_FILE" ]]; then
+    rm -f "$GH_TOKEN_FILE"
+  fi
+}
+trap cleanup EXIT
+
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  GH_TOKEN_FILE=$(mktemp)
+  printf '%s' "$GH_TOKEN" > "$GH_TOKEN_FILE"
+else
+  if command -v gh >/dev/null 2>&1; then
+    TOKEN=$(gh auth token 2>/dev/null || true)
+    if [[ -z "$TOKEN" ]]; then
+      echo "Set GH_TOKEN environment variable or login with 'gh auth login'." >&2
+      exit 1
+    fi
+    GH_TOKEN_FILE=$(mktemp)
+    printf '%s' "$TOKEN" > "$GH_TOKEN_FILE"
+  else
+    echo "gh CLI not found; please install gh or export GH_TOKEN." >&2
+    exit 1
+  fi
+fi
+
+export DOCKER_BUILDKIT=1
+
+echo "Building $IMAGE_TAG from $DOCKERFILE"
+docker build \
+  -f "$DOCKERFILE" \
+  --secret id=codex_auth,src="$CODEX_AUTH" \
+  --secret id=codex_config,src="$CODEX_CONFIG" \
+  --secret id=github_token,src="$GH_TOKEN_FILE" \
+  -t "$IMAGE_TAG" \
+  "$CONTEXT_DIR"
+
+echo "Pushing $IMAGE_TAG"
+docker push "$IMAGE_TAG"

--- a/apps/froussard/scripts/codex-bootstrap.sh
+++ b/apps/froussard/scripts/codex-bootstrap.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL=${REPO_URL:-https://github.com/gregkonush/lab}
+BASE_BRANCH=${BASE_BRANCH:-main}
+TARGET_DIR=${TARGET_DIR:-/workspace/lab}
+
+mkdir -p "$(dirname "$TARGET_DIR")"
+
+if [[ -d "$TARGET_DIR/.git" ]]; then
+  pushd "$TARGET_DIR" >/dev/null
+  git fetch --all --prune
+  git reset --hard "origin/${BASE_BRANCH}"
+  popd >/dev/null
+else
+  rm -rf "$TARGET_DIR"
+  gh repo clone "$REPO_URL" "$TARGET_DIR"
+  pushd "$TARGET_DIR" >/dev/null
+  git checkout "$BASE_BRANCH"
+  popd >/dev/null
+fi
+
+cd "$TARGET_DIR"
+exec "$@"

--- a/apps/froussard/scripts/codex-config-container.toml
+++ b/apps/froussard/scripts/codex-config-container.toml
@@ -1,0 +1,18 @@
+model = "gpt-5-codex"
+model_verbosity = "high"
+model_reasoning_summary = "detailed"
+model_reasoning_effort = "high"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[tools]
+web_search = true
+
+[shell_environment_policy]
+ignore_default_excludes = true
+
+[projects."/workspace/lab"]
+trust_level = "trusted"
+
+[projects."/root"]
+trust_level = "trusted"

--- a/apps/froussard/scripts/codex-plan.sh
+++ b/apps/froussard/scripts/codex-plan.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CODEX_PROMPT:?CODEX_PROMPT environment variable is required}"
+OUTPUT_PATH=${OUTPUT_PATH:-/workspace/lab/.codex-plan-output.md}
+POST_TO_GITHUB=${POST_TO_GITHUB:-false}
+ISSUE_REPO=${ISSUE_REPO:-gregkonush/lab}
+ISSUE_NUMBER=${ISSUE_NUMBER:-}
+
+printf '%s
+' "$CODEX_PROMPT" > /tmp/codex-prompt.txt
+
+codex exec --dangerously-bypass-approvals-and-sandbox - < /tmp/codex-prompt.txt > "$OUTPUT_PATH"
+
+if [[ "$POST_TO_GITHUB" == "true" ]]; then
+  if [[ -z "$ISSUE_NUMBER" ]]; then
+    echo "ISSUE_NUMBER must be set when POST_TO_GITHUB=true" >&2
+    exit 1
+  fi
+  gh issue comment "$ISSUE_REPO" "$ISSUE_NUMBER" --body-file "$OUTPUT_PATH"
+fi
+
+echo "Codex plan written to $OUTPUT_PATH"


### PR DESCRIPTION
## Summary
- add a Dockerfile and helper scripts to bake the Codex CLI, bun, and GitHub auth into the automation image
- ship a reproducible config without MCP servers and document the build/push flow
- provide a bootstrap entrypoint plus a non-interactive planning script for Argo workflows

## Testing
- apps/froussard/scripts/build-codex-image.sh
- docker run --rm -e CODEX_PROMPT='Draft a short bullet list for the workflow test.' -e OUTPUT_PATH=/workspace/lab/.codex-plan-test.md registry.ide-newton.ts.net/lab/codex-universal:latest /bin/bash -lc 'codex-plan.sh && cat /workspace/lab/.codex-plan-test.md'
