### PR TITLE
feat: enable temporal application

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -141,7 +141,7 @@ spec:
             annotations:
               argocd.argoproj.io/sync-wave: "4"
             automation: auto
-            enabled: "false"
+            enabled: "true"
           - name: airbyte
             path: argocd/applications/airbyte
             namespace: airbyte


### PR DESCRIPTION
## Summary
- enable the temporal platform application in the ApplicationSet so Argo CD reconciles it

## Testing
- not run (config change)
