### PR TITLE
feat: add observability stack

### DIFF
--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -1,0 +1,44 @@
+adminUser: admin
+adminPassword: changeme
+service:
+  type: LoadBalancer
+  annotations:
+    tailscale.com/hostname: grafana
+  loadBalancerClass: tailscale
+persistence:
+  enabled: true
+  storageClassName: longhorn
+  size: 10Gi
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        uid: loki
+        type: loki
+        access: proxy
+        url: http://observability-loki-gateway.observability.svc.cluster.local
+        isDefault: false
+      - name: Mimir
+        uid: prom
+        type: prometheus
+        access: proxy
+        url: http://observability-mimir-nginx.observability.svc.cluster.local/prometheus
+        isDefault: true
+      - name: Tempo
+        uid: tempo
+        type: tempo
+        access: proxy
+        url: http://observability-tempo-query-frontend.observability.svc.cluster.local:3100
+        isDefault: false
+        jsonData:
+          tracesToLogsV2:
+            datasourceUid: loki
+          lokiSearch:
+            datasourceUid: loki
+          tracesToMetrics:
+            datasourceUid: prom
+          serviceMap:
+            datasourceUid: prom
+testFramework:
+  enabled: false

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: observability
+
+resources:
+  - namespace.yaml
+  - minio-secret.yaml
+  - minio-deployment.yaml
+  - minio-buckets-job.yaml
+
+helmCharts:
+  - name: mimir-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 5.8.0
+    releaseName: observability-mimir
+    namespace: observability
+    includeCRDs: true
+    valuesFile: mimir-values.yaml
+  - name: loki-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 0.80.5
+    releaseName: observability-loki
+    namespace: observability
+    includeCRDs: true
+    valuesFile: loki-values.yaml
+  - name: tempo-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 1.48.0
+    releaseName: observability-tempo
+    namespace: observability
+    includeCRDs: true
+    valuesFile: tempo-values.yaml
+  - name: grafana
+    repo: https://grafana.github.io/helm-charts
+    version: 10.1.0
+    releaseName: observability-grafana
+    namespace: observability
+    valuesFile: grafana-values.yaml

--- a/argocd/applications/observability/loki-values.yaml
+++ b/argocd/applications/observability/loki-values.yaml
@@ -1,0 +1,48 @@
+loki:
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: boltdb-shipper
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+  storageConfig:
+    aws:
+      s3: http://observability-minio.observability.svc.cluster.local:9000
+      s3forcepathstyle: true
+      bucketnames: loki-data
+      access_key_id: grafana-loki
+      secret_access_key: supersecret
+      insecure: true
+    boltdb_shipper:
+      cache_location: /var/loki/index
+      shared_store: s3
+  compactor:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  ingester:
+    replicas: 2
+    persistence:
+      enabled: true
+      claims:
+        - name: data
+          size: 20Gi
+          storageClass: longhorn
+  querier:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 10Gi
+      storageClass: longhorn
+  ruler:
+    enabled: true
+    kind: StatefulSet
+    persistence:
+      enabled: true
+      size: 5Gi
+      storageClass: longhorn

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -1,0 +1,76 @@
+mimir:
+  structuredConfig:
+    limits:
+      ingestion_rate: 20000
+      ingestion_burst_size: 400000
+  runtimeConfig:
+    overrides:
+      anonymous:
+        ingestion_rate: 20000
+        ingestion_burst_size: 400000
+
+rollout_operator:
+  enabled: false
+
+admin_api:
+  replicas: 1
+
+distributor:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+
+ingester:
+  replicas: 2
+  zoneAwareReplication:
+    enabled: false
+  persistentVolume:
+    enabled: true
+    size: 20Gi
+    storageClass: longhorn
+
+querier:
+  replicas: 1
+
+query_frontend:
+  replicas: 1
+
+query_scheduler:
+  replicas: 1
+
+ruler:
+  replicas: 1
+
+store_gateway:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: false
+  persistentVolume:
+    enabled: true
+    size: 20Gi
+    storageClass: longhorn
+
+compactor:
+  replicas: 1
+  persistentVolume:
+    enabled: true
+    size: 20Gi
+    storageClass: longhorn
+
+alertmanager:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: false
+  persistence:
+    enabled: true
+    storageClass: longhorn
+    size: 5Gi
+
+minio:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 50Gi
+    storageClass: longhorn

