### PR TITLE
feat: bootstrap bun native worker bridge

### DIFF
--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.lock
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +145,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
@@ -506,12 +536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,12 +664,12 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "1.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
  "rustix",
- "windows-link 0.2.1",
+ "windows-targets",
 ]
 
 [[package]]
@@ -656,22 +680,28 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasip2",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -690,7 +720,7 @@ dependencies = [
  "futures-sink",
  "futures-timer",
  "futures-util",
- "getrandom 0.3.4",
+ "getrandom 0.3.3",
  "hashbrown 0.15.5",
  "nonzero_ext",
  "parking_lot",
@@ -735,7 +765,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -743,11 +773,6 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heck"
@@ -976,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
@@ -1000,6 +1025,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1048,7 +1084,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -1113,11 +1149,11 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
-version = "0.16.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1154,14 +1190,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "mio"
-version = "1.1.0"
+name = "miniz_oxide"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
- "windows-sys 0.61.2",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1256,6 +1301,15 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1669,7 +1723,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -1745,7 +1799,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1768,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1780,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1791,15 +1845,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
@@ -1855,6 +1909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.33"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1927,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2138,12 +2198,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2175,9 +2235,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2225,7 +2285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2445,26 +2505,29 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
+ "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2524,7 +2587,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs 0.8.2",
+ "rustls-native-certs 0.8.1",
  "socket2",
  "sync_wrapper",
  "tokio",
@@ -2757,7 +2820,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2788,6 +2851,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
 
 [[package]]
 name = "wasip2"
@@ -3026,16 +3098,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3053,31 +3125,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3096,22 +3151,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3120,22 +3163,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3144,22 +3175,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3168,22 +3187,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/build.rs
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/build.rs
@@ -1,0 +1,17 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(temporal_client_has_allow_insecure)");
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let client_path = manifest_dir
+        .join("../../vendor/sdk-core/client/src/lib.rs")
+        .canonicalize()
+        .unwrap_or_else(|_| manifest_dir.join("../../vendor/sdk-core/client/src/lib.rs"));
+
+    if let Ok(contents) = fs::read_to_string(&client_path) {
+        if contents.contains("allow_insecure") {
+            println!("cargo:rustc-cfg=temporal_client_has_allow_insecure");
+        }
+    }
+}

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/lib.rs
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/lib.rs
@@ -1,44 +1,47 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ffi::c_void;
-use std::net::SocketAddr;
+use std::fmt::Display;
+use std::mem::take;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
 
+use base64::{engine::general_purpose, Engine as _};
 use prost::Message;
+use prost_wkt_types::Duration as ProtoDuration;
 use serde::Deserialize;
 use temporal_client::{
-    tonic::IntoRequest, ClientOptionsBuilder, ConfiguredClient, Namespace, RetryClient,
-    TemporalServiceClient, WorkflowService,
+    tonic::IntoRequest, ClientOptionsBuilder, ClientTlsConfig, ConfiguredClient, Namespace,
+    RetryClient, TemporalServiceClient, TlsConfig, WorkflowService,
 };
