### PR TITLE
fix: allow argocd alloy to list services

### DIFF
--- a/argocd/applications/argocd/alloy-rbac.yaml
+++ b/argocd/applications/argocd/alloy-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: argocd
 rules:
   - apiGroups: ['']
-    resources: ['pods', 'pods/log', 'endpoints']
+    resources: ['pods', 'pods/log', 'endpoints', 'services']
     verbs: ['get', 'list', 'watch']
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
- add services to the argocd-alloy role so discovery can watch service endpoints correctly

## Testing
- kubectl -n argocd logs deployment/argocd-alloy --tail=20
