### PR TITLE
feat: add observability stack

### DIFF
--- a/argocd/applications/lgtm/lgtm-values.yaml
+++ b/argocd/applications/lgtm/lgtm-values.yaml
@@ -165,6 +165,15 @@ mimir:
       enabled: true
       size: 50Gi
       storageClass: longhorn
+  structuredConfig:
+    limits:
+      ingestion_burst_size: 400000
+      ingestion_rate: 20000
+  runtimeConfig:
+    overrides:
+      anonymous:
+        ingestion_burst_size: 400000
+        ingestion_rate: 20000
 
 tempo:
   enabled: true

--- a/argocd/applications/lgtm/lgtm-values.yaml
+++ b/argocd/applications/lgtm/lgtm-values.yaml
@@ -165,15 +165,6 @@ mimir:
       enabled: true
       size: 50Gi
       storageClass: longhorn
-  structuredConfig:
-    limits:
-      ingestion_burst_size: 400000
-      ingestion_rate: 20000
-  runtimeConfig:
-    overrides:
-      anonymous:
-        ingestion_burst_size: 400000
-        ingestion_rate: 20000
 
 tempo:
   enabled: true

--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -1,0 +1,44 @@
+adminUser: admin
+adminPassword: changeme
+service:
+  type: LoadBalancer
+  annotations:
+    tailscale.com/hostname: grafana
+  loadBalancerClass: tailscale
+persistence:
+  enabled: true
+  storageClassName: longhorn
+  size: 10Gi
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        uid: loki
+        type: loki
+        access: proxy
+        url: http://observability-loki-gateway.observability.svc.cluster.local
+        isDefault: false
+      - name: Mimir
+        uid: prom
+        type: prometheus
+        access: proxy
+        url: http://observability-mimir-nginx.observability.svc.cluster.local/prometheus
+        isDefault: true
+      - name: Tempo
+        uid: tempo
+        type: tempo
+        access: proxy
+        url: http://observability-tempo-query-frontend.observability.svc.cluster.local:3100
+        isDefault: false
+        jsonData:
+          tracesToLogsV2:
+            datasourceUid: loki
+          lokiSearch:
+            datasourceUid: loki
+          tracesToMetrics:
+            datasourceUid: prom
+          serviceMap:
+            datasourceUid: prom
+testFramework:
+  enabled: false

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: observability
+
+resources:
+  - namespace.yaml
+
+helmCharts:
+  - name: mimir-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 5.8.0
+    releaseName: observability-mimir
+    namespace: observability
+    includeCRDs: true
+    valuesFile: mimir-values.yaml
+  - name: loki-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 0.80.5
+    releaseName: observability-loki
+    namespace: observability
+    includeCRDs: true
+    valuesFile: loki-values.yaml
+  - name: tempo-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 1.48.0
+    releaseName: observability-tempo
+    namespace: observability
+    includeCRDs: true
+    valuesFile: tempo-values.yaml
+  - name: grafana
+    repo: https://grafana.github.io/helm-charts
+    version: 10.1.0
+    releaseName: observability-grafana
+    namespace: observability
+    valuesFile: grafana-values.yaml

--- a/argocd/applications/observability/loki-values.yaml
+++ b/argocd/applications/observability/loki-values.yaml
@@ -1,0 +1,43 @@
+loki:
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: boltdb-shipper
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+  storageConfig:
+    boltdb_shipper:
+      cache_location: /var/loki/index
+      shared_store: filesystem
+    filesystem:
+      directory: /var/loki/chunks
+  compactor:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  ingester:
+    replicas: 2
+    persistence:
+      enabled: true
+      claims:
+        - name: data
+          size: 20Gi
+          storageClass: longhorn
+  querier:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 10Gi
+      storageClass: longhorn
+  ruler:
+    enabled: true
+    kind: StatefulSet
+    persistence:
+      enabled: true
+      size: 5Gi
+      storageClass: longhorn

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -1,0 +1,76 @@
+mimir:
+  structuredConfig:
+    limits:
+      ingestion_rate: 20000
+      ingestion_burst_size: 400000
+  runtimeConfig:
+    overrides:
+      anonymous:
+        ingestion_rate: 20000
+        ingestion_burst_size: 400000
+
+rollout_operator:
+  enabled: false
+
+admin_api:
+  replicas: 1
+
+distributor:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+
+ingester:
+  replicas: 2
+  zoneAwareReplication:
+    enabled: false
+  persistentVolume:
+    enabled: true
+    size: 20Gi
+    storageClass: longhorn
+
+querier:
+  replicas: 1
+
+query_frontend:
+  replicas: 1
+
+query_scheduler:
+  replicas: 1
+
+ruler:
+  replicas: 1
+
+store_gateway:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: false
+  persistentVolume:
+    enabled: true
+    size: 20Gi
+    storageClass: longhorn
+
+compactor:
+  replicas: 1
+  persistentVolume:
+    enabled: true
+    size: 20Gi
+    storageClass: longhorn
+
+alertmanager:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: false
+  persistence:
+    enabled: true
+    storageClass: longhorn
+    size: 5Gi
+
+minio:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 50Gi
+    storageClass: longhorn

