### PR TITLE
fix(argocd): align alloy config with v1.11

### DIFF
--- a/argocd/applications/argo-workflows/alloy-configmap.yaml
+++ b/argocd/applications/argo-workflows/alloy-configmap.yaml
@@ -13,6 +13,10 @@ data:
     discovery.kubernetes "argo_workflows" {
       role = "pod"
 
+      namespaces {
+        names = ["argo-workflows"]
+      }
+
       selectors {
         role  = "pod"
         field = "metadata.namespace=argo-workflows"
@@ -22,9 +26,6 @@ data:
     loki.source.kubernetes "argo_workflows" {
       targets              = discovery.kubernetes.argo_workflows.targets
       forward_to           = [loki.process.argo_workflows.receiver]
-      drop_deleted_pods    = true
-      allow_out_of_order   = true
-      namespaces           = ["argo-workflows"]
     }
 
     loki.process "argo_workflows" {


### PR DESCRIPTION
## Summary
- drop deprecated loki.source.kubernetes flags removed in alloy v1.11
- scope discovery to argo-workflows namespace to satisfy existing RBAC

## Testing
- kubectl rollout restart deploy/argo-workflows-alloy -n argo-workflows
- kubectl get pods -n argo-workflows
- kubectl logs deploy/argo-workflows-alloy -n argo-workflows