### PR TITLE
feat: add bun-native workflow start

### DIFF
--- a/packages/temporal-bun-sdk/README.md
+++ b/packages/temporal-bun-sdk/README.md
@@ -61,11 +61,15 @@ pnpm --filter @proompteng/temporal-bun-sdk test
 import { createTemporalClient, loadTemporalConfig } from '@proompteng/temporal-bun-sdk'
 
 const { client } = await createTemporalClient()
-const workflow = await client.workflow.start('helloTemporal', {
+const workflow = await client.workflow.start({
+  workflowId: 'helloTemporal-001',
+  workflowType: 'helloTemporal',
   taskQueue: 'prix',
-  args: ['Proompteng']
+  args: ['Proompteng'],
 })
-console.log('Workflow execution started', workflow.workflowId)
+console.log('Workflow execution started', workflow.runId)
+
+> **Note:** The current Bun-native client supports workflow starts today. Signal, query, and termination APIs are under active development.
 ```
 
 Start the bundled worker (after building):

--- a/packages/temporal-bun-sdk/docs/ffi-surface.md
+++ b/packages/temporal-bun-sdk/docs/ffi-surface.md
@@ -44,7 +44,7 @@ Current progress snapshot:
 | Client | `temporal_bun_client_free(client_ptr)` | Dispose client | `native.clientShutdown` | ✅ |
 | Client | `temporal_bun_client_describe_namespace_async(client_ptr, payload_ptr, len)` | Describe namespace via async pending handle | `native.describeNamespace` | ✅ (new) |
 | Client | `temporal_bun_client_update_headers(client_ptr, headers_ptr, len)` | Update gRPC metadata (API key, custom headers) | `coreBridge.client.updateHeaders` | ⬜️ TODO |
-| Client | `temporal_bun_client_start_workflow(client_ptr, payload_ptr, len)` | Start workflow execution | `client.start` | ⬜️ TODO |
+| Client | `temporal_bun_client_start_workflow(client_ptr, payload_ptr, len)` | Start workflow execution | `client.workflow.start` | ✅ Implemented |
 | Client | `temporal_bun_client_signal(client_ptr, payload_ptr, len)` | Send signal to existing workflow | `client.signal` | ⬜️ TODO |
 | Client | `temporal_bun_client_query(client_ptr, payload_ptr, len)` | Run workflow query | `client.query` | ⬜️ TODO |
 | Client | `temporal_bun_client_terminate_workflow(...)` | Terminate workflow | `client.terminate` | ⬜️ TODO |

--- a/packages/temporal-bun-sdk/docs/migration-phases.md
+++ b/packages/temporal-bun-sdk/docs/migration-phases.md
@@ -28,6 +28,7 @@ flowchart LR
 
 - Implement FFI for client operations (start, signal, query, terminate, headers, TLS).
 - Rewrite `src/client.ts` to use new Core bridge client.
+- ✅ `start_workflow` wired through Rust bridge + Bun client (`createTemporalClient.workflow.start`).
 - Remove `@temporalio/client` dependency.
 - Add unit + integration tests for client operations.
 

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.lock
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.lock
@@ -2107,6 +2107,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "prost",
+ "prost-wkt-types",
  "serde",
  "serde_json",
  "temporal-client",
@@ -2116,6 +2117,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.toml
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.toml
@@ -17,4 +17,6 @@ serde_json = "1"
 thiserror = "1"
 url = "2"
 prost = "0.14"
+prost-wkt-types = "0.7"
 base64 = "0.22"
+uuid = { version = "1", features = ["v4"] }

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/lib.rs
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/lib.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
 
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use base64::{engine::general_purpose, Engine as _};
 use prost::Message;
+use prost_wkt_types::Duration as ProtoDuration;
 use serde::Deserialize;
 use temporal_client::{
     tonic::IntoRequest, ClientOptionsBuilder, ClientTlsConfig, ConfiguredClient, Namespace,
@@ -12,8 +14,15 @@ use temporal_client::{
 };
 use temporal_sdk_core::{CoreRuntime, TokioRuntimeBuilder};
 use temporal_sdk_core_api::telemetry::TelemetryOptions;
+use temporal_sdk_core_protos::temporal::api::common::v1::{
+    Header, Memo, Payload, Payloads, RetryPolicy, SearchAttributes, WorkflowType,
+};
+use temporal_sdk_core_protos::temporal::api::enums::v1::TaskQueueKind;
+use temporal_sdk_core_protos::temporal::api::taskqueue::v1::TaskQueue;
+use temporal_sdk_core_protos::temporal::api::workflowservice::v1::StartWorkflowExecutionRequest;
 use thiserror::Error;
 use url::Url;
+use uuid::Uuid;
 
 mod byte_array;
 mod error;
@@ -31,6 +40,7 @@ pub struct ClientHandle {
     runtime: Arc<CoreRuntime>,
     client: RetryClient<ConfiguredClient<TemporalServiceClient>>,
     namespace: String,
+    identity: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -49,7 +59,7 @@ struct ClientConfig {
     tls: Option<ClientTlsConfigPayload>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct ClientTlsConfigPayload {
     #[serde(default)]
     server_root_ca_cert: Option<String>,
@@ -63,6 +73,61 @@ struct ClientTlsConfigPayload {
 
 #[derive(Debug, Deserialize)]
 struct DescribeNamespaceRequestPayload {
+    namespace: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct StartWorkflowRequestPayload {
+    #[serde(default)]
+    namespace: Option<String>,
+    workflow_id: String,
+    workflow_type: String,
+    task_queue: String,
+    #[serde(default)]
+    args: Option<Vec<serde_json::Value>>,
+    #[serde(default)]
+    memo: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default)]
+    search_attributes: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default)]
+    headers: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default)]
+    cron_schedule: Option<String>,
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default)]
+    identity: Option<String>,
+    #[serde(default)]
+    workflow_execution_timeout_ms: Option<u64>,
+    #[serde(default)]
+    workflow_run_timeout_ms: Option<u64>,
+    #[serde(default)]
+    workflow_task_timeout_ms: Option<u64>,
+    #[serde(default)]
+    retry_policy: Option<RetryPolicyPayload>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RetryPolicyPayload {
+    #[serde(default)]
+    initial_interval_ms: Option<u64>,
+    #[serde(default)]
+    maximum_interval_ms: Option<u64>,
+    #[serde(default)]
+    maximum_attempts: Option<i32>,
+    #[serde(default)]
+    backoff_coefficient: Option<f64>,
+    #[serde(default)]
+    non_retryable_error_types: Option<Vec<String>>,
+}
+
+struct StartWorkflowDefaults<'a> {
+    namespace: &'a str,
+    identity: &'a str,
+}
+
+struct StartWorkflowResponseInfo {
+    workflow_id: String,
     namespace: String,
 }
 
@@ -84,6 +149,12 @@ enum BridgeError {
     ClientInit(String),
     #[error("Temporal request failed: {0}")]
     ClientRequest(String),
+    #[error("failed to encode payload: {0}")]
+    PayloadEncode(String),
+    #[error("failed to encode response payload: {0}")]
+    ResponseEncode(String),
+    #[error("invalid TLS configuration: {0}")]
+    InvalidTlsConfig(String),
 }
 
 #[unsafe(no_mangle)]
@@ -207,56 +278,19 @@ pub extern "C" fn temporal_bun_client_connect_async(
         .target_url(url)
         .client_name(client_name)
         .client_version(client_version)
-        .identity(identity);
+        .identity(identity.clone());
 
-    if let Some(api_key) = config.api_key {
+    if let Some(api_key) = config.api_key.clone() {
         builder.api_key(Some(api_key));
     }
 
-    if let Some(tls_payload) = config.tls {
-        let mut tls = TlsConfig {
-            server_root_ca_cert: None,
-            domain: tls_payload.server_name_override,
-            client_tls_config: None,
-        };
-
-        if let Some(ca_b64) = tls_payload.server_root_ca_cert {
-            match decode_base64_field(&ca_b64, "server_root_ca_cert") {
-                Ok(ca_bytes) => tls.server_root_ca_cert = Some(ca_bytes),
-                Err(err) => {
-                    return into_string_error(err) as *mut PendingClientHandle;
-                }
+    if let Some(tls_payload) = config.tls.clone() {
+        match tls_config_from_payload(tls_payload) {
+            Ok(tls_cfg) => {
+                builder.tls_cfg(tls_cfg);
             }
+            Err(err) => return into_string_error(err) as *mut PendingClientHandle,
         }
-
-        match (tls_payload.client_cert, tls_payload.client_private_key) {
-            (None, None) => {}
-            (Some(cert_b64), Some(key_b64)) => {
-                let cert_bytes = match decode_base64_field(&cert_b64, "client_cert") {
-                    Ok(bytes) => bytes,
-                    Err(err) => {
-                        return into_string_error(err) as *mut PendingClientHandle;
-                    }
-                };
-                let key_bytes = match decode_base64_field(&key_b64, "client_private_key") {
-                    Ok(bytes) => bytes,
-                    Err(err) => {
-                        return into_string_error(err) as *mut PendingClientHandle;
-                    }
-                };
-                tls.client_tls_config = Some(ClientTlsConfig {
-                    client_cert: cert_bytes,
-                    client_private_key: key_bytes,
-                });
-            }
-            _ => {
-                return into_string_error(BridgeError::InvalidConfig(
-                    "client TLS configuration requires both client_cert and client_private_key".to_owned(),
-                )) as *mut PendingClientHandle;
-            }
-        }
-
-        builder.tls_cfg(tls);
     }
 
     let options = match builder.build() {
@@ -269,6 +303,7 @@ pub extern "C" fn temporal_bun_client_connect_async(
 
     let namespace = config.namespace;
     let runtime_clone = runtime.clone();
+    let identity_clone = identity.clone();
     let (tx, rx) = channel();
 
     thread::spawn(move || {
@@ -278,6 +313,7 @@ pub extern "C" fn temporal_bun_client_connect_async(
                     runtime: runtime_clone.clone(),
                     client,
                     namespace,
+                    identity: identity_clone.clone(),
                 }),
                 Err(err) => Err(BridgeError::ClientInit(err.to_string()).to_string()),
             }
@@ -287,12 +323,6 @@ pub extern "C" fn temporal_bun_client_connect_async(
     });
 
     Box::into_raw(Box::new(PendingClientHandle::new(rx)))
-}
-
-fn decode_base64_field(value: &str, field: &str) -> Result<Vec<u8>, BridgeError> {
-    BASE64_STANDARD
-        .decode(value)
-        .map_err(|err| BridgeError::InvalidConfig(format!("invalid base64 for {field}: {err}")))
 }
 
 #[unsafe(no_mangle)]
@@ -403,6 +433,65 @@ pub extern "C" fn temporal_bun_client_describe_namespace_async(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_client_start_workflow(
+    client_ptr: *mut c_void,
+    payload_ptr: *const u8,
+    payload_len: usize,
+) -> *mut byte_array::ByteArray {
+    let client_handle = match client_from_ptr(client_ptr) {
+        Ok(client) => client,
+        Err(err) => return into_string_error(err) as *mut byte_array::ByteArray,
+    };
+
+    let payload = match request_from_raw::<StartWorkflowRequestPayload>(payload_ptr, payload_len) {
+        Ok(payload) => payload,
+        Err(err) => {
+            return into_string_error(BridgeError::InvalidRequest(err.to_string()))
+                as *mut byte_array::ByteArray
+        }
+    };
+
+    let defaults = StartWorkflowDefaults {
+        namespace: &client_handle.namespace,
+        identity: &client_handle.identity,
+    };
+
+    let (request, response_info) = match build_start_workflow_request(payload, defaults) {
+        Ok(result) => result,
+        Err(err) => return into_string_error(err) as *mut byte_array::ByteArray,
+    };
+
+    let runtime = client_handle.runtime.clone();
+    let client = client_handle.client.clone();
+
+    let response = runtime.tokio_handle().block_on(async move {
+        let mut inner = client.clone();
+        WorkflowService::start_workflow_execution(&mut inner, request.into_request()).await
+    });
+
+    let response = match response {
+        Ok(resp) => resp.into_inner(),
+        Err(err) => {
+            return into_string_error(BridgeError::ClientRequest(err.to_string()))
+                as *mut byte_array::ByteArray
+        }
+    };
+
+    let response_body = serde_json::json!({
+        "runId": response.run_id,
+        "workflowId": response_info.workflow_id,
+        "namespace": response_info.namespace,
+    });
+
+    let bytes = match json_bytes(&response_body) {
+        Ok(bytes) => bytes,
+        Err(err) => return into_string_error(err) as *mut byte_array::ByteArray,
+    };
+
+    byte_array::ByteArray::from_vec(bytes)
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn temporal_bun_byte_array_free(ptr: *mut byte_array::ByteArray) {
     if ptr.is_null() {
         return;
@@ -470,9 +559,201 @@ pub extern "C" fn temporal_bun_pending_byte_array_free(ptr: *mut pending::Pendin
     }
 }
 
+fn encode_payload(value: serde_json::Value) -> Result<Payload, BridgeError> {
+    let data = serde_json::to_vec(&value).map_err(|err| BridgeError::PayloadEncode(err.to_string()))?;
+    let mut metadata = HashMap::new();
+    metadata.insert("encoding".to_string(), b"json/plain".to_vec());
+    Ok(Payload { metadata, data })
+}
+
+fn build_start_workflow_request(
+    payload: StartWorkflowRequestPayload,
+    defaults: StartWorkflowDefaults,
+) -> Result<(StartWorkflowExecutionRequest, StartWorkflowResponseInfo), BridgeError> {
+    let StartWorkflowRequestPayload {
+        namespace,
+        workflow_id,
+        workflow_type,
+        task_queue,
+        args,
+        memo,
+        search_attributes,
+        headers,
+        cron_schedule,
+        request_id,
+        identity,
+        workflow_execution_timeout_ms,
+        workflow_run_timeout_ms,
+        workflow_task_timeout_ms,
+        retry_policy,
+    } = payload;
+
+    let namespace = namespace.unwrap_or_else(|| defaults.namespace.to_string());
+    let identity = identity.unwrap_or_else(|| defaults.identity.to_string());
+    let request_id = request_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    let mut request = StartWorkflowExecutionRequest {
+        namespace: namespace.clone(),
+        workflow_id: workflow_id.clone(),
+        workflow_type: Some(WorkflowType { name: workflow_type }),
+        task_queue: Some(TaskQueue {
+            name: task_queue,
+            kind: TaskQueueKind::Normal as i32,
+            normal_name: String::new(),
+        }),
+        identity,
+        request_id,
+        ..Default::default()
+    };
+
+    if let Some(values) = args {
+        let mut encoded = Vec::with_capacity(values.len());
+        for value in values {
+            encoded.push(encode_payload(value)?);
+        }
+        request.input = Some(Payloads { payloads: encoded });
+    }
+
+    match encode_payload_map(memo)? {
+        Some(fields) => request.memo = Some(Memo { fields }),
+        None => {}
+    }
+
+    match encode_payload_map(search_attributes)? {
+        Some(fields) => {
+            request.search_attributes = Some(SearchAttributes { indexed_fields: fields });
+        }
+        None => {}
+    }
+
+    match encode_payload_map(headers)? {
+        Some(fields) => request.header = Some(Header { fields }),
+        None => {}
+    }
+
+    if let Some(schedule) = cron_schedule {
+        request.cron_schedule = schedule;
+    }
+
+    if let Some(ms) = workflow_execution_timeout_ms {
+        request.workflow_execution_timeout = Some(duration_from_millis(ms));
+    }
+
+    if let Some(ms) = workflow_run_timeout_ms {
+        request.workflow_run_timeout = Some(duration_from_millis(ms));
+    }
+
+    if let Some(ms) = workflow_task_timeout_ms {
+        request.workflow_task_timeout = Some(duration_from_millis(ms));
+    }
+
+    if let Some(policy) = retry_policy {
+        request.retry_policy = Some(encode_retry_policy(policy)?);
+    }
+
+    let response_info = StartWorkflowResponseInfo {
+        workflow_id,
+        namespace,
+    };
+
+    Ok((request, response_info))
+}
+
+fn encode_payload_map(
+    map: Option<HashMap<String, serde_json::Value>>,
+) -> Result<Option<HashMap<String, Payload>>, BridgeError> {
+    match map {
+        Some(entries) => {
+            if entries.is_empty() {
+                return Ok(None);
+            }
+            let mut encoded = HashMap::with_capacity(entries.len());
+            for (key, value) in entries {
+                encoded.insert(key, encode_payload(value)?);
+            }
+            Ok(Some(encoded))
+        }
+        None => Ok(None),
+    }
+}
+
+fn encode_retry_policy(payload: RetryPolicyPayload) -> Result<RetryPolicy, BridgeError> {
+    let mut policy = RetryPolicy::default();
+    if let Some(ms) = payload.initial_interval_ms {
+        policy.initial_interval = Some(duration_from_millis(ms));
+    }
+    if let Some(ms) = payload.maximum_interval_ms {
+        policy.maximum_interval = Some(duration_from_millis(ms));
+    }
+    if let Some(attempts) = payload.maximum_attempts {
+        policy.maximum_attempts = attempts;
+    }
+    if let Some(coefficient) = payload.backoff_coefficient {
+        policy.backoff_coefficient = coefficient;
+    }
+    if let Some(errors) = payload.non_retryable_error_types {
+        policy.non_retryable_error_types = errors;
+    }
+    Ok(policy)
+}
+
+fn tls_config_from_payload(payload: ClientTlsConfigPayload) -> Result<TlsConfig, BridgeError> {
+    let mut tls = TlsConfig::default();
+
+    if let Some(server_root_ca) = payload.server_root_ca_cert {
+        let bytes = decode_base64(&server_root_ca)
+            .map_err(|err| BridgeError::InvalidTlsConfig(format!("invalid server_root_ca_cert: {err}")))?;
+        tls.server_root_ca_cert = Some(bytes);
+    }
+
+    match (payload.client_cert, payload.client_private_key) {
+        (Some(cert_b64), Some(key_b64)) => {
+            let cert = decode_base64(&cert_b64)
+                .map_err(|err| BridgeError::InvalidTlsConfig(format!("invalid client_cert: {err}")))?;
+            let key = decode_base64(&key_b64)
+                .map_err(|err| BridgeError::InvalidTlsConfig(format!("invalid client_private_key: {err}")))?;
+            tls.client_tls_config = Some(ClientTlsConfig {
+                client_cert: cert,
+                client_private_key: key,
+            });
+        }
+        (None, None) => {}
+        _ => {
+            return Err(BridgeError::InvalidTlsConfig(
+                "client_cert and client_private_key must both be provided".to_string(),
+            ));
+        }
+    }
+
+    if let Some(server_name) = payload.server_name_override {
+        if !server_name.is_empty() {
+            tls.domain = Some(server_name);
+        }
+    }
+
+    Ok(tls)
+}
+
+fn decode_base64(value: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    general_purpose::STANDARD.decode(value)
+}
+
+fn json_bytes<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, BridgeError> {
+    serde_json::to_vec(value).map_err(|err| BridgeError::ResponseEncode(err.to_string()))
+}
+
+fn duration_from_millis(ms: u64) -> ProtoDuration {
+    ProtoDuration {
+        seconds: (ms / 1_000) as i64,
+        nanos: ((ms % 1_000) * 1_000_000) as i32,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use serde_json::json;
 
     #[test]
     fn config_from_raw_parses_defaults() {
@@ -498,5 +779,151 @@ mod tests {
         let invalid =
             request_from_raw::<DescribeNamespaceRequestPayload>(br"{}".as_ptr(), 2).unwrap_err();
         assert!(matches!(invalid, BridgeError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn tls_config_from_payload_decodes_components() {
+        let payload = ClientTlsConfigPayload {
+            server_root_ca_cert: Some(general_purpose::STANDARD.encode(b"ROOT")),
+            client_cert: Some(general_purpose::STANDARD.encode(b"CERT")),
+            client_private_key: Some(general_purpose::STANDARD.encode(b"KEY")),
+            server_name_override: Some("server.test".to_string()),
+        };
+
+        let tls = tls_config_from_payload(payload).expect("parsed tls config");
+        assert_eq!(tls.server_root_ca_cert, Some(b"ROOT".to_vec()));
+        assert_eq!(tls.domain.as_deref(), Some("server.test"));
+        let client = tls.client_tls_config.expect("client tls");
+        assert_eq!(client.client_cert, b"CERT");
+        assert_eq!(client.client_private_key, b"KEY");
+    }
+
+    #[test]
+    fn tls_config_from_payload_errors_without_key_pair() {
+        let payload = ClientTlsConfigPayload {
+            server_root_ca_cert: None,
+            client_cert: Some(general_purpose::STANDARD.encode(b"CERT")),
+            client_private_key: None,
+            server_name_override: None,
+        };
+
+        let err = tls_config_from_payload(payload).unwrap_err();
+        assert!(matches!(err, BridgeError::InvalidTlsConfig(_)));
+    }
+
+    #[test]
+    fn build_start_workflow_request_applies_defaults() {
+        let payload = StartWorkflowRequestPayload {
+            namespace: None,
+            workflow_id: "wf-123".to_string(),
+            workflow_type: "ExampleWorkflow".to_string(),
+            task_queue: "prix".to_string(),
+            args: None,
+            memo: None,
+            search_attributes: None,
+            headers: None,
+            cron_schedule: None,
+            request_id: None,
+            identity: None,
+            workflow_execution_timeout_ms: None,
+            workflow_run_timeout_ms: None,
+            workflow_task_timeout_ms: None,
+            retry_policy: None,
+        };
+
+        let defaults = StartWorkflowDefaults {
+            namespace: "default",
+            identity: "worker-1",
+        };
+
+        let (request, info) = build_start_workflow_request(payload, defaults).expect("build request");
+        assert_eq!(request.namespace, "default");
+        assert_eq!(request.identity, "worker-1");
+        assert_eq!(request.workflow_id, "wf-123");
+        assert_eq!(request.task_queue.unwrap().name, "prix");
+        assert!(request.workflow_execution_timeout.is_none());
+        assert!(request.workflow_run_timeout.is_none());
+        assert!(request.workflow_task_timeout.is_none());
+        assert!(request.retry_policy.is_none());
+        assert_eq!(info.workflow_id, "wf-123");
+        assert_eq!(info.namespace, "default");
+    }
+
+    #[test]
+    fn build_start_workflow_request_encodes_payloads_timeouts_and_policy() {
+        let args = vec![json!("hello"), json!({ "count": 2 })];
+        let memo = HashMap::from([(String::from("note"), json!("memo"))]);
+        let headers = HashMap::from([(String::from("auth"), json!("bearer"))]);
+        let search = HashMap::from([(String::from("env"), json!("dev"))]);
+
+        let payload = StartWorkflowRequestPayload {
+            namespace: Some("analytics".to_string()),
+            workflow_id: "wf-xyz".to_string(),
+            workflow_type: "ExampleWorkflow".to_string(),
+            task_queue: "prix".to_string(),
+            args: Some(args),
+            memo: Some(memo),
+            search_attributes: Some(search),
+            headers: Some(headers),
+            cron_schedule: Some("*/5 * * * *".to_string()),
+            request_id: Some("req-1".to_string()),
+            identity: Some("custom-worker".to_string()),
+            workflow_execution_timeout_ms: Some(1_500),
+            workflow_run_timeout_ms: Some(2_000),
+            workflow_task_timeout_ms: Some(750),
+            retry_policy: Some(RetryPolicyPayload {
+                initial_interval_ms: Some(2_500),
+                maximum_interval_ms: Some(10_000),
+                maximum_attempts: Some(3),
+                backoff_coefficient: Some(2.0),
+                non_retryable_error_types: Some(vec!["Fatal".to_string()]),
+            }),
+        };
+
+        let defaults = StartWorkflowDefaults {
+            namespace: "default",
+            identity: "worker-1",
+        };
+
+        let (request, info) = build_start_workflow_request(payload, defaults).expect("build request");
+
+        let inputs = request.input.expect("payloads").payloads;
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(request.identity, "custom-worker");
+        assert_eq!(request.namespace, "analytics");
+        assert_eq!(info.namespace, "analytics");
+        assert_eq!(request.cron_schedule, "*/5 * * * *");
+
+        let execution_timeout = request
+            .workflow_execution_timeout
+            .expect("execution timeout");
+        assert_eq!(execution_timeout.seconds, 1);
+        assert_eq!(execution_timeout.nanos, 500_000_000);
+
+        let run_timeout = request.workflow_run_timeout.expect("run timeout");
+        assert_eq!(run_timeout.seconds, 2);
+        assert_eq!(run_timeout.nanos, 0);
+
+        let task_timeout = request.workflow_task_timeout.expect("task timeout");
+        assert_eq!(task_timeout.seconds, 0);
+        assert_eq!(task_timeout.nanos, 750_000_000);
+
+        let retry = request.retry_policy.expect("retry policy");
+        let initial_interval = retry.initial_interval.expect("initial interval");
+        assert_eq!(initial_interval.seconds, 2);
+        assert_eq!(initial_interval.nanos, 500_000_000);
+        let maximum_interval = retry.maximum_interval.expect("maximum interval");
+        assert_eq!(maximum_interval.seconds, 10);
+        assert_eq!(maximum_interval.nanos, 0);
+        assert_eq!(retry.maximum_attempts, 3);
+        assert_eq!(retry.backoff_coefficient, 2.0);
+        assert_eq!(retry.non_retryable_error_types, vec!["Fatal".to_string()]);
+
+        let memo_fields = request.memo.unwrap().fields;
+        assert!(memo_fields.contains_key("note"));
+        let header_fields = request.header.unwrap().fields;
+        assert!(header_fields.contains_key("auth"));
+        let search_fields = request.search_attributes.unwrap().indexed_fields;
+        assert!(search_fields.contains_key("env"));
     }
 }

--- a/packages/temporal-bun-sdk/package.json
+++ b/packages/temporal-bun-sdk/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@temporalio/activity": "^1.13.0",
     "@temporalio/common": "^1.13.0",
-    "@temporalio/client": "^1.13.0",
     "@temporalio/worker": "^1.13.0",
     "@temporalio/workflow": "^1.13.0",
     "zod": "^3.23.8"

--- a/packages/temporal-bun-sdk/src/client.ts
+++ b/packages/temporal-bun-sdk/src/client.ts
@@ -1,53 +1,313 @@
-import { Connection, WorkflowClient } from '@temporalio/client'
-import type { ConnectionOptions, WorkflowClientOptions } from '@temporalio/client'
-import { loadTemporalConfig, type TemporalConfig } from './config'
+import { z } from 'zod'
+import { loadTemporalConfig, type TemporalConfig, type TLSConfig } from './config'
+import { native, type NativeClient, type Runtime } from './internal/core-bridge/native'
 
-export interface CreateTemporalConnectionOptions {
-  config?: TemporalConfig
-  connectionOptions?: ConnectionOptions
+const startWorkflowResponseSchema = z.object({
+  runId: z.string().min(1),
+  workflowId: z.string().min(1),
+  namespace: z.string().min(1),
+})
+
+const retryPolicySchema = z
+  .object({
+    initialIntervalMs: z.number().int().positive().optional(),
+    maximumIntervalMs: z.number().int().positive().optional(),
+    maximumAttempts: z.number().int().optional(),
+    backoffCoefficient: z.number().positive().optional(),
+    nonRetryableErrorTypes: z.array(z.string().min(1)).optional(),
+  })
+  .optional()
+
+const startWorkflowOptionsSchema = z.object({
+  workflowId: z.string().min(1),
+  workflowType: z.string().min(1),
+  args: z.array(z.unknown()).optional(),
+  taskQueue: z.string().min(1).optional(),
+  namespace: z.string().min(1).optional(),
+  identity: z.string().min(1).optional(),
+  cronSchedule: z.string().min(1).optional(),
+  memo: z.record(z.unknown()).optional(),
+  headers: z.record(z.unknown()).optional(),
+  searchAttributes: z.record(z.unknown()).optional(),
+  requestId: z.string().min(1).optional(),
+  workflowExecutionTimeoutMs: z.number().int().positive().optional(),
+  workflowRunTimeoutMs: z.number().int().positive().optional(),
+  workflowTaskTimeoutMs: z.number().int().positive().optional(),
+  retryPolicy: retryPolicySchema,
+})
+
+export interface RetryPolicyOptions {
+  initialIntervalMs?: number
+  maximumIntervalMs?: number
+  maximumAttempts?: number
+  backoffCoefficient?: number
+  nonRetryableErrorTypes?: string[]
 }
 
-export const createTemporalConnection = async (options: CreateTemporalConnectionOptions = {}): Promise<Connection> => {
+export interface StartWorkflowOptions {
+  workflowId: string
+  workflowType: string
+  args?: unknown[]
+  taskQueue?: string
+  namespace?: string
+  identity?: string
+  cronSchedule?: string
+  memo?: Record<string, unknown>
+  headers?: Record<string, unknown>
+  searchAttributes?: Record<string, unknown>
+  requestId?: string
+  workflowExecutionTimeoutMs?: number
+  workflowRunTimeoutMs?: number
+  workflowTaskTimeoutMs?: number
+  retryPolicy?: RetryPolicyOptions
+}
+
+export type StartWorkflowResult = z.infer<typeof startWorkflowResponseSchema>
+
+export interface TemporalWorkflowClient {
+  start(options: StartWorkflowOptions): Promise<StartWorkflowResult>
+}
+
+export interface TemporalClient {
+  readonly namespace: string
+  readonly config: TemporalConfig
+  readonly workflow: TemporalWorkflowClient
+  startWorkflow(options: StartWorkflowOptions): Promise<StartWorkflowResult>
+  describeNamespace(namespace?: string): Promise<Uint8Array>
+  shutdown(): Promise<void>
+}
+
+export interface CreateTemporalClientOptions {
+  config?: TemporalConfig
+  runtimeOptions?: Record<string, unknown>
+  namespace?: string
+  identity?: string
+  taskQueue?: string
+}
+
+const textDecoder = new TextDecoder()
+
+export const createTemporalClient = async (
+  options: CreateTemporalClientOptions = {},
+): Promise<{ client: TemporalClient; config: TemporalConfig }> => {
   const config = options.config ?? (await loadTemporalConfig())
-  const baseOptions: ConnectionOptions = {
-    address: config.address,
-    ...(options.connectionOptions ?? {}),
-  }
-
-  if (config.apiKey && baseOptions.apiKey === undefined) {
-    baseOptions.apiKey = config.apiKey
-  }
-
-  if (config.tls && baseOptions.tls === undefined) {
-    baseOptions.tls = config.tls
-  }
 
   if (config.allowInsecureTls) {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
   }
 
-  return await Connection.connect(baseOptions)
-}
+  const namespace = options.namespace ?? config.namespace
+  const identity = options.identity ?? config.workerIdentity
+  const taskQueue = options.taskQueue ?? config.taskQueue
 
-export interface CreateTemporalClientOptions extends CreateTemporalConnectionOptions {
-  connection?: Connection
-  clientOptions?: WorkflowClientOptions
-}
+  const runtime = native.createRuntime(options.runtimeOptions ?? {})
+  const nativeConfig: Record<string, unknown> = {
+    address: formatTemporalAddress(config.address, Boolean(config.tls)),
+    namespace,
+    identity,
+  }
 
-export const createTemporalClient = async (options: CreateTemporalClientOptions = {}) => {
-  const config = options.config ?? (await loadTemporalConfig())
-  const connection =
-    options.connection ??
-    (await createTemporalConnection({
-      config,
-      connectionOptions: options.connectionOptions,
-    }))
+  if (config.apiKey) {
+    nativeConfig.apiKey = config.apiKey
+  }
 
-  const client = new WorkflowClient({
-    connection,
-    namespace: options.clientOptions?.namespace ?? config.namespace,
-    ...(options.clientOptions ?? {}),
+  const tlsPayload = serializeTlsConfig(config.tls)
+  if (tlsPayload) {
+    nativeConfig.tls = tlsPayload
+  }
+
+  if (config.allowInsecureTls) {
+    nativeConfig.allowInsecure = true
+  }
+
+  const clientHandle = await native.createClient(runtime, nativeConfig)
+
+  const client = new TemporalClientImpl({
+    runtime,
+    client: clientHandle,
+    config,
+    namespace,
+    identity,
+    taskQueue,
   })
 
-  return { client, connection, config }
+  return { client, config }
+}
+
+class TemporalClientImpl implements TemporalClient {
+  readonly namespace: string
+  readonly config: TemporalConfig
+  readonly workflow: TemporalWorkflowClient
+
+  private closed = false
+  private readonly runtime: Runtime
+  private readonly client: NativeClient
+  private readonly defaultIdentity: string
+  private readonly defaultTaskQueue: string
+
+  constructor(handles: {
+    runtime: Runtime
+    client: NativeClient
+    config: TemporalConfig
+    namespace: string
+    identity: string
+    taskQueue: string
+  }) {
+    this.runtime = handles.runtime
+    this.client = handles.client
+    this.config = handles.config
+    this.namespace = handles.namespace
+    this.defaultIdentity = handles.identity
+    this.defaultTaskQueue = handles.taskQueue
+    this.workflow = {
+      start: (options) => this.startWorkflow(options),
+    }
+  }
+
+  async startWorkflow(options: StartWorkflowOptions): Promise<StartWorkflowResult> {
+    const parsed = startWorkflowOptionsSchema.parse(options)
+    const payload = buildStartWorkflowPayload({
+      options: parsed,
+      defaults: {
+        namespace: this.namespace,
+        identity: this.defaultIdentity,
+        taskQueue: this.defaultTaskQueue,
+      },
+    })
+
+    const bytes = await native.startWorkflow(this.client, payload)
+    const response = parseJson(bytes)
+    return startWorkflowResponseSchema.parse(response)
+  }
+
+  async describeNamespace(targetNamespace?: string): Promise<Uint8Array> {
+    return native.describeNamespace(this.client, targetNamespace ?? this.namespace)
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.closed) return
+    this.closed = true
+    native.clientShutdown(this.client)
+    native.runtimeShutdown(this.runtime)
+  }
+}
+
+const parseJson = (bytes: Uint8Array): unknown => {
+  const text = textDecoder.decode(bytes)
+  try {
+    return JSON.parse(text)
+  } catch (error) {
+    throw new Error(`Failed to parse Temporal bridge response: ${(error as Error).message}`)
+  }
+}
+
+const buildStartWorkflowPayload = ({
+  options,
+  defaults,
+}: {
+  options: z.infer<typeof startWorkflowOptionsSchema>
+  defaults: { namespace: string; identity: string; taskQueue: string }
+}): Record<string, unknown> => {
+  const payload: Record<string, unknown> = {
+    namespace: options.namespace ?? defaults.namespace,
+    workflow_id: options.workflowId,
+    workflow_type: options.workflowType,
+    task_queue: options.taskQueue ?? defaults.taskQueue,
+    identity: options.identity ?? defaults.identity,
+    args: options.args ?? [],
+  }
+
+  if (options.cronSchedule) {
+    payload.cron_schedule = options.cronSchedule
+  }
+
+  if (options.memo) {
+    payload.memo = options.memo
+  }
+
+  if (options.headers) {
+    payload.headers = options.headers
+  }
+
+  if (options.searchAttributes) {
+    payload.search_attributes = options.searchAttributes
+  }
+
+  if (options.requestId) {
+    payload.request_id = options.requestId
+  }
+
+  if (options.workflowExecutionTimeoutMs) {
+    payload.workflow_execution_timeout_ms = options.workflowExecutionTimeoutMs
+  }
+
+  if (options.workflowRunTimeoutMs) {
+    payload.workflow_run_timeout_ms = options.workflowRunTimeoutMs
+  }
+
+  if (options.workflowTaskTimeoutMs) {
+    payload.workflow_task_timeout_ms = options.workflowTaskTimeoutMs
+  }
+
+  if (options.retryPolicy) {
+    payload.retry_policy = buildRetryPolicy(options.retryPolicy)
+  }
+
+  return payload
+}
+
+const buildRetryPolicy = (policy: RetryPolicyOptions): Record<string, unknown> => {
+  const payload: Record<string, unknown> = {}
+  if (policy.initialIntervalMs !== undefined) {
+    payload.initial_interval_ms = policy.initialIntervalMs
+  }
+  if (policy.maximumIntervalMs !== undefined) {
+    payload.maximum_interval_ms = policy.maximumIntervalMs
+  }
+  if (policy.maximumAttempts !== undefined) {
+    payload.maximum_attempts = policy.maximumAttempts
+  }
+  if (policy.backoffCoefficient !== undefined) {
+    payload.backoff_coefficient = policy.backoffCoefficient
+  }
+  if (policy.nonRetryableErrorTypes && policy.nonRetryableErrorTypes.length > 0) {
+    payload.non_retryable_error_types = policy.nonRetryableErrorTypes
+  }
+  return payload
+}
+
+const formatTemporalAddress = (address: string, useTls: boolean): string => {
+  if (/^https?:\/\//i.test(address)) {
+    return address
+  }
+  return `${useTls ? 'https' : 'http'}://${address}`
+}
+
+const serializeTlsConfig = (tls?: TLSConfig): Record<string, unknown> | undefined => {
+  if (!tls) return undefined
+
+  const payload: Record<string, unknown> = {}
+  const encode = (buffer?: Buffer) => buffer?.toString('base64')
+
+  const caCertificate = encode(tls.serverRootCACertificate)
+  if (caCertificate) {
+    payload.server_root_ca_cert = caCertificate
+  }
+
+  const clientCert = encode(tls.clientCertPair?.crt)
+  const clientPrivateKey = encode(tls.clientCertPair?.key)
+  if (clientCert && clientPrivateKey) {
+    payload.client_cert = clientCert
+    payload.client_private_key = clientPrivateKey
+  }
+
+  if (tls.serverNameOverride) {
+    payload.server_name_override = tls.serverNameOverride
+  }
+
+  if (Object.keys(payload).length === 0) {
+    return undefined
+  }
+
+  return payload
 }

--- a/packages/temporal-bun-sdk/src/client/index.ts
+++ b/packages/temporal-bun-sdk/src/client/index.ts
@@ -1,1 +1,1 @@
-export * from '../../vendor/sdk-typescript/packages/client/src/index.ts'
+export * from '../client'

--- a/packages/temporal-bun-sdk/src/config.ts
+++ b/packages/temporal-bun-sdk/src/config.ts
@@ -1,6 +1,5 @@
 import { readFile } from 'node:fs/promises'
 import { hostname } from 'node:os'
-import type { TLSConfig } from '@temporalio/client'
 import { z } from 'zod'
 
 const DEFAULT_HOST = '127.0.0.1'
@@ -64,6 +63,17 @@ export interface TemporalConfig {
   allowInsecureTls: boolean
   workerIdentity: string
   workerIdentityPrefix: string
+}
+
+export interface TLSCertPair {
+  crt: Buffer
+  key: Buffer
+}
+
+export interface TLSConfig {
+  serverRootCACertificate?: Buffer
+  serverNameOverride?: string
+  clientCertPair?: TLSCertPair
 }
 
 const buildTlsConfig = async (

--- a/packages/temporal-bun-sdk/tests/client.test.ts
+++ b/packages/temporal-bun-sdk/tests/client.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { TemporalConfig } from '../src/config'
+import { createTemporalClient } from '../src/client'
+import { native } from '../src/internal/core-bridge/native'
+
+const encodeJson = (value: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(value))
+
+describe('temporal client (native bridge)', () => {
+  const original = {
+    createRuntime: native.createRuntime,
+    runtimeShutdown: native.runtimeShutdown,
+    createClient: native.createClient,
+    clientShutdown: native.clientShutdown,
+    startWorkflow: native.startWorkflow,
+    describeNamespace: native.describeNamespace,
+  }
+
+  const runtimeHandle = { type: 'runtime', handle: 101 } as const
+  const clientHandle = { type: 'client', handle: 202 } as const
+
+  beforeEach(() => {
+    native.createRuntime = mock(() => runtimeHandle)
+    native.createClient = mock(async () => clientHandle)
+    native.clientShutdown = mock(() => {})
+    native.runtimeShutdown = mock(() => {})
+    native.describeNamespace = mock(async () => new Uint8Array())
+  })
+
+  afterEach(() => {
+    Object.assign(native, original)
+  })
+
+  test('startWorkflow forwards defaults and parses response', async () => {
+    const startWorkflowMock = mock(async (_: unknown, payload: Record<string, unknown>) => {
+      expect(payload.workflow_id).toBe('workflow-123')
+      expect(payload.workflow_type).toBe('ExampleWorkflow')
+      expect(payload.namespace).toBe('analytics')
+      expect(payload.task_queue).toBe('prix')
+      expect(payload.identity).toBe('bun-worker-01')
+      expect(payload.args).toEqual(['hello', 42])
+      return encodeJson({ runId: 'run-xyz', workflowId: payload.workflow_id, namespace: payload.namespace })
+    })
+
+    native.startWorkflow = startWorkflowMock
+
+    const config: TemporalConfig = {
+      host: '127.0.0.1',
+      port: 7233,
+      address: '127.0.0.1:7233',
+      namespace: 'default',
+      taskQueue: 'prix',
+      apiKey: undefined,
+      tls: undefined,
+      allowInsecureTls: false,
+      workerIdentity: 'bun-worker-01',
+      workerIdentityPrefix: 'temporal-bun-worker',
+    }
+
+    const { client } = await createTemporalClient({
+      config,
+      namespace: 'analytics',
+    })
+
+    const result = await client.workflow.start({
+      workflowId: 'workflow-123',
+      workflowType: 'ExampleWorkflow',
+      args: ['hello', 42],
+    })
+
+    expect(result).toEqual({ runId: 'run-xyz', workflowId: 'workflow-123', namespace: 'analytics' })
+    expect(startWorkflowMock).toHaveBeenCalledTimes(1)
+
+    await client.shutdown()
+    expect(native.clientShutdown).toHaveBeenCalledTimes(1)
+    expect(native.runtimeShutdown).toHaveBeenCalledTimes(1)
+  })
+
+  test('startWorkflow builds retry policy payload', async () => {
+    let captured: Record<string, unknown> | undefined
+    native.startWorkflow = mock(async (_: unknown, payload: Record<string, unknown>) => {
+      captured = payload
+      return encodeJson({ runId: 'run-abc', workflowId: payload.workflow_id, namespace: payload.namespace })
+    })
+
+    const config: TemporalConfig = {
+      host: 'localhost',
+      port: 7233,
+      address: 'localhost:7233',
+      namespace: 'default',
+      taskQueue: 'prix',
+      apiKey: undefined,
+      tls: undefined,
+      allowInsecureTls: false,
+      workerIdentity: 'worker-default',
+      workerIdentityPrefix: 'temporal-bun-worker',
+    }
+
+    const { client } = await createTemporalClient({ config })
+
+    await client.startWorkflow({
+      workflowId: 'wf-id',
+      workflowType: 'Example',
+      retryPolicy: {
+        initialIntervalMs: 1_000,
+        maximumIntervalMs: 10_000,
+        maximumAttempts: 5,
+        backoffCoefficient: 2,
+        nonRetryableErrorTypes: ['FatalError'],
+      },
+    })
+
+    expect(captured?.retry_policy).toEqual({
+      initial_interval_ms: 1_000,
+      maximum_interval_ms: 10_000,
+      maximum_attempts: 5,
+      backoff_coefficient: 2,
+      non_retryable_error_types: ['FatalError'],
+    })
+
+    await client.shutdown()
+  })
+
+  test('createTemporalClient forwards TLS and API key options to native bridge', async () => {
+    native.startWorkflow = mock(async (_: unknown, payload: Record<string, unknown>) => {
+      return encodeJson({ runId: 'run-123', workflowId: payload.workflow_id, namespace: payload.namespace })
+    })
+
+    const config: TemporalConfig = {
+      host: 'temporal.internal',
+      port: 7233,
+      address: 'temporal.internal:7233',
+      namespace: 'default',
+      taskQueue: 'prix',
+      apiKey: 'test-key',
+      allowInsecureTls: false,
+      workerIdentity: 'bun-worker',
+      workerIdentityPrefix: 'temporal-bun-worker',
+      tls: {
+        serverRootCACertificate: Buffer.from('ROOT'),
+        serverNameOverride: 'temporal.example.internal',
+        clientCertPair: {
+          crt: Buffer.from('CERT'),
+          key: Buffer.from('KEY'),
+        },
+      },
+    }
+
+    await createTemporalClient({ config })
+
+    expect(native.createClient).toHaveBeenLastCalledWith(runtimeHandle, {
+      address: 'https://temporal.internal:7233',
+      namespace: 'default',
+      identity: 'bun-worker',
+      apiKey: 'test-key',
+      tls: {
+        server_root_ca_cert: Buffer.from('ROOT').toString('base64'),
+        client_cert: Buffer.from('CERT').toString('base64'),
+        client_private_key: Buffer.from('KEY').toString('base64'),
+        server_name_override: 'temporal.example.internal',
+      },
+    })
+  })
+})

--- a/packages/temporal-bun-sdk/tsconfig.json
+++ b/packages/temporal-bun-sdk/tsconfig.json
@@ -4,9 +4,8 @@
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "moduleDetection": "force",
-    "allowImportingTsExtensions": true,
     "baseUrl": "./",
     "rootDirs": ["src", "vendor"],
     "paths": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,13 +178,13 @@ importers:
         version: 1.131.44(@tanstack/react-router@1.131.44(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(webpack@5.99.9)
       '@trpc/client':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251016))(typescript@6.0.0-dev.20251016)
+        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251017))(typescript@6.0.0-dev.20251017)
       '@trpc/server':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251016)
