### PR TITLE
chore: pre-pull codex workflow image on every node

### DIFF
--- a/argocd/applications/froussard/codex-image-prepull.yaml
+++ b/argocd/applications/froussard/codex-image-prepull.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: codex-prepull
+  namespace: argo-workflows
+spec:
+  selector:
+    matchLabels:
+      app: codex-prepull
+  template:
+    metadata:
+      labels:
+        app: codex-prepull
+    spec:
+      terminationGracePeriodSeconds: 0
+      initContainers:
+        - name: pull-codex
+          image: registry.ide-newton.ts.net/lab/codex-universal:latest
+          imagePullPolicy: Always
+          command: ['sh', '-c', 'echo "Codex image pre-pulled"']
+      containers:
+        - name: hold
+          image: registry.k8s.io/pause:3.9
+      tolerations:
+        - operator: "Exists"

--- a/argocd/applications/froussard/kustomization.yaml
+++ b/argocd/applications/froussard/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - github-codex-topic.yaml
   - github-codex-echo-workflow-template.yaml
   - github-codex-echo-sensor.yaml
+  - codex-image-prepull.yaml


### PR DESCRIPTION
## Summary
- add a minimal DaemonSet in argo-workflows namespace that runs an init container with the codex workflow image and keeps a pause container scheduled
- update the froussard kustomization so Argo CD deploys the pre-pull DaemonSet alongside the existing resources
- ensures every node caches `registry.ide-newton.ts.net/lab/codex-universal:latest` before workflows start, reducing cold-start latency

## Testing
- kubectl apply -k argocd/applications/froussard
- kubectl get pods -n argo-workflows -l app=codex-prepull
- docker run --rm ... (existing Codex planning workflow)