### PR TITLE
fix: keep platform template patch valid

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -280,7 +280,7 @@ spec:
     {{- range $key, $value := .annotations }}
         {{ $key }}: {{ $value | quote }}
     {{- end }}
-    {{- end }}
+    {{ end }}
 
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
     {{- $autoSync := eq .automation "auto" -}}


### PR DESCRIPTION
## Summary
- stop trimming the newline after metadata annotations in the platform ApplicationSet templatePatch
- this preserves the separator between annotations and spec so the rendered YAML stays valid

## Testing
- scripts/kubeconform.sh argocd