### PR TITLE
feat: acknowledge codex plan dispatch via reaction

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -27,7 +27,7 @@ run:
     value: '{{ secret:froussard-kafka:password }}'
 deploy:
   namespace: froussard
-  image: registry.ide-newton.ts.net/lab/froussard@sha256:59028f9b425d93542e10bf287b562265171bcb4c42290f3ae3a90632255c9a4f
+  image: registry.ide-newton.ts.net/lab/froussard@sha256:4759b53a622b64d6bd3873384771ec21eda73b44d20d19c4c2a411732ea7d72b
   annotations:
     serving.knative.dev/revision-history-limit: "3"
   options:

--- a/apps/froussard/src/github.test.ts
+++ b/apps/froussard/src/github.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { postIssueReaction } from './github'
+
+describe('postIssueReaction', () => {
+  it('reports missing token when GITHUB_TOKEN is not configured', async () => {
+    const result = await postIssueReaction({
+      repositoryFullName: 'owner/repo',
+      issueNumber: 12,
+      token: null,
+      reactionContent: 'rocket',
+      fetchImplementation: null,
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'missing-token' })
+  })
+
+  it('rejects invalid repository names', async () => {
+    const result = await postIssueReaction({
+      repositoryFullName: 'invalid-owner-only',
+      issueNumber: 99,
+      token: 'token',
+      reactionContent: 'rocket',
+      fetchImplementation: null,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid-repository')
+    }
+  })
+
+  it('posts reaction payload to the GitHub API', async () => {
+    const fetchSpy = vi.fn(async (_input: string, init) => {
+      return {
+        ok: true,
+        status: 201,
+        text: async () => '',
+      }
+    })
+
+    const result = await postIssueReaction({
+      repositoryFullName: 'acme/widgets',
+      issueNumber: 7,
+      token: 'secret-token',
+      reactionContent: 'rocket',
+      apiBaseUrl: 'https://example.test/api',
+      userAgent: 'custom-agent',
+      fetchImplementation: fetchSpy,
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('https://example.test/api/repos/acme/widgets/issues/7/reactions')
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toMatchObject({
+      Accept: 'application/vnd.github+json',
+      Authorization: 'Bearer secret-token',
+      'Content-Type': 'application/json',
+      'User-Agent': 'custom-agent',
+      'X-GitHub-Api-Version': '2022-11-28',
+    })
+    expect(init?.body).toBe(JSON.stringify({ content: 'rocket' }))
+  })
+
+  it('propagates http errors with status and body details', async () => {
+    const fetchSpy = vi.fn(async () => {
+      return {
+        ok: false,
+        status: 403,
+        text: async () => 'forbidden',
+      }
+    })
+
+    const result = await postIssueReaction({
+      repositoryFullName: 'acme/widgets',
+      issueNumber: 7,
+      token: 'secret-token',
+      reactionContent: 'rocket',
+      fetchImplementation: fetchSpy,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe('http-error')
+      expect(result.status).toBe(403)
+      expect(result.detail).toBe('forbidden')
+    }
+  })
+})

--- a/apps/froussard/src/github.ts
+++ b/apps/froussard/src/github.ts
@@ -1,0 +1,99 @@
+type FetchInit = {
+  method?: string
+  headers?: Record<string, string>
+  body?: string
+}
+
+interface FetchResponse {
+  ok: boolean
+  status: number
+  text(): Promise<string>
+}
+
+type FetchLike = (input: string, init?: FetchInit) => Promise<FetchResponse>
+
+export interface PostIssueReactionOptions {
+  repositoryFullName: string
+  issueNumber: number
+  token?: string | null
+  reactionContent: string
+  apiBaseUrl?: string
+  userAgent?: string
+  fetchImplementation?: FetchLike | null
+}
+
+export type PostIssueReactionFailureReason =
+  | 'missing-token'
+  | 'invalid-repository'
+  | 'no-fetch'
+  | 'http-error'
+  | 'network-error'
+
+export type PostIssueReactionResult =
+  | { ok: true }
+  | { ok: false; reason: PostIssueReactionFailureReason; status?: number; detail?: string }
+
+const DEFAULT_API_BASE_URL = 'https://api.github.com'
+const DEFAULT_USER_AGENT = 'froussard-webhook'
+
+const trimTrailingSlash = (value: string): string => {
+  return value.endsWith('/') ? value.slice(0, -1) : value
+}
+
+export const postIssueReaction = async (options: PostIssueReactionOptions): Promise<PostIssueReactionResult> => {
+  const {
+    repositoryFullName,
+    issueNumber,
+    token,
+    reactionContent,
+    apiBaseUrl = DEFAULT_API_BASE_URL,
+    userAgent = DEFAULT_USER_AGENT,
+    fetchImplementation = typeof globalThis.fetch === 'function' ? (globalThis.fetch as FetchLike) : null,
+  } = options
+
+  if (!token || token.trim().length === 0) {
+    return { ok: false, reason: 'missing-token' }
+  }
+
+  const [owner, repo] = repositoryFullName.split('/')
+  if (!owner || !repo) {
+    return { ok: false, reason: 'invalid-repository', detail: repositoryFullName }
+  }
+
+  const fetchFn = fetchImplementation
+  if (!fetchFn) {
+    return { ok: false, reason: 'no-fetch' }
+  }
+
+  const url = `${trimTrailingSlash(apiBaseUrl)}/repos/${owner}/${repo}/issues/${issueNumber}/reactions`
+
+  try {
+    const response = await fetchFn(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        Authorization: `Bearer ${token}`,
+        'User-Agent': userAgent,
+      },
+      body: JSON.stringify({ content: reactionContent }),
+    })
+
+    if (!response.ok) {
+      let detail: string | undefined
+      try {
+        detail = await response.text()
+      } catch (error: unknown) {
+        detail = error instanceof Error ? error.message : undefined
+      }
+
+      return { ok: false, reason: 'http-error', status: response.status, detail }
+    }
+
+    return { ok: true }
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : 'Unknown error'
+    return { ok: false, reason: 'network-error', detail }
+  }
+}


### PR DESCRIPTION
- Summary
  - add optional GitHub reaction acknowledgement after planning message dispatches
  - refactor acknowledgement logic into reusable helper with tests
  - expose deployment digest from latest `func deploy --build`
- Testing
  - pnpm --filter froussard test
