### PR TITLE
chore: scaffold bun native bridge follow-ups

### DIFF
--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/lib.rs
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/lib.rs
@@ -188,6 +188,28 @@ pub extern "C" fn temporal_bun_runtime_free(handle: *mut c_void) {
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_runtime_update_telemetry(
+    _runtime_ptr: *mut c_void,
+    _options_ptr: *const u8,
+    _options_len: usize,
+) -> i32 {
+    // TODO(codex): Configure telemetry exporters (Prometheus, OTLP) via CoreRuntime once the plan in
+    // docs/ffi-surface.md is implemented.
+    error::set_error("temporal_bun_runtime_update_telemetry is not implemented yet".to_string());
+    -1
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_runtime_set_logger(
+    _runtime_ptr: *mut c_void,
+    _callback_ptr: *mut c_void,
+) -> i32 {
+    // TODO(codex): Wire native Core logging into Bun callbacks per docs/ffi-surface.md.
+    error::set_error("temporal_bun_runtime_set_logger is not implemented yet".to_string());
+    -1
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn temporal_bun_error_message(len_out: *mut usize) -> *const u8 {
     error::take_error(len_out)
 }
@@ -334,6 +356,17 @@ pub extern "C" fn temporal_bun_client_free(handle: *mut c_void) {
     unsafe {
         let _ = Box::from_raw(handle as *mut ClientHandle);
     }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_client_update_headers(
+    _client_ptr: *mut c_void,
+    _headers_ptr: *const u8,
+    _headers_len: usize,
+) -> i32 {
+    // TODO(codex): Allow metadata mutation on the gRPC client (api keys, routing headers) as described in docs/ffi-surface.md.
+    error::set_error("temporal_bun_client_update_headers is not implemented yet".to_string());
+    -1
 }
 
 #[unsafe(no_mangle)]
@@ -492,6 +525,16 @@ pub extern "C" fn temporal_bun_client_start_workflow(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_byte_array_new(ptr: *const u8, len: usize) -> *mut byte_array::ByteArray {
+    // TODO(codex): Optimize zero-copy transfers once native bridge exposes shared buffers (docs/ffi-surface.md).
+    if ptr.is_null() || len == 0 {
+        return byte_array::ByteArray::empty();
+    }
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    byte_array::ByteArray::from_vec(slice.to_vec())
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn temporal_bun_byte_array_free(ptr: *mut byte_array::ByteArray) {
     if ptr.is_null() {
         return;
@@ -558,6 +601,62 @@ pub extern "C" fn temporal_bun_pending_byte_array_free(ptr: *mut pending::Pendin
         let _ = Box::from_raw(ptr);
     }
 }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_client_signal(
+    _client_ptr: *mut c_void,
+    _payload_ptr: *const u8,
+    _payload_len: usize,
+) -> *mut pending::PendingByteArray {
+    // TODO(codex): Implement workflow signal bridge invoking WorkflowService::signal_workflow_execution (docs/ffi-surface.md).
+    error::set_error("temporal_bun_client_signal is not implemented yet".to_string());
+    std::ptr::null_mut()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_client_query(
+    _client_ptr: *mut c_void,
+    _payload_ptr: *const u8,
+    _payload_len: usize,
+) -> *mut pending::PendingByteArray {
+    // TODO(codex): Implement workflow query bridge using QueryWorkflowRequest per docs/ffi-surface.md.
+    error::set_error("temporal_bun_client_query is not implemented yet".to_string());
+    std::ptr::null_mut()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_client_terminate_workflow(
+    _client_ptr: *mut c_void,
+    _payload_ptr: *const u8,
+    _payload_len: usize,
+) -> *mut pending::PendingByteArray {
+    // TODO(codex): Implement termination via WorkflowService::terminate_workflow_execution (docs/ffi-surface.md).
+    error::set_error("temporal_bun_client_terminate_workflow is not implemented yet".to_string());
+    std::ptr::null_mut()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_client_cancel_workflow(
+    _client_ptr: *mut c_void,
+    _payload_ptr: *const u8,
+    _payload_len: usize,
+) -> *mut pending::PendingByteArray {
+    // TODO(codex): Implement cancellation via WorkflowService::request_cancel_workflow_execution (docs/ffi-surface.md).
+    error::set_error("temporal_bun_client_cancel_workflow is not implemented yet".to_string());
+    std::ptr::null_mut()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_client_signal_with_start(
+    _client_ptr: *mut c_void,
+    _payload_ptr: *const u8,
+    _payload_len: usize,
+) -> *mut pending::PendingByteArray {
+    // TODO(codex): Implement signal-with-start using WorkflowService::signal_with_start_workflow_execution (docs/ffi-surface.md).
+    error::set_error("temporal_bun_client_signal_with_start is not implemented yet".to_string());
+    std::ptr::null_mut()
+}
+
 
 fn encode_payload(value: serde_json::Value) -> Result<Payload, BridgeError> {
     let data = serde_json::to_vec(&value).map_err(|err| BridgeError::PayloadEncode(err.to_string()))?;

--- a/packages/temporal-bun-sdk/src/client/serialization.ts
+++ b/packages/temporal-bun-sdk/src/client/serialization.ts
@@ -1,0 +1,78 @@
+import type { SignalWithStartOptions, StartWorkflowOptions, TerminateWorkflowOptions, WorkflowHandle } from './types'
+
+const DOCS_ROOT = 'packages/temporal-bun-sdk/docs'
+const FFI_SURFACE_DOC = `${DOCS_ROOT}/ffi-surface.md`
+const CLIENT_RUNTIME_DOC = `${DOCS_ROOT}/client-runtime.md`
+
+const notImplemented = (feature: string, docPath: string): never => {
+  throw new Error(`${feature} is not implemented yet. See ${docPath} for the step-by-step plan.`)
+}
+
+export const buildSignalRequest = (
+  handle: WorkflowHandle,
+  signalName: string,
+  args: unknown[],
+): Record<string, unknown> => {
+  void handle
+  void signalName
+  void args
+  // TODO(codex): Serialize workflow signal payloads according to ${FFI_SURFACE_DOC} (Client function matrix)
+  // and ${CLIENT_RUNTIME_DOC} §3 Request Serialization.
+  return notImplemented('Workflow signal serialization', `${DOCS_ROOT}/client-runtime.md`)
+}
+
+export const buildQueryRequest = (
+  handle: WorkflowHandle,
+  queryName: string,
+  args: unknown[],
+): Record<string, unknown> => {
+  void handle
+  void queryName
+  void args
+  // TODO(codex): Encode workflow query payloads and headers per ${CLIENT_RUNTIME_DOC} §3 before invoking the native bridge.
+  return notImplemented('Workflow query serialization', CLIENT_RUNTIME_DOC)
+}
+
+export const buildTerminateRequest = (
+  handle: WorkflowHandle,
+  options: TerminateWorkflowOptions,
+): Record<string, unknown> => {
+  void handle
+  void options
+  // TODO(codex): Map terminate options into the FFI payload expected by `temporal_bun_client_terminate_workflow`
+  // (see ${FFI_SURFACE_DOC}, Client exports table).
+  return notImplemented('Workflow terminate serialization', FFI_SURFACE_DOC)
+}
+
+export const buildCancelRequest = (handle: WorkflowHandle): Record<string, unknown> => {
+  void handle
+  // TODO(codex): Emit cancellation payloads for `temporal_bun_client_cancel_workflow` per ${FFI_SURFACE_DOC}.
+  return notImplemented('Workflow cancel serialization', FFI_SURFACE_DOC)
+}
+
+export const buildSignalWithStartRequest = ({
+  options,
+  defaults,
+}: {
+  options: SignalWithStartOptions
+  defaults: { namespace: string; identity: string; taskQueue: string }
+}): Record<string, unknown> => {
+  void options
+  void defaults
+  // TODO(codex): Combine start and signal payloads into the JSON envelope described in ${CLIENT_RUNTIME_DOC} §3.
+  return notImplemented('Signal-with-start serialization', CLIENT_RUNTIME_DOC)
+}
+
+export const buildStartWorkflowRequest = ({
+  options,
+  defaults,
+}: {
+  options: StartWorkflowOptions
+  defaults: { namespace: string; identity: string; taskQueue: string }
+}): Record<string, unknown> => {
+  void options
+  void defaults
+  // TODO(codex): Replace legacy start payload builder by delegating to this helper once implemented (see
+  // ${CLIENT_RUNTIME_DOC} completion checklist).
+  return notImplemented('Start workflow serialization helper', CLIENT_RUNTIME_DOC)
+}

--- a/packages/temporal-bun-sdk/src/client/types.ts
+++ b/packages/temporal-bun-sdk/src/client/types.ts
@@ -1,0 +1,44 @@
+export interface WorkflowHandle {
+  workflowId: string
+  runId?: string
+  firstExecutionRunId?: string
+  namespace: string
+}
+
+export interface RetryPolicyOptions {
+  initialIntervalMs?: number
+  maximumIntervalMs?: number
+  maximumAttempts?: number
+  backoffCoefficient?: number
+  nonRetryableErrorTypes?: string[]
+}
+
+export interface StartWorkflowOptions {
+  workflowId: string
+  workflowType: string
+  args?: unknown[]
+  taskQueue?: string
+  namespace?: string
+  identity?: string
+  cronSchedule?: string
+  memo?: Record<string, unknown>
+  headers?: Record<string, unknown>
+  searchAttributes?: Record<string, unknown>
+  requestId?: string
+  workflowExecutionTimeoutMs?: number
+  workflowRunTimeoutMs?: number
+  workflowTaskTimeoutMs?: number
+  retryPolicy?: RetryPolicyOptions
+}
+
+export interface TerminateWorkflowOptions {
+  reason?: string
+  details?: unknown[]
+  firstExecutionRunId?: string
+  runId?: string
+}
+
+export interface SignalWithStartOptions extends StartWorkflowOptions {
+  signalName: string
+  signalArgs?: unknown[]
+}

--- a/packages/temporal-bun-sdk/src/core-bridge/client.ts
+++ b/packages/temporal-bun-sdk/src/core-bridge/client.ts
@@ -70,6 +70,12 @@ export class Client {
     return await native.describeNamespace(handle, namespace)
   }
 
+  updateHeaders(headers: Record<string, string>): never {
+    // TODO(codex): Support dynamic metadata updates via `temporal_bun_client_update_headers`
+    // once the native bridge provides the export (docs/ffi-surface.md).
+    return native.updateClientHeaders(this.nativeHandle, headers)
+  }
+
   async shutdown(): Promise<void> {
     if (!this.#native) return
     native.clientShutdown(this.#native)

--- a/packages/temporal-bun-sdk/src/core-bridge/runtime.ts
+++ b/packages/temporal-bun-sdk/src/core-bridge/runtime.ts
@@ -23,6 +23,17 @@ export class Runtime {
     return this.#native
   }
 
+  configureTelemetry(options: Record<string, unknown> = {}): never {
+    // TODO(codex): Wire telemetry exporters through the native bridge once
+    // `temporal_bun_runtime_update_telemetry` exists (see packages/temporal-bun-sdk/docs/ffi-surface.md).
+    return native.configureTelemetry(this.nativeHandle, options)
+  }
+
+  installLogger(callback: (...args: unknown[]) => void): never {
+    // TODO(codex): Forward Temporal Core logs into Bun via the native bridge per docs/ffi-surface.md.
+    return native.installLogger(this.nativeHandle, callback)
+  }
+
   async shutdown(): Promise<void> {
     if (!this.#native) return
     native.runtimeShutdown(this.#native)

--- a/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
+++ b/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
@@ -157,6 +157,68 @@ export const native = {
     }
     return readByteArray(arrayPtr)
   },
+
+  configureTelemetry(runtime: Runtime, options: Record<string, unknown> = {}): never {
+    void runtime
+    void options
+    // TODO(codex): Bridge telemetry configuration through `temporal_bun_runtime_update_telemetry`
+    // per packages/temporal-bun-sdk/docs/ffi-surface.md (Function Matrix, Runtime section).
+    return notImplemented('Runtime telemetry configuration', 'docs/ffi-surface.md')
+  },
+
+  installLogger(runtime: Runtime, _callback: (...args: unknown[]) => void): never {
+    void runtime
+    // TODO(codex): Install Bun logger hook via `temporal_bun_runtime_set_logger` once the native bridge
+    // supports forwarding core logs (docs/ffi-surface.md — Runtime exports).
+    return notImplemented('Runtime logger installation', 'docs/ffi-surface.md')
+  },
+
+  updateClientHeaders(client: NativeClient, _headers: Record<string, string>): never {
+    void client
+    // TODO(codex): Expose metadata mutation via `temporal_bun_client_update_headers` as outlined in
+    // docs/ffi-surface.md (Client exports) to support API key rotation and custom headers.
+    return notImplemented('Client metadata updates', 'docs/ffi-surface.md')
+  },
+
+  async signalWorkflow(client: NativeClient, _request: Record<string, unknown>): Promise<never> {
+    void client
+    void _request
+    // TODO(codex): Call into `temporal_bun_client_signal` once implemented to deliver workflow signals
+    // per the packages/temporal-bun-sdk/docs/ffi-surface.md function matrix.
+    return Promise.reject(buildNotImplementedError('Workflow signal bridge', 'docs/ffi-surface.md'))
+  },
+
+  async queryWorkflow(client: NativeClient, _request: Record<string, unknown>): Promise<never> {
+    void client
+    void _request
+    // TODO(codex): Marshal workflow queries through `temporal_bun_client_query` once the native bridge
+    // is available (docs/ffi-surface.md — Client exports).
+    return Promise.reject(buildNotImplementedError('Workflow query bridge', 'docs/ffi-surface.md'))
+  },
+
+  async terminateWorkflow(client: NativeClient, _request: Record<string, unknown>): Promise<never> {
+    void client
+    void _request
+    // TODO(codex): Implement termination via `temporal_bun_client_terminate_workflow` per the native
+    // bridge plan documented in docs/ffi-surface.md.
+    return Promise.reject(buildNotImplementedError('Workflow termination bridge', 'docs/ffi-surface.md'))
+  },
+
+  async cancelWorkflow(client: NativeClient, _request: Record<string, unknown>): Promise<never> {
+    void client
+    void _request
+    // TODO(codex): Route cancellations through `temporal_bun_client_cancel_workflow` when the FFI export
+    // exists (docs/ffi-surface.md).
+    return Promise.reject(buildNotImplementedError('Workflow cancel bridge', 'docs/ffi-surface.md'))
+  },
+
+  async signalWithStart(client: NativeClient, _request: Record<string, unknown>): Promise<never> {
+    void client
+    void _request
+    // TODO(codex): Implement signal-with-start via `temporal_bun_client_signal_with_start` following the
+    // parity checklist in docs/ffi-surface.md and docs/client-runtime.md.
+    return Promise.reject(buildNotImplementedError('Signal-with-start bridge', 'docs/ffi-surface.md'))
+  },
 }
 
 function resolveBridgeLibraryPath(): string {
@@ -286,4 +348,14 @@ function readLastError(): string {
   } finally {
     temporal_bun_error_free(errPtr, len)
   }
+}
+
+function buildNotImplementedError(feature: string, docPath: string): Error {
+  return new Error(
+    `${feature} is not implemented yet. See packages/temporal-bun-sdk/${docPath} for the implementation plan.`,
+  )
+}
+
+function notImplemented(feature: string, docPath: string): never {
+  throw buildNotImplementedError(feature, docPath)
 }

--- a/packages/temporal-bun-sdk/src/worker/index.ts
+++ b/packages/temporal-bun-sdk/src/worker/index.ts
@@ -1,1 +1,3 @@
+// TODO(codex): Replace this re-export with the Bun-native worker runtime once implemented per
+// packages/temporal-bun-sdk/docs/worker-runtime.md.
 export * from '../../vendor/sdk-typescript/packages/worker/src/index.ts'

--- a/packages/temporal-bun-sdk/src/worker/runtime.ts
+++ b/packages/temporal-bun-sdk/src/worker/runtime.ts
@@ -1,0 +1,37 @@
+const WORKER_DOC = 'packages/temporal-bun-sdk/docs/worker-runtime.md'
+
+const notImplemented = (feature: string): never => {
+  throw new Error(`${feature} is not implemented yet. See ${WORKER_DOC} for implementation guidance.`)
+}
+
+export interface WorkerRuntimeOptions {
+  workflowsPath: string
+  activities?: Record<string, (...args: unknown[]) => unknown>
+  taskQueue?: string
+  namespace?: string
+  concurrency?: { workflow?: number; activity?: number }
+}
+
+export class WorkerRuntime {
+  constructor(private readonly options: WorkerRuntimeOptions) {
+    void options
+    // TODO(codex): Initialize native worker handles and runtime scaffolding per WORKER_DOC §1–§3.
+  }
+
+  static async create(options: WorkerRuntimeOptions): Promise<WorkerRuntime> {
+    // TODO(codex): Build async factory that wires Bun-native worker creation per WORKER_DOC §2.
+    void options
+    notImplemented('WorkerRuntime.create')
+  }
+
+  async run(): Promise<never> {
+    // TODO(codex): Kick off workflow and activity polling loops (WORKER_DOC §3).
+    notImplemented('WorkerRuntime.run')
+  }
+
+  async shutdown(_gracefulTimeoutMs?: number): Promise<never> {
+    // TODO(codex): Implement graceful shutdown semantics before swapping out the Node worker bridge.
+    void _gracefulTimeoutMs
+    notImplemented('WorkerRuntime.shutdown')
+  }
+}


### PR DESCRIPTION
## Summary
- stub native runtime/client FFI exports with TODO markers aligned to docs/ffi-surface.md
- surface Bun client APIs and serialization helpers to guide upcoming workflow operations
- add worker runtime placeholder referencing docs/worker-runtime.md and document remaining work

## Follow-up Issues
- #1444 — implement native telemetry configuration for Bun runtime
- #1445 — bridge Temporal core logging into Bun runtime
- #1446 — support client metadata updates via Bun bridge
- #1447 — implement workflow signal support in Bun client
- #1448 — implement workflow query support in Bun client
- #1449 — implement workflow termination support in Bun client
- #1450 — implement workflow cancel support in Bun client
- #1451 — implement signal-with-start support in Bun client
- #1452 — centralize Bun start workflow serialization
- #1453 — return workflow handles from Bun start API
- #1454 — deliver Bun-native worker runtime
- #1455 — optimize Bun bridge byte array allocation

## Testing
- not run (scaffolding only)
