### PR TITLE
feat: wire zig signal workflow bridge

### DIFF
--- a/packages/temporal-bun-sdk/docs/zig-production-readiness.md
+++ b/packages/temporal-bun-sdk/docs/zig-production-readiness.md
@@ -5,6 +5,7 @@ item is designed to be auditable during release reviews.
 
 ## 1. Technical Completeness
 - ✅ Feature parity issues closed for IDs `zig-rt-*`, `zig-cl-*`, `zig-wf-*`, `zig-buf-*`, `zig-pend-*`.
+- ✅ `zig-core-02`: Zig bridge signals invoke Temporal core (`signalWorkflowExecution`) with real status mapping (PR #1554).
 - ✅ All TODO markers removed or converted to tracked issues with owners.
 - ✅ Integration matrix (`docs/testing-plan.md`) updated with Zig scenarios alongside Rust.
 

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/build.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/build.zig
@@ -103,6 +103,9 @@ pub fn build(b: *std.Build) void {
         .link_libc = true,
     });
     test_module.addIncludePath(include_dir);
+    test_module.addAnonymousImport("bridge_tests", .{
+        .root_source_file = b.path("tests/core_signal_workflow.zig"),
+    });
 
     const unit_tests = b.addTest(.{
         .root_module = test_module,

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/lib.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/lib.zig
@@ -5,6 +5,7 @@ const client = @import("client.zig");
 const byte_array = @import("byte_array.zig");
 const pending = @import("pending.zig");
 const worker = @import("worker.zig");
+pub const core = @import("core.zig");
 
 fn sliceFrom(ptr: ?[*]const u8, len: u64) []const u8 {
     if (ptr == null or len == 0) {
@@ -240,6 +241,12 @@ pub export fn temporal_bun_worker_complete_activity_task(
 ) i32 {
     const payload = sliceFrom(payload_ptr, len);
     return worker.completeActivityTask(handle, payload);
+}
+
+comptime {
+    if (@import("builtin").is_test) {
+        _ = @import("bridge_tests");
+    }
 }
 
 pub export fn temporal_bun_worker_record_activity_heartbeat(

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/tests/core_signal_workflow.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/tests/core_signal_workflow.zig
@@ -1,0 +1,152 @@
+const std = @import("std");
+const testing = std.testing;
+const bridge = @import("root");
+const core = bridge.core;
+
+const SignalError = core.SignalWorkflowError;
+const RpcCallOptions = core.RpcCallOptions;
+const ClientRpcCallCallback = core.ClientRpcCallCallback;
+
+const signal_rpc_name = "SignalWorkflowExecution";
+
+fn fakeClient() ?*core.ClientOpaque {
+    return @as(?*core.ClientOpaque, @ptrFromInt(@as(usize, 0x10)));
+}
+
+fn makeStaticByteArray(bytes: []const u8) core.ByteArray {
+    return .{
+        .data = bytes.ptr,
+        .size = bytes.len,
+        .cap = bytes.len,
+        .disable_free = true,
+    };
+}
+
+fn expectSignalRequest(options: *const RpcCallOptions, expected: []const u8) void {
+    const rpc_slice = options.rpc.data[0..options.rpc.size];
+    std.debug.assert(std.mem.eql(u8, rpc_slice, signal_rpc_name));
+
+    const req_slice = options.req.data[0..options.req.size];
+    std.debug.assert(std.mem.eql(u8, req_slice, expected));
+}
+
+fn resolveCallback(
+    user_data: ?*anyopaque,
+    callback: ClientRpcCallCallback,
+    status_code: u32,
+    failure_message: ?*const core.ByteArray,
+) void {
+    callback(user_data, null, status_code, failure_message, null);
+}
+
+test "signalWorkflow resolves when Temporal core reports success" {
+    const request = "{\"namespace\":\"default\",\"workflow_id\":\"zig\"}";
+
+    const Stub = struct {
+        pub fn call(
+            client: *core.ClientOpaque,
+            options: *const RpcCallOptions,
+            user_data: ?*anyopaque,
+            callback: ClientRpcCallCallback,
+        ) callconv(.c) void {
+            std.debug.assert(client != null);
+            expectSignalRequest(options, request);
+            resolveCallback(user_data, callback, 0, null);
+        }
+    };
+
+    core.setClientRpcCallStubForTesting(Stub.call);
+    defer core.resetClientRpcCallStubForTesting();
+
+    try core.signalWorkflow(fakeClient(), request);
+}
+
+test "signalWorkflow surfaces not found errors" {
+    const request = "{\"namespace\":\"default\",\"workflow_id\":\"missing\"}";
+
+    const Stub = struct {
+        pub fn call(
+            _: *core.ClientOpaque,
+            options: *const RpcCallOptions,
+            user_data: ?*anyopaque,
+            callback: ClientRpcCallCallback,
+        ) callconv(.c) void {
+            expectSignalRequest(options, request);
+            resolveCallback(user_data, callback, 5, null);
+        }
+    };
+
+    core.setClientRpcCallStubForTesting(Stub.call);
+    defer core.resetClientRpcCallStubForTesting();
+
+    try testing.expectError(SignalError.NotFound, core.signalWorkflow(fakeClient(), request));
+}
+
+test "signalWorkflow surfaces unavailable errors" {
+    const request = "{\"namespace\":\"default\",\"workflow_id\":\"zig\"}";
+
+    const Stub = struct {
+        pub fn call(
+            _: *core.ClientOpaque,
+            options: *const RpcCallOptions,
+            user_data: ?*anyopaque,
+            callback: ClientRpcCallCallback,
+        ) callconv(.c) void {
+            expectSignalRequest(options, request);
+            resolveCallback(user_data, callback, 14, null);
+        }
+    };
+
+    core.setClientRpcCallStubForTesting(Stub.call);
+    defer core.resetClientRpcCallStubForTesting();
+
+    try testing.expectError(SignalError.ClientUnavailable, core.signalWorkflow(fakeClient(), request));
+}
+
+test "signalWorkflow treats unknown statuses as internal" {
+    const request = "{\"namespace\":\"default\",\"workflow_id\":\"zig\"}";
+
+    const Stub = struct {
+        pub fn call(
+            _: *core.ClientOpaque,
+            options: *const RpcCallOptions,
+            user_data: ?*anyopaque,
+            callback: ClientRpcCallCallback,
+        ) callconv(.c) void {
+            expectSignalRequest(options, request);
+            resolveCallback(user_data, callback, 9, null);
+        }
+    };
+
+    core.setClientRpcCallStubForTesting(Stub.call);
+    defer core.resetClientRpcCallStubForTesting();
+
+    try testing.expectError(SignalError.Internal, core.signalWorkflow(fakeClient(), request));
+}
+
+test "signalWorkflow treats failure payloads with ok status as internal" {
+    const request = "{\"namespace\":\"default\",\"workflow_id\":\"zig\"}";
+
+    const Stub = struct {
+        pub fn call(
+            _: *core.ClientOpaque,
+            options: *const RpcCallOptions,
+            user_data: ?*anyopaque,
+            callback: ClientRpcCallCallback,
+        ) callconv(.c) void {
+            expectSignalRequest(options, request);
+            var failure = makeStaticByteArray("internal error");
+            resolveCallback(user_data, callback, 0, &failure);
+        }
+    };
+
+    core.setClientRpcCallStubForTesting(Stub.call);
+    defer core.resetClientRpcCallStubForTesting();
+
+    try testing.expectError(SignalError.Internal, core.signalWorkflow(fakeClient(), request));
+}
+
+test "signalWorkflow returns ClientUnavailable when core client pointer is null" {
+    const request = "{\"namespace\":\"default\",\"workflow_id\":\"zig\"}";
+    try testing.expectError(SignalError.ClientUnavailable, core.signalWorkflow(null, request));
+}


### PR DESCRIPTION
## Summary
- add a blocking wrapper around temporal_core_client_rpc_call so Zig signalWorkflow forwards the real SignalWorkflowExecution RPC and maps key gRPC statuses
- update client.zig flow and expose a test stub plus new zig unit coverage for success/not-found/unavailable/internal paths
- mark zig-core-02 complete in the production readiness doc

## Testing
- zig build -Doptimize=Debug --build-file packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/build.zig test
- TEMPORAL_BUN_SDK_USE_ZIG=1 pnpm --filter @proompteng/temporal-bun-sdk test

Closes #1554