### PR TITLE
feat: add karapace schema registry

### DIFF
--- a/argocd/applications/kafka/karapace.yaml
+++ b/argocd/applications/kafka/karapace.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karapace
+  namespace: kafka
+  labels:
+    app.kubernetes.io/name: karapace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karapace
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karapace
+    spec:
+      containers:
+        - name: karapace
+          image: ghcr.io/aiven-open/karapace:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8081
+          env:
+            - name: KARAPACE_BOOTSTRAP_URI
+              value: kafka-kafka-bootstrap:9092
+            - name: KARAPACE_ADVERTISED_HOSTNAME
+              value: karapace
+            - name: KARAPACE_SCHEMA_REGISTRY_HOST
+              value: 0.0.0.0
+            - name: KARAPACE_SCHEMA_REGISTRY_PORT
+              value: "8081"
+            - name: KARAPACE_REST
+              value: "false"
+            - name: KARAPACE_REGISTRY
+              value: "true"
+            - name: KARAPACE_GROUP_ID
+              value: karapace-schema-registry
+            - name: KARAPACE_CLIENT_ID
+              value: karapace-schema-registry
+            - name: KARAPACE_TOPIC_NAME
+              value: _schemas
+            - name: KARAPACE_COMPATIBILITY
+              value: BACKWARD
+            - name: KARAPACE_SECURITY_PROTOCOL
+              value: SASL_PLAINTEXT
+            - name: KARAPACE_SASL_MECHANISM
+              value: SCRAM-SHA-512
+            - name: KARAPACE_SASL_PLAIN_USERNAME
+              value: karapace
+            - name: KARAPACE_SASL_PLAIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: karapace
+                  key: password
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: karapace
+  namespace: kafka
+  labels:
+    app.kubernetes.io/name: karapace
+spec:
+  selector:
+    app.kubernetes.io/name: karapace
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http

--- a/argocd/applications/kafka/kustomization.yaml
+++ b/argocd/applications/kafka/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
   - strimzi-operator-watched-crb.yaml
   - load-balancer.yaml
   - strimzi-kafka-cluster.yaml
+  - karapace.yaml
 patches:
   # Make the operator watch all namespaces
   - target:
@@ -156,6 +157,8 @@ helmCharts:
           clusters:
             - name: kafka
               bootstrapServers: kafka-kafka-bootstrap:9092
+              schemaRegistry: http://karapace:8081
+              defaultValueSerde: SchemaRegistry
               properties:
                 security.protocol: SASL_PLAINTEXT
                 sasl.mechanism: SCRAM-SHA-512

--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -59,3 +59,14 @@ metadata:
 spec:
   authentication:
     type: scram-sha-512
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: karapace
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  authentication:
+    type: scram-sha-512


### PR DESCRIPTION
## Description

- add karapace deployment and service to kafka kustomization
- provision strimzi scram user for karapace to authenticate
- point kafbat ui at karapace schema registry with schema serde defaults
