### PR TITLE
fix: auto-create french relay categories

### DIFF
--- a/apps/froussard/src/discord.test.ts
+++ b/apps/froussard/src/discord.test.ts
@@ -63,6 +63,119 @@ describe('chunkContent', () => {
   })
 })
 
+describe('createRelayChannel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (originalFetch) {
+      global.fetch = originalFetch
+    }
+  })
+
+  it('uses an existing category when capacity is available', async () => {
+    const fetchMock = vi.fn()
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          { id: 'category-1', type: 4, name: 'Codex Relay - Radiant Horizon' },
+          { id: 'channel-a', type: 0, parent_id: 'category-1' },
+        ]),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    )
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'channel-new' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const config = { botToken: 'token', guildId: 'guild', categoryId: 'category-1' }
+    const metadata = { repository: 'owner/repo', createdAt: new Date('2025-10-01T00:00:00Z') }
+
+    const result = await discord.createRelayChannel(config, metadata)
+
+    expect(result.categoryId).toBe('category-1')
+    expect(result.createdCategory).toBeFalsy()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://discord.com/api/v10/guilds/guild/channels',
+      expect.objectContaining({ method: 'GET' }),
+    )
+
+    const [, createRequest] = fetchMock.mock.calls[1] ?? []
+    expect(createRequest).toBeDefined()
+    const body = JSON.parse(((createRequest as RequestInit)?.body ?? '{}') as string)
+    expect(body.parent_id).toBe('category-1')
+  })
+
+  it('creates a new category with a fresh name when the configured one is full', async () => {
+    const fetchMock = vi.fn()
+    global.fetch = fetchMock as unknown as typeof global.fetch
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1)
+
+    try {
+      const channels = [
+        { id: 'category-1', type: 4, name: 'Production Codex' },
+        ...Array.from({ length: 50 }, (_, index) => ({
+          id: `channel-${index}`,
+          type: 0,
+          parent_id: 'category-1',
+        })),
+      ]
+
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify(channels), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'category-2' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'channel-new' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      const config = { botToken: 'token', guildId: 'guild', categoryId: 'category-1' }
+      const metadata = { repository: 'owner/repo', createdAt: new Date('2025-10-01T00:00:00Z') }
+
+      const result = await discord.createRelayChannel(config, metadata)
+
+      expect(result.categoryId).toBe('category-2')
+      expect(result.createdCategory).toBe(true)
+      expect(result.categoryName).toBe('Codex Relay - Sereine Salon')
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+
+      const createCategoryCall = fetchMock.mock.calls[1]
+      expect(createCategoryCall?.[0]).toBe('https://discord.com/api/v10/guilds/guild/channels')
+      const createCategoryBody = JSON.parse(((createCategoryCall?.[1] as RequestInit)?.body ?? '{}') as string)
+      expect(createCategoryBody.type).toBe(4)
+      expect(createCategoryBody.name).toBe('Codex Relay - Sereine Salon')
+
+      const createChannelCall = fetchMock.mock.calls[2]
+      const createChannelBody = JSON.parse(((createChannelCall?.[1] as RequestInit)?.body ?? '{}') as string)
+      expect(createChannelBody.parent_id).toBe('category-2')
+    } finally {
+      randomSpy.mockRestore()
+    }
+  })
+})
+
 describe('bootstrapRelay', () => {
   beforeEach(() => {
     delayMock.mockClear()
@@ -100,6 +213,12 @@ describe('bootstrapRelay', () => {
     const fetchMock = vi.fn()
     global.fetch = fetchMock as unknown as typeof global.fetch
     fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ id: 'channel-123' }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -126,13 +245,74 @@ describe('bootstrapRelay', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       'https://discord.com/api/v10/guilds/guild/channels',
-      expect.objectContaining({ method: 'POST' }),
+      expect.objectContaining({ method: 'GET' }),
     )
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
+      'https://discord.com/api/v10/guilds/guild/channels',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
       'https://discord.com/api/v10/channels/channel-123/messages',
       expect.objectContaining({ method: 'POST' }),
     )
+  })
+
+  it('echoes the newly created category name when a fresh category is required', async () => {
+    const fetchMock = vi.fn()
+    global.fetch = fetchMock as unknown as typeof global.fetch
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1)
+
+    try {
+      const channels = [
+        { id: 'category-1', type: 4, name: 'Production Codex' },
+        ...Array.from({ length: 50 }, (_, index) => ({
+          id: `channel-${index}`,
+          type: 0,
+          parent_id: 'category-1',
+        })),
+      ]
+
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify(channels), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'category-2' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'channel-abc' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      const config = { botToken: 'token', guildId: 'guild', categoryId: 'category-1' }
+      const metadata = { repository: 'owner/repo', createdAt: new Date('2025-10-01T00:00:00Z') }
+      const echoes: string[] = []
+
+      await discord.bootstrapRelay(config, metadata, { echo: (line) => echoes.push(line) })
+
+      expect(echoes[0]).toBe("Created Discord category 'Codex Relay - Sereine Salon' for Codex relay channels.")
+      expect(fetchMock).toHaveBeenCalledTimes(4)
+    } finally {
+      randomSpy.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
## Description

- add curated french adjective and noun lists for overflow relay categories
- detect full categories and create new discord parents before channel creation
- surface created category metadata and announce new categories during bootstrap
- extend relay tests to cover french naming and overflow behaviour
