### PR TITLE
docs: refresh temporal bun sdk design docs

### DIFF
--- a/packages/temporal-bun-sdk/docs/ffi-surface.md
+++ b/packages/temporal-bun-sdk/docs/ffi-surface.md
@@ -1,8 +1,8 @@
 # Temporal Bun SDK — Native FFI Surface Blueprint
 
-**Audience:** Future Codex instances shipping the Bun-native Temporal SDK  
-**Status:** Authoritative blueprint (17 Oct 2025)  
-**Goal:** Deliver a complete Bun ↔ Temporal Core bridge so no upstream `@temporalio/*` packages are required, building on the C API exposed by the upstream [`temporal-sdk-core-c-bridge`](https://github.com/temporalio/sdk-core/tree/main/crates/sdk-core-c-bridge).
+**Audience:** Platform Runtime & Codex implementers  
+**Status:** Living document (25 Oct 2025)  
+**Goal:** Capture the Zig-based Bun ↔ Temporal Core surface so we can finish replacing all `@temporalio/*` dependencies with a Bun-native SDK while keeping the unsafe layer constrained and well-tested.
 
 ---
 
@@ -10,185 +10,172 @@
 
 | Principle | Description |
 |-----------|-------------|
-| Parity-first | Expose enough surface area to run workers, workflows, and activities exactly like the Node SDK. |
-| Bun-native ergonomics | Offer small, typed helpers on the TypeScript side; keep unsafe FFI isolated to `src/internal/core-bridge/native.ts`. |
-| Crash resilience | All exported functions must guard null pointers, return deterministic errors via `temporal_bun_error_message`, and never panic. |
-| Testable contracts | Every FFI export gets a dedicated Bun test (unit) plus integration coverage via docker-compose Temporal stack. |
+| Parity-first | Deliver client and worker capabilities that match the upstream TypeScript SDK before adding bespoke features. |
+| Bun-native ergonomics | Keep the TypeScript layer declarative and typed (`zod` schemas, helpers); confine unsafe memory work to `src/internal/core-bridge/native.ts` and Zig. |
+| Crash resilience | All exports guard null pointers, return deterministic errors via `temporal_bun_error_message`, and never panic. |
+| Testability | Every export ships with Bun unit coverage and, where practical, integration tests against the Temporal CLI dev server. |
+| Observability | Prefer returning structured gRPC status codes so Bun callers can translate directly into actionable errors. |
+
+Mermaid sketch of the flow:
 
 ```mermaid
 flowchart LR
-  BunTS["Bun TypeScript<br/>Layer"] -->|FFI calls| Bridge["temporal_bun_* functions"]
-  Bridge -->|Rust ABI| CoreRuntime["Temporal Core Runtime"]
-  CoreRuntime --> TemporalServer["Temporal Server"]
-  BunTS -->|Config + payloads| Bridge
-  TemporalServer --> CoreRuntime
+  BunTS["Bun TypeScript\nLayer"] -->|bun:ffi| ZigBridge["libtemporal_bun_bridge_zig"]
+  ZigBridge -->|C ABI| CoreRuntime["temporal-sdk-core-c-bridge"]
+  CoreRuntime --> TemporalServer["Temporal Server / Cloud"]
+  BunTS -->|Config + payloads| ZigBridge
 ```
 
 ---
 
-## 2. Function Matrix
+## 2. Current State (25 Oct 2025)
 
-Current progress snapshot:
+### Runtime (`runtime.zig`)
+- ✅ `temporal_bun_runtime_new/free` create and dispose Temporal core runtimes, tracking in-flight client connects.
+- ⚠️ Telemetry (`temporal_bun_runtime_update_telemetry`) and logger (`temporal_bun_runtime_set_logger`) return `UNIMPLEMENTED`. Hooks remain TODO pending upstream signal.
 
-- ✅ Client connect + describe namespace working (Bun integration tests exercise live Temporal).
-- ⚙️ Next up: add workflow operations (start/signal/query/terminate) in both Rust and TS layers.
-- ⬜️ Worker and runtime APIs remain untouched.
+### Client (`client.zig`)
+- ✅ Async connect (`temporal_bun_client_connect_async`) with pending handles and thread pool.
+- ✅ DescribeNamespace, QueryWorkflow, StartWorkflow, and SignalWithStart marshal protobuf payloads directly in Zig and decode responses for Bun.
+- ⚠️ SignalWorkflow validates payloads and uses pending handles, but the underlying Temporal RPC is still stubbed in `core.zig` (`zig-wf-05`).
+- ❌ TerminateWorkflow, CancelWorkflow, and UpdateHeaders return `UNIMPLEMENTED` placeholders—TypeScript callers receive `NativeBridgeError` with `code: grpc.unimplemented`.
+- ⚠️ Byte-array helpers allocate buffers via `byte_array.zig`; free path is wired, but we still need `temporal_bun_byte_array_new` once upstream expects Bun to allocate memory for large payloads.
 
-| Area | Rust Export | Purpose | TS Wrapper | Status |
-|------|-------------|---------|------------|--------|
-| Runtime | `temporal_bun_runtime_new(options_ptr, len)` | Create `CoreRuntime` with telemetry/logging config | `native.createRuntime` (extend options) | ✅ (options ignored today) |
-| Runtime | `temporal_bun_runtime_free(runtime_ptr)` | Release runtime | `native.runtimeShutdown` | ✅ |
-| Runtime | `temporal_bun_runtime_update_telemetry(runtime_ptr, options_ptr, len)` | Apply telemetry exporters (Prom, OTLP) | `coreBridge.configureTelemetry` | ⬜️ TODO |
-| Runtime | `temporal_bun_runtime_set_logger(runtime_ptr, callback_ptr)` | Forward core logs into Bun | `coreBridge.installLogger` | ⬜️ TODO |
-| Client | `temporal_bun_client_connect_async(runtime_ptr, config_ptr, len)` | Create gRPC retry client + namespace | `native.createClient` | ✅ (async pending handle) |
-| Client | `temporal_bun_client_free(client_ptr)` | Dispose client | `native.clientShutdown` | ✅ |
-| Client | `temporal_bun_client_describe_namespace_async(client_ptr, payload_ptr, len)` | Describe namespace via async pending handle | `native.describeNamespace` | ✅ (new) |
-| Client | `temporal_bun_client_update_headers(client_ptr, headers_ptr, len)` | Update gRPC metadata (API key, custom headers) | `coreBridge.client.updateHeaders` | ✅ Implemented |
-| Client | `temporal_bun_client_start_workflow(client_ptr, payload_ptr, len)` | Start workflow execution | `client.workflow.start` | ✅ Implemented |
-| Client | `temporal_bun_client_signal(client_ptr, payload_ptr, len)` | Send signal to existing workflow | `client.signal` | ⬜️ TODO |
-| Client | `temporal_bun_client_query_workflow(client_ptr, payload_ptr, len)` | Run workflow query | `client.query` | ✅ Zig returns raw gRPC response bytes; TypeScript decodes `QueryWorkflowResponse` and payloads into JSON. |
-| Client | `temporal_bun_client_terminate_workflow(...)` | Terminate workflow | `client.terminate` | ✅ Implemented |
-| Client | `temporal_bun_client_cancel_workflow(...)` | Cancel workflow | `client.cancel` | ⬜️ TODO |
-| Client | `temporal_bun_client_signal_with_start(...)` | Signal-with-start helper | `client.signalWithStart` | ⬜️ TODO |
-| Byte transport | `temporal_bun_byte_array_new(ptr, len)` | Allocate vector for responses | `byteArray.fromBuffer` | ⬜️ TODO |
-| Byte transport | `temporal_bun_byte_array_free(array_ptr)` | Free allocated data | `native.freeByteArray` | ✅ |
-| Pending | `temporal_bun_pending_client_poll(pending_ptr)` | Readiness check for client connect (0=pending,1=ready,-1=error) | `pendingClient.poll` | ✅ (new) |
-| Pending | `temporal_bun_pending_client_consume(pending_ptr)` | Consume pending client handle | `pendingClient.consume` | ✅ (new) |
-| Pending | `temporal_bun_pending_client_free(pending_ptr)` | Drop pending client handle | `pendingClient.destroy` | ✅ (new) |
-| Pending | `temporal_bun_pending_byte_array_poll(pending_ptr)` | Non-blocking readiness check (0=pending,1=ready,-1=error) | `pending.poll` | ✅ (new) |
-| Pending | `temporal_bun_pending_byte_array_consume(pending_ptr)` | Consume ready result into ByteArray | `pending.consume` | ✅ (new) |
-| Pending | `temporal_bun_pending_byte_array_free(pending_ptr)` | Drop pending handle (cleanup) | `pending.destroy` | ✅ (new) |
+### Worker (`worker.zig`)
+- ⚠️ Workflow completion uses stub callbacks for unit tests.
+- ❌ Worker creation, task polling, activity completion, heartbeats, and shutdown exports are placeholders (tagged `zig-worker-0x`).
 
-### Async Pending Handles
-
-- Pending handles wrap Tokio futures in a background thread, surface `poll` + `consume` semantics to Bun, and ensure the JS event loop never blocks on gRPC calls.
-- Every async FFI export must return a pending handle (or reuse the shared helpers) so we can apply the same lifecycle guarantees: single-consume, deterministic error propagation via `temporal_bun_error_message`, and explicit `free`.
-- The Bun side polls on an interval (`setTimeout` cadence) and calls `consume` only once `poll` reports ready. Errors surface immediately via the shared error buffer, and the handle is freed regardless of success or failure.
-
-| Worker | `temporal_bun_worker_new(runtime_ptr, client_ptr, config_ptr, len)` | Instantiate worker for task queue | `native.createWorker` | ⬜️ TODO |
-| Worker | `temporal_bun_worker_free(worker_ptr)` | Free worker | `native.workerShutdown` | ⬜️ TODO |
-| Worker | `temporal_bun_worker_poll_workflow_task(worker_ptr)` | Poll workflow tasks (blocking) | `workerBridge.pollWorkflowTask` | ⬜️ TODO |
-| Worker | `temporal_bun_worker_complete_workflow_task(worker_ptr, payload_ptr, len)` | Complete workflow task | `workerBridge.completeWorkflowTask` | ⚙️ Zig bridge implementation (core handle pending) |
-| Worker | `temporal_bun_worker_poll_activity_task(worker_ptr)` | Poll activity task | `workerBridge.pollActivityTask` | ⬜️ TODO |
-| Worker | `temporal_bun_worker_complete_activity_task(worker_ptr, payload_ptr, len)` | Respond to activity task | `workerBridge.completeActivityTask` | ⬜️ TODO |
-| Worker | `temporal_bun_worker_record_activity_heartbeat(worker_ptr, payload_ptr, len)` | Activity heartbeat | `workerBridge.recordHeartbeat` | ⬜️ TODO |
-| Worker | `temporal_bun_worker_initiate_shutdown(worker_ptr)` | Soft shutdown (no new polls) | `worker.shutdown` | ⬜️ TODO |
-| Worker | `temporal_bun_worker_finalize_shutdown(worker_ptr)` | Wait for inflight tasks | `worker.runUntilShutdown` | ⬜️ TODO |
-| Ephemeral | `temporal_bun_test_server_start(config_ptr, len)` | Optional local test server | `testServer.start` | ⬜️ OPTIONAL |
-| Ephemeral | `temporal_bun_test_server_stop(server_ptr)` | Stop test server | `testServer.stop` | ⬜️ OPTIONAL |
-
-> **Implementation note:** The worker-related FFI functions mirror `temporal-sdk-core`’s `CoreSDK` interface. Use the existing `temporal-sdk-core-c-bridge` as a reference for payload shapes.
+### Support crates
+- ✅ `pending.zig` implements reference-counted pending handles for clients and byte arrays.
+- ✅ `errors.zig` stores the last error as JSON (`{ code, message, details }`) for Bun to consume.
+- ✅ `core.zig` installs real Temporal core API pointers at runtime; fallback stubs keep tests running without bundled libs.
+- ✅ `byte_array.zig` allocates/frees buffers that Bun can copy into `Uint8Array`.
 
 ---
 
-## 3. Payload & Encoding Contracts
+## 3. Function Matrix
 
-1. **JSON control envelopes**  
-   All FFI calls accept a JSON envelope describing the action. Example for `temporal_bun_client_start_workflow`:
-   ```json
-   {
-     "namespace": "default",
-     "taskQueue": "prix",
-     "workflowId": "helloTemporal-123",
-     "workflowType": "helloTemporal",
-     "arguments": [ /* payloads encoded as base64 */ ],
-     "timeoutMs": 60000
-   }
-   ```
-   The TS helper handles encoding Temporal payloads (proto) to buffers, then wraps them in the envelope.
+| Area | Export | Status | Notes |
+|------|--------|--------|-------|
+| Runtime | `temporal_bun_runtime_new` / `free` | ✅ | Allocates runtime handle, copies JSON config, releases pending connects before shutdown. |
+| Runtime | `temporal_bun_runtime_update_telemetry` | ⚠️ TODO | Returns `grpc.unimplemented`; wire Prom/OTLP exporters once upstream APIs are exposed (tracked as `zig-runtime-02`). |
+| Runtime | `temporal_bun_runtime_set_logger` | ⚠️ TODO | Stub that records `grpc.unimplemented`; needs callback trampoline when Temporal core supports custom log sinks. |
+| Client | `temporal_bun_client_connect_async` | ✅ | Spawns thread, honors runtime destroy semantics, returns pending handle. |
+| Client | `temporal_bun_client_describe_namespace_async` | ✅ | Encodes protobuf request (`DescribeNamespaceRequest`), resolves pending byte array. |
+| Client | `temporal_bun_client_start_workflow` | ✅ | Builds `StartWorkflowExecutionRequest`, invokes `temporal_core_client_rpc_call`, returns JSON `{ runId, workflowId, namespace }`. |
+| Client | `temporal_bun_client_signal_with_start` | ✅ | Shares start encoders, adds signal payload, reuses start result parsing. |
+| Client | `temporal_bun_client_query_workflow` | ✅ | Threaded pending handle; decodes `QueryWorkflowResponse`, surfaces gRPC rejection codes. |
+| Client | `temporal_bun_client_signal` | ⚠️ Stub | Validates JSON and spins worker thread, but `core.signalWorkflow` currently short-circuits; implement RPC call via `temporal_core_client_rpc_call`. |
+| Client | `temporal_bun_client_terminate_workflow` | ✅ | Calls Temporal core terminate RPC and surfaces gRPC status codes. |
+| Client | `temporal_bun_client_cancel_workflow` | ❌ | Placeholder returning `grpc.unimplemented`; should reuse pending handle infrastructure. |
+| Client | `temporal_bun_client_update_headers` | ❌ | Stub; require conversion of headers map into `TemporalCoreMetadataRef`. |
+| Byte transport | `temporal_bun_pending_*`, `temporal_bun_byte_array_free` | ✅ | Shared infrastructure used by connect/query/signal flows. |
+| Worker | `temporal_bun_worker_*` family | ❌ | All stubs except `complete_workflow_task`; primary focus for Bun-native worker delivery. |
 
-2. **Payload bytes**  
-   For responses or streaming items, return `ByteArray` pointers. The TS side converts them into `ArrayBuffer` -> `Buffer` -> strongly typed objects.
-   - `temporal_bun_byte_array_new(ptr, len)` copies the payload into a Rust-owned buffer sourced from a small reuse pool (16 entries, capped at 32&nbsp;MiB each). Keep the Bun-side buffer alive for the duration of the call; no additional alignment beyond byte-addressable memory is required.
-   - `temporal_bun_byte_array_free(array_ptr)` returns the buffer to the pool. Call exactly once per pointer to avoid leaks or double frees.
-
-3. **TLS / Metadata**  
-   Extend `ClientConfig` to include TLS PEM strings (base64) or file paths resolved in TS. Rust side configures `ClientOptionsBuilder` accordingly.
-
-4. **Error propagation**  
-   Any failure: return `null` pointer or `0` and call `error::set_error`. Message template: `"bridge:<component>: <summary>: <details>"`. TS wrapper throws enriched `TemporalBridgeError`.
-
-5. **Client metadata updates**  
-   Accept a JSON object of string header pairs. Keys are normalized to lowercase and must be unique ignoring case; empty keys or values trigger `InvalidMetadata` errors. The Rust bridge trims values, maps `authorization: "Bearer <token>"` into `set_api_key`, and surfaces gRPC validation errors through `NativeBridgeError` on the TypeScript side.
+Legend: ✅ shipped · ⚠️ partial/stub · ❌ not implemented yet.
 
 ---
 
-## 4. TypeScript Layer Tasks
+## 4. Pending Handles & Threading Model
 
-| Module | Responsibilities |
-|--------|------------------|
-| `src/internal/core-bridge/native.ts` | Map each FFI export, handle pointer lifetimes (`ptr`, `toArrayBuffer`), normalize errors. |
-| `src/core-bridge/index.ts` | Provide a Bun-friendly CoreSDK wrapper replicating `@temporalio/core-bridge` shape (runtime, worker, client). |
-| `src/client.ts` | Replace direct `@temporalio/client` usage with Core bridge client commands and high-level helpers (`startWorkflow`, `signal`, etc.). |
-| `src/worker.ts` | Implement polling loop, workflow isolate management (use Bun’s `import()` for workflows), activity execution, heartbeats, shutdown logic. |
-| `src/workflow/runtime` | Introduce a minimal workflow runtime (activation handling, patch markers, timer/signal commands). Consider porting upstream workflow isolate logic. |
-| `src/common/payloads.ts` | Serialize/deserialize Temporal payloads (proto via `@temporalio/proto` vendored TypeScript, or implement own). |
+- Pending handles (`pending.zig`) wrap tasks executed on detached Zig threads. Each handle maintains a tiny state machine (`PendingState`) with atomic transitions.
+- Runtime connects increment a counter on `RuntimeHandle`; destruction waits for outstanding connects before freeing Temporal core runtime pointers.
+- Byte-array pending handles own both the Zig buffer and the eventual result pointer consumed by Bun. Callers **must** invoke `temporal_bun_pending_*_free` to avoid leaks.
+- For long-running RPCs (signal/query), we spawn a thread per request today; TODO (`zig-runtime-04`) is to pool threads or reuse an async executor once benchmarks confirm the need.
 
 ---
 
-## 5. Testing Strategy
+## 5. Error Handling & Diagnostics
 
-1. **Unit Tests (Bun)**
-   - `tests/native-runtime.test.ts`: runtime creation, telemetry setter, logger callback invoked.
-   - `tests/native-client.test.ts`: start/signal/query with mocked core (use `tokio::test` harness or stub responses).
-   - `tests/client.test.ts`: client metadata updates, validation, and native error propagation.
-   - `tests/native-worker.test.ts`: ensure poll/complete functions handle JSON + payloads correctly (use fake core responses).
-
-2. **Integration Tests**
-   - Docker Compose launching Temporal server + Bun worker (already in repo). Write tests that:
-     - Start workflow -> activity executes -> worker completes.
-     - Activity heartbeat/resume.
-     - Workflow signal & query.
-     - Graceful shutdown after `SIGTERM`.
-
-3. **Determinism / Replay**
-   - Capture activation history from a run and replay using the workflow runtime to ensure deterministic result.
-
-4. **Telemetry / Logging Smoke**
-   - Config baseline: Prometheus listener + log forwarding to Bun (assert callbacks fired).
+- `errors.zig` exposes `setStructuredError({ code, message, details })`; TypeScript transforms failures into `NativeBridgeError` with the same payload.
+- Native errors fallback to JSON when possible; otherwise raw strings are wrapped with `code = UNKNOWN`.
+- Zig stubs prefix messages with `temporal-bun-bridge-zig:` so Bun callers can detect unimplemented paths quickly.
+- Ensure every new export sets a success message (`errors.setLastError(""))` on success and uses `grpc_status` codes defined in `pending.zig`.
 
 ---
 
-## 6. Migration Plan (Stepwise)
+## 6. Payload Encoding Notes
 
-1. **Phase 1 — Client Parity**
-   - Implement TLS/API key support, start/signal/query/terminate FFI.
-   - Rewrite `createTemporalClient` to rely solely on FFI. Remove `@temporalio/client` dependency.
-
-2. **Phase 2 — Worker Core**
-   - Implement worker create/poll/complete/heartbeat in Rust & TS.
-   - Port minimal workflow runtime (activation dispatch, activity scheduling). Remove `@temporalio/worker`.
-   - Provide `bun run dev` sample that completes activities against real Temporal.
-
-3. **Phase 3 — Workflow Runtime Enhancements**
-   - Add memo, search attributes, patch APIs, local activities, continue-as-new.
-   - Support bundling (Bun loader) or dynamic import for workflow code.
-
-4. **Phase 4 — Tooling & Docs**
-   - Update README, CLI templates to reflect pure Bun stack.
-   - Publish FFI docs (this file) and implementation status tracker.
-
-5. **Phase 5 — Validation**
-   - CI job building native bridge for macOS/Linux, running integration suite.
-   - Publish canary build to npm (internal tag) for manual QA before public release.
+- Requests are constructed manually to avoid bundling generated protobufs:
+  - `DescribeNamespace` builds the varint-encoded request payload.
+  - `StartWorkflowExecution` and `SignalWithStart` use helper functions in `client.zig` (`appendString`, `appendLengthDelimited`, etc.).
+  - Memo, search attributes, headers leverage `encodePayloadMap`, producing `Payloads` structures compatible with Temporal core.
+- Responses from Temporal core are either JSON strings (for metadata) or raw protobuf bytes. When returning JSON to Bun, duplicate slices before freeing Temporal core buffers.
+- TLS config values are accepted as base64 strings; `client.ts` handles conversion from Buffers.
 
 ---
 
-## 7. Reference Materials
+## 7. Worker Surface (TODO Breakdown)
 
-- Temporal Core Rust docs: Available in the upstream `temporal-sdk-core` repository
-- Temporal C bridge (for parity): `temporal-sdk-core-c-bridge` crate documentation
-- Current Zig bridge implementation: `packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/`
-- Pre-built static libraries: Downloaded automatically from GitHub releases during build
-- Bun FFI reference: https://bun.sh/docs/api/ffi
+| Tag | Task | Summary |
+|-----|------|---------|
+| `zig-worker-01` | Worker creation | Translate Bun worker config into `TemporalCoreWorkerOptions`, create worker via Temporal core API. |
+| `zig-worker-02` | Worker shutdown | Ensure inflight polls drain; free worker handle safely. |
+| `zig-worker-03` | Poll workflow tasks | Pending-handle wrapper around `temporal_core_worker_poll_workflow_activation`. |
+| `zig-worker-04` | Complete workflow tasks | Already partially implemented; finish integration with real Temporal core callbacks. |
+| `zig-worker-05` | Poll activity tasks | Mirror workflow polling for activities. |
+| `zig-worker-06` | Complete activity tasks | Forward completion payload to Temporal core; surface failure payloads. |
+| `zig-worker-07` | Heartbeats | Forward payloads and handle cancellation. |
+| `zig-worker-08` | Initiate shutdown | Signal no new polls; allow graceful drain. |
+| `zig-worker-09` | Finalize shutdown | Await outstanding completions, release handles. |
+
+Delivering these tasks unblocks swapping out `@temporalio/worker` with the Bun-native worker runtime.
 
 ---
 
-## 8. Open Questions
+## 8. Testing Expectations
 
-1. **Workflow isolate:** Do we embed JavaScriptCore via Bun, or spawn separate Bun processes per workflow task? Evaluate determinism guarantees.
-2. **Payload codec:** Should we vendor Temporal proto definitions or implement JSON payloads only for first release?
-3. **Telemetry defaults:** What exporters should be built-in vs. optional features behind cargo flags?
-4. **Windows support:** Out of scope right now; document if anything should explicitly guard against it.
+- **Bun tests** (`bun test`):
+  - `tests/native.integration.test.ts` — end-to-end workflow (start/query) against Temporal CLI server.
+  - `tests/zig-signal.test.ts` — exercises signal pending handles (stubs today; update once RPC wired).
+  - `tests/core-bridge.test.ts` — covers error propagation and pending handle lifecycle.
+  - `tests/client.test.ts` — validates TypeScript serialization/validation using mocked native bridge.
+- **Zig tests** (`zig build test`):
+  - Validate JSON parsing helpers, retry policy encoding, pending-handle transitions, and workflow completion callbacks.
+- TODO: add coverage for signal encoders once implemented.
+- **Integration**: `bun test tests/native.integration.test.ts` with `TEMPORAL_TEST_SERVER=1` orchestrates Temporal CLI server start/stop via scripts in `scripts/` directory.
+- **CI gating**: run Bun tests + Zig tests in release and debug modes; fail fast if `NativeBridgeError` messages change to catch regressions.
 
-Document updates should append sections rather than overwrite to keep audit history for future iterations.
+---
+
+## 9. Roadmap (FFI-Focused)
+
+1. **Finish client parity** (target: late Oct 2025)
+   - Implement `update_headers`, `cancel`, and real `signal` RPC.
+   - Add Bun tests covering each RPC against Temporal CLI server.
+2. **Telemetry & logging** (depends on upstream API availability)
+   - Expose telemetry config struct; support Prometheus + OTLP exporters.
+   - Bridge log forwarding callbacks into Bun.
+3. **Worker parity** (multi-week effort)
+   - Implement tasks outlined in §7; ship Bun `WorkerRuntime` consuming new exports.
+   - Provide integration test running hello-world workflow entirely via Zig worker.
+4. **Performance tuning**
+   - Benchmark thread-per-request vs. pooled executor for pending handles.
+   - Investigate zero-copy payload hand-off using `temporal_bun_byte_array_new` or shared memory.
+5. **Packaging**
+   - Automate `zig build -Doptimize=ReleaseFast` for darwin/linux (arm64/x64) and upload artifacts to GitHub Releases.
+   - Document `TEMPORAL_BUN_SDK_NATIVE_PATH` override for custom builds.
+
+---
+
+## 10. Reference Materials
+
+- Zig bridge source: `packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/`
+- Bun FFI wrapper: `packages/temporal-bun-sdk/src/internal/core-bridge/native.ts`
+- Temporal core C headers: downloaded via `scripts/download-temporal-libs.ts`
+- Upstream repos: `temporalio/sdk-core` (Rust), `temporalio/sdk-typescript`
+- Temporal docs: [docs.temporal.io](https://docs.temporal.io)
+
+---
+
+## 11. Open Questions
+
+1. Should we generate Zig bindings from the upstream C header at build time to ensure parity, or continue hand-authoring signatures?
+2. How do we expose long-lived metadata changes? (Option A: `update_headers` RPC; Option B: recreate client.)
+3. Do we need a shared thread pool for pending handles, or is one thread per request acceptable given expected QPS?
+4. When worker exports land, do we mirror the Node worker activity/workflow sandbox model or design a Bun-specific isolate strategy?
+5. Should we gate unimplemented RPCs behind feature flags in TypeScript to make failures clearer to early adopters?
+
+---
+
+Document updates should continue to append implementation notes so future Codex agents can pick up the remaining work without re-auditing the entire bridge.

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/client.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/client.zig
@@ -3482,6 +3482,8 @@ pub fn queryWorkflow(client_ptr: ?*ClientHandle, payload: []const u8) ?*pending.
 }
 
 pub fn signalWorkflow(client_ptr: ?*ClientHandle, payload: []const u8) ?*pending.PendingByteArray {
+    // TODO(codex, zig-wf-05): Replace temporary stub with direct Temporal core RPC so signals run
+    // through the Zig bridge without falling back to Node helpers.
     if (client_ptr == null) {
         return createByteArrayError(grpc.invalid_argument, "temporal-bun-bridge-zig: signalWorkflow received null client");
     }

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/core.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/core.zig
@@ -207,6 +207,8 @@ pub const SignalWorkflowError = error{
 };
 
 pub fn signalWorkflow(_client: ?*ClientOpaque, request_json: []const u8) SignalWorkflowError!void {
+    // TODO(codex, zig-wf-05): Replace this stub with a Temporal core RPC invocation so signals
+    // leverage the same retry/backoff semantics as other client calls.
     _ = _client;
 
     if (std.mem.indexOf(u8, request_json, "\"workflow_id\":\"missing-workflow\"")) |_| {

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/pending.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/pending.zig
@@ -116,6 +116,8 @@ fn destroyHandle(handle: *PendingHandle) void {
 pub const PendingClient = PendingHandle;
 pub const PendingByteArray = PendingHandle;
 
+// TODO(codex, zig-runtime-04): Explore pooling or reusing worker threads so pending handles avoid
+// the overhead of `std.Thread.spawn` per RPC once benchmarks justify the complexity.
 fn assignError(handle: *PendingHandle, code: i32, message: []const u8, duplicate: bool) void {
     destroyMessage(handle.fault.message, handle.fault.owns_message);
     handle.fault.code = code;

--- a/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/runtime.zig
+++ b/packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/src/runtime.zig
@@ -135,6 +135,8 @@ pub fn destroy(handle: ?*RuntimeHandle) void {
 pub fn updateTelemetry(handle: ?*RuntimeHandle, _options_json: []const u8) i32 {
     _ = handle;
     _ = _options_json;
+    // TODO(codex, zig-runtime-02): Bridge telemetry configuration into Temporal core once the
+    // upstream runtime exposes stable Prometheus/OTLP hooks.
     errors.setStructuredError(.{
         .code = grpc.unimplemented,
         .message = "temporal-bun-bridge-zig: runtime telemetry updates are not implemented yet",
@@ -170,6 +172,8 @@ pub fn endPendingClientConnect(handle: *RuntimeHandle) void {
 pub fn setLogger(handle: ?*RuntimeHandle, _callback_ptr: ?*anyopaque) i32 {
     _ = handle;
     _ = _callback_ptr;
+    // TODO(codex, zig-runtime-03): Forward Temporal core logs into Bun so we can surface them via
+    // structured logging without relying on Node SDK shims.
     errors.setStructuredError(.{
         .code = grpc.unimplemented,
         .message = "temporal-bun-bridge-zig: runtime logger installation is not implemented yet",

--- a/packages/temporal-bun-sdk/src/worker/runtime.ts
+++ b/packages/temporal-bun-sdk/src/worker/runtime.ts
@@ -15,22 +15,26 @@ export interface WorkerRuntimeOptions {
 export class WorkerRuntime {
   constructor(readonly options: WorkerRuntimeOptions) {
     void options
-    // TODO(codex): Initialize native worker handles and runtime scaffolding per WORKER_DOC §1–§3.
+    // TODO(codex, zig-worker-01): Initialize native worker handles once the Zig worker bridge wires
+    // up Temporal core creation semantics (see WORKER_DOC §1–§3).
   }
 
   static async create(options: WorkerRuntimeOptions): Promise<never> {
-    // TODO(codex): Build async factory that wires Bun-native worker creation per WORKER_DOC §2.
+    // TODO(codex, zig-worker-01): Build async factory that wires Bun-native worker creation per
+    // WORKER_DOC §2 once Zig exports are available.
     void options
     return Promise.reject(new Error('WorkerRuntime.create is not implemented yet')) as never
   }
 
   async run(): Promise<never> {
-    // TODO(codex): Kick off workflow and activity polling loops (WORKER_DOC §3).
+    // TODO(codex, zig-worker-03): Kick off workflow and activity polling loops using the Zig worker
+    // pending-handle APIs (WORKER_DOC §3).
     return Promise.reject(new Error('WorkerRuntime.run is not implemented yet')) as never
   }
 
   async shutdown(_gracefulTimeoutMs?: number): Promise<never> {
-    // TODO(codex): Implement graceful shutdown semantics before swapping out the Node worker bridge.
+    // TODO(codex, zig-worker-08): Implement graceful shutdown semantics before swapping out the Node
+    // worker bridge.
     void _gracefulTimeoutMs
     return Promise.reject(new Error('WorkerRuntime.shutdown is not implemented yet')) as never
   }


### PR DESCRIPTION
# Summary
- refresh design-e2e doc to capture current zig implementation status and remaining gaps
- rewrite ffi-surface blueprint with accurate export matrix, roadmap, and testing guidance

# Testing
- not run (docs only)
