### PR TITLE
fix: stop tracking knative lastModifier

### DIFF
--- a/apps/froussard/scripts/__tests__/deploy-script.test.ts
+++ b/apps/froussard/scripts/__tests__/deploy-script.test.ts
@@ -116,7 +116,7 @@ describe('deploy script', () => {
     expect(writtenYaml).toMatch(/^\s*resources:\s*\{\}/m)
     expect(writtenYaml).toMatch(/- name: FOO[\s\S]*- name: SECRET/)
     expect(writtenYaml).toMatch(/serving\.knative\.dev\/creator: system:admin/)
-    expect(writtenYaml).toMatch(/serving\.knative\.dev\/lastModifier: system:admin/)
+    expect(writtenYaml).not.toMatch(/serving\.knative\.dev\/lastModifier/)
     expect(writtenYaml).toMatch(/claims:\s*\n\s+- name: cache/)
 
     resetEnv(envKeys)

--- a/apps/froussard/scripts/deploy.ts
+++ b/apps/froussard/scripts/deploy.ts
@@ -6,7 +6,11 @@ import { fileURLToPath } from 'node:url'
 import { $ } from 'bun'
 import YAML from 'yaml'
 
-const ignoredAnnotations = new Set(['kubectl.kubernetes.io/last-applied-configuration', 'client.knative.dev/nonce'])
+const ignoredAnnotations = new Set([
+  'kubectl.kubernetes.io/last-applied-configuration',
+  'client.knative.dev/nonce',
+  'serving.knative.dev/lastModifier',
+])
 
 const namespace = process.env.FROUSSARD_NAMESPACE?.trim() || 'froussard'
 const service = process.env.FROUSSARD_SERVICE?.trim() || 'froussard'

--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: froussard
   annotations:
     serving.knative.dev/creator: system:admin
-    serving.knative.dev/lastModifier: system:admin
     serving.knative.dev/revision-history-limit: "3"
   labels:
     function.knative.dev/name: froussard


### PR DESCRIPTION
## Summary
- ignore the mutating serving.knative.dev/lastModifier annotation when exporting froussard's Knative Service
- adjust the helper test expectations and commit the cleaned manifest so Argo diff shows clean

## Testing
- pnpm --filter froussard test