### PR TITLE
feat: add bun deploy helper for froussard

### DIFF
--- a/apps/froussard/README.md
+++ b/apps/froussard/README.md
@@ -59,6 +59,11 @@ The local runtime exposes:
   `KAFKA_DISCORD_COMMAND_TOPIC` to control the output topic for normalized command events.
 - The structured stream is configured via `KAFKA_CODEX_TOPIC_STRUCTURED` (defaulting to `github.issues.codex.tasks`).
 
+### Local Deploy Script
+
+- Run `apps/froussard/scripts/deploy.ts` directly (the shebang invokes Bun) to build, push, and deploy with `pnpm --filter froussard run deploy`. The helper derives `FROUSSARD_VERSION` and `FROUSSARD_COMMIT` from `git describe --tags --always` and `git rev-parse HEAD`, but you can override them by exporting the environment variables first.
+- The script uses Bun Shell’s `$` tagged template literal to execute commands, which safely escapes interpolated values, and `$.env()` to scope the derived environment variables to the deploy invocation.
+
 ## Verification Checklist
 
 1. Create a GitHub issue in `gregkonush/lab` as the Codex trigger user.

--- a/apps/froussard/scripts/deploy.ts
+++ b/apps/froussard/scripts/deploy.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+import process from 'node:process'
+
+import { $ } from 'bun'
+
+const run = async () => {
+  $.throws(true)
+
+  const envVersion = process.env.FROUSSARD_VERSION?.trim()
+  const envCommit = process.env.FROUSSARD_COMMIT?.trim()
+
+  const version =
+    envVersion && envVersion.length > 0 ? envVersion : (await $`git describe --tags --always`.text()).trim()
+  const commit = envCommit && envCommit.length > 0 ? envCommit : (await $`git rev-parse HEAD`.text()).trim()
+
+  if (!version) {
+    throw new Error('Failed to determine FROUSSARD_VERSION')
+  }
+  if (!commit) {
+    throw new Error('Failed to determine FROUSSARD_COMMIT')
+  }
+
+  console.log(`Deploying froussard version ${version} (${commit})`)
+
+  const env = {
+    ...process.env,
+    FROUSSARD_VERSION: version,
+    FROUSSARD_COMMIT: commit,
+  }
+
+  const args = Bun.argv.slice(2)
+  const passThrough = args.length > 0 ? ['--', ...args] : []
+
+  await $.env(env)`pnpm --filter froussard run deploy ${passThrough}`
+}
+
+void run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- add a Bun deploy helper that auto-populates FROUSSARD_VERSION/FROUSSARD_COMMIT before running func
- allow passing additional CLI flags through to pnpm deploy
- document the new helper and reference the updated image digest

## Testing
- not run (deployment helper relies on func and registry access)
