### PR TITLE
feat: scaffold bun worker mvp runtime

### DIFF
--- a/.github/workflows/temporal-bun-worker-mvp.yml
+++ b/.github/workflows/temporal-bun-worker-mvp.yml
@@ -1,0 +1,60 @@
+name: temporal-bun-worker-mvp
+
+on:
+  push:
+    paths:
+      - 'packages/temporal-bun-sdk/**'
+      - '.github/workflows/temporal-bun-worker-mvp.yml'
+  pull_request:
+    paths:
+      - 'packages/temporal-bun-sdk/**'
+      - '.github/workflows/temporal-bun-worker-mvp.yml'
+
+jobs:
+  test:
+    name: Bun worker tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install pnpm dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.1.20
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.13.0
+
+      - name: Build Zig bridge (debug)
+        run: pnpm --filter @proompteng/temporal-bun-sdk run build:native:zig:debug
+
+      - name: Install package dependencies
+        working-directory: packages/temporal-bun-sdk
+        run: bun install
+
+      - name: Run worker MVP tests
+        working-directory: packages/temporal-bun-sdk
+        run: |
+          bun test tests/worker-mvp.e2e.test.ts | tee ../../worker-mvp-${{ matrix.os }}.log
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: worker-mvp-logs-${{ matrix.os }}
+          path: worker-mvp-${{ matrix.os }}.log
+          if-no-files-found: ignore

--- a/packages/temporal-bun-sdk/docs/worker-mvp.md
+++ b/packages/temporal-bun-sdk/docs/worker-mvp.md
@@ -1,0 +1,82 @@
+# Worker MVP
+
+The Worker MVP demonstrates the Bun worker runtime API and the surrounding ergonomics for
+activities. The implementation is intentionally minimal and uses an in-memory bridge for local
+execution while the Zig bridge is still under active development.
+
+## API overview
+
+```ts
+import { Worker } from '@proompteng/temporal-bun-sdk/worker'
+import { withHeartbeat } from '@proompteng/temporal-bun-sdk/worker'
+
+const worker = new Worker(nativeClient, { taskQueue: 'worker-mvp-tq', concurrency: 2 })
+worker.registerActivity('slowGreet', withHeartbeat(async (context, input) => {
+  await context.heartbeat({ status: 'started' })
+  await context.throwIfCancelled()
+  return `Hello, ${input.name}!`
+}))
+
+await worker.run()
+```
+
+### Activity context helpers
+
+* `context.heartbeat(details?)` — send a heartbeat payload.
+* `context.isCancelled()` / `context.throwIfCancelled()` — probe cancellation and throw a
+  structured `ActivityCancelledError`.
+* `context.scheduleHeartbeat(everyMs, detailsProvider)` — utility used by
+  `withHeartbeat` to emit periodic heartbeats.
+
+The `withHeartbeat` helper wraps an activity handler and automatically schedules heartbeats for the
+duration of the handler.
+
+## Environment
+
+The examples assume the default Temporal development stack:
+
+* Server endpoint: `localhost:7233`
+* Namespace: `default`
+* Task queue: `worker-mvp-tq`
+
+Override these values with environment variables when launching a worker:
+
+* `TEMPORAL_ADDRESS`
+* `TEMPORAL_NAMESPACE`
+* `TEMPORAL_TASK_QUEUE`
+* `TEMPORAL_WORKER_CONCURRENCY`
+
+## Running the example
+
+```bash
+cd packages/temporal-bun-sdk
+bun install
+bun run examples/worker-mvp/run.ts
+```
+
+The example uses an in-memory bridge so that the worker runtime can be exercised without a running
+Temporal server. The script starts a worker, enqueues three `slowGreet` activities, and waits for
+completion.
+
+## Tests
+
+```bash
+bun test tests/worker-mvp.e2e.test.ts
+```
+
+The test suite drives the worker through the in-memory bridge and verifies:
+
+* bounded concurrency (configured to 2 while scheduling 5 tasks)
+* heartbeats emitted at least twice for a long-running task
+* cancellation for a single in-flight task
+* graceful shutdown after a drain period
+
+## Troubleshooting
+
+* **Native bridge not available** — the Zig bridge currently exposes stub implementations for the
+  worker functions. Supply a custom bridge (see the tests and examples) to exercise worker logic
+  until the native layer is complete.
+* **No activity handler registered** — ensure the activity name passed to `registerActivity` matches
+  the `type` field in polled tasks.
+* **Cancellation not observed** — invoke `context.throwIfCancelled()` within your activity or rely on
+  `withHeartbeat`, which probes cancellation whenever it sends a heartbeat.

