### PR TITLE
fix: remove forced creator override

### DIFF
--- a/apps/froussard/scripts/__tests__/deploy-script.test.ts
+++ b/apps/froussard/scripts/__tests__/deploy-script.test.ts
@@ -115,12 +115,8 @@ describe('deploy script', () => {
     expect(writtenYaml).toContain(commit)
     expect(writtenYaml).toMatch(/^\s*resources:\s*\{\}/m)
     expect(writtenYaml).toMatch(/- name: FOO[\s\S]*- name: SECRET/)
-    expect(writtenYaml).toMatch(
-      /serving\.knative\.dev\/creator: system:serviceaccount:argocd:argocd-application-controller/,
-    )
-    expect(writtenYaml).toMatch(
-      /serving\.knative\.dev\/lastModifier: system:serviceaccount:argocd:argocd-application-controller/,
-    )
+    expect(writtenYaml).toMatch(/serving\.knative\.dev\/creator: system:admin/)
+    expect(writtenYaml).toMatch(/serving\.knative\.dev\/lastModifier: system:admin/)
     expect(writtenYaml).toMatch(
       /argocd\.argoproj\.io\/tracking-id: froussard:serving\.knative\.dev\/Service:froussard\/froussard/,
     )

--- a/apps/froussard/scripts/deploy.ts
+++ b/apps/froussard/scripts/deploy.ts
@@ -155,12 +155,6 @@ async function exportKnativeManifest({
 
   const annotations = sanitizeObject(parsed?.metadata?.annotations) ?? {}
   const templateAnnotations = sanitizeObject(parsed?.spec?.template?.metadata?.annotations) ?? {}
-
-  const knServiceAccount = 'system:serviceaccount:argocd:argocd-application-controller'
-  annotations['serving.knative.dev/creator'] = knServiceAccount
-  annotations['serving.knative.dev/lastModifier'] = knServiceAccount
-  templateAnnotations['serving.knative.dev/creator'] = knServiceAccount
-  templateAnnotations['serving.knative.dev/lastModifier'] = knServiceAccount
   annotations['argocd.argoproj.io/tracking-id'] =
     `${exportNamespace}:serving.knative.dev/Service:${exportNamespace}/${parsed?.metadata?.name ?? exportService}`
 


### PR DESCRIPTION
## Summary
- stop overriding serving.knative.dev/{creator,lastModifier} in the deploy export; keep the cluster values and only add the tracking annotation
- adjust the deploy-script test to expect the live annotations
- regenerate froussard manifest/image digest so Argo can sync without immutable annotation errors

## Testing
- pnpm --filter froussard test
- bun apps/froussard/scripts/deploy.ts -- --build=false --push=false