### PR TITLE
fix: preserve symlinks in codex resume flow

### DIFF
--- a/apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -27,7 +28,7 @@ const bunUtils = vi.hoisted(() => ({
 vi.mock('bun', () => bunUtils)
 
 const runnerMocks = vi.hoisted(() => ({
-  runCodexSession: vi.fn(async () => ({ agentMessages: [] })),
+  runCodexSession: vi.fn(async () => ({ agentMessages: [], sessionId: 'session-xyz' })),
   pushCodexEventsToLoki: vi.fn(async () => {}),
 }))
 
@@ -77,8 +78,34 @@ describe('runCodexImplementation', () => {
     }
     await writeFile(eventPath, JSON.stringify(payload))
 
-    runCodexSessionMock.mockClear()
-    pushCodexEventsToLokiMock.mockClear()
+    const runGit = async (args: string[]) =>
+      await new Promise<void>((resolve, reject) => {
+        const proc = spawn('git', args, { cwd: workdir })
+        let stderr = ''
+        proc.stderr?.on('data', (chunk) => {
+          stderr += chunk.toString()
+        })
+        proc.on('error', reject)
+        proc.on('close', (code) => {
+          if (code === 0) {
+            resolve()
+          } else {
+            reject(new Error(`git ${args.join(' ')} exited with ${code}: ${stderr}`))
+          }
+        })
+      })
+
+    await runGit(['init'])
+    await runGit(['config', 'user.email', 'codex@example.com'])
+    await runGit(['config', 'user.name', 'Codex Tester'])
+    await writeFile(join(workdir, '.gitkeep'), '', 'utf8')
+    await runGit(['add', '.gitkeep'])
+    await runGit(['commit', '-m', 'chore: initial'])
+
+    runCodexSessionMock.mockReset()
+    runCodexSessionMock.mockImplementation(async () => ({ agentMessages: [], sessionId: 'session-xyz' }))
+    pushCodexEventsToLokiMock.mockReset()
+    pushCodexEventsToLokiMock.mockImplementation(async () => {})
     buildDiscordRelayCommandMock.mockClear()
     utilMocks.pathExists.mockImplementation(async (path: string) => !path.includes('missing'))
   })
@@ -89,12 +116,13 @@ describe('runCodexImplementation', () => {
   })
 
   it('runs the implementation session and pushes events', async () => {
-    await runCodexImplementation(eventPath)
+    const result = await runCodexImplementation(eventPath)
 
     expect(runCodexSessionMock).toHaveBeenCalledTimes(1)
     const invocation = runCodexSessionMock.mock.calls[0]?.[0]
     expect(invocation?.stage).toBe('implementation')
     expect(invocation?.outputPath).toBe(join(workdir, '.codex-implementation.log'))
+    expect(invocation?.resumeSessionId).toBeUndefined()
     expect(invocation?.logger).toBeDefined()
     expect(pushCodexEventsToLokiMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -105,6 +133,15 @@ describe('runCodexImplementation', () => {
         runtimeLogPath: join(workdir, '.codex-implementation-runtime.log'),
       }),
     )
+    expect(result.patchPath).toBe(join(workdir, '.codex-implementation.patch'))
+    expect(result.statusPath).toBe(join(workdir, '.codex-implementation-status.txt'))
+    expect(result.archivePath).toBe(join(workdir, '.codex-implementation-changes.tar.gz'))
+    expect(result.sessionId).toBe('session-xyz')
+    await expect(stat(result.patchPath)).resolves.toEqual(expect.objectContaining({ size: expect.any(Number) }))
+    await expect(stat(result.statusPath)).resolves.toEqual(expect.objectContaining({ size: expect.any(Number) }))
+    await expect(stat(result.archivePath)).resolves.toEqual(expect.objectContaining({ size: expect.any(Number) }))
+    const resumeMetadataPath = join(workdir, '.codex', 'implementation-resume.json')
+    await expect(stat(resumeMetadataPath)).rejects.toThrow()
   })
 
   it('throws when the event file is missing', async () => {
@@ -137,5 +174,120 @@ describe('runCodexImplementation', () => {
     await writeFile(eventPath, JSON.stringify({ prompt: 'hi', repository: 'owner/repo', issueNumber: '' }), 'utf8')
 
     await expect(runCodexImplementation(eventPath)).rejects.toThrow('Missing issue number metadata in event payload')
+  })
+
+  it('resumes a previous implementation session when resume metadata is present', async () => {
+    const resumeSourceDir = await mkdtemp(join(tmpdir(), 'codex-impl-resume-src-'))
+    const manifest = {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      worktree: workdir,
+      repository: 'owner/repo',
+      issueNumber: '42',
+      prompt: 'Implementation prompt',
+      sessionId: 'resume-session-1',
+      trackedFiles: ['src/real.ts', 'src/example.ts'],
+      deletedFiles: [] as string[],
+    }
+
+    await mkdir(join(resumeSourceDir, 'metadata'), { recursive: true })
+    const filesSrcDir = join(resumeSourceDir, 'files', 'src')
+    await mkdir(filesSrcDir, { recursive: true })
+    await writeFile(join(resumeSourceDir, 'metadata', 'manifest.json'), JSON.stringify(manifest), 'utf8')
+    const resumeRealContent = 'console.log("from resume");\n'
+    await writeFile(join(filesSrcDir, 'real.ts'), resumeRealContent, 'utf8')
+    await symlink('./real.ts', join(filesSrcDir, 'example.ts'))
+
+    const archivePath = join(workdir, '.codex-implementation-changes.tar.gz')
+    await new Promise<void>((resolve, reject) => {
+      const tarProcess = spawn('tar', ['-czf', archivePath, '-C', resumeSourceDir, '.'])
+      tarProcess.on('error', reject)
+      tarProcess.on('close', (code) => {
+        if (code === 0) {
+          resolve()
+        } else {
+          reject(new Error(`tar exited with status ${code}`))
+        }
+      })
+    })
+
+    await mkdir(join(workdir, '.codex'), { recursive: true })
+    const resumeMetadataPath = join(workdir, '.codex', 'implementation-resume.json')
+    const resumeMetadata = {
+      ...manifest,
+      archivePath,
+      patchPath: join(workdir, '.codex-implementation.patch'),
+      statusPath: join(workdir, '.codex-implementation-status.txt'),
+      state: 'pending' as const,
+    }
+    await writeFile(resumeMetadataPath, JSON.stringify(resumeMetadata), 'utf8')
+
+    runCodexSessionMock.mockImplementationOnce(async (options) => {
+      expect(options.resumeSessionId).toBe('resume-session-1')
+      return { agentMessages: [], sessionId: 'resumed-session' }
+    })
+
+    try {
+      const result = await runCodexImplementation(eventPath)
+
+      expect(result.sessionId).toBe('resumed-session')
+      const invocation = runCodexSessionMock.mock.calls[0]?.[0]
+      expect(invocation?.resumeSessionId).toBe('resume-session-1')
+      const restoredLink = join(workdir, 'src', 'example.ts')
+      const restoredFile = join(workdir, 'src', 'real.ts')
+      const linkStats = await lstat(restoredLink)
+      expect(linkStats.isSymbolicLink()).toBe(true)
+      expect(await readlink(restoredLink)).toBe('./real.ts')
+      await expect(readFile(restoredFile, 'utf8')).resolves.toBe(resumeRealContent)
+      await expect(stat(resumeMetadataPath)).rejects.toThrow()
+    } finally {
+      await rm(resumeSourceDir, { recursive: true, force: true })
+    }
+  })
+
+  it('still writes artifact placeholders when implementation fails', async () => {
+    const linkTargetPath = join(workdir, 'linked.txt')
+    await writeFile(linkTargetPath, 'linked\n', 'utf8')
+    const linkPath = join(workdir, 'link.txt')
+    await symlink('linked.txt', linkPath)
+
+    runCodexSessionMock.mockRejectedValueOnce(new Error('codex failure'))
+
+    await expect(runCodexImplementation(eventPath)).rejects.toThrow('codex failure')
+
+    const patchPath = join(workdir, '.codex-implementation.patch')
+    const statusPath = join(workdir, '.codex-implementation-status.txt')
+    const archivePath = join(workdir, '.codex-implementation-changes.tar.gz')
+
+    await expect(stat(patchPath)).resolves.toEqual(expect.objectContaining({ size: expect.any(Number) }))
+    await expect(stat(statusPath)).resolves.toEqual(expect.objectContaining({ size: expect.any(Number) }))
+    await expect(stat(archivePath)).resolves.toEqual(expect.objectContaining({ size: expect.any(Number) }))
+    const resumeMetadataPath = join(workdir, '.codex', 'implementation-resume.json')
+    const resumeMetadataRaw = await readFile(resumeMetadataPath, 'utf8')
+    const resumeMetadata = JSON.parse(resumeMetadataRaw) as Record<string, unknown>
+    expect(resumeMetadata.state).toBe('pending')
+    expect(resumeMetadata.repository).toBe('owner/repo')
+    expect(resumeMetadata.issueNumber).toBe('42')
+
+    const extractionDir = await mkdtemp(join(tmpdir(), 'codex-impl-archive-'))
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tarProcess = spawn('tar', ['-xzf', archivePath, '-C', extractionDir])
+        tarProcess.on('error', reject)
+        tarProcess.on('close', (code) => {
+          if (code === 0) {
+            resolve()
+          } else {
+            reject(new Error(`tar exited with status ${code}`))
+          }
+        })
+      })
+      const extractedLinkPath = join(extractionDir, 'files', 'link.txt')
+      const linkStats = await lstat(extractedLinkPath)
+      expect(linkStats.isSymbolicLink()).toBe(true)
+      expect(await readlink(extractedLinkPath)).toBe('linked.txt')
+    } finally {
+      await rm(extractionDir, { recursive: true, force: true })
+    }
   })
 })

