### PR TITLE
fix: update dex password hash

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -31,6 +31,6 @@ data:
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai
-        hash: "$2b$10$e90kT7vnzJRNgYovJc1/7.FBVsmdsxWepKGIzzZV1rPnCpjxwPMFG"
+        hash: "$2b$10$ra1qX8LB233SZ/rgZ08n4eHlPfOpc5FMYAXYVN5csb6LPgg7VFUHq"
         username: admin
         userID: 86c47abf-4b23-4818-9b4c-76a2d17e7c98


### PR DESCRIPTION
## Summary
- refresh the Dex static admin password hash to match the newly generated credentials

## Testing
- kubectl apply -f argocd/applications/argocd/overlays/argocd-cm.yaml
- kubectl -n argocd rollout restart deploy argocd-dex-server
- confirmed login via https://workflows.proompteng.ai succeeds
