### PR TITLE
fix: bundle codex tooling

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.6
 FROM ghcr.io/openai/codex-universal:latest
 
+ARG ARGO_VERSION=v3.6.3
+ARG KUBECONFORM_VERSION=v0.6.7
+
 ENV DEBIAN_FRONTEND=noninteractive \
     WORKSPACE=/workspace \
     WORKTREE=/workspace/lab \
@@ -12,6 +15,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git gh jq python3 curl \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL -o /tmp/argo-linux-amd64.gz "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz" \
+    && gunzip -c /tmp/argo-linux-amd64.gz > /usr/local/bin/argo \
+    && chmod +x /usr/local/bin/argo \
+    && rm /tmp/argo-linux-amd64.gz \
+    && curl -fsSL -o /tmp/kubeconform-linux-amd64.tar.gz "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+    && tar -xzf /tmp/kubeconform-linux-amd64.tar.gz -C /tmp kubeconform \
+    && install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform \
+    && rm /tmp/kubeconform-linux-amd64.tar.gz /tmp/kubeconform
 
 RUN curl -fsSL https://bun.sh/install | bash \
     && mkdir -p /opt/homebrew/bin \
@@ -27,9 +39,10 @@ RUN --mount=type=secret,id=codex_auth,target=/tmp/codex_auth.json \
 
 COPY apps/froussard/scripts/codex-config-container.toml /root/.codex/config.toml
 
-# Authenticate gh using provided token
+# Authenticate gh using provided token and wire git credential helper
 RUN --mount=type=secret,id=github_token,target=/tmp/gh_token \
-    gh auth login --with-token < /tmp/gh_token
+    gh auth login --with-token < /tmp/gh_token \
+    && gh auth setup-git
 
 RUN git config --global user.name "codex-automation" \
     && git config --global user.email "codex-automation@users.noreply.github.com"

--- a/scripts/codex-config-template.toml
+++ b/scripts/codex-config-template.toml
@@ -1,8 +1,21 @@
 model = "gpt-5-codex"
+model_verbosity = "high"
+model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
 
-[projects."{{LOCAL_PROJECT}}"]
+[tools]
+web_search = true
+
+[shell_environment_policy]
+ignore_default_excludes = true
+
+[projects."{{REMOTE_PROJECT}}"]
 trust_level = "trusted"
 
-[projects."{{LOCAL_HOME}}"]
+[projects."{{REMOTE_HOME}}"]
+trust_level = "trusted"
+
+[projects."/root"]
 trust_level = "trusted"

--- a/scripts/sync-codex-cli.sh
+++ b/scripts/sync-codex-cli.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DEFAULT_WORKSPACE="proompteng"
+DEFAULT_WORKSPACE="lab"
 DEFAULT_LOCAL_AUTH="$HOME/.codex/auth.json"
 DEFAULT_CONFIG_TEMPLATE="$SCRIPT_DIR/codex-config-template.toml"
 DEFAULT_REMOTE_AUTH='~/.codex/auth.json'
@@ -143,13 +143,14 @@ trap 'if [[ -n "$tmp_config" && -f "$tmp_config" ]]; then rm -f "$tmp_config"; f
 
 local_home="$(cd "$HOME" && pwd)"
 local_repo="${local_home%/}/github.com/lab"
-remote_default_repo="${remote_home%/}/github.com/lab"
 remote_config_payload=$(cat "$template_path")
 remote_config_payload=${remote_config_payload//$'\r'/}
-remote_config_payload=${remote_config_payload//"{{LOCAL_PROJECT}}"/"$local_repo"}
-remote_config_payload=${remote_config_payload//"{{LOCAL_HOME}}"/"$local_home"}
-remote_config_payload=${remote_config_payload//"$local_repo"/"$remote_repo"}
-remote_config_payload=${remote_config_payload//"$local_home"/"$remote_home"}
+remote_config_payload=${remote_config_payload//"{{REMOTE_PROJECT}}"/"$remote_repo"}
+remote_config_payload=${remote_config_payload//"{{REMOTE_HOME}}"/"$remote_home"}
+remote_config_payload=${remote_config_payload//"{{LOCAL_PROJECT}}"/"$remote_repo"}
+remote_config_payload=${remote_config_payload//"{{LOCAL_HOME}}"/"$remote_home"}
+remote_config_payload=${remote_config_payload//"{{LOCAL_PROJECT_PATH}}"/"$local_repo"}
+remote_config_payload=${remote_config_payload//"{{LOCAL_HOME_PATH}}"/"$local_home"}
 if [[ "$remote_config_payload" != *$'\n' ]]; then
   remote_config_payload+=$'\n'
 fi


### PR DESCRIPTION
## Summary
- install argo and kubeconform CLIs in the Codex image so lint scripts run in automation
- configure gh auth setup-git during build to allow HTTPS pushes
- align codex config template/sync script defaults with the lab workspace

## Testing
- apps/froussard/scripts/build-codex-image.sh
