### PR TITLE
chore: always pull codex images

### DIFF
--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -22,6 +22,7 @@ spec:
           - name: eventBody
       container:
         image: registry.ide-newton.ts.net/lab/codex-universal:latest
+        imagePullPolicy: Always
         env:
           - name: DISCORD_BOT_TOKEN
             valueFrom:
@@ -41,6 +42,16 @@ spec:
                 name: discord-codex-bot
                 key: category-id
                 optional: true
+          - name: GH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
         command: ["/usr/local/bin/codex-bootstrap.sh"]
         args:
           - "/bin/bash"

--- a/argocd/applications/froussard/github-codex-planning-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-planning-workflow-template.yaml
@@ -22,6 +22,7 @@ spec:
           - name: eventBody
       container:
         image: registry.ide-newton.ts.net/lab/codex-universal:latest
+        imagePullPolicy: Always
         env:
           - name: DISCORD_BOT_TOKEN
             valueFrom:
@@ -41,6 +42,16 @@ spec:
                 name: discord-codex-bot
                 key: category-id
                 optional: true
+          - name: GH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
         command: ["/usr/local/bin/codex-bootstrap.sh"]
         args:
           - "/bin/bash"


### PR DESCRIPTION
## Summary
- set imagePullPolicy: Always on both codex workflow templates so pods always pull the latest image

## Testing
- kubectl apply -f argocd/applications/froussard/github-codex-planning-workflow-template.yaml
- kubectl apply -f argocd/applications/froussard/github-codex-implementation-workflow-template.yaml