### PR TITLE
feat: add codex one-shot workflow

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -63,7 +63,8 @@ RUN git config --global user.name "codex-automation" \
 COPY apps/froussard/scripts/codex-bootstrap.sh /usr/local/bin/codex-bootstrap.sh
 COPY apps/froussard/scripts/codex-plan.sh /usr/local/bin/codex-plan.sh
 COPY apps/froussard/scripts/codex-implement.sh /usr/local/bin/codex-implement.sh
-RUN chmod +x /usr/local/bin/codex-bootstrap.sh /usr/local/bin/codex-plan.sh /usr/local/bin/codex-implement.sh
+COPY apps/froussard/scripts/codex-one-shot.sh /usr/local/bin/codex-one-shot.sh
+RUN chmod +x /usr/local/bin/codex-bootstrap.sh /usr/local/bin/codex-plan.sh /usr/local/bin/codex-implement.sh /usr/local/bin/codex-one-shot.sh
 
 WORKDIR /workspace
 ENTRYPOINT ["/usr/local/bin/codex-bootstrap.sh"]

--- a/apps/froussard/scripts/codex-one-shot.sh
+++ b/apps/froussard/scripts/codex-one-shot.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: codex-one-shot.sh <event-json-path>" >&2
+  exit 1
+fi
+
+EVENT_PATH=$1
+if [[ ! -f "$EVENT_PATH" ]]; then
+  echo "Event payload file not found at '$EVENT_PATH'" >&2
+  exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKTREE=${WORKTREE:-/workspace/lab}
+PLAN_FILE=${PLAN_FILE:-${WORKTREE}/PLAN.md}
+DEFAULT_PLAN_OUTPUT_PATH=${PLAN_OUTPUT_PATH:-${WORKTREE}/.codex-plan-output.md}
+
+STAGE=$(jq -r '.stage // empty' "$EVENT_PATH")
+if [[ "$STAGE" != "one-shot" ]]; then
+  echo "Skipping unsupported stage: '$STAGE'" >&2
+  exit 0
+fi
+
+PLANNING_PROMPT=$(jq -r '.planningPrompt // empty' "$EVENT_PATH")
+if [[ -z "$PLANNING_PROMPT" ]]; then
+  echo "Missing planning prompt in event payload" >&2
+  exit 1
+fi
+
+IMPLEMENTATION_PROMPT=$(jq -r '.implementationPrompt // empty' "$EVENT_PATH")
+if [[ -z "$IMPLEMENTATION_PROMPT" ]]; then
+  echo "Missing implementation prompt template in event payload" >&2
+  exit 1
+fi
+
+PLAN_PLACEHOLDER=$(jq -r '.planPlaceholder // empty' "$EVENT_PATH")
+if [[ -z "$PLAN_PLACEHOLDER" || "$PLAN_PLACEHOLDER" == "null" ]]; then
+  PLAN_PLACEHOLDER='{{CODEX_ONE_SHOT_PLAN_BODY}}'
+fi
+
+ISSUE_REPO=$(jq -r '.repository // empty' "$EVENT_PATH")
+if [[ -z "$ISSUE_REPO" || "$ISSUE_REPO" == "null" ]]; then
+  echo "Missing repository metadata in event payload" >&2
+  exit 1
+fi
+
+ISSUE_NUMBER=$(jq -r '.issueNumber // empty' "$EVENT_PATH")
+if [[ -z "$ISSUE_NUMBER" || "$ISSUE_NUMBER" == "null" ]]; then
+  echo "Missing issue number metadata in event payload" >&2
+  exit 1
+fi
+
+BASE_BRANCH_VALUE=$(jq -r '.base // empty' "$EVENT_PATH")
+if [[ -n "$BASE_BRANCH_VALUE" && "$BASE_BRANCH_VALUE" != "null" ]]; then
+  export BASE_BRANCH="$BASE_BRANCH_VALUE"
+fi
+
+HEAD_BRANCH_VALUE=$(jq -r '.head // empty' "$EVENT_PATH")
+if [[ -n "$HEAD_BRANCH_VALUE" && "$HEAD_BRANCH_VALUE" != "null" ]]; then
+  export HEAD_BRANCH="$HEAD_BRANCH_VALUE"
+fi
+
+export WORKTREE
+export PLAN_OUTPUT_PATH="$DEFAULT_PLAN_OUTPUT_PATH"
+export CODEX_PROMPT="$PLANNING_PROMPT"
+export ISSUE_REPO
+export ISSUE_NUMBER
+
+if [[ -f "$PLAN_FILE" ]]; then
+  rm -f "$PLAN_FILE"
+fi
+
+echo "Running Codex planning for ${ISSUE_REPO}#${ISSUE_NUMBER}" >&2
+"${SCRIPT_DIR}/codex-plan.sh"
+
+if [[ ! -s "$PLAN_FILE" ]]; then
+  echo "Plan file not generated at '$PLAN_FILE'" >&2
+  exit 1
+fi
+
+TMP_JSON=$(mktemp)
+PLAN_PLACEHOLDER="$PLAN_PLACEHOLDER" \
+IMPLEMENTATION_PROMPT="$IMPLEMENTATION_PROMPT" \
+PLAN_FILE="$PLAN_FILE" \
+python3 - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+plan_file = Path(os.environ['PLAN_FILE'])
+plan_body = plan_file.read_text(encoding='utf-8').strip()
+if not plan_body:
+    print(f"Plan file '{plan_file}' is empty", file=sys.stderr)
+    sys.exit(1)
+
+implementation_prompt = os.environ['IMPLEMENTATION_PROMPT']
+placeholder = os.environ['PLAN_PLACEHOLDER']
+if placeholder not in implementation_prompt:
+    print(f"Placeholder '{placeholder}' not found in implementation prompt", file=sys.stderr)
+    sys.exit(1)
+
+final_prompt = implementation_prompt.replace(placeholder, plan_body)
+json.dump({'plan_body': plan_body, 'final_prompt': final_prompt}, sys.stdout)
+PY
+
+UPDATED_PROMPT=$(jq -r '.final_prompt' "$TMP_JSON")
+PLAN_BODY=$(jq -r '.plan_body' "$TMP_JSON")
+rm -f "$TMP_JSON"
+
+TMP_EVENT=$(mktemp)
+jq --arg prompt "$UPDATED_PROMPT" \
+   --arg plan "$PLAN_BODY" \
+   '.previousStage = (.previousStage // .stage) | .prompt = $prompt | .planCommentBody = $plan | .stage = "implementation"' \
+   "$EVENT_PATH" > "$TMP_EVENT"
+mv "$TMP_EVENT" "$EVENT_PATH"
+
+export PLAN_COMMENT_BODY="$PLAN_BODY"
+
+echo "Running Codex implementation for ${ISSUE_REPO}#${ISSUE_NUMBER}" >&2
+"${SCRIPT_DIR}/codex-implement.sh" "$EVENT_PATH"

