### PR TITLE
chore: right-size gha runner storage

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -34,7 +34,7 @@ spec:
               storageClassName: "local-path"
               resources:
                 requests:
-                  storage: 1Gi
+                  storage: 60Gi
           template:
             spec:
               nodeSelector:
@@ -63,11 +63,13 @@ spec:
                   command: ["/home/runner/run.sh"]
                   resources:
                     requests:
-                      cpu: "500m"
-                      memory: "2Gi"
+                      cpu: "4"
+                      memory: "16Gi"
+                      ephemeral-storage: "40Gi"
                     limits:
-                      cpu: "2000m"
-                      memory: "4Gi"
+                      cpu: "8"
+                      memory: "32Gi"
+                      ephemeral-storage: "80Gi"
                   env:
                     - name: ACTIONS_RUNNER_CONTAINER_HOOKS
                       value: /home/runner/k8s/index.js
@@ -92,11 +94,13 @@ spec:
                     - --group=$(DOCKER_GROUP_GID)
                   resources:
                     requests:
-                      cpu: "500m"
-                      memory: "2Gi"
-                    limits:
-                      cpu: "2000m"
+                      cpu: "1"
                       memory: "4Gi"
+                      ephemeral-storage: "30Gi"
+                    limits:
+                      cpu: "2"
+                      memory: "8Gi"
+                      ephemeral-storage: "50Gi"
                   env:
                     - name: DOCKER_GROUP_GID
                       value: "123"
@@ -118,7 +122,7 @@ spec:
                         storageClassName: "local-path"
                         resources:
                           requests:
-                            storage: 5Gi
+                            storage: 60Gi
                 - name: dind-sock
                   emptyDir: {}
                 - name: dind-externals


### PR DESCRIPTION
## Summary
- shrink runner pvc and ephemeral-storage requests to fit 150Gi worker disks
- keep cpu/memory sizing per new baseline while reducing dind disk footprint

## Testing
- kubectl get pvc -n arc
- kubectl describe node kube-worker-27