### PR TITLE
feat: implement workflow query support in Bun client

### DIFF
--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.lock
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.lock
@@ -53,6 +53,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +136,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,7 +180,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -154,6 +208,36 @@ checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -315,6 +399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +525,12 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -576,6 +672,12 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "governor"
@@ -918,6 +1020,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -930,6 +1041,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -952,6 +1073,16 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1017,6 +1148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1195,16 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nonzero_ext"
@@ -1389,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -1411,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1708,6 +1855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustfsm"
 version = "0.1.0"
 dependencies = [
@@ -1749,6 +1902,7 @@ version = "0.23.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1760,6 +1914,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
@@ -1767,7 +1934,16 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.5.1",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1785,6 +1961,7 @@ version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1819,12 +1996,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1985,9 +2175,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2079,11 +2269,14 @@ dependencies = [
  "hyper",
  "hyper-util",
  "parking_lot",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
  "slotmap",
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-rustls",
  "tonic",
  "tower",
  "tracing",
@@ -2112,7 +2305,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "itertools",
+ "itertools 0.14.0",
  "lru",
  "mockall",
  "opentelemetry",
@@ -2330,7 +2523,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.2",
  "socket2",
  "sync_wrapper",
  "tokio",

--- a/packages/temporal-bun-sdk/src/client/types.ts
+++ b/packages/temporal-bun-sdk/src/client/types.ts
@@ -1,8 +1,8 @@
 export interface WorkflowHandle {
   workflowId: string
+  namespace?: string
   runId?: string
   firstExecutionRunId?: string
-  namespace: string
 }
 
 export interface WorkflowHandleMetadata {

--- a/packages/temporal-bun-sdk/tests/native.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/native.integration.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { fileURLToPath } from 'node:url'
+import process from 'node:process'
 import { native } from '../src/internal/core-bridge/native.ts'
 
 const shouldRun = process.env.TEMPORAL_TEST_SERVER === '1'
@@ -7,13 +9,46 @@ const suite = shouldRun ? describe : describe.skip
 
 suite('native bridge integration', () => {
   let runtime: ReturnType<typeof native.createRuntime>
+  let workerProcess: ReturnType<typeof Bun.spawn> | undefined
+  const taskQueue = 'bun-sdk-query-tests'
+  const decoder = new TextDecoder()
 
-  beforeAll(() => {
+  beforeAll(async () => {
     runtime = native.createRuntime({})
+
+    const workerScript = fileURLToPath(new URL('./worker/run-query-worker.mjs', import.meta.url))
+    workerProcess = Bun.spawn(['node', workerScript], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        TEMPORAL_ADDRESS: '127.0.0.1:7233',
+        TEMPORAL_NAMESPACE: 'default',
+        TEMPORAL_TASK_QUEUE: taskQueue,
+      },
+    })
+
+    if (!workerProcess.stdout) {
+      throw new Error('Failed to capture worker stdout')
+    }
+
+    await waitForWorkerReady(workerProcess)
   })
 
-  afterAll(() => {
+  afterAll(async () => {
     native.runtimeShutdown(runtime)
+    if (workerProcess) {
+      try {
+        workerProcess.kill()
+      } catch (error) {
+        console.error('Failed to kill worker process', error)
+      }
+      try {
+        await workerProcess.exited
+      } catch {
+        // ignore
+      }
+    }
   })
 
   test('describe namespace succeeds against live Temporal server', async () => {
@@ -38,6 +73,74 @@ suite('native bridge integration', () => {
       native.clientShutdown(client)
     }
   })
+
+  test('queryWorkflow returns JSON payload for running workflow', async () => {
+    const maxAttempts = 10
+    const waitMs = 500
+
+    const client = await withRetry(
+      async () => {
+        return native.createClient(runtime, {
+          address: 'http://127.0.0.1:7233',
+          namespace: 'default',
+          identity: 'bun-integration-client',
+        })
+      },
+      maxAttempts,
+      waitMs,
+    )
+
+    try {
+      const workflowId = `query-workflow-${Date.now()}`
+      const startRequest = {
+        namespace: 'default',
+        workflow_id: workflowId,
+        workflow_type: 'queryWorkflowSample',
+        task_queue: taskQueue,
+        identity: 'bun-integration-client',
+        args: ['initial-state'],
+      }
+
+      const startBytes = await native.startWorkflow(client, startRequest)
+      const startInfo = JSON.parse(decoder.decode(startBytes)) as { runId: string }
+
+      const queryRequest = {
+        namespace: 'default',
+        workflow_id: workflowId,
+        run_id: startInfo.runId,
+        query_name: 'currentState',
+        args: [],
+      }
+
+      const resultBytes = await withRetry(async () => native.queryWorkflow(client, queryRequest), maxAttempts, waitMs)
+
+      const result = JSON.parse(decoder.decode(resultBytes)) as string
+      expect(result).toBe('initial-state')
+    } finally {
+      native.clientShutdown(client)
+    }
+  })
+
+  test('queryWorkflow surfaces errors for unknown workflow', async () => {
+    const client = await native.createClient(runtime, {
+      address: 'http://127.0.0.1:7233',
+      namespace: 'default',
+      identity: 'bun-integration-client',
+    })
+
+    try {
+      await expect(
+        native.queryWorkflow(client, {
+          namespace: 'default',
+          workflow_id: 'missing-workflow-id',
+          query_name: 'currentState',
+          args: [],
+        }),
+      ).rejects.toThrow()
+    } finally {
+      native.clientShutdown(client)
+    }
+  })
 })
 
 async function withRetry<T>(fn: () => T | Promise<T>, attempts: number, waitMs: number): Promise<T> {
@@ -52,4 +155,31 @@ async function withRetry<T>(fn: () => T | Promise<T>, attempts: number, waitMs: 
     }
   }
   throw lastError
+}
+
+async function waitForWorkerReady(proc: ReturnType<typeof Bun.spawn>, timeoutMs = 10_000): Promise<void> {
+  const reader = proc.stdout?.getReader()
+  if (!reader) {
+    throw new Error('Worker stdout is not readable')
+  }
+
+  const decoder = new TextDecoder()
+  const start = Date.now()
+  let buffer = ''
+
+  while (Date.now() - start < timeoutMs) {
+    const { value, done } = await reader.read()
+    if (done) {
+      break
+    }
+    buffer += decoder.decode(value, { stream: true })
+    if (buffer.includes('worker-ready')) {
+      reader.releaseLock()
+      return
+    }
+  }
+
+  reader.releaseLock()
+
+  throw new Error(`Worker did not become ready within ${timeoutMs}ms. stdout="${buffer}"`)
 }

--- a/packages/temporal-bun-sdk/tests/worker/run-query-worker.mjs
+++ b/packages/temporal-bun-sdk/tests/worker/run-query-worker.mjs
@@ -1,0 +1,49 @@
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import process from 'node:process'
+import { Worker, NativeConnection } from '@temporalio/worker'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const workflowsPath = join(__dirname, '../workflows/query-workflow.js')
+
+const address = process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233'
+const namespace = process.env.TEMPORAL_NAMESPACE ?? 'default'
+const taskQueue = process.env.TEMPORAL_TASK_QUEUE ?? 'bun-sdk-query-tests'
+
+let worker
+
+async function main() {
+  const connection = await NativeConnection.connect({ address })
+  worker = await Worker.create({
+    connection,
+    namespace,
+    taskQueue,
+    workflowsPath,
+  })
+
+  console.log('worker-ready')
+
+  process.once('SIGINT', shutdown)
+  process.once('SIGTERM', shutdown)
+
+  await worker.run()
+}
+
+async function shutdown() {
+  if (!worker) {
+    process.exit(0)
+    return
+  }
+  try {
+    await worker.shutdown()
+  } catch (err) {
+    console.error('worker shutdown failed', err)
+  } finally {
+    process.exit(0)
+  }
+}
+
+main().catch((err) => {
+  console.error('worker failed to start', err)
+  process.exit(1)
+})

--- a/packages/temporal-bun-sdk/tests/workflows/query-workflow.js
+++ b/packages/temporal-bun-sdk/tests/workflows/query-workflow.js
@@ -1,0 +1,10 @@
+import { defineQuery, setHandler, sleep } from '@temporalio/workflow'
+
+const currentStateQuery = defineQuery('currentState')
+
+export async function queryWorkflowSample(initialValue = 'unset') {
+  let state = initialValue
+  setHandler(currentStateQuery, () => state)
+  await sleep(2000)
+  return state
+}


### PR DESCRIPTION
## Summary
- implement workflow query serialization helpers and high-level client support
- wire queryWorkflow through Bun core bridge and native bridge, including async pending handling
- add query unit/integration coverage with a lightweight worker fixture

## Testing
- pnpm --filter @proompteng/temporal-bun-sdk build:native *(fails: vendor/sdk-core/client missing Cargo.toml to build native bridge)*
- pnpm --filter @proompteng/temporal-bun-sdk test -- tests/client.test.ts *(fails: missing native bridge artifact due to build failure above)*
- TEMPORAL_TEST_SERVER=1 pnpm --filter @proompteng/temporal-bun-sdk test -- tests/native.integration.test.ts *(fails: missing native bridge artifact due to build failure above)*

Closes #1448