### PR TITLE
fix: align facteur alloy config with river schema

### DIFF
--- a/argocd/applications/facteur/overlays/cluster/alloy-configmap.yaml
+++ b/argocd/applications/facteur/overlays/cluster/alloy-configmap.yaml
@@ -19,10 +19,8 @@ data:
     }
 
     loki.source.kubernetes "facteur" {
-      targets            = discovery.kubernetes.facteur.targets
-      forward_to         = [loki.process.facteur.receiver]
-      allow_out_of_order = true
-      drop_deleted_pods  = true
+      targets    = discovery.kubernetes.facteur.targets
+      forward_to = [loki.process.facteur.receiver]
     }
 
     loki.process "facteur" {


### PR DESCRIPTION
## Summary
- remove unsupported loki.source.kubernetes attributes from facteur alloy config
- keep discovery and forwarding aligned with stack conventions so alloy starts cleanly

## Testing
- not run (config only)
