### PR TITLE
feat: bootstrap facteur vector knowledge base

### DIFF
--- a/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
@@ -24,9 +24,10 @@ spec:
       owner: facteur
       dataChecksums: true
       encoding: "UTF8"
-      postInitApplicationSQL:
+      postInitSQL:
         - CREATE EXTENSION IF NOT EXISTS vector;
         - CREATE EXTENSION IF NOT EXISTS pgcrypto;
+      postInitApplicationSQL:
         - |
           CREATE SCHEMA IF NOT EXISTS codex_kb AUTHORIZATION facteur;
         - |

--- a/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: facteur-vector-cluster
+  namespace: facteur
+spec:
+  imageName: registry.ide-newton.ts.net/lab/vecteur:16
+  imagePullPolicy: Always
+  instances: 3
+  resources:
+    requests:
+      cpu: "1"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "1Gi"
+  storage:
+    storageClass: longhorn
+    size: 20Gi
+  bootstrap:
+    initdb:
+      database: facteur_kb
+      owner: facteur
+      dataChecksums: true
+      encoding: "UTF8"
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector;
+        - CREATE EXTENSION IF NOT EXISTS pgcrypto;
+        - |
+          CREATE SCHEMA IF NOT EXISTS codex_kb AUTHORIZATION facteur;
+        - |
+          CREATE TABLE IF NOT EXISTS codex_kb.runs (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            repo_slug TEXT NOT NULL,
+            issue_number INTEGER NOT NULL,
+            workflow TEXT NOT NULL,
+            run_started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            run_completed_at TIMESTAMPTZ,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+          );
+        - |
+          CREATE TABLE IF NOT EXISTS codex_kb.entries (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            run_id UUID NOT NULL REFERENCES codex_kb.runs(id) ON DELETE CASCADE,
+            step_label TEXT NOT NULL,
+            artifact_type TEXT NOT NULL,
+            artifact_stage TEXT NOT NULL,
+            embedding vector(1536),
+            content TEXT NOT NULL,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+          );
+        - |
+          CREATE INDEX IF NOT EXISTS codex_kb_entries_embedding_idx
+          ON codex_kb.entries
+          USING ivfflat (embedding vector_cosine_ops)
+          WITH (lists = 100);
+        - |
+          GRANT USAGE ON SCHEMA codex_kb TO facteur;
+        - |
+          ALTER DEFAULT PRIVILEGES IN SCHEMA codex_kb
+          GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO facteur;

--- a/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
@@ -41,6 +41,8 @@ spec:
             created_at TIMESTAMPTZ NOT NULL DEFAULT now()
           );
         - |
+          ALTER TABLE codex_kb.runs OWNER TO facteur;
+        - |
           CREATE TABLE IF NOT EXISTS codex_kb.entries (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
             run_id UUID NOT NULL REFERENCES codex_kb.runs(id) ON DELETE CASCADE,
@@ -53,12 +55,17 @@ spec:
             created_at TIMESTAMPTZ NOT NULL DEFAULT now()
           );
         - |
+          ALTER TABLE codex_kb.entries OWNER TO facteur;
+        - |
           CREATE INDEX IF NOT EXISTS codex_kb_entries_embedding_idx
           ON codex_kb.entries
           USING ivfflat (embedding vector_cosine_ops)
           WITH (lists = 100);
         - |
           GRANT USAGE ON SCHEMA codex_kb TO facteur;
+        - |
+          GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA codex_kb
+          TO facteur;
         - |
           ALTER DEFAULT PRIVILEGES IN SCHEMA codex_kb
           GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO facteur;

--- a/argocd/applications/facteur/overlays/cluster/kustomization.yaml
+++ b/argocd/applications/facteur/overlays/cluster/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ../../base
   - secrets.yaml
+  - facteur-vector-cluster.yaml

--- a/docs/facteur-discord-argo.md
+++ b/docs/facteur-discord-argo.md
@@ -49,6 +49,20 @@ The role map controls which Discord roles can invoke specific commands. Schema d
 - `kubernetes/facteur/base/redis.yaml` provisions an in-cluster Redis instance via the OT-Container-Kit Redis Operator; confirm the platform `redis-operator` Application stays healthy before syncing facteur.
 - Argo CD applications reside in `argocd/applications/facteur` and are referenced by `argocd/applicationsets/product.yaml` so the automation discovers and syncs the service.
 
