### PR TITLE
fix: align knative gc thresholds

### DIFF
--- a/argocd/applications/knative-serving/knative-serving.yaml
+++ b/argocd/applications/knative-serving/knative-serving.yaml
@@ -11,6 +11,7 @@ spec:
     domain:
       "proompteng.ai": ""
     gc:
+      min-non-active-revisions: "2"
       max-non-active-revisions: "5"
     certmanager:
       issuerRef: |


### PR DESCRIPTION
## Summary
- add min-non-active-revisions so gc config satisfies knative webhook

## Testing
- not run (infra config only)