### PR TITLE
fix: inject kustomize opts via template patch

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -281,6 +281,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
+
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
     {{- $autoSync := eq .automation "auto" -}}
     {{- $haveKustomizeOpts := hasKey . "kustomizeBuildOptions" -}}
@@ -296,7 +297,8 @@ spec:
         {{- if $useLovely }}
         plugin:
           name: lovely
-        {{- else if $haveKustomizeOpts }}
+        {{- end }}
+        {{- if $haveKustomizeOpts }}
         kustomize:
           buildOptions: {{ .kustomizeBuildOptions | quote }}
         {{- end }}


### PR DESCRIPTION
## Summary
- inject per-app kustomize build options via templatePatch while leaving default lovely renderer alone
- ensure kafka Application gets `--load-restrictor LoadRestrictionsNone` without breaking other apps

## Testing
- scripts/kubeconform.sh argocd