### PR TITLE
feat: add MinIO console for observability

### DIFF
--- a/argocd/applications/minio/kustomization.yaml
+++ b/argocd/applications/minio/kustomization.yaml
@@ -5,5 +5,9 @@ namespace: minio
 resources:
   - github.com/minio/operator?ref=v5.0.18
   - observability-minio-secret.yaml
+  - observability-minio-console-secret.yaml
   - observability-tenant.yaml
   - observability-minio-service.yaml
+  - observability-minio-console-deployment.yaml
+  - observability-minio-console-service.yaml
+  - observability-minio-console-tailscale.yaml

--- a/argocd/applications/minio/observability-minio-console-deployment.yaml
+++ b/argocd/applications/minio/observability-minio-console-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: observability-minio-console
+  namespace: minio
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/name: minio-console
+    app.kubernetes.io/instance: observability
+    app.kubernetes.io/component: console
+    app.kubernetes.io/part-of: observability-minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio-console
+      app.kubernetes.io/instance: observability
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio-console
+        app.kubernetes.io/instance: observability
+        app.kubernetes.io/component: console
+        app.kubernetes.io/part-of: observability-minio
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: console
+          image: registry.ide-newton.ts.net/lab/minio-console:v2.0.4
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: observability-minio-console-env
+          ports:
+            - name: http
+              containerPort: 9090
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 10
+            initialDelaySeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 30
+            initialDelaySeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+      terminationGracePeriodSeconds: 30

--- a/argocd/applications/minio/observability-minio-console-secret.yaml
+++ b/argocd/applications/minio/observability-minio-console-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: observability-minio-console-env
+  namespace: minio
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  encryptedData: {}
+  template:
+    metadata:
+      name: observability-minio-console-env
+      namespace: minio
+    type: Opaque

--- a/argocd/applications/minio/observability-minio-console-service.yaml
+++ b/argocd/applications/minio/observability-minio-console-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: observability-minio-console
+  namespace: minio
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    app.kubernetes.io/name: minio-console
+    app.kubernetes.io/instance: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: minio-console
+    app.kubernetes.io/instance: observability
+  ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: http

--- a/argocd/applications/minio/observability-minio-console-tailscale.yaml
+++ b/argocd/applications/minio/observability-minio-console-tailscale.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: observability-minio-console-tailscale
+  namespace: minio
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    tailscale.com/hostname: observability-minio-browser
+  labels:
+    app.kubernetes.io/name: minio-console
+    app.kubernetes.io/instance: observability
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: minio-console
+    app.kubernetes.io/instance: observability
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http

--- a/argocd/applications/minio/observability-minio-secret.yaml
+++ b/argocd/applications/minio/observability-minio-secret.yaml
@@ -4,6 +4,8 @@ kind: SealedSecret
 metadata:
   name: observability-minio-creds
   namespace: minio
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   encryptedData:
     accesskey: AgCVfry4uKaOwlwdjdrhlsxfn68eM4jQl+P263aVyqwwudJVI6QkfzZsv3z/xwlqM2p8IHjbq/iYqxtPzUs7OvDWs2T/2s8EHSK/G++fv/jQgpinOLHHXBrYletHabIgyFMT0nx1vSXB8aLF2tCWb9vIba3jQcb3TX/Np9oHNtMPs1pc7NQ9zg7agiRllyYm5W69Ufs0TMKmhb9mXl8kQYL5aLlkgqP/3KcqDGwJxtTxp+j5myIWlLSG5rxzgt00ODl/SbMQ4arpWFDFY7PD3D+QQ1kq9o44qm2kM/0ugwl+qt2YFV2Ji41nagySw5xbq7+YUtM6M82diV4Gq6fV0LvbMH7El/b1M6bH7XYkJ7bLxEYTJMUV0NYB7JgV8y4deRbu6G2ecnoFOVhVRUjS8wmkdA5wYgB8fLbwp2gC6KJeb5tulG+EJRDoN8fCks5BRvWZx/NahWcEPo460EkgsyZXnxFm9QL7eu+9VKN7uxu9ddxLfo0vnzSiblkuUVdZF/O3zwtWDLe3OKA7p5Ej09xlpwOpmrIIrWE2go7bO6CNLTfgId605ofkNgNK8X8lKpaF6nJ2U10VMWg5J2gE5fWIKXkmEf8BAbdFMMiwPaGQOFTYKn2r+2QnLyNe4r9z+Zpgb5456vCplz9D624GJ6EBUeqijUZM366w1lNdH/wcPBxsq+4BMzoSGCfrkQlKI8Gqq686+zP/v9jb5DDOtzyp

--- a/containers/minio-console/Dockerfile
+++ b/containers/minio-console/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+
+ARG MINIO_CONSOLE_VERSION=v2.0.4
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+FROM --platform=linux/amd64 golang:1.22-bookworm AS build
+ARG MINIO_CONSOLE_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+ENV CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOTOOLCHAIN=go1.24.4+auto
+WORKDIR /src
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go install github.com/minio/console@${MINIO_CONSOLE_VERSION}
+
+FROM gcr.io/distroless/base-debian12:nonroot
+ARG MINIO_CONSOLE_VERSION
+COPY --from=build /go/bin/console /usr/local/bin/console
+USER nonroot
+EXPOSE 9090
+ENV CONSOLE_MINIO_SERVER=http://localhost:9000
+ENTRYPOINT ["/usr/local/bin/console"]
+CMD ["server"]
+LABEL org.opencontainers.image.source="https://github.com/proompteng/lab" \
+      org.opencontainers.image.description="MinIO Console ${MINIO_CONSOLE_VERSION} packaged for the lab cluster" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opencontainers.image.title="MinIO Console"

