### PR TITLE
fix: pin redis exporter to latest digest

### DIFF
--- a/argocd/applications/dernier/base/redis.yaml
+++ b/argocd/applications/dernier/base/redis.yaml
@@ -18,7 +18,7 @@ spec:
     fsGroupChangePolicy: Always
   redisExporter:
     enabled: true
-    image: quay.io/opstree/redis-exporter:v1.78.0
+    image: quay.io/opstree/redis-exporter:v1.78.0@sha256:8edf2c77220a6e8fc290d13a4ec78bedcbdf08b8bf03a64119f448131f733d3f
   storage:
     volumeClaimTemplate:
       spec:


### PR DESCRIPTION
## Summary
- pin the redis exporter image to quay.io/opstree/redis-exporter:v1.78.0@sha256:8edf2c7… so ArgoCD always deploys the current latest tag
- document drift by applying the manifest and recycling the statefulset pod so the exporter comes up with the new digest

## Testing
- kubectl apply -k argocd/applications/dernier/overlays/cluster
- kubectl -n dernier delete pod dernier-redis-0
- kubectl -n dernier wait --for=condition=ready pod/dernier-redis-0 --timeout=120s
- kubectl -n dernier get pod dernier-redis-0 -o jsonpath='{.spec.containers[?(@.name=="redis-exporter")].image}'