--- a/apps/froussard/src/codex.test.ts
+++ b/apps/froussard/src/codex.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  ONE_SHOT_PLAN_PLACEHOLDER,
   PLAN_COMMENT_MARKER,
   PROGRESS_COMMENT_MARKER,
   buildCodexBranchName,
+  buildCodexOneShotPrompts,
   buildCodexPrompt,
   normalizeLogin,
   sanitizeBranchComponent,
@@ -123,5 +125,38 @@ describe('buildCodexPrompt', () => {
     })
 
     expect(prompt).toContain('"""\nNo description provided.\n"""')
+  })
+
+  it('builds one-shot prompts with the default plan placeholder', () => {
+    const prompts = buildCodexOneShotPrompts({
+      issueTitle: 'Automate combined workflow',
+      issueBody: 'Ensure one-shot flow runs plan then implementation.',
+      repositoryFullName: 'gregkonush/lab',
+      issueNumber: 303,
+      baseBranch: 'main',
+      headBranch: 'codex/issue-303-xyz',
+      issueUrl: 'https://github.com/gregkonush/lab/issues/303',
+    })
+
+    expect(prompts.planPlaceholder).toBe(ONE_SHOT_PLAN_PLACEHOLDER)
+    expect(prompts.planningPrompt).toContain('Draft the plan the next Codex run will execute.')
+    expect(prompts.implementationPrompt).toContain(ONE_SHOT_PLAN_PLACEHOLDER)
+    expect(prompts.implementationPrompt).toContain('Execute the approved plan end to end.')
+  })
+
+  it('builds one-shot prompts with a custom placeholder override', () => {
+    const prompts = buildCodexOneShotPrompts({
+      issueTitle: 'Automate combined workflow',
+      issueBody: 'Ensure one-shot flow runs plan then implementation.',
+      repositoryFullName: 'gregkonush/lab',
+      issueNumber: 304,
+      baseBranch: 'main',
+      headBranch: 'codex/issue-304-xyz',
+      issueUrl: 'https://github.com/gregkonush/lab/issues/304',
+      planPlaceholder: '__PLAN_BODY__',
+    })
+
+    expect(prompts.planPlaceholder).toBe('__PLAN_BODY__')
+    expect(prompts.implementationPrompt).toContain('__PLAN_BODY__')
   })
 })