--- a/argocd/applications/observability/minio-buckets-job.yaml
+++ b/argocd/applications/observability/minio-buckets-job.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: observability-minio-buckets
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: observability-minio-buckets
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: observability-minio-buckets
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: create-buckets
+          image: minio/mc:RELEASE.2025-06-28T18-58-08Z
+          env:
+            - name: MINIO_ENDPOINT
+              value: http://observability-minio.observability.svc.cluster.local:9000
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: rootPassword
+            - name: LOKI_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: lokiAccessKey
+            - name: LOKI_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: lokiSecretKey
+            - name: TEMPO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: tempoAccessKey
+            - name: TEMPO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: tempoSecretKey
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              until mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                echo "waiting for MinIO..."
+                sleep 5
+              done
+              mc admin user add minio "$LOKI_ACCESS_KEY" "$LOKI_SECRET_KEY" || true
+              mc admin user add minio "$TEMPO_ACCESS_KEY" "$TEMPO_SECRET_KEY" || true
+              mc mb -p minio/loki-data || true
+              mc mb -p minio/tempo-traces || true
+              mc admin policy attach minio readwrite --user "$LOKI_ACCESS_KEY"
+              mc admin policy attach minio readwrite --user "$TEMPO_ACCESS_KEY"

--- a/argocd/applications/observability/minio-deployment.yaml
+++ b/argocd/applications/observability/minio-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: observability-minio
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: observability-minio
+    app.kubernetes.io/component: object-store
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: observability-minio
+      app.kubernetes.io/component: object-store
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: observability-minio
+        app.kubernetes.io/component: object-store
+    spec:
+      serviceAccountName: minio-sa
+      containers:
+        - name: minio
+          image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+          args:
+            - server
+            - /data
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: rootPassword
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: public
+          ports:
+            - containerPort: 9000
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: observability-minio-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: observability-minio-data
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: observability-minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: longhorn
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: observability-minio
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: observability-minio
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9000
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: observability-minio
+    app.kubernetes.io/component: object-store

--- a/argocd/applications/observability/minio-secret.yaml
+++ b/argocd/applications/observability/minio-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: observability-minio-credentials
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: observability-minio
+    app.kubernetes.io/instance: observability-minio
+    app.kubernetes.io/component: object-store
+stringData:
+  rootUser: observability-root
+  rootPassword: observability-supersecret
+  lokiAccessKey: grafana-loki
+  lokiSecretKey: loki-supersecret
+  tempoAccessKey: grafana-tempo
+  tempoSecretKey: tempo-supersecret

--- a/argocd/applications/observability/namespace.yaml
+++ b/argocd/applications/observability/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability

--- a/argocd/applications/observability/tempo-values.yaml
+++ b/argocd/applications/observability/tempo-values.yaml
@@ -1,0 +1,38 @@
+gateway:
+  enabled: true
+
+tempo:
+  traces:
+    otlp:
+      http:
+        enabled: true
+      grpc:
+        enabled: true
+  distributor:
+    replicas: 1
+  ingester:
+    replicas: 2
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  compactor:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 20Gi
+      storageClass: longhorn
+  querier:
+    replicas: 1
+  queryFrontend:
+    replicas: 1
+  storage:
+    trace:
+      backend: s3
+      s3:
+        endpoint: http://observability-minio.observability.svc.cluster.local:9000
+        bucket: tempo-traces
+        access_key: grafana-tempo
+        secret_key: supersecret
+        insecure: true
+        s3forcepathstyle: true

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -102,6 +102,13 @@ spec:
               argocd.argoproj.io/sync-wave: "3"
             automation: auto
             enabled: "true"
+          - name: observability
+            path: argocd/applications/observability
+            namespace: observability
+            annotations:
+              argocd.argoproj.io/sync-wave: "3"
+            automation: manual
+            enabled: "true"
           - name: minio
             path: argocd/applications/minio
             namespace: minio


### PR DESCRIPTION
## Summary
- add an Argo CD `observability` application composed of the latest Grafana Mimir, Loki, Tempo, and Grafana releases with chart-managed MinIO storage
- expose Grafana via Tailscale at `grafana.ide-newton.ts.net` and wire OTLP endpoints for metrics, logs, and traces in the new namespace
- register the application with the platform ApplicationSet (manual sync) so Argo CD can manage the new stack

## Testing
- kubectl kustomize argocd/applications/observability --enable-helm | kubectl apply -f -
- kubectl -n observability get pods
- kubectl -n observability get svc observability-grafana
