### PR TITLE
refactor: migrate froussard services onto effect runtime

### DIFF
--- a/.github/workflows/froussard-ci.yml
+++ b/.github/workflows/froussard-ci.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run Biome check
+        run: pnpm exec biome check apps/froussard
+
       - name: Run froussard tests
         run: pnpm --filter froussard run test

--- a/apps/froussard/package.json
+++ b/apps/froussard/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@elysiajs/eden": "^1.4.1",
+    "@octokit/webhooks": "^14.1.3",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.53.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.55.0",
@@ -22,8 +23,8 @@
     "@opentelemetry/sdk-metrics": "^1.28.0",
     "@opentelemetry/sdk-node": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
-    "@octokit/webhooks": "^14.1.3",
     "discord-interactions": "^4.3.0",
+    "effect": "^3.18.4",
     "elysia": "^1.4.9",
     "kafkajs": "^2.2.4",
     "pino": "^9.12.0",

--- a/apps/froussard/scripts/discord-relay.ts
+++ b/apps/froussard/scripts/discord-relay.ts
@@ -1,12 +1,12 @@
 import process from 'node:process'
-import {
-  DISCORD_MESSAGE_LIMIT,
-  bootstrapRelay,
-  iterableFromStream,
-  relayStream,
-  type RelayMetadata,
-} from '../src/discord'
 import type { DiscordConfig } from '../src/discord'
+import {
+  bootstrapRelay,
+  DISCORD_MESSAGE_LIMIT,
+  iterableFromStream,
+  type RelayMetadata,
+  relayStream,
+} from '../src/discord'
 
 interface ParsedArgs {
   stage?: string

--- a/apps/froussard/src/codex.test.ts
+++ b/apps/froussard/src/codex.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  PLAN_COMMENT_MARKER,
-  PROGRESS_COMMENT_MARKER,
   buildCodexBranchName,
   buildCodexPrompt,
   normalizeLogin,
+  PLAN_COMMENT_MARKER,
+  PROGRESS_COMMENT_MARKER,
   sanitizeBranchComponent,
 } from './codex'
 