--- a/packages/temporal-bun-sdk/examples/worker-mvp/run.ts
+++ b/packages/temporal-bun-sdk/examples/worker-mvp/run.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from 'node:crypto'
+import { setTimeout as sleep } from 'node:timers/promises'
+import type { WorkerBridge, ActivityTask } from '../../src/worker'
+import { Worker } from '../../src/worker'
+import { slowGreet } from './slowGreet.activity'
+
+class InMemoryBridge implements WorkerBridge {
+  private readonly queue: ActivityTask[]
+  private readonly heartbeats = new Map<string, number>()
+  private readonly completions: Array<{ token: string; payload: Uint8Array }> = []
+  private readonly failures: Array<{ token: string; payload: Uint8Array }> = []
+  private readonly completionResolvers: Array<() => void> = []
+  private workerHandle = 1
+
+  constructor(tasks: ActivityTask[]) {
+    this.queue = [...tasks]
+  }
+
+  async createWorker(): Promise<number> {
+    return this.workerHandle
+  }
+
+  async setConcurrency(): Promise<void> {
+    // no-op for in-memory bridge
+  }
+
+  async pollActivity(): Promise<ActivityTask | null> {
+    await sleep(50)
+    return this.queue.shift() ?? null
+  }
+
+  async recordHeartbeat(_workerHandle: number, token: Uint8Array): Promise<void> {
+    const key = Buffer.from(token).toString('base64')
+    const count = this.heartbeats.get(key) ?? 0
+    this.heartbeats.set(key, count + 1)
+  }
+
+  async isCancelled(): Promise<boolean> {
+    return false
+  }
+
+  async completeActivity(_workerHandle: number, token: Uint8Array, payload: Uint8Array): Promise<void> {
+    this.completions.push({ token: Buffer.from(token).toString('base64'), payload })
+    this.notify()
+  }
+
+  async failActivity(_workerHandle: number, token: Uint8Array, payload: Uint8Array): Promise<void> {
+    this.failures.push({ token: Buffer.from(token).toString('base64'), payload })
+    this.notify()
+  }
+
+  async shutdownWorker(): Promise<void> {
+    // no-op
+  }
+
+  async waitForCompletion(expected: number): Promise<void> {
+    while (this.completions.length + this.failures.length < expected) {
+      await new Promise<void>((resolve) => this.completionResolvers.push(resolve))
+    }
+  }
+
+  private notify() {
+    const resolve = this.completionResolvers.shift()
+    if (resolve) {
+      resolve()
+    }
+  }
+}
+
+const taskQueue = process.env.TEMPORAL_TASK_QUEUE ?? 'worker-mvp-tq'
+const concurrency = Number.parseInt(process.env.TEMPORAL_WORKER_CONCURRENCY ?? '2', 10)
+
+const bridge = new InMemoryBridge(
+  Array.from({ length: 3 }, () => ({
+    taskToken: Buffer.from(randomUUID(), 'utf8'),
+    type: 'slowGreet',
+    input: { name: 'Temporal', delayMs: 1500 },
+  })),
+)
+
+const worker = new Worker({ type: 'client', handle: 1 }, { taskQueue, concurrency, bridge })
+worker.registerActivity('slowGreet', slowGreet)
+
+async function main() {
+  console.log(`Starting worker on task queue '${taskQueue}' with concurrency ${concurrency}`)
+  const runPromise = worker.run()
+  await bridge.waitForCompletion(3)
+  await worker.shutdown({ drainSeconds: 5 })
+  await runPromise
+  console.log('In-memory tasks complete.')
+}
+
+void main().catch((error) => {
+  console.error('Worker failed', error)
+  process.exitCode = 1
+})

--- a/packages/temporal-bun-sdk/examples/worker-mvp/slowGreet.activity.ts
+++ b/packages/temporal-bun-sdk/examples/worker-mvp/slowGreet.activity.ts
@@ -1,0 +1,30 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+import type { ActivityContext } from '../../src/worker'
+import { withHeartbeat } from '../../src/internal/heartbeat'
+
+export interface SlowGreetInput {
+  name: string
+  delayMs?: number
+}
+
+const BASE_DELAY_MS = 3000
+const HEARTBEAT_INTERVAL_MS = 500
+
+const slowGreetHandler = async (context: ActivityContext, input: SlowGreetInput): Promise<string> => {
+  const delayMs = Math.max(0, Math.floor(input.delayMs ?? BASE_DELAY_MS))
+  const start = Date.now()
+  const deadline = start + delayMs
+
+  while (Date.now() < deadline) {
+    await context.throwIfCancelled()
+    const remaining = Math.max(0, deadline - Date.now())
+    await sleep(Math.min(HEARTBEAT_INTERVAL_MS, remaining))
+  }
+
+  return `Hello, ${input.name}!`
+}
+
+export const slowGreet = withHeartbeat(slowGreetHandler, {
+  everyMs: HEARTBEAT_INTERVAL_MS,
+  detailsProvider: (input: SlowGreetInput) => ({ message: `Greeting ${input.name}` }),
+})

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/lib.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/lib.zig
@@ -15,6 +15,15 @@ fn sliceFrom(ptr: ?[*]const u8, len: u64) []const u8 {
     return ptr.?[0..size];
 }
 
