### PR TITLE
fix: enforce workflow ttl defaults

### DIFF
--- a/argocd/applications/argo-workflows/kustomization.yaml
+++ b/argocd/applications/argo-workflows/kustomization.yaml
@@ -17,6 +17,12 @@ helmCharts:
       controller:
         workflowNamespaces:
           - argo-workflows
+        workflowDefaults:
+          spec:
+            ttlStrategy:
+              secondsAfterSuccess: 43200 # 12h retention for successful runs
+              secondsAfterFailure: 604800 # 7d retention to keep failure diagnostics
+              secondsAfterCompletion: 604800
       server:
         secure: false
         authModes:


### PR DESCRIPTION
## Summary

- Enforce Argo controller workflowDefaults TTL so successful runs expire after 12 hours
- Keep failed or manually inspected workflows for seven days to preserve diagnostics
- Prevent Argo CLI backlog cost warnings by maintaining a capped queue of completed runs

## Related Issues

None

## Testing

- N/A – Helm values update; validation will occur after Argo CD sync

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
