### PR TITLE
fix: align alloy configs with river schema

### DIFF
--- a/argocd/applications/argo-workflows/alloy-configmap.yaml
+++ b/argocd/applications/argo-workflows/alloy-configmap.yaml
@@ -26,8 +26,6 @@ data:
     loki.source.kubernetes "argo_workflows" {
       targets              = discovery.kubernetes.argo_workflows.targets
       forward_to           = [loki.process.argo_workflows.receiver]
-      drop_deleted_pods    = true
-      allow_out_of_order   = true
     }
 
     loki.process "argo_workflows" {

--- a/argocd/applications/argocd/alloy-configmap.yaml
+++ b/argocd/applications/argocd/alloy-configmap.yaml
@@ -70,7 +70,7 @@ data:
     prometheus.scrape "argocd" {
       job_name        = "argocd"
       scrape_interval = "30s"
-      targets         = discovery.relabel.argocd_metrics.targets
+      targets         = discovery.relabel.argocd_metrics.output
       forward_to      = [prometheus.remote_write.mimir.receiver]
     }
 
@@ -82,8 +82,6 @@ data:
 
     loki.source.kubernetes "argocd_pod_logs" {
       targets            = discovery.kubernetes.argocd_pods.targets
-      drop_deleted_pods  = true
-      allow_out_of_order = true
       forward_to         = [loki.process.argocd_pod_logs.receiver]
     }
 

--- a/argocd/applications/lgtm/README.md
+++ b/argocd/applications/lgtm/README.md
@@ -22,9 +22,9 @@ synchronized into the `lgtm` namespace.
 
 All in-cluster observability shippers (e.g., `argocd/alloy-*.yaml`, `argo-workflows/alloy-*.yaml`) share the same Grafana Alloy conventions. Keep River syntax consistent to avoid startup errors:
 
-- Scope Kubernetes discovery with the nested block syntax: `namespaces { names = ["<namespace>"] }`. Inline attributes like `namespaces = [...]` are rejected by Alloy v1.11+ and cause the controller to crash before shipping telemetry. citeturn0search0
-- Chain discovery relabelers into Prometheus scrapes via the `output` receiver. Example: `targets = discovery.relabel.argocd_metrics.targets`. This matches the exported label set from the relabel component. citeturn1search0turn4search1
-- `loki.source.kubernetes` inherits namespace selection from the discovery targets—it does **not** expose its own `namespaces` field. If you need to scope logs, do it on the discovery component feeding the source. citeturn2search5
+- Scope Kubernetes discovery with the nested block syntax: `namespaces { names = ["<namespace>"] }`. Inline attributes like `namespaces = [...]` are rejected by Alloy v1.11+ and cause the controller to crash before shipping telemetry (see the Grafana Alloy `discovery.kubernetes` reference). 
+- Chain discovery relabelers into Prometheus scrapes via the `output` receiver. Example: `targets = discovery.relabel.argocd_metrics.output`. This matches the exported target list from the relabel component (documented in Grafana Alloy `discovery.relabel`). 
+- `loki.source.kubernetes` inherits namespace selection from the discovery targets—it does **not** expose its own `namespaces` field. If you need to scope logs, do it on the discovery component feeding the source (per the Grafana Alloy `loki.source.kubernetes` reference). 
 - Keep OTLP writers pointed at the shared LGTM gateways (`lgtm-mimir-nginx`, `lgtm-tempo-gateway`, `lgtm-loki-gateway`) so every Alloy instance stays aligned with the central stack.
 
 When adding another Alloy deployment, copy one of the existing configs and validate with `kubectl kustomize` (or `alloy check`) before syncing Argo CD.


### PR DESCRIPTION
## Summary
- switch argocd alloy scrape back to discovery.relabel.*.output and drop unsupported loki source flags so the pod starts
- mirror the same flag cleanup in the argo-workflows alloy config
- document the output export in the LGTM alloy notes so future shippers reference the right field

## Testing
- kubectl kustomize argocd/applications/argocd
