### PR TITLE
feat: add codex one-shot workflow

### DIFF
--- a/apps/froussard/package.json
+++ b/apps/froussard/package.json
@@ -18,6 +18,7 @@
     "kafkajs": "^2.2.4"
   },
   "devDependencies": {
+    "bun-types": "^1.2.23",
     "@types/bun": "^1.2.23",
     "@types/node": "^24.7.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/apps/froussard/scripts/codex-one-shot.sh
+++ b/apps/froussard/scripts/codex-one-shot.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT_PATH=${1:-}
+if [[ -z "$EVENT_PATH" ]]; then
+  echo "Usage: codex-one-shot.sh <event-json-path>" >&2
+  exit 1
+fi
+
+if [[ ! -f "$EVENT_PATH" ]]; then
+  echo "Event payload file not found at '$EVENT_PATH'" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to process Codex one-shot events" >&2
+  exit 1
+fi
+
+PLACEHOLDER="__CODEX_ONE_SHOT_PLAN_PLACEHOLDER__"
+
+planning_prompt=$(jq -r '.prompts.planning // empty' "$EVENT_PATH")
+if [[ -z "$planning_prompt" || "$planning_prompt" == "null" ]]; then
+  echo "Missing planning prompt in one-shot event payload" >&2
+  exit 1
+fi
+
+implementation_template=$(jq -r '.prompts.implementation // empty' "$EVENT_PATH")
+if [[ -z "$implementation_template" || "$implementation_template" == "null" ]]; then
+  echo "Missing implementation prompt in one-shot event payload" >&2
+  exit 1
+fi
+
+issue_repo=$(jq -r '.repository // empty' "$EVENT_PATH")
+if [[ -z "$issue_repo" || "$issue_repo" == "null" ]]; then
+  echo "Missing repository metadata in event payload" >&2
+  exit 1
+fi
+
+issue_number=$(jq -r '.issueNumber // empty' "$EVENT_PATH")
+if [[ -z "$issue_number" || "$issue_number" == "null" ]]; then
+  echo "Missing issue number metadata in event payload" >&2
+  exit 1
+fi
+
+issue_title=$(jq -r '.issueTitle // empty' "$EVENT_PATH")
+if [[ "$issue_title" == "null" ]]; then
+  issue_title=""
+fi
+
+base_branch=$(jq -r '.base // empty' "$EVENT_PATH")
+if [[ "$base_branch" == "null" ]]; then
+  base_branch=""
+fi
+
+head_branch=$(jq -r '.head // empty' "$EVENT_PATH")
+if [[ "$head_branch" == "null" ]]; then
+  head_branch=""
+fi
+
+WORKTREE=${WORKTREE:-/workspace/lab}
+PLAN_OUTPUT_PATH=${PLAN_OUTPUT_PATH:-${WORKTREE}/.codex-one-shot-plan.md}
+
+rm -f "$PLAN_OUTPUT_PATH"
+mkdir -p "$(dirname "$PLAN_OUTPUT_PATH")"
+
+export CODEX_PROMPT="$planning_prompt"
+export ISSUE_REPO="$issue_repo"
+export ISSUE_NUMBER="$issue_number"
+export WORKTREE
+export PLAN_OUTPUT_PATH
+
+if [[ -n "$base_branch" ]]; then
+  export BASE_BRANCH="$base_branch"
+else
+  export BASE_BRANCH=${BASE_BRANCH:-main}
+fi
+
+if [[ -n "$head_branch" ]]; then
+  export HEAD_BRANCH="$head_branch"
+fi
+
+if [[ -n "$issue_title" ]]; then
+  export ISSUE_TITLE=${ISSUE_TITLE:-$issue_title}
+fi
+
+echo "Running Codex one-shot planning for ${ISSUE_REPO}#${ISSUE_NUMBER}" >&2
+codex-plan.sh
+
+if [[ ! -s "$PLAN_OUTPUT_PATH" ]]; then
+  echo "Codex plan output file '$PLAN_OUTPUT_PATH' is missing or empty" >&2
+  exit 1
+fi
+
+plan_body=$(cat "$PLAN_OUTPUT_PATH")
+
+implementation_prompt=$(jq -r --arg placeholder "$PLACEHOLDER" --arg plan "$plan_body" '
+  (.prompts.implementation // "") | gsub($placeholder; $plan)
+' "$EVENT_PATH")
+
+if [[ -z "$implementation_prompt" ]]; then
+  echo "Failed to derive implementation prompt from one-shot event payload" >&2
+  exit 1
+fi
+
+if [[ "$implementation_prompt" == *"$PLACEHOLDER"* ]]; then
+  echo "Warning: implementation prompt still contains placeholder; continuing with generated plan" >&2
+  implementation_prompt=${implementation_prompt//"$PLACEHOLDER"/$plan_body}
+fi
+
+tmp_event=$(mktemp)
+jq --arg stage "implementation" \
+  --arg prompt "$implementation_prompt" \
+  --arg plan "$plan_body" \
+  '.stage = $stage | .prompt = $prompt | .planCommentBody = $plan | del(.prompts)' \
+  "$EVENT_PATH" >"$tmp_event"
+mv "$tmp_event" "$EVENT_PATH"
+
+echo "One-shot planning complete; invoking implementation stage" >&2
+codex-implement.sh "$EVENT_PATH"

--- a/apps/froussard/scripts/discord-relay.ts
+++ b/apps/froussard/scripts/discord-relay.ts
@@ -45,24 +45,39 @@ const parseArgs = (argv: string[]): ParsedArgs => {
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i]
+    if (typeof arg === 'undefined') {
+      continue
+    }
+
+    const requireValue = (flag: string): string => {
+      const value = argv[i + 1]
+      if (typeof value === 'undefined') {
+        console.error(`Option ${flag} requires a value`)
+        usage()
+        process.exit(1)
+      }
+      i += 1
+      return value
+    }
+
     switch (arg) {
       case '--stage':
-        options.stage = argv[++i]
+        options.stage = requireValue('--stage')
         break
       case '--repo':
-        options.repository = argv[++i]
+        options.repository = requireValue('--repo')
         break
       case '--issue':
-        options.issue = argv[++i]
+        options.issue = requireValue('--issue')
         break
       case '--title':
-        options.title = argv[++i]
+        options.title = requireValue('--title')
         break
       case '--run-id':
-        options.runId = argv[++i]
+        options.runId = requireValue('--run-id')
         break
       case '--timestamp':
-        options.timestamp = argv[++i]
+        options.timestamp = requireValue('--timestamp')
         break
       case '--dry-run':
         options.dryRun = true

--- a/apps/froussard/src/config.ts
+++ b/apps/froussard/src/config.ts
@@ -27,6 +27,7 @@ export interface AppConfig {
   codex: {
     triggerLogin: string
     implementationTriggerPhrase: string
+    oneShotTriggerPhrase: string
   }
   github: {
     token: string | null
@@ -61,6 +62,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AppConfig => {
     codex: {
       triggerLogin: (env.CODEX_TRIGGER_LOGIN ?? 'gregkonush').toLowerCase(),
       implementationTriggerPhrase: (env.CODEX_IMPLEMENTATION_TRIGGER ?? 'execute plan').trim(),
+      oneShotTriggerPhrase: (env.CODEX_ONE_SHOT_TRIGGER ?? 'execute plan one-shot').trim(),
     },
     github: {
       token: env.GITHUB_TOKEN ?? null,

--- a/apps/froussard/src/discord.test.ts
+++ b/apps/froussard/src/discord.test.ts
@@ -34,8 +34,13 @@ describe('chunkContent', () => {
     const { chunks, remainder } = consumeChunks(sample, 100)
 
     expect(chunks.length).toBeGreaterThan(0)
-    expect(chunks[0].endsWith('line-010')).toBeTruthy()
-    expect(chunks[1].startsWith('line-011')).toBeTruthy()
+    const firstChunk = chunks.at(0)
+    const secondChunk = chunks.at(1)
+    if (!firstChunk || !secondChunk) {
+      throw new Error('Expected at least two chunks to validate newline boundaries')
+    }
+    expect(firstChunk.endsWith('line-010')).toBeTruthy()
+    expect(secondChunk.startsWith('line-011')).toBeTruthy()
     expect(chunks.every((chunk) => chunk.length <= 100)).toBeTruthy()
     expect(chunks.at(-1)?.length ?? 0).toBeLessThanOrEqual(100)
     expect(remainder.startsWith('line-110')).toBeTruthy()

--- a/apps/froussard/src/index.ts
+++ b/apps/froussard/src/index.ts
@@ -26,6 +26,7 @@ export const createApp = () => {
     github: config.github,
     codexTriggerLogin: config.codex.triggerLogin,
     codexImplementationTriggerPhrase: config.codex.implementationTriggerPhrase,
+    codexOneShotTriggerPhrase: config.codex.oneShotTriggerPhrase,
     topics: config.kafka.topics,
   }
 

--- a/argocd/applications/froussard/github-codex-one-shot-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-one-shot-workflow-template.yaml
@@ -1,0 +1,89 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: github-codex-one-shot
+  namespace: argo-workflows
+  labels:
+    codex.stage: one-shot
+spec:
+  serviceAccountName: argo-workflows-workflow
+  entrypoint: execute
+  arguments:
+    parameters:
+      - name: rawEvent
+        value: '{}'
+      - name: eventBody
+        value: '{}'
+  templates:
+    - name: execute
+      inputs:
+        parameters:
+          - name: rawEvent
+          - name: eventBody
+      container:
+        image: registry.ide-newton.ts.net/lab/codex-universal:latest
+        imagePullPolicy: Always
+        env:
+          - name: DISCORD_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: discord-codex-bot
+                key: bot-token
+                optional: true
+          - name: DISCORD_GUILD_ID
+            valueFrom:
+              secretKeyRef:
+                name: discord-codex-bot
+                key: guild-id
+                optional: true
+          - name: DISCORD_CATEGORY_ID
+            valueFrom:
+              secretKeyRef:
+                name: discord-codex-bot
+                key: category-id
+                optional: true
+          - name: GH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+          - name: LGTM_LOKI_ENDPOINT
+            value: http://lgtm-loki-gateway.lgtm.svc.cluster.local/loki/api/v1/push
+        command: ["/usr/local/bin/codex-bootstrap.sh"]
+        args:
+          - "/bin/bash"
+          - "-lc"
+          - |
+            set -euo pipefail
+
+            EVENT_FILE=$(mktemp)
+            cat <<'JSON' > "$EVENT_FILE"
+            {{inputs.parameters.eventBody}}
+            JSON
+
+            STAGE=$(jq -r '.stage // ""' "$EVENT_FILE")
+            if [[ "$STAGE" != "one-shot" ]]; then
+              echo "Skipping unsupported stage: '$STAGE'"
+              exit 0
+            fi
+
+            export POST_TO_GITHUB=true
+            WORKTREE_DIR="${WORKTREE:-/workspace/lab}"
+
+            echo "Executing one-shot Codex workflow" >&2
+            "${WORKTREE_DIR}/apps/froussard/scripts/codex-one-shot.sh" "$EVENT_FILE"
+        resources:
+          requests:
+            cpu: "4"
+            memory: 8Gi
+          limits:
+            cpu: "6"
+            memory: 12Gi
+      retryStrategy:
+        limit: 3
+        retryPolicy: OnFailure

--- a/argocd/applications/froussard/github-codex-sensor.yaml
+++ b/argocd/applications/froussard/github-codex-sensor.yaml
@@ -23,6 +23,15 @@ spec:
             type: string
             value:
               - implementation
+    - eventName: github-codex-tasks
+      eventSourceName: github-codex
+      name: one-shot-event
+      filters:
+        data:
+          - path: body.stage
+            type: string
+            value:
+              - one-shot
   eventBusName: default
   template:
     serviceAccountName: github-codex-sensor
@@ -93,3 +102,36 @@ spec:
                       value: '{}'
                 workflowTemplateRef:
                   name: github-codex-implementation
+    - template:
+        name: one-shot-workflow
+        conditions: "one-shot-event"
+        k8s:
+          group: argoproj.io
+          version: v1alpha1
+          operation: create
+          parameters:
+            - dest: spec.arguments.parameters.0.value
+              src:
+                dependencyName: one-shot-event
+                dataTemplate: '{{ .Input | toJson }}'
+            - dest: spec.arguments.parameters.1.value
+              src:
+                dependencyName: one-shot-event
+                dataTemplate: '{{ .Input.body | toJson }}'
+          resource: workflows
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: github-codex-one-shot-
+                namespace: argo-workflows
+              spec:
+                arguments:
+                  parameters:
+                    - name: rawEvent
+                      value: '{}'
+                    - name: eventBody
+                      value: '{}'
+                workflowTemplateRef:
+                  name: github-codex-one-shot

--- a/argocd/applications/froussard/kustomization.yaml
+++ b/argocd/applications/froussard/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - github-codex-topic.yaml
   - github-codex-planning-workflow-template.yaml
   - github-codex-implementation-workflow-template.yaml
+  - github-codex-one-shot-workflow-template.yaml
   - github-codex-sensor.yaml
   - coder-workspace-access.yaml

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      bun-types:
+        specifier: ^1.2.23
+        version: 1.2.23(@types/react@19.1.15)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -136,13 +139,13 @@ importers:
         version: 1.131.44(@tanstack/react-router@1.131.44(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(webpack@5.99.9)
       '@trpc/client':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006)
+        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251008))(typescript@6.0.0-dev.20251008)
       '@trpc/server':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251006)
+        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251008)
       '@trpc/tanstack-react-query':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251006)
+        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251008))(typescript@6.0.0-dev.20251008))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251008))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251008)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -191,7 +194,7 @@ importers:
         version: 7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.0-dev.20251006)(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 5.1.4(typescript@6.0.0-dev.20251008)(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
 
   apps/nata:
     dependencies:
@@ -9459,8 +9462,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20251006:
-    resolution: {integrity: sha512-DHt+o3xZV+a3cambN7XN1l0RH9PP3bYhUn2pwWyHqSA7j5HSR4MjTEf2hFGpty3/IZj6zHztEBtq4B6bGRdJgg==}
+  typescript@6.0.0-dev.20251008:
+    resolution: {integrity: sha512-akqwl9XdobElV/XntkoCZ8w4NuY4zleLjYCO5lBCUaJ9suB7SotGJKuw5MoVZZ9drObDYXCyZL4z0RqQPtEm0A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -15389,23 +15392,23 @@ snapshots:
       long: 5.3.1
       protobufjs: 7.4.0
 
-  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006)':
+  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251008))(typescript@6.0.0-dev.20251008)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251006)
-      typescript: 6.0.0-dev.20251006
+      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251008)
+      typescript: 6.0.0-dev.20251008
 
