### PR TITLE
fix: limit knative revisions to five

### DIFF
--- a/argocd/applications/knative-serving/knative-serving.yaml
+++ b/argocd/applications/knative-serving/knative-serving.yaml
@@ -10,6 +10,8 @@ spec:
   config:
     domain:
       "proompteng.ai": ""
+    gc:
+      max-non-active-revisions: "5"
     certmanager:
       issuerRef: |
         kind: ClusterIssuer


### PR DESCRIPTION
## Summary
- cap Knative GC at five inactive revisions to reduce facteur rollout clutter

## Testing
- not run (config change only)