### PR TITLE
chore: disable prt application

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -72,7 +72,7 @@ spec:
             annotations:
               argocd.argoproj.io/sync-wave: "5"
             automation: auto
-            enabled: true
+            enabled: false
           - name: ecran
             path: argocd/applications/ecran
             namespace: ecran


### PR DESCRIPTION
## Summary
- disable the prt ApplicationSet entry so Argo CD stops managing it

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6c4d371348324b942b9ff28681875