-use temporal_sdk_core::{
-    telemetry::{build_otlp_metric_exporter, start_prometheus_metric_exporter},
-    CoreRuntime, TokioRuntimeBuilder,
+use temporal_sdk_core::{CoreRuntime, TokioRuntimeBuilder, Worker, WorkerConfigBuilder, init_worker};
+use temporal_sdk_core_api::{telemetry::TelemetryOptions, worker::WorkerVersioningStrategy, Worker as _};
+use temporal_sdk_core_protos::temporal::api::common::v1::{
+    Header, Memo, Payload, Payloads, RetryPolicy, SearchAttributes, WorkflowExecution, WorkflowType,
 };
-use temporal_sdk_core_api::telemetry::{
-    metrics::CoreMeter, HistogramBucketOverrides, MetricTemporality, OtelCollectorOptionsBuilder,
-    OtlpProtocol, PrometheusExporterOptions, PrometheusExporterOptionsBuilder, TelemetryOptions,
+use temporal_sdk_core_protos::temporal::api::enums::v1::{
+    QueryRejectCondition, TaskQueueKind, WorkflowExecutionStatus,
 };
-use temporal_sdk_core_protos::temporal::api::enums::v1::WorkflowExecutionStatus;
+use temporal_sdk_core_protos::temporal::api::query::v1::WorkflowQuery;
+use temporal_sdk_core_protos::temporal::api::taskqueue::v1::TaskQueue;
+use temporal_sdk_core_protos::temporal::api::workflowservice::v1::{
+    QueryWorkflowRequest, SignalWithStartWorkflowExecutionRequest, StartWorkflowExecutionRequest,
+    TerminateWorkflowExecutionRequest,
+};
 use thiserror::Error;
-use tokio::task::AbortHandle;
 use url::Url;
+use uuid::Uuid;
 
 mod byte_array;
 mod error;
-mod metadata;
 mod pending;
-mod request;
 
 type PendingClientHandle = pending::PendingResult<ClientHandle>;
 
 #[repr(C)]
 pub struct RuntimeHandle {
     runtime: Arc<CoreRuntime>,
-    prometheus_abort: Option<AbortHandle>,
-    prometheus_config: Option<PrometheusTelemetryPayload>,
 }
 
 #[repr(C)]
@@ -47,6 +50,12 @@ pub struct ClientHandle {
     client: RetryClient<ConfiguredClient<TemporalServiceClient>>,
     namespace: String,
     identity: String,
+}
+
+#[repr(C)]
+pub struct WorkerHandle {
+    runtime: Arc<CoreRuntime>,
+    worker: Arc<Worker>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -63,6 +72,8 @@ struct ClientConfig {
     api_key: Option<String>,
     #[serde(default, alias = "allowInsecureTls")]
     allow_insecure_tls: Option<bool>,
+    #[serde(default, rename = "allowInsecure")]
+    allow_insecure: Option<bool>,
     #[serde(default)]
     tls: Option<ClientTlsConfigPayload>,
 }
@@ -154,85 +165,18 @@ struct QueryWorkflowRequestPayload {
     args: Option<Vec<serde_json::Value>>,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TelemetryUpdatePayload {
-    metrics: MetricsExporterPayload,
+struct StartWorkflowDefaults<'a> {
+    namespace: &'a str,
+    identity: &'a str,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
-enum MetricsExporterPayload {
-    Prometheus(PrometheusTelemetryPayload),
-    Otlp(OtlpTelemetryPayload),
+struct QueryWorkflowDefaults<'a> {
+    namespace: &'a str,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct PrometheusTelemetryPayload {
-    bind_address: String,
-    #[serde(default)]
-    global_tags: HashMap<String, String>,
-    #[serde(default)]
-    counters_total_suffix: bool,
-    #[serde(default)]
-    unit_suffix: bool,
-    #[serde(default)]
-    use_seconds_for_durations: bool,
-    #[serde(default)]
-    histogram_bucket_overrides: HashMap<String, Vec<f64>>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct OtlpTelemetryPayload {
-    url: String,
-    #[serde(default)]
-    protocol: Option<OtlpProtocolTag>,
-    #[serde(default)]
-    headers: HashMap<String, String>,
-    #[serde(default)]
-    metric_periodicity_ms: Option<u64>,
-    #[serde(default)]
-    metric_temporality: Option<MetricTemporalityTag>,
-    #[serde(default)]
-    global_tags: HashMap<String, String>,
-    #[serde(default)]
-    use_seconds_for_durations: bool,
-    #[serde(default)]
-    histogram_bucket_overrides: HashMap<String, Vec<f64>>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum MetricTemporalityTag {
-    Cumulative,
-    Delta,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum OtlpProtocolTag {
-    Http,
-    Grpc,
-}
-
-impl From<MetricTemporalityTag> for MetricTemporality {
-    fn from(value: MetricTemporalityTag) -> Self {
-        match value {
-            MetricTemporalityTag::Cumulative => MetricTemporality::Cumulative,
-            MetricTemporalityTag::Delta => MetricTemporality::Delta,
-        }
-    }
-}
-
-impl From<OtlpProtocolTag> for OtlpProtocol {
-    fn from(value: OtlpProtocolTag) -> Self {
-        match value {
-            OtlpProtocolTag::Http => OtlpProtocol::Http,
-            OtlpProtocolTag::Grpc => OtlpProtocol::Grpc,
-        }
-    }
+struct StartWorkflowResponseInfo {
+    workflow_id: String,
+    namespace: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -250,6 +194,11 @@ struct TerminateWorkflowRequestPayload {
     details: Option<Vec<serde_json::Value>>,
 }
 
+struct TerminateWorkflowDefaults<'a> {
+    namespace: &'a str,
+    identity: &'a str,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 struct ClientCertPairPayload {
     #[serde(alias = "client_cert")]
@@ -258,16 +207,34 @@ struct ClientCertPairPayload {
     key: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct WorkerConfigPayload {
+    namespace: String,
+    task_queue: String,
+    #[serde(default)]
+    identity: Option<String>,
+    #[serde(default)]
+    build_id: Option<String>,
+    #[serde(default)]
+    max_cached_workflows: Option<usize>,
+    #[serde(default)]
+    no_remote_activities: Option<bool>,
+}
+
 #[derive(Debug, Error)]
 enum BridgeError {
     #[error("invalid runtime handle")]
     InvalidRuntimeHandle,
     #[error("invalid client handle")]
     InvalidClientHandle,
+    #[error("invalid worker handle")]
+    InvalidWorkerHandle,
     #[error("missing configuration payload")]
     MissingConfig,
     #[error("failed to parse client configuration: {0}")]
     InvalidConfig(String),
+    #[error("failed to parse worker configuration: {0}")]
+    InvalidWorkerConfig(String),
     #[error("failed to parse request payload: {0}")]
     InvalidRequest(String),
     #[error("failed to parse Temporal address: {0}")]
@@ -276,6 +243,10 @@ enum BridgeError {
     ClientInit(String),
     #[error("Temporal request failed: {0}")]
     ClientRequest(String),
+    #[error("Temporal worker initialization failed: {0}")]
+    WorkerInit(String),
+    #[error("Temporal worker operation failed: {0}")]
+    WorkerOperation(String),
     #[error("failed to encode payload: {0}")]
     PayloadEncode(String),
     #[error("failed to encode response payload: {0}")]
@@ -284,12 +255,6 @@ enum BridgeError {
     InvalidTlsConfig(String),
     #[error("invalid client metadata: {0}")]
     InvalidMetadata(String),
-    #[error("invalid telemetry configuration: {0}")]
-    InvalidTelemetry(String),
-    #[error("failed to configure telemetry exporters: {0}")]
-    TelemetryConfiguration(String),
-    #[error("runtime is currently in use; telemetry configuration cannot be updated")]
-    RuntimeInUse,
 }
 
 #[unsafe(no_mangle)]
@@ -301,8 +266,6 @@ pub extern "C" fn temporal_bun_runtime_new(
         Ok(runtime) => {
             let handle = RuntimeHandle {
                 runtime: Arc::new(runtime),
-                prometheus_abort: None,
-                prometheus_config: None,
             };
             Box::into_raw(Box::new(handle)) as *mut c_void
         }
@@ -320,42 +283,20 @@ pub extern "C" fn temporal_bun_runtime_free(handle: *mut c_void) {
     }
 
     unsafe {
-        let mut handle = Box::from_raw(handle as *mut RuntimeHandle);
-        if let Some(task) = handle.prometheus_abort.take() {
-            task.abort();
-        }
+        let _ = Box::from_raw(handle as *mut RuntimeHandle);
     }
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn temporal_bun_runtime_update_telemetry(
-    runtime_ptr: *mut c_void,
-    options_ptr: *const u8,
-    options_len: usize,
+    _runtime_ptr: *mut c_void,
+    _options_ptr: *const u8,
+    _options_len: usize,
 ) -> i32 {
-    let handle = match runtime_handle_mut_from_ptr(runtime_ptr) {
-        Ok(handle) => handle,
-        Err(err) => {
-            error::set_error(err.to_string());
-            return -1;
-        }
-    };
-
-    let payload = match request_from_raw::<TelemetryUpdatePayload>(options_ptr, options_len) {
-        Ok(payload) => payload,
-        Err(err) => {
-            error::set_error(err.to_string());
-            return -1;
-        }
-    };
-
-    match configure_runtime_telemetry(handle, payload) {
-        Ok(()) => 0,
-        Err(err) => {
-            error::set_error(err.to_string());
-            -1
-        }
-    }
+    // TODO(codex): Configure telemetry exporters (Prometheus, OTLP) via CoreRuntime once the plan in
+    // docs/ffi-surface.md is implemented.
+    error::set_error("temporal_bun_runtime_update_telemetry is not implemented yet".to_string());
+    -1
 }
 
 #[unsafe(no_mangle)]
@@ -387,188 +328,6 @@ fn runtime_from_ptr(ptr: *mut c_void) -> Result<Arc<CoreRuntime>, BridgeError> {
     Ok(runtime.runtime.clone())
 }
 
-fn runtime_handle_mut_from_ptr<'a>(ptr: *mut c_void) -> Result<&'a mut RuntimeHandle, BridgeError> {
-    if ptr.is_null() {
-        return Err(BridgeError::InvalidRuntimeHandle);
-    }
-    Ok(unsafe { &mut *(ptr as *mut RuntimeHandle) })
-}
-
-fn configure_runtime_telemetry(
-    handle: &mut RuntimeHandle,
-    payload: TelemetryUpdatePayload,
-) -> Result<(), BridgeError> {
-    match payload.metrics {
-        MetricsExporterPayload::Prometheus(config) => configure_prometheus(handle, config),
-        MetricsExporterPayload::Otlp(config) => configure_otlp(handle, config),
-    }
-}
-
-fn ensure_runtime_exclusive(handle: &mut RuntimeHandle) -> Result<(), BridgeError> {
-    if Arc::get_mut(&mut handle.runtime).is_some() {
-        Ok(())
-    } else {
-        Err(BridgeError::RuntimeInUse)
-    }
-}
-
-fn with_runtime<T>(
-    handle: &mut RuntimeHandle,
-    f: impl FnOnce(&mut CoreRuntime) -> Result<T, BridgeError>,
-) -> Result<T, BridgeError> {
-    let runtime = Arc::get_mut(&mut handle.runtime).ok_or(BridgeError::RuntimeInUse)?;
-    let _subscriber_guard = runtime
-        .telemetry()
-        .trace_subscriber()
-        .map(|sub| tracing::subscriber::set_default(sub));
-    let _tokio_guard = runtime.tokio_handle().enter();
-    f(runtime)
-}
-
-fn configure_prometheus(
-    handle: &mut RuntimeHandle,
-    config: PrometheusTelemetryPayload,
-) -> Result<(), BridgeError> {
-    ensure_runtime_exclusive(handle)?;
-    let options = build_prometheus_options(&config)?;
-
-    let previous_config = handle.prometheus_config.clone();
-    let previous_abort = handle.prometheus_abort.take();
-
-    if let Some(task) = previous_abort {
-        task.abort();
-    }
-
-    let abort_handle = match with_runtime(handle, move |runtime| {
-        let exporter = start_prometheus_metric_exporter(options).map_err(|err| {
-            BridgeError::TelemetryConfiguration(format!(
-                "failed to start Prometheus exporter: {err}"
-            ))
-        })?;
-        runtime
-            .telemetry_mut()
-            .attach_late_init_metrics(exporter.meter.clone());
-        Ok::<AbortHandle, BridgeError>(exporter.abort_handle)
-    }) {
-        Ok(handle) => handle,
-        Err(err) => {
-            if let Some(prev_config) = previous_config {
-                if let Err(rollback_err) = restart_prometheus(handle, &prev_config) {
-                    return Err(BridgeError::TelemetryConfiguration(format!(
-                        "failed to start Prometheus exporter: {err}; rollback failed: {rollback_err}"
-                    )));
-                }
-            }
-            return Err(err);
-        }
-    };
-
-    handle.prometheus_abort = Some(abort_handle);
-    handle.prometheus_config = Some(config);
-    Ok(())
-}
-
-fn build_prometheus_options(
-    config: &PrometheusTelemetryPayload,
-) -> Result<PrometheusExporterOptions, BridgeError> {
-    let socket_addr: SocketAddr = config.bind_address.parse().map_err(|err| {
-        BridgeError::InvalidTelemetry(format!("invalid Prometheus bind address: {err}"))
-    })?;
-
-    let mut builder = PrometheusExporterOptionsBuilder::default();
-    builder
-        .socket_addr(socket_addr)
-        .global_tags(config.global_tags.clone())
-        .counters_total_suffix(config.counters_total_suffix)
-        .unit_suffix(config.unit_suffix)
-        .use_seconds_for_durations(config.use_seconds_for_durations)
-        .histogram_bucket_overrides(HistogramBucketOverrides {
-            overrides: config.histogram_bucket_overrides.clone(),
-        });
-
-    builder.build().map_err(|err| {
-        BridgeError::InvalidTelemetry(format!("failed to build Prometheus options: {err}"))
-    })
-}
-
-fn restart_prometheus(
-    handle: &mut RuntimeHandle,
-    config: &PrometheusTelemetryPayload,
-) -> Result<(), BridgeError> {
-    let options = build_prometheus_options(config)?;
-    let abort_handle = with_runtime(handle, move |runtime| {
-        let exporter = start_prometheus_metric_exporter(options).map_err(|err| {
-            BridgeError::TelemetryConfiguration(format!(
-                "failed to restart Prometheus exporter: {err}"
-            ))
-        })?;
-        runtime
-            .telemetry_mut()
-            .attach_late_init_metrics(exporter.meter.clone());
-        Ok::<AbortHandle, BridgeError>(exporter.abort_handle)
-    })?;
-
-    handle.prometheus_abort = Some(abort_handle);
-    handle.prometheus_config = Some(config.clone());
-
-    Ok(())
-}
-
-fn configure_otlp(
-    handle: &mut RuntimeHandle,
-    config: OtlpTelemetryPayload,
-) -> Result<(), BridgeError> {
-    let mut builder = OtelCollectorOptionsBuilder::default();
-    let url = Url::parse(&config.url).map_err(|err| {
-        BridgeError::InvalidTelemetry(format!("invalid OTLP collector URL: {err}"))
-    })?;
-    builder
-        .url(url)
-        .headers(config.headers.clone())
-        .use_seconds_for_durations(config.use_seconds_for_durations)
-        .global_tags(config.global_tags.clone())
-        .histogram_bucket_overrides(HistogramBucketOverrides {
-            overrides: config.histogram_bucket_overrides.clone(),
-        });
-
-    if let Some(period_ms) = config.metric_periodicity_ms {
-        if period_ms == 0 {
-            return Err(BridgeError::InvalidTelemetry(
-                "otlp.metricPeriodicityMs must be greater than zero".to_string(),
-            ));
-        }
-        builder.metric_periodicity(Duration::from_millis(period_ms));
-    }
-
-    if let Some(temporality) = config.metric_temporality {
-        builder.metric_temporality(temporality.into());
-    }
-
-    if let Some(protocol) = config.protocol {
-        builder.protocol(protocol.into());
-    }
-
-    let options = builder.build().map_err(|err| {
-        BridgeError::InvalidTelemetry(format!("failed to build OTLP options: {err}"))
-    })?;
-
-    with_runtime(handle, move |runtime| {
-        let exporter = build_otlp_metric_exporter(options).map_err(|err| {
-            BridgeError::TelemetryConfiguration(format!("failed to start OTLP exporter: {err}"))
-        })?;
-        let meter: Arc<dyn CoreMeter + 'static> = Arc::new(exporter);
-        runtime.telemetry_mut().attach_late_init_metrics(meter);
-        Ok(())
-    })?;
-
-    if let Some(task) = handle.prometheus_abort.take() {
-        task.abort();
-    }
-    handle.prometheus_config = None;
-
-    Ok(())
-}
-
 fn config_from_raw(ptr: *const u8, len: usize) -> Result<ClientConfig, BridgeError> {
     if ptr.is_null() || len == 0 {
         return Err(BridgeError::MissingConfig);
@@ -590,6 +349,62 @@ where
     serde_json::from_slice(bytes).map_err(|err| BridgeError::InvalidRequest(err.to_string()))
 }
 
+fn extract_bearer_token(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    let (scheme, token) = trimmed.split_once(' ')?;
+    if scheme.eq_ignore_ascii_case("bearer") {
+        let token = token.trim();
+        if token.is_empty() {
+            None
+        } else {
+            Some(token)
+        }
+    } else {
+        None
+    }
+}
+
+fn normalize_metadata_headers(
+    raw_headers: HashMap<String, String>,
+) -> Result<(HashMap<String, String>, Option<String>), BridgeError> {
+    let mut normalized: HashMap<String, String> = HashMap::with_capacity(raw_headers.len());
+    let mut bearer: Option<String> = None;
+
+    for (key, value) in raw_headers.into_iter() {
+        let trimmed_key = key.trim();
+        if trimmed_key.is_empty() {
+            return Err(BridgeError::InvalidMetadata("header keys must be non-empty".into()));
+        }
+
+        let lower_key = trimmed_key.to_ascii_lowercase();
+        if normalized.contains_key(&lower_key)
+            || (lower_key == "authorization" && bearer.is_some())
+        {
+            return Err(BridgeError::InvalidMetadata(format!(
+                "duplicate header key '{lower_key}'",
+            )));
+        }
+
+        let trimmed_value = value.trim();
+        if trimmed_value.is_empty() {
+            return Err(BridgeError::InvalidMetadata(format!(
+                "header '{lower_key}' must have a non-empty value",
+            )));
+        }
+
+        if lower_key == "authorization" {
+            if let Some(token) = extract_bearer_token(trimmed_value) {
+                bearer = Some(token.to_string());
+                continue;
+            }
+        }
+
+        normalized.insert(lower_key, trimmed_value.to_string());
+    }
+
+    Ok((normalized, bearer))
+}
+
 fn into_string_error(err: BridgeError) -> *mut c_void {
     error::set_error(err.to_string());
     std::ptr::null_mut()
@@ -600,6 +415,13 @@ fn client_from_ptr(ptr: *mut c_void) -> Result<&'static ClientHandle, BridgeErro
         return Err(BridgeError::InvalidClientHandle);
     }
     Ok(unsafe { &*(ptr as *mut ClientHandle) })
+}
+
+fn worker_from_ptr(ptr: *mut c_void) -> Result<&'static WorkerHandle, BridgeError> {
+    if ptr.is_null() {
+        return Err(BridgeError::InvalidWorkerHandle);
+    }
+    Ok(unsafe { &*(ptr as *mut WorkerHandle) })
 }
 
 #[unsafe(no_mangle)]
@@ -642,19 +464,28 @@ pub extern "C" fn temporal_bun_client_connect_async(
         .client_name(client_name)
         .client_version(client_version)
         .identity(identity.clone());
-    let _allow_insecure_tls = config.allow_insecure_tls.unwrap_or(false);
+
+    let allow_insecure = config
+        .allow_insecure
+        .or(config.allow_insecure_tls)
+        .unwrap_or(false);
 
     if let Some(api_key) = config.api_key.clone() {
         builder.api_key(Some(api_key));
     }
 
     if let Some(tls_payload) = config.tls.clone() {
-        match metadata::tls_config_from_payload(tls_payload) {
-            Ok(tls_cfg) => {
+        match tls_config_from_payload(tls_payload) {
+            Ok(mut tls_cfg) => {
+                set_allow_insecure(&mut tls_cfg, allow_insecure);
                 builder.tls_cfg(tls_cfg);
             }
             Err(err) => return into_string_error(err) as *mut PendingClientHandle,
         }
+    } else if allow_insecure {
+        let mut tls_cfg = TlsConfig::default();
+        set_allow_insecure(&mut tls_cfg, allow_insecure);
+        builder.tls_cfg(tls_cfg);
     }
 
     let options = match builder.build() {
@@ -721,7 +552,7 @@ pub extern "C" fn temporal_bun_client_update_headers(
         }
     };
 
-    let (normalized, bearer_token) = match metadata::normalize_metadata_headers(raw_headers) {
+    let (normalized, bearer_token) = match normalize_metadata_headers(raw_headers) {
         Ok(result) => result,
         Err(err) => {
             error::set_error(err.to_string());
@@ -862,12 +693,12 @@ pub extern "C" fn temporal_bun_client_start_workflow(
         }
     };
 
-    let defaults = request::StartWorkflowDefaults {
+    let defaults = StartWorkflowDefaults {
         namespace: &client_handle.namespace,
         identity: &client_handle.identity,
     };
 
-    let (request, response_info) = match request::build_start_workflow_request(payload, defaults) {
+    let (request, response_info) = match build_start_workflow_request(payload, defaults) {
         Ok(result) => result,
         Err(err) => return into_string_error(err) as *mut byte_array::ByteArray,
     };
@@ -894,7 +725,7 @@ pub extern "C" fn temporal_bun_client_start_workflow(
         "namespace": response_info.namespace,
     });
 
-    let bytes = match request::json_bytes(&response_body) {
+    let bytes = match json_bytes(&response_body) {
         Ok(bytes) => bytes,
         Err(err) => return into_string_error(err) as *mut byte_array::ByteArray,
     };
@@ -992,6 +823,58 @@ pub extern "C" fn temporal_bun_pending_byte_array_free(ptr: *mut pending::Pendin
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_pending_unit_poll(ptr: *mut pending::PendingUnit) -> i32 {
+    if ptr.is_null() {
+        error::set_error("invalid pending handle".to_string());
+        return -1;
+    }
+
+    let pending = unsafe { &*ptr };
+
+    match pending.poll() {
+        pending::PendingState::Pending => 0,
+        pending::PendingState::ReadyOk => 1,
+        pending::PendingState::ReadyErr(err) => {
+            error::set_error(err);
+            -1
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_pending_unit_consume(ptr: *mut pending::PendingUnit) -> i32 {
+    if ptr.is_null() {
+        error::set_error("invalid pending handle".to_string());
+        return -1;
+    }
+
+    let pending = unsafe { &*ptr };
+
+    match pending.take_result() {
+        Some(Ok(())) => 1,
+        Some(Err(err)) => {
+            error::set_error(err);
+            0
+        }
+        None => {
+            error::set_error("pending result not ready".to_string());
+            -1
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_pending_unit_free(ptr: *mut pending::PendingUnit) {
+    if ptr.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = Box::from_raw(ptr);
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn temporal_bun_client_signal(
     _client_ptr: *mut c_void,
     _payload_ptr: *const u8,
@@ -1022,11 +905,11 @@ pub extern "C" fn temporal_bun_client_query_workflow(
     };
 
     let default_namespace = client_handle.namespace.clone();
-    let defaults = request::QueryWorkflowDefaults {
+    let defaults = QueryWorkflowDefaults {
         namespace: &default_namespace,
     };
 
-    let request = match request::build_query_workflow_request(payload, defaults) {
+    let request = match build_query_workflow_request(payload, defaults) {
         Ok(request) => request,
         Err(err) => return into_string_error(err) as *mut pending::PendingByteArray,
     };
@@ -1056,8 +939,8 @@ pub extern "C" fn temporal_bun_client_query_workflow(
                 )));
             }
 
-            let value = request::decode_query_result(response.query_result)?;
-            request::json_bytes(&value)
+            let value = decode_query_result(response.query_result)?;
+            json_bytes(&value)
         });
 
         let outcome = result.map_err(|err| err.to_string());
@@ -1090,12 +973,12 @@ pub extern "C" fn temporal_bun_client_terminate_workflow(
             }
         };
 
-    let defaults = request::TerminateWorkflowDefaults {
+    let defaults = TerminateWorkflowDefaults {
         namespace: &client_handle.namespace,
         identity: &client_handle.identity,
     };
 
-    let request = match request::build_terminate_workflow_request(payload, defaults) {
+    let request = match build_terminate_workflow_request(payload, defaults) {
         Ok(request) => request,
         Err(err) => {
             error::set_error(err.to_string());
@@ -1154,13 +1037,12 @@ pub extern "C" fn temporal_bun_client_signal_with_start(
         }
     };
 
-    let defaults = request::StartWorkflowDefaults {
+    let defaults = StartWorkflowDefaults {
         namespace: &client_handle.namespace,
         identity: &client_handle.identity,
     };
 
-    let (request, response_info) = match request::build_signal_with_start_request(payload, defaults)
-    {
+    let (request, response_info) = match build_signal_with_start_request(payload, defaults) {
         Ok(result) => result,
         Err(err) => return into_string_error(err) as *mut byte_array::ByteArray,
     };
@@ -1188,7 +1070,7 @@ pub extern "C" fn temporal_bun_client_signal_with_start(
         "namespace": response_info.namespace,
     });
 
-    let bytes = match request::json_bytes(&response_body) {
+    let bytes = match json_bytes(&response_body) {
         Ok(bytes) => bytes,
         Err(err) => return into_string_error(err) as *mut byte_array::ByteArray,
     };
@@ -1196,5 +1078,1053 @@ pub extern "C" fn temporal_bun_client_signal_with_start(
     byte_array::ByteArray::from_vec(bytes)
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_worker_new(
+    runtime_ptr: *mut c_void,
+    client_ptr: *mut c_void,
+    config_ptr: *const u8,
+    config_len: usize,
+) -> *mut c_void {
+    let runtime = match runtime_from_ptr(runtime_ptr) {
+        Ok(runtime) => runtime,
+        Err(err) => return into_string_error(err),
+    };
+
+    let client_handle = match client_from_ptr(client_ptr) {
+        Ok(client) => client,
+        Err(err) => return into_string_error(err),
+    };
+
+    let payload = match request_from_raw::<WorkerConfigPayload>(config_ptr, config_len) {
+        Ok(payload) => payload,
+        Err(err) => return into_string_error(BridgeError::InvalidWorkerConfig(err.to_string())),
+    };
+
+    let mut builder = WorkerConfigBuilder::default();
+    builder.namespace(payload.namespace);
+    builder.task_queue(payload.task_queue);
+    if let Some(identity) = payload.identity {
+        builder.client_identity_override(identity);
+    }
+    if let Some(max_cached) = payload.max_cached_workflows {
+        builder.max_cached_workflows(max_cached);
+    }
+    if let Some(no_remote) = payload.no_remote_activities {
+        builder.no_remote_activities(no_remote);
+    }
+    if let Some(build_id) = payload.build_id {
+        builder.versioning_strategy(WorkerVersioningStrategy::None { build_id });
+    }
+
+    let config = match builder.build() {
+        Ok(config) => config,
+        Err(err) => {
+            return into_string_error(BridgeError::InvalidWorkerConfig(err.to_string()));
+        }
+    };
+
+    let worker = match init_worker(runtime.as_ref(), config, client_handle.client.clone()) {
+        Ok(worker) => worker,
+        Err(err) => return into_string_error(BridgeError::WorkerInit(err.to_string())),
+    };
+
+    let handle = WorkerHandle {
+        runtime: runtime.clone(),
+        worker: Arc::new(worker),
+    };
+
+    Box::into_raw(Box::new(handle)) as *mut c_void
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_worker_free(handle: *mut c_void) {
+    if handle.is_null() {
+        return;
+    }
+
+    unsafe {
+        let _ = Box::from_raw(handle as *mut WorkerHandle);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_worker_initiate_shutdown(worker_ptr: *mut c_void) {
+    let worker_handle = match worker_from_ptr(worker_ptr) {
+        Ok(worker) => worker,
+        Err(err) => {
+            into_string_error(err);
+            return;
+        }
+    };
+
+    worker_handle.worker.initiate_shutdown();
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_worker_validate_async(
+    worker_ptr: *mut c_void,
+) -> *mut pending::PendingUnit {
+    let worker_handle = match worker_from_ptr(worker_ptr) {
+        Ok(worker) => worker,
+        Err(err) => return into_string_error(err) as *mut pending::PendingUnit,
+    };
+
+    let runtime = worker_handle.runtime.clone();
+    let worker = worker_handle.worker.clone();
+    let (tx, rx) = channel();
+
+    thread::spawn(move || {
+        let result = runtime.tokio_handle().block_on(async {
+            worker
+                .validate()
+                .await
+                .map_err(|err| BridgeError::WorkerOperation(err.to_string()).to_string())
+        });
+
+        let send_result = match result {
+            Ok(()) => Ok(()),
+            Err(err) => Err(err),
+        };
+
+        let _ = tx.send(send_result);
+    });
+
+    Box::into_raw(Box::new(pending::PendingUnit::new(rx)))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_worker_shutdown_async(
+    worker_ptr: *mut c_void,
+) -> *mut pending::PendingUnit {
+    let worker_handle = match worker_from_ptr(worker_ptr) {
+        Ok(worker) => worker,
+        Err(err) => return into_string_error(err) as *mut pending::PendingUnit,
+    };
+
+    let runtime = worker_handle.runtime.clone();
+    let worker = worker_handle.worker.clone();
+    let (tx, rx) = channel();
+
+    thread::spawn(move || {
+        let result = runtime.tokio_handle().block_on(async {
+            worker.shutdown().await.into_shutdown_result()
+        });
+
+        let send_result = match result {
+            Ok(()) => Ok(()),
+            Err(err) => Err(BridgeError::WorkerOperation(err).to_string()),
+        };
+
+        let _ = tx.send(send_result);
+    });
+
+    Box::into_raw(Box::new(pending::PendingUnit::new(rx)))
+}
+
+trait ShutdownResultExt {
+    fn into_shutdown_result(self) -> Result<(), String>;
+}
+
+impl ShutdownResultExt for () {
+    fn into_shutdown_result(self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+impl<E> ShutdownResultExt for Result<(), E>
+where
+    E: Display,
+{
+    fn into_shutdown_result(self) -> Result<(), String> {
+        self.map_err(|err| err.to_string())
+    }
+}
+
+fn encode_payload(value: serde_json::Value) -> Result<Payload, BridgeError> {
+    let data =
+        serde_json::to_vec(&value).map_err(|err| BridgeError::PayloadEncode(err.to_string()))?;
+    let mut metadata = HashMap::new();
+    metadata.insert("encoding".to_string(), b"json/plain".to_vec());
+    Ok(Payload { metadata, data })
+}
+
+fn encode_payloads_from_vec(values: Vec<serde_json::Value>) -> Result<Payloads, BridgeError> {
+    let mut encoded = Vec::with_capacity(values.len());
+    for value in values {
+        encoded.push(encode_payload(value)?);
+    }
+    Ok(Payloads { payloads: encoded })
+}
+
+fn build_start_workflow_request(
+    payload: StartWorkflowRequestPayload,
+    defaults: StartWorkflowDefaults,
+) -> Result<(StartWorkflowExecutionRequest, StartWorkflowResponseInfo), BridgeError> {
+    let StartWorkflowRequestPayload {
+        namespace,
+        workflow_id,
+        workflow_type,
+        task_queue,
+        args,
+        memo,
+        search_attributes,
+        headers,
+        cron_schedule,
+        request_id,
+        identity,
+        workflow_execution_timeout_ms,
+        workflow_run_timeout_ms,
+        workflow_task_timeout_ms,
+        retry_policy,
+    } = payload;
+
+    let namespace = namespace.unwrap_or_else(|| defaults.namespace.to_string());
+    let identity = identity.unwrap_or_else(|| defaults.identity.to_string());
+    let request_id = request_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    let mut request = StartWorkflowExecutionRequest {
+        namespace: namespace.clone(),
+        workflow_id: workflow_id.clone(),
+        workflow_type: Some(WorkflowType {
+            name: workflow_type,
+        }),
+        task_queue: Some(TaskQueue {
+            name: task_queue,
+            kind: TaskQueueKind::Normal as i32,
+            normal_name: String::new(),
+        }),
+        identity,
+        request_id,
+        ..Default::default()
+    };
+
+    if let Some(values) = args {
+        let mut encoded = Vec::with_capacity(values.len());
+        for value in values {
+            encoded.push(encode_payload(value)?);
+        }
+        request.input = Some(Payloads { payloads: encoded });
+    }
+
+    match encode_payload_map(memo)? {
+        Some(fields) => request.memo = Some(Memo { fields }),
+        None => {}
+    }
+
+    match encode_payload_map(search_attributes)? {
+        Some(fields) => {
+            request.search_attributes = Some(SearchAttributes {
+                indexed_fields: fields,
+            });
+        }
+        None => {}
+    }
+
+    match encode_payload_map(headers)? {
+        Some(fields) => request.header = Some(Header { fields }),
+        None => {}
+    }
+
+    if let Some(schedule) = cron_schedule {
+        request.cron_schedule = schedule;
+    }
+
+    if let Some(ms) = workflow_execution_timeout_ms {
+        request.workflow_execution_timeout = Some(duration_from_millis(ms));
+    }
+
+    if let Some(ms) = workflow_run_timeout_ms {
+        request.workflow_run_timeout = Some(duration_from_millis(ms));
+    }
+
+    if let Some(ms) = workflow_task_timeout_ms {
+        request.workflow_task_timeout = Some(duration_from_millis(ms));
+    }
+
+    if let Some(policy) = retry_policy {
+        request.retry_policy = Some(encode_retry_policy(policy)?);
+    }
+
+    let response_info = StartWorkflowResponseInfo {
+        workflow_id,
+        namespace,
+    };
+
+    Ok((request, response_info))
+}
+
+fn build_terminate_workflow_request(
+    payload: TerminateWorkflowRequestPayload,
+    defaults: TerminateWorkflowDefaults,
+) -> Result<TerminateWorkflowExecutionRequest, BridgeError> {
+    let TerminateWorkflowRequestPayload {
+        namespace,
+        workflow_id,
+        run_id,
+        first_execution_run_id,
+        reason,
+        details,
+    } = payload;
+
+    let namespace = namespace.unwrap_or_else(|| defaults.namespace.to_string());
+
+    let mut request = TerminateWorkflowExecutionRequest {
+        namespace,
+        identity: defaults.identity.to_string(),
+        workflow_execution: Some(WorkflowExecution {
+            workflow_id,
+            run_id: run_id.unwrap_or_default(),
+        }),
+        reason: reason.unwrap_or_default(),
+        first_execution_run_id: first_execution_run_id.unwrap_or_default(),
+        ..Default::default()
+    };
+
+    if let Some(values) = details {
+        request.details = Some(encode_payloads_from_vec(values)?);
+    }
+
+    Ok(request)
+}
+
+fn build_signal_with_start_request(
+    payload: SignalWithStartRequestPayload,
+    defaults: StartWorkflowDefaults,
+) -> Result<
+    (
+        SignalWithStartWorkflowExecutionRequest,
+        StartWorkflowResponseInfo,
+    ),
+    BridgeError,
+> {
+    let SignalWithStartRequestPayload {
+        start,
+        signal_name,
+        signal_args,
+    } = payload;
+
+    let (mut start_request, response_info) = build_start_workflow_request(start, defaults)?;
+
+    let mut request = SignalWithStartWorkflowExecutionRequest {
+        namespace: response_info.namespace.clone(),
+        workflow_id: response_info.workflow_id.clone(),
+        signal_name,
+        ..Default::default()
+    };
+
+    request.workflow_type = start_request.workflow_type.take();
+    request.task_queue = start_request.task_queue.take();
+    request.input = start_request.input.take();
+    request.identity = take(&mut start_request.identity);
+    request.request_id = take(&mut start_request.request_id);
+    request.workflow_execution_timeout = start_request.workflow_execution_timeout.take();
+    request.workflow_run_timeout = start_request.workflow_run_timeout.take();
+    request.workflow_task_timeout = start_request.workflow_task_timeout.take();
+    request.retry_policy = start_request.retry_policy.take();
+    request.memo = start_request.memo.take();
+    request.search_attributes = start_request.search_attributes.take();
+    request.header = start_request.header.take();
+    request.cron_schedule = take(&mut start_request.cron_schedule);
+
+    let mut encoded_signal = Vec::with_capacity(signal_args.len());
+    for value in signal_args {
+        encoded_signal.push(encode_payload(value)?);
+    }
+    request.signal_input = Some(Payloads {
+        payloads: encoded_signal,
+    });
+
+    Ok((request, response_info))
+}
+
+fn build_query_workflow_request(
+    payload: QueryWorkflowRequestPayload,
+    defaults: QueryWorkflowDefaults,
+) -> Result<QueryWorkflowRequest, BridgeError> {
+    let QueryWorkflowRequestPayload {
+        namespace,
+        workflow_id,
+        run_id,
+        first_execution_run_id: _,
+        query_name,
+        args,
+    } = payload;
+
+    if workflow_id.trim().is_empty() {
+        return Err(BridgeError::InvalidRequest(
+            "workflow_id cannot be empty for query".to_string(),
+        ));
+    }
+
+    if query_name.trim().is_empty() {
+        return Err(BridgeError::InvalidRequest(
+            "query_name cannot be empty".to_string(),
+        ));
+    }
+
+    let namespace = namespace.unwrap_or_else(|| defaults.namespace.to_string());
+
+    let mut encoded_args = Vec::new();
+    if let Some(values) = args {
+        for value in values {
+            encoded_args.push(encode_payload(value)?);
+        }
+    }
+
+    let query = WorkflowQuery {
+        query_type: query_name,
+        query_args: Some(Payloads {
+            payloads: encoded_args,
+        }),
+        header: None,
+    };
+
+    let execution = WorkflowExecution {
+        workflow_id,
+        run_id: run_id.unwrap_or_default(),
+    };
+
+    Ok(QueryWorkflowRequest {
+        namespace,
+        execution: Some(execution),
+        query: Some(query),
+        query_reject_condition: QueryRejectCondition::None as i32,
+    })
+}
+
+fn decode_query_result(payloads: Option<Payloads>) -> Result<serde_json::Value, BridgeError> {
+    match payloads {
+        Some(payloads) => {
+            let mut values = Vec::with_capacity(payloads.payloads.len());
+            for payload in payloads.payloads {
+                values.push(decode_payload(payload)?);
+            }
+
+            match values.len() {
+                0 => Ok(serde_json::Value::Null),
+                1 => Ok(values.into_iter().next().unwrap()),
+                _ => Ok(serde_json::Value::Array(values)),
+            }
+        }
+        None => Ok(serde_json::Value::Null),
+    }
+}
+
+fn decode_payload(payload: Payload) -> Result<serde_json::Value, BridgeError> {
+    let encoding = payload
+        .metadata
+        .get("encoding")
+        .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+        .ok_or_else(|| {
+            BridgeError::ResponseEncode("missing payload encoding metadata".to_string())
+        })?;
+
+    if !encoding.to_ascii_lowercase().contains("json") {
+        return Err(BridgeError::ResponseEncode(format!(
+            "unsupported payload encoding: {encoding}",
+        )));
+    }
+
+    serde_json::from_slice(&payload.data)
+        .map_err(|err| BridgeError::ResponseEncode(err.to_string()))
+}
+
+fn encode_payload_map(
+    map: Option<HashMap<String, serde_json::Value>>,
+) -> Result<Option<HashMap<String, Payload>>, BridgeError> {
+    match map {
+        Some(entries) => {
+            if entries.is_empty() {
+                return Ok(None);
+            }
+            let mut encoded = HashMap::with_capacity(entries.len());
+            for (key, value) in entries {
+                encoded.insert(key, encode_payload(value)?);
+            }
+            Ok(Some(encoded))
+        }
+        None => Ok(None),
+    }
+}
+
+fn encode_retry_policy(payload: RetryPolicyPayload) -> Result<RetryPolicy, BridgeError> {
+    let mut policy = RetryPolicy::default();
+    if let Some(ms) = payload.initial_interval_ms {
+        policy.initial_interval = Some(duration_from_millis(ms));
+    }
+    if let Some(ms) = payload.maximum_interval_ms {
+        policy.maximum_interval = Some(duration_from_millis(ms));
+    }
+    if let Some(attempts) = payload.maximum_attempts {
+        policy.maximum_attempts = attempts;
+    }
+    if let Some(coefficient) = payload.backoff_coefficient {
+        policy.backoff_coefficient = coefficient;
+    }
+    if let Some(errors) = payload.non_retryable_error_types {
+        policy.non_retryable_error_types = errors;
+    }
+    Ok(policy)
+}
+
+fn tls_config_from_payload(payload: ClientTlsConfigPayload) -> Result<TlsConfig, BridgeError> {
+    let ClientTlsConfigPayload {
+        server_root_ca_cert,
+        client_cert,
+        client_private_key,
+        server_name_override,
+        client_cert_pair,
+    } = payload;
+
+    let mut tls = TlsConfig::default();
+
+    if let Some(server_root_ca) = server_root_ca_cert {
+        let bytes = decode_base64(&server_root_ca).map_err(|err| {
+            BridgeError::InvalidTlsConfig(format!("invalid serverRootCACertificate/server_root_ca_cert: {err}"))
+        })?;
+        tls.server_root_ca_cert = Some(bytes);
+    }
+
+    if let Some(pair) = client_cert_pair {
+        let cert = decode_base64(&pair.crt).map_err(|err| {
+            BridgeError::InvalidTlsConfig(format!("invalid clientCertPair.crt: {err}"))
+        })?;
+        let key = decode_base64(&pair.key).map_err(|err| {
+            BridgeError::InvalidTlsConfig(format!("invalid clientCertPair.key: {err}"))
+        })?;
+        tls.client_tls_config = Some(ClientTlsConfig {
+            client_cert: cert,
+            client_private_key: key,
+        });
+    } else {
+        match (client_cert, client_private_key) {
+            (Some(cert_b64), Some(key_b64)) => {
+                let cert = decode_base64(&cert_b64).map_err(|err| {
+                    BridgeError::InvalidTlsConfig(format!("invalid client_cert/clientCert: {err}"))
+                })?;
+                let key = decode_base64(&key_b64).map_err(|err| {
+                    BridgeError::InvalidTlsConfig(format!("invalid client_private_key/clientPrivateKey: {err}"))
+                })?;
+                tls.client_tls_config = Some(ClientTlsConfig {
+                    client_cert: cert,
+                    client_private_key: key,
+                });
+            }
+            (None, None) => {}
+            _ => {
+                return Err(BridgeError::InvalidTlsConfig(
+                    "client_cert/clientCert and client_private_key/clientPrivateKey must both be provided"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+
+    if let Some(server_name) = server_name_override {
+        if !server_name.is_empty() {
+            tls.domain = Some(server_name);
+        }
+    }
+
+    Ok(tls)
+}
+
+fn decode_base64(value: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    general_purpose::STANDARD.decode(value)
+}
+
+fn set_allow_insecure(config: &mut TlsConfig, value: bool) {
+    #[cfg(temporal_client_has_allow_insecure)]
+    {
+        config.allow_insecure = value;
+    }
+
+    #[cfg(not(temporal_client_has_allow_insecure))]
+    {
+        let _ = config;
+        let _ = value;
+    }
+}
+
+fn json_bytes<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, BridgeError> {
+    serde_json::to_vec(value).map_err(|err| BridgeError::ResponseEncode(err.to_string()))
+}
+
+fn duration_from_millis(ms: u64) -> ProtoDuration {
+    ProtoDuration {
+        seconds: (ms / 1_000) as i64,
+        nanos: ((ms % 1_000) * 1_000_000) as i32,
+    }
+}
+
 #[cfg(test)]
-mod tests;
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn byte_array_new_round_trips_large_payload() {
+        let _guard = byte_array::test_lock();
+        byte_array::clear_pool();
+
+        let len = 8 * 1024 * 1024;
+        let mut payload = vec![0u8; len];
+        for (idx, byte) in payload.iter_mut().enumerate() {
+            *byte = (idx % 251) as u8;
+        }
+
+        let array_ptr = temporal_bun_byte_array_new(payload.as_ptr(), payload.len());
+        assert!(!array_ptr.is_null());
+
+        unsafe {
+            let array = &*array_ptr;
+            assert_eq!(array.len, payload.len());
+            let slice = std::slice::from_raw_parts(array.ptr, array.len);
+            assert_eq!(slice, payload.as_slice());
+        }
+
+        temporal_bun_byte_array_free(array_ptr);
+        assert!(
+            byte_array::pool_len() >= 1,
+            "expected pool to contain at least one recycled buffer"
+        );
+    }
+
+    #[test]
+    fn byte_array_new_reuses_pooled_buffers() {
+        let _guard = byte_array::test_lock();
+        byte_array::clear_pool();
+        assert_eq!(byte_array::pool_len(), 0);
+
+        let payload_a = vec![1u8; 1024];
+        let array_a = temporal_bun_byte_array_new(payload_a.as_ptr(), payload_a.len());
+        let (ptr_a, cap_a) = unsafe {
+            let array = &*array_a;
+            (array.ptr, array.cap)
+        };
+        temporal_bun_byte_array_free(array_a);
+        assert_eq!(byte_array::pool_len(), 1);
+
+        let payload_b = vec![2u8; payload_a.len()];
+        let array_b = temporal_bun_byte_array_new(payload_b.as_ptr(), payload_b.len());
+        let (ptr_b, cap_b) = unsafe {
+            let array = &*array_b;
+            (array.ptr, array.cap)
+        };
+        assert_eq!(byte_array::pool_len(), 0);
+        assert_eq!(ptr_a, ptr_b);
+        assert_eq!(cap_a, cap_b);
+
+        temporal_bun_byte_array_free(array_b);
+        assert_eq!(byte_array::pool_len(), 1);
+    }
+
+    #[test]
+    fn config_from_raw_parses_defaults() {
+        let json = br#"{"address":"http://localhost:7233","namespace":"default"}"#;
+        let cfg = config_from_raw(json.as_ptr(), json.len()).expect("config parsed");
+        assert_eq!(cfg.address, "http://localhost:7233");
+        assert_eq!(cfg.namespace, "default");
+    }
+
+    #[test]
+    fn config_from_raw_errors_on_missing_payload() {
+        let err = config_from_raw(std::ptr::null(), 0).unwrap_err();
+        assert!(matches!(err, BridgeError::MissingConfig));
+    }
+
+    #[test]
+    fn request_from_raw_validates_payload() {
+        let json = br#"{"namespace":"test"}"#;
+        let payload: DescribeNamespaceRequestPayload =
+            request_from_raw(json.as_ptr(), json.len()).expect("parsed request");
+        assert_eq!(payload.namespace, "test");
+
+        let invalid =
+            request_from_raw::<DescribeNamespaceRequestPayload>(br"{}".as_ptr(), 2).unwrap_err();
+        assert!(matches!(invalid, BridgeError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn tls_config_from_payload_decodes_components() {
+        let payload = ClientTlsConfigPayload {
+            server_root_ca_cert: Some(general_purpose::STANDARD.encode(b"ROOT")),
+            client_cert: Some(general_purpose::STANDARD.encode(b"CERT")),
+            client_private_key: Some(general_purpose::STANDARD.encode(b"KEY")),
+            server_name_override: Some("server.test".to_string()),
+            client_cert_pair: None,
+        };
+
+        let tls = tls_config_from_payload(payload).expect("parsed tls config");
+        assert_eq!(tls.server_root_ca_cert, Some(b"ROOT".to_vec()));
+        assert_eq!(tls.domain.as_deref(), Some("server.test"));
+        let client = tls.client_tls_config.expect("client tls");
+        assert_eq!(client.client_cert, b"CERT");
+        assert_eq!(client.client_private_key, b"KEY");
+    }
+
+    #[test]
+    fn tls_config_from_payload_errors_without_key_pair() {
+        let payload = ClientTlsConfigPayload {
+            server_root_ca_cert: None,
+            client_cert: Some(general_purpose::STANDARD.encode(b"CERT")),
+            client_private_key: None,
+            server_name_override: None,
+            client_cert_pair: None,
+        };
+
+        let err = tls_config_from_payload(payload).unwrap_err();
+        assert!(matches!(err, BridgeError::InvalidTlsConfig(_)));
+    }
+
+    #[test]
+    fn build_start_workflow_request_applies_defaults() {
+        let payload = StartWorkflowRequestPayload {
+            namespace: None,
+            workflow_id: "wf-123".to_string(),
+            workflow_type: "ExampleWorkflow".to_string(),
+            task_queue: "prix".to_string(),
+            args: None,
+            memo: None,
+            search_attributes: None,
+            headers: None,
+            cron_schedule: None,
+            request_id: None,
+            identity: None,
+            workflow_execution_timeout_ms: None,
+            workflow_run_timeout_ms: None,
+            workflow_task_timeout_ms: None,
+            retry_policy: None,
+        };
+
+        let defaults = StartWorkflowDefaults {
+            namespace: "default",
+            identity: "worker-1",
+        };
+
+        let (request, info) =
+            build_start_workflow_request(payload, defaults).expect("build request");
+        assert_eq!(request.namespace, "default");
+        assert_eq!(request.identity, "worker-1");
+        assert_eq!(request.workflow_id, "wf-123");
+        assert_eq!(request.task_queue.unwrap().name, "prix");
+        assert!(request.workflow_execution_timeout.is_none());
+        assert!(request.workflow_run_timeout.is_none());
+        assert!(request.workflow_task_timeout.is_none());
+        assert!(request.retry_policy.is_none());
+        assert_eq!(info.workflow_id, "wf-123");
+        assert_eq!(info.namespace, "default");
+    }
+
+    #[test]
+    fn build_start_workflow_request_encodes_payloads_timeouts_and_policy() {
+        let args = vec![json!("hello"), json!({ "count": 2 })];
+        let memo = HashMap::from([(String::from("note"), json!("memo"))]);
+        let headers = HashMap::from([(String::from("auth"), json!("bearer"))]);
+        let search = HashMap::from([(String::from("env"), json!("dev"))]);
+
+        let payload = StartWorkflowRequestPayload {
+            namespace: Some("analytics".to_string()),
+            workflow_id: "wf-xyz".to_string(),
+            workflow_type: "ExampleWorkflow".to_string(),
+            task_queue: "prix".to_string(),
+            args: Some(args),
+            memo: Some(memo),
+            search_attributes: Some(search),
+            headers: Some(headers),
+            cron_schedule: Some("*/5 * * * *".to_string()),
+            request_id: Some("req-1".to_string()),
+            identity: Some("custom-worker".to_string()),
+            workflow_execution_timeout_ms: Some(1_500),
+            workflow_run_timeout_ms: Some(2_000),
+            workflow_task_timeout_ms: Some(750),
+            retry_policy: Some(RetryPolicyPayload {
+                initial_interval_ms: Some(2_500),
+                maximum_interval_ms: Some(10_000),
+                maximum_attempts: Some(3),
+                backoff_coefficient: Some(2.0),
+                non_retryable_error_types: Some(vec!["Fatal".to_string()]),
+            }),
+        };
+
+        let defaults = StartWorkflowDefaults {
+            namespace: "default",
+            identity: "worker-1",
+        };
+
+        let (request, info) =
+            build_start_workflow_request(payload, defaults).expect("build request");
+
+        let inputs = request.input.expect("payloads").payloads;
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(request.identity, "custom-worker");
+        assert_eq!(request.namespace, "analytics");
+        assert_eq!(info.namespace, "analytics");
+        assert_eq!(request.cron_schedule, "*/5 * * * *");
+
+        let execution_timeout = request
+            .workflow_execution_timeout
+            .expect("execution timeout");
+        assert_eq!(execution_timeout.seconds, 1);
+        assert_eq!(execution_timeout.nanos, 500_000_000);
+
+        let run_timeout = request.workflow_run_timeout.expect("run timeout");
+        assert_eq!(run_timeout.seconds, 2);
+        assert_eq!(run_timeout.nanos, 0);
+
+        let task_timeout = request.workflow_task_timeout.expect("task timeout");
+        assert_eq!(task_timeout.seconds, 0);
+        assert_eq!(task_timeout.nanos, 750_000_000);
+
+        let retry = request.retry_policy.expect("retry policy");
+        let initial_interval = retry.initial_interval.expect("initial interval");
+        assert_eq!(initial_interval.seconds, 2);
+        assert_eq!(initial_interval.nanos, 500_000_000);
+        let maximum_interval = retry.maximum_interval.expect("maximum interval");
+        assert_eq!(maximum_interval.seconds, 10);
+        assert_eq!(maximum_interval.nanos, 0);
+        assert_eq!(retry.maximum_attempts, 3);
+        assert_eq!(retry.backoff_coefficient, 2.0);
+        assert_eq!(retry.non_retryable_error_types, vec!["Fatal".to_string()]);
+
+        let memo_fields = request.memo.unwrap().fields;
+        assert!(memo_fields.contains_key("note"));
+        let header_fields = request.header.unwrap().fields;
+        assert!(header_fields.contains_key("auth"));
+        let search_fields = request.search_attributes.unwrap().indexed_fields;
+        assert!(search_fields.contains_key("env"));
+    }
+
+    #[test]
+    fn build_terminate_workflow_request_applies_defaults() {
+        let payload = TerminateWorkflowRequestPayload {
+            namespace: None,
+            workflow_id: "wf-terminate".to_string(),
+            run_id: None,
+            first_execution_run_id: None,
+            reason: None,
+            details: None,
+        };
+
+        let defaults = TerminateWorkflowDefaults {
+            namespace: "default",
+            identity: "worker-1",
+        };
+
+        let request = build_terminate_workflow_request(payload, defaults).expect("request");
+        assert_eq!(request.namespace, "default");
+        assert_eq!(request.identity, "worker-1");
+        assert_eq!(request.reason, "");
+        assert_eq!(request.first_execution_run_id, "");
+        assert!(request.details.is_none());
+
+        let execution = request.workflow_execution.expect("execution");
+        assert_eq!(execution.workflow_id, "wf-terminate");
+        assert_eq!(execution.run_id, "");
+    }
+
+    #[test]
+    fn build_terminate_workflow_request_encodes_reason_and_details() {
+        let payload = TerminateWorkflowRequestPayload {
+            namespace: Some("analytics".to_string()),
+            workflow_id: "terminate-me".to_string(),
+            run_id: Some("run-123".to_string()),
+            first_execution_run_id: Some("run-initial".to_string()),
+            reason: Some("done".to_string()),
+            details: Some(vec![json!("cleanup"), json!({ "ok": true })]),
+        };
+
+        let defaults = TerminateWorkflowDefaults {
+            namespace: "fallback",
+            identity: "worker-2",
+        };
+
+        let request = build_terminate_workflow_request(payload, defaults).expect("request");
+        assert_eq!(request.namespace, "analytics");
+        assert_eq!(request.identity, "worker-2");
+        assert_eq!(request.reason, "done");
+        assert_eq!(request.first_execution_run_id, "run-initial");
+
+        let execution = request.workflow_execution.expect("execution");
+        assert_eq!(execution.workflow_id, "terminate-me");
+        assert_eq!(execution.run_id, "run-123");
+
+        let details = request.details.expect("details");
+        let decoded: Vec<serde_json::Value> = details
+            .payloads
+            .iter()
+            .map(|payload| {
+                serde_json::from_slice::<serde_json::Value>(&payload.data).expect("json")
+            })
+            .collect();
+        assert_eq!(decoded, vec![json!("cleanup"), json!({ "ok": true })]);
+        for payload in details.payloads {
+            assert_eq!(
+                payload.metadata.get("encoding"),
+                Some(&b"json/plain".to_vec())
+            );
+        }
+    }
+
+    #[test]
+    fn temporal_bun_client_terminate_workflow_sets_error_for_invalid_handle() {
+        let status =
+            temporal_bun_client_terminate_workflow(std::ptr::null_mut(), std::ptr::null(), 0);
+        assert_eq!(status, -1);
+
+        let mut len: usize = 0;
+        let ptr = error::take_error(&mut len as *mut usize);
+        assert!(len > 0);
+        assert!(!ptr.is_null());
+
+        let message = unsafe { std::slice::from_raw_parts(ptr, len) };
+        let message = std::str::from_utf8(message).expect("utf8");
+        assert!(message.contains("invalid client handle"));
+
+        unsafe {
+            error::free_error(ptr as *mut u8, len);
+        }
+    }
+
+    #[test]
+    fn normalize_metadata_headers_lowercases_and_extracts_bearer() {
+        let headers = HashMap::from([
+            (String::from("Authorization"), String::from(" Bearer super-secret ")),
+            (String::from("X-Custom"), String::from(" value ")),
+        ]);
+
+        let (normalized, bearer) =
+            normalize_metadata_headers(headers).expect("headers normalized");
+
+        assert_eq!(
+            normalized.get("x-custom"),
+            Some(&"value".to_string())
+        );
+        assert!(!normalized.contains_key("authorization"));
+        assert_eq!(bearer.as_deref(), Some("super-secret"));
+    }
+
+    #[test]
+    fn normalize_metadata_headers_preserves_non_bearer_authorization() {
+        let headers = HashMap::from([(String::from("Authorization"), String::from("Basic abc"))]);
+
+        let (normalized, bearer) =
+            normalize_metadata_headers(headers).expect("headers normalized");
+
+        assert_eq!(normalized.get("authorization"), Some(&"Basic abc".to_string()));
+        assert_eq!(bearer, None);
+    }
+
+    #[test]
+    fn normalize_metadata_headers_rejects_invalid_input() {
+        let dup_headers = HashMap::from([
+            (String::from("Foo"), String::from("one")),
+            (String::from("foo"), String::from("two")),
+        ]);
+        let duplicate_err = normalize_metadata_headers(dup_headers).unwrap_err();
+        assert!(matches!(
+            duplicate_err,
+            BridgeError::InvalidMetadata(message) if message.contains("duplicate header key")
+        ));
+
+        let empty_key = HashMap::from([(String::from("   "), String::from("value"))]);
+        let err = normalize_metadata_headers(empty_key).unwrap_err();
+        assert!(matches!(
+            err,
+            BridgeError::InvalidMetadata(message) if message.contains("non-empty")
+        ));
+
+        let empty_value = HashMap::from([(String::from("auth"), String::from("   "))]);
+        let err = normalize_metadata_headers(empty_value).unwrap_err();
+        assert!(matches!(
+            err,
+            BridgeError::InvalidMetadata(message)
+                if message.contains("must have a non-empty value")
+        ));
+    }
+
+    #[test]
+    fn extract_bearer_token_handles_case_insensitive_scheme() {
+        assert_eq!(extract_bearer_token("Bearer abc"), Some("abc"));
+        assert_eq!(extract_bearer_token("bearer  abc"), Some("abc"));
+        assert_eq!(extract_bearer_token("Basic abc"), None);
+        assert_eq!(extract_bearer_token("Bearer   "), None);
+    }
+
+    #[test]
+    fn build_signal_with_start_request_merges_components() {
+        let payload = SignalWithStartRequestPayload {
+            start: StartWorkflowRequestPayload {
+                namespace: Some("custom".to_string()),
+                workflow_id: "wf-789".to_string(),
+                workflow_type: "SampleWorkflow".to_string(),
+                task_queue: "primary".to_string(),
+                args: Some(vec![json!("payload")]),
+                memo: None,
+                search_attributes: None,
+                headers: None,
+                cron_schedule: Some("0 * * * *".to_string()),
+                request_id: Some("req-123".to_string()),
+                identity: Some("client-id".to_string()),
+                workflow_execution_timeout_ms: Some(1_000),
+                workflow_run_timeout_ms: Some(2_000),
+                workflow_task_timeout_ms: Some(500),
+                retry_policy: Some(RetryPolicyPayload {
+                    initial_interval_ms: Some(500),
+                    ..Default::default()
+                }),
+            },
+            signal_name: "notify".to_string(),
+            signal_args: vec![json!({"event": "start"})],
+        };
+
+        let defaults = StartWorkflowDefaults {
+            namespace: "default",
+            identity: "default-id",
+        };
+
+        let (request, info) =
+            build_signal_with_start_request(payload, defaults).expect("built request");
+
+        assert_eq!(info.workflow_id, "wf-789");
+        assert_eq!(info.namespace, "custom");
+        assert_eq!(request.namespace, "custom");
+        assert_eq!(request.workflow_id, "wf-789");
+        assert_eq!(request.signal_name, "notify");
+        assert_eq!(request.identity, "client-id");
+        assert_eq!(request.request_id, "req-123");
+        assert_eq!(request.cron_schedule, "0 * * * *");
+
+        let start_payloads = request.input.expect("start payloads").payloads;
+        assert_eq!(start_payloads.len(), 1);
+        let start_value: serde_json::Value =
+            serde_json::from_slice(&start_payloads[0].data).expect("decode start payload");
+        assert_eq!(start_value, json!("payload"));
+
+        let signal_payloads = request.signal_input.expect("signal payloads").payloads;
+        assert_eq!(signal_payloads.len(), 1);
+        let signal_value: serde_json::Value =
+            serde_json::from_slice(&signal_payloads[0].data).expect("decode signal payload");
+        assert_eq!(signal_value, json!({"event": "start"}));
+
+        let execution_timeout = request
+            .workflow_execution_timeout
+            .expect("execution timeout");
+        assert_eq!(execution_timeout.seconds, 1);
+        assert_eq!(execution_timeout.nanos, 0);
+
+        let run_timeout = request.workflow_run_timeout.expect("run timeout");
+        assert_eq!(run_timeout.seconds, 2);
+        assert_eq!(run_timeout.nanos, 0);
+
+        let task_timeout = request.workflow_task_timeout.expect("task timeout");
+        assert_eq!(task_timeout.seconds, 0);
+        assert_eq!(task_timeout.nanos, 500_000_000);
+
+        let retry = request.retry_policy.expect("retry policy");
+        let initial_interval = retry.initial_interval.expect("initial interval");
+        assert_eq!(initial_interval.seconds, 0);
+        assert_eq!(initial_interval.nanos, 500_000_000);
+    }
+}

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/pending.rs
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/pending.rs
@@ -3,13 +3,13 @@ use std::sync::Mutex;
 use std::vec::Vec;
 
 #[repr(C)]
-pub(crate) struct PendingResult<T> {
+pub struct PendingResult<T> {
     receiver: Mutex<Option<Receiver<Result<T, String>>>>,
     result: Mutex<Option<Result<T, String>>>,
 }
 
 #[derive(Debug)]
-pub(crate) enum PendingState {
+pub enum PendingState {
     Pending,
     ReadyOk,
     ReadyErr(String),
@@ -70,7 +70,8 @@ impl<T> PendingResult<T> {
     }
 }
 
-pub(crate) type PendingByteArray = PendingResult<Vec<u8>>;
+pub type PendingByteArray = PendingResult<Vec<u8>>;
+pub type PendingUnit = PendingResult<()>;
 
 #[cfg(test)]
 mod tests {

--- a/packages/temporal-bun-sdk/src/core-bridge/client.ts
+++ b/packages/temporal-bun-sdk/src/core-bridge/client.ts
@@ -16,6 +16,7 @@ export interface ClientOptions {
   readonly clientVersion?: string
   readonly apiKey?: string
   readonly tls?: ClientTlsOptions
+  readonly allowInsecure?: boolean
 }
 
 export class Client {
@@ -52,6 +53,10 @@ export class Client {
     const tlsPayload = serializeTlsOptions(this.options.tls)
     if (tlsPayload) {
       payload.tls = tlsPayload
+    }
+
+    if (this.options.allowInsecure !== undefined) {
+      payload.allowInsecure = this.options.allowInsecure
     }
 
     this.#native = await native.createClient(nativeRuntime, payload)

--- a/packages/temporal-bun-sdk/src/core-bridge/index.ts
+++ b/packages/temporal-bun-sdk/src/core-bridge/index.ts
@@ -1,4 +1,5 @@
 export * from './runtime.ts'
 export * from './client.ts'
+export * from './worker.ts'
 export * as native from '../internal/core-bridge/native.js'
 export * from '../../vendor/sdk-typescript/packages/core-bridge/ts/errors'

--- a/packages/temporal-bun-sdk/src/core-bridge/worker.ts
+++ b/packages/temporal-bun-sdk/src/core-bridge/worker.ts
@@ -1,0 +1,98 @@
+import type { Runtime } from './runtime.ts'
+import { Client } from './client.ts'
+import { native, type NativeWorker } from '../internal/core-bridge/native.ts'
+
+export interface WorkerOptions {
+  readonly namespace: string
+  readonly taskQueue: string
+  readonly identity?: string
+  readonly buildId?: string
+  readonly maxCachedWorkflows?: number
+  readonly noRemoteActivities?: boolean
+}
+
+const finalizeWorker = (worker: NativeWorker): void => {
+  try {
+    native.workerFree(worker)
+  } catch {
+    // Ignore errors triggered during GC cleanup.
+  }
+}
+
+const workerFinalizer = new FinalizationRegistry<NativeWorker>(finalizeWorker)
+
+export class Worker {
+  #native: NativeWorker | undefined
+
+  static async create(runtime: Runtime, client: Client, options: WorkerOptions): Promise<Worker> {
+    const worker = new Worker(runtime, client, options)
+    await worker.#init()
+    return worker
+  }
+
+  private constructor(
+    private readonly runtime: Runtime,
+    private readonly client: Client,
+    private readonly options: WorkerOptions,
+  ) {}
+
+  async #init(): Promise<void> {
+    const payload: Record<string, unknown> = {
+      namespace: this.options.namespace,
+      task_queue: this.options.taskQueue,
+    }
+
+    if (this.options.identity) {
+      payload.identity = this.options.identity
+    }
+
+    if (this.options.buildId) {
+      payload.build_id = this.options.buildId
+    }
+
+    if (typeof this.options.maxCachedWorkflows === 'number') {
+      payload.max_cached_workflows = this.options.maxCachedWorkflows
+    }
+
+    if (typeof this.options.noRemoteActivities === 'boolean') {
+      payload.no_remote_activities = this.options.noRemoteActivities
+    }
+
+    this.#native = native.createWorker(this.runtime.nativeHandle, this.client.nativeHandle, payload)
+    workerFinalizer.register(this, this.#native, this)
+  }
+
+  get nativeHandle(): NativeWorker {
+    if (!this.#native) {
+      throw new Error('Worker has already been shut down')
+    }
+    return this.#native
+  }
+
+  async validate(): Promise<void> {
+    await native.workerValidate(this.nativeHandle)
+  }
+
+  initiateShutdown(): void {
+    native.workerInitiateShutdown(this.nativeHandle)
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.#native) return
+    try {
+      await native.workerShutdown(this.#native)
+    } finally {
+      native.workerFree(this.#native)
+      workerFinalizer.unregister(this)
+      this.#native = undefined
+    }
+  }
+}
+
+export const createWorker = async (runtime: Runtime, client: Client, options: WorkerOptions): Promise<Worker> => {
+  return await Worker.create(runtime, client, options)
+}
+
+export const __TEST__ = {
+  finalizeWorker,
+}

--- a/packages/temporal-bun-sdk/tests/core-bridge-worker.test.ts
+++ b/packages/temporal-bun-sdk/tests/core-bridge-worker.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, mock, spyOn, test } from 'bun:test'
+import { createRuntime } from '../src/core-bridge/runtime.ts'
+import { createClient } from '../src/core-bridge/client.ts'
+import { createWorker } from '../src/core-bridge/worker.ts'
+import * as nativeModule from '../src/internal/core-bridge/native.ts'
+
+const runtimeHandle = { type: 'runtime', handle: 10 } as const
+const clientHandle = { type: 'client', handle: 20 } as const
+const workerHandle = { type: 'worker', handle: 30 } as const
+
+describe('core-bridge worker', () => {
+  test('wires options into native worker lifecycle', async () => {
+    const createRuntimeSpy = spyOn(nativeModule.native, 'createRuntime').mockReturnValue(runtimeHandle)
+    const runtimeShutdown = mock(() => {})
+    const runtimeShutdownSpy = spyOn(nativeModule.native, 'runtimeShutdown').mockImplementation(runtimeShutdown)
+
+    const createClientSpy = spyOn(nativeModule.native, 'createClient').mockResolvedValue(clientHandle)
+    const clientShutdown = mock(() => {})
+    const clientShutdownSpy = spyOn(nativeModule.native, 'clientShutdown').mockImplementation(clientShutdown)
+
+    const createWorkerSpy = spyOn(nativeModule.native, 'createWorker').mockReturnValue(workerHandle)
+    const workerValidateSpy = spyOn(nativeModule.native, 'workerValidate').mockResolvedValue(undefined)
+    const workerShutdownSpy = spyOn(nativeModule.native, 'workerShutdown').mockResolvedValue(undefined)
+    const workerInitiateShutdownSpy = spyOn(nativeModule.native, 'workerInitiateShutdown').mockImplementation(() => {})
+    const workerFreeSpy = spyOn(nativeModule.native, 'workerFree').mockImplementation(() => {})
+
+    try {
+      const runtime = createRuntime()
+      const client = await createClient(runtime, {
+        address: '127.0.0.1:7233',
+        namespace: 'default',
+      })
+
+      const worker = await createWorker(runtime, client, {
+        namespace: 'default',
+        taskQueue: 'prix',
+        identity: 'worker-1',
+        buildId: 'build-123',
+        maxCachedWorkflows: 5,
+        noRemoteActivities: true,
+      })
+
+      expect(createWorkerSpy).toHaveBeenCalledTimes(1)
+      const [, , payload] = createWorkerSpy.mock.calls[0]
+      expect(payload).toEqual({
+        namespace: 'default',
+        task_queue: 'prix',
+        identity: 'worker-1',
+        build_id: 'build-123',
+        max_cached_workflows: 5,
+        no_remote_activities: true,
+      })
+
+      await worker.validate()
+      expect(workerValidateSpy).toHaveBeenCalledWith(workerHandle)
+
+      worker.initiateShutdown()
+      expect(workerInitiateShutdownSpy).toHaveBeenCalledWith(workerHandle)
+
+      await worker.shutdown()
+      expect(workerShutdownSpy).toHaveBeenCalledWith(workerHandle)
+      expect(workerFreeSpy).toHaveBeenCalledWith(workerHandle)
+
+      await client.shutdown()
+      await runtime.shutdown()
+
+      expect(clientShutdownSpy).toHaveBeenCalledWith(clientHandle)
+      expect(runtimeShutdownSpy).toHaveBeenCalledWith(runtimeHandle)
+    } finally {
+      createWorkerSpy.mockRestore()
+      workerValidateSpy.mockRestore()
+      workerShutdownSpy.mockRestore()
+      workerInitiateShutdownSpy.mockRestore()
+      workerFreeSpy.mockRestore()
+      createClientSpy.mockRestore()
+      clientShutdownSpy.mockRestore()
+      createRuntimeSpy.mockRestore()
+      runtimeShutdownSpy.mockRestore()
+    }
+  })
+})

--- a/packages/temporal-bun-sdk/tests/helpers/temporal.ts
+++ b/packages/temporal-bun-sdk/tests/helpers/temporal.ts
@@ -1,0 +1,39 @@
+import net from 'node:net'
+
+const DEFAULT_TEMPORAL_PORT = 7233
+
+export const resolveTemporalAddress = (address: string): { host: string; port: number; url: string } => {
+  if (!address) {
+    return { host: '127.0.0.1', port: DEFAULT_TEMPORAL_PORT, url: 'http://127.0.0.1:7233' }
+  }
+
+  const hasScheme = address.includes('://')
+  const url = new URL(hasScheme ? address : `http://${address}`)
+  const port = url.port ? Number(url.port) : DEFAULT_TEMPORAL_PORT
+
+  return { host: url.hostname, port, url: hasScheme ? address : url.toString().replace(/\/$/, '') }
+}
+
+export const isTemporalServerReachable = async (
+  address: string,
+  options: { timeoutMs?: number } = {},
+): Promise<boolean> => {
+  const { host, port } = resolveTemporalAddress(address)
+  const timeoutMs = options.timeoutMs ?? 1_000
+
+  return await new Promise<boolean>((resolve) => {
+    const socket = net.createConnection({ host, port })
+
+    const finalize = (result: boolean) => {
+      socket.removeAllListeners()
+      if (!socket.destroyed) {
+        socket.destroy()
+      }
+      resolve(result)
+    }
+
+    socket.on('connect', () => finalize(true))
+    socket.on('error', () => finalize(false))
+    socket.setTimeout(timeoutMs, () => finalize(false))
+  })
+}

--- a/packages/temporal-bun-sdk/tests/native-client.test.ts
+++ b/packages/temporal-bun-sdk/tests/native-client.test.ts
@@ -1,0 +1,88 @@
+import { Buffer } from 'node:buffer'
+import { describe, expect, mock, spyOn, test } from 'bun:test'
+import type { TemporalConfig } from '../src/config.ts'
+import * as configModule from '../src/config.ts'
+import * as nativeModule from '../src/internal/core-bridge/native.ts'
+import { createTemporalClient } from '../src/client.ts'
+
+const baseConfig: TemporalConfig = {
+  host: '127.0.0.1',
+  port: 7233,
+  address: '127.0.0.1:7233',
+  namespace: 'default',
+  taskQueue: 'prix',
+  apiKey: 'test-api-key',
+  tls: {
+    serverRootCACertificate: Buffer.from('CA'),
+    clientCertPair: {
+      crt: Buffer.from('CERT'),
+      key: Buffer.from('KEY'),
+    },
+    serverNameOverride: 'tls.example',
+  },
+  allowInsecureTls: true,
+  workerIdentity: 'worker-identity-123',
+  workerIdentityPrefix: 'temporal-bun-worker',
+}
+
+const originalConsoleError = console.error
+
+describe('createTemporalClient', () => {
+  test('passes TLS payload and allow_insecure to native client', async () => {
+    const runtimeHandle = { type: 'runtime', handle: 10 } as const
+    const clientHandle = { type: 'client', handle: 20 } as const
+
+    const createRuntimeSpy = spyOn(nativeModule.native, 'createRuntime').mockReturnValue(runtimeHandle)
+    const createClientSpy = spyOn(nativeModule.native, 'createClient').mockResolvedValue(clientHandle)
+    const clientShutdownSpy = spyOn(nativeModule.native, 'clientShutdown').mockImplementation(() => {})
+    const runtimeShutdownSpy = spyOn(nativeModule.native, 'runtimeShutdown').mockImplementation(() => {})
+    const describeNamespaceSpy = spyOn(nativeModule.native, 'describeNamespace').mockResolvedValue(
+      new Uint8Array([1, 2]),
+    )
+    const startWorkflowSpy = spyOn(nativeModule.native, 'startWorkflow').mockResolvedValue(
+      new TextEncoder().encode(JSON.stringify({ runId: 'run-123', workflowId: 'wf-123', namespace: 'default' })),
+    )
+    const loadConfigSpy = spyOn(configModule, 'loadTemporalConfig').mockResolvedValue({ ...baseConfig })
+
+    try {
+      const { client } = await createTemporalClient()
+
+      expect(createRuntimeSpy).toHaveBeenCalledWith({})
+      expect(createClientSpy).toHaveBeenCalledTimes(1)
+      const [runtimePtr, clientPayload] = createClientSpy.mock.calls[0]
+      expect(runtimePtr).toEqual(runtimeHandle)
+      expect(clientPayload.address).toBe('https://127.0.0.1:7233')
+      expect(clientPayload.identity).toBe('worker-identity-123')
+      expect(clientPayload.allowInsecure).toBe(true)
+      expect(clientPayload.tls).toMatchObject({
+        server_root_ca_cert: Buffer.from('CA').toString('base64'),
+        client_cert: Buffer.from('CERT').toString('base64'),
+        client_private_key: Buffer.from('KEY').toString('base64'),
+        server_name_override: 'tls.example',
+      })
+
+      await client.describeNamespace()
+      expect(describeNamespaceSpy).toHaveBeenCalledWith(clientHandle, 'default')
+
+      await client.shutdown()
+      expect(clientShutdownSpy).toHaveBeenCalledWith(clientHandle)
+      expect(runtimeShutdownSpy).toHaveBeenCalledWith(runtimeHandle)
+
+      // Sanity check startWorkflow path delegates to native bridge.
+      const result = await client.workflow.start({
+        workflowId: 'wf-id',
+        workflowType: 'wf-type',
+      })
+      expect(startWorkflowSpy).toHaveBeenCalledWith(clientHandle, expect.any(Object))
+      expect(result.runId).toBe('run-123')
+    } finally {
+      createRuntimeSpy.mockRestore()
+      createClientSpy.mockRestore()
+      clientShutdownSpy.mockRestore()
+      runtimeShutdownSpy.mockRestore()
+      describeNamespaceSpy.mockRestore()
+      startWorkflowSpy.mockRestore()
+      loadConfigSpy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add native worker FFI exports plus Bun-side wrapper with lifecycle helpers
- expose experimental native client entrypoint and document current milestones
- seed unit coverage for native client + worker bridge plumbing

## Testing
- pnpm --filter @proompteng/temporal-bun-sdk run build:native
- bun test packages/temporal-bun-sdk/tests/native-client.test.ts packages/temporal-bun-sdk/tests/core-bridge-worker.test.ts

## Follow-ups
- implement workflow/activity polling + completion FFI and Bun task loops
- integrate workflow runtime execution and telemetry hooks before replacing @temporalio/worker],