### PR TITLE
feat: extend coder workspace access

### DIFF
--- a/argocd/applications/argo-workflows/rbac.yaml
+++ b/argocd/applications/argo-workflows/rbac.yaml
@@ -74,3 +74,17 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: argo-workflows-sso-admin
 type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coder-workspace-cluster-admin
+  namespace: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: coder
+    namespace: coder

--- a/argocd/applications/froussard/coder-workspace-access.yaml
+++ b/argocd/applications/froussard/coder-workspace-access.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coder-workspace-cluster-admin
+  namespace: froussard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: coder
+    namespace: coder

--- a/argocd/applications/froussard/kustomization.yaml
+++ b/argocd/applications/froussard/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - github-codex-planning-workflow-template.yaml
   - github-codex-implementation-workflow-template.yaml
   - github-codex-sensor.yaml
+  - coder-workspace-access.yaml


### PR DESCRIPTION
## Summary
- grant the `coder` service account cluster-admin in the `froussard` namespace via a new Argo CD-managed RoleBinding
- bind the same service account to `cluster-admin` in `argo-workflows` so coder pods can manage workflow resources
- extend the workspace bootstrap script to install the GitHub CLI alongside kubectl and argocd

## Testing
- `terraform fmt kubernetes/coder/main.tf` ✅ (run via temporary Terraform 1.8.5 download because terraform was absent in the environment)
- `terraform fmt -check kubernetes/coder/main.tf` ✅
- `pnpm run lint:proompteng` ⚠️ fails: Biome reports existing custom Tailwind `@custom-variant`, `@theme`, `@apply` at-rule usage and static `id` attributes in `apps/proompteng`
- `go test ./...` ⚠️ fails: `no packages to test`

Closes #1261
