### PR TITLE
fix: scale mimir ingester replicas

### DIFF
--- a/argocd/applications/lgtm/lgtm-values.yaml
+++ b/argocd/applications/lgtm/lgtm-values.yaml
@@ -128,7 +128,7 @@ mimir:
         cpu: 100m
         memory: 256Mi
   ingester:
-    replicas: 1
+    replicas: 2
     persistentVolume:
       enabled: true
       size: 20Gi


### PR DESCRIPTION
## Summary
- increase Grafana Mimir ingester replicas to 2 so writes meet the distributor replication requirement

## Testing
- not run (manifest change only)
