### PR TITLE
fix: drop codex verbosity override

### DIFF
--- a/apps/froussard/scripts/codex-config-container.toml
+++ b/apps/froussard/scripts/codex-config-container.toml
@@ -1,5 +1,4 @@
 model = "gpt-5-codex"
-model_verbosity = "high"
 model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
 approval_policy = "never"

--- a/scripts/codex-config-template.toml
+++ b/scripts/codex-config-template.toml
@@ -1,5 +1,4 @@
 model = "gpt-5-codex"
-model_verbosity = "high"
 model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
 approval_policy = "never"


### PR DESCRIPTION
## Summary
- remove the gpt-5-codex model_verbosity override that the runtime ignores
- rebuild and push the codex container image to registry.ide-newton.ts.net/lab/codex-universal:latest (sha256:d645af31295952cd35c3cb476c72143cb25544ffe03fde402e989728af06d0d6)

## Testing
- bun apps/froussard/src/codex/cli/build-codex-image.ts
