### PR TITLE
feat: deliver Bun-native worker runtime

### DIFF
--- a/packages/temporal-bun-sdk/src/bin/start-worker.ts
+++ b/packages/temporal-bun-sdk/src/bin/start-worker.ts
@@ -3,11 +3,11 @@
 import { createWorker } from '../worker.js'
 
 const main = async () => {
-  const { worker } = await createWorker()
+  const { runtime } = await createWorker()
 
   const shutdown = async (signal: string) => {
     console.log(`Received ${signal}, shutting down Temporal worker…`)
-    await worker.shutdown()
+    await runtime.shutdown()
     process.exit(0)
   }
 
@@ -18,7 +18,7 @@ const main = async () => {
     void shutdown('SIGTERM')
   })
 
-  await worker.run()
+  await runtime.run()
 }
 
 await main().catch((error) => {

--- a/packages/temporal-bun-sdk/src/internal/worker/native.ts
+++ b/packages/temporal-bun-sdk/src/internal/worker/native.ts
@@ -1,0 +1,304 @@
+import { dlopen, FFIType, ptr, toArrayBuffer } from 'bun:ffi'
+import { existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { NativeClient, Runtime } from '../core-bridge/native.ts'
+
+type Pointer = number
+
+type WorkerPtr = Pointer
+
+interface WorkerBindingSymbols {
+  temporal_bun_worker_new: (runtimePtr: Pointer, clientPtr: Pointer, payloadPtr: Pointer, payloadLen: number) => Pointer
+  temporal_bun_worker_free: (workerPtr: Pointer) => void
+  temporal_bun_worker_poll_workflow_task: (workerPtr: Pointer) => Pointer
+  temporal_bun_worker_complete_workflow_task: (workerPtr: Pointer, payloadPtr: Pointer, payloadLen: number) => number
+  temporal_bun_worker_poll_activity_task: (workerPtr: Pointer) => Pointer
+  temporal_bun_worker_complete_activity_task: (workerPtr: Pointer, payloadPtr: Pointer, payloadLen: number) => number
+  temporal_bun_worker_record_activity_heartbeat: (workerPtr: Pointer, payloadPtr: Pointer, payloadLen: number) => number
+  temporal_bun_worker_initiate_shutdown: (workerPtr: Pointer) => number
+  temporal_bun_worker_finalize_shutdown: (workerPtr: Pointer) => number
+  temporal_bun_error_message: (lenOutPtr: Pointer) => Pointer
+  temporal_bun_error_free: (ptr: Pointer, len: number) => void
+  temporal_bun_byte_array_free: (ptr: Pointer) => void
+}
+
+export interface NativeWorker {
+  type: 'worker'
+  handle: WorkerPtr
+}
+
+const libraryPath = resolveBridgeLibraryPath()
+
+let workerSymbols: WorkerBindingSymbols | null = null
+let loadFailure: Error | null = null
+
+try {
+  const { symbols } = dlopen(libraryPath, {
+    temporal_bun_worker_new: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.uint64_t],
+      returns: FFIType.ptr,
+    },
+    temporal_bun_worker_free: {
+      args: [FFIType.ptr],
+      returns: FFIType.void,
+    },
+    temporal_bun_worker_poll_workflow_task: {
+      args: [FFIType.ptr],
+      returns: FFIType.ptr,
+    },
+    temporal_bun_worker_complete_workflow_task: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.uint64_t],
+      returns: FFIType.int32_t,
+    },
+    temporal_bun_worker_poll_activity_task: {
+      args: [FFIType.ptr],
+      returns: FFIType.ptr,
+    },
+    temporal_bun_worker_complete_activity_task: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.uint64_t],
+      returns: FFIType.int32_t,
+    },
+    temporal_bun_worker_record_activity_heartbeat: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.uint64_t],
+      returns: FFIType.int32_t,
+    },
+    temporal_bun_worker_initiate_shutdown: {
+      args: [FFIType.ptr],
+      returns: FFIType.int32_t,
+    },
+    temporal_bun_worker_finalize_shutdown: {
+      args: [FFIType.ptr],
+      returns: FFIType.int32_t,
+    },
+    temporal_bun_error_message: {
+      args: [FFIType.ptr],
+      returns: FFIType.ptr,
+    },
+    temporal_bun_error_free: {
+      args: [FFIType.ptr, FFIType.uint64_t],
+      returns: FFIType.void,
+    },
+    temporal_bun_byte_array_free: {
+      args: [FFIType.ptr],
+      returns: FFIType.void,
+    },
+  })
+
+  workerSymbols = symbols as WorkerBindingSymbols
+} catch (error) {
+  loadFailure = error instanceof Error ? error : new Error(String(error))
+}
+
+export const native = {
+  get hasWorkerBindings(): boolean {
+    return workerSymbols !== null
+  },
+
+  createWorker(runtime: Runtime, client: NativeClient, config: Record<string, unknown>): NativeWorker {
+    const symbols = ensureSymbols()
+    const payload = encodePayload(config)
+    const handle = Number(
+      symbols.temporal_bun_worker_new(runtime.handle, client.handle, ptr(payload), payload.byteLength),
+    )
+    if (!handle) {
+      throw new Error(readLastError(symbols))
+    }
+    return { type: 'worker', handle }
+  },
+
+  workerShutdown(worker: NativeWorker): void {
+    const symbols = ensureSymbols()
+    try {
+      symbols.temporal_bun_worker_free(worker.handle)
+    } catch (error) {
+      throw formatNativeError(error)
+    }
+  },
+
+  pollWorkflowTask(worker: NativeWorker): Uint8Array | null {
+    const symbols = ensureSymbols()
+    const pointer = Number(symbols.temporal_bun_worker_poll_workflow_task(worker.handle))
+    if (!pointer) {
+      const message = readLastError(symbols)
+      if (message === 'Unknown native error') {
+        return null
+      }
+      throw new Error(message)
+    }
+    return readByteArray(symbols, pointer)
+  },
+
+  completeWorkflowTask(worker: NativeWorker, payload: PayloadInput): void {
+    const symbols = ensureSymbols()
+    const buffer = encodePayload(payload)
+    const status = Number(
+      symbols.temporal_bun_worker_complete_workflow_task(worker.handle, ptr(buffer), buffer.byteLength),
+    )
+    if (status !== 0) {
+      throw new Error(readLastError(symbols))
+    }
+  },
+
+  pollActivityTask(worker: NativeWorker): Uint8Array | null {
+    const symbols = ensureSymbols()
+    const pointer = Number(symbols.temporal_bun_worker_poll_activity_task(worker.handle))
+    if (!pointer) {
+      const message = readLastError(symbols)
+      if (message === 'Unknown native error') {
+        return null
+      }
+      throw new Error(message)
+    }
+    return readByteArray(symbols, pointer)
+  },
+
+  completeActivityTask(worker: NativeWorker, payload: PayloadInput): void {
+    const symbols = ensureSymbols()
+    const buffer = encodePayload(payload)
+    const status = Number(
+      symbols.temporal_bun_worker_complete_activity_task(worker.handle, ptr(buffer), buffer.byteLength),
+    )
+    if (status !== 0) {
+      throw new Error(readLastError(symbols))
+    }
+  },
+
+  recordActivityHeartbeat(worker: NativeWorker, payload: PayloadInput): void {
+    const symbols = ensureSymbols()
+    const buffer = encodePayload(payload)
+    const status = Number(
+      symbols.temporal_bun_worker_record_activity_heartbeat(worker.handle, ptr(buffer), buffer.byteLength),
+    )
+    if (status !== 0) {
+      throw new Error(readLastError(symbols))
+    }
+  },
+
+  initiateShutdown(worker: NativeWorker): void {
+    const symbols = ensureSymbols()
+    const status = Number(symbols.temporal_bun_worker_initiate_shutdown(worker.handle))
+    if (status !== 0) {
+      throw new Error(readLastError(symbols))
+    }
+  },
+
+  finalizeShutdown(worker: NativeWorker): void {
+    const symbols = ensureSymbols()
+    const status = Number(symbols.temporal_bun_worker_finalize_shutdown(worker.handle))
+    if (status !== 0) {
+      throw new Error(readLastError(symbols))
+    }
+  },
+}
+
+type PayloadInput = Uint8Array | ArrayBuffer | ArrayBufferView | Record<string, unknown> | readonly unknown[]
+
+function encodePayload(payload: PayloadInput): Buffer {
+  if (payload instanceof Uint8Array) {
+    return Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength)
+  }
+  if (payload instanceof ArrayBuffer) {
+    return Buffer.from(payload)
+  }
+  if (ArrayBuffer.isView(payload)) {
+    return Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength)
+  }
+  return Buffer.from(JSON.stringify(payload), 'utf8')
+}
+
+function readByteArray(symbols: WorkerBindingSymbols, pointer: number): Uint8Array {
+  const header = new BigUint64Array(toArrayBuffer(pointer, 0, 24))
+  const dataPtr = Number(header[0])
+  const len = Number(header[1])
+  if (!dataPtr || !len) {
+    symbols.temporal_bun_byte_array_free(pointer)
+    return new Uint8Array(0)
+  }
+  const view = new Uint8Array(toArrayBuffer(dataPtr, 0, len))
+  const copy = new Uint8Array(view)
+  symbols.temporal_bun_byte_array_free(pointer)
+  return copy
+}
+
+function readLastError(symbols: WorkerBindingSymbols): string {
+  const lenBuffer = new BigUint64Array(1)
+  const errPtr = Number(symbols.temporal_bun_error_message(ptr(lenBuffer)))
+  const len = Number(lenBuffer[0])
+  if (!errPtr || len === 0) {
+    return 'Unknown native error'
+  }
+  try {
+    const buffer = Buffer.from(toArrayBuffer(errPtr, 0, len))
+    return buffer.toString('utf8')
+  } finally {
+    symbols.temporal_bun_error_free(errPtr, len)
+  }
+}
+
+function ensureSymbols(): WorkerBindingSymbols {
+  if (!workerSymbols) {
+    throw buildLoadError()
+  }
+  return workerSymbols
+}
+
+function buildLoadError(): Error {
+  const base =
+    'Temporal Bun worker native bindings are unavailable. Ensure the native bridge exposes worker symbols per packages/temporal-bun-sdk/docs/ffi-surface.md.'
+  if (!loadFailure) {
+    return new Error(base)
+  }
+  return new Error(`${base} Loader error: ${loadFailure.message}`)
+}
+
+function formatNativeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error
+  }
+  return new Error(String(error))
+}
+
+function resolveBridgeLibraryPath(): string {
+  const override = process.env.TEMPORAL_BUN_SDK_NATIVE_PATH
+  if (override) {
+    if (!existsSync(override)) {
+      throw new Error(`Temporal Bun bridge override not found at ${override}`)
+    }
+    return override
+  }
+
+  const targetDir = fileURLToPath(new URL('../../../native/temporal-bun-bridge/target', import.meta.url))
+  const baseName =
+    process.platform === 'win32'
+      ? 'temporal_bun_bridge.dll'
+      : process.platform === 'darwin'
+        ? 'libtemporal_bun_bridge.dylib'
+        : 'libtemporal_bun_bridge.so'
+
+  const releasePath = join(targetDir, 'release', baseName)
+  if (existsSync(releasePath)) {
+    return releasePath
+  }
+
+  const debugPath = join(targetDir, 'debug', baseName)
+  if (existsSync(debugPath)) {
+    return debugPath
+  }
+
+  const depsDir = join(targetDir, 'debug', 'deps')
+  if (existsSync(depsDir)) {
+    const prefix = baseName.replace(/\.[^./]+$/, '')
+    const candidate = readdirSync(depsDir)
+      .filter((file) => file.startsWith(prefix))
+      .map((file) => join(depsDir, file))
+      .find((file) => existsSync(file))
+    if (candidate) {
+      return candidate
+    }
+  }
+
+  throw new Error(
+    `Temporal Bun bridge library not found. Expected at ${releasePath} or ${debugPath}. Did you build the native bridge?`,
+  )
+}