+        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251017)
       '@trpc/tanstack-react-query':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251016))(typescript@6.0.0-dev.20251016))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251016))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251016)
+        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251017))(typescript@6.0.0-dev.20251017))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251017))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251017)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -233,7 +233,7 @@ importers:
         version: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.0-dev.20251016)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 5.1.4(typescript@6.0.0-dev.20251017)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
 
   apps/nata:
     dependencies:
@@ -597,9 +597,6 @@ importers:
       '@temporalio/activity':
         specifier: ^1.13.0
         version: 1.13.1
-      '@temporalio/client':
-        specifier: ^1.13.0
-        version: 1.13.0
       '@temporalio/common':
         specifier: ^1.13.0
         version: 1.13.1
@@ -9858,8 +9855,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20251016:
-    resolution: {integrity: sha512-J+NPFklPwcYOagyuzRC5nLrTlVxU/cXOusqxMuWbbQR3k9sfj1PHPjv0qcPtzmiTI0MdKZ/7jVCB2e46nB4TIw==}
+  typescript@6.0.0-dev.20251017:
+    resolution: {integrity: sha512-soyESex6lT2ey9PbehWuvUjc1sMdcuPIG/6kfWYi5Opb+V6SNsNgi+/pY31QQt0xBeDuU3N8Kci2GWatOFOzUw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -15998,23 +15995,23 @@ snapshots:
       '@temporalio/proto': 1.13.1
       nexus-rpc: 0.0.1
 
-  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251016))(typescript@6.0.0-dev.20251016)':
+  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251017))(typescript@6.0.0-dev.20251017)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251016)
-      typescript: 6.0.0-dev.20251016
+      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251017)
+      typescript: 6.0.0-dev.20251017
 