--- a/apps/froussard/src/config.ts
+++ b/apps/froussard/src/config.ts
@@ -27,6 +27,7 @@ export interface AppConfig {
   codex: {
     triggerLogin: string
     implementationTriggerPhrase: string
+    oneShotTriggerPhrase: string
   }
   github: {
     token: string | null
@@ -61,6 +62,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AppConfig => {
     codex: {
       triggerLogin: (env.CODEX_TRIGGER_LOGIN ?? 'gregkonush').toLowerCase(),
       implementationTriggerPhrase: (env.CODEX_IMPLEMENTATION_TRIGGER ?? 'execute plan').trim(),
+      oneShotTriggerPhrase: (env.CODEX_ONE_SHOT_TRIGGER ?? 'execute one-shot').trim(),
     },
     github: {
       token: env.GITHUB_TOKEN ?? null,

--- a/apps/froussard/src/index.ts
+++ b/apps/froussard/src/index.ts
@@ -26,6 +26,7 @@ export const createApp = () => {
     github: config.github,
     codexTriggerLogin: config.codex.triggerLogin,
     codexImplementationTriggerPhrase: config.codex.implementationTriggerPhrase,
+    codexOneShotTriggerPhrase: config.codex.oneShotTriggerPhrase,
     topics: config.kafka.topics,
   }
 

--- a/argocd/applications/froussard/github-codex-one-shot-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-one-shot-workflow-template.yaml
@@ -1,0 +1,51 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: github-codex-one-shot
+  namespace: argo-workflows
+spec:
+  serviceAccountName: argo-workflows-workflow
+  entrypoint: run
+  arguments:
+    parameters:
+      - name: rawEvent
+        value: '{}'
+      - name: eventBody
+        value: '{}'
+  templates:
+    - name: run
+      inputs:
+        parameters:
+          - name: rawEvent
+          - name: eventBody
+      container:
+        image: registry.ide-newton.ts.net/lab/codex-universal:latest
+        command: ["/usr/local/bin/codex-bootstrap.sh"]
+        args:
+          - "/bin/bash"
+          - "-lc"
+          - |
+            set -euo pipefail
+
+            EVENT_FILE=$(mktemp)
+            cat <<'JSON' > "$EVENT_FILE"
+            {{inputs.parameters.eventBody}}
+            JSON
+
+            STAGE=$(jq -r '.stage // ""' "$EVENT_FILE")
+            if [[ "$STAGE" != "one-shot" ]]; then
+              echo "Skipping unsupported stage: '$STAGE'"
+              exit 0
+            fi
+
+            WORKTREE_DIR="${WORKTREE:-/workspace/lab}"
+
+            echo "Executing one-shot Codex workflow" >&2
+            "${WORKTREE_DIR}/apps/froussard/scripts/codex-one-shot.sh" "$EVENT_FILE"
+      resources:
+        requests:
+          cpu: "4"
+          memory: 8Gi
+        limits:
+          cpu: "6"
+          memory: 12Gi

--- a/argocd/applications/froussard/github-codex-one-shot-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-one-shot-workflow-template.yaml
@@ -42,10 +42,10 @@ spec:
 
             echo "Executing one-shot Codex workflow" >&2
             "${WORKTREE_DIR}/apps/froussard/scripts/codex-one-shot.sh" "$EVENT_FILE"
-      resources:
-        requests:
-          cpu: "4"
-          memory: 8Gi
-        limits:
-          cpu: "6"
-          memory: 12Gi
+        resources:
+          requests:
+            cpu: "4"
+            memory: 8Gi
+          limits:
+            cpu: "6"
+            memory: 12Gi

--- a/argocd/applications/froussard/github-codex-sensor.yaml
+++ b/argocd/applications/froussard/github-codex-sensor.yaml
@@ -23,6 +23,15 @@ spec:
             type: string
             value:
               - implementation
+    - eventName: github-codex-tasks
+      eventSourceName: github-codex
+      name: one-shot-event
+      filters:
+        data:
+          - path: body.stage
+            type: string
+            value:
+              - one-shot
   eventBusName: default
   template:
     serviceAccountName: github-codex-sensor
@@ -93,3 +102,36 @@ spec:
                       value: '{}'
                 workflowTemplateRef:
                   name: github-codex-implementation
+    - template:
+        name: one-shot-workflow
+        conditions: "one-shot-event"
+        k8s:
+          group: argoproj.io
+          version: v1alpha1
+          operation: create
+          parameters:
+            - dest: spec.arguments.parameters.0.value
+              src:
+                dependencyName: one-shot-event
+                dataTemplate: '{{ .Input | toJson }}'
+            - dest: spec.arguments.parameters.1.value
+              src:
+                dependencyName: one-shot-event
+                dataTemplate: '{{ .Input.body | toJson }}'
+          resource: workflows
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: github-codex-one-shot-
+                namespace: argo-workflows
+              spec:
+                arguments:
+                  parameters:
+                    - name: rawEvent
+                      value: '{}'
+                    - name: eventBody
+                      value: '{}'
+                workflowTemplateRef:
+                  name: github-codex-one-shot

--- a/argocd/applications/froussard/kustomization.yaml
+++ b/argocd/applications/froussard/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
   - github-codex-topic.yaml
   - github-codex-planning-workflow-template.yaml
   - github-codex-implementation-workflow-template.yaml
+  - github-codex-one-shot-workflow-template.yaml
   - github-codex-sensor.yaml
   - coder-workspace-access.yaml

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "@biomejs/biome": "2.2.4",
     "@commitlint/cli": "19.6.0",
     "@commitlint/config-conventional": "19.6.0",
-    "lint-staged": "16.2.3",
+    "bun-types": "^1.2.23",
     "husky": "9.1.7",
+    "lint-staged": "16.2.3",
     "typescript": "5.9.3"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: 19.6.0
         version: 19.6.0
+      bun-types:
+        specifier: ^1.2.23
+        version: 1.2.23(@types/react@19.1.15)
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -7435,6 +7438,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:
@@ -11579,7 +11583,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -11592,14 +11596,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.15.2)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@24.7.0)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -11624,7 +11628,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -11642,7 +11646,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -11664,7 +11668,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -11734,7 +11738,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -15456,7 +15460,7 @@ snapshots:
 
   '@types/bunyan@1.8.9':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/chai@5.2.2':
     dependencies:
@@ -15464,11 +15468,11 @@ snapshots:
 
   '@types/connect@3.4.36':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/d3-array@3.2.2': {}
 
@@ -15526,7 +15530,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/hast@3.0.4':
     dependencies:
@@ -15560,17 +15564,17 @@ snapshots:
 
   '@types/memcached@2.2.10':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/ms@2.1.0': {}
 
   '@types/mysql@2.15.26':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       form-data: 4.0.2
 
   '@types/node@16.18.126': {}
@@ -15601,7 +15605,7 @@ snapshots:
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       pg-protocol: 1.7.1
       pg-types: 2.2.0
 
@@ -15629,16 +15633,16 @@ snapshots:
 
   '@types/stream-buffers@3.0.7':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       minipass: 4.2.8
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/triple-beam@1.3.5': {}
 
@@ -15650,7 +15654,7 @@ snapshots:
 
   '@types/ws@8.18.0':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -16164,12 +16168,12 @@ snapshots:
 
   bun-types@1.2.23(@types/react@19.1.13):
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       '@types/react': 19.1.13
 
   bun-types@1.2.23(@types/react@19.1.15):
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       '@types/react': 19.1.15
 
   c12@3.3.0(magicast@0.3.5):
@@ -17988,7 +17992,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -18058,7 +18062,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.15.2)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@24.7.0)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.26.9
       '@jest/test-sequencer': 29.7.0