-  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006)':
+  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251008)':
     dependencies:
-      typescript: 6.0.0-dev.20251006
+      typescript: 6.0.0-dev.20251008
 
-  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251006)':
+  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251008))(typescript@6.0.0-dev.20251008))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251008))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251008)':
     dependencies:
       '@tanstack/react-query': 5.89.0(react@19.0.0)
-      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251006))(typescript@6.0.0-dev.20251006)
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251006)
+      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251008))(typescript@6.0.0-dev.20251008)
+      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251008)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      typescript: 6.0.0-dev.20251006
+      typescript: 6.0.0-dev.20251008
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -15526,7 +15529,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
 
   '@types/hast@3.0.4':
     dependencies:
@@ -16164,12 +16167,12 @@ snapshots:
 
   bun-types@1.2.23(@types/react@19.1.13):
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       '@types/react': 19.1.13
 
   bun-types@1.2.23(@types/react@19.1.15):
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       '@types/react': 19.1.15
 
   c12@3.3.0(magicast@0.3.5):
@@ -16841,7 +16844,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20251006
+      typescript: 6.0.0-dev.20251008
 
   dunder-proto@1.0.1:
     dependencies:
@@ -21020,9 +21023,9 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.8(@swc/helpers@0.5.15)
 
-  tsconfck@3.1.5(typescript@6.0.0-dev.20251006):
+  tsconfck@3.1.5(typescript@6.0.0-dev.20251008):
     optionalDependencies:
-      typescript: 6.0.0-dev.20251006
+      typescript: 6.0.0-dev.20251008
 
   tslib@1.14.1: {}
 
@@ -21060,7 +21063,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.0-dev.20251006: {}
+  typescript@6.0.0-dev.20251008: {}
 
   ufo@1.5.4: {}
 
@@ -21359,11 +21362,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251006)(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251008)(vite@7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.5(typescript@6.0.0-dev.20251006)
+      tsconfck: 3.1.5(typescript@6.0.0-dev.20251008)
     optionalDependencies:
       vite: 7.1.5(@types/node@24.7.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- add a `one-shot` Codex stage with prompt helpers and tests
- wire the new trigger phrase through Froussard, executor script, and Argo workflow template
- document how to trigger and validate one-shot runs end to end

## Validation
- pnpm --filter froussard run test
- pnpm --filter froussard run typecheck
- scripts/argo-lint.sh
- scripts/kubeconform.sh argocd

Closes #1252