--- a/apps/froussard/src/codex/cli/__tests__/build-codex-image.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/build-codex-image.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runBuildCodexImage } from '../build-codex-image'
 
 const bunMocks = vi.hoisted(() => {

--- a/apps/froussard/src/codex/cli/__tests__/codex-bootstrap.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-bootstrap.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { mkdtemp, mkdir, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import process from 'node:process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runCodexBootstrap } from '../codex-bootstrap'
 
 const bunMocks = vi.hoisted(() => {

--- a/apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runCodexImplementation } from '../codex-implement'
 
 const utilMocks = vi.hoisted(() => ({

--- a/apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
@@ -92,10 +92,15 @@ describe('runCodexImplementation', () => {
     const invocation = runCodexSessionMock.mock.calls[0]?.[0]
     expect(invocation?.stage).toBe('implementation')
     expect(invocation?.outputPath).toBe(join(workdir, '.codex-implementation.log'))
+    expect(invocation?.logger).toBeDefined()
     expect(pushCodexEventsToLokiMock).toHaveBeenCalledWith(
-      'implementation',
-      join(workdir, '.codex-implementation-events.jsonl'),
-      'http://localhost/loki',
+      expect.objectContaining({
+        stage: 'implementation',
+        endpoint: 'http://localhost/loki',
+        jsonPath: join(workdir, '.codex-implementation-events.jsonl'),
+        agentLogPath: join(workdir, '.codex-implementation-agent.log'),
+        runtimeLogPath: join(workdir, '.codex-implementation-runtime.log'),
+      }),
     )
   })
 

--- a/apps/froussard/src/codex/cli/__tests__/codex-plan.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-plan.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runCodexPlan } from '../codex-plan'
 
 const utilMocks = vi.hoisted(() => ({

--- a/apps/froussard/src/codex/cli/__tests__/codex-plan.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-plan.test.ts
@@ -92,10 +92,15 @@ describe('runCodexPlan', () => {
     expect(invocation?.outputPath).toBe(join(workdir, '.codex-plan-output.md'))
     expect(invocation?.jsonOutputPath).toBe(join(workdir, '.codex-plan-events.jsonl'))
     expect(invocation?.agentOutputPath).toBe(join(workdir, '.codex-plan-agent.log'))
+    expect(invocation?.logger).toBeDefined()
     expect(pushCodexEventsToLokiMock).toHaveBeenCalledWith(
-      'planning',
-      join(workdir, '.codex-plan-events.jsonl'),
-      'http://localhost/loki',
+      expect.objectContaining({
+        stage: 'planning',
+        endpoint: 'http://localhost/loki',
+        jsonPath: join(workdir, '.codex-plan-events.jsonl'),
+        agentLogPath: join(workdir, '.codex-plan-agent.log'),
+        runtimeLogPath: join(workdir, '.codex-plan-runtime.log'),
+      }),
     )
   })
 

--- a/apps/froussard/src/codex/cli/__tests__/codex-progress-comment.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-progress-comment.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runCodexProgressComment } from '../codex-progress-comment'
 
 const bunMocks = vi.hoisted(() => {

--- a/apps/froussard/src/codex/cli/build-codex-image.ts
+++ b/apps/froussard/src/codex/cli/build-codex-image.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
-import { $, which } from 'bun'
 import { createHash } from 'node:crypto'
 import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
-import { runCli } from './lib/cli'
 import { fileURLToPath } from 'node:url'
+import { $, which } from 'bun'
+import { runCli } from './lib/cli'
 
 const pathExists = async (path: string) => {
   try {

--- a/apps/froussard/src/codex/cli/codex-bootstrap.ts
+++ b/apps/froussard/src/codex/cli/codex-bootstrap.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
-import { $, spawn, which } from 'bun'
-import { rm, mkdir, stat } from 'node:fs/promises'
+import { mkdir, rm, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
+import { $, spawn, which } from 'bun'
 import { runCli } from './lib/cli'
 
 const pathExists = async (path: string) => {

--- a/apps/froussard/src/codex/cli/codex-implement.ts
+++ b/apps/froussard/src/codex/cli/codex-implement.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env bun
-import process from 'node:process'
 import { readFile, stat } from 'node:fs/promises'
-import { runCodexSession, pushCodexEventsToLoki } from './lib/codex-runner'
+import process from 'node:process'
+import { runCli } from './lib/cli'
+import { pushCodexEventsToLoki, runCodexSession } from './lib/codex-runner'
 import {
+  buildDiscordRelayCommand,
+  copyAgentLogIfNeeded,
   pathExists,
   randomRunId,
   timestampUtc,
-  copyAgentLogIfNeeded,
-  buildDiscordRelayCommand,
 } from './lib/codex-utils'
-import { runCli } from './lib/cli'
 import { createCodexLogger } from './lib/logger'
 
 interface ImplementationEventPayload {

--- a/apps/froussard/src/codex/cli/codex-implement.ts
+++ b/apps/froussard/src/codex/cli/codex-implement.ts
@@ -10,6 +10,7 @@ import {
   buildDiscordRelayCommand,
 } from './lib/codex-utils'
 import { runCli } from './lib/cli'
+import { createCodexLogger } from './lib/logger'
 
 interface ImplementationEventPayload {
   prompt?: string
@@ -69,8 +70,11 @@ export const runCodexImplementation = async (eventPath: string) => {
   const outputPath = process.env.OUTPUT_PATH ?? defaultOutputPath
   const jsonOutputPath = process.env.JSON_OUTPUT_PATH ?? `${worktree}/.codex-implementation-events.jsonl`
   const agentOutputPath = process.env.AGENT_OUTPUT_PATH ?? `${worktree}/.codex-implementation-agent.log`
+  const runtimeLogPath = process.env.CODEX_RUNTIME_LOG_PATH ?? `${worktree}/.codex-implementation-runtime.log`
   const lokiEndpoint =
     process.env.LGTM_LOKI_ENDPOINT ?? 'http://lgtm-loki-gateway.lgtm.svc.cluster.local/loki/api/v1/push'
+  const lokiTenant = process.env.LGTM_LOKI_TENANT
+  const lokiBasicAuth = process.env.LGTM_LOKI_BASIC_AUTH
 
   const baseBranch = sanitizeNullableString(event.base) || process.env.BASE_BRANCH || 'main'
   const headBranch = sanitizeNullableString(event.head) || process.env.HEAD_BRANCH || ''
@@ -94,7 +98,7 @@ export const runCodexImplementation = async (eventPath: string) => {
   process.env.ISSUE_TITLE = issueTitle
 
   process.env.CODEX_STAGE = process.env.CODEX_STAGE ?? 'implementation'
-  process.env.RUST_LOG = process.env.RUST_LOG ?? 'codex_core=info,codex_exec=debug'
+  process.env.RUST_LOG = process.env.RUST_LOG ?? 'codex_core=info,codex_exec=info'
   process.env.RUST_BACKTRACE = process.env.RUST_BACKTRACE ?? '1'
 
   const relayScript = process.env.RELAY_SCRIPT ?? 'apps/froussard/scripts/discord-relay.ts'
@@ -103,76 +107,109 @@ export const runCodexImplementation = async (eventPath: string) => {
     process.env.CODEX_RELAY_RUN_ID ?? process.env.ARGO_WORKFLOW_NAME ?? process.env.ARGO_WORKFLOW_UID ?? randomRunId()
   const relayRunId = relayRunIdSource.slice(0, 24).toLowerCase()
 
-  let discordRelayCommand: string[] | undefined
-  const discordToken = process.env.DISCORD_BOT_TOKEN ?? ''
-  const discordGuild = process.env.DISCORD_GUILD_ID ?? ''
-  const discordScriptExists = await pathExists(relayScript)
-
-  if (discordToken && discordGuild && discordScriptExists) {
-    const args = [
-      '--stage',
-      'implementation',
-      '--repo',
+  const logger = await createCodexLogger({
+    logPath: runtimeLogPath,
+    context: {
+      stage: 'implementation',
       repository,
-      '--issue',
-      issueNumber,
-      '--timestamp',
-      relayTimestamp,
-    ]
-    if (relayRunId) {
-      args.push('--run-id', relayRunId)
-    }
-    if (issueTitle) {
-      args.push('--title', issueTitle)
-    }
-    if (process.env.DISCORD_RELAY_DRY_RUN === '1') {
-      args.push('--dry-run')
-    }
-    try {
-      discordRelayCommand = await buildDiscordRelayCommand(relayScript, args)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      console.error(`Discord relay disabled: ${message}`)
-    }
-  } else {
-    console.error('Discord relay disabled: missing credentials or relay script')
-  }
-
-  console.error(`Running Codex implementation for ${repository}#${issueNumber}`)
-
-  await runCodexSession({
-    stage: 'implementation',
-    prompt,
-    outputPath,
-    jsonOutputPath,
-    agentOutputPath,
-    discordRelay: discordRelayCommand
-      ? {
-          command: discordRelayCommand,
-          onError: (error) => console.error(`Discord relay failed: ${error.message}`),
-        }
-      : undefined,
+      issue: issueNumber,
+      workflow: process.env.ARGO_WORKFLOW_NAME ?? undefined,
+      namespace: process.env.ARGO_WORKFLOW_NAMESPACE ?? undefined,
+      run_id: relayRunId || undefined,
+    },
   })
 
-  await copyAgentLogIfNeeded(outputPath, agentOutputPath)
-  await pushCodexEventsToLoki('implementation', jsonOutputPath, lokiEndpoint)
-
-  console.log(`Codex execution logged to ${outputPath}`)
   try {
-    const jsonStats = await stat(jsonOutputPath)
-    if (jsonStats.size > 0) {
-      console.log(`Codex JSON events stored at ${jsonOutputPath}`)
-    }
-  } catch {
-    // ignore missing json log
-  }
+    let discordRelayCommand: string[] | undefined
+    const discordToken = process.env.DISCORD_BOT_TOKEN ?? ''
+    const discordGuild = process.env.DISCORD_GUILD_ID ?? ''
+    const discordScriptExists = await pathExists(relayScript)
 
-  return {
-    repository,
-    issueNumber,
-    outputPath,
-    jsonOutputPath,
-    agentOutputPath,
+    if (discordToken && discordGuild && discordScriptExists) {
+      const args = [
+        '--stage',
+        'implementation',
+        '--repo',
+        repository,
+        '--issue',
+        issueNumber,
+        '--timestamp',
+        relayTimestamp,
+      ]
+      if (relayRunId) {
+        args.push('--run-id', relayRunId)
+      }
+      if (issueTitle) {
+        args.push('--title', issueTitle)
+      }
+      if (process.env.DISCORD_RELAY_DRY_RUN === '1') {
+        args.push('--dry-run')
+      }
+      try {
+        discordRelayCommand = await buildDiscordRelayCommand(relayScript, args)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        logger.warn(`Discord relay disabled: ${message}`)
+      }
+    } else {
+      logger.warn('Discord relay disabled: missing credentials or relay script')
+    }
+
+    logger.info(`Running Codex implementation for ${repository}#${issueNumber}`)
+
+    await runCodexSession({
+      stage: 'implementation',
+      prompt,
+      outputPath,
+      jsonOutputPath,
+      agentOutputPath,
+      logger,
+      discordRelay: discordRelayCommand
+        ? {
+            command: discordRelayCommand,
+            onError: (error) => logger.error(`Discord relay failed: ${error.message}`),
+          }
+        : undefined,
+    })
+
+    await copyAgentLogIfNeeded(outputPath, agentOutputPath)
+    await pushCodexEventsToLoki({
+      stage: 'implementation',
+      endpoint: lokiEndpoint,
+      jsonPath: jsonOutputPath,
+      agentLogPath: agentOutputPath,
+      runtimeLogPath,
+      labels: {
+        repository,
+        issue: issueNumber,
+        workflow: process.env.ARGO_WORKFLOW_NAME ?? undefined,
+        namespace: process.env.ARGO_WORKFLOW_NAMESPACE ?? undefined,
+        run_id: relayRunId || undefined,
+      },
+      tenant: lokiTenant,
+      basicAuth: lokiBasicAuth,
+      logger,
+    })
+
+    console.log(`Codex execution logged to ${outputPath}`)
+    try {
+      const jsonStats = await stat(jsonOutputPath)
+      if (jsonStats.size > 0) {
+        console.log(`Codex JSON events stored at ${jsonOutputPath}`)
+      }
+    } catch {
+      // ignore missing json log
+    }
+
+    return {
+      repository,
+      issueNumber,
+      outputPath,
+      jsonOutputPath,
+      agentOutputPath,
+    }
+  } finally {
+    await logger.flush()
   }
 }
 

--- a/apps/froussard/src/codex/cli/codex-plan.ts
+++ b/apps/froussard/src/codex/cli/codex-plan.ts
@@ -1,18 +1,18 @@
 #!/usr/bin/env bun
-import process from 'node:process'
 import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { runCodexSession, pushCodexEventsToLoki } from './lib/codex-runner'
+import { join } from 'node:path'
+import process from 'node:process'
+import { runCli } from './lib/cli'
+import { pushCodexEventsToLoki, runCodexSession } from './lib/codex-runner'
 import {
-  pathExists,
+  buildDiscordRelayCommand,
+  copyAgentLogIfNeeded,
   parseBoolean,
+  pathExists,
   randomRunId,
   timestampUtc,
-  copyAgentLogIfNeeded,
-  buildDiscordRelayCommand,
 } from './lib/codex-utils'
-import { runCli } from './lib/cli'
 import { createCodexLogger } from './lib/logger'
 
 const dedent = (value: string) => {

--- a/apps/froussard/src/codex/cli/codex-progress-comment.ts
+++ b/apps/froussard/src/codex/cli/codex-progress-comment.ts
@@ -4,7 +4,7 @@ import { appendFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import process from 'node:process'
-import { ensureFileDirectory } from './lib/codex-runner'
+import { ensureFileDirectory } from './lib/fs'
 import { runCli } from './lib/cli'
 
 interface Options {

--- a/apps/froussard/src/codex/cli/codex-progress-comment.ts
+++ b/apps/froussard/src/codex/cli/codex-progress-comment.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env bun
-import { $, which } from 'bun'
 import { appendFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import process from 'node:process'
-import { ensureFileDirectory } from './lib/fs'
+import { $, which } from 'bun'
 import { runCli } from './lib/cli'
+import { ensureFileDirectory } from './lib/fs'
 
 interface Options {
   bodyFile?: string

--- a/apps/froussard/src/codex/cli/lib/__tests__/cli.test.ts
+++ b/apps/froussard/src/codex/cli/lib/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from 'vitest'
 import process from 'node:process'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isMainModule, runCli } from '../cli'
 
 describe('isMainModule', () => {

--- a/apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
+++ b/apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { runCodexSession, pushCodexEventsToLoki } from '../codex-runner'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { pushCodexEventsToLoki, runCodexSession } from '../codex-runner'
 
 const bunGlobals = vi.hoisted(() => {
   const spawn = vi.fn()

--- a/apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
+++ b/apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
@@ -134,12 +134,67 @@ describe('codex-runner', () => {
     const fetchMock = vi.fn(async () => ({ ok: true }))
     global.fetch = fetchMock as unknown as typeof fetch
 
-    await pushCodexEventsToLoki('planning', jsonPath, 'https://loki.example.com/api/v1/push')
+    await pushCodexEventsToLoki({
+      stage: 'planning',
+      endpoint: 'https://loki.example.com/api/v1/push',
+      jsonPath,
+    })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const body = (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.body
     expect(typeof body).toBe('string')
-    expect(body as string).toContain('codex-exec')
+    const payload = JSON.parse(body as string)
+    expect(Array.isArray(payload.streams)).toBe(true)
+    expect(payload.streams[0]?.stream).toMatchObject({ stage: 'planning', stream_type: 'json' })
+  })
+
+  it('pushes agent and runtime logs and applies tenant headers when provided', async () => {
+    const jsonPath = join(workspace, 'events.jsonl')
+    const agentPath = join(workspace, 'agent.log')
+    const runtimePath = join(workspace, 'runtime.log')
+
+    await writeFile(jsonPath, JSON.stringify({ type: 'info', detail: 'queued' }), 'utf8')
+    await writeFile(agentPath, 'Agent says hello\nAnother line', 'utf8')
+    await writeFile(runtimePath, 'runtime started\nruntime finished', 'utf8')
+
+    const fetchMock = vi.fn(async () => ({ ok: true }))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await pushCodexEventsToLoki({
+      stage: 'implementation',
+      endpoint: 'https://loki.example.com/api/v1/push',
+      jsonPath,
+      agentLogPath: agentPath,
+      runtimeLogPath: runtimePath,
+      tenant: 'lab',
+      basicAuth: 'token-123',
+      labels: {
+        repository: 'owner/repo',
+        issue: '42',
+      },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, options] = fetchMock.mock.calls[0] ?? []
+    const headers = options?.headers as Record<string, string>
+    expect(headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'X-Scope-OrgID': 'lab',
+      Authorization: 'Basic token-123',
+    })
+
+    const bodyRaw = options?.body as string
+    const payload = JSON.parse(bodyRaw)
+    expect(payload.streams).toHaveLength(3)
+    const sources = payload.streams.map((item: { stream: { source: string } }) => item.stream.source).sort()
+    expect(sources).toEqual(['codex-agent', 'codex-events', 'codex-runtime'])
+    const runtimeStream = payload.streams.find(
+      (item: { stream: { stream_type: string } }) => item.stream.stream_type === 'runtime',
+    )
+    expect(runtimeStream).toBeDefined()
+    expect(runtimeStream.stream.repository).toBe('owner/repo')
+    expect(runtimeStream.stream.issue).toBe('42')
+    expect(runtimeStream.values[0][1]).toBe('runtime started')
   })
 
   it('throws when Codex exits with a non-zero status', async () => {
@@ -201,7 +256,11 @@ describe('codex-runner', () => {
     const fetchMock = vi.fn()
     global.fetch = fetchMock as unknown as typeof fetch
 
-    await pushCodexEventsToLoki('planning', join(workspace, 'missing.jsonl'), 'https://loki.example.com/api/v1/push')
+    await pushCodexEventsToLoki({
+      stage: 'planning',
+      endpoint: 'https://loki.example.com/api/v1/push',
+      jsonPath: join(workspace, 'missing.jsonl'),
+    })
 
     expect(fetchMock).not.toHaveBeenCalled()
   })

--- a/apps/froussard/src/codex/cli/lib/__tests__/codex-utils.test.ts
+++ b/apps/froussard/src/codex/cli/lib/__tests__/codex-utils.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const whichMock = vi.hoisted(() => vi.fn(async () => '/usr/local/bin/bun'))
 

--- a/apps/froussard/src/codex/cli/lib/__tests__/logger.test.ts
+++ b/apps/froussard/src/codex/cli/lib/__tests__/logger.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
-import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createCodexLogger } from '../logger'
 
 describe('createCodexLogger', () => {

--- a/apps/froussard/src/codex/cli/lib/__tests__/logger.test.ts
+++ b/apps/froussard/src/codex/cli/lib/__tests__/logger.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createCodexLogger } from '../logger'
+
+describe('createCodexLogger', () => {
+  const originalLog = console.log
+  const originalWarn = console.warn
+  const originalError = console.error
+  const originalDebug = console.debug
+
+  let workspace: string
+  let logPath: string
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'codex-logger-test-'))
+    logPath = join(workspace, 'runtime.log')
+    console.log = vi.fn()
+    console.warn = vi.fn()
+    console.error = vi.fn()
+    console.debug = vi.fn()
+  })
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true })
+    console.log = originalLog
+    console.warn = originalWarn
+    console.error = originalError
+    console.debug = originalDebug
+  })
+
+  it('writes structured log entries with context and flushes the stream', async () => {
+    const logger = await createCodexLogger({
+      logPath,
+      context: {
+        stage: 'implementation',
+        repository: 'owner/repo',
+        run_id: 'abc123',
+        'bad key': ' value ',
+        empty: '',
+        undefinedValue: undefined,
+      },
+    })
+
+    logger.info('Starting run', { status: 'ready' })
+    logger.error(new Error('boom'))
+
+    await logger.flush()
+
+    const raw = await readFile(logPath, 'utf8')
+    const lines = raw.trim().split('\n')
+    expect(lines).toHaveLength(2)
+
+    const [infoEntry, errorEntry] = lines.map((line) => JSON.parse(line))
+    expect(infoEntry.stage).toBe('implementation')
+    expect(infoEntry.repository).toBe('owner/repo')
+    expect(infoEntry.run_id).toBe('abc123')
+    expect(infoEntry).not.toHaveProperty('bad key')
+    expect(infoEntry.message).toContain('Starting run')
+    expect(infoEntry.message).toContain('"status":"ready"')
+    expect(typeof infoEntry.timestamp).toBe('string')
+
+    expect(errorEntry.message).toContain('boom')
+
+    // flush again to ensure idempotence
+    await logger.flush()
+  })
+
+  it('truncates existing log file on new logger creation', async () => {
+    const firstLogger = await createCodexLogger({ logPath })
+    firstLogger.info('first run')
+    await firstLogger.flush()
+
+    const firstContents = (await readFile(logPath, 'utf8')).trim()
+    expect(firstContents).toContain('first run')
+
+    const secondLogger = await createCodexLogger({ logPath })
+    secondLogger.info('second run')
+    await secondLogger.flush()
+
+    const after = (await readFile(logPath, 'utf8')).trim().split('\n')
+    expect(after).toHaveLength(1)
+    expect(after[0]).toContain('second run')
+    expect(after[0]).not.toContain('first run')
+  })
+})

--- a/apps/froussard/src/codex/cli/lib/cli.ts
+++ b/apps/froussard/src/codex/cli/lib/cli.ts
@@ -1,5 +1,5 @@
-import { fileURLToPath } from 'node:url'
 import process from 'node:process'
+import { fileURLToPath } from 'node:url'
 
 export const isMainModule = (meta: ImportMeta): boolean => {
   if (typeof meta.main === 'boolean') {

--- a/apps/froussard/src/codex/cli/lib/codex-runner.ts
+++ b/apps/froussard/src/codex/cli/lib/codex-runner.ts
@@ -2,7 +2,7 @@ import { createWriteStream, type WriteStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import process from 'node:process'
 import { ensureFileDirectory } from './fs'
-import { consoleLogger, type CodexLogger } from './logger'
+import { type CodexLogger, consoleLogger } from './logger'
 
 export interface DiscordRelayOptions {
   command: string[]

--- a/apps/froussard/src/codex/cli/lib/codex-runner.ts
+++ b/apps/froussard/src/codex/cli/lib/codex-runner.ts
@@ -1,7 +1,8 @@
 import { createWriteStream, type WriteStream } from 'node:fs'
-import { mkdir, stat } from 'node:fs/promises'
-import { dirname } from 'node:path'
+import { stat } from 'node:fs/promises'
 import process from 'node:process'
+import { ensureFileDirectory } from './fs'
+import { consoleLogger, type CodexLogger } from './logger'
 
 export interface DiscordRelayOptions {
   command: string[]
@@ -15,10 +16,23 @@ export interface RunCodexSessionOptions {
   jsonOutputPath: string
   agentOutputPath: string
   discordRelay?: DiscordRelayOptions
+  logger?: CodexLogger
 }
 
 export interface RunCodexSessionResult {
   agentMessages: string[]
+}
+
+export interface PushCodexEventsToLokiOptions {
+  stage: string
+  endpoint?: string
+  jsonPath?: string
+  agentLogPath?: string
+  runtimeLogPath?: string
+  labels?: Record<string, string | undefined>
+  tenant?: string
+  basicAuth?: string
+  logger?: CodexLogger
 }
 
 const decoder = new TextDecoder()
@@ -102,10 +116,6 @@ const closeStream = (stream: WriteStream) => {
   })
 }
 
-export const ensureFileDirectory = async (filePath: string) => {
-  await mkdir(dirname(filePath), { recursive: true })
-}
-
 export const runCodexSession = async ({
   stage,
   prompt,
@@ -113,7 +123,10 @@ export const runCodexSession = async ({
   jsonOutputPath,
   agentOutputPath,
   discordRelay,
+  logger,
 }: RunCodexSessionOptions): Promise<RunCodexSessionResult> => {
+  const log = logger ?? consoleLogger
+
   await Promise.all([
     ensureFileDirectory(outputPath),
     ensureFileDirectory(jsonOutputPath),
@@ -139,7 +152,7 @@ export const runCodexSession = async ({
       if (handle) {
         discordWriter = handle
       } else {
-        console.error('Discord relay process did not expose stdin; disabling relay')
+        log.warn('Discord relay process did not expose stdin; disabling relay')
         discordProcess.kill()
         discordProcess = undefined
         discordWriter = undefined
@@ -148,7 +161,7 @@ export const runCodexSession = async ({
       if (discordRelay.onError && error instanceof Error) {
         discordRelay.onError(error)
       } else {
-        console.error('Failed to start Discord relay:', error)
+        log.error('Failed to start Discord relay:', error)
       }
     }
   }
@@ -211,13 +224,13 @@ export const runCodexSession = async ({
             if (discordRelay?.onError && error instanceof Error) {
               discordRelay.onError(error)
             } else {
-              console.error('Failed to write to Discord relay stream:', error)
+              log.error('Failed to write to Discord relay stream:', error)
             }
           }
         }
       }
     } catch (error) {
-      console.error('Failed to parse Codex event line as JSON:', error)
+      log.error('Failed to parse Codex event line as JSON:', error)
     }
   }
 
@@ -265,79 +278,193 @@ export const runCodexSession = async ({
   return { agentMessages }
 }
 
-export const pushCodexEventsToLoki = async (stage: string, jsonPath: string, endpoint?: string) => {
+export const pushCodexEventsToLoki = async ({
+  stage,
+  endpoint,
+  jsonPath,
+  agentLogPath,
+  runtimeLogPath,
+  labels,
+  tenant,
+  basicAuth,
+  logger,
+}: PushCodexEventsToLokiOptions) => {
   if (!endpoint) {
     return
   }
 
-  try {
-    const stats = await stat(jsonPath)
-    if (stats.size === 0) {
-      console.error('Codex JSON event log is empty; skipping log export')
-      return
+  const log = logger ?? consoleLogger
+  const baseLabels = buildLokiLabels(stage, labels)
+  const nextTimestamp = createTimestampGenerator()
+  const streams: LokiStreamPayload[] = []
+
+  if (jsonPath) {
+    const jsonLines = await loadLogLines(jsonPath, 'Codex JSON event log', log)
+    if (jsonLines && jsonLines.length > 0) {
+      const values: Array<[string, string]> = []
+      jsonLines.forEach((line) => {
+        try {
+          const payload = JSON.stringify(JSON.parse(line))
+          values.push([nextTimestamp(), payload])
+        } catch (error) {
+          log.error('Skipping Codex event line that failed to parse for Loki export:', error)
+        }
+      })
+      if (values.length > 0) {
+        streams.push({
+          stream: { ...baseLabels, stream_type: 'json', source: 'codex-events' },
+          values,
+        })
+      } else {
+        log.warn('Codex JSON event payload empty after parsing; skipping Loki export')
+      }
     }
-  } catch (error) {
-    if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
-      console.error(`Codex JSON event log not found at ${jsonPath}; skipping log export`)
-      return
-    }
-    throw error
   }
 
-  const raw = await Bun.file(jsonPath).text()
-  const lines = raw
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
+  if (agentLogPath) {
+    const agentLines = await loadLogLines(agentLogPath, 'Codex agent log', log)
+    if (agentLines && agentLines.length > 0) {
+      streams.push({
+        stream: { ...baseLabels, stream_type: 'agent', source: 'codex-agent' },
+        values: agentLines.map<[string, string]>((line) => [nextTimestamp(), line]),
+      })
+    }
+  }
 
-  if (lines.length === 0) {
-    console.error('Codex JSON event payload empty; skipping log export')
+  if (runtimeLogPath) {
+    const runtimeLines = await loadLogLines(runtimeLogPath, 'Codex runtime log', log)
+    if (runtimeLines && runtimeLines.length > 0) {
+      streams.push({
+        stream: { ...baseLabels, stream_type: 'runtime', source: 'codex-runtime' },
+        values: runtimeLines.map<[string, string]>((line) => [nextTimestamp(), line]),
+      })
+    }
+  }
+
+  if (streams.length === 0) {
+    log.warn('No Codex log payloads available; skipping Loki export')
     return
   }
 
-  const baseTimestampNs = BigInt(Date.now()) * 1_000_000n
-  const values: Array<[string, string]> = []
-
-  lines.forEach((line, index) => {
-    try {
-      const parsed = JSON.parse(line)
-      const payload = JSON.stringify(parsed)
-      const timestamp = (baseTimestampNs + BigInt(index)).toString()
-      values.push([timestamp, payload])
-    } catch (error) {
-      console.error('Skipping Codex event line that failed to parse for Loki export:', error)
-    }
-  })
-
-  if (values.length === 0) {
-    console.error('Codex JSON event payload empty after parsing; skipping log export')
-    return
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
   }
 
-  const body = JSON.stringify({
-    streams: [
-      {
-        stream: { job: 'codex-exec', stage },
-        values,
-      },
-    ],
-  })
+  if (tenant) {
+    headers['X-Scope-OrgID'] = tenant
+  }
+
+  if (basicAuth) {
+    headers.Authorization = basicAuth.startsWith('Basic ') ? basicAuth : `Basic ${basicAuth}`
+  }
 
   try {
     const response = await fetch(endpoint, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body,
+      headers,
+      body: JSON.stringify({ streams }),
     })
 
     if (!response.ok) {
-      console.error(`Failed to push Codex events to Loki at ${endpoint}: ${response.status} ${response.statusText}`)
+      log.error(`Failed to push Codex events to Loki at ${endpoint}: ${response.status} ${response.statusText}`)
     } else {
-      console.error(`Pushed Codex events to Loki at ${endpoint}`)
+      log.info(`Pushed Codex events to Loki at ${endpoint}`)
     }
   } catch (error) {
-    console.error('Failed to push Codex events to Loki:', error)
+    log.error('Failed to push Codex events to Loki:', error)
   }
+}
+
+const loadLogLines = async (path: string, description: string, log: CodexLogger) => {
+  try {
+    const stats = await stat(path)
+    if (stats.size === 0) {
+      log.warn(`${description} is empty; skipping log export`)
+      return undefined
+    }
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      log.warn(`${description} not found at ${path}; skipping log export`)
+      return undefined
+    }
+    throw error
+  }
+
+  const raw = await Bun.file(path).text()
+  const lines: string[] = []
+
+  raw.split(/\r?\n/).forEach((line) => {
+    if (line.trim().length > 0) {
+      lines.push(line)
+    }
+  })
+
+  if (lines.length === 0) {
+    log.warn(`${description} payload empty after parsing; skipping log export`)
+    return undefined
+  }
+
+  return lines
+}
+
+const createTimestampGenerator = () => {
+  const base = BigInt(Date.now()) * 1_000_000n
+  let offset = 0n
+  return () => {
+    const timestamp = base + offset
+    offset += 1n
+    return timestamp.toString()
+  }
+}
+
+const buildLokiLabels = (stage: string, labels?: Record<string, string | undefined>): Record<string, string> => {
+  const result: Record<string, string> = {
+    job: 'codex-exec',
+  }
+
+  const stageValue = sanitizeLabelValue(stage)
+  if (stageValue) {
+    result.stage = stageValue
+  }
+
+  if (labels) {
+    for (const [key, value] of Object.entries(labels)) {
+      if (!key || value === undefined || value === null) {
+        continue
+      }
+      const sanitizedKey = sanitizeLabelKey(key)
+      if (!sanitizedKey || sanitizedKey === 'stage' || sanitizedKey === 'job') {
+        continue
+      }
+      const sanitizedValue = sanitizeLabelValue(value)
+      if (!sanitizedValue) {
+        continue
+      }
+      result[sanitizedKey] = sanitizedValue
+    }
+  }
+
+  return result
+}
+
+const sanitizeLabelKey = (key: string) => key.trim().replace(/[^A-Za-z0-9_]/g, '_')
+
+const sanitizeLabelValue = (value: unknown) => {
+  if (value === undefined || value === null) {
+    return ''
+  }
+  const normalized = `${value}`.trim()
+  return normalized === 'null' ? '' : normalized
+}
+
+const isNotFoundError = (error: unknown): error is NodeJS.ErrnoException => {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  return 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT'
+}
+
+interface LokiStreamPayload {
+  stream: Record<string, string>
+  values: Array<[string, string]>
 }

--- a/apps/froussard/src/codex/cli/lib/codex-utils.ts
+++ b/apps/froussard/src/codex/cli/lib/codex-utils.ts
@@ -1,5 +1,5 @@
-import { which } from 'bun'
 import { copyFile, stat } from 'node:fs/promises'
+import { which } from 'bun'
 
 export const pathExists = async (path: string): Promise<boolean> => {
   try {

--- a/apps/froussard/src/codex/cli/lib/fs.ts
+++ b/apps/froussard/src/codex/cli/lib/fs.ts
@@ -1,0 +1,6 @@
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+export const ensureFileDirectory = async (filePath: string) => {
+  await mkdir(dirname(filePath), { recursive: true })
+}

--- a/apps/froussard/src/codex/cli/lib/logger.ts
+++ b/apps/froussard/src/codex/cli/lib/logger.ts
@@ -1,0 +1,141 @@
+import { createWriteStream, type WriteStream } from 'node:fs'
+import { ensureFileDirectory } from './fs'
+
+export interface CodexLogger {
+  info: (...args: unknown[]) => void
+  warn: (...args: unknown[]) => void
+  error: (...args: unknown[]) => void
+  debug: (...args: unknown[]) => void
+  flush: () => Promise<void>
+  logPath?: string
+}
+
+export interface CreateCodexLoggerOptions {
+  logPath?: string
+  context?: Record<string, string | undefined>
+}
+
+export const consoleLogger: CodexLogger = {
+  info: (...args: unknown[]) => console.log(...args),
+  warn: (...args: unknown[]) => console.warn(...args),
+  error: (...args: unknown[]) => console.error(...args),
+  debug: (...args: unknown[]) => console.debug(...args),
+  flush: async () => {},
+}
+
+export const createCodexLogger = async ({ logPath, context }: CreateCodexLoggerOptions = {}): Promise<CodexLogger> => {
+  const sanitizedContext = sanitizeContext(context)
+  let stream: WriteStream | undefined
+
+  if (logPath) {
+    await ensureFileDirectory(logPath)
+    stream = createWriteStream(logPath, { flags: 'w' })
+  }
+
+  const writeEntry = (level: LogLevel, args: unknown[]) => {
+    if (!stream) {
+      return
+    }
+
+    const entry: Record<string, unknown> = {
+      timestamp: new Date().toISOString(),
+      level,
+      message: formatLogMessage(args),
+      ...sanitizedContext,
+    }
+
+    writeLine(stream, JSON.stringify(entry)).catch((error) => {
+      console.error('Failed to write Codex log entry', error)
+    })
+  }
+
+  const logWithLevel = (level: LogLevel, consoleFn: (...args: unknown[]) => void, args: unknown[]) => {
+    consoleFn(...args)
+    writeEntry(level, args)
+  }
+
+  const flush = async () => {
+    if (!stream) {
+      return
+    }
+    await new Promise<void>((resolve, reject) => {
+      stream?.end((error) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
+    })
+    stream = undefined
+  }
+
+  return {
+    info: (...args: unknown[]) => logWithLevel('info', console.log, args),
+    warn: (...args: unknown[]) => logWithLevel('warn', console.warn, args),
+    error: (...args: unknown[]) => logWithLevel('error', console.error, args),
+    debug: (...args: unknown[]) => logWithLevel('debug', console.debug, args),
+    flush,
+    logPath,
+  }
+}
+
+type LogLevel = 'info' | 'warn' | 'error' | 'debug'
+
+const writeLine = (stream: WriteStream, content: string) => {
+  return new Promise<void>((resolve, reject) => {
+    stream.write(`${content}\n`, (error) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+const sanitizeContext = (context?: Record<string, string | undefined>): Record<string, string> => {
+  if (!context) {
+    return {}
+  }
+
+  const entries: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(context)) {
+    if (!key) {
+      continue
+    }
+    if (value === undefined || value === null) {
+      continue
+    }
+    const sanitizedKey = key.trim().replace(/[^A-Za-z0-9_]/g, '_')
+    if (!sanitizedKey) {
+      continue
+    }
+    const normalizedValue = `${value}`.trim()
+    if (!normalizedValue || normalizedValue === 'null') {
+      continue
+    }
+    entries[sanitizedKey] = normalizedValue
+  }
+
+  return entries
+}
+
+const formatLogMessage = (args: unknown[]) => {
+  return args
+    .map((value) => {
+      if (value instanceof Error) {
+        return value.stack ?? value.message
+      }
+      if (typeof value === 'object' && value !== null) {
+        try {
+          return JSON.stringify(value)
+        } catch {
+          return String(value)
+        }
+      }
+      return String(value)
+    })
+    .join(' ')
+}

--- a/apps/froussard/src/discord-commands.test.ts
+++ b/apps/froussard/src/discord-commands.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   buildDeferredResponsePayload,
   buildPlanModalResponse,
+  type DiscordApplicationCommandInteraction,
+  type DiscordModalSubmitInteraction,
   INTERACTION_TYPE,
   toCommandEvent,
   toPlanModalEvent,
   verifyDiscordRequest,
-  type DiscordApplicationCommandInteraction,
-  type DiscordModalSubmitInteraction,
 } from '@/discord-commands'
 
 const { verifyKeyMock } = vi.hoisted(() => ({

--- a/apps/froussard/src/discord-commands.ts
+++ b/apps/froussard/src/discord-commands.ts
@@ -1,5 +1,5 @@
-import { logger } from '@/logger'
 import { verifyKey } from 'discord-interactions'
+import { logger } from '@/logger'
 
 const SIGNATURE_HEADER = 'x-signature-ed25519'
 const TIMESTAMP_HEADER = 'x-signature-timestamp'

--- a/apps/froussard/src/effect/config.ts
+++ b/apps/froussard/src/effect/config.ts
@@ -1,0 +1,7 @@
+import { Effect, Layer } from 'effect'
+
+import { loadConfig, type AppConfig } from '@/config'
+
+export class AppConfigService extends Effect.Tag('@froussard/AppConfig')<AppConfigService, AppConfig>() {}
+
+export const AppConfigLayer = Layer.sync(AppConfigService, () => loadConfig())

--- a/apps/froussard/src/effect/config.ts
+++ b/apps/froussard/src/effect/config.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer } from 'effect'
 
-import { loadConfig, type AppConfig } from '@/config'
+import { type AppConfig, loadConfig } from '@/config'
 
 export class AppConfigService extends Effect.Tag('@froussard/AppConfig')<AppConfigService, AppConfig>() {}
 

--- a/apps/froussard/src/effect/runtime.ts
+++ b/apps/froussard/src/effect/runtime.ts
@@ -1,10 +1,10 @@
 import { Layer } from 'effect'
-import { make as makeManagedRuntime, type ManagedRuntime } from 'effect/ManagedRuntime'
+import { type ManagedRuntime, make as makeManagedRuntime } from 'effect/ManagedRuntime'
 
 import { AppConfigLayer } from '@/effect/config'
 import { AppLoggerLayer } from '@/logger'
-import { KafkaProducerLayer } from '@/services/kafka'
 import { GithubServiceLayer } from '@/services/github'
+import { KafkaProducerLayer } from '@/services/kafka'
 
 const BaseAppLayer = Layer.mergeAll(AppConfigLayer, AppLoggerLayer, KafkaProducerLayer, GithubServiceLayer)
 

--- a/apps/froussard/src/effect/runtime.ts
+++ b/apps/froussard/src/effect/runtime.ts
@@ -1,0 +1,17 @@
+import { Layer } from 'effect'
+import { make as makeManagedRuntime, type ManagedRuntime } from 'effect/ManagedRuntime'
+
+import { AppConfigLayer } from '@/effect/config'
+import { AppLoggerLayer } from '@/logger'
+import { KafkaProducerLayer } from '@/services/kafka'
+import { GithubServiceLayer } from '@/services/github'
+
+const BaseAppLayer = Layer.mergeAll(AppConfigLayer, AppLoggerLayer, KafkaProducerLayer, GithubServiceLayer)
+
+export type AppRuntimeLayer = typeof BaseAppLayer
+
+export const AppLayer = BaseAppLayer
+
+export type AppRuntime = ManagedRuntime<Layer.Success<AppRuntimeLayer>, Layer.Error<AppRuntimeLayer>>
+
+export const makeAppRuntime = (): AppRuntime => makeManagedRuntime(AppLayer)

--- a/apps/froussard/src/index.ts
+++ b/apps/froussard/src/index.ts
@@ -1,15 +1,15 @@
 import '@/telemetry'
 
 import { Webhooks } from '@octokit/webhooks'
-import { Elysia } from 'elysia'
 import { Effect } from 'effect'
+import { Elysia } from 'elysia'
 
 import { AppConfigService } from '@/effect/config'
 import { makeAppRuntime } from '@/effect/runtime'
 import { logger } from '@/logger'
-import { KafkaProducer } from '@/services/kafka'
 import { createHealthHandlers } from '@/routes/health'
 import { createWebhookHandler, type WebhookConfig } from '@/routes/webhooks'
+import { KafkaProducer } from '@/services/kafka'
 
 const runtime = makeAppRuntime()
 const config = runtime.runSync(

--- a/apps/froussard/src/routes/health.test.ts
+++ b/apps/froussard/src/routes/health.test.ts
@@ -2,31 +2,38 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { createHealthHandlers } from '@/routes/health'
 
+const createRuntime = () => ({
+  runSync: vi.fn(),
+})
+
 describe('createHealthHandlers', () => {
-  const kafka = {
-    isReady: vi.fn(),
-  }
+  const kafkaEffect = Symbol('kafka-Ready') as never
 
   it('returns OK for liveness', () => {
-    const handlers = createHealthHandlers(kafka as never)
+    const runtime = createRuntime()
+    const handlers = createHealthHandlers({ runtime, kafka: { isReady: kafkaEffect } as never })
     const response = handlers.liveness()
 
     expect(response.status).toBe(200)
   })
 
   it('returns 503 when kafka is not ready', () => {
-    kafka.isReady.mockReturnValue(false)
-    const handlers = createHealthHandlers(kafka as never)
+    const runtime = createRuntime()
+    runtime.runSync.mockReturnValue(false)
+    const handlers = createHealthHandlers({ runtime, kafka: { isReady: kafkaEffect } as never })
     const response = handlers.readiness()
 
     expect(response.status).toBe(503)
+    expect(runtime.runSync).toHaveBeenCalledWith(kafkaEffect)
   })
 
   it('returns OK when kafka is ready', () => {
-    kafka.isReady.mockReturnValue(true)
-    const handlers = createHealthHandlers(kafka as never)
+    const runtime = createRuntime()
+    runtime.runSync.mockReturnValue(true)
+    const handlers = createHealthHandlers({ runtime, kafka: { isReady: kafkaEffect } as never })
     const response = handlers.readiness()
 
     expect(response.status).toBe(200)
+    expect(runtime.runSync).toHaveBeenCalledWith(kafkaEffect)
   })
 })

--- a/apps/froussard/src/routes/health.ts
+++ b/apps/froussard/src/routes/health.ts
@@ -1,5 +1,5 @@
-import { logger } from '@/logger'
 import type { AppRuntime } from '@/effect/runtime'
+import { logger } from '@/logger'
 import type { KafkaProducerService } from '@/services/kafka'
 
 export interface HealthHandlers {

--- a/apps/froussard/src/routes/health.ts
+++ b/apps/froussard/src/routes/health.ts
@@ -1,19 +1,26 @@
 import { logger } from '@/logger'
-import type { KafkaManager } from '@/services/kafka'
+import type { AppRuntime } from '@/effect/runtime'
+import type { KafkaProducerService } from '@/services/kafka'
 
 export interface HealthHandlers {
   liveness: () => Response
   readiness: () => Response
 }
 
-export const createHealthHandlers = (kafka: KafkaManager): HealthHandlers => {
+interface HealthDependencies {
+  runtime: AppRuntime
+  kafka: KafkaProducerService
+}
+
+export const createHealthHandlers = ({ runtime, kafka }: HealthDependencies): HealthHandlers => {
   return {
     liveness: () => {
       logger.debug('Liveness check request received')
       return new Response('OK', { status: 200 })
     },
     readiness: () => {
-      if (!kafka.isReady()) {
+      const ready = runtime.runSync(kafka.isReady)
+      if (!ready) {
         logger.warn('Readiness check failed: Kafka producer not connected')
         return new Response('Kafka producer not connected', { status: 503 })
       }

--- a/apps/froussard/src/routes/webhooks.test.ts
+++ b/apps/froussard/src/routes/webhooks.test.ts
@@ -1,11 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Effect, Layer } from 'effect'
-import { make as makeManagedRuntime, type ManagedRuntime } from 'effect/ManagedRuntime'
+import { type ManagedRuntime, make as makeManagedRuntime } from 'effect/ManagedRuntime'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AppLogger } from '@/logger'
 import { createWebhookHandler, type WebhookConfig } from '@/routes/webhooks'
-import { KafkaProducer, type KafkaMessage } from '@/services/kafka'
 import { GithubService } from '@/services/github'
+import { type KafkaMessage, KafkaProducer } from '@/services/kafka'
 
 const { mockVerifyDiscordRequest, mockBuildPlanModalResponse, mockToPlanModalEvent } = vi.hoisted(() => ({
   mockVerifyDiscordRequest: vi.fn(async () => true),

--- a/apps/froussard/src/routes/webhooks.test.ts
+++ b/apps/froussard/src/routes/webhooks.test.ts
@@ -1,6 +1,11 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Effect, Layer } from 'effect'
+import { make as makeManagedRuntime, type ManagedRuntime } from 'effect/ManagedRuntime'
 
+import { AppLogger } from '@/logger'
 import { createWebhookHandler, type WebhookConfig } from '@/routes/webhooks'
+import { KafkaProducer, type KafkaMessage } from '@/services/kafka'
+import { GithubService } from '@/services/github'
 
 const { mockVerifyDiscordRequest, mockBuildPlanModalResponse, mockToPlanModalEvent } = vi.hoisted(() => ({
   mockVerifyDiscordRequest: vi.fn(async () => true),
@@ -43,11 +48,6 @@ vi.mock('@/codex', () => ({
   normalizeLogin: vi.fn((value: string | undefined | null) => (value ? value.toLowerCase() : null)),
 }))
 
-vi.mock('@/services/github', () => ({
-  postIssueReaction: vi.fn(async () => ({ ok: true })),
-  findLatestPlanComment: vi.fn(async () => ({ ok: false, reason: 'not-found' })),
-}))
-
 vi.mock('@/codex-workflow', () => ({
   selectReactionRepository: vi.fn((issueRepository, repository) => issueRepository ?? repository),
 }))
@@ -78,8 +78,11 @@ const buildDiscordRequest = (body: unknown, headers: Record<string, string> = {}
 }
 
 describe('createWebhookHandler', () => {
-  const kafka = {
-    publish: vi.fn(async () => undefined),
+  let runtime: ManagedRuntime<unknown, never>
+  let publishedMessages: KafkaMessage[]
+  let githubServiceMock: {
+    postIssueReaction: ReturnType<typeof vi.fn>
+    findLatestPlanComment: ReturnType<typeof vi.fn>
   }
 
   const webhooks = {
@@ -113,28 +116,64 @@ describe('createWebhookHandler', () => {
     },
   }
 
-  afterEach(() => {
+  const provideRuntime = () => {
+    const kafkaLayer = Layer.succeed(KafkaProducer, {
+      publish: (message: KafkaMessage) =>
+        Effect.sync(() => {
+          publishedMessages.push(message)
+        }),
+      ensureConnected: Effect.succeed(undefined),
+      isReady: Effect.succeed(true),
+    })
+
+    const loggerLayer = Layer.succeed(AppLogger, {
+      debug: () => Effect.succeed(undefined),
+      info: () => Effect.succeed(undefined),
+      warn: () => Effect.succeed(undefined),
+      error: () => Effect.succeed(undefined),
+    })
+    const githubLayer = Layer.succeed(GithubService, {
+      postIssueReaction: githubServiceMock.postIssueReaction,
+      findLatestPlanComment: githubServiceMock.findLatestPlanComment,
+    })
+
+    runtime = makeManagedRuntime(Layer.mergeAll(loggerLayer, kafkaLayer, githubLayer))
+  }
+
+  beforeEach(() => {
+    publishedMessages = []
+    githubServiceMock = {
+      postIssueReaction: vi.fn(() => Effect.succeed({ ok: true })),
+      findLatestPlanComment: vi.fn(() => Effect.succeed({ ok: false, reason: 'not-found' })),
+    }
+    provideRuntime()
+  })
+
+  afterEach(async () => {
+    await runtime.dispose()
     vi.clearAllMocks()
   })
 
   it('rejects unsupported providers', async () => {
-    const handler = createWebhookHandler({ kafka: kafka as never, webhooks: webhooks as never, config: baseConfig })
+    const handler = createWebhookHandler({ runtime, webhooks: webhooks as never, config: baseConfig })
     const response = await handler(
       new Request('http://localhost/webhooks/slack', { method: 'POST', body: '' }),
       'slack',
     )
     expect(response.status).toBe(400)
     expect(webhooks.verify).not.toHaveBeenCalled()
+    expect(publishedMessages).toHaveLength(0)
   })
 
   it('returns 401 when signature header missing', async () => {
-    const handler = createWebhookHandler({ kafka: kafka as never, webhooks: webhooks as never, config: baseConfig })
+    const handler = createWebhookHandler({ runtime, webhooks: webhooks as never, config: baseConfig })
     const response = await handler(buildRequest({}, {}), 'github')
     expect(response.status).toBe(401)
+    expect(publishedMessages).toHaveLength(0)
   })
 
   it('publishes planning message on issue opened', async () => {
-    const handler = createWebhookHandler({ kafka: kafka as never, webhooks: webhooks as never, config: baseConfig })
+    const handler = createWebhookHandler({ runtime, webhooks: webhooks as never, config: baseConfig })
     const payload = {
       action: 'opened',
       issue: {
@@ -159,28 +198,21 @@ describe('createWebhookHandler', () => {
     )
 
     expect(response.status).toBe(202)
-    expect(kafka.publish).toHaveBeenCalledWith(
-      expect.objectContaining({
-        topic: 'codex-topic',
-        key: 'issue-1-planning',
-      }),
-    )
-    expect(kafka.publish).toHaveBeenCalledWith(
-      expect.objectContaining({
-        topic: 'raw-topic',
-        key: 'delivery-123',
-      }),
+    expect(publishedMessages).toHaveLength(2)
+    const [planningMessage, rawMessage] = publishedMessages
+    expect(planningMessage).toMatchObject({ topic: 'codex-topic', key: 'issue-1-planning' })
+    expect(rawMessage).toMatchObject({ topic: 'raw-topic', key: 'delivery-123' })
+    expect(githubServiceMock.postIssueReaction).toHaveBeenCalledWith(
+      expect.objectContaining({ repositoryFullName: 'owner/repo', issueNumber: 1 }),
     )
   })
 
   it('publishes implementation message when trigger comment is received', async () => {
-    const { findLatestPlanComment } = await import('@/services/github')
-    vi.mocked(findLatestPlanComment).mockResolvedValueOnce({
-      ok: true,
-      comment: { id: 10, body: 'Plan', htmlUrl: 'https://comment' },
-    })
+    githubServiceMock.findLatestPlanComment.mockReturnValueOnce(
+      Effect.succeed({ ok: true, comment: { id: 10, body: 'Plan', htmlUrl: 'https://comment' } }),
+    )
 
-    const handler = createWebhookHandler({ kafka: kafka as never, webhooks: webhooks as never, config: baseConfig })
+    const handler = createWebhookHandler({ runtime, webhooks: webhooks as never, config: baseConfig })
     const payload = {
       action: 'created',
       issue: {
@@ -204,19 +236,16 @@ describe('createWebhookHandler', () => {
       'github',
     )
 
-    expect(findLatestPlanComment).toHaveBeenCalled()
-    expect(kafka.publish).toHaveBeenCalledWith(
-      expect.objectContaining({
-        topic: 'codex-topic',
-        key: 'issue-2-implementation',
-      }),
-    )
-    expect(kafka.publish).toHaveBeenCalledWith(expect.objectContaining({ topic: 'raw-topic', key: 'delivery-999' }))
+    expect(githubServiceMock.findLatestPlanComment).toHaveBeenCalled()
+    expect(publishedMessages).toHaveLength(2)
+    const [implementationMessage, rawMessage] = publishedMessages
+    expect(implementationMessage).toMatchObject({ topic: 'codex-topic', key: 'issue-2-implementation' })
+    expect(rawMessage).toMatchObject({ topic: 'raw-topic', key: 'delivery-999' })
   })
 
   it('returns 401 when Discord signature verification fails', async () => {
     mockVerifyDiscordRequest.mockResolvedValueOnce(false)
-    const handler = createWebhookHandler({ kafka: kafka as never, webhooks: webhooks as never, config: baseConfig })
+    const handler = createWebhookHandler({ runtime, webhooks: webhooks as never, config: baseConfig })
 
     const response = await handler(
       buildDiscordRequest(
@@ -232,11 +261,11 @@ describe('createWebhookHandler', () => {
     )
 
     expect(response.status).toBe(401)
-    expect(kafka.publish).not.toHaveBeenCalled()
+    expect(publishedMessages).toHaveLength(0)
   })
 
   it('returns plan modal response for slash command', async () => {
-    const handler = createWebhookHandler({ kafka: kafka as never, webhooks: webhooks as never, config: baseConfig })
+    const handler = createWebhookHandler({ runtime, webhooks: webhooks as never, config: baseConfig })
 
     const response = await handler(
       buildDiscordRequest(
@@ -261,7 +290,7 @@ describe('createWebhookHandler', () => {
     expect(mockVerifyDiscordRequest).toHaveBeenCalled()
     expect(mockBuildPlanModalResponse).toHaveBeenCalled()
     expect(mockToPlanModalEvent).not.toHaveBeenCalled()
-    expect(kafka.publish).not.toHaveBeenCalled()
+    expect(publishedMessages).toHaveLength(0)
 
     const payload = await response.json()
     expect(response.status).toBe(200)
@@ -276,7 +305,7 @@ describe('createWebhookHandler', () => {
   })
 
   it('publishes plan modal submissions and returns acknowledgement', async () => {
-    const handler = createWebhookHandler({ kafka: kafka as never, webhooks: webhooks as never, config: baseConfig })
+    const handler = createWebhookHandler({ runtime, webhooks: webhooks as never, config: baseConfig })
 
     const response = await handler(
       buildDiscordRequest(
@@ -297,16 +326,12 @@ describe('createWebhookHandler', () => {
     expect(mockVerifyDiscordRequest).toHaveBeenCalled()
     expect(mockToPlanModalEvent).toHaveBeenCalled()
     expect(mockBuildPlanModalResponse).not.toHaveBeenCalled()
-    expect(kafka.publish).toHaveBeenCalledWith(
-      expect.objectContaining({
-        topic: 'discord-topic',
-        key: 'interaction-123',
-      }),
-    )
+    expect(publishedMessages).toHaveLength(1)
 
-    const publishArgs = kafka.publish.mock.calls[0]?.[0]
-    expect(publishArgs).toBeTruthy()
-    const eventValue = JSON.parse(publishArgs.value)
+    const [discordMessage] = publishedMessages
+    expect(discordMessage).toMatchObject({ topic: 'discord-topic', key: 'interaction-123' })
+
+    const eventValue = JSON.parse(discordMessage.value)
     expect(eventValue.options).toEqual(
       expect.objectContaining({
         content: 'Ship the release with QA gating',
@@ -319,7 +344,6 @@ describe('createWebhookHandler', () => {
     expect(parsedPayload.postToGithub).toBe(false)
     expect(parsedPayload.stage).toBe('planning')
     expect(parsedPayload.runId).toBe('interaction-123')
-    expect(parsedPayload.user?.id).toBe('user-1')
 
     const payload = await response.json()
     expect(response.status).toBe(200)
@@ -333,7 +357,7 @@ describe('createWebhookHandler', () => {
   })
 
   it('responds to Discord ping interactions', async () => {
-    const handler = createWebhookHandler({ kafka: kafka as never, webhooks: webhooks as never, config: baseConfig })
+    const handler = createWebhookHandler({ runtime, webhooks: webhooks as never, config: baseConfig })
 
     const response = await handler(
       buildDiscordRequest(
@@ -350,7 +374,7 @@ describe('createWebhookHandler', () => {
 
     expect(mockBuildPlanModalResponse).not.toHaveBeenCalled()
     expect(mockToPlanModalEvent).not.toHaveBeenCalled()
-    expect(kafka.publish).not.toHaveBeenCalled()
+    expect(publishedMessages).toHaveLength(0)
     const payload = await response.json()
     expect(payload).toEqual({ type: 1 })
   })

--- a/apps/froussard/src/routes/webhooks.ts
+++ b/apps/froussard/src/routes/webhooks.ts
@@ -1,2 +1,2 @@
-export { createWebhookHandler } from '@/webhooks'
 export type { WebhookConfig } from '@/webhooks'
+export { createWebhookHandler } from '@/webhooks'

--- a/apps/froussard/src/server.test.ts
+++ b/apps/froussard/src/server.test.ts
@@ -1,33 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Effect, Layer } from 'effect'
 
-interface MockApp {
-  get: (...args: unknown[]) => MockApp
-  on: (...args: unknown[]) => MockApp
-  onError: (...args: unknown[]) => MockApp
-  post: (...args: unknown[]) => MockApp
-  listen: (port: number) => MockApp
-  server?: { hostname?: string; port?: number }
-}
+import type { AppConfig } from '@/effect/config'
 
-const mockApp: MockApp = {
-  get: vi.fn(() => mockApp),
-  on: vi.fn(() => mockApp),
-  onError: vi.fn(() => mockApp),
-  post: vi.fn(() => mockApp),
-  listen: vi.fn((_port: number) => {
-    mockApp.server = { hostname: '127.0.0.1', port: 8080 }
-    return mockApp
-  }),
-}
+const ensureConnectedSpy = vi.fn()
 
-const mockKafkaManager = {
-  connect: vi.fn(async () => undefined),
-  disconnect: vi.fn(async () => undefined),
-  isReady: vi.fn(() => false),
-}
+vi.mock('@/effect/config', () => {
+  const effect = require('effect')
+  const { Effect, Layer } = effect
 
-vi.mock('@/config', () => ({
-  loadConfig: vi.fn(() => ({
+  class AppConfigService extends Effect.Tag('@test/AppConfig')<AppConfigService, AppConfig>() {}
+
+  const config: AppConfig = {
     githubWebhookSecret: 'secret',
     kafka: {
       brokers: ['broker:9092'],
@@ -35,6 +19,11 @@ vi.mock('@/config', () => ({
       password: 'pass',
       clientId: 'client',
       topics: { raw: 'raw', codex: 'codex', discordCommands: 'discord' },
+      sasl: {
+        mechanism: 'scram-sha-512',
+        username: 'user',
+        password: 'pass',
+      },
     },
     codebase: {
       baseBranch: 'main',
@@ -54,52 +43,132 @@ vi.mock('@/config', () => ({
       apiBaseUrl: 'https://api.github.com',
       userAgent: 'agent',
     },
-  })),
+  }
+
+  const AppConfigLayer = Layer.succeed(AppConfigService, config)
+
+  return {
+    AppConfigService,
+    AppConfigLayer,
+  }
+})
+
+vi.mock('@/services/kafka', () => {
+  const effect = require('effect')
+  const { Effect, Layer } = effect
+
+  class KafkaProducer extends Effect.Tag('@test/KafkaProducer')<
+    KafkaProducer,
+    {
+      publish: (message: unknown) => ReturnType<typeof Effect.succeed>
+      ensureConnected: ReturnType<typeof Effect.succeed>
+      isReady: ReturnType<typeof Effect.succeed<boolean>>
+    }
+  >() {}
+
+  const KafkaProducerLayer = Layer.succeed(KafkaProducer, {
+    publish: () => Effect.succeed(undefined),
+    ensureConnected: Effect.sync(() => {
+      ensureConnectedSpy()
+    }),
+    isReady: Effect.succeed(true),
+  })
+
+  const parseBrokerList = (raw: string) => raw.split(',')
+
+  return {
+    KafkaProducer,
+    KafkaProducerLayer,
+    parseBrokerList,
+  }
+})
+
+vi.mock('@/services/github', () => {
+  const effect = require('effect')
+  const { Effect, Layer } = effect
+
+  class GithubService extends Effect.Tag('@test/GithubService')<
+    GithubService,
+    {
+      postIssueReaction: (options: unknown) => ReturnType<typeof Effect.succeed>
+      findLatestPlanComment: (options: unknown) => ReturnType<typeof Effect.succeed>
+    }
+  >() {}
+
+  const GithubServiceLayer = Layer.succeed(GithubService, {
+    postIssueReaction: () => Effect.succeed({ ok: true }),
+    findLatestPlanComment: () => Effect.succeed({ ok: false, reason: 'not-found' }),
+  })
+
+  return {
+    GithubService,
+    GithubServiceLayer,
+    postIssueReaction: vi.fn(),
+    findLatestPlanComment: vi.fn(),
+  }
+})
+
+const mockCreateHealthHandlers = vi.fn(() => ({
+  liveness: () => new Response('OK'),
+  readiness: () => new Response('OK'),
 }))
 
-vi.mock('@/services/kafka', () => ({
-  KafkaManager: vi.fn(() => mockKafkaManager),
+vi.mock('@/routes/health', () => ({
+  createHealthHandlers: mockCreateHealthHandlers,
+}))
+
+const mockCreateWebhookHandler = vi.fn(() => vi.fn())
+
+vi.mock('@/routes/webhooks', () => ({
+  createWebhookHandler: mockCreateWebhookHandler,
+  WebhookConfig: {} as never,
+}))
+
+const mockApp = {
+  get: vi.fn(() => mockApp),
+  on: vi.fn(() => mockApp),
+  onError: vi.fn(() => mockApp),
+  post: vi.fn(() => mockApp),
+  listen: vi.fn((_port: number) => {
+    mockApp.server = { hostname: '127.0.0.1', port: 8080 }
+    return mockApp
+  }),
+  server: undefined as { hostname?: string; port?: number } | undefined,
+}
+
+vi.mock('elysia', () => ({
+  Elysia: vi.fn(() => mockApp),
 }))
 
 vi.mock('@octokit/webhooks', () => ({
   Webhooks: vi.fn(() => ({ verify: vi.fn(async () => true) })),
 }))
 
-vi.mock('@/routes/health', () => ({
-  createHealthHandlers: vi.fn(() => ({
-    liveness: () => new Response('OK'),
-    readiness: () => new Response('OK'),
-  })),
-}))
-
-vi.mock('@/routes/webhooks', () => ({
-  createWebhookHandler: vi.fn(() => vi.fn()),
-}))
-
-vi.mock('elysia', () => ({
-  Elysia: vi.fn(() => mockApp),
-}))
-
 describe('server bootstrap', () => {
-  const oldEnv = process.env
+  const originalEnv = process.env
 
   beforeEach(() => {
     process.env = {
-      ...oldEnv,
+      ...originalEnv,
       NODE_ENV: 'test',
     }
-  })
-
-  afterEach(() => {
-    process.env = oldEnv
-    vi.resetModules()
+    mockApp.server = undefined
     vi.clearAllMocks()
   })
 
-  it('bootstraps server without throwing', async () => {
+  afterEach(() => {
+    process.env = originalEnv
+    vi.resetModules()
+  })
+
+  it('bootstraps server without throwing and connects Kafka', async () => {
     const { startServer } = await import('@/index')
     startServer()
+
     expect(mockApp.listen).toHaveBeenCalled()
-    expect(mockKafkaManager.connect).toHaveBeenCalled()
+    await Promise.resolve()
+    expect(ensureConnectedSpy).toHaveBeenCalled()
+    expect(mockCreateHealthHandlers).toHaveBeenCalled()
+    expect(mockCreateWebhookHandler).toHaveBeenCalled()
   })
 })

--- a/apps/froussard/src/server.test.ts
+++ b/apps/froussard/src/server.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Effect, Layer } from 'effect'
 
 import type { AppConfig } from '@/effect/config'
 

--- a/apps/froussard/src/services/github.test.ts
+++ b/apps/froussard/src/services/github.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
 import { Effect } from 'effect'
+import { describe, expect, it, vi } from 'vitest'
 
 import { PLAN_COMMENT_MARKER } from '@/codex'
 import { findLatestPlanComment, postIssueReaction } from '@/services/github'

--- a/apps/froussard/src/services/github.test.ts
+++ b/apps/froussard/src/services/github.test.ts
@@ -1,29 +1,34 @@
 import { describe, expect, it, vi } from 'vitest'
+import { Effect } from 'effect'
 
 import { PLAN_COMMENT_MARKER } from '@/codex'
 import { findLatestPlanComment, postIssueReaction } from '@/services/github'
 
 describe('postIssueReaction', () => {
   it('reports missing token when GITHUB_TOKEN is not configured', async () => {
-    const result = await postIssueReaction({
-      repositoryFullName: 'owner/repo',
-      issueNumber: 12,
-      token: null,
-      reactionContent: 'rocket',
-      fetchImplementation: null,
-    })
+    const result = await Effect.runPromise(
+      postIssueReaction({
+        repositoryFullName: 'owner/repo',
+        issueNumber: 12,
+        token: null,
+        reactionContent: 'rocket',
+        fetchImplementation: null,
+      }),
+    )
 
     expect(result).toEqual({ ok: false, reason: 'missing-token' })
   })
 
   it('rejects invalid repository names', async () => {
-    const result = await postIssueReaction({
-      repositoryFullName: 'invalid-owner-only',
-      issueNumber: 99,
-      token: 'token',
-      reactionContent: 'rocket',
-      fetchImplementation: null,
-    })
+    const result = await Effect.runPromise(
+      postIssueReaction({
+        repositoryFullName: 'invalid-owner-only',
+        issueNumber: 99,
+        token: 'token',
+        reactionContent: 'rocket',
+        fetchImplementation: null,
+      }),
+    )
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -40,15 +45,17 @@ describe('postIssueReaction', () => {
       }
     })
 
-    const result = await postIssueReaction({
-      repositoryFullName: 'acme/widgets',
-      issueNumber: 7,
-      token: 'secret-token',
-      reactionContent: 'rocket',
-      apiBaseUrl: 'https://example.test/api',
-      userAgent: 'custom-agent',
-      fetchImplementation: fetchSpy,
-    })
+    const result = await Effect.runPromise(
+      postIssueReaction({
+        repositoryFullName: 'acme/widgets',
+        issueNumber: 7,
+        token: 'secret-token',
+        reactionContent: 'rocket',
+        apiBaseUrl: 'https://example.test/api',
+        userAgent: 'custom-agent',
+        fetchImplementation: fetchSpy,
+      }),
+    )
 
     expect(result).toEqual({ ok: true })
     expect(fetchSpy).toHaveBeenCalledTimes(1)
@@ -78,13 +85,15 @@ describe('postIssueReaction', () => {
       }
     })
 
-    const result = await postIssueReaction({
-      repositoryFullName: 'acme/widgets',
-      issueNumber: 7,
-      token: 'secret-token',
-      reactionContent: 'rocket',
-      fetchImplementation: fetchSpy,
-    })
+    const result = await Effect.runPromise(
+      postIssueReaction({
+        repositoryFullName: 'acme/widgets',
+        issueNumber: 7,
+        token: 'secret-token',
+        reactionContent: 'rocket',
+        fetchImplementation: fetchSpy,
+      }),
+    )
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -95,27 +104,31 @@ describe('postIssueReaction', () => {
   })
 
   it('indicates when no fetch implementation is available', async () => {
-    const result = await postIssueReaction({
-      repositoryFullName: 'owner/repo',
-      issueNumber: 13,
-      token: 'token',
-      reactionContent: 'heart',
-      fetchImplementation: null,
-    })
+    const result = await Effect.runPromise(
+      postIssueReaction({
+        repositoryFullName: 'owner/repo',
+        issueNumber: 13,
+        token: 'token',
+        reactionContent: 'heart',
+        fetchImplementation: null,
+      }),
+    )
 
     expect(result).toEqual({ ok: false, reason: 'no-fetch' })
   })
 
   it('surfaces network errors thrown by the fetch implementation', async () => {
-    const result = await postIssueReaction({
-      repositoryFullName: 'owner/repo',
-      issueNumber: 99,
-      token: 'token',
-      reactionContent: 'eyes',
-      fetchImplementation: async () => {
-        throw new Error('boom')
-      },
-    })
+    const result = await Effect.runPromise(
+      postIssueReaction({
+        repositoryFullName: 'owner/repo',
+        issueNumber: 99,
+        token: 'token',
+        reactionContent: 'eyes',
+        fetchImplementation: async () => {
+          throw new Error('boom')
+        },
+      }),
+    )
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -131,14 +144,16 @@ describe('postIssueReaction', () => {
       text: async () => '',
     }))
 
-    await postIssueReaction({
-      repositoryFullName: 'acme/widgets',
-      issueNumber: 5,
-      token: 'secret-token',
-      reactionContent: 'rocket',
-      apiBaseUrl: 'https://example.test/api/',
-      fetchImplementation: fetchSpy,
-    })
+    await Effect.runPromise(
+      postIssueReaction({
+        repositoryFullName: 'acme/widgets',
+        issueNumber: 5,
+        token: 'secret-token',
+        reactionContent: 'rocket',
+        apiBaseUrl: 'https://example.test/api/',
+        fetchImplementation: fetchSpy,
+      }),
+    )
 
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     const trailingCall = fetchSpy.mock.calls[0]
@@ -157,15 +172,17 @@ describe('findLatestPlanComment', () => {
       { id: 202, body: `${PLAN_COMMENT_MARKER}\nApproved steps`, html_url: 'https://example.com/comment/202' },
     ]
 
-    const result = await findLatestPlanComment({
-      repositoryFullName: 'gregkonush/lab',
-      issueNumber: 12,
-      fetchImplementation: async () => ({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify(payload),
+    const result = await Effect.runPromise(
+      findLatestPlanComment({
+        repositoryFullName: 'gregkonush/lab',
+        issueNumber: 12,
+        fetchImplementation: async () => ({
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify(payload),
+        }),
       }),
-    })
+    )
 
     expect(result.ok).toBe(true)
     if (!result.ok) {
@@ -179,27 +196,31 @@ describe('findLatestPlanComment', () => {
   it('returns not-found when no comment carries the plan marker', async () => {
     const payload = [{ id: 303, body: 'No marker here' }]
 
-    const result = await findLatestPlanComment({
-      repositoryFullName: 'gregkonush/lab',
-      issueNumber: 99,
-      fetchImplementation: async () => ({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify(payload),
+    const result = await Effect.runPromise(
+      findLatestPlanComment({
+        repositoryFullName: 'gregkonush/lab',
+        issueNumber: 99,
+        fetchImplementation: async () => ({
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify(payload),
+        }),
       }),
-    })
+    )
 
     expect(result).toEqual({ ok: false, reason: 'not-found' })
   })
 
   it('rejects repositories without owner and name segments', async () => {
-    const result = await findLatestPlanComment({
-      repositoryFullName: 'invalid-repo',
-      issueNumber: 5,
-      fetchImplementation: async () => {
-        throw new Error('fetch should not be called')
-      },
-    })
+    const result = await Effect.runPromise(
+      findLatestPlanComment({
+        repositoryFullName: 'invalid-repo',
+        issueNumber: 5,
+        fetchImplementation: async () => {
+          throw new Error('fetch should not be called')
+        },
+      }),
+    )
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -208,45 +229,51 @@ describe('findLatestPlanComment', () => {
   })
 
   it('returns invalid-json when the response body is not an array', async () => {
-    const result = await findLatestPlanComment({
-      repositoryFullName: 'owner/repo',
-      issueNumber: 4,
-      fetchImplementation: async () => ({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ foo: 'bar' }),
+    const result = await Effect.runPromise(
+      findLatestPlanComment({
+        repositoryFullName: 'owner/repo',
+        issueNumber: 4,
+        fetchImplementation: async () => ({
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ foo: 'bar' }),
+        }),
       }),
-    })
+    )
 
-    expect(result).toEqual({ ok: false, reason: 'invalid-json', detail: 'Expected array of issue comments' })
+    expect(result).toEqual({ ok: false, reason: 'invalid-json', detail: 'Expected array response from GitHub API' })
   })
 
   it('returns invalid-comment when id cannot be coerced to a number', async () => {
     const payload = [{ id: 'abc', body: `${PLAN_COMMENT_MARKER} body` }]
 
-    const result = await findLatestPlanComment({
-      repositoryFullName: 'owner/repo',
-      issueNumber: 6,
-      fetchImplementation: async () => ({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify(payload),
+    const result = await Effect.runPromise(
+      findLatestPlanComment({
+        repositoryFullName: 'owner/repo',
+        issueNumber: 6,
+        fetchImplementation: async () => ({
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify(payload),
+        }),
       }),
-    })
+    )
 
-    expect(result).toEqual({ ok: false, reason: 'invalid-comment', detail: 'Missing numeric comment id' })
+    expect(result).toEqual({ ok: false, reason: 'invalid-comment', detail: 'Comment missing numeric id' })
   })
 
   it('propagates JSON parse errors as invalid-json', async () => {
-    const result = await findLatestPlanComment({
-      repositoryFullName: 'owner/repo',
-      issueNumber: 7,
-      fetchImplementation: async () => ({
-        ok: true,
-        status: 200,
-        text: async () => '{invalid}',
+    const result = await Effect.runPromise(
+      findLatestPlanComment({
+        repositoryFullName: 'owner/repo',
+        issueNumber: 7,
+        fetchImplementation: async () => ({
+          ok: true,
+          status: 200,
+          text: async () => '{invalid}',
+        }),
       }),
-    })
+    )
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -255,27 +282,31 @@ describe('findLatestPlanComment', () => {
   })
 
   it('returns http-error when GitHub responds with failure', async () => {
-    const result = await findLatestPlanComment({
-      repositoryFullName: 'owner/repo',
-      issueNumber: 8,
-      fetchImplementation: async () => ({
-        ok: false,
-        status: 500,
-        text: async () => 'server failure',
+    const result = await Effect.runPromise(
+      findLatestPlanComment({
+        repositoryFullName: 'owner/repo',
+        issueNumber: 8,
+        fetchImplementation: async () => ({
+          ok: false,
+          status: 500,
+          text: async () => 'server failure',
+        }),
       }),
-    })
+    )
 
     expect(result).toEqual({ ok: false, reason: 'http-error', status: 500, detail: 'server failure' })
   })
 
   it('returns network-error when fetch implementation throws', async () => {
-    const result = await findLatestPlanComment({
-      repositoryFullName: 'owner/repo',
-      issueNumber: 9,
-      fetchImplementation: async () => {
-        throw new Error('network down')
-      },
-    })
+    const result = await Effect.runPromise(
+      findLatestPlanComment({
+        repositoryFullName: 'owner/repo',
+        issueNumber: 9,
+        fetchImplementation: async () => {
+          throw new Error('network down')
+        },
+      }),
+    )
 
     expect(result).toEqual({ ok: false, reason: 'network-error', detail: 'network down' })
   })

--- a/apps/froussard/src/services/kafka.test.ts
+++ b/apps/froussard/src/services/kafka.test.ts
@@ -1,12 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Effect, Layer } from 'effect'
+import { make as makeManagedRuntime } from 'effect/ManagedRuntime'
 
-import { KafkaManager, parseBrokerList, type KafkaConfig, type KafkaMessage } from '@/services/kafka'
+import { AppConfigService, type AppConfig } from '@/effect/config'
+import { AppLogger } from '@/logger'
+import { KafkaProducer, KafkaProducerLayer, parseBrokerList, type KafkaMessage } from '@/services/kafka'
 
 const producerFactory = vi.fn()
 
 vi.mock('kafkajs', () => {
   return {
-    Kafka: vi.fn((config: KafkaConfig) => ({
+    Kafka: vi.fn((config: AppConfig['kafka']) => ({
       producer: producerFactory,
       __config: config,
     })),
@@ -23,25 +27,45 @@ describe('parseBrokerList', () => {
   })
 })
 
-describe('KafkaManager', () => {
-  beforeEach(() => {
-    producerFactory.mockReset()
-  })
-
-  const createProducer = () => {
-    const connect = vi.fn().mockResolvedValue(undefined)
-    const send = vi.fn().mockResolvedValue(undefined)
-    const disconnect = vi.fn().mockResolvedValue(undefined)
-    return { connect, send, disconnect }
-  }
-
-  const baseConfig: KafkaConfig = {
-    brokers: ['broker:9092'],
-    clientId: 'test-client',
-    sasl: {
-      mechanism: 'scram-sha-512',
+describe('KafkaProducerLayer', () => {
+  const baseConfig: AppConfig = {
+    githubWebhookSecret: 'secret',
+    kafka: {
+      brokers: ['broker:9092'],
       username: 'user',
       password: 'pass',
+      clientId: 'test-client',
+      topics: {
+        raw: 'raw-topic',
+        codex: 'codex-topic',
+        discordCommands: 'discord-topic',
+      },
+      sasl: {
+        mechanism: 'scram-sha-512',
+        username: 'user',
+        password: 'pass',
+      },
+    },
+    codebase: {
+      baseBranch: 'main',
+      branchPrefix: 'codex/issue-',
+    },
+    codex: {
+      triggerLogin: 'user',
+      implementationTriggerPhrase: 'execute plan',
+    },
+    discord: {
+      publicKey: 'public',
+      defaultResponse: {
+        deferType: 'channel-message',
+        ephemeral: true,
+      },
+    },
+    github: {
+      token: 'token',
+      ackReaction: '+1',
+      apiBaseUrl: 'https://api.github.com',
+      userAgent: 'froussard',
     },
   }
 
@@ -52,70 +76,100 @@ describe('KafkaManager', () => {
     headers: {},
   }
 
-  it('connects and reuses existing promise on subsequent calls', async () => {
+  const createProducer = () => {
+    const connect = vi.fn().mockResolvedValue(undefined)
+    const send = vi.fn().mockResolvedValue(undefined)
+    const disconnect = vi.fn().mockResolvedValue(undefined)
+    return { connect, send, disconnect }
+  }
+
+  const createRuntime = () => {
+    const configLayer = Layer.succeed(AppConfigService, baseConfig)
+    const loggerLayer = Layer.succeed(AppLogger, {
+      debug: () => Effect.succeed(undefined),
+      info: () => Effect.succeed(undefined),
+      warn: () => Effect.succeed(undefined),
+      error: () => Effect.succeed(undefined),
+    })
+
+    const layer = KafkaProducerLayer.pipe(Layer.provide(configLayer), Layer.provide(loggerLayer))
+    const runtime = makeManagedRuntime(layer)
+
+    return { runtime }
+  }
+
+  beforeEach(() => {
+    producerFactory.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('connects on first publish and reuses producer', async () => {
     const producer = createProducer()
     producerFactory.mockReturnValue(producer)
 
-    const manager = new KafkaManager(baseConfig)
-    const first = manager.connect()
-    const second = manager.connect()
-    await Promise.all([first, second])
+    const { runtime } = createRuntime()
+    const kafka = await runtime.runPromise(
+      Effect.gen(function* (_) {
+        return yield* KafkaProducer
+      }),
+    )
+
+    await runtime.runPromise(kafka.publish(baseMessage))
 
     expect(producerFactory).toHaveBeenCalledTimes(1)
     expect(producer.connect).toHaveBeenCalledTimes(1)
-    expect(manager.isReady()).toBe(true)
+    expect(producer.send).toHaveBeenCalledTimes(1)
+
+    const ready = await runtime.runPromise(kafka.isReady)
+    expect(ready).toBe(true)
+
+    await runtime.dispose()
   })
 
-  it('publishes messages through the producer', async () => {
-    const producer = createProducer()
-    producerFactory.mockReturnValue(producer)
-
-    const manager = new KafkaManager(baseConfig)
-    await manager.publish(baseMessage)
-
-    expect(producer.connect).toHaveBeenCalledTimes(1)
-    expect(producer.send).toHaveBeenCalledWith({
-      topic: baseMessage.topic,
-      messages: [
-        {
-          key: baseMessage.key,
-          value: baseMessage.value,
-          headers: baseMessage.headers,
-        },
-      ],
-    })
-  })
-
-  it('recreates producer after a send failure', async () => {
+  it('recreates producer after send failure', async () => {
     const firstProducer = createProducer()
     firstProducer.send.mockRejectedValueOnce(new Error('boom'))
     const secondProducer = createProducer()
 
     producerFactory.mockImplementationOnce(() => firstProducer).mockImplementationOnce(() => secondProducer)
 
-    const manager = new KafkaManager(baseConfig)
+    const { runtime } = createRuntime()
+    const kafka = await runtime.runPromise(
+      Effect.gen(function* (_) {
+        return yield* KafkaProducer
+      }),
+    )
 
-    await expect(manager.publish(baseMessage)).rejects.toThrow('boom')
+    await expect(runtime.runPromise(kafka.publish(baseMessage))).rejects.toThrow('boom')
 
     expect(firstProducer.connect).toHaveBeenCalled()
     expect(firstProducer.send).toHaveBeenCalled()
+    expect(firstProducer.disconnect).toHaveBeenCalled()
 
-    await manager.publish(baseMessage)
+    await runtime.runPromise(kafka.publish(baseMessage))
 
     expect(producerFactory).toHaveBeenCalledTimes(2)
     expect(secondProducer.connect).toHaveBeenCalledTimes(1)
     expect(secondProducer.send).toHaveBeenCalledTimes(1)
+
+    await runtime.dispose()
   })
 
-  it('disconnects producer and resets flags', async () => {
+  it('disconnects producer when runtime is disposed', async () => {
     const producer = createProducer()
     producerFactory.mockReturnValue(producer)
 
-    const manager = new KafkaManager(baseConfig)
-    await manager.publish(baseMessage)
+    const { runtime } = createRuntime()
+    await runtime.runPromise(
+      Effect.gen(function* (_) {
+        return yield* KafkaProducer
+      }),
+    )
 
-    await manager.disconnect()
-    expect(producer.disconnect).toHaveBeenCalledTimes(1)
-    expect(manager.isReady()).toBe(false)
+    await runtime.dispose()
+    expect(producer.disconnect).toHaveBeenCalled()
   })
 })

--- a/apps/froussard/src/services/kafka.test.ts
+++ b/apps/froussard/src/services/kafka.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Effect, Layer } from 'effect'
 import { make as makeManagedRuntime } from 'effect/ManagedRuntime'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { AppConfigService, type AppConfig } from '@/effect/config'
+import { type AppConfig, AppConfigService } from '@/effect/config'
 import { AppLogger } from '@/logger'
-import { KafkaProducer, KafkaProducerLayer, parseBrokerList, type KafkaMessage } from '@/services/kafka'
+import { type KafkaMessage, KafkaProducer, KafkaProducerLayer, parseBrokerList } from '@/services/kafka'
 
 const producerFactory = vi.fn()
 

--- a/apps/froussard/src/services/kafka.ts
+++ b/apps/froussard/src/services/kafka.ts
@@ -29,7 +29,11 @@ export const KafkaProducerLayer = Layer.scoped(
       clientId: config.kafka.clientId,
       brokers: config.kafka.brokers,
       ssl: false,
-      sasl: config.kafka.sasl,
+      sasl: {
+        mechanism: 'scram-sha-512',
+        username: config.kafka.username,
+        password: config.kafka.password,
+      },
     })
 
     const createProducer = () => kafka.producer({ allowAutoTopicCreation: false })
@@ -100,8 +104,6 @@ export const KafkaProducerLayer = Layer.scoped(
       )
 
     const isReady = Ref.get(readyRef)
-
-    yield* connect
 
     return yield* Effect.acquireRelease(
       Effect.succeed<KafkaProducerService>({

--- a/apps/froussard/src/services/kafka.ts
+++ b/apps/froussard/src/services/kafka.ts
@@ -1,14 +1,8 @@
-import { Kafka, type Producer } from 'kafkajs'
+import { Effect, Layer, Ref } from 'effect'
+import { Kafka } from 'kafkajs'
 
-export interface KafkaConfig {
-  brokers: string[]
-  clientId: string
-  sasl: {
-    mechanism: 'scram-sha-512'
-    username: string
-    password: string
-  }
-}
+import { AppConfigService } from '@/effect/config'
+import { AppLogger } from '@/logger'
 
 export interface KafkaMessage {
   topic: string
@@ -17,77 +11,108 @@ export interface KafkaMessage {
   headers: Record<string, string>
 }
 
-export class KafkaManager {
-  private readonly kafka: Kafka
-  private producer: Producer
-  private connectPromise: Promise<void> | null = null
-  private ready = false
+export interface KafkaProducerService {
+  readonly publish: (message: KafkaMessage) => Effect.Effect<void>
+  readonly ensureConnected: Effect.Effect<void>
+  readonly isReady: Effect.Effect<boolean>
+}
 
-  constructor(config: KafkaConfig, allowAutoTopicCreation = false) {
-    this.kafka = new Kafka({
-      clientId: config.clientId,
-      brokers: config.brokers,
+export class KafkaProducer extends Effect.Tag('@froussard/KafkaProducer')<KafkaProducer, KafkaProducerService>() {}
+
+export const KafkaProducerLayer = Layer.scoped(
+  KafkaProducer,
+  Effect.gen(function* (_) {
+    const config = yield* AppConfigService
+    const logger = yield* AppLogger
+
+    const kafka = new Kafka({
+      clientId: config.kafka.clientId,
+      brokers: config.kafka.brokers,
       ssl: false,
-      sasl: config.sasl,
+      sasl: config.kafka.sasl,
     })
 
-    this.producer = this.kafka.producer({ allowAutoTopicCreation })
-  }
+    const createProducer = () => kafka.producer({ allowAutoTopicCreation: false })
+    let producer = createProducer()
+    const readyRef = yield* Ref.make(false)
 
-  async connect(): Promise<void> {
-    if (this.connectPromise) {
-      return this.connectPromise
-    }
+    const connect = Effect.tryPromise(() => producer.connect()).pipe(
+      Effect.tap(() => Ref.set(readyRef, true)),
+      Effect.tap(() =>
+        logger.info('Kafka producer connected', {
+          clientId: config.kafka.clientId,
+          brokers: config.kafka.brokers.join(','),
+        }),
+      ),
+    )
 
-    this.connectPromise = this.producer
-      .connect()
-      .then(() => {
-        this.ready = true
-      })
-      .catch((error) => {
-        this.ready = false
-        this.connectPromise = null
-        throw error
-      })
+    const disconnect = Effect.tryPromise(() => producer.disconnect()).pipe(
+      Effect.tap(() => Ref.set(readyRef, false)),
+      Effect.tap(() => logger.info('Kafka producer disconnected', { clientId: config.kafka.clientId })),
+    )
 
-    return this.connectPromise
-  }
+    const ensureConnected = Ref.get(readyRef).pipe(Effect.flatMap((ready) => (ready ? Effect.void : connect)))
 
-  isReady(): boolean {
-    return this.ready
-  }
+    const resetProducer = Effect.sync(() => {
+      producer = createProducer()
+    })
 
-  async publish(message: KafkaMessage): Promise<void> {
-    await this.connect()
+    const publish = (message: KafkaMessage) =>
+      ensureConnected.pipe(
+        Effect.flatMap(() =>
+          Effect.tryPromise({
+            try: () =>
+              producer.send({
+                topic: message.topic,
+                messages: [
+                  {
+                    key: message.key,
+                    value: message.value,
+                    headers: message.headers,
+                  },
+                ],
+              }),
+            catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+          }).pipe(
+            Effect.tap(() =>
+              logger.info('published kafka message', {
+                topic: message.topic,
+                key: message.key,
+              }),
+            ),
+            Effect.tapError((error) =>
+              Ref.set(readyRef, false).pipe(
+                Effect.zipRight(
+                  Effect.tryPromise(() => producer.disconnect()).pipe(Effect.catchAll(() => Effect.succeed(undefined))),
+                ),
+                Effect.zipRight(resetProducer),
+                Effect.zipRight(
+                  logger.error('failed to publish kafka message', {
+                    err: error instanceof Error ? error.message : String(error),
+                    topic: message.topic,
+                    key: message.key,
+                  }),
+                ),
+              ),
+            ),
+          ),
+        ),
+      )
 
-    try {
-      await this.producer.send({
-        topic: message.topic,
-        messages: [
-          {
-            key: message.key,
-            value: message.value,
-            headers: message.headers,
-          },
-        ],
-      })
-    } catch (error) {
-      this.ready = false
-      this.connectPromise = null
-      this.producer = this.kafka.producer({ allowAutoTopicCreation: false })
-      throw error
-    }
-  }
+    const isReady = Ref.get(readyRef)
 
-  async disconnect(): Promise<void> {
-    try {
-      await this.producer.disconnect()
-    } finally {
-      this.ready = false
-      this.connectPromise = null
-    }
-  }
-}
+    yield* connect
+
+    return yield* Effect.acquireRelease(
+      Effect.succeed<KafkaProducerService>({
+        publish,
+        ensureConnected,
+        isReady,
+      }),
+      () => disconnect.pipe(Effect.zipRight(resetProducer)),
+    )
+  }),
+)
 
 export const parseBrokerList = (raw: string): string[] => {
   return raw

--- a/apps/froussard/src/telemetry.ts
+++ b/apps/froussard/src/telemetry.ts
@@ -1,10 +1,10 @@
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api'
+import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { Resource } from '@opentelemetry/resources'
 import { type MetricReader, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
 import { NodeSDK } from '@opentelemetry/sdk-node'
-import { Resource } from '@opentelemetry/resources'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR)

--- a/apps/froussard/src/webhooks/discord.ts
+++ b/apps/froussard/src/webhooks/discord.ts
@@ -1,14 +1,14 @@
-import { logger } from '@/logger'
 import {
-  INTERACTION_TYPE,
   buildPlanModalResponse,
+  type DiscordApplicationCommandInteraction,
+  type DiscordCommandEvent,
+  type DiscordModalSubmitInteraction,
+  INTERACTION_TYPE,
   toPlanModalEvent,
   verifyDiscordRequest,
-  type DiscordApplicationCommandInteraction,
-  type DiscordModalSubmitInteraction,
-  type DiscordCommandEvent,
 } from '@/discord-commands'
 import type { AppRuntime } from '@/effect/runtime'
+import { logger } from '@/logger'
 
 import type { WebhookConfig } from './types'
 import { publishKafkaMessage } from './utils'

--- a/apps/froussard/src/webhooks/discord.ts
+++ b/apps/froussard/src/webhooks/discord.ts
@@ -8,7 +8,7 @@ import {
   type DiscordModalSubmitInteraction,
   type DiscordCommandEvent,
 } from '@/discord-commands'
-import type { KafkaManager } from '@/services/kafka'
+import type { AppRuntime } from '@/effect/runtime'
 
 import type { WebhookConfig } from './types'
 import { publishKafkaMessage } from './utils'
@@ -22,12 +22,12 @@ const jsonResponse = (payload: unknown, status = 200) =>
 const EPHEMERAL_FLAG = 1 << 6
 
 export interface DiscordWebhookDependencies {
-  kafka: KafkaManager
+  runtime: AppRuntime
   config: WebhookConfig
 }
 
 export const createDiscordWebhookHandler =
-  ({ kafka, config }: DiscordWebhookDependencies) =>
+  ({ runtime, config }: DiscordWebhookDependencies) =>
   async (body: Uint8Array, headers: Headers): Promise<Response> => {
     if (!(await verifyDiscordRequest(body, headers, config.discord.publicKey))) {
       logger.error({ headers: Array.from(headers.keys()) }, 'discord signature verification failed')
@@ -133,12 +133,14 @@ export const createDiscordWebhookHandler =
         kafkaHeaders['x-discord-user-id'] = event.user.id
       }
 
-      await publishKafkaMessage(kafka, {
-        topic: config.topics.discordCommands,
-        key: event.interactionId,
-        value: JSON.stringify(event),
-        headers: kafkaHeaders,
-      })
+      await runtime.runPromise(
+        publishKafkaMessage({
+          topic: config.topics.discordCommands,
+          key: event.interactionId,
+          value: JSON.stringify(event),
+          headers: kafkaHeaders,
+        }),
+      )
 
       return jsonResponse({
         type: 4,

--- a/apps/froussard/src/webhooks/github.ts
+++ b/apps/froussard/src/webhooks/github.ts
@@ -1,24 +1,26 @@
 import type { Webhooks } from '@octokit/webhooks'
 import { randomUUID } from 'node:crypto'
 
+import { Effect } from 'effect'
+
 import { buildCodexBranchName, buildCodexPrompt, normalizeLogin, type CodexTaskMessage } from '@/codex'
 import { selectReactionRepository } from '@/codex-workflow'
 import { deriveRepositoryFullName, isGithubIssueCommentEvent, isGithubIssueEvent } from '@/github-payload'
 import { logger } from '@/logger'
-import type { KafkaManager } from '@/services/kafka'
-import { findLatestPlanComment, postIssueReaction } from '@/services/github'
+import type { AppRuntime } from '@/effect/runtime'
+import { GithubService } from '@/services/github'
 
 import type { WebhookConfig } from './types'
 import { publishKafkaMessage } from './utils'
 
 export interface GithubWebhookDependencies {
-  kafka: KafkaManager
+  runtime: AppRuntime
   webhooks: Webhooks
   config: WebhookConfig
 }
 
 export const createGithubWebhookHandler =
-  ({ kafka, webhooks, config }: GithubWebhookDependencies) =>
+  ({ runtime, webhooks, config }: GithubWebhookDependencies) =>
   async (rawBody: string, request: Request): Promise<Response> => {
     const signatureHeader = request.headers.get('x-hub-signature-256')
     if (!signatureHeader) {
@@ -32,6 +34,12 @@ export const createGithubWebhookHandler =
       logger.error({ deliveryId, signatureHeader }, 'github webhook signature verification failed')
       return new Response('Unauthorized', { status: 401 })
     }
+
+    const githubService = runtime.runSync(
+      Effect.gen(function* (_) {
+        return yield* GithubService
+      }),
+    )
 
     let parsedPayload: unknown
     try {
@@ -105,23 +113,27 @@ export const createGithubWebhookHandler =
                 issuedAt: new Date().toISOString(),
               }
 
-              await publishKafkaMessage(kafka, {
-                topic: config.topics.codex,
-                key: `issue-${issueNumber}-planning`,
-                value: JSON.stringify(codexMessage),
-                headers: { ...headers, 'x-codex-task-stage': 'planning' },
-              })
+              await runtime.runPromise(
+                publishKafkaMessage({
+                  topic: config.topics.codex,
+                  key: `issue-${issueNumber}-planning`,
+                  value: JSON.stringify(codexMessage),
+                  headers: { ...headers, 'x-codex-task-stage': 'planning' },
+                }),
+              )
 
               codexStageTriggered = 'planning'
 
-              const reactionResult = await postIssueReaction({
-                repositoryFullName,
-                issueNumber,
-                token: config.github.token,
-                reactionContent: config.github.ackReaction,
-                apiBaseUrl: config.github.apiBaseUrl,
-                userAgent: config.github.userAgent,
-              })
+              const reactionResult = await runtime.runPromise(
+                githubService.postIssueReaction({
+                  repositoryFullName,
+                  issueNumber,
+                  token: config.github.token,
+                  reactionContent: config.github.ackReaction,
+                  apiBaseUrl: config.github.apiBaseUrl,
+                  userAgent: config.github.userAgent,
+                }),
+              )
 
               if (reactionResult.ok) {
                 logger.info(
@@ -164,13 +176,15 @@ export const createGithubWebhookHandler =
             let planCommentId: number | undefined
             let planCommentUrl: string | undefined
 
-            const planLookup = await findLatestPlanComment({
-              repositoryFullName,
-              issueNumber,
-              token: config.github.token,
-              apiBaseUrl: config.github.apiBaseUrl,
-              userAgent: config.github.userAgent,
-            })
+            const planLookup = await runtime.runPromise(
+              githubService.findLatestPlanComment({
+                repositoryFullName,
+                issueNumber,
+                token: config.github.token,
+                apiBaseUrl: config.github.apiBaseUrl,
+                userAgent: config.github.userAgent,
+              }),
+            )
 
             if (planLookup.ok) {
               planCommentBody = planLookup.comment.body
@@ -207,24 +221,28 @@ export const createGithubWebhookHandler =
               planCommentUrl,
             }
 
-            await publishKafkaMessage(kafka, {
-              topic: config.topics.codex,
-              key: `issue-${issueNumber}-implementation`,
-              value: JSON.stringify(codexMessage),
-              headers: { ...headers, 'x-codex-task-stage': 'implementation' },
-            })
+            await runtime.runPromise(
+              publishKafkaMessage({
+                topic: config.topics.codex,
+                key: `issue-${issueNumber}-implementation`,
+                value: JSON.stringify(codexMessage),
+                headers: { ...headers, 'x-codex-task-stage': 'implementation' },
+              }),
+            )
 
             codexStageTriggered = 'implementation'
           }
         }
       }
 
-      await publishKafkaMessage(kafka, {
-        topic: config.topics.raw,
-        key: deliveryId,
-        value: rawBody,
-        headers,
-      })
+      await runtime.runPromise(
+        publishKafkaMessage({
+          topic: config.topics.raw,
+          key: deliveryId,
+          value: rawBody,
+          headers,
+        }),
+      )
 
       return new Response(
         JSON.stringify({

--- a/apps/froussard/src/webhooks/github.ts
+++ b/apps/froussard/src/webhooks/github.ts
@@ -1,13 +1,13 @@
-import type { Webhooks } from '@octokit/webhooks'
 import { randomUUID } from 'node:crypto'
+import type { Webhooks } from '@octokit/webhooks'
 
 import { Effect } from 'effect'
 
-import { buildCodexBranchName, buildCodexPrompt, normalizeLogin, type CodexTaskMessage } from '@/codex'
+import { buildCodexBranchName, buildCodexPrompt, type CodexTaskMessage, normalizeLogin } from '@/codex'
 import { selectReactionRepository } from '@/codex-workflow'
+import type { AppRuntime } from '@/effect/runtime'
 import { deriveRepositoryFullName, isGithubIssueCommentEvent, isGithubIssueEvent } from '@/github-payload'
 import { logger } from '@/logger'
-import type { AppRuntime } from '@/effect/runtime'
 import { GithubService } from '@/services/github'
 
 import type { WebhookConfig } from './types'

--- a/apps/froussard/src/webhooks/index.ts
+++ b/apps/froussard/src/webhooks/index.ts
@@ -1,7 +1,7 @@
 import type { Webhooks } from '@octokit/webhooks'
 
 import { logger } from '@/logger'
-import type { KafkaManager } from '@/services/kafka'
+import type { AppRuntime } from '@/effect/runtime'
 
 import { createDiscordWebhookHandler } from './discord'
 import { createGithubWebhookHandler } from './github'
@@ -10,14 +10,14 @@ import type { WebhookConfig } from './types'
 export type { WebhookConfig } from './types'
 
 interface WebhookDependencies {
-  kafka: KafkaManager
+  runtime: AppRuntime
   webhooks: Webhooks
   config: WebhookConfig
 }
 
-export const createWebhookHandler = ({ kafka, webhooks, config }: WebhookDependencies) => {
-  const discordHandler = createDiscordWebhookHandler({ kafka, config })
-  const githubHandler = createGithubWebhookHandler({ kafka, webhooks, config })
+export const createWebhookHandler = ({ runtime, webhooks, config }: WebhookDependencies) => {
+  const discordHandler = createDiscordWebhookHandler({ runtime, config })
+  const githubHandler = createGithubWebhookHandler({ runtime, webhooks, config })
 
   return async (request: Request, provider: string): Promise<Response> => {
     logger.info({ provider }, 'webhook request received')

--- a/apps/froussard/src/webhooks/index.ts
+++ b/apps/froussard/src/webhooks/index.ts
@@ -1,7 +1,6 @@
 import type { Webhooks } from '@octokit/webhooks'
-
-import { logger } from '@/logger'
 import type { AppRuntime } from '@/effect/runtime'
+import { logger } from '@/logger'
 
 import { createDiscordWebhookHandler } from './discord'
 import { createGithubWebhookHandler } from './github'

--- a/apps/froussard/src/webhooks/utils.ts
+++ b/apps/froussard/src/webhooks/utils.ts
@@ -1,7 +1,12 @@
-import { logger } from '@/logger'
-import type { KafkaMessage, KafkaManager } from '@/services/kafka'
+import { Effect } from 'effect'
 
-export const publishKafkaMessage = async (kafka: KafkaManager, message: KafkaMessage): Promise<void> => {
-  await kafka.publish(message)
-  logger.info({ topic: message.topic, key: message.key }, 'published kafka message')
-}
+import { AppLogger } from '@/logger'
+import { KafkaProducer, type KafkaMessage } from '@/services/kafka'
+
+export const publishKafkaMessage = (message: KafkaMessage): Effect.Effect<void> =>
+  Effect.gen(function* (_) {
+    const kafka = yield* KafkaProducer
+    const logger = yield* AppLogger
+    yield* kafka.publish(message)
+    yield* logger.info('published kafka message', { topic: message.topic, key: message.key })
+  })

--- a/apps/froussard/src/webhooks/utils.ts
+++ b/apps/froussard/src/webhooks/utils.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect'
 
 import { AppLogger } from '@/logger'
-import { KafkaProducer, type KafkaMessage } from '@/services/kafka'
+import { type KafkaMessage, KafkaProducer } from '@/services/kafka'
 
 export const publishKafkaMessage = (message: KafkaMessage): Effect.Effect<void> =>
   Effect.gen(function* (_) {

--- a/argocd/applications/argo-workflows/alloy-configmap.yaml
+++ b/argocd/applications/argo-workflows/alloy-configmap.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argo-workflows-alloy
+  namespace: argo-workflows
+data:
+  config.river: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+
+    discovery.kubernetes "argo_workflows" {
+      role = "pod"
+
+      selectors {
+        role  = "pod"
+        field = "metadata.namespace=argo-workflows"
+      }
+    }
+
+    loki.source.kubernetes "argo_workflows" {
+      targets              = discovery.kubernetes.argo_workflows.targets
+      forward_to           = [loki.process.argo_workflows.receiver]
+      drop_deleted_pods    = true
+      allow_out_of_order   = true
+      namespaces           = ["argo-workflows"]
+    }
+
+    loki.process "argo_workflows" {
+      stage.labels {
+        values = {
+          namespace = "{{ .Labels.namespace }}"
+          pod       = "{{ .Labels.pod }}"
+          container = "{{ .Labels.container }}"
+        }
+      }
+
+      stage.static_labels {
+        values = {
+          job = "argo-workflows"
+        }
+      }
+
+      forward_to = [loki.write.default.receiver]
+    }
+
+    loki.write "default" {
+      endpoint {
+        url = "http://lgtm-loki-gateway.lgtm.svc.cluster.local/loki/api/v1/push"
+      }
+    }

--- a/argocd/applications/argo-workflows/alloy-deployment.yaml
+++ b/argocd/applications/argo-workflows/alloy-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-workflows-alloy
+  namespace: argo-workflows
+  labels:
+    app.kubernetes.io/name: argo-workflows-alloy
+    app.kubernetes.io/component: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-workflows-alloy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argo-workflows-alloy
+        app.kubernetes.io/component: logging
+    spec:
+      serviceAccountName: argo-workflows-alloy
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/alloy/config.river
+          ports:
+            - name: http-metrics
+              containerPort: 12345
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: argo-workflows-alloy
+            items:
+              - key: config.river
+                path: config.river

--- a/argocd/applications/argo-workflows/alloy-rbac.yaml
+++ b/argocd/applications/argo-workflows/alloy-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-workflows-alloy
+  namespace: argo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-workflows-alloy
+  namespace: argo-workflows
+rules:
+  - apiGroups: ['']
+    resources: ['pods', 'pods/log']
+    verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflows-alloy
+  namespace: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-workflows-alloy
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflows-alloy
+    namespace: argo-workflows

--- a/argocd/applications/argo-workflows/kustomization.yaml
+++ b/argocd/applications/argo-workflows/kustomization.yaml
@@ -4,6 +4,9 @@ resources:
   - rbac.yaml
   - ingressroute.yaml
   - argo-workflows-sso-sealedsecret.yaml
+  - alloy-rbac.yaml
+  - alloy-configmap.yaml
+  - alloy-deployment.yaml
 helmCharts:
   - name: argo-workflows
     repo: https://argoproj.github.io/argo-helm

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       discord-interactions:
         specifier: ^4.3.0
         version: 4.3.0
+      effect:
+        specifier: ^3.18.4
+        version: 3.18.4
       elysia:
         specifier: ^1.4.9
         version: 1.4.9(@sinclair/typebox@0.27.8)(exact-mirror@0.2.2(@sinclair/typebox@0.27.8))(openapi-types@12.1.3)(typescript@5.9.3)
@@ -209,7 +212,7 @@ importers:
         version: 2.2.4
       '@types/bun':
         specifier: latest
-        version: 1.2.23(@types/react@19.1.13)
+        version: 1.3.0(@types/react@19.1.13)
       '@types/react':
         specifier: ^19.1.13
         version: 19.1.13
@@ -437,7 +440,7 @@ importers:
         version: 2.2.4
       '@types/bun':
         specifier: latest
-        version: 1.2.23(@types/react@19.1.15)
+        version: 1.3.0(@types/react@19.1.15)
       '@types/node':
         specifier: ^22.13.9
         version: 22.13.10
@@ -4873,6 +4876,9 @@ packages:
   '@types/bun@1.2.23':
     resolution: {integrity: sha512-le8ueOY5b6VKYf19xT3McVbXqLqmxzPXHsQT/q9JHgikJ2X22wyTW3g3ohz2ZMnp7dod6aduIiq8A14Xyimm0A==}
 
+  '@types/bun@1.3.0':
+    resolution: {integrity: sha512-+lAGCYjXjip2qY375xX/scJeVRmZ5cY0wyHYyCYxNcdEXrQ4AOe3gACgd4iQ8ksOslJtW4VNxBJ8llUwc3a6AA==}
+
   '@types/bunyan@1.8.9':
     resolution: {integrity: sha512-ZqS9JGpBxVOvsawzmVt30sP++gSQMTejCkIAQ3VdadOcRE8izTyW66hufvwLeH+YEGP6Js2AW7Gz+RMyvrEbmw==}
 
@@ -5449,6 +5455,11 @@ packages:
 
   bun-types@1.2.23:
     resolution: {integrity: sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw==}
+    peerDependencies:
+      '@types/react': ^19
+
+  bun-types@1.3.0:
+    resolution: {integrity: sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ==}
     peerDependencies:
       '@types/react': ^19
 
@@ -6191,6 +6202,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.18.4:
+    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -6470,6 +6484,10 @@ packages:
   eyes@0.1.8:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
@@ -9497,8 +9515,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20251009:
-    resolution: {integrity: sha512-krib5VNghWUzlMA/nk+cmLCPrbnsRL1oOvPpahGnBb4Qf3nZatATP0t8jDxRl+qQLBu1B0pElpzZjyaf1JGAvA==}
+  typescript@6.0.0-dev.20251011:
+    resolution: {integrity: sha512-K4qBcmtTwrcjwko9jMLONmjCy3FIbF7MdcxPuJWvrfRDjB+nWd3C4QG5CVED9Dv6YtuXqlZvSS6zFTbk2JJnBQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -11617,7 +11635,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -11702,7 +11720,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -15480,15 +15498,21 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.9
 
-  '@types/bun@1.2.23(@types/react@19.1.13)':
-    dependencies:
-      bun-types: 1.2.23(@types/react@19.1.13)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@types/bun@1.2.23(@types/react@19.1.15)':
     dependencies:
       bun-types: 1.2.23(@types/react@19.1.15)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@types/bun@1.3.0(@types/react@19.1.13)':
+    dependencies:
+      bun-types: 1.3.0(@types/react@19.1.13)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@types/bun@1.3.0(@types/react@19.1.15)':
+    dependencies:
+      bun-types: 1.3.0(@types/react@19.1.15)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -16200,14 +16224,19 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  bun-types@1.2.23(@types/react@19.1.13):
-    dependencies:
-      '@types/node': 22.15.2
-      '@types/react': 19.1.13
-
   bun-types@1.2.23(@types/react@19.1.15):
     dependencies:
       '@types/node': 22.15.2
+      '@types/react': 19.1.15
+
+  bun-types@1.3.0(@types/react@19.1.13):
+    dependencies:
+      '@types/node': 24.7.0
+      '@types/react': 19.1.13
+
+  bun-types@1.3.0(@types/react@19.1.15):
+    dependencies:
+      '@types/node': 24.7.0
       '@types/react': 19.1.15
 
   c12@3.3.0(magicast@0.3.5):
@@ -16881,7 +16910,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20251009
+      typescript: 6.0.0-dev.20251011
 
   dunder-proto@1.0.1:
     dependencies:
@@ -16894,6 +16923,11 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
+
+  effect@3.18.4:
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      fast-check: 3.23.2
 
   ejs@3.1.10:
     dependencies:
@@ -17260,6 +17294,10 @@ snapshots:
   extend@3.0.2: {}
 
   eyes@0.1.8: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-content-type-parse@2.0.1: {}
 
@@ -18163,7 +18201,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -18237,7 +18275,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -18265,7 +18303,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -18330,7 +18368,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.7.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -21100,7 +21138,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.0-dev.20251009: {}
+  typescript@6.0.0-dev.20251011: {}
 
   ufo@1.5.4: {}
 


### PR DESCRIPTION
## Summary
- migrate froussard server + services to Effect-managed runtime (config, logger, Kafka, GitHub)
- add LGTM Alloy collector for argo-workflows logs
- expand test coverage for new Effect services and CLI logging

## Testing
- pnpm --filter froussard test -- --runInBand