@@ -18083,7 +18087,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       ts-node: 10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -18113,7 +18117,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -18123,7 +18127,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -18162,7 +18166,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -18197,7 +18201,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -18225,7 +18229,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -18271,7 +18275,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -18290,7 +18294,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -18306,7 +18310,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -19966,7 +19970,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       long: 5.3.1
 
   proxy-from-env@1.1.0: {}


### PR DESCRIPTION
## Summary
- add a `one-shot` Codex stage with combined prompt builder and schema updates for webhook payloads
- introduce `codex-one-shot.sh` so the workflow runs planning then implementation in a single pod
- wire a new Argo WorkflowTemplate and sensor trigger, update docs, and bundle the script in the Codex image

## Validation
- 
> froussard@0.0.1 test /workspace/lab/apps/froussard
> vitest run


 RUN  v3.2.4 /workspace/lab/apps/froussard

stdout | src/routes/health.test.ts > createHealthHandlers > returns OK for liveness
Liveness check request received

stdout | src/routes/health.test.ts > createHealthHandlers > returns OK when kafka is ready
Readiness check request received

 ✓ src/routes/health.test.ts (3 tests) 10ms
stdout | src/server.test.ts > server bootstrap > bootstraps server without throwing
🦊 Elysia is running at 127.0.0.1:8080
Kafka producer connected

 ✓ src/services/kafka.test.ts (6 tests) 16ms
 ✓ src/server.test.ts (1 test) 66ms
 ✓ src/services/github.test.ts (15 tests) 19ms