--- a/argocd/applications/observability/namespace.yaml
+++ b/argocd/applications/observability/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability

--- a/argocd/applications/observability/tempo-values.yaml
+++ b/argocd/applications/observability/tempo-values.yaml
@@ -1,0 +1,33 @@
+gateway:
+  enabled: true
+
+tempo:
+  traces:
+    otlp:
+      http:
+        enabled: true
+      grpc:
+        enabled: true
+  distributor:
+    replicas: 1
+  ingester:
+    replicas: 2
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  compactor:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  querier:
+    replicas: 1
+  queryFrontend:
+    replicas: 1
+  storage:
+    trace:
+      backend: local
+      block:
+        version: vParquet3

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -101,6 +101,13 @@ spec:
               argocd.argoproj.io/sync-wave: "3"
             automation: auto
             enabled: "true"
+          - name: observability
+            path: argocd/applications/observability
+            namespace: observability
+            annotations:
+              argocd.argoproj.io/sync-wave: "3"
+            automation: manual
+            enabled: "true"
           - name: minio
             path: argocd/applications/minio
             namespace: minio

--- a/services/facteur/internal/telemetry/telemetry.go
+++ b/services/facteur/internal/telemetry/telemetry.go
@@ -32,6 +32,11 @@ var (
 	shutdownFn func(context.Context) error
 )
 
+var dropTargetInfoView = sdkmetric.NewView(
+	sdkmetric.Instrument{Name: "target_info"},
+	sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
+)
+
 // Setup configures OpenTelemetry exporters for traces and metrics. It returns a
 // shutdown function that should be invoked during service teardown.
 func Setup(ctx context.Context, serviceName string, protocol string) (func(context.Context) error, error) {
@@ -85,6 +90,7 @@ func Setup(ctx context.Context, serviceName string, protocol string) (func(conte
 		meterProvider := sdkmetric.NewMeterProvider(
 			sdkmetric.WithResource(res),
 			sdkmetric.WithReader(metricReader),
+			sdkmetric.WithView(dropTargetInfoView),
 		)
 
 		otel.SetTracerProvider(tracerProvider)

--- a/services/facteur/internal/telemetry/telemetry_target_info_test.go
+++ b/services/facteur/internal/telemetry/telemetry_target_info_test.go
@@ -1,0 +1,39 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestTargetInfoMetricDroppedByView(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithView(dropTargetInfoView),
+	)
+
+	meter := provider.Meter("test")
+
+	gauge, err := meter.Float64ObservableGauge("target_info")
+	require.NoError(t, err)
+
+	_, err = meter.RegisterCallback(func(ctx context.Context, observer metric.Observer) error {
+		observer.ObserveFloat64(gauge, 1)
+		return nil
+	}, gauge)
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	for _, scopeMetrics := range rm.ScopeMetrics {
+		for _, m := range scopeMetrics.Metrics {
+			require.NotEqual(t, "target_info", m.Name, "target_info metric should be dropped by view")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add an `observability` Argo CD application that deploys the latest Grafana Mimir 2.17, Loki 3.5, Tempo 2.8, and Grafana 12.2 releases with a bundled MinIO backend
- expose Grafana through Tailscale (`grafana.ide-newton.ts.net`) and configure OTLP endpoints for metrics, logs, and traces in the new namespace
- register the application with the platform ApplicationSet (manual sync) so the stack is discoverable by Argo CD

## Testing
- kubectl kustomize argocd/applications/observability --enable-helm | kubectl apply -f -
- kubectl -n observability get pods
- kubectl -n observability get svc observability-grafana