--- a/packages/temporal-bun-sdk/src/worker/index.ts
+++ b/packages/temporal-bun-sdk/src/worker/index.ts
@@ -1,3 +1,4 @@
-// TODO(codex): Replace this re-export with the Bun-native worker runtime once implemented per
-// packages/temporal-bun-sdk/docs/worker-runtime.md.
-export * from '../../vendor/sdk-typescript/packages/worker/src/index.ts'
+export { WorkerRuntime } from './runtime.ts'
+export type { WorkerRuntimeOptions, ActivityFunction, ActivityRegistryInput } from './runtime.ts'
+export { createWorker, runWorker } from '../worker.ts'
+export type { CreateWorkerOptions, CreateWorkerResult } from '../worker.ts'

--- a/packages/temporal-bun-sdk/src/worker/isolate-manager.ts
+++ b/packages/temporal-bun-sdk/src/worker/isolate-manager.ts
@@ -1,0 +1,191 @@
+import { isAbsolute, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export type WorkflowFunction = (...args: unknown[]) => unknown | Promise<unknown>
+
+export interface WorkflowActivationJob {
+  type: 'start' | 'signal' | 'shutdown'
+  args?: unknown[]
+  signalName?: string
+}
+
+export interface WorkflowActivation {
+  taskToken: string
+  runId: string
+  workflowId: string
+  workflowType: string
+  job: WorkflowActivationJob
+}
+
+export interface SerializedWorkflowError {
+  name?: string
+  message: string
+  stack?: string
+}
+
+export interface WorkflowCompletion {
+  taskToken: string
+  runId: string
+  workflowId: string
+  status: 'completed' | 'failed'
+  result?: unknown
+  error?: SerializedWorkflowError
+}
+
+interface WorkflowInstanceOptions {
+  runId: string
+  workflowId: string
+  workflowType: string
+  workflowFn: WorkflowFunction
+}
+
+class WorkflowInstance {
+  #started = false
+  #workflowFn: WorkflowFunction
+
+  constructor(private readonly options: WorkflowInstanceOptions) {
+    this.#workflowFn = options.workflowFn
+  }
+
+  async handle(job: WorkflowActivationJob): Promise<unknown> {
+    switch (job.type) {
+      case 'start':
+        if (this.#started) {
+          throw new Error(`Workflow run ${this.options.runId} already started`)
+        }
+        this.#started = true
+        return await this.#workflowFn(...(job.args ?? []))
+      case 'signal':
+        throw new Error('Workflow signal handling is not implemented yet')
+      case 'shutdown':
+        return undefined
+      default:
+        throw new Error(`Unsupported workflow job type: ${(job as WorkflowActivationJob).type}`)
+    }
+  }
+
+  get runId(): string {
+    return this.options.runId
+  }
+
+  get workflowType(): string {
+    return this.options.workflowType
+  }
+}
+
+export class WorkflowIsolateManager {
+  #workflowsPath: string
+  #instances = new Map<string, WorkflowInstance>()
+  #functionCache = new Map<string, WorkflowFunction>()
+
+  constructor(workflowsPath: string) {
+    this.#workflowsPath = workflowsPath
+  }
+
+  async execute(activation: WorkflowActivation): Promise<WorkflowCompletion> {
+    const instance = await this.#getOrCreateInstance(activation)
+    try {
+      const result = await instance.handle(activation.job)
+      const completion: WorkflowCompletion = {
+        taskToken: activation.taskToken,
+        runId: activation.runId,
+        workflowId: activation.workflowId,
+        status: 'completed',
+        result,
+      }
+      if (activation.job.type !== 'signal') {
+        this.#instances.delete(activation.runId)
+      }
+      return completion
+    } catch (error) {
+      this.#instances.delete(activation.runId)
+      return {
+        taskToken: activation.taskToken,
+        runId: activation.runId,
+        workflowId: activation.workflowId,
+        status: 'failed',
+        error: serializeWorkflowError(error),
+      }
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.#instances.clear()
+    this.#functionCache.clear()
+  }
+
+  async #getOrCreateInstance(activation: WorkflowActivation): Promise<WorkflowInstance> {
+    const existing = this.#instances.get(activation.runId)
+    if (existing) {
+      return existing
+    }
+
+    const workflowFn = await this.#loadWorkflowFunction(activation.workflowType)
+    const instance = new WorkflowInstance({
+      runId: activation.runId,
+      workflowId: activation.workflowId,
+      workflowType: activation.workflowType,
+      workflowFn,
+    })
+    this.#instances.set(activation.runId, instance)
+    return instance
+  }
+
+  async #loadWorkflowFunction(workflowType: string): Promise<WorkflowFunction> {
+    const cached = this.#functionCache.get(workflowType)
+    if (cached) {
+      return cached
+    }
+
+    const moduleSpecifier = buildWorkflowSpecifier(this.#workflowsPath, workflowType)
+    const mod = await import(moduleSpecifier)
+    const fn = resolveWorkflowFunction(mod, workflowType)
+    this.#functionCache.set(workflowType, fn)
+    return fn
+  }
+}
+
+const serializeWorkflowError = (error: unknown): SerializedWorkflowError => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    }
+  }
+
+  return {
+    message: typeof error === 'string' ? error : JSON.stringify(error),
+  }
+}
+
+const buildWorkflowSpecifier = (workflowsPath: string, workflowType: string): string => {
+  const base = resolveSpecifier(workflowsPath)
+  const separator = base.includes('?') ? '&' : '?'
+  return `${base}${separator}workflow=${encodeURIComponent(workflowType)}`
+}
+
+const resolveSpecifier = (workflowsPath: string): string => {
+  if (
+    workflowsPath.startsWith('file:') ||
+    workflowsPath.startsWith('http://') ||
+    workflowsPath.startsWith('https://')
+  ) {
+    return workflowsPath
+  }
+  const absolute = isAbsolute(workflowsPath) ? workflowsPath : resolve(workflowsPath)
+  return pathToFileURL(absolute).href
+}
+
+const resolveWorkflowFunction = (moduleExports: Record<string, unknown>, workflowType: string): WorkflowFunction => {
+  const candidate = moduleExports[workflowType]
+  if (typeof candidate === 'function') {
+    return candidate as WorkflowFunction
+  }
+
+  if (moduleExports.default && typeof (moduleExports.default as Record<string, unknown>)[workflowType] === 'function') {
+    return (moduleExports.default as Record<string, WorkflowFunction>)[workflowType]
+  }
+
+  throw new Error(`Workflow \"${workflowType}\" not found in loaded module`)
+}

