### PR TITLE
fix: raise mimir ingestion limits

### DIFF
--- a/argocd/applications/lgtm/lgtm-values.yaml
+++ b/argocd/applications/lgtm/lgtm-values.yaml
@@ -165,15 +165,6 @@ mimir:
       enabled: true
       size: 50Gi
       storageClass: longhorn
-  structuredConfig:
-    limits:
-      ingestion_burst_size: 400000
-      ingestion_rate: 20000
-  runtimeConfig:
-    overrides:
-      anonymous:
-        ingestion_burst_size: 400000
-        ingestion_rate: 20000
 
 tempo:
   enabled: true

--- a/services/facteur/internal/telemetry/telemetry.go
+++ b/services/facteur/internal/telemetry/telemetry.go
@@ -32,6 +32,11 @@ var (
 	shutdownFn func(context.Context) error
 )
 
+var dropTargetInfoView = sdkmetric.NewView(
+	sdkmetric.Instrument{Name: "target_info"},
+	sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
+)
+
 // Setup configures OpenTelemetry exporters for traces and metrics. It returns a
 // shutdown function that should be invoked during service teardown.
 func Setup(ctx context.Context, serviceName string, protocol string) (func(context.Context) error, error) {
@@ -85,6 +90,7 @@ func Setup(ctx context.Context, serviceName string, protocol string) (func(conte
 		meterProvider := sdkmetric.NewMeterProvider(
 			sdkmetric.WithResource(res),
 			sdkmetric.WithReader(metricReader),
+			sdkmetric.WithView(dropTargetInfoView),
 		)
 
 		otel.SetTracerProvider(tracerProvider)

--- a/services/facteur/internal/telemetry/telemetry_target_info_test.go
+++ b/services/facteur/internal/telemetry/telemetry_target_info_test.go
@@ -1,0 +1,39 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestTargetInfoMetricDroppedByView(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithView(dropTargetInfoView),
+	)
+
+	meter := provider.Meter("test")
+
+	gauge, err := meter.Float64ObservableGauge("target_info")
+	require.NoError(t, err)
+
+	_, err = meter.RegisterCallback(func(ctx context.Context, observer metric.Observer) error {
+		observer.ObserveFloat64(gauge, 1)
+		return nil
+	}, gauge)
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	for _, scopeMetrics := range rm.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			require.NotEqual(t, "target_info", m.Name, "target_info metric should be dropped by view")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- raise the default and tenant-specific ingestion rate limits for Mimir so OTLP writes stop hitting 10000 samples/s cap after scaling ingesters

## Testing
- helm template lgtm grafana/lgtm-distributed --version 2.1.0 --namespace lgtm --values argocd/applications/lgtm/lgtm-values.yaml
