### PR TITLE
feat: scale mimir to satisfy smoke test

### DIFF
--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -13,21 +13,6 @@ global:
 
 mimir:
   structuredConfig:
-    compactor:
-      enabled: true
-      sharding_enabled: false
-      uploads:
-        parallel: 1
-      clean_store:
-        keep_per_series: 0
-    common:
-      storage_config:
-        s3:
-          bucket_lookup_type: path
-          endpoint: observability-minio.minio.svc.cluster.local:9000
-          access_key_id: ${MIMIR_S3_ACCESS_KEY_ID}
-          secret_access_key: ${MIMIR_S3_SECRET_ACCESS_KEY}
-          insecure: true
     limits:
       ingestion_rate: 20000
       ingestion_burst_size: 400000
@@ -63,8 +48,6 @@ mimir:
     usage_stats:
       enabled: false
       installation_mode: helm
-    continuous_test:
-      enabled: false
   runtimeConfig:
     overrides:
       anonymous:

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -61,14 +61,14 @@ admin_api:
   replicas: 1
 
 distributor:
-  replicas: 1
+  replicas: 2
   resources:
     requests:
       cpu: 200m
       memory: 512Mi
 
 ingester:
-  replicas: 2
+  replicas: 3
   zoneAwareReplication:
     enabled: false
   persistentVolume:

--- a/argocd/applications/observability/minio-buckets-job.yaml
+++ b/argocd/applications/observability/minio-buckets-job.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: observability-minio-buckets
   annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
     argocd.argoproj.io/sync-options: Replace=true
 spec:
   manualSelector: true


### PR DESCRIPTION
## Summary
- increase the Mimir distributor replica count to 2 and ingester replica count to 3
- keep the smoketest enabled but ensure at least two ingesters will be Ready when it runs

## Testing
- kubectl kustomize --enable-helm argocd/applications/observability | kubectl apply -f -
- kubectl -n observability get pods | grep mimir
- kubectl -n observability delete job observability-mimir-smoke-test --ignore-not-found &&   kubectl kustomize --enable-helm argocd/applications/observability | kubectl apply -f -
