### PR TITLE
feat: launch courriel workflow mailer (#1259)

### DIFF
--- a/apps/courriel/Dockerfile
+++ b/apps/courriel/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.7
+FROM node:22.19.0-slim AS base
+
+WORKDIR /workspace
+
+ENV NODE_ENV=production
+
+RUN corepack enable && corepack prepare pnpm@9.15.2 --activate
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/courriel/package.json ./apps/courriel/package.json
+
+RUN pnpm install --filter courriel... --frozen-lockfile
+
+COPY . .
+
+CMD ["pnpm", "--filter", "courriel", "start"]

--- a/apps/courriel/README.md
+++ b/apps/courriel/README.md
@@ -1,0 +1,49 @@
+# Courriel
+
+Courriel consumes the `argo.workflows.completions` Kafka topic and delivers workflow completion
+notifications through Resend email. The service validates its environment configuration with Zod,
+formats contextual email bodies, and guards against duplicate deliveries using idempotency keys.
+
+## Environment
+
+| Variable | Description |
+| --- | --- |
+| `KAFKA_BROKERS` | Comma-separated Kafka broker list, e.g. `broker-0:9092,broker-1:9092`. |
+| `KAFKA_CLIENT_ID` | Client identifier used when connecting to Kafka. |
+| `KAFKA_GROUP_ID` | Consumer group id for the courriel worker. |
+| `KAFKA_TOPIC` | Source topic name (defaults to `argo.workflows.completions`). |
+| `KAFKA_USERNAME` | SASL username provisioned in `kafka-codex-credentials`. |
+| `KAFKA_PASSWORD` | SASL password provisioned in `kafka-codex-credentials`. |
+| `KAFKA_SASL_MECHANISM` | Optional SASL mechanism (`scram-sha-512`, `scram-sha-256`, or `plain`). Defaults to `scram-sha-512`. |
+| `KAFKA_USE_SSL` | Optional flag (`true`/`false`) to enable TLS. Defaults to `true`. |
+| `RESEND_API_KEY` | Resend API key. Must be stored in the target namespace secret. |
+| `RESEND_FROM` | Default `from` header, e.g. `Courriel <courriel@example.com>`. |
+| `RESEND_TO` | Optional comma-separated fallback recipient list. |
+| `COURIEL_SUBJECT_PREFIX` | Optional subject prefix (e.g. `[Argo]`). |
+| `COURIEL_LOG_LEVEL` | Pino log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`, `silent`). Defaults to `info`. |
+
+Workflow authors can provide overrides through annotations:
+
+- `courriel/email-to`, `courriel/email-cc`, `courriel/email-bcc` for recipient targeting
+- `courriel/email-from` and `courriel/email-reply-to` for sender metadata
+- `courriel/email-subject` to replace the generated subject
+
+The repository ships `fixtures/argo-completion.json`, a redacted completion payload used by the
+Vitest suite and for manual testing.
+
+## Local Development
+
+```bash
+pnpm --filter courriel install
+pnpm --filter courriel exec tsc --noEmit
+pnpm --filter courriel test
+pnpm --filter courriel start
+```
+
+The `start` script runs the TypeScript entrypoint via `tsx` and expects the required environment
+variables to be present.
+
+## Container Image
+
+A slim Node 22 image is provided in `Dockerfile`. It installs only the dependencies required for the
+`courriel` workspace and executes the service with `pnpm --filter courriel start`.

--- a/apps/courriel/fixtures/argo-completion.json
+++ b/apps/courriel/fixtures/argo-completion.json
@@ -1,0 +1,56 @@
+{
+  "metadata": {
+    "name": "notify-artifacts-20251005-1700",
+    "namespace": "argo-workflows",
+    "uid": "2b4e2d68-1f62-4fb8-9a7f-67a2cb3986aa",
+    "labels": {
+      "workflows.argoproj.io/completed": "true",
+      "workflows.argoproj.io/creator": "pipeline-bot",
+      "workflows.argoproj.io/phase": "Succeeded"
+    },
+    "annotations": {
+      "courriel/email-to": "data-team@example.com, ops@example.com",
+      "courriel/email-from": "Argo Bot <argo-bot@example.com>",
+      "courriel/email-subject": "Dataset refresh completed",
+      "courriel/email-reply-to": "ml-oncall@example.com"
+    }
+  },
+  "status": {
+    "phase": "Succeeded",
+    "message": "workflow completed successfully",
+    "progress": "5/5",
+    "startedAt": "2025-10-05T17:03:23Z",
+    "finishedAt": "2025-10-05T17:05:42Z",
+    "nodes": {
+      "notify-artifacts-20251005-1700": {
+        "displayName": "notify-artifacts-20251005-1700",
+        "type": "Workflow",
+        "phase": "Succeeded",
+        "startedAt": "2025-10-05T17:03:23Z",
+        "finishedAt": "2025-10-05T17:05:42Z",
+        "outputs": {
+          "artifacts": [
+            {
+              "name": "summary",
+              "s3": {
+                "key": "workflows/notify-artifacts-20251005-1700/summary.json",
+                "bucket": "argo-artifacts",
+                "endpoint": "https://s3.example.com"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "spec": {
+    "arguments": {
+      "parameters": [
+        {
+          "name": "notify_to",
+          "value": "pipeline-owner@example.com"
+        }
+      ]
+    }
+  }
+}

--- a/apps/courriel/package.json
+++ b/apps/courriel/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "courriel",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "kafkajs": "^2.2.4",
+    "pino": "^10.0.0",
+    "resend": "^6.1.2",
+    "tsx": "^4.20.6",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/apps/courriel/src/config.test.ts
+++ b/apps/courriel/src/config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { configSchema, parseConfig } from './config'
+
+const baseEnv = {
+  KAFKA_BROKERS: 'broker-1:9092,broker-2:9092',
+  KAFKA_CLIENT_ID: 'courriel-test',
+  KAFKA_GROUP_ID: 'courriel-group',
+  KAFKA_TOPIC: 'argo.workflows.completions',
+  KAFKA_USERNAME: 'test-user',
+  KAFKA_PASSWORD: 'test-pass',
+  RESEND_API_KEY: 're_abcd',
+  RESEND_FROM: 'Courriel <courriel@example.com>',
+  RESEND_TO: 'fallback@example.com, secondary@example.com',
+  COURIEL_SUBJECT_PREFIX: '[Argo]',
+  COURIEL_LOG_LEVEL: 'debug',
+} satisfies NodeJS.ProcessEnv
+
+describe('config', () => {
+  it('parses valid environment variables', () => {
+    const result = parseConfig(baseEnv)
+
+    expect(result.kafka).toEqual({
+      brokers: ['broker-1:9092', 'broker-2:9092'],
+      clientId: 'courriel-test',
+      groupId: 'courriel-group',
+      topic: 'argo.workflows.completions',
+      sasl: {
+        mechanism: 'scram-sha-512',
+        username: 'test-user',
+        password: 'test-pass',
+      },
+      ssl: true,
+    })
+
+    expect(result.resend).toEqual({
+      apiKey: 're_abcd',
+      from: 'Courriel <courriel@example.com>',
+      fallbackRecipients: ['fallback@example.com', 'secondary@example.com'],
+    })
+
+    expect(result.email.subjectPrefix).toBe('[Argo]')
+    expect(result.logging.level).toBe('debug')
+  })
+
+  it('fails when required entries are missing', () => {
+    const parsed = configSchema.safeParse({})
+    expect(parsed.success).toBe(false)
+
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]?.path).toContain('KAFKA_BROKERS')
+    }
+  })
+
+  it('defaults optional entries when absent', () => {
+    const env = {
+      ...baseEnv,
+      RESEND_TO: undefined,
+      COURIEL_SUBJECT_PREFIX: undefined,
+      COURIEL_LOG_LEVEL: undefined,
+    }
+
+    const result = parseConfig(env)
+
+    expect(result.resend.fallbackRecipients).toEqual([])
+    expect(result.email.subjectPrefix).toBeNull()
+    expect(result.logging.level).toBe('info')
+  })
+})

--- a/apps/courriel/src/config.ts
+++ b/apps/courriel/src/config.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+
+type CsvOptions = {
+  field?: string
+  minItems?: number
+}
+
+const commaSeparatedList = (options: CsvOptions = {}) =>
+  z
+    .string()
+    .transform((raw) =>
+      raw
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+    )
+    .refine(
+      (items) => items.length >= (options.minItems ?? 0),
+      options.field
+        ? { message: `${options.field} must include at least ${options.minItems ?? 0} value(s)` }
+        : undefined,
+    )
+
+const logLevelSchema = z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
+
+const rawConfigSchema = z.object({
+  KAFKA_BROKERS: commaSeparatedList({ field: 'KAFKA_BROKERS', minItems: 1 }),
+  KAFKA_CLIENT_ID: z.string().min(1, 'KAFKA_CLIENT_ID is required'),
+  KAFKA_GROUP_ID: z.string().min(1, 'KAFKA_GROUP_ID is required'),
+  KAFKA_TOPIC: z.string().min(1, 'KAFKA_TOPIC is required'),
+  KAFKA_SASL_MECHANISM: z.enum(['scram-sha-512', 'scram-sha-256', 'plain']).default('scram-sha-512'),
+  KAFKA_USERNAME: z.string().min(1, 'KAFKA_USERNAME is required'),
+  KAFKA_PASSWORD: z.string().min(1, 'KAFKA_PASSWORD is required'),
+  KAFKA_USE_SSL: z.coerce.boolean().default(true),
+  RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
+  RESEND_FROM: z.string().min(1, 'RESEND_FROM is required'),
+  RESEND_TO: z
+    .string()
+    .transform((raw) =>
+      raw
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+    )
+    .optional()
+    .default([]),
+  COURIEL_SUBJECT_PREFIX: z.string().optional(),
+  COURIEL_LOG_LEVEL: logLevelSchema.default('info'),
+})
+
+export const configSchema = rawConfigSchema.transform((value) => ({
+  kafka: {
+    brokers: value.KAFKA_BROKERS,
+    clientId: value.KAFKA_CLIENT_ID,
+    groupId: value.KAFKA_GROUP_ID,
+    topic: value.KAFKA_TOPIC,
+    sasl: {
+      mechanism: value.KAFKA_SASL_MECHANISM,
+      username: value.KAFKA_USERNAME,
+      password: value.KAFKA_PASSWORD,
+    },
+    ssl: value.KAFKA_USE_SSL,
+  },
+  resend: {
+    apiKey: value.RESEND_API_KEY,
+    from: value.RESEND_FROM,
+    fallbackRecipients: value.RESEND_TO ?? [],
+  },
+  email: {
+    subjectPrefix: value.COURIEL_SUBJECT_PREFIX ?? null,
+  },
+  logging: {
+    level: value.COURIEL_LOG_LEVEL,
+  },
+}))
+
+export type AppConfig = z.infer<typeof configSchema>
+
+export const parseConfig = (env: NodeJS.ProcessEnv = process.env): AppConfig => configSchema.parse(env)
+
+let cachedConfig: AppConfig | null = null
+
+export const getConfig = (): AppConfig => {
+  if (cachedConfig) {
+    return cachedConfig
+  }
+
+  cachedConfig = parseConfig()
+  return cachedConfig
+}

--- a/apps/courriel/src/email/completion.test.ts
+++ b/apps/courriel/src/email/completion.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AppConfig } from '../config'
+import { buildCompletionEmail } from './completion'
+import fixture from '../../fixtures/argo-completion.json' with { type: 'json' }
+
+const baseConfig: AppConfig = {
+  kafka: {
+    brokers: ['broker:9092'],
+    clientId: 'courriel',
+    groupId: 'courriel-group',
+    topic: 'argo.workflows.completions',
+    sasl: {
+      mechanism: 'scram-sha-512',
+      username: 'user',
+      password: 'pass',
+    },
+    ssl: true,
+  },
+  resend: {
+    apiKey: 're_test',
+    from: 'Courriel <courriel@example.com>',
+    fallbackRecipients: ['fallback@example.com'],
+  },
+  email: {
+    subjectPrefix: '[Argo]',
+  },
+  logging: {
+    level: 'info',
+  },
+}
+
+describe('buildCompletionEmail', () => {
+  it('uses annotations to populate recipients and metadata', () => {
+    const email = buildCompletionEmail(fixture, baseConfig)
+
+    expect(email.from).toBe('Argo Bot <argo-bot@example.com>')
+    expect(email.to).toContain('data-team@example.com')
+    expect(email.subject).toContain('Dataset refresh completed')
+    expect(email.replyTo).toBe('ml-oncall@example.com')
+    expect(email.headers['X-Courriel-Workflow-UID']).toBe(fixture.metadata.uid)
+    expect(email.html).toContain('notify-artifacts-20251005-1700')
+  })
+
+  it('falls back to configured recipients when no annotations resolve', () => {
+    const payload = JSON.parse(JSON.stringify(fixture))
+    delete payload.metadata.annotations?.['courriel/email-to']
+    payload.metadata.annotations = {}
+    payload.spec.arguments = { parameters: [] }
+
+    const email = buildCompletionEmail(payload, baseConfig)
+
+    expect(email.to).toEqual(['fallback@example.com'])
+    expect(email.from).toBe(baseConfig.resend.from)
+    expect(email.subject).toContain('Workflow notify-artifacts-20251005-1700')
+  })
+})

--- a/apps/courriel/src/email/completion.ts
+++ b/apps/courriel/src/email/completion.ts
@@ -1,0 +1,205 @@
+import type { AppConfig } from '../config'
+import type { WorkflowCompletion } from '../schema/completion'
+
+export interface CompletionEmail {
+  from: string
+  to: string[]
+  cc: string[]
+  bcc: string[]
+  subject: string
+  text: string
+  html: string
+  replyTo?: string
+  headers: Record<string, string>
+}
+
+const EMAIL_TO_ANNOTATION = 'courriel/email-to'
+const EMAIL_CC_ANNOTATION = 'courriel/email-cc'
+const EMAIL_BCC_ANNOTATION = 'courriel/email-bcc'
+const EMAIL_FROM_ANNOTATION = 'courriel/email-from'
+const EMAIL_SUBJECT_ANNOTATION = 'courriel/email-subject'
+const EMAIL_REPLY_TO_ANNOTATION = 'courriel/email-reply-to'
+
+const candidateParameterNames = ['notify_to', 'notify-to', 'email_to', 'email-to', 'emailRecipients']
+
+const splitAddresses = (raw: string | undefined): string[] => {
+  if (!raw) {
+    return []
+  }
+
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+}
+
+const unique = (values: string[]): string[] => {
+  const seen = new Set<string>()
+  const deduped: string[] = []
+
+  for (const value of values) {
+    const normalized = value.toLowerCase()
+    if (seen.has(normalized)) {
+      continue
+    }
+
+    seen.add(normalized)
+    deduped.push(value)
+  }
+
+  return deduped
+}
+
+const formatDateTime = (iso: string | undefined): string | null => {
+  if (!iso) {
+    return null
+  }
+
+  const parsed = new Date(iso)
+  if (Number.isNaN(parsed.getTime())) {
+    return iso
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  }).format(parsed)
+}
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+const resolveParameterRecipients = (completion: WorkflowCompletion): string[] => {
+  const parameters = completion.spec?.arguments?.parameters ?? []
+
+  for (const candidate of candidateParameterNames) {
+    const match = parameters.find((parameter) => parameter.name.toLowerCase() === candidate.toLowerCase())
+    if (match?.value) {
+      const addresses = splitAddresses(match.value)
+      if (addresses.length > 0) {
+        return addresses
+      }
+    }
+  }
+
+  return []
+}
+
+const resolveRecipients = (
+  completion: WorkflowCompletion,
+  fallbackRecipients: string[],
+): { to: string[]; cc: string[]; bcc: string[] } => {
+  const annotations = completion.metadata.annotations ?? {}
+
+  const toCandidates = splitAddresses(annotations[EMAIL_TO_ANNOTATION])
+  const parameterRecipients = resolveParameterRecipients(completion)
+  const to = unique([
+    ...toCandidates,
+    ...parameterRecipients,
+    ...(toCandidates.length === 0 && parameterRecipients.length === 0 ? fallbackRecipients : []),
+  ])
+
+  const cc = unique(splitAddresses(annotations[EMAIL_CC_ANNOTATION]))
+  const bcc = unique(splitAddresses(annotations[EMAIL_BCC_ANNOTATION]))
+
+  return { to, cc, bcc }
+}
+
+const resolveFromAddress = (completion: WorkflowCompletion, defaultFrom: string): string => {
+  const annotations = completion.metadata.annotations ?? {}
+  return annotations[EMAIL_FROM_ANNOTATION]?.trim() || defaultFrom
+}
+
+const resolveReplyTo = (completion: WorkflowCompletion): string | undefined => {
+  const annotations = completion.metadata.annotations ?? {}
+  const replyTo = annotations[EMAIL_REPLY_TO_ANNOTATION]?.trim()
+  return replyTo && replyTo.length > 0 ? replyTo : undefined
+}
+
+const buildSubject = (completion: WorkflowCompletion, subjectPrefix: string | null, defaultPhase: string): string => {
+  const annotations = completion.metadata.annotations ?? {}
+  const annotatedSubject = annotations[EMAIL_SUBJECT_ANNOTATION]?.trim()
+  if (annotatedSubject && annotatedSubject.length > 0) {
+    return annotatedSubject
+  }
+
+  const prefix = subjectPrefix ? `${subjectPrefix.trim()} ` : ''
+  return `${prefix}Workflow ${completion.metadata.name} ${defaultPhase}`.trim()
+}
+
+const buildSummaryLines = (completion: WorkflowCompletion): string[] => {
+  const lines = [
+    `Workflow: ${completion.metadata.name}`,
+    `Namespace: ${completion.metadata.namespace}`,
+    `UID: ${completion.metadata.uid}`,
+    `Status: ${completion.status.phase}`,
+  ]
+
+  if (completion.status.progress) {
+    lines.push(`Progress: ${completion.status.progress}`)
+  }
+
+  if (completion.status.message) {
+    lines.push(`Message: ${completion.status.message}`)
+  }
+
+  const startedAt = formatDateTime(completion.status.startedAt)
+  const finishedAt = formatDateTime(completion.status.finishedAt)
+
+  if (startedAt) {
+    lines.push(`Started: ${startedAt}`)
+  }
+
+  if (finishedAt) {
+    lines.push(`Finished: ${finishedAt}`)
+  }
+
+  return lines
+}
+
+const linesToHtml = (lines: string[]): string => {
+  const items = lines.map((line) => `<li>${escapeHtml(line)}</li>`).join('')
+
+  return `<ul>${items}</ul>`
+}
+
+const linesToText = (lines: string[]): string => lines.join('\n')
+
+export const buildCompletionEmail = (completion: WorkflowCompletion, config: AppConfig): CompletionEmail => {
+  const { to, cc, bcc } = resolveRecipients(completion, config.resend.fallbackRecipients)
+  const from = resolveFromAddress(completion, config.resend.from)
+  const replyTo = resolveReplyTo(completion)
+  const subject = buildSubject(completion, config.email.subjectPrefix, completion.status.phase)
+
+  const summaryLines = buildSummaryLines(completion)
+
+  const html = `
+    <h1>${escapeHtml(subject)}</h1>
+    ${linesToHtml(summaryLines)}
+    <p>This notification was sent by courriel from the argo.workflows.completions topic.</p>
+  `
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  const text = `${subject}\n\n${linesToText(summaryLines)}\n\nThis notification was sent by courriel.`
+
+  return {
+    from,
+    to,
+    cc,
+    bcc,
+    subject,
+    text,
+    html,
+    replyTo,
+    headers: {
+      'X-Courriel-Workflow-UID': completion.metadata.uid,
+      'X-Courriel-Workflow-Name': completion.metadata.name,
+    },
+  }
+}

--- a/apps/courriel/src/index.ts
+++ b/apps/courriel/src/index.ts
@@ -1,0 +1,59 @@
+import { Kafka, logLevel as kafkaLogLevel, type SASLOptions } from 'kafkajs'
+import pino from 'pino'
+import { Resend } from 'resend'
+
+import { getConfig } from './config'
+import { IdempotencyCache, startCourrielConsumer } from './runner'
+
+const config = getConfig()
+
+const logger = pino({
+  name: 'courriel',
+  level: config.logging.level,
+})
+
+const kafka = new Kafka({
+  clientId: config.kafka.clientId,
+  brokers: config.kafka.brokers,
+  ssl: config.kafka.ssl,
+  sasl: config.kafka.sasl as SASLOptions,
+  logLevel: kafkaLogLevel.NOTHING,
+})
+
+const consumer = kafka.consumer({
+  groupId: config.kafka.groupId,
+  allowAutoTopicCreation: false,
+})
+
+const resend = new Resend(config.resend.apiKey)
+const idempotencyCache = new IdempotencyCache(2048)
+
+const shutdown = async () => {
+  logger.info('shutting down courriel consumer')
+  await consumer.disconnect().catch((error) => {
+    logger.error({ err: error }, 'failed to disconnect Kafka consumer')
+  })
+}
+
+process.on('SIGINT', () => {
+  shutdown().finally(() => process.exit(0))
+})
+
+process.on('SIGTERM', () => {
+  shutdown().finally(() => process.exit(0))
+})
+
+startCourrielConsumer({
+  config,
+  logger,
+  kafkaConsumer: consumer,
+  resend,
+  idempotencyCache,
+})
+  .then(() => {
+    logger.info('courriel consumer exited')
+  })
+  .catch((error) => {
+    logger.fatal({ err: error }, 'courriel consumer terminated with an error')
+    void shutdown().finally(() => process.exit(1))
+  })

--- a/apps/courriel/src/runner.test.ts
+++ b/apps/courriel/src/runner.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AppConfig } from './config'
+import { createMessageProcessor, IdempotencyCache } from './runner'
+import fixture from '../fixtures/argo-completion.json' with { type: 'json' }
+
+const baseConfig: AppConfig = {
+  kafka: {
+    brokers: ['broker:9092'],
+    clientId: 'courriel',
+    groupId: 'courriel-group',
+    topic: 'argo.workflows.completions',
+    sasl: {
+      mechanism: 'scram-sha-512',
+      username: 'user',
+      password: 'pass',
+    },
+    ssl: true,
+  },
+  resend: {
+    apiKey: 're_test',
+    from: 'Courriel <courriel@example.com>',
+    fallbackRecipients: ['fallback@example.com'],
+  },
+  email: {
+    subjectPrefix: '[Argo]',
+  },
+  logging: {
+    level: 'info',
+  },
+}
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as const
+
+describe('createMessageProcessor', () => {
+  it('suppresses duplicate messages based on UID', async () => {
+    const resend = {
+      emails: {
+        send: vi.fn().mockResolvedValue({ id: 'email-1' }),
+      },
+    }
+
+    const processor = createMessageProcessor({
+      config: baseConfig,
+      resend: resend as any,
+      logger: logger as any,
+      idempotencyCache: new IdempotencyCache(10),
+    })
+
+    const payload = {
+      topic: baseConfig.kafka.topic,
+      partition: 0,
+      message: {
+        key: Buffer.from('dedupe-key'),
+        value: Buffer.from(JSON.stringify(fixture)),
+        offset: '0',
+        timestamp: Date.now().toString(),
+        headers: {},
+      },
+      heartbeat: vi.fn(),
+      pause: vi.fn(),
+      commitOffsetsIfNecessary: vi.fn(),
+      uncommittedOffsets: vi.fn(),
+      isRunning: () => true,
+      isStale: () => false,
+    }
+
+    await processor(payload as any)
+    await processor(payload as any)
+
+    expect(resend.emails.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call Resend when payload lacks recipients', async () => {
+    const resend = {
+      emails: {
+        send: vi.fn().mockResolvedValue({ id: 'email-1' }),
+      },
+    }
+
+    const processor = createMessageProcessor({
+      config: {
+        ...baseConfig,
+        resend: {
+          ...baseConfig.resend,
+          fallbackRecipients: [],
+        },
+      },
+      resend: resend as any,
+      logger: logger as any,
+      idempotencyCache: new IdempotencyCache(10),
+    })
+
+    const payload = {
+      topic: baseConfig.kafka.topic,
+      partition: 0,
+      message: {
+        key: Buffer.from('no-recipient'),
+        value: Buffer.from(
+          JSON.stringify({
+            metadata: {
+              name: 'no-recipients',
+              namespace: 'argo',
+              uid: 'uid-1',
+              annotations: {},
+              labels: {},
+            },
+            status: {
+              phase: 'Succeeded',
+            },
+          }),
+        ),
+        offset: '0',
+        timestamp: Date.now().toString(),
+        headers: {},
+      },
+      heartbeat: vi.fn(),
+      pause: vi.fn(),
+      commitOffsetsIfNecessary: vi.fn(),
+      uncommittedOffsets: vi.fn(),
+      isRunning: () => true,
+      isStale: () => false,
+    }
+
+    await processor(payload as any)
+
+    expect(resend.emails.send).not.toHaveBeenCalled()
+  })
+})

--- a/apps/courriel/src/runner.ts
+++ b/apps/courriel/src/runner.ts
@@ -1,0 +1,172 @@
+import type { Consumer, EachMessagePayload } from 'kafkajs'
+import type { Logger } from 'pino'
+import type { Resend } from 'resend'
+
+import type { AppConfig } from './config'
+import { buildCompletionEmail } from './email/completion'
+import { parseCompletion } from './schema/completion'
+
+export class IdempotencyCache {
+  private readonly maxSize: number
+  private readonly entries = new Map<string, number>()
+
+  constructor(maxSize = 1024) {
+    this.maxSize = maxSize
+  }
+
+  has(id: string): boolean {
+    return this.entries.has(id)
+  }
+
+  add(id: string): void {
+    if (this.entries.has(id)) {
+      this.entries.delete(id)
+    }
+
+    this.entries.set(id, Date.now())
+
+    if (this.entries.size > this.maxSize) {
+      const iterator = this.entries.keys().next()
+      if (!iterator.done) {
+        this.entries.delete(iterator.value)
+      }
+    }
+  }
+}
+
+export interface MessageProcessorDependencies {
+  config: AppConfig
+  resend: Resend
+  logger: Logger
+  idempotencyCache?: IdempotencyCache
+}
+
+export const createMessageProcessor = ({
+  config,
+  resend,
+  logger,
+  idempotencyCache = new IdempotencyCache(),
+}: MessageProcessorDependencies) => {
+  return async ({ topic, partition, message }: EachMessagePayload): Promise<void> => {
+    const rawKey = message.key?.toString('utf8') ?? undefined
+    const rawValue = message.value?.toString('utf8')
+
+    if (!rawValue) {
+      logger.warn({ topic, partition, offset: message.offset }, 'received message without a value – skipping')
+      return
+    }
+
+    let completion
+    try {
+      const parsed = JSON.parse(rawValue)
+      completion = parseCompletion(parsed)
+    } catch (error) {
+      logger.error(
+        {
+          err: error,
+          topic,
+          partition,
+          offset: message.offset,
+        },
+        'failed to parse workflow completion payload',
+      )
+      return
+    }
+
+    const dedupeId = rawKey ?? completion.metadata.uid
+    if (dedupeId && idempotencyCache.has(dedupeId)) {
+      logger.debug({ dedupeId, topic, partition, offset: message.offset }, 'duplicate completion skipped')
+      return
+    }
+
+    const email = buildCompletionEmail(completion, config)
+
+    if (email.to.length === 0) {
+      logger.warn(
+        {
+          dedupeId,
+          topic,
+          partition,
+          offset: message.offset,
+          metadata: completion.metadata,
+        },
+        'workflow completion has no resolved recipients – skipping email',
+      )
+      return
+    }
+
+    try {
+      const response = await resend.emails.send({
+        from: email.from,
+        to: email.to,
+        cc: email.cc.length > 0 ? email.cc : undefined,
+        bcc: email.bcc.length > 0 ? email.bcc : undefined,
+        subject: email.subject,
+        html: email.html,
+        text: email.text,
+        replyTo: email.replyTo,
+        headers: email.headers,
+      })
+
+      if (response.error) {
+        throw new Error(`Resend API error: ${response.error.message}`)
+      }
+
+      const messageId = response.data?.id ?? null
+
+      if (dedupeId) {
+        idempotencyCache.add(dedupeId)
+      }
+
+      logger.info(
+        {
+          dedupeId,
+          topic,
+          partition,
+          offset: message.offset,
+          resendId: messageId ?? undefined,
+        },
+        'email delivered for workflow completion',
+      )
+    } catch (error) {
+      logger.error(
+        {
+          err: error,
+          dedupeId,
+          topic,
+          partition,
+          offset: message.offset,
+        },
+        'failed to deliver Resend notification',
+      )
+      throw error
+    }
+  }
+}
+
+export interface CourrielConsumerDependencies {
+  config: AppConfig
+  logger: Logger
+  kafkaConsumer: Consumer
+  resend: Resend
+  idempotencyCache?: IdempotencyCache
+}
+
+export const startCourrielConsumer = async ({
+  config,
+  logger,
+  kafkaConsumer,
+  resend,
+  idempotencyCache,
+}: CourrielConsumerDependencies): Promise<void> => {
+  const processor = createMessageProcessor({
+    config,
+    resend,
+    logger,
+    idempotencyCache,
+  })
+
+  await kafkaConsumer.connect()
+  await kafkaConsumer.subscribe({ topic: config.kafka.topic, fromBeginning: false })
+  await kafkaConsumer.run({ eachMessage: processor })
+}

--- a/apps/courriel/src/schema/completion.test.ts
+++ b/apps/courriel/src/schema/completion.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseCompletion } from './completion'
+import fixture from '../../fixtures/argo-completion.json' with { type: 'json' }
+
+describe('completion schema', () => {
+  it('parses the workflow completion fixture', () => {
+    const completion = parseCompletion(fixture)
+
+    expect(completion.metadata.name).toBe('notify-artifacts-20251005-1700')
+    expect(completion.metadata.annotations?.['courriel/email-to']).toContain('data-team@example.com')
+    expect(completion.status.phase).toBe('Succeeded')
+  })
+
+  it('throws on invalid payloads', () => {
+    expect(() => parseCompletion({})).toThrowError()
+  })
+})

--- a/apps/courriel/src/schema/completion.ts
+++ b/apps/courriel/src/schema/completion.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+
+const parameterSchema = z.object({
+  name: z.string(),
+  value: z.string().optional(),
+})
+
+const metadataSchema = z.object({
+  name: z.string(),
+  namespace: z.string(),
+  uid: z.string().min(1, 'metadata.uid is required'),
+  annotations: z.record(z.string(), z.string()).optional().default({}),
+  labels: z.record(z.string(), z.string()).optional().default({}),
+})
+
+const statusSchema = z.object({
+  phase: z.string().min(1, 'status.phase is required'),
+  message: z.string().optional(),
+  progress: z.string().optional(),
+  startedAt: z.string().optional(),
+  finishedAt: z.string().optional(),
+  nodes: z.record(z.string(), z.unknown()).optional(),
+})
+
+const specSchema = z
+  .object({
+    arguments: z
+      .object({
+        parameters: z.array(parameterSchema).optional().default([]),
+      })
+      .partial()
+      .optional()
+      .default({}),
+  })
+  .partial()
+  .optional()
+  .default({})
+
+export const completionSchema = z.object({
+  metadata: metadataSchema,
+  status: statusSchema,
+  spec: specSchema,
+})
+
+export type WorkflowCompletion = z.infer<typeof completionSchema>
+
+export const parseCompletion = (payload: unknown): WorkflowCompletion => {
+  return completionSchema.parse(payload)
+}

--- a/apps/courriel/tsconfig.json
+++ b/apps/courriel/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "module": "esnext",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "baseUrl": "./",
+    "paths": {
+      "@courriel/*": ["src/*"]
+    }
+  },
+  "include": ["src", "fixtures"]
+}

--- a/apps/courriel/vitest.config.ts
+++ b/apps/courriel/vitest.config.ts
@@ -1,0 +1,20 @@
+import path from 'node:path'
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@courriel': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+    },
+  },
+})

--- a/argocd/applications/courriel/deployment.yaml
+++ b/argocd/applications/courriel/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: courriel
+  namespace: argo-workflows
+  labels:
+    app.kubernetes.io/name: courriel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: courriel
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: courriel
+    spec:
+      serviceAccountName: courriel
+      containers:
+        - name: courriel
+          image: registry.ide-newton.ts.net/lab/courriel:0.1.0
+          imagePullPolicy: Always
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: KAFKA_BROKERS
+              value: kafka-kafka-bootstrap.kafka:9092
+            - name: KAFKA_TOPIC
+              value: argo.workflows.completions
+            - name: KAFKA_CLIENT_ID
+              value: courriel
+            - name: KAFKA_GROUP_ID
+              value: courriel
+            - name: KAFKA_SASL_MECHANISM
+              value: scram-sha-512
+            - name: KAFKA_USE_SSL
+              value: "true"
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-codex-credentials
+                  key: username
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-codex-credentials
+                  key: password
+            - name: RESEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: courriel-resend
+                  key: api-key
+            - name: RESEND_FROM
+              value: Courriel <courriel@proompteng.ai>
+            - name: RESEND_TO
+              value: data-team@proompteng.ai
+            - name: COURIEL_SUBJECT_PREFIX
+              value: "[Argo]"
+            - name: COURIEL_LOG_LEVEL
+              value: info
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/argocd/applications/courriel/kustomization.yaml
+++ b/argocd/applications/courriel/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebinding.yaml
+  - deployment.yaml
+  - topic.yaml

--- a/argocd/applications/courriel/role.yaml
+++ b/argocd/applications/courriel/role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: courriel
+  namespace: argo-workflows
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - kafka-codex-credentials
+      - courriel-resend
+    verbs: ["get"]

--- a/argocd/applications/courriel/rolebinding.yaml
+++ b/argocd/applications/courriel/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: courriel
+  namespace: argo-workflows
+subjects:
+  - kind: ServiceAccount
+    name: courriel
+    namespace: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: courriel

--- a/argocd/applications/courriel/serviceaccount.yaml
+++ b/argocd/applications/courriel/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: courriel
+  namespace: argo-workflows

--- a/argocd/applications/courriel/topic.yaml
+++ b/argocd/applications/courriel/topic.yaml
@@ -1,0 +1,15 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: argo-workflows-completions
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  topicName: argo.workflows.completions
+  partitions: 3
+  replicas: 3
+  config:
+    cleanup.policy: delete
+    retention.ms: 604800000
+    segment.bytes: 134217728

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -163,6 +163,13 @@ spec:
               argocd.argoproj.io/sync-wave: "3"
             automation: auto
             enabled: "true"
+          - name: courriel
+            path: argocd/applications/courriel
+            namespace: argo-workflows
+            annotations:
+              argocd.argoproj.io/sync-wave: "4"
+            automation: manual
+            enabled: "false"
           - name: arc
             path: argocd/applications/arc
             namespace: arc

--- a/docs/kafka-topics.md
+++ b/docs/kafka-topics.md
@@ -30,6 +30,7 @@ spec:
 | ----------- | ------- | ----- |
 | `github.webhook.events` | Raw GitHub webhook payloads published by the `froussard` service. | Strimzi resource: `github-webhook-events`. 7-day retention. |
 | `github.codex.tasks` | Issue-driven automation tasks consumed by Argo Workflows and Codex. | Defined in `argocd/applications/froussard/github-codex-topic.yaml`. |
+| `argo.workflows.completions` | Workflow completion status records consumed by Courriel for Resend email notifications. | Strimzi resource: `argo-workflows-completions`. 7-day retention. |
 
 Add new rows whenever a topic is provisioned so downstream teams can reason about ownership and retention.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,31 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  apps/courriel:
+    dependencies:
+      kafkajs:
+        specifier: ^2.2.4
+        version: 2.2.4
+      pino:
+        specifier: ^10.0.0
+        version: 10.0.0
+      resend:
+        specifier: ^6.1.2
+        version: 6.1.2
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.15.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+
   apps/docs:
     dependencies:
       fumadocs-core:
@@ -136,13 +161,13 @@ importers:
         version: 1.131.44(@tanstack/react-router@1.131.44(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(webpack@5.99.9)
       '@trpc/client':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006)
+        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251007))(typescript@6.0.0-dev.20251007)
       '@trpc/server':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251006)
+        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251007)
       '@trpc/tanstack-react-query':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251006)
+        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251007))(typescript@6.0.0-dev.20251007))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251007))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251007)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -191,7 +216,7 @@ importers:
         version: 7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.0-dev.20251006)(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 5.1.4(typescript@6.0.0-dev.20251007)(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
 
   apps/nata:
     dependencies:
@@ -8368,6 +8393,10 @@ packages:
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
+  pino@10.0.0:
+    resolution: {integrity: sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==}
+    hasBin: true
+
   pino@9.12.0:
     resolution: {integrity: sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw==}
     hasBin: true
@@ -8736,6 +8765,15 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  resend@6.1.2:
+    resolution: {integrity: sha512-C9Q+YkRe57P8MQlkHG3yatSR/B6sqBGA06Ri2DveJfkz9Vm16182FC/iHB0K6IAfmqZ4yRrFebFw1EPuktLtSg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -9459,8 +9497,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20251006:
-    resolution: {integrity: sha512-DHt+o3xZV+a3cambN7XN1l0RH9PP3bYhUn2pwWyHqSA7j5HSR4MjTEf2hFGpty3/IZj6zHztEBtq4B6bGRdJgg==}
+  typescript@6.0.0-dev.20251007:
+    resolution: {integrity: sha512-kMMKTLV882uaJepZV/jbSOYGPdMhaJ43MA1caMbI8YtAXAxXBGj3+9OGv9ASwbTjRlVYiX6fC9LNJGHdTq0vLQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10006,8 +10044,8 @@ packages:
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
-  zod@4.1.11:
-    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+  zod@4.1.12:
+    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -15389,23 +15427,23 @@ snapshots:
       long: 5.3.1
       protobufjs: 7.4.0
 
-  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006)':
+  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251007))(typescript@6.0.0-dev.20251007)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251006)
-      typescript: 6.0.0-dev.20251006
+      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251007)
+      typescript: 6.0.0-dev.20251007
 
-  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006)':
+  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251007)':
     dependencies:
-      typescript: 6.0.0-dev.20251006
+      typescript: 6.0.0-dev.20251007
 
-  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251006)':
+  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251007))(typescript@6.0.0-dev.20251007))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251007))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251007)':
     dependencies:
       '@tanstack/react-query': 5.89.0(react@19.0.0)
-      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006)
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251006)
+      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251007))(typescript@6.0.0-dev.20251007)
+      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251007)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      typescript: 6.0.0-dev.20251006
+      typescript: 6.0.0-dev.20251007
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -15717,6 +15755,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.5(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.5(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/mocker@3.2.4(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
@@ -16841,7 +16887,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20251006
+      typescript: 6.0.0-dev.20251007
 
   dunder-proto@1.0.1:
     dependencies:
@@ -17416,7 +17462,7 @@ snapshots:
       tinyglobby: 0.2.15
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      zod: 4.1.11
+      zod: 4.1.12
     optionalDependencies:
       next: 15.5.3(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
@@ -18299,7 +18345,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.7.0
+      '@types/node': 22.15.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
     optional: true
@@ -19838,6 +19884,20 @@ snapshots:
 
   pino-std-serializers@7.0.0: {}
 
+  pino@10.0.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      slow-redact: 0.3.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
   pino@9.12.0:
     dependencies:
       atomic-sleep: 1.0.0
@@ -20316,6 +20376,8 @@ snapshots:
       - supports-color
 
   require-main-filename@2.0.0: {}
+
+  resend@6.1.2: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -21020,9 +21082,9 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.8(@swc/helpers@0.5.15)
 
-  tsconfck@3.1.5(typescript@6.0.0-dev.20251006):
+  tsconfck@3.1.5(typescript@6.0.0-dev.20251007):
     optionalDependencies:
-      typescript: 6.0.0-dev.20251006
+      typescript: 6.0.0-dev.20251007
 
   tslib@1.14.1: {}
 
@@ -21060,7 +21122,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.0-dev.20251006: {}
+  typescript@6.0.0-dev.20251007: {}
 
   ufo@1.5.4: {}
 
@@ -21338,6 +21400,27 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.5(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
@@ -21359,11 +21442,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251006)(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251007)(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.5(typescript@6.0.0-dev.20251006)
+      tsconfck: 3.1.5(typescript@6.0.0-dev.20251007)
     optionalDependencies:
       vite: 7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
@@ -21388,6 +21471,23 @@ snapshots:
       yaml: 2.8.1
     optional: true
 
+  vite@7.1.5(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.0
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.50.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.15.2
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      terser: 5.39.0
+      tsx: 4.20.6
+      yaml: 2.8.1
+
   vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.0
@@ -21408,6 +21508,48 @@ snapshots:
   vitefu@1.1.1(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
     optionalDependencies:
       vite: 7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.5(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.15.2
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
@@ -21695,6 +21837,6 @@ snapshots:
 
   zod@3.24.2: {}
 
-  zod@4.1.11: {}
+  zod@4.1.12: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- stand up the `apps/courriel` workspace with Zod config, Kafka consumer pipeline, email templating, and Vitest coverage to exercise config, parsing, and dedupe
- add container/runtime assets, README, and fixtures plus pnpm wiring so the service can run locally or in CI
- provision Argo CD manifests and a Strimzi topic for `argo.workflows.completions`, register the app in the platform ApplicationSet, and document the new Kafka stream

## Testing
- `pnpm --filter courriel exec tsc --noEmit`
- `pnpm --filter courriel test`
- `/root/.local/share/mise/installs/go/1.24.3/bin/kustomize build argocd/applications/courriel`
- `scripts/kubeconform.sh argocd/applications/courriel --strict` *(fails: kubeconform v0.6.7 segfaults even with `-n 1`; no manifests reported)*

Closes #1259
