### PR TITLE
fix: unblock facteur deployment

### DIFF
--- a/argocd/applications/facteur/overlays/cluster/secrets.yaml
+++ b/argocd/applications/facteur/overlays/cluster/secrets.yaml
@@ -1,5 +1,3 @@
-# Placeholder SealedSecrets for facteur Discord credentials and Redis DSN.
-# Replace `encryptedData` with output from `kubeseal` prior to enabling sync.
 ---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
@@ -8,24 +6,9 @@ metadata:
   namespace: facteur
 spec:
   encryptedData:
-    bot-token: PLACEHOLDER
-    application-id: PLACEHOLDER
+    application-id: AgCnUNUzR4nBwXRnkfzcasUHOepRAIa+5Kr1CHfqHjLY9efLz16eAr0wuSnBHfvIu+TKoiQxLU3ib0aVZdLmPegtl8WCZnthQeb/bzW6CTU3c4ujtH7CCE6UKHPCn6x0+QkdJ4/pM03cxWFkN6M2tm5MoswDwklayrl7wqvtP6isdnggeeXxOrqIdUkiqUEgxWpKFzT4z3Q/nG0RYuYg83T2DE/zZqbgrtSkoPSK0ECCNCNvPntecv7kPC4SQ4Yc6rnqToGlbo19SsZujrleTVXyyrG0ArwMvKiVeJKIgirx1futWs9dRL8bdtMz2sbI21ByCD1qNDBvFC6RBCa/rZt2C9lT5+smPRc2MS7iDOp0vT/OY6YHtH+rnRXwkBYeBa1ExTuLiHui1dEY4Cp1Or6RkGiJQ56simvfeL8t0xuLRZL8kk8a8eHnJVrHKQQGDmiu4UwvoxMAqS+4hRWzyM9p4e1IiIhtxihNm4Z5xzc8z09uP2oR/XrrHNh0aPMOCAFTDNwmmwZ8L5g2luCnhlg0SBKmg8wQaHUvwiQP+v2XuRzMVYGy2C2lAzvhWlt0T7erPHXUbvBc6rKEgiGyXAqoc0ghvSWoPBw6B1vp7Yg2Ic75gDP/Gg4fdExqwiwud4tTZ3yIK7nmdsye7lWjqpwXaui5jahN7H2V3m3NhXXxLcaO6NMaGb/DHVnArxmpMtUhmqR8VtB7g2Fw07NRnlzPsQ7b
+    bot-token: AgCQNuXWSHA+HDQG1SX/NnxdkwwXaX6QKHASsTxVXrUN9bbuzY2jBmcX9FMm0faIO6Y0OaARs7kjoVD6ky3o13uzfv7hnf/l2SCBtZ+s6wkmtiFjUYrCRkXaTPOl+0up5GaadRGBenWPkY1M4ApHiitoX7aGvDdGNTiBiJygL6Gks7ZnjzHKPLAMtHntk02O+ZJzt9WlMqyg/Nr9N2OvL6JBSXEuczVo5XKSrHAjiuL9IJNWM/YmqNfdgeR13vCDqbUXwj9Id26r9QA7UfI9R3D63Gb3KIC6knK2yrT0/hlUMPsHnIx27d2JMa/tRunL0FA2V9Aq+5Wb7Gwsnbxm+zdwL2+LdlUiu4nDK59G1evq+kzPr7v/w1La5llMEbhx0D0uMfE5oJQkFX85Qt4yPVDZxRjOWzY4+MuEmWkdz/BsZL/qBpJEpcCDcxN6yw9KTaxstQOcTSK7dc5x8FmT/MZEpk3pCqu9ASnBrAaOGEy0obvIWKPiaQP17TSRdPahaB0jEZTpQ5eK79pSNWqoadO2MxDG+RFQYPixZvlkc5ni8Eeut2PbbePiQaqC0g80juU3dM2b/3ueituMuo/eeq6hXP+Qb4WUlRjkgnfhK+dqxvqeZBNPl7zMGvSpdAHlT0cvWKGCP8u0t8Qt+1hbFNyE/L3Lri/YWvzis78XR7vruQT9xMZ6l0zJNF6R7e39gS/0rNEtbcuJZ3bK1QJg0f/wyh5yP7pTkc2pk2Pj6pRWcBHJN9h/x2VomYH4ELFPIn25KWnlnvEsbCBBgCQdKHj7pFHZ8x4YSrY=
   template:
     metadata:
       name: facteur-discord
       namespace: facteur
-    type: Opaque
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: facteur-redis
-  namespace: facteur
-spec:
-  encryptedData:
-    url: PLACEHOLDER
-  template:
-    metadata:
-      name: facteur-redis
-      namespace: facteur
-    type: Opaque

--- a/kubernetes/facteur/base/service.yaml
+++ b/kubernetes/facteur/base/service.yaml
@@ -9,6 +9,7 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "100"
+        deploy.knative.dev/rollout: "2025-10-09T04:30:00Z"
     spec:
       serviceAccountName: facteur
       containers:

--- a/services/facteur/Dockerfile
+++ b/services/facteur/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 	CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags='-s -w' -o /out/facteur ./cmd/facteur
 
 FROM gcr.io/distroless/static-debian12:nonroot
-COPY --from=build /out/facteur /usr/local/bin/facteur
+COPY --from=build --chmod=0555 /out/facteur /usr/local/bin/facteur
 
 ENTRYPOINT ["/usr/local/bin/facteur"]
 CMD ["serve"]


### PR DESCRIPTION
## Summary
- reseal and commit the facteur Discord credentials while keeping the SealedSecret in-git
- remove the unused facteur Redis SealedSecret placeholder and keep facteur on manual sync
- ensure the distroless image copies the facteur binary with execute permissions so Knative can launch it after syncs

## Testing
- docker build -t facteur-test -f services/facteur/Dockerfile .
- kubectl apply -k argocd/applications/facteur/overlays/cluster
- argocd app sync facteur