### PR TITLE
fix(workflow): add contents write permission for release creation

### DIFF
--- a/.github/workflows/temporal-static-libraries.yml
+++ b/.github/workflows/temporal-static-libraries.yml
@@ -13,6 +13,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: write
+  
 jobs:
   build:
     name: Build Static Libraries


### PR DESCRIPTION
## Problem

The temporal-static-libraries workflow failed with error:


This happens when trying to create a GitHub release because the workflow doesn't have the required permissions.

## Solution

Add  permission to the workflow, which is required for:
- Creating GitHub releases
- Uploading release assets

## Error Details

From the failed workflow run:


## Impact

After this fix, the workflow will be able to successfully create releases with the built static library artifacts.