### PR TITLE
feat: add zig workflow cancel support

### DIFF
--- a/packages/temporal-bun-sdk/bruke/src/client/workflows/cancel.zig
+++ b/packages/temporal-bun-sdk/bruke/src/client/workflows/cancel.zig
@@ -1,11 +1,164 @@
+const std = @import("std");
 const common = @import("../common.zig");
 const pending = @import("../../pending.zig");
+const byte_array = @import("../../byte_array.zig");
+const core = @import("../../core.zig");
 
 const grpc = common.grpc;
 
-pub fn cancelWorkflow(_client: ?*common.ClientHandle, _payload: []const u8) ?*pending.PendingByteArray {
-    // TODO(codex, zig-wf-06): Route workflow cancellation through Temporal core client once implemented.
-    _ = _client;
-    _ = _payload;
-    return common.createByteArrayError(grpc.unimplemented, "temporal-bun-bridge-zig: cancelWorkflow is not implemented yet");
+const CancelPayloadError = error{
+    InvalidJson,
+    MissingNamespace,
+    MissingWorkflowId,
+    InvalidRunId,
+    InvalidFirstExecutionRunId,
+};
+
+const CancelPayloadValidator = struct {
+    namespace: []const u8,
+    workflow_id: []const u8,
+    run_id: ?[]const u8 = null,
+    first_execution_run_id: ?[]const u8 = null,
+};
+
+const CancelWorkerContext = struct {
+    handle: *pending.PendingByteArray,
+    client: *common.ClientHandle,
+    payload: []u8,
+};
+
+fn validateCancelPayload(payload: []const u8) CancelPayloadError!void {
+    const allocator = std.heap.c_allocator;
+    var parsed = std.json.parseFromSlice(CancelPayloadValidator, allocator, payload, .{
+        .ignore_unknown_fields = true,
+    }) catch {
+        return CancelPayloadError.InvalidJson;
+    };
+    defer parsed.deinit();
+
+    if (parsed.value.namespace.len == 0) {
+        return CancelPayloadError.MissingNamespace;
+    }
+
+    if (parsed.value.workflow_id.len == 0) {
+        return CancelPayloadError.MissingWorkflowId;
+    }
+
+    if (parsed.value.run_id) |run| {
+        if (run.len == 0) {
+            return CancelPayloadError.InvalidRunId;
+        }
+    }
+
+    if (parsed.value.first_execution_run_id) |first| {
+        if (first.len == 0) {
+            return CancelPayloadError.InvalidFirstExecutionRunId;
+        }
+    }
+}
+
+fn runCancelWorkflow(context: CancelWorkerContext) void {
+    defer std.heap.c_allocator.free(context.payload);
+    defer pending.release(context.handle);
+
+    core.cancelWorkflow(context.client.core_client, context.payload) catch |err| {
+        const Rejection = struct { code: i32, message: []const u8 };
+        const failure: Rejection = switch (err) {
+            core.CancelWorkflowError.NotFound => .{ .code = grpc.not_found, .message = "temporal-bun-bridge-zig: workflow not found" },
+            core.CancelWorkflowError.ClientUnavailable => .{ .code = grpc.unavailable, .message = "temporal-bun-bridge-zig: Temporal core client unavailable" },
+            core.CancelWorkflowError.Internal => .{ .code = grpc.internal, .message = "temporal-bun-bridge-zig: failed to cancel workflow" },
+        };
+        _ = pending.rejectByteArray(context.handle, failure.code, failure.message);
+        return;
+    };
+
+    const ack = byte_array.allocate(.{ .slice = "" }) orelse {
+        const message = "temporal-bun-bridge-zig: failed to allocate cancel acknowledgment";
+        _ = pending.rejectByteArray(context.handle, grpc.internal, message);
+        return;
+    };
+
+    if (!pending.resolveByteArray(context.handle, ack)) {
+        byte_array.free(ack);
+        const message = "temporal-bun-bridge-zig: failed to resolve cancel pending handle";
+        _ = pending.rejectByteArray(context.handle, grpc.internal, message);
+    }
+}
+
+pub fn cancelWorkflow(client_ptr: ?*common.ClientHandle, payload: []const u8) ?*pending.PendingByteArray {
+    if (client_ptr == null) {
+        return common.createByteArrayError(
+            grpc.invalid_argument,
+            "temporal-bun-bridge-zig: cancelWorkflow received null client",
+        );
+    }
+
+    if (payload.len == 0) {
+        return common.createByteArrayError(
+            grpc.invalid_argument,
+            "temporal-bun-bridge-zig: cancelWorkflow payload must be non-empty",
+        );
+    }
+
+    validateCancelPayload(payload) catch |err| {
+        const message = switch (err) {
+            CancelPayloadError.InvalidJson => "temporal-bun-bridge-zig: cancelWorkflow payload must be valid JSON",
+            CancelPayloadError.MissingNamespace => "temporal-bun-bridge-zig: cancelWorkflow namespace must be a non-empty string",
+            CancelPayloadError.MissingWorkflowId => "temporal-bun-bridge-zig: cancelWorkflow workflow_id must be a non-empty string",
+            CancelPayloadError.InvalidRunId => "temporal-bun-bridge-zig: cancelWorkflow run_id must be a non-empty string",
+            CancelPayloadError.InvalidFirstExecutionRunId => "temporal-bun-bridge-zig: cancelWorkflow first_execution_run_id must be a non-empty string",
+        };
+        return common.createByteArrayError(grpc.invalid_argument, message);
+    };
+
+    const allocator = std.heap.c_allocator;
+    const copy = allocator.alloc(u8, payload.len) catch {
+        return common.createByteArrayError(
+            grpc.resource_exhausted,
+            "temporal-bun-bridge-zig: failed to allocate cancel payload copy",
+        );
+    };
+    @memcpy(copy, payload);
+
+    const pending_handle_ptr = pending.createPendingInFlight() orelse {
+        allocator.free(copy);
+        return common.createByteArrayError(
+            grpc.internal,
+            "temporal-bun-bridge-zig: failed to allocate pending cancel handle",
+        );
+    };
+
+    const pending_handle = @as(*pending.PendingByteArray, @ptrCast(pending_handle_ptr));
+    const client_handle = client_ptr.?;
+
+    const context = CancelWorkerContext{
+        .handle = pending_handle,
+        .client = client_handle,
+        .payload = copy,
+    };
+
+    if (!pending.retain(pending_handle_ptr)) {
+        allocator.free(copy);
+        pending.free(pending_handle_ptr);
+        return common.createByteArrayError(
+            grpc.resource_exhausted,
+            "temporal-bun-bridge-zig: failed to retain pending cancel handle",
+        );
+    }
+
+    const thread = std.Thread.spawn(.{}, runCancelWorkflow, .{context}) catch |err| {
+        allocator.free(copy);
+        pending.release(pending_handle_ptr);
+        pending.free(pending_handle_ptr);
+        var scratch: [128]u8 = undefined;
+        const formatted = std.fmt.bufPrint(
+            &scratch,
+            "temporal-bun-bridge-zig: failed to spawn cancel worker thread: {}",
+            .{err},
+        ) catch "temporal-bun-bridge-zig: failed to spawn cancel worker thread";
+        return common.createByteArrayError(grpc.internal, formatted);
+    };
+    thread.detach();
+
+    return pending_handle;
 }

--- a/packages/temporal-bun-sdk/bruke/src/client_cancel_workflow_test.zig
+++ b/packages/temporal-bun-sdk/bruke/src/client_cancel_workflow_test.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const client = @import("client.zig");
+const pending = @import("pending.zig");
+const errors = @import("errors.zig");
+
+fn makeStubClient() !*client.ClientHandle {
+    const allocator = std.heap.c_allocator;
+    const handle = try allocator.create(client.ClientHandle);
+    handle.* = .{
+        .id = 1,
+        .runtime = null,
+        .config = ""[0..0],
+        .core_client = null,
+    };
+    return handle;
+}
+
+fn destroyStubClient(handle: *client.ClientHandle) void {
+    const allocator = std.heap.c_allocator;
+    allocator.destroy(handle);
+}
+
+fn freePendingHandle(handle: ?*pending.PendingByteArray) void {
+    if (handle) |ptr| {
+        const any_handle: ?*pending.PendingHandle = @as(?*pending.PendingHandle, @ptrCast(ptr));
+        pending.free(any_handle);
+    }
+}
+
+test "cancelWorkflow returns structured error when client is null" {
+    errors.setLastError(""[0..0]);
+    const payload = "{\"namespace\":\"default\",\"workflow_id\":\"wf\"}"[0..];
+    const handle = client.cancelWorkflow(null, payload);
+    defer freePendingHandle(handle);
+
+    try std.testing.expect(handle != null);
+    const snapshot = errors.snapshot();
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "\"code\":3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "cancelWorkflow received null client") != null);
+    errors.setLastError(""[0..0]);
+}
+
+test "cancelWorkflow rejects payload missing namespace" {
+    const stub_client = try makeStubClient();
+    defer destroyStubClient(stub_client);
+
+    errors.setLastError(""[0..0]);
+    const payload = "{\"workflow_id\":\"wf\"}"[0..];
+    const handle = client.cancelWorkflow(stub_client, payload);
+    defer freePendingHandle(handle);
+
+    try std.testing.expect(handle != null);
+    const snapshot = errors.snapshot();
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "\"code\":3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "cancelWorkflow namespace must be a non-empty string") != null);
+    errors.setLastError(""[0..0]);
+}
+
+test "cancelWorkflow rejects empty run_id value" {
+    const stub_client = try makeStubClient();
+    defer destroyStubClient(stub_client);
+
+    errors.setLastError(""[0..0]);
+    const payload = "{\"namespace\":\"default\",\"workflow_id\":\"wf\",\"run_id\":\"\"}"[0..];
+    const handle = client.cancelWorkflow(stub_client, payload);
+    defer freePendingHandle(handle);
+
+    try std.testing.expect(handle != null);
+    const snapshot = errors.snapshot();
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "\"code\":3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "cancelWorkflow run_id must be a non-empty string") != null);
+    errors.setLastError(""[0..0]);
+}

--- a/packages/temporal-bun-sdk/src/client/serialization.ts
+++ b/packages/temporal-bun-sdk/src/client/serialization.ts
@@ -7,14 +7,6 @@ import type {
   WorkflowHandle,
 } from './types'
 
-const DOCS_ROOT = 'packages/temporal-bun-sdk/docs'
-const FFI_SURFACE_DOC = `${DOCS_ROOT}/ffi-surface.md`
-const _CLIENT_RUNTIME_DOC = `${DOCS_ROOT}/client-runtime.md`
-
-const notImplemented = (feature: string, docPath: string): never => {
-  throw new Error(`${feature} is not implemented yet. See ${docPath} for the step-by-step plan.`)
-}
-
 const ensureWorkflowNamespace = (handle: WorkflowHandle): string => {
   if (!handle.namespace || handle.namespace.trim().length === 0) {
     throw new Error('Workflow handle must include a non-empty namespace')
@@ -249,9 +241,25 @@ export const buildTerminateRequest = (
 }
 
 export const buildCancelRequest = (handle: WorkflowHandle): Record<string, unknown> => {
-  void handle
-  // TODO(codex): Emit cancellation payloads for `temporal_bun_client_cancel_workflow` per ${FFI_SURFACE_DOC}.
-  return notImplemented('Workflow cancel serialization', FFI_SURFACE_DOC)
+  if (!handle.workflowId || handle.workflowId.trim().length === 0) {
+    throw new Error('Workflow handle must include a non-empty workflowId')
+  }
+
+  const namespace = ensureWorkflowNamespace(handle)
+  const payload: Record<string, unknown> = {
+    namespace,
+    workflow_id: handle.workflowId,
+  }
+
+  if (handle.runId && handle.runId.trim().length > 0) {
+    payload.run_id = handle.runId
+  }
+
+  if (handle.firstExecutionRunId && handle.firstExecutionRunId.trim().length > 0) {
+    payload.first_execution_run_id = handle.firstExecutionRunId
+  }
+
+  return payload
 }
 
 export const buildSignalWithStartRequest = ({


### PR DESCRIPTION
## Summary
- route `client.cancelWorkflow` through Temporal core with serialized RequestCancelWorkflowExecution payloads
- implement Zig bridge cancellation helper plus pending-handle validator tests and integration coverage
- update design doc status around cancellation RPC wiring and CI follow-ups

## Related Issues
- Fixes #1499

## Testing
- `zig build -Doptimize=Debug --build-file packages/temporal-bun-sdk/bruke/build.zig`
- `TEMPORAL_TEST_SERVER=1 TEMPORAL_BUN_SDK_USE_ZIG=1 pnpm --filter @proompteng/temporal-bun-sdk test` *(fails: Temporal server unreachable at http://127.0.0.1:7233; reran with server disabled)*
- `TEMPORAL_TEST_SERVER=0 TEMPORAL_BUN_SDK_USE_ZIG=1 pnpm --filter @proompteng/temporal-bun-sdk test`
- `pnpm exec biome check packages/temporal-bun-sdk/src/client/serialization.ts packages/temporal-bun-sdk/src/internal/core-bridge/native.ts packages/temporal-bun-sdk/tests/native.integration.test.ts`

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
