### PR TITLE
fix(workflow): add missing temporal-sdk-core-c-bridge library to build

### DIFF
--- a/.github/workflows/temporal-static-libraries.yml
+++ b/.github/workflows/temporal-static-libraries.yml
@@ -77,6 +77,7 @@ jobs:
           # Build each crate as a static library
           TARGET="${{ matrix.target }}"
           cargo rustc -p temporal-sdk-core --crate-type staticlib --target "$TARGET" --release
+          cargo rustc -p temporal-sdk-core-c-bridge --crate-type staticlib --target "$TARGET" --release
           cargo rustc -p temporal-client --crate-type staticlib --target "$TARGET" --release
           cargo rustc -p temporal-sdk-core-api --crate-type staticlib --target "$TARGET" --release
           cargo rustc -p temporal-sdk-core-protos --crate-type staticlib --target "$TARGET" --release
@@ -91,6 +92,7 @@ jobs:
 
           # Copy static libraries
           cp "$TARGET_DIR/libtemporal_sdk_core.a" artifacts/
+          cp "$TARGET_DIR/libtemporal_sdk_core_c_bridge.a" artifacts/
           cp "$TARGET_DIR/libtemporal_client.a" artifacts/
           cp "$TARGET_DIR/libtemporal_sdk_core_api.a" artifacts/
           cp "$TARGET_DIR/libtemporal_sdk_core_protos.a" artifacts/


### PR DESCRIPTION
## Problem

The temporal-static-libraries workflow was missing the  crate, causing published artifacts to be incomplete. The build system expects 5 libraries but only 4 were being built:

**Expected by build.zig:**
- libtemporal_sdk_core.a
- libtemporal_sdk_core_c_bridge.a ❌ **Missing**
- libtemporal_client.a  
- libtemporal_sdk_core_api.a
- libtemporal_sdk_core_protos.a

**Currently built by workflow:**
- libtemporal_sdk_core.a ✅
- libtemporal_client.a ✅
- libtemporal_sdk_core_api.a ✅
- libtemporal_sdk_core_protos.a ✅

## Solution

Add the missing crate to both:
1. Build step: 
2. Artifact collection: 

## Impact

This fixes the issue where downloaded libraries don't contain all expected Temporal SDK files, causing builds to fail with missing library errors.

After this is merged, the workflow can be run to publish complete artifacts.