--- a/docs/minio-console.md
+++ b/docs/minio-console.md
@@ -1,0 +1,52 @@
+# MinIO Console Operations
+
+## Background
+MinIO no longer ships community console images and distributes the UI as source-only artifacts beginning with the September 2025 releases. The upstream console repository now requires you to build binaries yourself (for example, release v2.0.4 is the latest tagged version used in this rollout).citeturn13search1turn13search0
+
+## Build and Publish the Internal Image
+1. Set the desired tag (defaults to the current commit SHA) and optionally override the console version:
+   ```bash
+   MINIO_CONSOLE_VERSION=v2.0.4 scripts/build-minio-console.sh <tag>
+   ```
+2. The script runs a `docker buildx --platform linux/amd64` build using `containers/minio-console/Dockerfile`, compiles the upstream Go module, and pushes `registry.ide-newton.ts.net/lab/minio-console:<tag>`.
+3. If MinIO publishes a new console release, bump `MINIO_CONSOLE_VERSION` in the Dockerfile and script, rebuild, and update the deployment image.
+
+## Provision Console Credentials
+### Create a Scoped MinIO User
+Use the existing `mc` administration tooling against the `observability` tenant to create a console-only user and policy. Adjust bucket scopes as needed for production:
+```bash
+mc admin user add observability/ console <GENERATED-SECRET>
+mc admin policy create observability/ consoleAdmin admin.json
+mc admin policy attach observability/ consoleAdmin --user console
+```
+The upstream console README documents the default admin-style policy; treat it as a starting point and trim permissions for least privilege.citeturn21view0
+
+### Seal the Environment Variables
+1. Install `kubeseal` and ensure the sealed-secrets controller public certificate is available (either via `kubeseal --fetch-cert` or the saved PEM file).
+2. Run the generator from the repo root to emit all three sealed secrets, including the console env secret:
+   ```bash
+   bun run scripts/generate-observability-minio-secrets.ts --print-values
+   ```
+   The script now creates `argocd/applications/minio/observability-minio-console-secret.yaml` alongside the existing MinIO secrets with fresh access/secret keys plus PBKDF inputs matching the console defaults.
+3. Commit the updated sealed secrets once resealed with production credentials. The committed placeholder is intentionally empty; replace it before deploying.
+
+## Deploy and Verify
+1. Render the manifests to confirm the new resources are valid:
+   ```bash
+   kustomize build argocd/applications/minio
+   ```
+2. After Argo CD syncs, verify the pods and services:
+   ```bash
+   kubectl -n minio get deploy,svc observability-minio-console observability-minio-console-tailscale
+   ```
+3. Confirm the Tailscale load balancer receives a hostname via the operator-managed `loadBalancerClass: tailscale` service.citeturn22view0
+
+## Credential Rotation
+1. Re-run the sealed-secret generator to mint new MinIO console credentials and PBKDF material.
+2. Update the console user password in MinIO (`mc admin user svcacct reset` or policy-specific workflow) and reseal the secret.
+3. Trigger an Argo CD sync. The Deployment consumes the new secret on the next rollout, and the Tailscale load balancer keeps the DNS name stable.
+
+## Operational Notes
+- Document real credentials outside of Git and rotate them if the console binary is regenerated.
+- If the upstream repository changes build requirements (for example, a new Go toolchain), update the Dockerfile base image accordingly before the next release.
+- Leave a reminder in the deployment notes to reseal the console secret with the production public key during the final rollout review.

--- a/scripts/build-minio-console.sh
+++ b/scripts/build-minio-console.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_NAME="registry.ide-newton.ts.net/lab/minio-console"
+DOCKERFILE="containers/minio-console/Dockerfile"
+CONTEXT_PATH="."
+
+TAG="${1:-$(git rev-parse --short HEAD)}"
+MINIO_CONSOLE_VERSION="${MINIO_CONSOLE_VERSION:-v2.0.4}"
+FULL_IMAGE_NAME="${IMAGE_NAME}:${TAG}"
+
+echo "[minio-console] Building ${FULL_IMAGE_NAME} (console ${MINIO_CONSOLE_VERSION})"
+docker buildx build \
+  --platform linux/amd64 \
+  --file "${DOCKERFILE}" \
+  --tag "${FULL_IMAGE_NAME}" \
+  --build-arg MINIO_CONSOLE_VERSION="${MINIO_CONSOLE_VERSION}" \
+  "${CONTEXT_PATH}" \
+  --push
+
+echo "[minio-console] Image published: ${FULL_IMAGE_NAME}"


### PR DESCRIPTION
## Summary
- package the upstream console @ v2.0.4 via a new internal Dockerfile and helper build script
- extend the observability secret generator to emit the console env sealed secret and wire new Argo CD manifests, including a Tailscale load balancer
- document credential provisioning and rotation steps for the observability console

## Testing
- [x] pnpm exec biome check scripts/generate-observability-minio-secrets.ts docs/minio-console.md
- [ ] docker buildx build --load -f containers/minio-console/Dockerfile . *(blocked: docker binary unavailable in workspace)*
- [ ] kustomize build argocd/applications/minio *(blocked: kustomize binary unavailable in workspace)*
- [ ] kubectl -n minio get svc observability-minio-console *(pending post-deploy validation)*

Closes #1598