### PR TITLE
feat: run codex automation in full auto mode

### DIFF
--- a/apps/froussard/scripts/codex-implement.sh
+++ b/apps/froussard/scripts/codex-implement.sh
@@ -180,7 +180,7 @@ if [[ "$DISCORD_READY" -eq 1 ]]; then
   fi
   set +e
   set +o pipefail
-  printf '%s' "$CODEX_PROMPT" | codex exec --dangerously-bypass-approvals-and-sandbox --json --output-last-message "$OUTPUT_PATH" - \
+  printf '%s' "$CODEX_PROMPT" | codex exec --full-auto --dangerously-bypass-approvals-and-sandbox --json --output-last-message "$OUTPUT_PATH" - \
     | tee >(cat >"$JSON_OUTPUT_PATH") \
     | jq -r 'select(.type == "item.completed" and .item.type == "agent_message") | .item.text // empty' \
     | tee >("${relay_cmd[@]}" "${relay_args[@]}") >(cat >"$AGENT_OUTPUT_PATH")
@@ -210,7 +210,7 @@ if [[ "$DISCORD_READY" -eq 1 ]]; then
 else
   set +e
   set +o pipefail
-  printf '%s' "$CODEX_PROMPT" | codex exec --dangerously-bypass-approvals-and-sandbox --json --output-last-message "$OUTPUT_PATH" - \
+  printf '%s' "$CODEX_PROMPT" | codex exec --full-auto --dangerously-bypass-approvals-and-sandbox --json --output-last-message "$OUTPUT_PATH" - \
     | tee >(cat >"$JSON_OUTPUT_PATH") \
     | jq -r 'select(.type == "item.completed" and .item.type == "agent_message") | .item.text // empty' \
     | tee >(cat >"$AGENT_OUTPUT_PATH")

--- a/apps/froussard/scripts/codex-plan.sh
+++ b/apps/froussard/scripts/codex-plan.sh
@@ -132,7 +132,7 @@ if [[ "$DISCORD_READY" -eq 1 ]]; then
   fi
   set +e
   set +o pipefail
-  printf '%s' "$PROMPT" | codex exec --dangerously-bypass-approvals-and-sandbox --json --output-last-message "$OUTPUT_PATH" - \
+  printf '%s' "$PROMPT" | codex exec --full-auto --dangerously-bypass-approvals-and-sandbox --json --output-last-message "$OUTPUT_PATH" - \
     | tee >(cat >"$JSON_OUTPUT_PATH") \
     | jq -r 'select(.type == "item.completed" and .item.type == "agent_message") | .item.text // empty' \
     | tee >("${relay_cmd[@]}" "${relay_args[@]}") >(cat >"$AGENT_OUTPUT_PATH")
@@ -162,7 +162,7 @@ if [[ "$DISCORD_READY" -eq 1 ]]; then
 else
   set +e
   set +o pipefail
-  printf '%s' "$PROMPT" | codex exec --dangerously-bypass-approvals-and-sandbox --json --output-last-message "$OUTPUT_PATH" - \
+  printf '%s' "$PROMPT" | codex exec --full-auto --dangerously-bypass-approvals-and-sandbox --json --output-last-message "$OUTPUT_PATH" - \
     | tee >(cat >"$JSON_OUTPUT_PATH") \
     | jq -r 'select(.type == "item.completed" and .item.type == "agent_message") | .item.text // empty' \
     | tee >(cat >"$AGENT_OUTPUT_PATH")

--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -104,7 +104,7 @@ Codex sessions are stored locally under `~/.codex/auth.json`. When recreating th
    - Optional flags: `--workspace <name>`, `--auth <path>`, `--config <path>`, `--remote-home <path>`, `--remote-repo <path>`.
      - The script checks for both `rsync` and the OpenSSH client locally and will exit early if either is missing.
    - By default the script consumes `scripts/codex-config-template.toml` (no MCP stanza) and renders it for the remote paths, so `/home/coder` and `/home/coder/github.com/lab` remain trusted on Ubuntu. Supply `--config <path>` if you need a different template.
-   - After syncing it installs a shell wrapper function in `~/.profile`, `~/.bashrc`, and `~/.zshrc` so running `codex …` automatically expands to `codex --dangerously-bypass-approvals-and-sandbox --search --model gpt-5-codex …` without shadowing the binary.
+   - After syncing it installs a shell wrapper function in `~/.profile`, `~/.bashrc`, and `~/.zshrc` so running `codex …` automatically expands to `codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5-codex …` without shadowing the binary.
    - Both files are locked down with `chmod 600` after transfer.
 3. Verify on the remote host if desired:
    ```bash

--- a/scripts/sync-codex-cli.sh
+++ b/scripts/sync-codex-cli.sh
@@ -169,7 +169,7 @@ ssh "${ssh_opts[@]}" "$coder_host" "chmod 600 $(shell_escape "$remote_config")"
 ssh "${ssh_opts[@]}" "$coder_host" bash -s <<'REMOTE'
 set -euo pipefail
 codex_marker="# Managed by sync-codex-cli codex wrapper"
-codex_function=$'codex() {\n  command codex --dangerously-bypass-approvals-and-sandbox --search --model gpt-5-codex "$@"\n}'
+codex_function=$'codex() {\n  command codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5-codex "$@"\n}'
 for rc in ~/.profile ~/.bashrc ~/.zshrc; do
   touch "${rc}"
   tmp="$(mktemp)"


### PR DESCRIPTION
## Summary
- add `--full-auto` to Codex planning and implementation pipelines (Discord + non-Discord)
- ensure the `sync-codex-cli.sh` wrapper prepends `--full-auto`
- refresh the coder bootstrap docs to mention the new flag

## Validation
- shellcheck apps/froussard/scripts/codex-plan.sh apps/froussard/scripts/codex-implement.sh scripts/sync-codex-cli.sh
- pnpm run format
- pnpm run lint:proompteng *(fails: Biome flags existing @custom-variant/@theme/@apply rules and static ids in apps/proompteng; outside this issue scope)*
- pnpm run build:proompteng

Closes #1291