### PR TITLE
chore: update node and pnpm versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Build, Test & Development Commands
 
-- Install dependencies with `pnpm install` (Node 22.19.0) and run `go mod tidy` inside each Go service.
+- Install dependencies with `pnpm install` (Node 22.20.0) and run `go mod tidy` inside each Go service.
 - Start UIs with `pnpm run dev:proompteng`; swap the suffix for sibling apps.
 - Build and smoke test via `pnpm run build:<app>` then `pnpm run start:<app>`.
 - Format and lint using `pnpm run format` and `pnpm run lint:<app>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,10 +107,10 @@ kubectl --kubeconfig ~/.kube/altra.yaml apply -f ./tofu/harvester/templates
 ### Key Technologies
 
 - **Frontend**: Next.js 15, React 19, TanStack Router, tRPC, Tailwind CSS
-- **Backend**: Go 1.24, Node.js 22.14, Python 3.9-3.13
+- **Backend**: Go 1.24, Node.js 22.20, Python 3.9-3.13
 - **Data**: Dagster, Temporal, PostgreSQL, Kafka, Milvus
 - **Infrastructure**: Kubernetes (K3s), ArgoCD, Harvester, Ansible
-- **Tooling**: PNPM 9.15.2, Biome, Turbo, Docker, UV
+- **Tooling**: PNPM 10.18.1, Biome, Turbo, Docker, UV
 
 ### Application Patterns
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A multi-language monorepo for experimenting with conversational tooling, data pi
 ## Quick Start
 
 1. **Prerequisites**
-   - Node.js 22.19.x and pnpm 9+
+   - Node.js 22.20.x and pnpm 10+
    - Go 1.24+
    - Bun (optional, see `bun.lock`)
    - Docker / Kubernetes tooling if you plan to run services or apply manifests locally

--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -130,6 +130,6 @@ Following this loop keeps the template lineage clean and ensures future Codex ru
 ## Latest Findings (September 28, 2025)
 
 - Bootstrap script v1.0.17 now tolerates the node module’s nested `~/.nvm/nvm` layout, waits for Node 22, and re-installs nvm if the module lags.
-- Tooling validated inside `greg/proompteng` on template version `xenodochial_jackson9` (Node v22.20.0, pnpm 9.15.9, Convex 1.27.0, codex-cli 0.42.0, kubectl v1.34.1, Argo CD v3.1.7).
+- Tooling validated inside `greg/proompteng` on template version `xenodochial_jackson9` (Node v22.20.0, pnpm 10.18.1, Convex 1.27.0, codex-cli 0.42.0, kubectl v1.34.1, Argo CD v3.1.7).
 - Repository auto-detection fixes the previous `/home/coder/github.com/workspace` miss; `pnpm install --frozen-lockfile` now runs automatically when `pnpm-lock.yaml` is present.
 - `kubectl` and `argocd` binaries are symlinked into `/tmp/coder-script-data/bin`, so `coder ssh workspace -- <command>` works without shell init files.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -4,8 +4,8 @@ This guide consolidates the CLI and runtime tooling used across the Experimentat
 
 ## Node.js, pnpm, and Bun
 
-- Node.js 22.19.0 (managed by `nvm` inside the Coder template)
-- pnpm 9.x (installed automatically by `corepack` in the template)
+- Node.js 22.20.0 (managed by `nvm` inside the Coder template)
+- pnpm 10.18.1 (installed automatically by `corepack` in the template)
 - Optional Bun runtime:
   ```bash
   curl -fsSL https://bun.sh/install | bash

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "version": "0.0.1",
   "engines": {
-    "node": "22.19.0"
+    "node": "22.20.0"
   },
   "scripts": {
     "dev:proompteng": "pnpm -r --parallel --filter proompteng --filter @proompteng/backend dev",
@@ -43,7 +43,7 @@
     "apps/*",
     "packages/*"
   ],
-  "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321",
+  "packageManager": "pnpm@10.18.1+sha512.77a884a165cbba2d8d1c19e3b4880eee6d2fcabd0d879121e282196b80042351d5eb3ca0935fa599da1dc51265cc68816ad2bddd2a2de5ea9fdf92adbec7cd34",
   "dependencies": {
     "@headlessui/react": "^2.2.6"
   }

--- a/packages/bonjour/Dockerfile
+++ b/packages/bonjour/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:22.19.0-bullseye-slim AS builder
+FROM node:22.20.0-bullseye-slim AS builder
 ENV PNPM_HOME=/root/.local/share/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 ENV HUSKY=0
@@ -21,7 +21,7 @@ RUN pnpm install --frozen-lockfile --filter @proompteng/bonjour...
 COPY packages/bonjour packages/bonjour
 RUN pnpm --filter @proompteng/bonjour build
 
-FROM node:22.19.0-bullseye-slim AS prod-deps
+FROM node:22.20.0-bullseye-slim AS prod-deps
 ENV PNPM_HOME=/root/.local/share/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 ENV HUSKY=0
@@ -34,7 +34,7 @@ COPY packages/bonjour/package.json packages/bonjour/package.json
 
 RUN pnpm install --prod --frozen-lockfile --filter @proompteng/bonjour...
 
-FROM node:22.19.0-bullseye-slim AS runtime
+FROM node:22.20.0-bullseye-slim AS runtime
 ENV NODE_ENV=production
 WORKDIR /opt/app
 


### PR DESCRIPTION
## Summary
- bump engines.node to 22.20.0 and refresh LTS references in docs
- pin pnpm to 10.18.1 and update Docker base images to match
- keep repo tooling guidance consistent with the active stack

## Testing
- not run (docs-only)