### PR TITLE
fix: copy facteur module files from service path

### DIFF
--- a/services/facteur/Dockerfile
+++ b/services/facteur/Dockerfile
@@ -3,13 +3,14 @@
 FROM --platform=$BUILDPLATFORM golang:1.24 AS build
 ARG TARGETOS
 ARG TARGETARCH
+ARG SERVICE_PATH=services/facteur
 WORKDIR /workspace
 
-COPY go.mod go.sum ./
+COPY ${SERVICE_PATH}/go.mod ${SERVICE_PATH}/go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
 	go mod download
 
-COPY . .
+COPY ${SERVICE_PATH}/ ./
 RUN --mount=type=cache,target=/go/pkg/mod \
 	CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags='-s -w' -o /out/facteur ./cmd/facteur
 


### PR DESCRIPTION
## Description
- add SERVICE_PATH build arg for the facteur Dockerfile
- copy go.mod/go.sum from the facteur service directory before downloading modules
- stage only facteur sources for go build to keep module metadata available
- verify facteur via `go test ./...` in the service and `docker build -f services/facteur/Dockerfile .`