-  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251016)':
+  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251017)':
     dependencies:
-      typescript: 6.0.0-dev.20251016
+      typescript: 6.0.0-dev.20251017
 
-  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251016))(typescript@6.0.0-dev.20251016))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251016))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251016)':
+  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251017))(typescript@6.0.0-dev.20251017))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251017))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251017)':
     dependencies:
       '@tanstack/react-query': 5.89.0(react@19.0.0)
-      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251016))(typescript@6.0.0-dev.20251016)
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251016)
+      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251017))(typescript@6.0.0-dev.20251017)
+      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251017)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      typescript: 6.0.0-dev.20251016
+      typescript: 6.0.0-dev.20251017
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -17439,7 +17436,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20251016
+      typescript: 6.0.0-dev.20251017
 
   dunder-proto@1.0.1:
     dependencies:
@@ -21738,9 +21735,9 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.8(@swc/helpers@0.5.15)
 
-  tsconfck@3.1.5(typescript@6.0.0-dev.20251016):
+  tsconfck@3.1.5(typescript@6.0.0-dev.20251017):
     optionalDependencies:
-      typescript: 6.0.0-dev.20251016
+      typescript: 6.0.0-dev.20251017
 
   tslib@1.14.1: {}
 
@@ -21778,7 +21775,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.0-dev.20251016: {}
+  typescript@6.0.0-dev.20251017: {}
 
   ufo@1.5.4: {}
 
@@ -22075,11 +22072,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251016)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251017)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.5(typescript@6.0.0-dev.20251016)
+      tsconfck: 3.1.5(typescript@6.0.0-dev.20251017)
     optionalDependencies:
       vite: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- replace the SDK client with a Bun-native implementation that uses our FFI bridge
- propagate TLS and API key metadata into the Rust bridge and expose start-workflow
- add coverage (Rust + Bun tests) for payload encoding and TLS decoding, and document the updated workflow

## Testing
- cargo test --manifest-path packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.toml
- pnpm --filter @proompteng/temporal-bun-sdk run build:native
- bun test packages/temporal-bun-sdk/tests/client.test.ts
- pnpm install --frozen-lockfile

## Known Limitations
- pnpm --filter @proompteng/temporal-bun-sdk build still fails because the vendored Temporal TypeScript packages pull in upstream-only dependencies; this already happens on main.