### PR TITLE
fix: force facteur to pull new image

### DIFF
--- a/kubernetes/facteur/base/service.yaml
+++ b/kubernetes/facteur/base/service.yaml
@@ -9,13 +9,13 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "100"
-        deploy.knative.dev/rollout: "2025-10-09T04:30:00Z"
+        deploy.knative.dev/rollout: "2025-10-09T05:05:00Z"
     spec:
       serviceAccountName: facteur
       containers:
         - name: facteur
           image: registry.ide-newton.ts.net/lab/facteur:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
               name: http1

--- a/services/facteur/Dockerfile
+++ b/services/facteur/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 COPY ${SERVICE_PATH}/ ./
 RUN --mount=type=cache,target=/go/pkg/mod \
-	CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags='-s -w' -o /out/facteur ./cmd/facteur
+	CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags='-s -w' -o /out/facteur .
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build --chmod=0555 /out/facteur /usr/local/bin/facteur


### PR DESCRIPTION
## Summary
- set the facteur Knative Service to always pull its image and bump the rollout annotation so Knative makes a fresh revision
- update the Dockerfile to build the root module (not the library package) so the resulting binary is a real executable on arm64

## Testing
- docker build -t facteur-test -f services/facteur/Dockerfile .
- kubectl apply -k kubernetes/facteur/overlays/cluster
- argocd app sync facteur