### PR TITLE
feat: bridge Temporal core logging into Bun runtime

### DIFF
--- a/packages/temporal-bun-sdk/docs/ffi-surface.md
+++ b/packages/temporal-bun-sdk/docs/ffi-surface.md
@@ -39,7 +39,7 @@ Current progress snapshot:
 | Runtime | `temporal_bun_runtime_new(options_ptr, len)` | Create `CoreRuntime` with telemetry/logging config | `native.createRuntime` (extend options) | ✅ (options ignored today) |
 | Runtime | `temporal_bun_runtime_free(runtime_ptr)` | Release runtime | `native.runtimeShutdown` | ✅ |
 | Runtime | `temporal_bun_runtime_update_telemetry(runtime_ptr, options_ptr, len)` | Apply telemetry exporters (Prom, OTLP) | `coreBridge.configureTelemetry` | ⬜️ TODO |
-| Runtime | `temporal_bun_runtime_set_logger(runtime_ptr, callback_ptr)` | Forward core logs into Bun | `coreBridge.installLogger` | ⬜️ TODO |
+| Runtime | `temporal_bun_runtime_set_logger(runtime_ptr, callback_ptr)` | Forward core logs into Bun | `coreBridge.installLogger` | ✅ Implemented |
 | Client | `temporal_bun_client_connect_async(runtime_ptr, config_ptr, len)` | Create gRPC retry client + namespace | `native.createClient` | ✅ (async pending handle) |
 | Client | `temporal_bun_client_free(client_ptr)` | Dispose client | `native.clientShutdown` | ✅ |
 | Client | `temporal_bun_client_describe_namespace_async(client_ptr, payload_ptr, len)` | Describe namespace via async pending handle | `native.describeNamespace` | ✅ (new) |

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.lock
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.lock
@@ -2116,6 +2116,8 @@ dependencies = [
  "temporal-sdk-core-protos",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
+ "tracing-core",
  "url",
  "uuid",
 ]

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.toml
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/Cargo.toml
@@ -20,3 +20,5 @@ prost = "0.14"
 prost-wkt-types = "0.7"
 base64 = "0.22"
 uuid = { version = "1", features = ["v4"] }
+tracing = "0.1"
+tracing-core = "0.1"

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/lib.rs
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge/src/lib.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::sync::mpsc::channel;
-use std::sync::Arc;
+use std::fmt;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::str;
+use std::sync::{mpsc::channel, Arc, RwLock};
 use std::thread;
 
 use base64::{engine::general_purpose, Engine as _};
@@ -12,8 +14,10 @@ use temporal_client::{
     tonic::IntoRequest, ClientOptionsBuilder, ClientTlsConfig, ConfiguredClient, Namespace,
     RetryClient, TemporalServiceClient, TlsConfig, WorkflowService,
 };
-use temporal_sdk_core::{CoreRuntime, TokioRuntimeBuilder};
-use temporal_sdk_core_api::telemetry::TelemetryOptions;
+use temporal_sdk_core::{CoreRuntime, TokioRuntimeBuilder, telemetry::construct_filter_string};
+use temporal_sdk_core_api::telemetry::{CoreLog, CoreLogConsumer, Logger, TelemetryOptionsBuilder};
+use tracing::Level as TracingLevel;
+use tracing_core::Level as TracingCoreLevel;
 use temporal_sdk_core_protos::temporal::api::common::v1::{
     Header, Memo, Payload, Payloads, RetryPolicy, SearchAttributes, WorkflowType,
 };
@@ -31,8 +35,147 @@ mod pending;
 type PendingClientHandle = pending::PendingResult<ClientHandle>;
 
 #[repr(C)]
