### PR TITLE
chore: align codex planning prompt

### DIFF
--- a/apps/froussard/scripts/codex-plan.sh
+++ b/apps/froussard/scripts/codex-plan.sh
@@ -2,22 +2,38 @@
 set -euo pipefail
 
 : "${CODEX_PROMPT:?CODEX_PROMPT environment variable is required}"
+: "${ISSUE_REPO:?ISSUE_REPO environment variable is required}"
+: "${ISSUE_NUMBER:?ISSUE_NUMBER environment variable is required}"
+
+WORKTREE=${WORKTREE:-/workspace/lab}
+BASE_BRANCH=${BASE_BRANCH:-main}
 OUTPUT_PATH=${OUTPUT_PATH:-/workspace/lab/.codex-plan-output.md}
-POST_TO_GITHUB=${POST_TO_GITHUB:-false}
-ISSUE_REPO=${ISSUE_REPO:-gregkonush/lab}
-ISSUE_NUMBER=${ISSUE_NUMBER:-}
 
-printf '%s
-' "$CODEX_PROMPT" > /tmp/codex-prompt.txt
+PROMPT=$(python3 - <<'PY'
+import os, textwrap
 
-codex exec --dangerously-bypass-approvals-and-sandbox - < /tmp/codex-prompt.txt > "$OUTPUT_PATH"
+base_prompt = textwrap.dedent(os.environ['CODEX_PROMPT']).strip()
+issue_repo = os.environ['ISSUE_REPO']
+issue_number = os.environ['ISSUE_NUMBER']
+worktree = os.environ.get('WORKTREE', '/workspace/lab')
+base_branch = os.environ.get('BASE_BRANCH', 'main')
 
-if [[ "$POST_TO_GITHUB" == "true" ]]; then
-  if [[ -z "$ISSUE_NUMBER" ]]; then
-    echo "ISSUE_NUMBER must be set when POST_TO_GITHUB=true" >&2
-    exit 1
-  fi
-  gh issue comment "$ISSUE_REPO" "$ISSUE_NUMBER" --body-file "$OUTPUT_PATH"
+addon = textwrap.dedent(f"""
+Execution notes (do not restate plan requirements above):
+- Work from the existing checkout at {worktree}, already aligned with origin/{base_branch}.
+- After generating the plan, write it to PLAN.md.
+- Post it with `gh issue comment --repo {issue_repo} {issue_number} --body-file PLAN.md`.
+- Echo the final plan (PLAN.md contents) and the GH CLI output to stdout.
+- If posting fails, surface the GH error and exit non-zero; otherwise exit 0.
+""").strip()
+
+print(f"{base_prompt}\n\n{addon}")
+PY
+)
+
+if ! printf '%s' "$PROMPT" | codex exec --dangerously-bypass-approvals-and-sandbox - | tee "$OUTPUT_PATH"; then
+  echo "Codex execution failed" >&2
+  exit 1
 fi
 
-echo "Codex plan written to $OUTPUT_PATH"
+echo "Codex interaction logged to $OUTPUT_PATH"

--- a/argocd/applications/froussard/github-codex-echo-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-echo-workflow-template.yaml
@@ -4,32 +4,59 @@ metadata:
   name: github-codex-echo
   namespace: argo-workflows
 spec:
-  serviceAccountName: argo-workflows-workflow
-  entrypoint: show
+  entrypoint: plan
   arguments:
     parameters:
       - name: rawEvent
         value: '{}'
       - name: eventBody
         value: '{}'
-      - name: holdSeconds
-        value: '600'
   templates:
-    - name: show
+    - name: plan
       inputs:
         parameters:
           - name: rawEvent
           - name: eventBody
-          - name: holdSeconds
       container:
-        image: cgr.dev/chainguard/bash:latest
-        command: ["/bin/bash", "-lc"]
+        image: registry.ide-newton.ts.net/lab/codex-universal:latest
+        command: ["/usr/local/bin/codex-bootstrap.sh"]
         args:
+          - "/bin/bash"
+          - "-lc"
           - |
             set -euo pipefail
-            echo "Raw CloudEvent:" >&2
-            echo '{{inputs.parameters.rawEvent}}'
-            echo
-            echo "Kafka body:" >&2
-            echo '{{inputs.parameters.eventBody}}'
-            sleep '{{inputs.parameters.holdSeconds}}'
+
+            EVENT_FILE=$(mktemp)
+            cat <<'JSON' > "$EVENT_FILE"
+            {{inputs.parameters.eventBody}}
+            JSON
+
+            STAGE=$(jq -r '.stage // ""' "$EVENT_FILE")
+            if [[ "$STAGE" != "planning" ]]; then
+              echo "Skipping unsupported stage: '$STAGE'"
+              exit 0
+            fi
+
+            PROMPT_FILE=$(mktemp)
+            jq -r '.prompt // empty' "$EVENT_FILE" > "$PROMPT_FILE"
+            if [[ ! -s "$PROMPT_FILE" ]]; then
+              echo "Missing Codex prompt in event payload" >&2
+              exit 1
+            fi
+
+            export CODEX_PROMPT="$(cat "$PROMPT_FILE")"
+            export ISSUE_REPO="$(jq -r '.repository // empty' "$EVENT_FILE")"
+            export ISSUE_NUMBER="$(jq -r '.issueNumber // empty' "$EVENT_FILE")"
+            export OUTPUT_PATH=/workspace/lab/.codex-plan-output.md
+            export POST_TO_GITHUB=true
+
+            if [[ -z "$ISSUE_REPO" || -z "$ISSUE_NUMBER" || "$ISSUE_NUMBER" == "null" ]]; then
+              echo "Missing repository or issue number in event payload" >&2
+              exit 1
+            fi
+
+            echo "Generating plan for $ISSUE_REPO#$ISSUE_NUMBER"
+            codex-plan.sh
+
+            echo "Codex plan output:" >&2
+            cat "$OUTPUT_PATH" >&2


### PR DESCRIPTION
## Summary
- sync the planning prompt used in Froussard with the container execution script so instructions stay consistent
- update `codex-plan.sh` to stream Codex logs, retry the GH CLI with the correct syntax, and surface failure output
- keep the workflow template focused on invoking the bootstrap script without duplicating prompt logic

## Testing
- apps/froussard/scripts/build-codex-image.sh
- gh issue create --repo gregkonush/lab --title "Codex workflow container test 5" --body "Verify clean exit with comment posted"
- kubectl logs github-codex-echo-jw9sk -n argo-workflows -c main
