### PR TITLE
fix: align facteur service probes

### DIFF
--- a/kubernetes/facteur/base/service.yaml
+++ b/kubernetes/facteur/base/service.yaml
@@ -19,6 +19,7 @@ spec:
           ports:
             - containerPort: 8080
               name: http1
+              protocol: TCP
           env:
             - name: FACTEUR_CONFIG_FILE
               value: /config/config.yaml
@@ -38,6 +39,10 @@ spec:
               value: argo
             - name: FACTEUR_ARGO_WORKFLOW_TEMPLATE
               value: facteur-dispatch
+          readinessProbe:
+            successThreshold: 1
+            tcpSocket:
+              port: http1
           resources:
             requests:
               cpu: 50m
@@ -48,6 +53,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
+              readOnly: true
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
## Summary
- add the tcp socket readiness probe to the facteur Knative Service manifest
- mark the config volume mount read-only to match the live configuration
- keep the container port protocol explicit so ArgoCD stops flagging defaults

## Testing
- kubectl apply -k kubernetes/facteur/overlays/cluster
- argocd app sync facteur