+struct BunLogSlice {
+    data: *const u8,
+    len: usize,
+}
+
+impl BunLogSlice {
+    fn from_bytes(bytes: &[u8]) -> Self {
+        Self {
+            data: bytes.as_ptr(),
+            len: bytes.len(),
+        }
+    }
+}
+
+#[repr(C)]
+struct BunLogRecord {
+    level: i32,
+    timestamp_ms: u64,
+    target: BunLogSlice,
+    message: BunLogSlice,
+    fields_json: BunLogSlice,
+    spans_json: BunLogSlice,
+}
+
+type LoggerCallback = unsafe extern "C" fn(*const BunLogRecord);
+
+#[derive(Default)]
+struct LoggerState {
+    callback: RwLock<Option<LoggerCallback>>,
+}
+
+impl LoggerState {
+    fn set_callback(&self, callback: Option<LoggerCallback>) {
+        let mut guard = self.callback.write().expect("logger callback write lock");
+        *guard = callback;
+    }
+
+    fn get_callback(&self) -> Option<LoggerCallback> {
+        let guard = self.callback.read().expect("logger callback read lock");
+        *guard
+    }
+
+    fn clear(&self) {
+        self.set_callback(None);
+    }
+}
+
+#[repr(i32)]
+enum BunLogLevel {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+}
+
+impl From<TracingCoreLevel> for BunLogLevel {
+    fn from(level: TracingCoreLevel) -> Self {
+        match level {
+            TracingCoreLevel::TRACE => BunLogLevel::Trace,
+            TracingCoreLevel::DEBUG => BunLogLevel::Debug,
+            TracingCoreLevel::INFO => BunLogLevel::Info,
+            TracingCoreLevel::WARN => BunLogLevel::Warn,
+            TracingCoreLevel::ERROR => BunLogLevel::Error,
+        }
+    }
+}
+
+struct BunLogConsumer {
+    state: Arc<LoggerState>,
+}
+
+impl BunLogConsumer {
+    fn new(state: Arc<LoggerState>) -> Self {
+        Self { state }
+    }
+
+    fn dispatch(&self, log: CoreLog) {
+        let callback = match self.state.get_callback() {
+            Some(callback) => callback,
+            None => return,
+        };
+
+        let CoreLog {
+            target,
+            message,
+            timestamp,
+            level,
+            fields,
+            span_contexts,
+        } = log;
+
+        let target = target.into_bytes();
+        let message = message.into_bytes();
+        let fields_json = serde_json::to_vec(&fields).unwrap_or_else(|_| b"{}".to_vec());
+        let spans_json =
+            serde_json::to_vec(&span_contexts).unwrap_or_else(|_| b"[]".to_vec());
+
+        let record = BunLogRecord {
+            level: BunLogLevel::from(level) as i32,
+            timestamp_ms: timestamp
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
+            target: BunLogSlice::from_bytes(&target),
+            message: BunLogSlice::from_bytes(&message),
+            fields_json: BunLogSlice::from_bytes(&fields_json),
+            spans_json: BunLogSlice::from_bytes(&spans_json),
+        };
+
+        let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+            callback(&record);
+        }));
+
+        if result.is_err() {
+            eprintln!(
+                "temporal-bun-bridge: logger callback panicked; disabling logger forwarding"
+            );
+            self.state.clear();
+        }
+    }
+}
+
+impl CoreLogConsumer for BunLogConsumer {
+    fn on_log(&self, log: CoreLog) {
+        self.dispatch(log);
+    }
+}
+
+impl fmt::Debug for BunLogConsumer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<bun log consumer>")
+    }
+}
+
+#[repr(C)]
 pub struct RuntimeHandle {
     runtime: Arc<CoreRuntime>,
+    logger_state: Arc<LoggerState>,
 }
 
 #[repr(C)]
