### PR TITLE
feat: implement workflow cancel support in Bun client

### DIFF
--- a/packages/temporal-bun-sdk/src/client.ts
+++ b/packages/temporal-bun-sdk/src/client.ts
@@ -278,7 +278,10 @@ class TemporalClientImpl implements TemporalClient {
   }
 
   async cancelWorkflow(handle: WorkflowHandle): Promise<void> {
-    const request = buildCancelRequest(handle)
+    const request = buildCancelRequest(handle, {
+      namespace: this.namespace,
+      identity: this.defaultIdentity,
+    })
     await native.cancelWorkflow(this.client, request)
   }
 

--- a/packages/temporal-bun-sdk/src/client/serialization.ts
+++ b/packages/temporal-bun-sdk/src/client/serialization.ts
@@ -97,10 +97,34 @@ export const buildTerminateRequest = (
   return payload
 }
 
-export const buildCancelRequest = (handle: WorkflowHandle): Record<string, unknown> => {
-  void handle
-  // TODO(codex): Emit cancellation payloads for `temporal_bun_client_cancel_workflow` per ${FFI_SURFACE_DOC}.
-  return notImplemented('Workflow cancel serialization', FFI_SURFACE_DOC)
+export const buildCancelRequest = (
+  handle: WorkflowHandle,
+  defaults: { namespace: string; identity: string },
+): Record<string, unknown> => {
+  if (!handle.workflowId) {
+    throw new Error('Workflow handle is missing workflowId')
+  }
+
+  const namespace = handle.namespace ?? defaults.namespace
+  if (!namespace) {
+    throw new Error('Workflow namespace is not available')
+  }
+
+  const request: Record<string, unknown> = {
+    namespace,
+    workflow_id: handle.workflowId,
+    identity: defaults.identity,
+  }
+
+  if (handle.runId) {
+    request.run_id = handle.runId
+  }
+
+  if (handle.firstExecutionRunId) {
+    request.first_execution_run_id = handle.firstExecutionRunId
+  }
+
+  return request
 }
 
 export const buildSignalWithStartRequest = ({

--- a/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
+++ b/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
@@ -43,12 +43,13 @@ const {
     temporal_bun_pending_client_free,
     temporal_bun_pending_byte_array_poll,
     temporal_bun_pending_byte_array_consume,
-    temporal_bun_pending_byte_array_free,
-    temporal_bun_byte_array_free,
-    temporal_bun_client_start_workflow,
-    temporal_bun_client_terminate_workflow,
-    temporal_bun_client_signal_with_start,
-    temporal_bun_client_query_workflow,
+   temporal_bun_pending_byte_array_free,
+   temporal_bun_byte_array_free,
+   temporal_bun_client_start_workflow,
+   temporal_bun_client_terminate_workflow,
+   temporal_bun_client_signal_with_start,
+   temporal_bun_client_query_workflow,
+   temporal_bun_client_cancel_workflow,
   },
 } = dlopen(libraryFile, {
   temporal_bun_runtime_new: {
@@ -124,6 +125,10 @@ const {
     returns: FFIType.ptr,
   },
   temporal_bun_client_query_workflow: {
+    args: [FFIType.ptr, FFIType.ptr, FFIType.uint64_t],
+    returns: FFIType.ptr,
+  },
+  temporal_bun_client_cancel_workflow: {
     args: [FFIType.ptr, FFIType.ptr, FFIType.uint64_t],
     returns: FFIType.ptr,
   },
@@ -237,12 +242,17 @@ export const native = {
     }
   },
 
-  async cancelWorkflow(client: NativeClient, _request: Record<string, unknown>): Promise<never> {
-    void client
-    void _request
-    // TODO(codex): Route cancellations through `temporal_bun_client_cancel_workflow` when the FFI export
-    // exists (docs/ffi-surface.md).
-    return Promise.reject(buildNotImplementedError('Workflow cancel bridge', 'docs/ffi-surface.md'))
+  async cancelWorkflow(client: NativeClient, request: Record<string, unknown>): Promise<void> {
+    const payload = Buffer.from(JSON.stringify(request), 'utf8')
+    const pendingHandle = Number(temporal_bun_client_cancel_workflow(client.handle, ptr(payload), payload.byteLength))
+    if (!pendingHandle) {
+      throw new Error(readLastError())
+    }
+    try {
+      await waitForByteArray(pendingHandle)
+    } finally {
+      temporal_bun_pending_byte_array_free(pendingHandle)
+    }
   },
 
   async signalWithStart(client: NativeClient, request: Record<string, unknown>): Promise<Uint8Array> {

--- a/packages/temporal-bun-sdk/tests/native.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/native.integration.test.ts
@@ -141,6 +141,55 @@ suite('native bridge integration', () => {
       native.clientShutdown(client)
     }
   })
+
+  test('cancel workflow resolves for in-flight execution', async () => {
+    const maxAttempts = 10
+    const waitMs = 500
+    const workflowId = `integration-cancel-${Date.now()}`
+    const identity = 'bun-integration-client'
+
+    const client = await withRetry(
+      async () => {
+        return native.createClient(runtime, {
+          address: 'http://127.0.0.1:7233',
+          namespace: 'default',
+          identity,
+        })
+      },
+      maxAttempts,
+      waitMs,
+    )
+
+    try {
+      const payload = {
+        namespace: 'default',
+        workflow_id: workflowId,
+        workflow_type: 'TemporalTestWorkflow',
+        task_queue: 'default',
+        identity,
+        args: [],
+      }
+
+      const responseBytes = await withRetry(() => native.startWorkflow(client, payload), maxAttempts, waitMs)
+      const response = JSON.parse(decoder.decode(responseBytes)) as {
+        runId: string
+      }
+
+      await withRetry(
+        () =>
+          native.cancelWorkflow(client, {
+            namespace: 'default',
+            workflow_id: workflowId,
+            run_id: response.runId,
+            identity,
+          }),
+        maxAttempts,
+        waitMs,
+      )
+    } finally {
+      native.clientShutdown(client)
+    }
+  })
 })
 
 async function withRetry<T>(fn: () => T | Promise<T>, attempts: number, waitMs: number): Promise<T> {


### PR DESCRIPTION
## Summary
- add cancel workflow serialization in the Bun client and default to client namespace/identity
- wire the native TypeScript bridge to the new `temporal_bun_client_cancel_workflow` FFI export
- implement the Rust bridge request pipeline, queueing async cancels and add integration/bridge unit tests

## Testing
- `pnpm run format`
- `cargo fmt --manifest-path packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.toml`
- `cargo test --manifest-path packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.toml` *(fails: missing vendor/sdk-core sources in repo)*
- `pnpm --filter @proompteng/temporal-bun-sdk test` *(fails: temporal_bun_bridge library not built; TEMPORAL_BUN_SDK_NATIVE_PATH unresolved)*

Closes #1450
