### PR TITLE
fix: restore AppConfig layer wiring for froussard runtime

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -47,7 +47,7 @@ run:
     value: http/protobuf
 deploy:
   namespace: froussard
-  image: registry.ide-newton.ts.net/lab/froussard@sha256:4812cf5a37726c9eb0d34eb270d0bdf43ec527cb907ff3fff0dbea6e49857dcd
+  image: registry.ide-newton.ts.net/lab/froussard@sha256:90022c798c7c8f8595f2bb9a6494c51f850fdc56339479e9b872dfe8057d7b4f
   annotations:
     serving.knative.dev/revision-history-limit: "3"
   options:

--- a/apps/froussard/src/config.ts
+++ b/apps/froussard/src/config.ts
@@ -1,4 +1,4 @@
-import { parseBrokerList } from '@/services/kafka'
+import { parseBrokerList } from '@/utils/kafka'
 
 const requireEnv = (env: NodeJS.ProcessEnv, name: string): string => {
   const value = env[name]

--- a/apps/froussard/src/effect/runtime.test.ts
+++ b/apps/froussard/src/effect/runtime.test.ts
@@ -1,0 +1,86 @@
+import { Effect } from 'effect'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const producerFactory = vi.fn()
+const kafkaConstructor = vi.fn(() => ({
+  producer: producerFactory,
+}))
+
+vi.mock('kafkajs', () => ({
+  Kafka: kafkaConstructor,
+}))
+
+const createProducer = () => {
+  const connect = vi.fn().mockResolvedValue(undefined)
+  const disconnect = vi.fn().mockResolvedValue(undefined)
+  const send = vi.fn().mockResolvedValue(undefined)
+
+  return { connect, disconnect, send }
+}
+
+describe('makeAppRuntime', () => {
+  const originalEnv = process.env
+  const requiredEnv = {
+    GITHUB_WEBHOOK_SECRET: 'secret',
+    KAFKA_BROKERS: 'broker:9092',
+    KAFKA_USERNAME: 'user',
+    KAFKA_PASSWORD: 'pass',
+    KAFKA_TOPIC: 'raw-topic',
+    KAFKA_CODEX_TOPIC: 'codex-topic',
+    KAFKA_DISCORD_COMMAND_TOPIC: 'discord.commands.incoming',
+    DISCORD_PUBLIC_KEY: 'public-key',
+  }
+  let producers: Array<ReturnType<typeof createProducer>>
+
+  beforeEach(() => {
+    producers = []
+    producerFactory.mockImplementation(() => {
+      const producer = createProducer()
+      producers.push(producer)
+      return producer
+    })
+    kafkaConstructor.mockClear()
+    process.env = {
+      ...originalEnv,
+      ...requiredEnv,
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.clearAllMocks()
+  })
+
+  it('provides AppConfigService and KafkaProducer without missing dependencies', async () => {
+    const { makeAppRuntime } = await import('@/effect/runtime')
+    const { AppConfigService } = await import('@/effect/config')
+    const { KafkaProducer } = await import('@/services/kafka')
+
+    const runtime = makeAppRuntime()
+
+    const config = await runtime.runPromise(
+      Effect.gen(function* (_) {
+        return yield* AppConfigService
+      }),
+    )
+
+    expect(config.githubWebhookSecret).toBe('secret')
+    expect(config.kafka.brokers).toEqual(['broker:9092'])
+
+    const kafka = await runtime.runPromise(
+      Effect.gen(function* (_) {
+        return yield* KafkaProducer
+      }),
+    )
+
+    await runtime.runPromise(kafka.ensureConnected)
+
+    expect(kafkaConstructor).toHaveBeenCalledTimes(1)
+    expect(producerFactory).toHaveBeenCalledTimes(1)
+    expect(producers).toHaveLength(1)
+    expect(producers[0]?.connect).toHaveBeenCalledTimes(1)
+
+    await runtime.dispose()
+    expect(producers[0]?.disconnect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/froussard/src/effect/runtime.ts
+++ b/apps/froussard/src/effect/runtime.ts
@@ -6,7 +6,12 @@ import { AppLoggerLayer } from '@/logger'
 import { GithubServiceLayer } from '@/services/github'
 import { KafkaProducerLayer } from '@/services/kafka'
 
-const BaseAppLayer = Layer.mergeAll(AppConfigLayer, AppLoggerLayer, KafkaProducerLayer, GithubServiceLayer)
+const CoreAppLayer = Layer.mergeAll(AppConfigLayer, AppLoggerLayer)
+const BaseAppLayer = Layer.mergeAll(
+  CoreAppLayer,
+  GithubServiceLayer,
+  KafkaProducerLayer.pipe(Layer.provide(CoreAppLayer)),
+)
 
 export type AppRuntimeLayer = typeof BaseAppLayer
 

--- a/apps/froussard/src/services/kafka.ts
+++ b/apps/froussard/src/services/kafka.ts
@@ -4,6 +4,8 @@ import { Kafka } from 'kafkajs'
 import { AppConfigService } from '@/effect/config'
 import { AppLogger } from '@/logger'
 
+export { parseBrokerList } from '@/utils/kafka'
+
 export interface KafkaMessage {
   topic: string
   key: string
@@ -115,10 +117,3 @@ export const KafkaProducerLayer = Layer.scoped(
     )
   }),
 )
-
-export const parseBrokerList = (raw: string): string[] => {
-  return raw
-    .split(',')
-    .map((broker) => broker.trim())
-    .filter((broker) => broker.length > 0)
-}

--- a/apps/froussard/src/utils/kafka.ts
+++ b/apps/froussard/src/utils/kafka.ts
@@ -1,0 +1,6 @@
+export const parseBrokerList = (raw: string): string[] => {
+  return raw
+    .split(',')
+    .map((broker) => broker.trim())
+    .filter((broker) => broker.length > 0)
+}


### PR DESCRIPTION
## Description
- move `parseBrokerList` into `apps/froussard/src/utils/kafka.ts` and re-export from `apps/froussard/src/services/kafka.ts`
- update `apps/froussard/src/effect/runtime.ts` to provide the shared config/logger layer into the Kafka producer layer
- adjust `apps/froussard/src/config.ts` to consume the new utility to avoid circular imports
- add `apps/froussard/src/effect/runtime.test.ts` regression test covering runtime layer wiring

## Screenshots (if applicable)
