### PR TITLE
chore: document redis secret and align installer

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -16,6 +16,17 @@ argocd/
 └── root.yaml         # Root application
 ```
 
+## Bootstrap Prerequisites
+
+- **Redis auth secret**: The upstream HA manifest expects a `argocd/argocd-redis` secret with the `auth` key. On a fresh cluster create it before the first sync:
+
+  ```bash
+  openssl rand -base64 32 | tr -d '\n' | \
+    kubectl -n argocd create secret generic argocd-redis --from-literal=auth="$(cat)"
+  ```
+
+  Prefer a managed source (SealedSecret, ExternalSecret, etc.) for long-term storage; the imperative command above is a one-time bootstrap.
+
 ## ApplicationSets
 
 Applications in the `applications/` directory are automatically discovered and deployed by the ApplicationSet defined in `applicationsets/lovely-apps.yaml`. This removes the need for creating individual Application resources.


### PR DESCRIPTION
## Summary
- bump Argo CD HA install to v3.1.8 and disable bootstrap auto sync
- document the required argocd-redis secret for fresh installs
- align bun-based k3s installer with bash script and clear known_hosts

## Testing
- bun kubernetes/install-k3s.ts --dry-run
