### PR TITLE
fix: auto-create french relay categories

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -53,7 +53,7 @@ run:
     value: http/protobuf
 deploy:
   namespace: froussard
-  image: registry.ide-newton.ts.net/lab/froussard@sha256:b68ac30cac55092e02a583cc51150de4c99599ccfc1824c688d1289fba884482
+  image: registry.ide-newton.ts.net/lab/froussard@sha256:fc1b4a91fef8accb889ab693aaa0f547a1f1a12314c8f85bfa7eb48025860ead
   annotations:
     serving.knative.dev/revision-history-limit: "3"
   options:

--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -29,7 +29,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: user-container
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:b68ac30cac55092e02a583cc51150de4c99599ccfc1824c688d1289fba884482
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:fc1b4a91fef8accb889ab693aaa0f547a1f1a12314c8f85bfa7eb48025860ead
           env:
             - name: GITHUB_WEBHOOK_SECRET
               valueFrom:
@@ -70,9 +70,9 @@ spec:
             - name: OTEL_SERVICE_NAMESPACE
               value: froussard
             - name: FROUSSARD_VERSION
-              value: v0.249.0-5-g9672adbc
+              value: v0.254.1-1-g70ff585f
             - name: FROUSSARD_COMMIT
-              value: 9672adbc6770ca468fe34b77fba233c0dcfabd6f
+              value: 70ff585f21d12fc9d846cc661f983bd30d5b7221
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Description

- swap relay overflow naming to french-inspired adjective/noun pools
- auto-create codex relay categories when existing parents reach 50 channels
- emit category metadata during bootstrap for operators
- cover naming and overflow flows with additional unit tests

## Screenshots (if applicable)
N/A

## Testing
- pnpm --filter froussard test
- bun apps/froussard/scripts/deploy.ts

## Breaking Changes
None

## References
None