--- a/apps/froussard/src/codex/cli/codex-implement.ts
+++ b/apps/froussard/src/codex/cli/codex-implement.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
-import { readFile, stat } from 'node:fs/promises'
+import { spawn as spawnChild } from 'node:child_process'
+import { copyFile, lstat, mkdtemp, readFile, readlink, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import process from 'node:process'
 import { runCli } from './lib/cli'
 import { pushCodexEventsToLoki, runCodexSession } from './lib/codex-runner'
@@ -10,7 +13,8 @@ import {
   randomRunId,
   timestampUtc,
 } from './lib/codex-utils'
-import { createCodexLogger } from './lib/logger'
+import { ensureFileDirectory } from './lib/fs'
+import { type CodexLogger, createCodexLogger } from './lib/logger'
 
 interface ImplementationEventPayload {
   prompt?: string
@@ -42,6 +46,559 @@ const sanitizeNullableString = (value: string | null | undefined) => {
   return value
 }
 
+interface CommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+const runCommand = async (command: string, args: string[], options: { cwd?: string } = {}): Promise<CommandResult> => {
+  return await new Promise<CommandResult>((resolve, reject) => {
+    const child = spawnChild(command, args, {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString()
+    })
+
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString()
+    })
+
+    child.on('error', (error) => {
+      reject(error)
+    })
+
+    child.on('close', (code) => {
+      resolve({
+        exitCode: code ?? -1,
+        stdout,
+        stderr,
+      })
+    })
+  })
+}
+
+interface CaptureImplementationArtifactsOptions {
+  worktree: string
+  archivePath: string
+  patchPath: string
+  statusPath: string
+  jsonEventsPath?: string
+  resumeMetadataPath: string
+  repository: string
+  issueNumber: string
+  prompt: string
+  sessionId?: string
+  resumedSessionId?: string
+  markForResume: boolean
+  logger: CodexLogger
+}
+
+interface ImplementationManifest {
+  version: number
+  generatedAt: string
+  worktree: string
+  repository: string
+  issueNumber: string
+  prompt: string
+  sessionId?: string
+  trackedFiles: string[]
+  deletedFiles: string[]
+}
+
+interface ResumeMetadataFile extends ImplementationManifest {
+  resumedFromSessionId?: string
+  archivePath: string
+  patchPath: string
+  statusPath: string
+  state: 'pending' | 'cleared'
+}
+
+interface ResumeContext {
+  path: string
+  metadata: ResumeMetadataFile
+}
+
+const RESUME_METADATA_RELATIVE_PATH = ['.codex', 'implementation-resume.json']
+
+const getResumeMetadataPath = (worktree: string) => join(worktree, ...RESUME_METADATA_RELATIVE_PATH)
+
+const isSafeRelativePath = (filePath: string) => {
+  return !!filePath && !filePath.startsWith('/') && !filePath.includes('..')
+}
+
+const isNotFoundError = (error: unknown): error is NodeJS.ErrnoException =>
+  Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      typeof (error as { code?: unknown }).code === 'string' &&
+      (error as { code?: string }).code === 'ENOENT',
+  )
+
+const extractSessionIdFromParsedEvent = (parsed: Record<string, unknown>): string | undefined => {
+  const candidates = [
+    parsed?.session instanceof Object ? (parsed.session as Record<string, unknown>).id : parsed?.session,
+    parsed?.session_id,
+    parsed?.sessionId,
+    parsed?.conversation_id,
+    parsed?.conversationId,
+    parsed?.item instanceof Object && 'session' in (parsed.item as object)
+      ? ((parsed.item as Record<string, unknown>).session as Record<string, unknown> | undefined)?.id
+      : undefined,
+    parsed?.item instanceof Object ? (parsed.item as Record<string, unknown>).session_id : undefined,
+    parsed?.item instanceof Object ? (parsed.item as Record<string, unknown>).sessionId : undefined,
+  ]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+  }
+  return undefined
+}
+
+const extractSessionIdFromEvents = async (eventsPath: string | undefined, logger: CodexLogger) => {
+  if (!eventsPath) {
+    return undefined
+  }
+
+  try {
+    const raw = await readFile(eventsPath, 'utf8')
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed) {
+        continue
+      }
+      try {
+        const parsed = JSON.parse(trimmed) as Record<string, unknown>
+        const sessionId = extractSessionIdFromParsedEvent(parsed)
+        if (sessionId) {
+          return sessionId
+        }
+      } catch (error) {
+        logger.warn('Failed to parse Codex events while extracting session id', error)
+      }
+    }
+  } catch (error) {
+    logger.warn(`Unable to read Codex events at ${eventsPath} while extracting session id`, error)
+  }
+
+  return undefined
+}
+
+const normalizeIssueNumber = (value: string | number) => String(value)
+
+const readResumeContext = async (path: string, logger: CodexLogger): Promise<ResumeContext | undefined> => {
+  if (!(await pathExists(path))) {
+    return undefined
+  }
+  try {
+    const raw = await readFile(path, 'utf8')
+    const parsed = JSON.parse(raw) as ResumeMetadataFile
+    if (typeof parsed.version !== 'number' || parsed.version < 1) {
+      logger.warn(`Unsupported implementation resume metadata version in ${path}`)
+      return undefined
+    }
+    return { metadata: parsed, path }
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return undefined
+    }
+    logger.warn(`Failed to parse implementation resume metadata at ${path}`, error)
+    return undefined
+  }
+}
+
+const loadResumeMetadata = async ({
+  worktree,
+  repository,
+  issueNumber,
+  logger,
+}: {
+  worktree: string
+  repository: string
+  issueNumber: string
+  logger: CodexLogger
+}): Promise<ResumeContext | undefined> => {
+  const metadataPath = getResumeMetadataPath(worktree)
+  const context = await readResumeContext(metadataPath, logger)
+  if (!context) {
+    return undefined
+  }
+
+  const normalizedIssue = normalizeIssueNumber(issueNumber)
+  if (context.metadata.state !== 'pending') {
+    return undefined
+  }
+
+  if (context.metadata.repository !== repository || context.metadata.issueNumber !== normalizedIssue) {
+    logger.info(
+      `Ignoring resume state for ${context.metadata.repository}#${context.metadata.issueNumber}; requested ${repository}#${normalizedIssue}`,
+    )
+    return undefined
+  }
+
+  return context
+}
+
+const clearResumeMetadata = async (path: string, logger: CodexLogger) => {
+  try {
+    await rm(path, { force: true })
+  } catch (error) {
+    logger.warn(`Failed to clear resume metadata at ${path}`, error)
+  }
+}
+
+const extractArchiveTo = async (archivePath: string, destination: string) => {
+  await new Promise<void>((resolve, reject) => {
+    const tarProcess = spawnChild('tar', ['-xzf', archivePath, '-C', destination], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+    })
+    tarProcess.on('error', (error) => reject(error))
+    tarProcess.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`tar exited with status ${code}`))
+      }
+    })
+  })
+}
+
+const applyResumeContext = async ({
+  worktree,
+  context,
+  logger,
+}: {
+  worktree: string
+  context: ResumeContext
+  logger: CodexLogger
+}) => {
+  const archivePath = context.metadata.archivePath
+  if (!archivePath || !(await pathExists(archivePath))) {
+    logger.warn(`Implementation resume archive not found at ${archivePath}`)
+    return false
+  }
+
+  let extractionRoot: string | undefined
+  try {
+    extractionRoot = await mkdtemp(join(tmpdir(), 'codex-impl-resume-'))
+    await extractArchiveTo(archivePath, extractionRoot)
+
+    const manifestPath = join(extractionRoot, 'metadata', 'manifest.json')
+    let manifest: ImplementationManifest | undefined
+    if (await pathExists(manifestPath)) {
+      try {
+        const manifestRaw = await readFile(manifestPath, 'utf8')
+        manifest = JSON.parse(manifestRaw) as ImplementationManifest
+      } catch (error) {
+        logger.warn('Failed to parse implementation resume manifest; continuing with recorded metadata', error)
+      }
+    }
+
+    const trackedFiles = new Set(context.metadata.trackedFiles ?? [])
+    const deletedFiles = new Set(context.metadata.deletedFiles ?? [])
+
+    if (manifest) {
+      manifest.trackedFiles.forEach((file) => {
+        trackedFiles.add(file)
+      })
+      manifest.deletedFiles.forEach((file) => {
+        deletedFiles.add(file)
+      })
+    }
+
+    const filesDir = join(extractionRoot, 'files')
+    let copiedCount = 0
+
+    for (const relativePath of trackedFiles) {
+      if (!isSafeRelativePath(relativePath)) {
+        logger.warn(`Skipping unsafe resume path '${relativePath}'`)
+        continue
+      }
+      const sourcePath = join(filesDir, relativePath)
+      if (!(await pathExists(sourcePath))) {
+        logger.warn(`Resume archive missing file '${relativePath}'`)
+        continue
+      }
+      const destinationPath = join(worktree, relativePath)
+      await ensureFileDirectory(destinationPath)
+      await rm(destinationPath, { force: true, recursive: true })
+      try {
+        const stats = await lstat(sourcePath)
+        if (stats.isSymbolicLink()) {
+          const linkTarget = await readlink(sourcePath)
+          await symlink(linkTarget, destinationPath)
+        } else if (stats.isFile()) {
+          await copyFile(sourcePath, destinationPath)
+        } else {
+          logger.warn(`Skipping non-file path '${relativePath}' in resume archive`)
+          continue
+        }
+      } catch (error) {
+        logger.warn(`Failed to restore '${relativePath}' from resume archive`, error)
+        continue
+      }
+      copiedCount += 1
+    }
+
+    let removedCount = 0
+    for (const relativePath of deletedFiles) {
+      if (!isSafeRelativePath(relativePath)) {
+        logger.warn(`Skipping unsafe delete path '${relativePath}' in resume metadata`)
+        continue
+      }
+      const targetPath = join(worktree, relativePath)
+      try {
+        await rm(targetPath, { force: true, recursive: true })
+        removedCount += 1
+      } catch (error) {
+        logger.warn(`Failed to remove '${relativePath}' while applying resume metadata`, error)
+      }
+    }
+
+    logger.info(
+      `Restored implementation resume state with ${copiedCount} file(s) copied and ${removedCount} file(s) removed`,
+    )
+    return true
+  } catch (error) {
+    logger.error('Failed to apply implementation resume state', error)
+    return false
+  } finally {
+    if (extractionRoot) {
+      await rm(extractionRoot, { recursive: true, force: true })
+    }
+  }
+}
+
+const captureImplementationArtifacts = async ({
+  worktree,
+  archivePath,
+  patchPath,
+  statusPath,
+  jsonEventsPath,
+  resumeMetadataPath,
+  repository,
+  issueNumber,
+  prompt,
+  sessionId,
+  resumedSessionId,
+  markForResume,
+  logger,
+}: CaptureImplementationArtifactsOptions) => {
+  const cleanupBundle = async (bundleRoot: string) => {
+    try {
+      await rm(bundleRoot, { recursive: true, force: true })
+    } catch (error) {
+      logger.warn('Failed to clean up implementation artifact bundle directory', error)
+    }
+  }
+
+  let bundleRoot: string | undefined
+
+  try {
+    bundleRoot = await mkdtemp(join(tmpdir(), 'codex-impl-artifacts-'))
+    const metadataDir = join(bundleRoot, 'metadata')
+    const filesDir = join(bundleRoot, 'files')
+    await ensureFileDirectory(join(metadataDir, '.keep'))
+
+    let statusContent = ''
+    try {
+      const statusResult = await runCommand('git', ['status', '--short', '--branch'], { cwd: worktree })
+      if (statusResult.exitCode === 0) {
+        statusContent = statusResult.stdout.trim()
+      } else {
+        statusContent = `git status failed (exit ${statusResult.exitCode}): ${statusResult.stderr.trim()}`
+        logger.warn('git status failed while capturing implementation artifacts', statusResult.stderr.trim())
+      }
+    } catch (error) {
+      statusContent = `git status failed: ${error instanceof Error ? error.message : String(error)}`
+      logger.warn('git status threw while capturing implementation artifacts', error)
+    }
+
+    await ensureFileDirectory(statusPath)
+    await writeFile(statusPath, `${statusContent}\n`, 'utf8')
+    await ensureFileDirectory(join(metadataDir, 'git-status.txt'))
+    await writeFile(join(metadataDir, 'git-status.txt'), `${statusContent}\n`, 'utf8')
+
+    let diffContent = ''
+    try {
+      const diffResult = await runCommand('git', ['diff', '--binary', 'HEAD'], { cwd: worktree })
+      if (diffResult.exitCode === 0) {
+        diffContent = diffResult.stdout
+      } else {
+        diffContent = `git diff failed (exit ${diffResult.exitCode}): ${diffResult.stderr.trim()}`
+        logger.warn('git diff failed while capturing implementation artifacts', diffResult.stderr.trim())
+      }
+    } catch (error) {
+      diffContent = `git diff failed: ${error instanceof Error ? error.message : String(error)}`
+      logger.warn('git diff threw while capturing implementation artifacts', error)
+    }
+
+    await ensureFileDirectory(patchPath)
+    await writeFile(patchPath, diffContent, 'utf8')
+    await ensureFileDirectory(join(metadataDir, 'git-diff.patch'))
+    await writeFile(join(metadataDir, 'git-diff.patch'), diffContent, 'utf8')
+
+    const trackedFiles = new Set<string>()
+    const deletedFiles: string[] = []
+
+    try {
+      const trackedResult = await runCommand('git', ['diff', '--name-only', '--diff-filter=ACMRTUXB', 'HEAD'], {
+        cwd: worktree,
+      })
+      if (trackedResult.exitCode === 0) {
+        trackedResult.stdout
+          .split('\n')
+          .map((entry) => entry.trim())
+          .filter((entry) => entry.length > 0)
+          .forEach((entry) => {
+            trackedFiles.add(entry)
+          })
+      } else {
+        logger.warn('git diff --name-only failed while capturing implementation artifacts', trackedResult.stderr.trim())
+      }
+    } catch (error) {
+      logger.warn('git diff --name-only threw while capturing implementation artifacts', error)
+    }
+
+    try {
+      const deletedResult = await runCommand('git', ['diff', '--name-only', '--diff-filter=D', 'HEAD'], {
+        cwd: worktree,
+      })
+      if (deletedResult.exitCode === 0) {
+        deletedResult.stdout
+          .split('\n')
+          .map((entry) => entry.trim())
+          .filter((entry) => entry.length > 0)
+          .forEach((entry) => {
+            deletedFiles.push(entry)
+          })
+      }
+    } catch (error) {
+      logger.warn('git diff --name-only for deletions threw while capturing implementation artifacts', error)
+    }
+
+    try {
+      const untrackedResult = await runCommand('git', ['ls-files', '--others', '--exclude-standard'], {
+        cwd: worktree,
+      })
+      if (untrackedResult.exitCode === 0) {
+        untrackedResult.stdout
+          .split('\n')
+          .map((entry) => entry.trim())
+          .filter((entry) => entry.length > 0)
+          .forEach((entry) => {
+            trackedFiles.add(entry)
+          })
+      } else {
+        logger.warn('git ls-files failed while capturing implementation artifacts', untrackedResult.stderr.trim())
+      }
+    } catch (error) {
+      logger.warn('git ls-files threw while capturing implementation artifacts', error)
+    }
+
+    const manifest = {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      worktree,
+      repository,
+      issueNumber,
+      prompt,
+      sessionId: sessionId ?? (await extractSessionIdFromEvents(jsonEventsPath, logger)),
+      trackedFiles: Array.from(trackedFiles).sort(),
+      deletedFiles: deletedFiles.sort(),
+    } satisfies ImplementationManifest
+
+    await ensureFileDirectory(join(metadataDir, 'manifest.json'))
+    await writeFile(join(metadataDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8')
+
+    for (const relativePath of trackedFiles) {
+      const sourcePath = join(worktree, relativePath)
+      const destinationPath = join(filesDir, relativePath)
+
+      let stats: import('node:fs').Stats
+      try {
+        stats = await lstat(sourcePath)
+      } catch {
+        continue
+      }
+
+      if (!stats.isFile() && !stats.isSymbolicLink()) {
+        continue
+      }
+
+      try {
+        await ensureFileDirectory(destinationPath)
+        await rm(destinationPath, { force: true })
+        if (stats.isSymbolicLink()) {
+          const linkTarget = await readlink(sourcePath)
+          await symlink(linkTarget, destinationPath)
+        } else {
+          await copyFile(sourcePath, destinationPath)
+        }
+      } catch (error) {
+        logger.warn(`Failed to copy changed path '${relativePath}' into artifact bundle`, error)
+      }
+    }
+
+    await ensureFileDirectory(archivePath)
+    const tarProcess = spawnChild('tar', ['-czf', archivePath, '-C', bundleRoot, '.'], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+    })
+    const tarExit = await new Promise<number>((resolve, reject) => {
+      tarProcess.on('error', (tarError) => {
+        reject(tarError)
+      })
+      tarProcess.on('close', (code) => {
+        resolve(code ?? -1)
+      })
+    })
+    if (tarExit !== 0) {
+      throw new Error(`tar exited with status ${tarExit}`)
+    }
+
+    const resumeMetadata: ResumeMetadataFile = {
+      ...manifest,
+      archivePath,
+      patchPath,
+      statusPath,
+      state: markForResume ? 'pending' : 'cleared',
+      resumedFromSessionId: resumedSessionId,
+    }
+
+    if (markForResume) {
+      await ensureFileDirectory(resumeMetadataPath)
+      await writeFile(resumeMetadataPath, JSON.stringify(resumeMetadata, null, 2), 'utf8')
+    } else {
+      await clearResumeMetadata(resumeMetadataPath, logger)
+    }
+  } catch (error) {
+    logger.error('Failed to capture implementation change artifacts', error)
+    try {
+      await ensureFileDirectory(archivePath)
+      await writeFile(
+        archivePath,
+        `Failed to capture implementation artifacts: ${error instanceof Error ? error.message : String(error)}\n`,
+        'utf8',
+      )
+    } catch (writeError) {
+      logger.error('Failed to write fallback implementation artifact payload', writeError)
+    }
+  } finally {
+    if (bundleRoot) {
+      await cleanupBundle(bundleRoot)
+    }
+  }
+}
+
 export const runCodexImplementation = async (eventPath: string) => {
   if (!(await pathExists(eventPath))) {
     throw new Error(`Event payload file not found at '${eventPath}'`)
@@ -71,6 +628,11 @@ export const runCodexImplementation = async (eventPath: string) => {
   const jsonOutputPath = process.env.JSON_OUTPUT_PATH ?? `${worktree}/.codex-implementation-events.jsonl`
   const agentOutputPath = process.env.AGENT_OUTPUT_PATH ?? `${worktree}/.codex-implementation-agent.log`
   const runtimeLogPath = process.env.CODEX_RUNTIME_LOG_PATH ?? `${worktree}/.codex-implementation-runtime.log`
+  const patchPath = process.env.IMPLEMENTATION_PATCH_PATH ?? `${worktree}/.codex-implementation.patch`
+  const statusPath = process.env.IMPLEMENTATION_STATUS_PATH ?? `${worktree}/.codex-implementation-status.txt`
+  const archivePath =
+    process.env.IMPLEMENTATION_CHANGES_ARCHIVE_PATH ?? `${worktree}/.codex-implementation-changes.tar.gz`
+  const resumeMetadataPath = getResumeMetadataPath(worktree)
   const lokiEndpoint =
     process.env.LGTM_LOKI_ENDPOINT ??
     'http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push'
@@ -97,6 +659,9 @@ export const runCodexImplementation = async (eventPath: string) => {
   process.env.WORKTREE = worktree
   process.env.OUTPUT_PATH = outputPath
   process.env.ISSUE_TITLE = issueTitle
+  process.env.IMPLEMENTATION_PATCH_PATH = patchPath
+  process.env.IMPLEMENTATION_STATUS_PATH = statusPath
+  process.env.IMPLEMENTATION_CHANGES_ARCHIVE_PATH = archivePath
 
   process.env.CODEX_STAGE = process.env.CODEX_STAGE ?? 'implementation'
   process.env.RUST_LOG = process.env.RUST_LOG ?? 'codex_core=info,codex_exec=info'
@@ -120,7 +685,40 @@ export const runCodexImplementation = async (eventPath: string) => {
     },
   })
 
+  const normalizedIssueNumber = issueNumber
+  let resumeContext: ResumeContext | undefined
+  let resumeSessionId: string | undefined
+  let capturedSessionId: string | undefined
+  let runSucceeded = false
+
   try {
+    resumeContext = await loadResumeMetadata({
+      worktree,
+      repository,
+      issueNumber: normalizedIssueNumber,
+      logger,
+    })
+
+    if (resumeContext) {
+      logger.info(
+        `Found pending resume state from ${resumeContext.metadata.generatedAt}; attempting to restore implementation changes`,
+      )
+      const applied = await applyResumeContext({ worktree, context: resumeContext, logger })
+      if (applied) {
+        if (resumeContext.metadata.sessionId && resumeContext.metadata.sessionId.trim().length > 0) {
+          resumeSessionId = resumeContext.metadata.sessionId.trim()
+          logger.info(`Resuming Codex session ${resumeSessionId}`)
+        } else {
+          resumeSessionId = '--last'
+          logger.warn('Resume metadata missing session id; falling back to --last to resume the latest Codex session')
+        }
+      } else {
+        logger.warn('Failed to restore resume archive; proceeding with a fresh Codex session')
+      }
+    }
+
+    capturedSessionId = resumeSessionId
+
     let discordRelayCommand: string[] | undefined
     const discordToken = process.env.DISCORD_BOT_TOKEN ?? ''
     const discordGuild = process.env.DISCORD_GUILD_ID ?? ''
@@ -156,14 +754,19 @@ export const runCodexImplementation = async (eventPath: string) => {
       logger.warn('Discord relay disabled: missing credentials or relay script')
     }
 
-    logger.info(`Running Codex implementation for ${repository}#${issueNumber}`)
+    if (resumeSessionId) {
+      logger.info(`Running Codex implementation for ${repository}#${issueNumber} (resume mode)`)
+    } else {
+      logger.info(`Running Codex implementation for ${repository}#${issueNumber}`)
+    }
 
-    await runCodexSession({
+    const sessionResult = await runCodexSession({
       stage: 'implementation',
       prompt,
       outputPath,
       jsonOutputPath,
       agentOutputPath,
+      resumeSessionId,
       logger,
       discordRelay: discordRelayCommand
         ? {
@@ -172,6 +775,11 @@ export const runCodexImplementation = async (eventPath: string) => {
           }
         : undefined,
     })
+    capturedSessionId =
+      sessionResult.sessionId ?? resumeContext?.metadata.sessionId ?? capturedSessionId ?? resumeSessionId
+    if (capturedSessionId) {
+      logger.info(`Codex session id: ${capturedSessionId}`)
+    }
 
     await copyAgentLogIfNeeded(outputPath, agentOutputPath)
     await pushCodexEventsToLoki({
@@ -202,14 +810,38 @@ export const runCodexImplementation = async (eventPath: string) => {
       // ignore missing json log
     }
 
+    runSucceeded = true
     return {
       repository,
       issueNumber,
       outputPath,
       jsonOutputPath,
       agentOutputPath,
+      patchPath,
+      statusPath,
+      archivePath,
+      sessionId: capturedSessionId,
     }
   } finally {
+    try {
+      await captureImplementationArtifacts({
+        worktree,
+        archivePath,
+        patchPath,
+        statusPath,
+        jsonEventsPath: jsonOutputPath,
+        resumeMetadataPath,
+        repository,
+        issueNumber: normalizedIssueNumber,
+        prompt,
+        sessionId: capturedSessionId,
+        resumedSessionId: resumeContext?.metadata.sessionId,
+        markForResume: !runSucceeded,
+        logger,
+      })
+    } catch (error) {
+      logger.error('Failed while finalizing implementation artifacts', error)
+    }
     await logger.flush()
   }
 }

--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -86,3 +86,11 @@ spec:
           limits:
             cpu: "6"
             memory: 12Gi
+      outputs:
+        artifacts:
+          - name: implementation-changes
+            path: /workspace/lab/.codex-implementation-changes.tar.gz
+          - name: implementation-patch
+            path: /workspace/lab/.codex-implementation.patch
+          - name: implementation-status
+            path: /workspace/lab/.codex-implementation-status.txt


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- preserve symlink metadata when packaging Codex implementation artifacts
- restore symlinks accurately during resume rehydration to avoid corrupting worktrees
- extend implementation tests to cover symlink scenarios and git bootstrapping

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- pnpm --filter froussard test -- --run apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
- pnpm --filter froussard test -- --run apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