--- a/packages/temporal-bun-sdk/src/worker/polling-loop.ts
+++ b/packages/temporal-bun-sdk/src/worker/polling-loop.ts
@@ -1,0 +1,43 @@
+const DEFAULT_IDLE_DELAY_MS = 10
+
+export interface PollingLoopOptions<T> {
+  signal: AbortSignal
+  poll: () => Promise<T | null> | T | null
+  handler: (value: T) => Promise<void> | void
+  onError?: (error: unknown) => void
+  idleDelayMs?: number
+}
+
+export const createPollingLoop = async <T>(options: PollingLoopOptions<T>): Promise<void> => {
+  const { signal, poll, handler, onError, idleDelayMs = DEFAULT_IDLE_DELAY_MS } = options
+
+  while (!signal.aborted) {
+    try {
+      const value = await poll()
+      if (signal.aborted) {
+        break
+      }
+
+      if (value == null) {
+        if (idleDelayMs > 0) {
+          await wait(idleDelayMs)
+        }
+        continue
+      }
+
+      await handler(value)
+    } catch (error) {
+      if (signal.aborted) {
+        break
+      }
+      onError?.(error)
+      if (idleDelayMs > 0) {
+        await wait(idleDelayMs)
+      }
+    }
+  }
+}
+
+const wait = async (delayMs: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, delayMs))
+}

