### PR TITLE
build: add vecteur pgvector image builder

### DIFF
--- a/.github/workflows/vecteur-manual-build-push.yaml
+++ b/.github/workflows/vecteur-manual-build-push.yaml
@@ -1,0 +1,50 @@
+name: Vecteur Manual Build and Push
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Tag to publish (e.g., pg18-trixie)'
+        required: true
+        default: 'pg18-trixie'
+      platforms:
+        description: 'Comma-separated platforms to build (default: linux/arm64)'
+        required: false
+        default: 'linux/arm64'
+
+jobs:
+  build-and-push:
+    runs-on: arc-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: registry.ide-newton.ts.net/lab/vecteur
+          tags: |
+            type=raw,value=${{ inputs.image_tag }}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/vecteur
+          file: services/vecteur/Dockerfile
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/vecteur:latest
+          cache-to: type=inline

--- a/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: facteur-vector-cluster
   namespace: facteur
 spec:
-  imageName: registry.ide-newton.ts.net/lab/vecteur:16
+  imageName: registry.ide-newton.ts.net/lab/vecteur:pg18-trixie
   imagePullPolicy: Always
   instances: 3
   resources:

--- a/docs/facteur-discord-argo.md
+++ b/docs/facteur-discord-argo.md
@@ -53,7 +53,7 @@ The role map controls which Discord roles can invoke specific commands. Schema d
 
 Facteur now owns a dedicated CloudNativePG cluster so Codex automation can persist the artefacts generated during `plan` → `implement` → `review` runs.
 
-- Cluster: `facteur-vector-cluster` (namespace `facteur`) running `registry.ide-newton.ts.net/lab/vecteur:16`, three instances, 20&nbsp;Gi Longhorn volumes with data checksums enabled.
+- Cluster: `facteur-vector-cluster` (namespace `facteur`) running `registry.ide-newton.ts.net/lab/vecteur:pg18-trixie`, three instances, 20&nbsp;Gi Longhorn volumes with data checksums enabled.
 - Database: `facteur_kb`, owned by the `facteur` role. The bootstrap routine enables the `pgcrypto` and `vector` extensions before seeding schema objects.
 - Connection secret: `facteur-vector-cluster-app` (namespace `facteur`). It follows the standard CloudNativePG app secret contract (`host`, `port`, `dbname`, `user`, `password`, `uri`). Mount or template this secret into consuming workloads to hydrate Codex clients.
 - Schema: `codex_kb` with two tables.

--- a/scripts/build-vecteur.sh
+++ b/scripts/build-vecteur.sh
@@ -4,15 +4,14 @@
 IMAGE_NAME="registry.ide-newton.ts.net/lab/vecteur"
 DOCKERFILE="services/vecteur/Dockerfile"
 CONTEXT_PATH="services/vecteur"
-
+DEFAULT_TAG="pg18-trixie"
 TARGETARCH="arm64"
 
 # Check if a tag is provided as an argument
 if [ $# -eq 1 ]; then
     TAG=$1
 else
-    # If no tag is provided, use the current date and time
-    TAG=$(date +"%Y%m%d_%H%M%S")
+    TAG="${DEFAULT_TAG}"
 fi
 
 # Full image name with tag

--- a/services/vecteur/Dockerfile
+++ b/services/vecteur/Dockerfile
@@ -1,0 +1,19 @@
+ARG PG_MAJOR=18
+ARG RELEASE=202509290807
+ARG FLAVOR=minimal
+ARG OS=trixie
+
+FROM ghcr.io/cloudnative-pg/postgresql:${PG_MAJOR}.0-${RELEASE}-${FLAVOR}-${OS}
+
+ARG PG_MAJOR
+
+USER root
+
+RUN set -euxo pipefail \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    postgresql-${PG_MAJOR}-pgvector \
+  && rm -rf /var/lib/apt/lists/*
+
+USER 26


### PR DESCRIPTION
## Summary
- add vecteur Dockerfile based on the CNPG Postgres 18 minimal trixie image with pgvector installed
- default the vecteur build script and cluster manifest/docs to the new pg18-trixie tag
- add a manual GitHub Actions workflow to build and push the vecteur image on demand

## Testing
- ./scripts/build-vecteur.sh
