### PR TITLE
feat: enable auto sync for application sets

### DIFF
--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -13,7 +13,7 @@ spec:
             path: packages/bonjour
             namespace: bonjour
             image: registry.ide-newton.ts.net/lab/bonjour:latest
-            automation: manual
+            automation: auto
             enabled: true
             annotations:
               argocd.argoproj.io/sync-wave: "6"

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -14,77 +14,77 @@ spec:
             namespace: cloudnative-pg
             annotations:
               argocd.argoproj.io/sync-wave: "-1"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: redis-operator
             path: argocd/applications/redis-operator
             namespace: redis-operator
             annotations:
               argocd.argoproj.io/sync-wave: "-1"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: external-dns
             path: argocd/applications/external-dns
             namespace: external-dns
             annotations:
               argocd.argoproj.io/sync-wave: "0"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: cloudflare
             path: argocd/applications/cloudflare
             namespace: cloudflare
             annotations:
               argocd.argoproj.io/sync-wave: "0"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: istio-system
             path: argocd/applications/istio-system
             namespace: istio-system
             annotations:
               argocd.argoproj.io/sync-wave: "0"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: istio-ingress
             path: argocd/applications/istio-ingress
             namespace: istio-ingress
             annotations:
               argocd.argoproj.io/sync-wave: "1"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: knative
             path: argocd/applications/knative
             namespace: knative
             annotations:
               argocd.argoproj.io/sync-wave: "1"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: knative-serving
             path: argocd/applications/knative-serving
             namespace: knative-serving
             annotations:
               argocd.argoproj.io/sync-wave: "2"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: knative-eventing
             path: argocd/applications/knative-eventing
             namespace: knative-eventing
             annotations:
               argocd.argoproj.io/sync-wave: "2"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: fission
             path: argocd/applications/fission
             namespace: fission
             annotations:
               argocd.argoproj.io/sync-wave: "2"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: kafka
             path: argocd/applications/kafka
             namespace: kafka
             annotations:
               argocd.argoproj.io/sync-wave: "2"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: argo-workflows
             path: argocd/applications/argo-workflows
@@ -98,91 +98,91 @@ spec:
             namespace: lgtm
             annotations:
               argocd.argoproj.io/sync-wave: "3"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: minio
             path: argocd/applications/minio
             namespace: minio
             annotations:
               argocd.argoproj.io/sync-wave: "3"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: milvus
             path: argocd/applications/milvus
             namespace: milvus
             annotations:
               argocd.argoproj.io/sync-wave: "4"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: tigresse
             path: argocd/applications/tigresse
             namespace: tigresse-system
             annotations:
               argocd.argoproj.io/sync-wave: "3"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: temporal
             path: argocd/applications/temporal
             namespace: temporal
             annotations:
               argocd.argoproj.io/sync-wave: "4"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: airbyte
             path: argocd/applications/airbyte
             namespace: airbyte
             annotations:
               argocd.argoproj.io/sync-wave: "4"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: dagster
             path: argocd/applications/dagster
             namespace: dagster
             annotations:
               argocd.argoproj.io/sync-wave: "4"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: verdaccio
             path: argocd/applications/verdaccio
             namespace: verdaccio
             annotations:
               argocd.argoproj.io/sync-wave: "3"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: spark
             path: argocd/applications/spark
             namespace: spark
             annotations:
               argocd.argoproj.io/sync-wave: "3"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: coder
             path: argocd/applications/coder
             namespace: coder
             annotations:
               argocd.argoproj.io/sync-wave: "3"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: arc
             path: argocd/applications/arc
             namespace: arc
             annotations:
               argocd.argoproj.io/sync-wave: "4"
-            automation: manual
+            automation: auto
             enabled: "true"
           - name: backstage
             path: argocd/applications/backstage
             namespace: backstage
             annotations:
               argocd.argoproj.io/sync-wave: "4"
-            automation: manual
+            automation: auto
             enabled: "false"
           - name: convex
             path: argocd/applications/convex
             namespace: convex
             annotations:
               argocd.argoproj.io/sync-wave: "4"
-            automation: manual
+            automation: auto
             enabled: "false"
       selector:
         matchExpressions:

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -49,7 +49,7 @@ spec:
               argocd-image-updater.argoproj.io/git-repository: git@github.com:gregkonush/lab.git
               argocd-image-updater.argoproj.io/git-branch: main:release/{{.SHA256}}
               argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/kitty-krew
-            automation: manual
+            automation: auto
             enabled: false
           - name: reviseur
             path: argocd/applications/reviseur
@@ -63,7 +63,7 @@ spec:
               argocd-image-updater.argoproj.io/git-repository: git@github.com:gregkonush/lab.git
               argocd-image-updater.argoproj.io/git-branch: main:release/{{.SHA256}}
               argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/reviseur
-            automation: manual
+            automation: auto
             enabled: false
           - name: prt
             path: argocd/applications/prt
@@ -71,35 +71,35 @@ spec:
             renderWithLovely: false
             annotations:
               argocd.argoproj.io/sync-wave: "5"
-            automation: manual
+            automation: auto
             enabled: true
           - name: ecran
             path: argocd/applications/ecran
             namespace: ecran
             annotations:
               argocd.argoproj.io/sync-wave: "6"
-            automation: manual
+            automation: auto
             enabled: false
           - name: eclair
             path: argocd/applications/eclair
             namespace: eclair
             annotations:
               argocd.argoproj.io/sync-wave: "6"
-            automation: manual
+            automation: auto
             enabled: false
           - name: galette
             path: argocd/applications/galette
             namespace: galette
             annotations:
               argocd.argoproj.io/sync-wave: "6"
-            automation: manual
+            automation: auto
             enabled: false
           - name: miel
             path: argocd/applications/miel
             namespace: miel
             annotations:
               argocd.argoproj.io/sync-wave: "6"
-            automation: manual
+            automation: auto
             enabled: false
           - name: froussard
             path: argocd/applications/froussard


### PR DESCRIPTION
## Summary
- enable auto sync for platform ApplicationSet entries except `argo-workflows`
- enable auto sync for product ApplicationSet entries while keeping `froussard` manual
- set `bonjour` in the cdk8s ApplicationSet to auto so the template emits automated sync policy

## Testing
- `rg 'automation: manual' argocd/applicationsets`
- `git diff --stat`
- `pnpm run format`
- `pnpm run lint:proompteng` *(fails: Biome flags existing custom at-rules and static IDs in apps/proompteng)*
- `go test ./...` *(fails: repository exposes no Go packages)*

Closes #1265