stdout | shutdown (/workspace/lab/apps/froussard/src/index.ts:79:13)
Kafka producer disconnected

stdout | src/routes/webhooks.test.ts > createWebhookHandler > rejects unsupported providers
Received webhook for provider: slack

stdout | src/routes/webhooks.test.ts > createWebhookHandler > rejects unsupported providers
Webhook event received for unsupported provider 'slack': 

stdout | src/routes/webhooks.test.ts > createWebhookHandler > returns 401 when signature header missing
Received webhook for provider: github

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes planning message on issue opened
Received webhook for provider: github

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes planning message on issue opened
Published Kafka message: topic=codex-topic, key=issue-1-planning

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes planning message on issue opened
Added :+1: reaction to issue 1 in owner/repo (delivery delivery-123).

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes planning message on issue opened
Published Kafka message: topic=raw-topic, key=delivery-123

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes implementation message when trigger comment is received
Received webhook for provider: github

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes implementation message when trigger comment is received
Published Kafka message: topic=codex-topic, key=issue-2-implementation

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes implementation message when trigger comment is received
Published Kafka message: topic=raw-topic, key=delivery-999

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes one-shot message when the one-shot trigger comment is received
Received webhook for provider: github

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes one-shot message when the one-shot trigger comment is received
Published Kafka message: topic=codex-topic, key=issue-3-one-shot

stdout | src/routes/webhooks.test.ts > createWebhookHandler > publishes one-shot message when the one-shot trigger comment is received
Published Kafka message: topic=raw-topic, key=delivery-1000

 ✓ src/routes/webhooks.test.ts (5 tests) 39ms
 ✓ src/github-payload.test.ts (10 tests) 13ms
 ✓ src/codex.test.ts (11 tests) 11ms
 ✓ src/codex-workflow.test.ts (3 tests) 5ms
 ✓ src/config.test.ts (3 tests) 12ms

 Test Files  9 passed (9)
      Tests  57 passed (57)
   Start at  07:15:34
   Duration  1.21s (transform 582ms, setup 0ms, collect 1.34s, tests 191ms, environment 2ms, prepare 1.50s)
- 
> froussard@0.0.1 typecheck /workspace/lab/apps/froussard
> tsc --noEmit
- ::group::argo lint /workspace/lab/argocd/applications/froussard/github-codex-planning-workflow-template.yaml
::endgroup::
::group::argo lint /workspace/lab/argocd/applications/froussard/github-codex-one-shot-workflow-template.yaml
::endgroup::
::group::argo lint /workspace/lab/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
::endgroup:: *(fails:  reports Exec format error on this host)*
-  *(fails:  reports Exec format error on this host)*

Closes #1252