### PR TITLE
fix: align vecteur image tag and knative env

### DIFF
--- a/.github/workflows/vecteur-manual-build-push.yaml
+++ b/.github/workflows/vecteur-manual-build-push.yaml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Tag to publish (e.g., pg18-trixie)'
+        description: 'Tag to publish (e.g., 18-trixie)'
         required: true
-        default: 'pg18-trixie'
+        default: '18-trixie'
       platforms:
         description: 'Comma-separated platforms to build (default: linux/arm64)'
         required: false

--- a/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-vector-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: facteur-vector-cluster
   namespace: facteur
 spec:
-  imageName: registry.ide-newton.ts.net/lab/vecteur:pg18-trixie
+  imageName: registry.ide-newton.ts.net/lab/vecteur:18-trixie
   imagePullPolicy: Always
   instances: 3
   resources:

--- a/docs/facteur-discord-argo.md
+++ b/docs/facteur-discord-argo.md
@@ -53,7 +53,7 @@ The role map controls which Discord roles can invoke specific commands. Schema d
 
 Facteur now owns a dedicated CloudNativePG cluster so Codex automation can persist the artefacts generated during `plan` → `implement` → `review` runs.
 
-- Cluster: `facteur-vector-cluster` (namespace `facteur`) running `registry.ide-newton.ts.net/lab/vecteur:pg18-trixie`, three instances, 20&nbsp;Gi Longhorn volumes with data checksums enabled.
+- Cluster: `facteur-vector-cluster` (namespace `facteur`) running `registry.ide-newton.ts.net/lab/vecteur:18-trixie`, three instances, 20&nbsp;Gi Longhorn volumes with data checksums enabled.
 - Database: `facteur_kb`, owned by the `facteur` role. The bootstrap routine enables the `pgcrypto` and `vector` extensions before seeding schema objects.
 - Connection secret: `facteur-vector-cluster-app` (namespace `facteur`). It follows the standard CloudNativePG app secret contract (`host`, `port`, `dbname`, `user`, `password`, `uri`). Mount or template this secret into consuming workloads to hydrate Codex clients.
 - Schema: `codex_kb` with two tables.

--- a/kubernetes/facteur/base/service.yaml
+++ b/kubernetes/facteur/base/service.yaml
@@ -42,9 +42,7 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: facteur
             - name: OTEL_SERVICE_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: facteur
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
               value: http/protobuf
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT

--- a/scripts/build-vecteur.sh
+++ b/scripts/build-vecteur.sh
@@ -4,7 +4,7 @@
 IMAGE_NAME="registry.ide-newton.ts.net/lab/vecteur"
 DOCKERFILE="services/vecteur/Dockerfile"
 CONTEXT_PATH="services/vecteur"
-DEFAULT_TAG="pg18-trixie"
+DEFAULT_TAG="18-trixie"
 TARGETARCH="arm64"
 
 # Check if a tag is provided as an argument


### PR DESCRIPTION
## Summary
- retag vecteur image to PostgreSQL-major-prefixed format to satisfy CNPG validation
- update facteur Knative env config and docs to match new tag
- refresh manual workflow defaults for building the vecteur image

## Testing
- scripts/build-vecteur.sh
- kubectl kustomize argocd/applications/facteur/overlays/cluster