### PR TITLE
docs: align zig worker todo markers

### DIFF
--- a/packages/temporal-bun-sdk/src/worker/runtime.ts
+++ b/packages/temporal-bun-sdk/src/worker/runtime.ts
@@ -91,13 +91,11 @@ export const destroyNativeWorker = (worker: NativeWorker | null | undefined): vo
 export class WorkerRuntime {
   constructor(readonly options: WorkerRuntimeOptions) {
     void options
-    // TODO(codex, zig-worker-01): Initialize native worker handles once the Zig worker bridge wires
-    // up Temporal core creation semantics (see WORKER_DOC §1–§3).
+    // TODO(codex, zig-worker-03): Wire native worker polling loops and manage handle lifetimes.
   }
 
   static async create(options: WorkerRuntimeOptions): Promise<never> {
-    // TODO(codex, zig-worker-01): Build async factory that wires Bun-native worker creation per
-    // WORKER_DOC §2 once Zig exports are available.
+    // TODO(codex, zig-worker-03): Build async factory once polling/completion are implemented.
     void options
     return Promise.reject(new Error('WorkerRuntime.create is not implemented yet')) as never
   }


### PR DESCRIPTION
## Summary
- retarget the WorkerRuntime TODO markers to zig-worker-03 now that worker creation is wired
- no code behaviour changes; serves as bookkeeping for the zig-worker-01 milestone

Closes #1504

## Testing
- USE_PREBUILT_LIBS=1 zig build -Doptimize=Debug --build-file packages/temporal-bun-sdk/native/temporal-bun-bridge-zig/build.zig test
- TEMPORAL_TEST_SERVER=1 TEMPORAL_BUN_SDK_USE_ZIG=1 pnpm --filter @proompteng/temporal-bun-sdk test *(fails: temporal CLI binary missing so start-dev cannot run)*