### PR TITLE
fix: align kafka webhook selector

### DIFF
--- a/argocd/applications/knative-eventing/kustomization.yaml
+++ b/argocd/applications/knative-eventing/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - knative-eventing.yaml
   - https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.19.7/eventing-kafka-controller.yaml
   - https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.19.7/eventing-kafka-source.yaml
+patchesStrategicMerge:
+  - mutating-webhook-namespace-selector-patch.yaml

--- a/argocd/applications/knative-eventing/mutating-webhook-namespace-selector-patch.yaml
+++ b/argocd/applications/knative-eventing/mutating-webhook-namespace-selector-patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: pods.defaulting.webhook.kafka.eventing.knative.dev
+webhooks:
+  - name: pods.defaulting.webhook.kafka.eventing.knative.dev
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kafka-webhook-eventing
+        namespace: knative-eventing
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: webhooks.knative.dev/exclude
+          operator: DoesNotExist
+      matchLabels:
+        kubernetes.io/metadata.name: knative-eventing


### PR DESCRIPTION
## Summary
- add strategic merge patch so webhook namespace selector matches controller-managed state
- ensure Argo CD renders the webhooks.knative.dev/exclude matchExpression to avoid drift

## Testing
- not run (manifest change only)
