### PR TITLE
fix: prevent knative annotation drift

### DIFF
--- a/apps/froussard/scripts/__tests__/deploy-script.test.ts
+++ b/apps/froussard/scripts/__tests__/deploy-script.test.ts
@@ -115,8 +115,9 @@ describe('deploy script', () => {
     expect(writtenYaml).toContain(commit)
     expect(writtenYaml).toMatch(/^\s*resources:\s*\{\}/m)
     expect(writtenYaml).toMatch(/- name: FOO[\s\S]*- name: SECRET/)
-    expect(writtenYaml).toMatch(/serving\.knative\.dev\/creator: system:admin/)
-    expect(writtenYaml).toMatch(/serving\.knative\.dev\/lastModifier: system:admin/)
+    expect(writtenYaml).not.toMatch(/serving\.knative\.dev\/creator/)
+    expect(writtenYaml).not.toMatch(/serving\.knative\.dev\/lastModifier/)
+    expect(writtenYaml).toMatch(/argocd\.argoproj\.io\/compare-options: IgnoreExtraneous/)
     expect(writtenYaml).toMatch(
       /argocd\.argoproj\.io\/tracking-id: froussard:serving\.knative\.dev\/Service:froussard\/froussard/,
     )

--- a/apps/froussard/scripts/deploy.ts
+++ b/apps/froussard/scripts/deploy.ts
@@ -6,7 +6,12 @@ import { fileURLToPath } from 'node:url'
 import { $ } from 'bun'
 import YAML from 'yaml'
 
-const ignoredAnnotations = new Set(['kubectl.kubernetes.io/last-applied-configuration', 'client.knative.dev/nonce'])
+const ignoredAnnotations = new Set([
+  'client.knative.dev/nonce',
+  'kubectl.kubernetes.io/last-applied-configuration',
+  'serving.knative.dev/creator',
+  'serving.knative.dev/lastModifier',
+])
 
 const namespace = process.env.FROUSSARD_NAMESPACE?.trim() || 'froussard'
 const service = process.env.FROUSSARD_SERVICE?.trim() || 'froussard'
@@ -157,6 +162,7 @@ async function exportKnativeManifest({
   const templateAnnotations = sanitizeObject(parsed?.spec?.template?.metadata?.annotations) ?? {}
   annotations['argocd.argoproj.io/tracking-id'] =
     `${exportNamespace}:serving.knative.dev/Service:${exportNamespace}/${parsed?.metadata?.name ?? exportService}`
+  annotations['argocd.argoproj.io/compare-options'] = 'IgnoreExtraneous'
 
   const sanitizedManifest = {
     apiVersion: 'serving.knative.dev/v1',

--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -5,8 +5,7 @@ metadata:
   name: froussard
   namespace: froussard
   annotations:
-    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
-    serving.knative.dev/lastModifier: system:serviceaccount:argocd:argocd-application-controller
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
     serving.knative.dev/revision-history-limit: "3"
     argocd.argoproj.io/tracking-id: froussard:serving.knative.dev/Service:froussard/froussard
   labels:
@@ -17,9 +16,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/min-scale: "1"
-        serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
         serving.knative.dev/revision-history-limit: "3"
-        serving.knative.dev/lastModifier: system:serviceaccount:argocd:argocd-application-controller
       labels:
         function.knative.dev/name: froussard
         function.knative.dev/runtime: typescript


### PR DESCRIPTION
## Summary
- drop Knative-managed creator/lastModifier annotations before exporting manifests
- add compare-options hint so Argo ignores runtime extras on the Service
- extend deploy script test to cover the new filtering

## Testing
- pnpm --filter froussard test
