### PR TITLE
fix: ignore froussard annotation drift

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -127,6 +127,11 @@ spec:
             namespace: froussard
             annotations:
               argocd.argoproj.io/sync-wave: "6"
+            ignoreDifferences:
+              - group: serving.knative.dev
+                kind: Service
+                jsonPointers:
+                  - /metadata/annotations
             automation: manual
             enabled: true
       selector:
@@ -150,6 +155,7 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true
   templatePatch: |
     {{- if .annotations }}
     metadata:
@@ -159,17 +165,22 @@ spec:
     {{- end }}
     {{- end }}
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-    {{- if or $useLovely (eq .automation "auto") }}
+    {{- $auto := eq .automation "auto" -}}
+    {{- $needsSpec := or $useLovely (or $auto (hasKey . "ignoreDifferences")) -}}
+    {{- if $needsSpec }}
     spec:
       {{- if $useLovely }}
       source:
         plugin:
           name: lovely
       {{- end }}
-      {{- if eq .automation "auto" }}
+      {{- if $auto }}
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
+      {{- end }}
+      {{- if hasKey . "ignoreDifferences" }}
+      ignoreDifferences: {{ toJson .ignoreDifferences }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
## Summary

- add an ignoreDifferences rule for the froussard application to stop Knative Service annotation drift alerts
- teach the product ApplicationSet template to pass ignoreDifferences into generated Application specs and respect them during sync

## Related Issues

None

## Testing

- kubectl apply -f argocd/root.yaml

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
