### PR TITLE
chore: fix observability loki gateway

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -48,7 +48,7 @@ run:
   - name: LGTM_MIMIR_METRICS_ENDPOINT
     value: http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics
   - name: LGTM_LOKI_ENDPOINT
-    value: http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push
+    value: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push
   - name: OTEL_EXPORTER_OTLP_PROTOCOL
     value: http/protobuf
 deploy:

--- a/apps/froussard/src/codex/cli/codex-implement.ts
+++ b/apps/froussard/src/codex/cli/codex-implement.ts
@@ -73,7 +73,7 @@ export const runCodexImplementation = async (eventPath: string) => {
   const runtimeLogPath = process.env.CODEX_RUNTIME_LOG_PATH ?? `${worktree}/.codex-implementation-runtime.log`
   const lokiEndpoint =
     process.env.LGTM_LOKI_ENDPOINT ??
-    'http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push'
+    'http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push'
   const lokiTenant = process.env.LGTM_LOKI_TENANT
   const lokiBasicAuth = process.env.LGTM_LOKI_BASIC_AUTH
 

--- a/apps/froussard/src/codex/cli/codex-plan.ts
+++ b/apps/froussard/src/codex/cli/codex-plan.ts
@@ -141,7 +141,7 @@ export const runCodexPlan = async () => {
   const runtimeLogPath = process.env.CODEX_RUNTIME_LOG_PATH ?? `${worktree}/.codex-plan-runtime.log`
   const lokiEndpoint =
     process.env.LGTM_LOKI_ENDPOINT ??
-    'http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push'
+    'http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push'
   const lokiTenant = process.env.LGTM_LOKI_TENANT
   const lokiBasicAuth = process.env.LGTM_LOKI_BASIC_AUTH
 

--- a/argocd/applications/argo-workflows/alloy-configmap.yaml
+++ b/argocd/applications/argo-workflows/alloy-configmap.yaml
@@ -48,6 +48,6 @@ data:
 
     loki.write "default" {
       endpoint {
-        url = "http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
+        url = "http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push"
       }
     }

--- a/argocd/applications/argocd/alloy-configmap.yaml
+++ b/argocd/applications/argocd/alloy-configmap.yaml
@@ -76,7 +76,7 @@ data:
 
     loki.write "default" {
       endpoint {
-        url = "http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
+        url = "http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push"
       }
     }
 

--- a/argocd/applications/facteur/overlays/cluster/alloy-configmap.yaml
+++ b/argocd/applications/facteur/overlays/cluster/alloy-configmap.yaml
@@ -43,6 +43,6 @@ data:
 
     loki.write "default" {
       endpoint {
-        url = "http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
+        url = "http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push"
       }
     }

--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -53,7 +53,7 @@ spec:
                 name: github-token
                 key: token
           - name: LGTM_LOKI_ENDPOINT
-            value: http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push
+            value: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push
         command: ["/usr/local/bin/codex-bootstrap"]
         args:
           - "/bin/bash"

--- a/argocd/applications/froussard/github-codex-planning-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-planning-workflow-template.yaml
@@ -53,7 +53,7 @@ spec:
                 name: github-token
                 key: token
           - name: LGTM_LOKI_ENDPOINT
-            value: http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push
+            value: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push
         command: ["/usr/local/bin/codex-bootstrap"]
         args:
           - "/bin/bash"

--- a/argocd/applications/miel/README.md
+++ b/argocd/applications/miel/README.md
@@ -35,7 +35,7 @@ Restart the deployment after updating the ConfigMap so the new environment varia
 
 - `OTEL_SERVICE_NAME=miel`
 - `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
-- OTLP endpoints for traces (`observability-tempo-distributor`), metrics (`observability-mimir-nginx`), and logs (`observability-loki-gateway`).
+- OTLP endpoints for traces (`observability-tempo-distributor`), metrics (`observability-mimir-nginx`), and logs (`observability-loki-loki-distributed-gateway`).
 
 Override these values as needed for other environments, then restart the deployment (or let Argo CD roll pods) to pick up the new telemetry configuration.
 

--- a/argocd/applications/miel/configmap.yaml
+++ b/argocd/applications/miel/configmap.yaml
@@ -18,7 +18,7 @@ data:
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://observability-tempo-distributor.observability:4318"
   OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://observability-mimir-nginx.observability/otlp"
-  OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://observability-loki-gateway.observability/otlp"
+  OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://observability-loki-loki-distributed-gateway.observability/otlp"
   TIGERBEETLE_ENABLED: "false"
   TIGERBEETLE_ADDRESSES: ""
   TIGERBEETLE_CLUSTER_ID: ""

--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -17,7 +17,7 @@ datasources:
         uid: loki
         type: loki
         access: proxy
-        url: http://observability-loki-gateway.observability.svc.cluster.local
+        url: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local
         isDefault: false
       - name: Mimir
         uid: prom

--- a/docs/facteur-discord-argo.md
+++ b/docs/facteur-discord-argo.md
@@ -160,7 +160,7 @@ Facteur initialises OpenTelemetry during startup, enabling spans and metrics acr
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` | Aligns with the observability stack's OTLP HTTP gateways. |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces` | Tempo ingestion endpoint. |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | `http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics` | Mimir ingestion endpoint. |
-| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | `http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push` | Loki ingestion endpoint (reserved for future log exporting). |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | `http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push` | Loki ingestion endpoint (reserved for future log exporting). |
 
 Knative does not inject the observability wiring automatically; the Argo CD overlay now provisions a dedicated Grafana Alloy deployment (`facteur-alloy`) that tails all pods in the `facteur` namespace and pushes the output to the in-cluster Loki gateway. The manifests live in `argocd/applications/facteur/overlays/cluster/alloy-*.yaml`, keeping the observability routing alongside the rest of the service configuration.
 

--- a/kubernetes/facteur/base/service.yaml
+++ b/kubernetes/facteur/base/service.yaml
@@ -50,7 +50,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
               value: http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics
             - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-              value: http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push
+              value: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push
           readinessProbe:
             successThreshold: 1
             tcpSocket:

--- a/kubernetes/facteur/base/workflowtemplate.yaml
+++ b/kubernetes/facteur/base/workflowtemplate.yaml
@@ -38,7 +38,7 @@ spec:
                 key: category-id
                 optional: true
           - name: LGTM_LOKI_ENDPOINT
-            value: http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push
+            value: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push
         command: ["/usr/local/bin/codex-bootstrap"]
         args:
           - "/bin/bash"

--- a/packages/bonjour/infra/server-chart.ts
+++ b/packages/bonjour/infra/server-chart.ts
@@ -37,7 +37,8 @@ export class ServerChart extends Chart {
     const mimirMetricsEndpoint =
       props.mimirMetricsEndpoint ?? 'http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics'
     const lokiEndpoint =
-      props.lokiEndpoint ?? 'http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push'
+      props.lokiEndpoint ??
+      'http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push'
 
     const deployment = new Deployment(this, 'server', {
       metadata: {

--- a/services/facteur/README.md
+++ b/services/facteur/README.md
@@ -29,11 +29,11 @@ Facteur boots with OpenTelemetry telemetry enabled. Traces and metrics are expor
 - `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
 - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces`
 - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics`
-- `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://observability-loki-gateway.observability.svc.cluster.local/loki/api/v1/push`
+- `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push`
 
 When running locally, point these values at your observability environment to keep telemetry flowing. The service emits counters such as `facteur_command_events_processed_total`, `facteur_command_events_failed_total`, and `facteur_command_events_dlq_total`, and wraps the Fiber HTTP server with OTEL middleware so HTTP requests appear in traces.
 
-Cluster deployments rely on a namespace-scoped Grafana Alloy deployment (`argocd/applications/facteur/overlays/cluster/alloy-*.yaml`) to forward Knative pod logs to the observability Loki gateway, since the Knative stack does not configure log shipping on its own.
+Cluster deployments rely on a namespace-scoped Grafana Alloy deployment (`argocd/applications/facteur/overlays/cluster/alloy-*.yaml`) to forward Knative pod logs to the observability Loki gateway (`observability-loki-loki-distributed-gateway`), since the Knative stack does not configure log shipping on its own.
 
 ## Container image
 

--- a/services/miel/README.md
+++ b/services/miel/README.md
@@ -39,7 +39,7 @@ Set the following environment variables before running the service. Paper-tradin
 | `OTEL_EXPORTER_OTLP_PROTOCOL`         | OTLP transport protocol.                      | `http/protobuf`                           |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | OTLP traces endpoint (observability Tempo).   | `http://observability-tempo-distributor.observability:4318` |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | OTLP metrics endpoint (observability Mimir).  | `http://observability-mimir-nginx.observability/otlp`       |
-| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | OTLP logs endpoint (observability Loki).      | `http://observability-loki-gateway.observability/otlp`      |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | OTLP logs endpoint (observability Loki).      | `http://observability-loki-loki-distributed-gateway.observability/otlp`      |
 
 ### TigerBeetle ledger (optional)
 


### PR DESCRIPTION
## Summary
- point log exporters and Alloy remotes to the actual observability Loki gateway service name
- sync Codex workflows, service manifests, and docs so defaults match the new gateway
- tune Grafana Loki datasource and stack references for the observability namespace

## Testing
- pnpm --filter froussard test
