### PR TITLE
chore: bump froussard deploy image

### DIFF
--- a/apps/froussard/func.yaml
+++ b/apps/froussard/func.yaml
@@ -53,7 +53,7 @@ run:
     value: http/protobuf
 deploy:
   namespace: froussard
-  image: registry.ide-newton.ts.net/lab/froussard@sha256:d8bac396f71ba442b41bd8c6c469f6a1acaf73fd3537cb47b00d553f665f7ebc
+  image: registry.ide-newton.ts.net/lab/froussard@sha256:71b7b60b9283dc9e73f6e6602dba1120dbc68db46c6f0024b1311a004139c9f8
   annotations:
     serving.knative.dev/revision-history-limit: "3"
   options:

--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -29,7 +29,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: user-container
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:d8bac396f71ba442b41bd8c6c469f6a1acaf73fd3537cb47b00d553f665f7ebc
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:71b7b60b9283dc9e73f6e6602dba1120dbc68db46c6f0024b1311a004139c9f8
           env:
             - name: GITHUB_WEBHOOK_SECRET
               valueFrom:
@@ -70,9 +70,9 @@ spec:
             - name: OTEL_SERVICE_NAMESPACE
               value: froussard
             - name: FROUSSARD_VERSION
-              value: v0.254.7-2-gea0d171f
+              value: v0.258.0-18-gd964763d
             - name: FROUSSARD_COMMIT
-              value: ea0d171fcf2a89979a5a21ee92d6ba3877e5083e
+              value: d964763da85e2db618821de5662b4c484363b11f
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Bumped the Froussard func manifest to the freshly built image digest.
- Updated Knative deployment env vars with the new version and commit metadata.
- Captured the deployment output from the CLI helper for GitOps parity.

## Related Issues

None

## Testing

- bun packages/scripts/src/froussard/deploy-service.ts

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
