### PR TITLE
fix: wire observability stack to dedicated minio

### DIFF
--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -36,3 +36,75 @@ helmCharts:
     releaseName: observability-grafana
     namespace: observability
     valuesFile: grafana-values.yaml
+
+patches:
+  - target:
+      kind: StatefulSet
+      name: observability-mimir-compactor
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: observability-mimir-compactor
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: StatefulSet
+      name: observability-mimir-ingester
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: observability-mimir-ingester
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: StatefulSet
+      name: observability-mimir-store-gateway
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: observability-mimir-store-gateway
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: StatefulSet
+      name: observability-tempo-ingester
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: observability-tempo-ingester
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: StatefulSet
+      name: observability-tempo-memcached
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: observability-tempo-memcached
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: StatefulSet
+      name: observability-loki-loki-distributed-ingester
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: observability-loki-loki-distributed-ingester
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
+  - target:
+      kind: StatefulSet
+      name: observability-loki-loki-distributed-querier
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: observability-loki-loki-distributed-querier
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true

--- a/argocd/applications/observability/loki-values.yaml
+++ b/argocd/applications/observability/loki-values.yaml
@@ -3,7 +3,7 @@ loki:
     configs:
       - from: "2024-01-01"
         store: boltdb-shipper
-        object_store: filesystem
+        object_store: s3
         schema: v13
         index:
           prefix: loki_index_
@@ -14,7 +14,7 @@ loki:
       s3forcepathstyle: true
       bucketnames: loki-data
       access_key_id: grafana-loki
-      secret_access_key: supersecret
+      secret_access_key: loki-supersecret
       insecure: true
     boltdb_shipper:
       cache_location: /var/loki/index

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -1,8 +1,50 @@
+global:
+  extraEnv:
+    - name: MIMIR_S3_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: observability-minio-credentials
+          key: mimirAccessKey
+    - name: MIMIR_S3_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: observability-minio-credentials
+          key: mimirSecretKey
+
 mimir:
   structuredConfig:
     limits:
       ingestion_rate: 20000
       ingestion_burst_size: 400000
+    blocks_storage:
+      backend: s3
+      bucket_store:
+        sync_dir: /data/tsdb-sync
+      s3:
+        endpoint: http://observability-minio.observability.svc.cluster.local:9000
+        bucket_name: mimir-blocks
+        access_key_id: ${MIMIR_S3_ACCESS_KEY_ID}
+        secret_access_key: ${MIMIR_S3_SECRET_ACCESS_KEY}
+        insecure: true
+        s3forcepathstyle: true
+    alertmanager_storage:
+      backend: s3
+      s3:
+        endpoint: http://observability-minio.observability.svc.cluster.local:9000
+        bucket_name: mimir-alertmanager
+        access_key_id: ${MIMIR_S3_ACCESS_KEY_ID}
+        secret_access_key: ${MIMIR_S3_SECRET_ACCESS_KEY}
+        insecure: true
+        s3forcepathstyle: true
+    ruler_storage:
+      backend: s3
+      s3:
+        endpoint: http://observability-minio.observability.svc.cluster.local:9000
+        bucket_name: mimir-ruler
+        access_key_id: ${MIMIR_S3_ACCESS_KEY_ID}
+        secret_access_key: ${MIMIR_S3_SECRET_ACCESS_KEY}
+        insecure: true
+        s3forcepathstyle: true
   runtimeConfig:
     overrides:
       anonymous:
@@ -69,8 +111,4 @@ alertmanager:
     size: 5Gi
 
 minio:
-  enabled: true
-  persistence:
-    enabled: true
-    size: 50Gi
-    storageClass: longhorn
+  enabled: false

--- a/argocd/applications/observability/minio-buckets-job.yaml
+++ b/argocd/applications/observability/minio-buckets-job.yaml
@@ -48,6 +48,16 @@ spec:
                 secretKeyRef:
                   name: observability-minio-credentials
                   key: tempoSecretKey
+            - name: MIMIR_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: mimirAccessKey
+            - name: MIMIR_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-credentials
+                  key: mimirSecretKey
           command:
             - /bin/sh
             - -c
@@ -59,7 +69,12 @@ spec:
               done
               mc admin user add minio "$LOKI_ACCESS_KEY" "$LOKI_SECRET_KEY" || true
               mc admin user add minio "$TEMPO_ACCESS_KEY" "$TEMPO_SECRET_KEY" || true
+              mc admin user add minio "$MIMIR_ACCESS_KEY" "$MIMIR_SECRET_KEY" || true
               mc mb -p minio/loki-data || true
               mc mb -p minio/tempo-traces || true
-              mc admin policy attach minio readwrite --user "$LOKI_ACCESS_KEY"
-              mc admin policy attach minio readwrite --user "$TEMPO_ACCESS_KEY"
+              mc mb -p minio/mimir-blocks || true
+              mc mb -p minio/mimir-ruler || true
+              mc mb -p minio/mimir-alertmanager || true
+              mc admin policy attach minio readwrite --user "$LOKI_ACCESS_KEY" || true
+              mc admin policy attach minio readwrite --user "$TEMPO_ACCESS_KEY" || true
+              mc admin policy attach minio readwrite --user "$MIMIR_ACCESS_KEY" || true

--- a/argocd/applications/observability/minio-deployment.yaml
+++ b/argocd/applications/observability/minio-deployment.yaml
@@ -69,7 +69,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Gi
+      storage: 50Gi
   storageClassName: longhorn
 ---
 apiVersion: v1

--- a/argocd/applications/observability/minio-secret.yaml
+++ b/argocd/applications/observability/minio-secret.yaml
@@ -14,3 +14,5 @@ stringData:
   lokiSecretKey: loki-supersecret
   tempoAccessKey: grafana-tempo
   tempoSecretKey: tempo-supersecret
+  mimirAccessKey: grafana-mimir
+  mimirSecretKey: mimir-supersecret

--- a/argocd/applications/observability/tempo-values.yaml
+++ b/argocd/applications/observability/tempo-values.yaml
@@ -33,6 +33,6 @@ tempo:
         endpoint: http://observability-minio.observability.svc.cluster.local:9000
         bucket: tempo-traces
         access_key: grafana-tempo
-        secret_key: supersecret
+        secret_key: tempo-supersecret
         insecure: true
         s3forcepathstyle: true


### PR DESCRIPTION
## Summary
- deploy a dedicated `observability-minio` object store (secret, deployment, PVC, service, bucket bootstrap job) so Loki and Tempo share a proper S3 backend
- retune the observability kustomization: disable the chart-managed MinIO, add Argo `Replace=true` patches for all stateful sets, and point Loki/Tempo at the new MinIO credentials
- rebalance storage requests (MinIO PVC down to 50Gi) to keep Longhorn admission happy while the new stack rolls out

## Testing
- kubectl kustomize argocd/applications/observability --enable-helm | kubectl apply -f -
- kubectl -n observability get pods
- kubectl -n observability get pvc observability-minio-data