--- a/packages/temporal-bun-sdk/src/worker/runtime.ts
+++ b/packages/temporal-bun-sdk/src/worker/runtime.ts
@@ -1,37 +1,629 @@
-const WORKER_DOC = 'packages/temporal-bun-sdk/docs/worker-runtime.md'
+import { createClient, type Client, type ClientOptions } from '../core-bridge/client.ts'
+import { createRuntime, type Runtime } from '../core-bridge/runtime.ts'
+import { native, type NativeWorker } from '../internal/worker/native.ts'
+import {
+  WorkflowIsolateManager,
+  type WorkflowActivation,
+  type WorkflowCompletion,
+  type WorkflowActivationJob,
+} from './isolate-manager.ts'
+import { createPollingLoop } from './polling-loop.ts'
 
-const notImplemented = (feature: string): never => {
-  throw new Error(`${feature} is not implemented yet. See ${WORKER_DOC} for implementation guidance.`)
-}
+const DEFAULT_WORKFLOW_CONCURRENCY = 8
+const DEFAULT_ACTIVITY_CONCURRENCY = 16
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000
+const MIN_HEARTBEAT_INTERVAL_MS = 100
+
+const textDecoder = new TextDecoder()
+
+export type ActivityFunction = (...args: unknown[]) => unknown | Promise<unknown>
+
+export type ActivityRegistryInput =
+  | Record<string, ActivityFunction>
+  | Map<string, ActivityFunction>
+  | Iterable<[string, ActivityFunction]>
 
 export interface WorkerRuntimeOptions {
   workflowsPath: string
-  activities?: Record<string, (...args: unknown[]) => unknown>
-  taskQueue?: string
-  namespace?: string
+  activities?: ActivityRegistryInput
+  taskQueue: string
+  namespace: string
+  clientOptions: ClientOptions
+  runtimeOptions?: Record<string, unknown>
   concurrency?: { workflow?: number; activity?: number }
 }
 
