### PR TITLE
feat: add hourly emoji progress guidance

### DIFF
--- a/apps/froussard/src/codex.test.ts
+++ b/apps/froussard/src/codex.test.ts
@@ -92,6 +92,9 @@ describe('buildCodexPrompt', () => {
     expect(prompt).toContain('Approved plan:')
     expect(prompt).toContain('1. Step one')
     expect(prompt).toContain('Implementation branch: codex/issue-77-abc123')
+    expect(prompt).toContain(
+      'Post an emoji-led progress update on the issue hourly, summarizing findings and completed work so far.',
+    )
     expect(prompt).toContain('Run formatters, lint, tests, and record outputs or failures.')
     expect(prompt).toContain('Closes #77')
   })

--- a/apps/froussard/src/codex.ts
+++ b/apps/froussard/src/codex.ts
@@ -118,6 +118,7 @@ const buildImplementationPrompt = ({
     '- Work in the existing checkout; keep commits small and reference the issue.',
     `- Create or update the \`${headBranch}\` branch from \`${baseBranch}\`.`,
     '- Follow the plan step by step, noting context for any adjustments.',
+    '- Post an emoji-led progress update on the issue hourly, summarizing findings and completed work so far.',
     '- Run formatters, lint, tests, and record outputs or failures.',
     `- Open a draft pull request targeting \`${baseBranch}\` that summarises the work, validation, and references "Closes #${issueNumber}" to auto-close the issue on merge.`,
     '- Comment on the issue with the PR link, highlights, and remaining follow-ups.',


### PR DESCRIPTION
## Summary
- add hourly emoji progress instructions to the implementation prompt
- cover the new checklist item in codex prompt tests

## Testing
- pnpm run format
- pnpm --filter froussard test

Closes #1242