### PR TITLE
chore: use bun run for discord relay

### DIFF
--- a/apps/froussard/scripts/codex-implement.sh
+++ b/apps/froussard/scripts/codex-implement.sh
@@ -36,16 +36,16 @@ RELAY_RUN_ID=$(printf '%s' "$RELAY_RUN_ID" | tr '[:upper:]' '[:lower:]')
 
 DISCORD_READY=0
 if [[ -n "${DISCORD_BOT_TOKEN:-}" && -n "${DISCORD_GUILD_ID:-}" && -f "$RELAY_SCRIPT" ]]; then
-  if command -v bunx >/dev/null 2>&1; then
+  if command -v bun >/dev/null 2>&1; then
     DISCORD_READY=1
   else
-    echo "Discord relay disabled: bunx not available in PATH" >&2
+    echo "Discord relay disabled: bun not available in PATH" >&2
   fi
 else
   echo "Discord relay disabled: missing credentials or relay script" >&2
 fi
 
-relay_cmd=(bunx tsx "$RELAY_SCRIPT")
+relay_cmd=(bun run "$RELAY_SCRIPT")
 
 event_prompt=$(jq -r '.prompt // empty' "$EVENT_PATH")
 if [[ -z "$event_prompt" ]]; then

--- a/apps/froussard/scripts/codex-plan.sh
+++ b/apps/froussard/scripts/codex-plan.sh
@@ -30,16 +30,16 @@ RELAY_RUN_ID=$(printf '%s' "$RELAY_RUN_ID" | tr '[:upper:]' '[:lower:]')
 
 DISCORD_READY=0
 if [[ -n "${DISCORD_BOT_TOKEN:-}" && -n "${DISCORD_GUILD_ID:-}" && -f "$RELAY_SCRIPT" ]]; then
-  if command -v bunx >/dev/null 2>&1; then
+  if command -v bun >/dev/null 2>&1; then
     DISCORD_READY=1
   else
-    echo "Discord relay disabled: bunx not available in PATH" >&2
+    echo "Discord relay disabled: bun not available in PATH" >&2
   fi
 else
   echo "Discord relay disabled: missing credentials or relay script" >&2
 fi
 
-relay_cmd=(bunx tsx "$RELAY_SCRIPT")
+relay_cmd=(bun run "$RELAY_SCRIPT")
 
 PROMPT=$(python3 - <<'PY'
 import os, textwrap


### PR DESCRIPTION
## Summary
- replace bunx tsx with bun run for the Codex Discord relay scripts since bun can execute them directly
- keep existing logic for detecting bun and gating the relay on credentials

## Testing
- n/a (relay path change only)