+interface ActivityTaskPayload {
+  taskToken: string
+  activityType: string
+  args: unknown[]
+  workflowRunId?: string
+  workflowId?: string
+  heartbeatDetails?: unknown
+  heartbeatTimeoutMs?: number
+  timeoutMs?: number
+}
+
+type ActivityCompletionOutcome = { status: 'completed'; result?: unknown } | { status: 'failed'; error: unknown }
+
+type WorkerState = 'idle' | 'running' | 'shutting-down' | 'stopped'
+
+interface Deferred<T> {
+  resolve(value: T | PromiseLike<T>): void
+  reject(reason?: unknown): void
+  promise: Promise<T>
+}
+
+const createDeferred = <T>(): Deferred<T> => {
+  let resolve!: Deferred<T>['resolve']
+  let reject!: Deferred<T>['reject']
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { resolve, reject, promise }
+}
+
 export class WorkerRuntime {
-  constructor(private readonly options: WorkerRuntimeOptions) {
-    void options
-    // TODO(codex): Initialize native worker handles and runtime scaffolding per WORKER_DOC §1–§3.
-  }
-
   static async create(options: WorkerRuntimeOptions): Promise<WorkerRuntime> {
-    // TODO(codex): Build async factory that wires Bun-native worker creation per WORKER_DOC §2.
-    void options
-    notImplemented('WorkerRuntime.create')
+    validateWorkerOptions(options)
+
+    const runtime = createRuntime({ options: options.runtimeOptions })
+    const client = await createClient(runtime, {
+      ...options.clientOptions,
+      namespace: options.clientOptions.namespace ?? options.namespace,
+    })
+
+    const workerPayload: Record<string, unknown> = {
+      task_queue: options.taskQueue,
+      namespace: options.namespace ?? options.clientOptions.namespace,
+      max_concurrent_workflow_tasks: options.concurrency?.workflow ?? DEFAULT_WORKFLOW_CONCURRENCY,
+      max_concurrent_activity_tasks: options.concurrency?.activity ?? DEFAULT_ACTIVITY_CONCURRENCY,
+    }
+
+    const workerHandle = native.createWorker(runtime.nativeHandle, client.nativeHandle, workerPayload)
+
+    return new WorkerRuntime({
+      options,
+      runtime,
+      client,
+      worker: workerHandle,
+      workflowConcurrency: workerPayload.max_concurrent_workflow_tasks as number,
+      activityConcurrency: workerPayload.max_concurrent_activity_tasks as number,
+      activities: normalizeActivities(options.activities),
+    })
   }
 
-  async run(): Promise<never> {
-    // TODO(codex): Kick off workflow and activity polling loops (WORKER_DOC §3).
-    notImplemented('WorkerRuntime.run')
+  #state: WorkerState = 'idle'
+  #runtime: Runtime
+  #client: Client
+  #worker: NativeWorker
+  #workflowManager: WorkflowIsolateManager
+  #workflowConcurrency: number
+  #activityConcurrency: number
+  #activities: Map<string, ActivityFunction>
+  #workflowAbort?: AbortController
+  #activityAbort?: AbortController
+  #workflowLoops: Promise<void>[] = []
+  #activityLoops: Promise<void>[] = []
+  #pollingPromise?: Promise<void>
+  #shutdownDeferred = createDeferred<void>()
+  #shutdownPromise?: Promise<void>
+  #activeWorkflowTasks = 0
+  #activeActivityTasks = 0
+  #stopped = false
+
+  private constructor(params: {
+    options: WorkerRuntimeOptions
+    runtime: Runtime
+    client: Client
+    worker: NativeWorker
+    workflowConcurrency: number
+    activityConcurrency: number
+    activities: Map<string, ActivityFunction>
+  }) {
+    this.options = params.options
+    this.#runtime = params.runtime
+    this.#client = params.client
+    this.#worker = params.worker
+    this.#workflowManager = new WorkflowIsolateManager(params.options.workflowsPath)
+    this.#workflowConcurrency = params.workflowConcurrency
+    this.#activityConcurrency = params.activityConcurrency
+    this.#activities = params.activities
   }
 
-  async shutdown(_gracefulTimeoutMs?: number): Promise<never> {
-    // TODO(codex): Implement graceful shutdown semantics before swapping out the Node worker bridge.
-    void _gracefulTimeoutMs
-    notImplemented('WorkerRuntime.shutdown')
+  readonly options: WorkerRuntimeOptions
+
+  get state(): WorkerState {
+    return this.#state
   }
+
+  get activeWorkflowTasks(): number {
+    return this.#activeWorkflowTasks
+  }
+
+  get activeActivityTasks(): number {
+    return this.#activeActivityTasks
+  }
+
+  async run(): Promise<void> {
+    if (this.#state === 'stopped') {
+      throw new Error('WorkerRuntime has already been shut down')
+    }
+    if (this.#state === 'running') {
+      throw new Error('WorkerRuntime is already running')
+    }
+    if (this.#state === 'shutting-down') {
+      throw new Error('WorkerRuntime is shutting down')
+    }
+
+    this.#state = 'running'
+    this.#workflowAbort = new AbortController()
+    this.#activityAbort = new AbortController()
+
+    this.#workflowLoops = Array.from({ length: this.#workflowConcurrency }, () =>
+      createPollingLoop({
+        signal: this.#workflowAbort!.signal,
+        poll: () => native.pollWorkflowTask(this.#worker),
+        handler: async (payload) => {
+          this.#activeWorkflowTasks += 1
+          try {
+            await this.#handleWorkflowTask(payload)
+          } finally {
+            this.#activeWorkflowTasks -= 1
+          }
+        },
+        onError: (error) => this.#handleLoopError('workflow', error),
+      }),
+    )
+    this.#activityLoops = Array.from({ length: this.#activityConcurrency }, () =>
+      createPollingLoop({
+        signal: this.#activityAbort!.signal,
+        poll: () => native.pollActivityTask(this.#worker),
+        handler: async (payload) => {
+          this.#activeActivityTasks += 1
+          try {
+            await this.#handleActivityTask(payload)
+          } finally {
+            this.#activeActivityTasks -= 1
+          }
+        },
+        onError: (error) => this.#handleLoopError('activity', error),
+      }),
+    )
+
+    this.#pollingPromise = Promise.allSettled([...this.#workflowLoops, ...this.#activityLoops]).then(() => {
+      if (!this.#stopped) {
+        this.#shutdownDeferred.resolve()
+      }
+    })
+
+    await this.#shutdownDeferred.promise
+  }
+
+  async shutdown(gracefulTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS): Promise<void> {
+    if (this.#stopped) {
+      return
+    }
+
+    if (!this.#shutdownPromise) {
+      this.#shutdownPromise = this.#performShutdown(gracefulTimeoutMs)
+    }
+
+    await this.#shutdownPromise
+  }
+
+  async #performShutdown(gracefulTimeoutMs: number): Promise<void> {
+    if (this.#state === 'idle') {
+      this.#state = 'shutting-down'
+    } else if (this.#state === 'running') {
+      this.#state = 'shutting-down'
+    } else if (this.#state === 'stopped') {
+      return
+    }
+
+    try {
+      native.initiateShutdown(this.#worker)
+    } catch (error) {
+      this.#handleLoopError('worker', error)
+    }
+
+    this.#workflowAbort?.abort()
+    this.#activityAbort?.abort()
+
+    const waitForLoops = async (): Promise<void> => {
+      if (!this.#pollingPromise) return
+      await this.#pollingPromise
+    }
+
+    try {
+      await settleWithTimeout(waitForLoops(), gracefulTimeoutMs)
+    } catch (error) {
+      this.#handleLoopError('worker', error)
+    }
+
+    try {
+      native.finalizeShutdown(this.#worker)
+    } catch (error) {
+      this.#handleLoopError('worker', error)
+    }
+
+    try {
+      await this.#workflowManager.shutdown()
+    } catch (error) {
+      this.#handleLoopError('worker', error)
+    }
+
+    native.workerShutdown(this.#worker)
+
+    const shutdownResults = await Promise.allSettled([this.#client.shutdown(), this.#runtime.shutdown()])
+    shutdownResults.forEach((result) => {
+      if (result.status === 'rejected') {
+        this.#handleLoopError('worker', result.reason)
+      }
+    })
+
+    this.#stopped = true
+    this.#state = 'stopped'
+    this.#shutdownDeferred.resolve()
+  }
+
+  async #handleWorkflowTask(payload: Uint8Array): Promise<void> {
+    const activation = decodeWorkflowActivation(payload)
+    let completion: WorkflowCompletion
+    try {
+      completion = await this.#workflowManager.execute(activation)
+    } catch (error) {
+      completion = buildWorkflowFailure(activation, error)
+    }
+
+    try {
+      native.completeWorkflowTask(this.#worker, { ...completion } as Record<string, unknown>)
+    } catch (error) {
+      this.#handleLoopError('workflow', error)
+    }
+  }
+
+  async #handleActivityTask(payload: Uint8Array): Promise<void> {
+    const task = decodeActivityTask(payload)
+    const activity = this.#activities.get(task.activityType)
+
+    if (!activity) {
+      this.#completeActivity(task, {
+        status: 'failed',
+        error: new Error(`Activity \"${task.activityType}\" is not registered`),
+      })
+      return
+    }
+
+    const stopHeartbeat = this.#startActivityHeartbeat(task)
+
+    try {
+      const result = await runWithTimeout(Promise.resolve(activity(...task.args)), task.timeoutMs)
+      stopHeartbeat()
+      this.#completeActivity(task, { status: 'completed', result })
+    } catch (error) {
+      stopHeartbeat()
+      this.#completeActivity(task, { status: 'failed', error })
+    }
+  }
+
+  #handleLoopError(scope: 'workflow' | 'activity' | 'worker', error: unknown): void {
+    const message = error instanceof Error ? (error.stack ?? error.message) : String(error)
+    console.error(`[temporal-bun-sdk] ${scope} loop error: ${message}`)
+  }
+
+  #completeActivity(task: ActivityTaskPayload, outcome: ActivityCompletionOutcome): void {
+    const payload = buildActivityCompletion(task, outcome)
+    try {
+      native.completeActivityTask(this.#worker, payload)
+    } catch (error) {
+      this.#handleLoopError('activity', error)
+    }
+  }
+
+  #startActivityHeartbeat(task: ActivityTaskPayload): () => void {
+    const intervalMs = normalizeHeartbeatInterval(task.heartbeatTimeoutMs)
+    if (!intervalMs) {
+      return () => {}
+    }
+
+    let active = true
+    const sendHeartbeat = () => {
+      if (!active) return
+      try {
+        native.recordActivityHeartbeat(this.#worker, {
+          taskToken: task.taskToken,
+          details: task.heartbeatDetails ?? null,
+        })
+      } catch (error) {
+        this.#handleLoopError('activity', error)
+      }
+    }
+
+    sendHeartbeat()
+    const timer = setInterval(sendHeartbeat, intervalMs)
+
+    return () => {
+      active = false
+      clearInterval(timer)
+    }
+  }
+}
+
+const decodeWorkflowActivation = (payload: Uint8Array): WorkflowActivation => {
+  const data = parseJsonPayload<Record<string, unknown>>(payload, 'workflow activation')
+  const taskToken = requireString(data.taskToken, 'workflow activation taskToken')
+  const runId = requireString(data.runId ?? data.workflowRunId, 'workflow activation runId')
+  const workflowId = requireString(data.workflowId ?? runId, 'workflow activation workflowId')
+  const workflowType = requireString(data.workflowType, 'workflow activation workflowType')
+
+  const jobPayload = data.job
+  if (!jobPayload || typeof jobPayload !== 'object') {
+    throw new Error('Workflow activation is missing job payload')
+  }
+
+  const jobRecord = jobPayload as Record<string, unknown>
+  const jobType = requireString(jobRecord.type, 'workflow activation job.type')
+  const args = jobRecord.args == null ? [] : ensureArray(jobRecord.args)
+
+  let job: WorkflowActivationJob
+  switch (jobType) {
+    case 'start':
+      job = { type: 'start', args }
+      break
+    case 'signal': {
+      const signalName = requireString(jobRecord.signalName, 'workflow activation job.signalName')
+      job = { type: 'signal', args, signalName }
+      break
+    }
+    case 'shutdown':
+      job = { type: 'shutdown', args }
+      break
+    default:
+      throw new Error(`Unsupported workflow activation job type: ${jobType}`)
+  }
+
+  return {
+    taskToken,
+    runId,
+    workflowId,
+    workflowType,
+    job,
+  }
+}
+
+const decodeActivityTask = (payload: Uint8Array): ActivityTaskPayload => {
+  const data = parseJsonPayload<Record<string, unknown>>(payload, 'activity task')
+  const taskToken = requireString(data.taskToken, 'activity task taskToken')
+  const activityType = requireString(data.activityType ?? data.activity_name, 'activity task activityType')
+
+  const argsSource = data.args ?? data.input ?? []
+  const args = Array.isArray(argsSource) ? argsSource : [argsSource]
+
+  const heartbeatTimeoutMs = toNumber(data.heartbeatTimeoutMs ?? data.heartbeat_timeout_ms)
+  const timeoutMs =
+    toNumber(data.startToCloseTimeoutMs ?? data.start_to_close_timeout_ms) ??
+    toNumber(data.scheduleToCloseTimeoutMs ?? data.schedule_to_close_timeout_ms)
+
+  return {
+    taskToken,
+    activityType,
+    args,
+    workflowRunId: typeof data.workflowRunId === 'string' ? data.workflowRunId : undefined,
+    workflowId: typeof data.workflowId === 'string' ? data.workflowId : undefined,
+    heartbeatDetails: data.heartbeatDetails ?? data.heartbeat_details,
+    heartbeatTimeoutMs: heartbeatTimeoutMs ?? undefined,
+    timeoutMs: timeoutMs ?? undefined,
+  }
+}
+
+const buildWorkflowFailure = (activation: WorkflowActivation, error: unknown): WorkflowCompletion => ({
+  taskToken: activation.taskToken,
+  runId: activation.runId,
+  workflowId: activation.workflowId,
+  status: 'failed',
+  error: serializeError(error),
+})
+
+const buildActivityCompletion = (
+  task: ActivityTaskPayload,
+  outcome: ActivityCompletionOutcome,
+): Record<string, unknown> => {
+  const base: Record<string, unknown> = {
+    taskToken: task.taskToken,
+    workflowRunId: task.workflowRunId,
+    workflowId: task.workflowId,
+  }
+
+  if (outcome.status === 'completed') {
+    if (outcome.result !== undefined) {
+      base.result = outcome.result
+    }
+    return { ...base, status: 'completed' }
+  }
+
+  return {
+    ...base,
+    status: 'failed',
+    error: serializeError(outcome.error),
+  }
+}
+
+const parseJsonPayload = <T>(payload: Uint8Array, description: string): T => {
+  try {
+    const json = textDecoder.decode(payload)
+    return JSON.parse(json) as T
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to parse ${description} payload: ${message}`)
+  }
+}
+
+const requireString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Expected ${field} to be a non-empty string`)
+  }
+  return value
+}
+
+const ensureArray = (value: unknown): unknown[] => {
+  if (Array.isArray(value)) {
+    return value
+  }
+  return [value]
+}
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+  return undefined
+}
+
+const serializeError = (error: unknown): { name?: string; message: string; stack?: string } => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    }
+  }
+
+  if (typeof error === 'string') {
+    return { message: error }
+  }
+
+  return {
+    message: JSON.stringify(error),
+  }
+}
+
+const normalizeHeartbeatInterval = (timeoutMs?: number): number | undefined => {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return undefined
+  }
+  const half = Math.floor(timeoutMs / 2)
+  return Math.max(half, MIN_HEARTBEAT_INTERVAL_MS)
+}
+
+const runWithTimeout = async <T>(promise: Promise<T>, timeoutMs?: number): Promise<T> => {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return await promise
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`Activity timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
+function normalizeActivities(input?: ActivityRegistryInput): Map<string, ActivityFunction> {
+  const registry = new Map<string, ActivityFunction>()
+  if (!input) return registry
+
+  if (input instanceof Map) {
+    for (const [name, fn] of input) {
+      assertActivity(name, fn)
+      registry.set(name, fn)
+    }
+    return registry
+  }
+
+  if (Array.isArray(input)) {
+    for (const entry of input as Array<[string, ActivityFunction]>) {
+      const [name, fn] = entry
+      assertActivity(name, fn)
+      registry.set(name, fn)
+    }
+    return registry
+  }
+
+  if (typeof (input as Iterable<[string, ActivityFunction]>)[Symbol.iterator] === 'function') {
+    for (const [name, fn] of input as Iterable<[string, ActivityFunction]>) {
+      assertActivity(name, fn)
+      registry.set(name, fn)
+    }
+    return registry
+  }
+
+  Object.entries(input as Record<string, ActivityFunction>).forEach(([name, fn]) => {
+    assertActivity(name, fn)
+    registry.set(name, fn)
+  })
+
+  return registry
+}
+
+function assertActivity(name: string, fn: ActivityFunction): void {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error(`Invalid activity name: ${String(name)}`)
+  }
+  if (typeof fn !== 'function') {
+    throw new Error(`Activity "${name}" must be a function`)
+  }
+}
+
+function validateWorkerOptions(options: WorkerRuntimeOptions): void {
+  if (!options.workflowsPath) {
+    throw new Error('WorkerRuntime options require a workflowsPath')
+  }
+  if (!options.taskQueue) {
+    throw new Error('WorkerRuntime options require a taskQueue')
+  }
+  if (!options.namespace && !options.clientOptions.namespace) {
+    throw new Error('WorkerRuntime options require a namespace')
+  }
+  if (!options.clientOptions || !options.clientOptions.address) {
+    throw new Error('WorkerRuntime options require clientOptions.address')
+  }
+  const workflowConcurrency = options.concurrency?.workflow ?? DEFAULT_WORKFLOW_CONCURRENCY
+  const activityConcurrency = options.concurrency?.activity ?? DEFAULT_ACTIVITY_CONCURRENCY
+  if (workflowConcurrency <= 0) {
+    throw new Error('workflow concurrency must be greater than 0')
+  }
+  if (activityConcurrency <= 0) {
+    throw new Error('activity concurrency must be greater than 0')
+  }
+}
+
+async function settleWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  if (timeoutMs <= 0) {
+    return await promise
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race<T>([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('Worker shutdown timed out')), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
+async function wait(delayMs: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delayMs))
 }

--- a/packages/temporal-bun-sdk/tests/fixtures/workflows/example-workflows.ts
+++ b/packages/temporal-bun-sdk/tests/fixtures/workflows/example-workflows.ts
@@ -1,0 +1,7 @@
+export const exampleWorkflow = async (name: string): Promise<string> => {
+  return `Hello, ${name}!`
+}
+
+export const failingWorkflow = async (): Promise<never> => {
+  throw new Error('intentional failure')
+}

--- a/packages/temporal-bun-sdk/tests/worker.runtime.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker.runtime.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { fileURLToPath } from 'node:url'
+import { WorkerRuntime, type ActivityRegistryInput } from '../src/worker/runtime.ts'
+import { native as workerNative } from '../src/internal/worker/native.ts'
+import {
+  native as coreNative,
+  type NativeClient,
+  type Runtime as NativeRuntime,
+} from '../src/internal/core-bridge/native.ts'
+import type { NativeWorker } from '../src/internal/worker/native.ts'
+
+const WORKFLOWS_PATH = fileURLToPath(new URL('./fixtures/workflows/example-workflows.ts', import.meta.url))
+const textEncoder = new TextEncoder()
+
+const encode = (payload: unknown): Uint8Array => textEncoder.encode(JSON.stringify(payload))
+
+const wait = async (ms: number): Promise<void> => await new Promise((resolve) => setTimeout(resolve, ms))
+
+const waitFor = async (predicate: () => boolean, timeoutMs = 1_000, intervalMs = 10): Promise<void> => {
+  const deadline = Date.now() + timeoutMs
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error('Timed out waiting for condition')
+    }
+    await wait(intervalMs)
+  }
+}
+
+describe('WorkerRuntime', () => {
+  const originalWorkerNative = { ...workerNative }
+  const originalCoreNative = { ...coreNative }
+
+  let workflowTasks: Uint8Array[]
+  let activityTasks: Uint8Array[]
+  let workflowCompletions: unknown[]
+  let activityCompletions: unknown[]
+  let heartbeats: unknown[]
+  let shutdownCalls: number
+  let finalizeCalls: number
+  let workerFreed: boolean
+  let runtimeShutdownCalls: number
+  let clientShutdownCalls: number
+
+  const runtimeHandle: NativeRuntime = { type: 'runtime', handle: 101 }
+  const clientHandle: NativeClient = { type: 'client', handle: 202 }
+  const workerHandle: NativeWorker = { type: 'worker', handle: 303 }
+
+  beforeEach(() => {
+    workflowTasks = []
+    activityTasks = []
+    workflowCompletions = []
+    activityCompletions = []
+    heartbeats = []
+    shutdownCalls = 0
+    finalizeCalls = 0
+    workerFreed = false
+    runtimeShutdownCalls = 0
+    clientShutdownCalls = 0
+
+    workerNative.createWorker = mock(() => workerHandle)
+    workerNative.workerShutdown = mock(() => {
+      workerFreed = true
+    })
+    workerNative.pollWorkflowTask = mock(() => workflowTasks.shift() ?? null)
+    workerNative.pollActivityTask = mock(() => activityTasks.shift() ?? null)
+    workerNative.completeWorkflowTask = mock((_worker, payload: unknown) => {
+      workflowCompletions.push(payload)
+    })
+    workerNative.completeActivityTask = mock((_worker, payload: unknown) => {
+      activityCompletions.push(payload)
+    })
+    workerNative.recordActivityHeartbeat = mock((_worker, payload: unknown) => {
+      heartbeats.push(payload)
+    })
+    workerNative.initiateShutdown = mock(() => {
+      shutdownCalls += 1
+    })
+    workerNative.finalizeShutdown = mock(() => {
+      finalizeCalls += 1
+    })
+
+    coreNative.createRuntime = mock(() => runtimeHandle)
+    coreNative.runtimeShutdown = mock(() => {
+      runtimeShutdownCalls += 1
+    })
+    coreNative.createClient = mock(async () => clientHandle)
+    coreNative.clientShutdown = mock(() => {
+      clientShutdownCalls += 1
+    })
+  })
+
+  afterEach(() => {
+    Object.assign(workerNative, originalWorkerNative)
+    Object.assign(coreNative, originalCoreNative)
+  })
+
+  test('processes workflow tasks and completes', async () => {
+    const runtime = await createRuntime({ activities: {} })
+    const runPromise = runtime.run()
+
+    workflowTasks.push(
+      encode({
+        taskToken: 'wf-1',
+        runId: 'run-1',
+        workflowId: 'workflow-1',
+        workflowType: 'exampleWorkflow',
+        job: { type: 'start', args: ['Temporal Bun'] },
+      }),
+    )
+
+    await waitFor(() => workflowCompletions.length === 1)
+
+    expect(workflowCompletions[0]).toEqual({
+      taskToken: 'wf-1',
+      runId: 'run-1',
+      workflowId: 'workflow-1',
+      status: 'completed',
+      result: 'Hello, Temporal Bun!',
+    })
+
+    await runtime.shutdown()
+    await runPromise
+
+    expect(shutdownCalls).toBe(1)
+    expect(finalizeCalls).toBe(1)
+    expect(workerFreed).toBe(true)
+  })
+
+  test('records heartbeats for long running activities', async () => {
+    const activities: ActivityRegistryInput = {
+      slowEcho: async (value: string) => {
+        await wait(150)
+        return `activity:${value}`
+      },
+    }
+
+    const runtime = await createRuntime({ activities })
+    const runPromise = runtime.run()
+
+    activityTasks.push(
+      encode({
+        taskToken: 'activity-1',
+        activityType: 'slowEcho',
+        args: ['payload'],
+        heartbeatTimeoutMs: 200,
+      }),
+    )
+
+    await waitFor(() => activityCompletions.length === 1)
+
+    expect(activityCompletions[0]).toEqual({
+      taskToken: 'activity-1',
+      workflowRunId: undefined,
+      workflowId: undefined,
+      status: 'completed',
+      result: 'activity:payload',
+    })
+    expect(heartbeats.length).toBeGreaterThanOrEqual(1)
+    expect(heartbeats[0]).toEqual({
+      taskToken: 'activity-1',
+      details: null,
+    })
+
+    await runtime.shutdown()
+    await runPromise
+  })
+
+  test('shutdown finalizes native worker lifecycle', async () => {
+    const runtime = await createRuntime({ activities: {} })
+    const runPromise = runtime.run()
+
+    await wait(20)
+
+    await runtime.shutdown()
+    await runPromise
+
+    expect(shutdownCalls).toBe(1)
+    expect(finalizeCalls).toBe(1)
+    expect(workerFreed).toBe(true)
+    expect(clientShutdownCalls).toBe(1)
+    expect(runtimeShutdownCalls).toBe(1)
+  })
+
+  const createRuntime = async ({
+    activities = {},
+    workflowsPath = WORKFLOWS_PATH,
+  }: {
+    activities?: ActivityRegistryInput
+    workflowsPath?: string
+  }): Promise<WorkerRuntime> => {
+    return await WorkerRuntime.create({
+      workflowsPath,
+      activities,
+      taskQueue: 'test-task-queue',
+      namespace: 'default',
+      concurrency: { workflow: 1, activity: 1 },
+      clientOptions: {
+        address: '127.0.0.1:7233',
+        namespace: 'default',
+        identity: 'worker-runtime-test',
+      },
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- add Bun worker native bindings and runtime orchestration
- replace legacy worker entrypoints and CLI scaffolding with WorkerRuntime
- introduce polling/isolate helpers and coverage for workflow + activity loops

## Testing
- pnpm --filter @proompteng/temporal-bun-sdk build *(fails: repository lacks vendored SDK + TypeScript ts-extension support)*
- pnpm --filter @proompteng/temporal-bun-sdk test *(fails: native Temporal bridge library is not built; tests mock after load)*

Closes #1454