### PR TITLE
fix: drop empty resources from ksvc export

### DIFF
--- a/apps/froussard/scripts/__tests__/deploy-script.test.ts
+++ b/apps/froussard/scripts/__tests__/deploy-script.test.ts
@@ -58,6 +58,12 @@ describe('deploy script', () => {
                 ],
                 readinessProbe: { httpGet: { path: '/ready', port: 0 } },
                 livenessProbe: { httpGet: { path: '/live', port: 0 } },
+                resources: {
+                  limits: {},
+                  requests: {
+                    cpu: '',
+                  },
+                },
               },
             ],
           },
@@ -104,6 +110,7 @@ describe('deploy script', () => {
     expect(writtenYaml).toContain('secretKeyRef')
     expect(writtenYaml).toContain(version)
     expect(writtenYaml).toContain(commit)
+    expect(writtenYaml).not.toMatch(/^\s*resources:/m)
 
     resetEnv(envKeys)
   })


### PR DESCRIPTION
## Summary
- sanitize knative export to omit empty resources objects
- ensure deploy script test covers empty resource cases so YAML stays clean

## Testing
- pnpm --filter froussard test