### PR TITLE
fix: align knative metadata with runtime

### DIFF
--- a/apps/froussard/scripts/__tests__/deploy-script.test.ts
+++ b/apps/froussard/scripts/__tests__/deploy-script.test.ts
@@ -115,8 +115,8 @@ describe('deploy script', () => {
     expect(writtenYaml).toContain(commit)
     expect(writtenYaml).toMatch(/^\s*resources:\s*\{\}/m)
     expect(writtenYaml).toMatch(/- name: FOO[\s\S]*- name: SECRET/)
-    expect(writtenYaml).not.toMatch(/serving\.knative\.dev\/creator/)
-    expect(writtenYaml).not.toMatch(/serving\.knative\.dev\/lastModifier/)
+    expect(writtenYaml).toMatch(/serving\.knative\.dev\/creator: system:admin/)
+    expect(writtenYaml).toMatch(/serving\.knative\.dev\/lastModifier: system:admin/)
     expect(writtenYaml).toMatch(/argocd\.argoproj\.io\/compare-options: IgnoreExtraneous/)
     expect(writtenYaml).toMatch(
       /argocd\.argoproj\.io\/tracking-id: froussard:serving\.knative\.dev\/Service:froussard\/froussard/,

--- a/apps/froussard/scripts/deploy.ts
+++ b/apps/froussard/scripts/deploy.ts
@@ -6,12 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { $ } from 'bun'
 import YAML from 'yaml'
 
-const ignoredAnnotations = new Set([
-  'client.knative.dev/nonce',
-  'kubectl.kubernetes.io/last-applied-configuration',
-  'serving.knative.dev/creator',
-  'serving.knative.dev/lastModifier',
-])
+const ignoredAnnotations = new Set(['client.knative.dev/nonce', 'kubectl.kubernetes.io/last-applied-configuration'])
 
 const namespace = process.env.FROUSSARD_NAMESPACE?.trim() || 'froussard'
 const service = process.env.FROUSSARD_SERVICE?.trim() || 'froussard'

--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: froussard
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
+    serving.knative.dev/creator: system:admin
+    serving.knative.dev/lastModifier: system:admin
     serving.knative.dev/revision-history-limit: "3"
     argocd.argoproj.io/tracking-id: froussard:serving.knative.dev/Service:froussard/froussard
   labels:
@@ -16,7 +18,9 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/min-scale: "1"
+        serving.knative.dev/creator: system:admin
         serving.knative.dev/revision-history-limit: "3"
+        serving.knative.dev/lastModifier: system:admin
       labels:
         function.knative.dev/name: froussard
         function.knative.dev/runtime: typescript


### PR DESCRIPTION
## Summary
- keep Knative creator/lastModifier annotations when exporting the froussard service
- publish the live system:admin values so Argo applies without tripping immutability rules
- update the deploy script test to cover the expected annotations

## Testing
- pnpm --filter froussard test
- kubectl apply -n froussard -f argocd/applications/froussard/knative-service.yaml