@@ -162,10 +305,28 @@ pub extern "C" fn temporal_bun_runtime_new(
     _options_ptr: *const u8,
     _options_len: usize,
 ) -> *mut c_void {
-    match CoreRuntime::new(TelemetryOptions::default(), TokioRuntimeBuilder::default()) {
+    let logger_state = Arc::new(LoggerState::default());
+    let consumer: Arc<dyn CoreLogConsumer> = Arc::new(BunLogConsumer::new(logger_state.clone()));
+
+    let telemetry_options = match TelemetryOptionsBuilder::default()
+        .logging(Logger::Push {
+            filter: construct_filter_string(TracingLevel::INFO, TracingLevel::WARN),
+            consumer,
+        })
+        .build()
+    {
+        Ok(options) => options,
+        Err(err) => {
+            error::set_error(format!("failed to configure Temporal telemetry: {err}"));
+            return std::ptr::null_mut();
+        }
+    };
+
+    match CoreRuntime::new(telemetry_options, TokioRuntimeBuilder::default()) {
         Ok(runtime) => {
             let handle = RuntimeHandle {
                 runtime: Arc::new(runtime),
+                logger_state,
             };
             Box::into_raw(Box::new(handle)) as *mut c_void
         }
@@ -183,7 +344,8 @@ pub extern "C" fn temporal_bun_runtime_free(handle: *mut c_void) {
     }
 
     unsafe {
-        let _ = Box::from_raw(handle as *mut RuntimeHandle);
+        let handle = Box::from_raw(handle as *mut RuntimeHandle);
+        handle.logger_state.clear();
     }
 }
 
@@ -204,9 +366,73 @@ pub extern "C" fn temporal_bun_runtime_set_logger(
     _runtime_ptr: *mut c_void,
     _callback_ptr: *mut c_void,
 ) -> i32 {
-    // TODO(codex): Wire native Core logging into Bun callbacks per docs/ffi-surface.md.
-    error::set_error("temporal_bun_runtime_set_logger is not implemented yet".to_string());
-    -1
+    let handle = match runtime_handle_from_ptr(_runtime_ptr) {
+        Ok(handle) => handle,
+        Err(err) => {
+            error::set_error(err.to_string());
+            return -1;
+        }
+    };
+
+    if _callback_ptr.is_null() {
+        handle.logger_state.clear();
+        return 0;
+    }
+
+    let callback: LoggerCallback = unsafe { std::mem::transmute(_callback_ptr) };
+    handle.logger_state.set_callback(Some(callback));
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn temporal_bun_runtime_emit_test_log(
+    runtime_ptr: *mut c_void,
+    level: i32,
+    message_ptr: *const u8,
+    message_len: usize,
+) -> i32 {
+    let _ = match runtime_handle_from_ptr(runtime_ptr) {
+        Ok(handle) => handle,
+        Err(err) => {
+            error::set_error(err.to_string());
+            return -1;
+        }
+    };
+
+    let message = if message_ptr.is_null() || message_len == 0 {
+        "temporal-bun test log".to_string()
+    } else {
+        let bytes = unsafe { std::slice::from_raw_parts(message_ptr, message_len) };
+        match str::from_utf8(bytes) {
+            Ok(value) => value.to_string(),
+            Err(_) => {
+                error::set_error("log message must be valid UTF-8".to_string());
+                return -1;
+            }
+        }
+    };
+
+    let level = match level {
+        0 => TracingLevel::TRACE,
+        1 => TracingLevel::DEBUG,
+        2 => TracingLevel::INFO,
+        3 => TracingLevel::WARN,
+        4 => TracingLevel::ERROR,
+        _ => {
+            error::set_error("invalid log level".to_string());
+            return -1;
+        }
+    };
+
+    match level {
+        TracingLevel::TRACE => tracing::event!(target: "temporal_sdk_core::bridge::test", tracing::Level::TRACE, payload = %message, "{}", message),
+        TracingLevel::DEBUG => tracing::event!(target: "temporal_sdk_core::bridge::test", tracing::Level::DEBUG, payload = %message, "{}", message),
+        TracingLevel::INFO => tracing::event!(target: "temporal_sdk_core::bridge::test", tracing::Level::INFO, payload = %message, "{}", message),
+        TracingLevel::WARN => tracing::event!(target: "temporal_sdk_core::bridge::test", tracing::Level::WARN, payload = %message, "{}", message),
+        TracingLevel::ERROR => tracing::event!(target: "temporal_sdk_core::bridge::test", tracing::Level::ERROR, payload = %message, "{}", message),
+    };
+
+    0
 }
 
 #[unsafe(no_mangle)]
@@ -220,12 +446,17 @@ pub extern "C" fn temporal_bun_error_free(ptr: *mut u8, len: usize) {
 }
 
 fn runtime_from_ptr(ptr: *mut c_void) -> Result<Arc<CoreRuntime>, BridgeError> {
+    let handle = runtime_handle_from_ptr(ptr)?;
+    Ok(handle.runtime.clone())
+}
+
+fn runtime_handle_from_ptr(ptr: *mut c_void) -> Result<&'static RuntimeHandle, BridgeError> {
     if ptr.is_null() {
         return Err(BridgeError::InvalidRuntimeHandle);
     }
 
     let runtime = unsafe { &*(ptr as *mut RuntimeHandle) };
-    Ok(runtime.runtime.clone())
+    Ok(runtime)
 }
 
 fn config_from_raw(ptr: *const u8, len: usize) -> Result<ClientConfig, BridgeError> {

--- a/packages/temporal-bun-sdk/src/core-bridge/runtime.ts
+++ b/packages/temporal-bun-sdk/src/core-bridge/runtime.ts
@@ -1,11 +1,30 @@
-import { native, type Runtime as NativeRuntime } from '../internal/core-bridge/native.ts'
+import {
+  native,
+  type LogLevelName,
+  type NativeLogRecord,
+  type Runtime as NativeRuntime,
+} from '../internal/core-bridge/native.ts'
 
 export interface RuntimeOptions {
   readonly options?: Record<string, unknown>
 }
 
+export interface RuntimeLogRecord {
+  readonly level: number
+  readonly levelName: LogLevelName
+  readonly timestampMs: number
+  readonly timestamp: Date
+  readonly target: string
+  readonly message: string
+  readonly fields: Readonly<Record<string, unknown>>
+  readonly spanContexts: readonly string[]
+}
+
+export type RuntimeLogger = (record: RuntimeLogRecord) => void
+
 export class Runtime {
   #native: NativeRuntime | undefined
+  #loggerTeardown?: () => void
 
   static create(options: RuntimeOptions = {}): Runtime {
     return new Runtime(options)
@@ -29,13 +48,44 @@ export class Runtime {
     return native.configureTelemetry(this.nativeHandle, options)
   }
 
-  installLogger(callback: (...args: unknown[]) => void): never {
-    // TODO(codex): Forward Temporal Core logs into Bun via the native bridge per docs/ffi-surface.md.
-    return native.installLogger(this.nativeHandle, callback)
+  installLogger(callback: RuntimeLogger): () => void {
+    if (typeof callback !== 'function') {
+      throw new TypeError('installLogger expects a function callback')
+    }
+
+    const nativeRuntime = this.nativeHandle
+
+    if (this.#loggerTeardown) {
+      this.#loggerTeardown()
+      this.#loggerTeardown = undefined
+    }
+
+    let released = false
+
+    const teardownNative = native.installLogger(nativeRuntime, (record: NativeLogRecord) => {
+      callback(normalizeLogRecord(record))
+    })
+
+    const teardown = () => {
+      if (released) {
+        return
+      }
+      released = true
+      teardownNative()
+      if (this.#loggerTeardown === teardown) {
+        this.#loggerTeardown = undefined
+      }
+    }
+
+    this.#loggerTeardown = teardown
+    return teardown
   }
 
   async shutdown(): Promise<void> {
     if (!this.#native) return
+    const teardown = this.#loggerTeardown
+    this.#loggerTeardown = undefined
+    teardown?.()
     native.runtimeShutdown(this.#native)
     runtimeFinalizer.unregister(this)
     this.#native = undefined
@@ -57,3 +107,14 @@ export const createRuntime = (options: RuntimeOptions = {}): Runtime => Runtime.
 export const __TEST__ = {
   finalizeRuntime,
 }
+
+const normalizeLogRecord = (record: NativeLogRecord): RuntimeLogRecord => ({
+  level: record.level,
+  levelName: record.levelName,
+  timestampMs: record.timestampMs,
+  timestamp: new Date(record.timestampMs),
+  target: record.target,
+  message: record.message,
+  fields: Object.freeze({ ...record.fields }),
+  spanContexts: Object.freeze([...(record.spanContexts ?? [])]),
+})

--- a/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
+++ b/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
@@ -27,6 +27,7 @@ const {
     temporal_bun_runtime_free,
     temporal_bun_runtime_set_logger,
     temporal_bun_runtime_emit_test_log,
+    temporal_bun_log_record_free,
     temporal_bun_error_message,
     temporal_bun_error_free,
     temporal_bun_client_connect_async,
@@ -57,6 +58,10 @@ const {
   temporal_bun_runtime_emit_test_log: {
     args: [FFIType.ptr, FFIType.int32_t, FFIType.ptr, FFIType.uint64_t],
     returns: FFIType.int32_t,
+  },
+  temporal_bun_log_record_free: {
+    args: [FFIType.ptr],
+    returns: FFIType.void,
   },
   temporal_bun_error_message: {
     args: [FFIType.ptr],
@@ -282,16 +287,22 @@ export const native = {
         if (!recordPtr) {
           return
         }
-        const record = decodeLogRecord(Number(recordPtr))
+
+        const recordPointer = Number(recordPtr)
+        const record = decodeLogRecord(recordPointer)
+
         try {
           handler(record)
         } catch (error) {
           console.error('[temporal-bun-sdk] logger handler threw', error)
+        } finally {
+          temporal_bun_log_record_free(recordPointer)
         }
       },
       {
         args: [FFIType.ptr],
         returns: FFIType.void,
+        threads: true,
       },
     )
 


### PR DESCRIPTION
## Summary
- add native logger forwarding with Bun-consumable records and a test log helper
- wire native bridge symbols through JS FFI, keep callbacks alive via JSCallback, and expose native.installLogger/emitTestLog
- surface Runtime.installLogger with teardown tracking, add unit coverage, and mark docs runtime logger row as implemented

## Testing
- PROTOC_INCLUDE=/usr/include pnpm --filter @proompteng/temporal-bun-sdk run build:native
- pnpm --filter @proompteng/temporal-bun-sdk test
