### PR TITLE
chore: resize harvester workers

### DIFF
--- a/tofu/harvester/main.tf
+++ b/tofu/harvester/main.tf
@@ -16,10 +16,10 @@ provider "harvester" {
 
 locals {
   kube_master_cpu       = 8
-  kube_worker_cpu       = 8
+  kube_worker_cpu       = 16
   docker_vm_cpu         = 8
   kube_master_memory    = "32Gi"
-  kube_worker_memory    = "24Gi"
+  kube_worker_memory    = "30Gi"
   docker_vm_memory      = "32Gi"
   kube_node_disk_size   = "150Gi"
   docker_node_disk_size = "100Gi"


### PR DESCRIPTION
## Summary
- increase default Harvester worker flavor to 16 vCPU and 30 GiB RAM via Terraform
- leave workflow configuration unchanged; future runner sizing will depend on updated workers

## Testing
- not run (infrastructure sizing change)