+fn sliceFromI32(ptr: ?[*]const u8, len: i32) []const u8 {
+    if (len <= 0) {
+        return ""[0..0];
+    }
+
+    const size: u64 = @intCast(len);
+    return sliceFrom(ptr, size);
+}
+
 fn toPendingHandle(ptr: ?*anyopaque) ?*pending.PendingHandle {
     return if (ptr) |nonNull| @as(?*pending.PendingHandle, @ptrCast(@alignCast(nonNull))) else null;
 }
@@ -154,6 +163,71 @@ pub export fn temporal_bun_client_signal_with_start(
 ) ?*byte_array.ByteArray {
     const payload = sliceFrom(payload_ptr, len);
     return client.signalWithStart(client_ptr, payload);
+}
+
+pub export fn te_worker_create(
+    client_handle: u64,
+    task_queue_ptr: ?[*]const u8,
+    task_queue_len: i32,
+    out_worker: ?*u64,
+) i32 {
+    const task_queue = sliceFromI32(task_queue_ptr, task_queue_len);
+    return worker.createStubWorker(client_handle, task_queue, out_worker);
+}
+
+pub export fn te_worker_set_concurrency(worker_handle: u64, concurrency: i32) i32 {
+    return worker.setStubConcurrency(worker_handle, concurrency);
+}
+
+pub export fn te_act_poll(
+    worker_handle: u64,
+    out_ptr: ?*[*]const u8,
+    out_len: ?*i32,
+) i32 {
+    return worker.pollStubActivity(worker_handle, out_ptr, out_len);
+}
+
+pub export fn te_act_heartbeat(
+    worker_handle: u64,
+    token_ptr: ?[*]const u8,
+    token_len: i32,
+    details_ptr: ?[*]const u8,
+    details_len: i32,
+) i32 {
+    return worker.recordStubHeartbeat(worker_handle, token_ptr, token_len, details_ptr, details_len);
+}
+
+pub export fn te_act_is_cancelled(
+    worker_handle: u64,
+    token_ptr: ?[*]const u8,
+    token_len: i32,
+    out_bool: ?*i32,
+) i32 {
+    return worker.stubIsCancelled(worker_handle, token_ptr, token_len, out_bool);
+}
+
+pub export fn te_act_complete(
+    worker_handle: u64,
+    token_ptr: ?[*]const u8,
+    token_len: i32,
+    result_ptr: ?[*]const u8,
+    result_len: i32,
+) i32 {
+    return worker.stubCompleteActivity(worker_handle, token_ptr, token_len, result_ptr, result_len);
+}
+
+pub export fn te_act_fail(
+    worker_handle: u64,
+    token_ptr: ?[*]const u8,
+    token_len: i32,
+    err_ptr: ?[*]const u8,
+    err_len: i32,
+) i32 {
+    return worker.stubFailActivity(worker_handle, token_ptr, token_len, err_ptr, err_len);
+}
+
+pub export fn te_worker_shutdown(worker_handle: u64, drain_seconds: i32) i32 {
+    return worker.stubShutdownWorker(worker_handle, drain_seconds);
 }
 
 pub export fn temporal_bun_client_query_workflow(

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/worker.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/worker.zig
@@ -8,6 +8,160 @@ const builtin = @import("builtin");
 
 const grpc = pending.GrpcStatus;
 
+pub fn createStubWorker(
+    client_handle: u64,
+    task_queue: []const u8,
+    out_worker: ?*u64,
+) i32 {
+    _ = client_handle;
+    _ = task_queue;
+
+    if (out_worker == null) {
+        errors.setStructuredErrorJson(.{
+            .code = grpc.invalid_argument,
+            .message = "temporal-bun-bridge-zig: worker output pointer is null",
+            .details = null,
+        });
+        return -1;
+    }
+
+    out_worker.?.* = 0;
+    errors.setStructuredErrorJson(.{
+        .code = grpc.unimplemented,
+        .message = "temporal-bun-bridge-zig: worker runtime is not implemented",
+        .details = null,
+    });
+    return -1;
+}
+
+pub fn setStubConcurrency(worker_handle: u64, concurrency: i32) i32 {
+    _ = worker_handle;
+    _ = concurrency;
+    errors.setStructuredErrorJson(.{
+        .code = grpc.unimplemented,
+        .message = "temporal-bun-bridge-zig: worker concurrency is not implemented",
+        .details = null,
+    });
+    return -1;
+}
+
+pub fn pollStubActivity(
+    worker_handle: u64,
+    out_ptr: ?*[*]const u8,
+    out_len: ?*i32,
+) i32 {
+    _ = worker_handle;
+    if (out_ptr) |ptr| {
+        ptr.* = null;
+    }
+    if (out_len) |len| {
+        len.* = 0;
+    }
+    errors.setStructuredErrorJson(.{
+        .code = grpc.unimplemented,
+        .message = "temporal-bun-bridge-zig: activity polling is not implemented",
+        .details = null,
+    });
+    return -1;
+}
+
+pub fn recordStubHeartbeat(
+    worker_handle: u64,
+    token_ptr: ?[*]const u8,
+    token_len: i32,
+    details_ptr: ?[*]const u8,
+    details_len: i32,
+) i32 {
+    _ = worker_handle;
+    _ = token_ptr;
+    _ = token_len;
+    _ = details_ptr;
+    _ = details_len;
+    errors.setStructuredErrorJson(.{
+        .code = grpc.unimplemented,
+        .message = "temporal-bun-bridge-zig: activity heartbeat is not implemented",
+        .details = null,
+    });
+    return -1;
+}
+
+pub fn stubIsCancelled(
+    worker_handle: u64,
+    token_ptr: ?[*]const u8,
+    token_len: i32,
+    out_bool: ?*i32,
+) i32 {
+    _ = worker_handle;
+    _ = token_ptr;
+    _ = token_len;
+    if (out_bool == null) {
+        errors.setStructuredErrorJson(.{
+            .code = grpc.invalid_argument,
+            .message = "temporal-bun-bridge-zig: cancellation output pointer is null",
+            .details = null,
+        });
+        return -1;
+    }
+    out_bool.?.* = 0;
+    errors.setStructuredErrorJson(.{
+        .code = grpc.unimplemented,
+        .message = "temporal-bun-bridge-zig: activity cancellation detection is not implemented",
+        .details = null,
+    });
+    return -1;
+}
+
+pub fn stubCompleteActivity(
+    worker_handle: u64,
+    token_ptr: ?[*]const u8,
+    token_len: i32,
+    result_ptr: ?[*]const u8,
+    result_len: i32,
+) i32 {
+    _ = worker_handle;
+    _ = token_ptr;
+    _ = token_len;
+    _ = result_ptr;
+    _ = result_len;
+    errors.setStructuredErrorJson(.{
+        .code = grpc.unimplemented,
+        .message = "temporal-bun-bridge-zig: activity completion is not implemented",
+        .details = null,
+    });
+    return -1;
+}
+
+pub fn stubFailActivity(
+    worker_handle: u64,
+    token_ptr: ?[*]const u8,
+    token_len: i32,
+    err_ptr: ?[*]const u8,
+    err_len: i32,
+) i32 {
+    _ = worker_handle;
+    _ = token_ptr;
+    _ = token_len;
+    _ = err_ptr;
+    _ = err_len;
+    errors.setStructuredErrorJson(.{
+        .code = grpc.unimplemented,
+        .message = "temporal-bun-bridge-zig: activity failure is not implemented",
+        .details = null,
+    });
+    return -1;
+}
+
+pub fn stubShutdownWorker(worker_handle: u64, drain_seconds: i32) i32 {
+    _ = worker_handle;
+    _ = drain_seconds;
+    errors.setStructuredErrorJson(.{
+        .code = grpc.unimplemented,
+        .message = "temporal-bun-bridge-zig: worker shutdown is not implemented",
+        .details = null,
+    });
+    return -1;
+}
+
 pub const WorkerHandle = struct {
     id: u64,
     runtime: ?*runtime.RuntimeHandle,

--- a/packages/temporal-bun-sdk/package.json
+++ b/packages/temporal-bun-sdk/package.json
@@ -40,6 +40,7 @@
     "dev": "bun --watch src/bin/start-worker.ts",
     "build": "bunx tsc --project tsconfig.json --pretty false",
     "test": "bun test",
+    "test:worker-mvp": "bun test tests/worker-mvp.e2e.test.ts",
     "test:coverage": "bun test --coverage",
     "start:worker": "bun run dist/bin/start-worker.js",
     "build:native": "bun run scripts/run-with-rust-toolchain.ts -- zig build -Doptimize=ReleaseFast --build-file native/temporal-bun-bridge-zig/build.zig",

--- a/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
+++ b/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
@@ -438,6 +438,33 @@ export const native = {
     }
     return readByteArray(arrayPtr)
   },
+
+  workerBridge: {
+    async createWorker(_clientHandle: number | bigint, _taskQueue: Uint8Array): Promise<number> {
+      throw buildNotImplementedError('Activity worker bridge', 'docs/worker-mvp.md')
+    },
+    async setConcurrency(_workerHandle: number, _concurrency: number): Promise<void> {
+      throw buildNotImplementedError('Activity worker bridge', 'docs/worker-mvp.md')
+    },
+    async pollActivity(_workerHandle: number): Promise<never> {
+      throw buildNotImplementedError('Activity worker bridge', 'docs/worker-mvp.md')
+    },
+    async recordHeartbeat(_workerHandle: number, _token: Uint8Array, _details: Uint8Array): Promise<never> {
+      throw buildNotImplementedError('Activity worker bridge', 'docs/worker-mvp.md')
+    },
+    async isCancelled(_workerHandle: number, _token: Uint8Array): Promise<never> {
+      throw buildNotImplementedError('Activity worker bridge', 'docs/worker-mvp.md')
+    },
+    async completeActivity(_workerHandle: number, _token: Uint8Array, _payload: Uint8Array): Promise<never> {
+      throw buildNotImplementedError('Activity worker bridge', 'docs/worker-mvp.md')
+    },
+    async failActivity(_workerHandle: number, _token: Uint8Array, _payload: Uint8Array): Promise<never> {
+      throw buildNotImplementedError('Activity worker bridge', 'docs/worker-mvp.md')
+    },
+    async shutdownWorker(_workerHandle: number, _drainSeconds: number): Promise<never> {
+      throw buildNotImplementedError('Activity worker bridge', 'docs/worker-mvp.md')
+    },
+  },
 }
 
 function resolvePackageRoot(): string {

--- a/packages/temporal-bun-sdk/src/internal/heartbeat.ts
+++ b/packages/temporal-bun-sdk/src/internal/heartbeat.ts
@@ -1,0 +1,22 @@
+import type { ActivityContext } from '../worker'
+
+export interface HeartbeatOptions<TInput = unknown> {
+  everyMs?: number
+  detailsProvider?: (input: TInput) => unknown | Promise<unknown>
+}
+
+export const withHeartbeat = <TInput = unknown, TResult = unknown>(
+  handler: (context: ActivityContext, input: TInput) => Promise<TResult>,
+  options: HeartbeatOptions<TInput> = {},
+): ((context: ActivityContext, input: TInput) => Promise<TResult>) => {
+  const interval = Math.max(1, Math.floor(options.everyMs ?? 1000))
+
+  return async (context, input) => {
+    const stop = context.scheduleHeartbeat(interval, () => options.detailsProvider?.(input as TInput))
+    try {
+      return await handler(context, input as TInput)
+    } finally {
+      stop()
+    }
+  }
+}

--- a/packages/temporal-bun-sdk/src/worker.ts
+++ b/packages/temporal-bun-sdk/src/worker.ts
@@ -1,55 +1,280 @@
-import { fileURLToPath } from 'node:url'
-import { NativeConnection, type NativeConnectionOptions, Worker, type WorkerOptions } from '@temporalio/worker'
-import { loadTemporalConfig, type TemporalConfig } from './config'
-import * as defaultActivities from './activities'
+import { EventEmitter } from 'node:events'
+import { setTimeout as sleep } from 'node:timers/promises'
+import type { NativeClient } from './internal/core-bridge/native'
 
-const DEFAULT_WORKFLOWS_PATH = fileURLToPath(new URL('./workflows/index.js', import.meta.url))
+const textEncoder = new TextEncoder()
 
-export type WorkerOptionOverrides = Omit<WorkerOptions, 'connection' | 'taskQueue' | 'workflowsPath' | 'activities'>
-
-export interface CreateWorkerOptions {
-  config?: TemporalConfig
-  connection?: NativeConnection
-  taskQueue?: string
-  workflowsPath?: WorkerOptions['workflowsPath']
-  activities?: WorkerOptions['activities']
-  workerOptions?: WorkerOptionOverrides
-  nativeConnectionOptions?: NativeConnectionOptions
+export interface WorkerBridge {
+  createWorker(clientHandle: bigint | number, taskQueue: Uint8Array): Promise<number>
+  setConcurrency(workerHandle: number, concurrency: number): Promise<void>
+  pollActivity(workerHandle: number): Promise<ActivityTask | null>
+  recordHeartbeat(workerHandle: number, token: Uint8Array, details: Uint8Array): Promise<void>
+  isCancelled(workerHandle: number, token: Uint8Array): Promise<boolean>
+  completeActivity(workerHandle: number, token: Uint8Array, payload: Uint8Array): Promise<void>
+  failActivity(workerHandle: number, token: Uint8Array, error: Uint8Array): Promise<void>
+  shutdownWorker(workerHandle: number, drainSeconds: number): Promise<void>
 }
 
-export const createWorker = async (options: CreateWorkerOptions = {}) => {
-  const config = options.config ?? (await loadTemporalConfig())
-  if (config.allowInsecureTls) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+export interface WorkerOptions {
+  taskQueue: string
+  concurrency?: number
+  bridge?: WorkerBridge
+  shutdownSignalDrainSeconds?: number
+}
+
+export interface ActivityTask {
+  readonly taskToken: Uint8Array
+  readonly type: string
+  readonly input: unknown
+}
+
+export interface ActivityContext {
+  readonly taskToken: Uint8Array
+  heartbeat(details?: unknown): Promise<void>
+  isCancelled(): Promise<boolean>
+  throwIfCancelled(): Promise<void>
+  scheduleHeartbeat(everyMs: number, detailsProvider?: () => unknown | Promise<unknown>): () => void
+}
+
+export type ActivityHandler = (context: ActivityContext, input: unknown) => Promise<unknown>
+
+export class ActivityCancelledError extends Error {
+  constructor(message = 'Activity cancelled') {
+    super(message)
+    this.name = 'ActivityCancelledError'
   }
-  const connection =
-    options.connection ??
-    (await NativeConnection.connect({
-      address: config.address,
-      ...(config.tls ? { tls: config.tls } : {}),
-      ...(config.apiKey ? { apiKey: config.apiKey } : {}),
-      ...(options.nativeConnectionOptions ?? {}),
-    }))
-
-  const taskQueue = options.taskQueue ?? config.taskQueue
-  const workflowsPath = options.workflowsPath ?? DEFAULT_WORKFLOWS_PATH
-  const activities = options.activities ?? defaultActivities
-
-  const worker = await Worker.create({
-    connection,
-    taskQueue,
-    workflowsPath,
-    activities,
-    identity: config.workerIdentity,
-    namespace: config.namespace,
-    ...(options.workerOptions ?? {}),
-  })
-
-  return { worker, config, connection }
 }
 
-export const runWorker = async (options?: CreateWorkerOptions) => {
-  const { worker } = await createWorker(options)
-  await worker.run()
-  return worker
+class ActivityContextImpl extends EventEmitter implements ActivityContext {
+  private stopped = false
+  private readonly timers = new Set<NodeJS.Timeout>()
+
+  constructor(
+    readonly taskToken: Uint8Array,
+    private readonly bridge: WorkerBridge,
+    private readonly workerHandle: number,
+  ) {
+    super()
+  }
+
+  stop() {
+    this.stopped = true
+    for (const timer of this.timers) {
+      clearInterval(timer)
+    }
+    this.timers.clear()
+  }
+
+  async heartbeat(details?: unknown): Promise<void> {
+    if (this.stopped) return
+    const payload = details === undefined ? new Uint8Array() : textEncoder.encode(JSON.stringify(details))
+    await this.bridge.recordHeartbeat(this.workerHandle, this.taskToken, payload)
+  }
+
+  async isCancelled(): Promise<boolean> {
+    if (this.stopped) return false
+    return await this.bridge.isCancelled(this.workerHandle, this.taskToken)
+  }
+
+  async throwIfCancelled(): Promise<void> {
+    const cancelled = await this.isCancelled()
+    if (cancelled) {
+      throw new ActivityCancelledError()
+    }
+  }
+
+  scheduleHeartbeat(everyMs: number, detailsProvider?: () => unknown | Promise<unknown>): () => void {
+    if (everyMs <= 0) {
+      throw new Error('Heartbeat interval must be positive')
+    }
+
+    const timer = setInterval(async () => {
+      if (this.stopped) return
+      try {
+        const details = detailsProvider ? await detailsProvider() : undefined
+        await this.heartbeat(details)
+        await this.throwIfCancelled()
+      } catch (error) {
+        this.emit('heartbeatError', error)
+      }
+    }, everyMs)
+
+    this.timers.add(timer)
+
+    return () => {
+      clearInterval(timer)
+      this.timers.delete(timer)
+    }
+  }
 }
+
+export class Worker {
+  private readonly client: NativeClient
+  private readonly taskQueue: string
+  private readonly concurrency: number
+  private readonly bridge: WorkerBridge
+  private workerHandle: number | null = null
+  private running = false
+  private stopping = false
+  private readonly activities = new Map<string, ActivityHandler>()
+  private readonly activeTasks = new Set<Promise<void>>()
+  private readonly availability: Array<() => void> = []
+  private signalHandlersInstalled = false
+  private runPromise: Promise<void> | null = null
+  private readonly signalHandler: () => void
+  private readonly shutdownDrainSeconds: number
+
+  constructor(client: NativeClient, options: WorkerOptions) {
+    if (!options?.taskQueue) {
+      throw new Error('Worker requires a task queue')
+    }
+
+    this.client = client
+    this.taskQueue = options.taskQueue
+    this.concurrency = Math.max(1, options.concurrency ?? 1)
+    this.bridge = options.bridge ?? native.workerBridge
+    this.shutdownDrainSeconds = Math.max(0, options.shutdownSignalDrainSeconds ?? 5)
+    this.signalHandler = () => {
+      void this.shutdown({ drainSeconds: this.shutdownDrainSeconds })
+    }
+  }
+
+  registerActivity(name: string, handler: ActivityHandler): void {
+    if (this.activities.has(name)) {
+      throw new Error(`Activity '${name}' is already registered`)
+    }
+    this.activities.set(name, handler)
+  }
+
+  async run(): Promise<void> {
+    if (this.running) {
+      return this.runPromise ?? Promise.resolve()
+    }
+
+    this.running = true
+    const handle = await this.bridge.createWorker(this.client.handle, textEncoder.encode(this.taskQueue))
+    this.workerHandle = handle
+    await this.bridge.setConcurrency(handle, this.concurrency)
+    this.installSignalHandlers()
+
+    const loop = async () => {
+      while (!this.stopping) {
+        if (this.activeTasks.size >= this.concurrency) {
+          await this.waitForAvailability()
+          continue
+        }
+
+        const task = await this.bridge.pollActivity(handle)
+        if (!task) {
+          await sleep(50)
+          continue
+        }
+
+        this.dispatch(task)
+      }
+
+      await Promise.allSettled(this.activeTasks)
+    }
+
+    this.runPromise = loop().finally(() => {
+      this.running = false
+      this.removeSignalHandlers()
+    })
+    return this.runPromise
+  }
+
+  async shutdown(options: { drainSeconds?: number } = {}): Promise<void> {
+    if (this.stopping) {
+      return this.runPromise ?? Promise.resolve()
+    }
+
+    this.stopping = true
+    const drainSeconds = options.drainSeconds ?? this.shutdownDrainSeconds
+    if (this.workerHandle) {
+      await this.bridge.shutdownWorker(this.workerHandle, drainSeconds)
+    }
+    const runPromise = this.runPromise ?? Promise.resolve()
+    await runPromise
+  }
+
+  private dispatch(task: ActivityTask) {
+    const handler = this.activities.get(task.type)
+    if (!handler) {
+      const errorPayload = textEncoder.encode(
+        JSON.stringify({
+          name: 'ActivityNotRegisteredError',
+          message: `Activity '${task.type}' is not registered`,
+        }),
+      )
+      void this.bridge.failActivity(this.workerHandle!, task.taskToken, errorPayload)
+      return
+    }
+
+    const context = new ActivityContextImpl(task.taskToken, this.bridge, this.workerHandle!)
+    const promise = (async () => {
+      try {
+        const result = await handler(context, task.input)
+        const payload = textEncoder.encode(JSON.stringify({ result }))
+        await this.bridge.completeActivity(this.workerHandle!, task.taskToken, payload)
+      } catch (error) {
+        if (error instanceof ActivityCancelledError) {
+          const payload = textEncoder.encode(JSON.stringify({ cancelled: true, message: error.message }))
+          await this.bridge.failActivity(this.workerHandle!, task.taskToken, payload)
+          return
+        }
+
+        const payload = textEncoder.encode(
+          JSON.stringify({
+            cancelled: false,
+            name: error instanceof Error ? error.name : 'Error',
+            message: error instanceof Error ? error.message : String(error),
+          }),
+        )
+        await this.bridge.failActivity(this.workerHandle!, task.taskToken, payload)
+      } finally {
+        context.stop()
+      }
+    })()
+
+    this.activeTasks.add(promise)
+    promise
+      .finally(() => {
+        this.activeTasks.delete(promise)
+        this.notifyAvailability()
+      })
+      .catch(() => {})
+  }
+
+  private notifyAvailability() {
+    const resolve = this.availability.shift()
+    if (resolve) {
+      resolve()
+    }
+  }
+
+  private waitForAvailability(): Promise<void> {
+    if (this.activeTasks.size < this.concurrency) {
+      return Promise.resolve()
+    }
+
+    return new Promise((resolve) => {
+      this.availability.push(resolve)
+    })
+  }
+
+  private installSignalHandlers() {
+    if (this.signalHandlersInstalled) return
+    process.on('SIGINT', this.signalHandler)
+    process.on('SIGTERM', this.signalHandler)
+    this.signalHandlersInstalled = true
+  }
+
+  private removeSignalHandlers() {
+    if (!this.signalHandlersInstalled) return
+    process.off('SIGINT', this.signalHandler)
+    process.off('SIGTERM', this.signalHandler)
+    this.signalHandlersInstalled = false
+  }
+}
+
+export { withHeartbeat } from './internal/heartbeat'

--- a/packages/temporal-bun-sdk/src/worker/index.ts
+++ b/packages/temporal-bun-sdk/src/worker/index.ts
@@ -1,3 +1,1 @@
-// TODO(codex): Replace this re-export with the Bun-native worker runtime once implemented per
-// packages/temporal-bun-sdk/docs/worker-runtime.md.
-export * from '../../vendor/sdk-typescript/packages/worker/src/index.ts'
+export * from '../worker.ts'

--- a/packages/temporal-bun-sdk/tests/worker-mvp.e2e.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker-mvp.e2e.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { setTimeout as sleep } from 'node:timers/promises'
+import type { ActivityTask, WorkerBridge } from '../src/worker'
+import { Worker } from '../src/worker'
+import { slowGreet } from '../examples/worker-mvp/slowGreet.activity'
+
+interface RecordedFailure {
+  token: string
+  payload: Record<string, unknown>
+}
+
+interface RecordedCompletion {
+  token: string
+  payload: Record<string, unknown>
+}
+
+class TestBridge implements WorkerBridge {
+  private readonly queue: ActivityTask[]
+  private readonly heartbeats = new Map<string, number>()
+  private readonly cancelled = new Set<string>()
+  private readonly completions: RecordedCompletion[] = []
+  private readonly failures: RecordedFailure[] = []
+  private readonly waiters: Array<() => void> = []
+  private handle = 1
+
+  constructor(tasks: ActivityTask[]) {
+    this.queue = [...tasks]
+  }
+
+  async createWorker(): Promise<number> {
+    return this.handle
+  }
+
+  async setConcurrency(): Promise<void> {
+    // no-op
+  }
+
+  async pollActivity(): Promise<ActivityTask | null> {
+    await sleep(10)
+    return this.queue.shift() ?? null
+  }
+
+  async recordHeartbeat(_workerHandle: number, token: Uint8Array): Promise<void> {
+    const key = Buffer.from(token).toString('base64')
+    const count = this.heartbeats.get(key) ?? 0
+    this.heartbeats.set(key, count + 1)
+  }
+
+  async isCancelled(_workerHandle: number, token: Uint8Array): Promise<boolean> {
+    const key = Buffer.from(token).toString('base64')
+    return this.cancelled.has(key)
+  }
+
+  async completeActivity(_workerHandle: number, token: Uint8Array, payload: Uint8Array): Promise<void> {
+    const key = Buffer.from(token).toString('base64')
+    this.completions.push({ token: key, payload: JSON.parse(Buffer.from(payload).toString('utf8') || '{}') })
+    this.notify()
+  }
+
+  async failActivity(_workerHandle: number, token: Uint8Array, payload: Uint8Array): Promise<void> {
+    const key = Buffer.from(token).toString('base64')
+    this.failures.push({ token: key, payload: JSON.parse(Buffer.from(payload).toString('utf8') || '{}') })
+    this.notify()
+  }
+
+  async shutdownWorker(): Promise<void> {
+    // no-op
+  }
+
+  cancelToken(token: Uint8Array) {
+    const key = Buffer.from(token).toString('base64')
+    this.cancelled.add(key)
+  }
+
+  async waitForResults(expected: number): Promise<void> {
+    while (this.completions.length + this.failures.length < expected) {
+      await new Promise<void>((resolve) => this.waiters.push(resolve))
+    }
+  }
+
+  heartbeatCount(token: Uint8Array): number {
+    const key = Buffer.from(token).toString('base64')
+    return this.heartbeats.get(key) ?? 0
+  }
+
+  getResults() {
+    return { completions: this.completions, failures: this.failures }
+  }
+
+  private notify() {
+    const resolve = this.waiters.shift()
+    if (resolve) {
+      resolve()
+    }
+  }
+}
+
+describe('Worker MVP', () => {
+  let tasks: ActivityTask[]
+  let bridge: TestBridge
+  let worker: Worker
+  let concurrencyTracker = { current: 0, max: 0 }
+
+  beforeEach(() => {
+    concurrencyTracker = { current: 0, max: 0 }
+    tasks = Array.from({ length: 5 }, (_, index) => ({
+      taskToken: Buffer.from(randomUUID(), 'utf8'),
+      type: 'slowGreet',
+      input: { name: `Task ${index + 1}`, delayMs: 1500 },
+    }))
+    bridge = new TestBridge(tasks)
+    worker = new Worker({ type: 'client', handle: 1 }, { taskQueue: 'worker-mvp-tq', concurrency: 2, bridge })
+    worker.registerActivity('slowGreet', async (context, input) => {
+      concurrencyTracker.current += 1
+      concurrencyTracker.max = Math.max(concurrencyTracker.max, concurrencyTracker.current)
+      try {
+        return await slowGreet(context, input as { name: string; delayMs?: number })
+      } finally {
+        concurrencyTracker.current -= 1
+      }
+    })
+  })
+
+  it('processes tasks with bounded concurrency, heartbeats, and cancellation', async () => {
+    const cancelToken = tasks[2].taskToken
+    const runPromise = worker.run()
+
+    void (async () => {
+      await sleep(500)
+      bridge.cancelToken(cancelToken)
+    })()
+
+    await bridge.waitForResults(tasks.length)
+    await worker.shutdown({ drainSeconds: 5 })
+    await runPromise
+
+    expect(concurrencyTracker.max).toBeLessThanOrEqual(2)
+    expect(bridge.heartbeatCount(tasks[0].taskToken)).toBeGreaterThanOrEqual(2)
+
+    const { completions, failures } = bridge.getResults()
+    const cancelled = failures.find((entry) => entry.token === Buffer.from(cancelToken).toString('base64'))
+    expect(cancelled).toBeDefined()
+    expect(cancelled?.payload.cancelled).toBe(true)
+
+    expect(completions).toHaveLength(tasks.length - 1)
+    expect(failures).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- scaffold a Bun worker runtime with activity context, heartbeat helper, and cancellation support
- add an in-memory example plus docs and end-to-end tests for concurrency, heartbeats, and cancellation
- wire up stub Zig FFI exports and CI coverage for the worker MVP path

## Testing
- bun test tests/worker-mvp.e2e.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f71c6ca6508324b3b887461ab1d674