+## Codex knowledge base persistence
+
+Facteur now owns a dedicated CloudNativePG cluster so Codex automation can persist the artefacts generated during `plan` → `implement` → `review` runs.
+
+- Cluster: `facteur-vector-cluster` (namespace `facteur`) running `registry.ide-newton.ts.net/lab/vecteur:16`, three instances, 20&nbsp;Gi Longhorn volumes with data checksums enabled.
+- Database: `facteur_kb`, owned by the `facteur` role. The bootstrap routine enables the `pgcrypto` and `vector` extensions before seeding schema objects.
+- Connection secret: `facteur-vector-cluster-app` (namespace `facteur`). It follows the standard CloudNativePG app secret contract (`host`, `port`, `dbname`, `user`, `password`, `uri`). Mount or template this secret into consuming workloads to hydrate Codex clients.
+- Schema: `codex_kb` with two tables.
+  - `runs` – UUID primary key (defaults to `gen_random_uuid()`), stores `repo_slug`, `issue_number`, `workflow`, lifecycle timestamps, and JSONB `metadata`. Intended to capture one Codex execution per issue/workflow combination.
+  - `entries` – UUID primary key with a foreign key to `runs.id`, carries `step_label`, `artifact_type`, `artifact_stage`, free-form `content`, JSONB `metadata`, and a `vector(1536)` embedding column. An IVFFLAT index (`codex_kb_entries_embedding_idx`, cosine distance, 100 lists) accelerates similarity search.
+- Privileges: the bootstrap script grants the `facteur` role usage on the schema plus default table privileges so new objects remain writeable without extra migrations.
+
+Future changes to the embedding dimensionality will require `ALTER TABLE codex_kb.entries ALTER COLUMN embedding TYPE vector(<new_dim>)` followed by `REINDEX INDEX codex_kb_entries_embedding_idx`.
+
 ## Initial command contract
 
 The first public cut will ship three Discord slash commands that map to the existing workflow submission bridge. All commands run against the configured `argo.workflow_template`; the dispatcher injects an `action` parameter that mirrors the command name, and the Discord option names become workflow parameters after merging with static defaults defined under `argo.parameters`. The dispatcher still prefixes workflow names with the command that was invoked so we can trace intent in Argo.

--- a/docs/facteur-discord-argo.md
+++ b/docs/facteur-discord-argo.md
@@ -59,7 +59,7 @@ Facteur now owns a dedicated CloudNativePG cluster so Codex automation can persi
 - Schema: `codex_kb` with two tables.
   - `runs` – UUID primary key (defaults to `gen_random_uuid()`), stores `repo_slug`, `issue_number`, `workflow`, lifecycle timestamps, and JSONB `metadata`. Intended to capture one Codex execution per issue/workflow combination.
   - `entries` – UUID primary key with a foreign key to `runs.id`, carries `step_label`, `artifact_type`, `artifact_stage`, free-form `content`, JSONB `metadata`, and a `vector(1536)` embedding column. An IVFFLAT index (`codex_kb_entries_embedding_idx`, cosine distance, 100 lists) accelerates similarity search.
-- Privileges: the bootstrap script grants the `facteur` role usage on the schema plus default table privileges so new objects remain writeable without extra migrations.
+- Privileges: the bootstrap script assigns ownership of `runs` and `entries` to the `facteur` role, grants schema usage, applies direct CRUD privileges on existing tables, and sets default table grants so future objects remain writeable without extra migrations.
 
 Future changes to the embedding dimensionality will require `ALTER TABLE codex_kb.entries ALTER COLUMN embedding TYPE vector(<new_dim>)` followed by `REINDEX INDEX codex_kb_entries_embedding_idx`.
 


### PR DESCRIPTION
## Summary
- add CloudNativePG cluster overlay for Facteur with vecteur image and pgcrypto/vector extensions
- seed codex_kb.runs and codex_kb.entries tables with facteur ownership and grants for Codex automation
- document the facteur-vector-cluster-app secret contract and schema usage expectations

## Validation
- `kustomize build argocd/applications/facteur/overlays/cluster | kubeconform -summary -strict` *(fails on upstream CRDs without published schemas; reran with `--ignore-missing-schemas` to confirm native resources)*
- `kustomize build argocd/applications/facteur/overlays/cluster | kubeconform -summary -strict --ignore-missing-schemas`
- `yamllint argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml`

Closes #1305