### PR TITLE
feat: initialize Zig runtime via Temporal core

### DIFF
--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/build.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/build.zig
@@ -7,6 +7,7 @@ const TemporalCrate = struct {
 
 const temporal_crates = [_]TemporalCrate{
     .{ .package = "temporal-sdk-core", .archive = "temporal_sdk_core" },
+    .{ .package = "temporal-sdk-core-c-bridge", .archive = "temporal_sdk_core_c_bridge" },
     .{ .package = "temporal-client", .archive = "temporal_client" },
     .{ .package = "temporal-sdk-core-api", .archive = "temporal_sdk_core_api" },
     .{ .package = "temporal-sdk-core-protos", .archive = "temporal_sdk_core_protos" },

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/include/temporal-sdk-core-c-bridge.h
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/include/temporal-sdk-core-c-bridge.h
@@ -403,7 +403,6 @@ typedef const void *(*TemporalCoreCustomMetricMeterAttributesNewCallback)(const 
 
 typedef void (*TemporalCoreCustomMetricMeterAttributesFreeCallback)(const void *attributes);
 
-typedef void (*TemporalCoreCustomMetricMeterMeterFreeCallback)(const struct TemporalCoreCustomMetricMeter *meter);
 
 /**
  * No parameters in the callbacks below should be assumed to live beyond the
@@ -421,7 +420,7 @@ typedef struct TemporalCoreCustomMetricMeter {
   TemporalCoreCustomMetricMeterMetricRecordDurationCallback metric_record_duration;
   TemporalCoreCustomMetricMeterAttributesNewCallback attributes_new;
   TemporalCoreCustomMetricMeterAttributesFreeCallback attributes_free;
-  TemporalCoreCustomMetricMeterMeterFreeCallback meter_free;
+  void (*meter_free)(const struct TemporalCoreCustomMetricMeter *meter);
 } TemporalCoreCustomMetricMeter;
 
 /**

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/runtime.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/runtime.zig
@@ -5,6 +5,53 @@ const pending = @import("pending.zig");
 
 const grpc = pending.GrpcStatus;
 
+const RuntimeNewFn = *const fn ([*c]const core.RuntimeOptions) callconv(.c) core.RuntimeOrFail;
+const RuntimeFreeFn = *const fn (?*core.Runtime) callconv(.c) void;
+const RuntimeByteArrayFreeFn = *const fn (?*core.Runtime, [*c]const core.ByteArray) callconv(.c) void;
+
+var runtime_new_impl: RuntimeNewFn = core.api.runtime_new;
+var runtime_free_impl: RuntimeFreeFn = core.api.runtime_free;
+var runtime_byte_array_free_impl: RuntimeByteArrayFreeFn = core.api.byte_array_free;
+
+fn runtimeNew(options: ?*const core.RuntimeOptions) core.RuntimeOrFail {
+    const pointer: [*c]const core.RuntimeOptions = if (options) |value|
+        @as([*c]const core.RuntimeOptions, @ptrCast(value))
+    else
+        @ptrFromInt(0);
+    return runtime_new_impl(pointer);
+}
+
+fn runtimeFree(runtime: ?*core.Runtime) void {
+    runtime_free_impl(runtime);
+}
+
+fn runtimeByteArrayFree(runtime: ?*core.Runtime, bytes: ?*const core.ByteArray) void {
+    runtime_byte_array_free_impl(runtime, bytes);
+}
+
+fn byteArraySlice(bytes_ptr: ?*const core.ByteArray) []const u8 {
+    if (bytes_ptr == null) {
+        return ""[0..0];
+    }
+
+    const bytes = bytes_ptr.?;
+    if (bytes.data == null or bytes.size == 0) {
+        return ""[0..0];
+    }
+
+    return bytes.data[0..bytes.size];
+}
+
+fn resetCoreApiOverrides() void {
+    runtime_new_impl = core.api.runtime_new;
+    runtime_free_impl = core.api.runtime_free;
+    runtime_byte_array_free_impl = core.api.byte_array_free;
+}
+
+const DummyRuntime = extern struct {
+    pad: u8 = 0,
+};
+
 /// Placeholder handle that mirrors the pointer-based interface exposed by the Rust bridge.
 pub const RuntimeHandle = struct {
     id: u64,
@@ -51,8 +98,38 @@ pub fn create(options_json: []const u8) ?*RuntimeHandle {
         .core_runtime = null,
     };
 
-    // TODO(codex, zig-rt-01): Initialize the Temporal core runtime through the Rust C-ABI
-    // (`temporal_sdk_core_runtime_new`) and store the opaque pointer on the handle.
+    // Temporal core expects a valid options struct even when telemetry is absent; initialize with defaults.
+    var options = core.RuntimeOptions{
+        .telemetry = null,
+    };
+
+    const runtime_or_fail = runtimeNew(&options);
+    const runtime_ptr = runtime_or_fail.runtime;
+
+    if (runtime_or_fail.fail) |fail_ptr| {
+        const fail_message = byteArraySlice(fail_ptr);
+        const fallback =
+            "temporal-bun-bridge-zig: temporal core runtime initialization failed";
+        const description = if (fail_message.len > 0) fail_message else fallback;
+        errors.setStructuredError(.{
+            .code = grpc.internal,
+            .message = description,
+            .details = if (fail_message.len > 0) fail_message else null,
+        });
+
+        // Temporal core allocates the failure payload; release it with the runtime before freeing the runtime itself.
+        runtimeByteArrayFree(runtime_ptr, fail_ptr);
+        runtimeFree(runtime_ptr);
+
+        allocator.free(copy);
+        allocator.destroy(handle);
+        return null;
+    }
+
+    handle.core_runtime = runtime_ptr;
+
+    // Temporal core indicates success by leaving `.fail` null. Clear any sticky errors to match Bun expectations.
+    errors.setLastError(""[0..0]);
 
     return handle;
 }
@@ -97,4 +174,136 @@ pub fn setLogger(handle: ?*RuntimeHandle, _callback_ptr: ?*anyopaque) i32 {
         .message = "temporal-bun-bridge-zig: runtime logger installation is not implemented yet",
     });
     return -1;
+}
+
+test "create stores Temporal core runtime pointer when runtime_new succeeds" {
+    const testing = std.testing;
+    resetCoreApiOverrides();
+    defer resetCoreApiOverrides();
+    errors.setLastError(""[0..0]);
+
+    const Stubs = struct {
+        var runtime_new_calls: usize = 0;
+        var runtime_free_calls: usize = 0;
+        var byte_array_free_calls: usize = 0;
+        var last_options_ptr: usize = 0;
+        var runtime_storage: DummyRuntime = .{};
+
+        fn runtimePointer() *core.Runtime {
+            return @as(*core.Runtime, @ptrCast(&runtime_storage));
+        }
+
+        fn runtimeNew(options: [*c]const core.RuntimeOptions) callconv(.c) core.RuntimeOrFail {
+            runtime_new_calls += 1;
+            last_options_ptr = @intFromPtr(options);
+            return .{
+                .runtime = runtimePointer(),
+                .fail = null,
+            };
+        }
+
+        fn runtimeFree(runtime: ?*core.Runtime) callconv(.c) void {
+            _ = runtime;
+            runtime_free_calls += 1;
+        }
+
+        fn runtimeByteArrayFree(runtime: ?*core.Runtime, bytes: ?*const core.ByteArray) callconv(.c) void {
+            _ = runtime;
+            _ = bytes;
+            byte_array_free_calls += 1;
+        }
+    };
+
+    runtime_new_impl = Stubs.runtimeNew;
+    runtime_free_impl = Stubs.runtimeFree;
+    runtime_byte_array_free_impl = Stubs.runtimeByteArrayFree;
+
+    const payload = "{\"namespace\":\"default\"}"[0..];
+    const handle_opt = create(payload);
+    try testing.expect(handle_opt != null);
+    const handle = handle_opt.?;
+    defer destroy(handle);
+
+    try testing.expectEqual(@as(usize, 1), Stubs.runtime_new_calls);
+    try testing.expectEqual(@as(usize, 0), Stubs.runtime_free_calls);
+    try testing.expectEqual(@as(usize, 0), Stubs.byte_array_free_calls);
+    try testing.expect(Stubs.last_options_ptr != 0);
+    try testing.expect(handle.core_runtime != null);
+    try testing.expectEqual(@intFromPtr(Stubs.runtimePointer()), @intFromPtr(handle.core_runtime.?));
+    try testing.expectEqualStrings("", errors.snapshot());
+}
+
+test "create surfaces Temporal core runtime failure and frees resources" {
+    const testing = std.testing;
+    resetCoreApiOverrides();
+    defer resetCoreApiOverrides();
+    errors.setLastError(""[0..0]);
+
+    const fail_message = "core runtime exploded"[0..];
+    var fail_array = core.ByteArray{
+        .data = fail_message.ptr,
+        .size = fail_message.len,
+        .cap = fail_message.len,
+        .disable_free = false,
+    };
+
+    const Stubs = struct {
+        var runtime_new_calls: usize = 0;
+        var runtime_free_calls: usize = 0;
+        var byte_array_free_calls: usize = 0;
+        var last_runtime_free_ptr: ?*core.Runtime = null;
+        var last_byte_array_free_runtime: ?*core.Runtime = null;
+        var last_byte_array_free_ptr: ?*const core.ByteArray = null;
+        var last_options_ptr: usize = 0;
+        var fail_ptr: ?*const core.ByteArray = null;
+        var runtime_storage: DummyRuntime = .{};
+
+        fn runtimePointer() *core.Runtime {
+            return @as(*core.Runtime, @ptrCast(&runtime_storage));
+        }
+
+        fn runtimeNew(options: [*c]const core.RuntimeOptions) callconv(.c) core.RuntimeOrFail {
+            runtime_new_calls += 1;
+            last_options_ptr = @intFromPtr(options);
+            return .{
+                .runtime = runtimePointer(),
+                .fail = fail_ptr,
+            };
+        }
+
+        fn runtimeFree(runtime: ?*core.Runtime) callconv(.c) void {
+            runtime_free_calls += 1;
+            last_runtime_free_ptr = runtime;
+        }
+
+        fn runtimeByteArrayFree(runtime: ?*core.Runtime, bytes: ?*const core.ByteArray) callconv(.c) void {
+            byte_array_free_calls += 1;
+            last_byte_array_free_runtime = runtime;
+            last_byte_array_free_ptr = bytes;
+        }
+    };
+
+    Stubs.fail_ptr = @as(?*const core.ByteArray, @ptrCast(&fail_array));
+
+    runtime_new_impl = Stubs.runtimeNew;
+    runtime_free_impl = Stubs.runtimeFree;
+    runtime_byte_array_free_impl = Stubs.runtimeByteArrayFree;
+
+    const handle_opt = create("{\"fail\":true}"[0..]);
+    try testing.expect(handle_opt == null);
+
+    try testing.expectEqual(@as(usize, 1), Stubs.runtime_new_calls);
+    try testing.expectEqual(@as(usize, 1), Stubs.byte_array_free_calls);
+    try testing.expectEqual(@as(usize, 1), Stubs.runtime_free_calls);
+    try testing.expect(Stubs.last_options_ptr != 0);
+    try testing.expect(Stubs.last_byte_array_free_runtime != null);
+    try testing.expect(Stubs.last_byte_array_free_ptr != null);
+    try testing.expectEqual(@intFromPtr(Stubs.runtimePointer()), @intFromPtr(Stubs.last_byte_array_free_runtime.?));
+    try testing.expectEqual(@intFromPtr(Stubs.fail_ptr.?), @intFromPtr(Stubs.last_byte_array_free_ptr.?));
+    try testing.expect(Stubs.last_runtime_free_ptr != null);
+    try testing.expectEqual(@intFromPtr(Stubs.runtimePointer()), @intFromPtr(Stubs.last_runtime_free_ptr.?));
+
+    const expected_error =
+        "{\"code\":13,\"message\":\"core runtime exploded\",\"details\":\"core runtime exploded\"}";
+    try testing.expectEqualStrings(expected_error, errors.snapshot());
 }


### PR DESCRIPTION
## Summary
- call `temporal_core_runtime_new` from the Zig runtime bridge so we store the Temporal core pointer and surface failures
- add Zig unit tests that stub the C bridge to cover success and failure cases
- link the Temporal core c-bridge static library and tweak the header typedef to keep Zig's cimport happy

## Testing
- zig build -Doptimize=Debug --build-file packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/build.zig
- TEMPORAL_BUN_SDK_USE_ZIG=1 pnpm --filter @proompteng/temporal-bun-sdk test

Closes #1487