### PR TITLE
build: enforce digest deploys for dernier

### DIFF
--- a/argocd/applications/dernier/base/kservice.yaml
+++ b/argocd/applications/dernier/base/kservice.yaml
@@ -13,6 +13,7 @@ spec:
       containers:
         - name: api
           image: registry.ide-newton.ts.net/lab/dernier:latest
+          imagePullPolicy: Always
           env:
             - name: RAILS_ENV
               value: production


### PR DESCRIPTION
## Summary
- update `scripts/deploy-dernier.ts` to build with BuildKit secrets, tag images with branch+sha, push, resolve digests, and deploy via `kn service update` using the immutable digest
- set `imagePullPolicy: Always` on the Dernier Knative Service so new digests are pulled when Argo reapplies the manifest

## Testing
- kubectl apply -k argocd/applications/dernier/overlays/cluster
