### PR TITLE
fix: add readiness probe defaults for dernier

### DIFF
--- a/argocd/applications/dernier/base/kservice.yaml
+++ b/argocd/applications/dernier/base/kservice.yaml
@@ -40,6 +40,7 @@ spec:
           ports:
             - containerPort: 3000
               name: http1
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /health
@@ -47,11 +48,14 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 20
           readinessProbe:
+            failureThreshold: 3
             httpGet:
               path: /health
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## Summary
- add explicit protocol and readiness probe thresholds to the Dernier Knative Service spec so Argo CD agrees with the defaults applied by the controller
- reapply the overlay to ensure the live object matches the manifest

## Testing
- kubectl apply -k argocd/applications/dernier/overlays/cluster
