### PR TITLE
chore: remove observability namespace manifest

### DIFF
--- a/argocd/applications/observability/namespace.yaml
+++ b/argocd/applications/observability/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: observability


### PR DESCRIPTION
## Summary
- drop the  manifest so the ApplicationSet owns namespace creation
- patch the live  namespace to remove Argo CD tracking/last-applied annotations and leave the namespace intact

## Testing
- kubectl patch namespace observability --type=json -p='[{"op":"remove","path":"/metadata/annotations/argocd.argoproj.io~1tracking-id"}]'
- kubectl patch namespace observability --type=json -p='[{"op":"remove","path":"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration"}]'
- kubectl get namespace observability -o yaml
