### PR TITLE
chore: redeploy facteur

### DIFF
--- a/ansible/INSTALL.md
+++ b/ansible/INSTALL.md
@@ -42,6 +42,18 @@ ansible-playbook -i inventory/hosts.ini playbooks/install_tailscale.yml
 ansible-playbook -i inventory/hosts.ini playbooks/start_enable_tailscale.yml
 ```
 
+If you need to fan the run out across all Kubernetes masters and workers at once (30 parallel forks), while passing an auth key from the shell and relaxing host-key checks for newly rebuilt nodes:
+
+```bash
+ANSIBLE_CONFIG=ansible/ansible.cfg \
+  TAILSCALE_AUTHKEY="${TAILSCALE_AUTHKEY}" \
+  ansible-playbook -i ansible/inventory/hosts.ini -u kalmyk -b \
+    ansible/playbooks/start_enable_tailscale.yml \
+    -l 'kube_masters:kube_workers' -f 30 \
+    --ssh-extra-args '-o StrictHostKeyChecking=accept-new' \
+    --ask-vault-pass
+```
+
 ### Supplying the Ansible Vault password
 
 - Prompt each run:

--- a/argocd/applications/facteur/overlays/cluster/facteur-service.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-service.yaml
@@ -9,7 +9,7 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "100"
-        deploy.knative.dev/rollout: "2025-10-31T08:59:38.656Z"
+        deploy.knative.dev/rollout: "2025-11-01T05:48:00.091Z"
     spec:
       serviceAccountName: facteur
       containers:

--- a/argocd/applications/facteur/overlays/cluster/kustomization.yaml
+++ b/argocd/applications/facteur/overlays/cluster/kustomization.yaml
@@ -20,4 +20,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/facteur
-    newTag: 6e5ddc13
+    newTag: a1fa04ce


### PR DESCRIPTION
## Summary
- document the tailscale redeploy playbook command in ansible docs
- rebuild facteur with commit a1fa04ce and push new image
- update knative service overlay to use the new tag and rollout annotation

## Testing
- bun packages/scripts/src/facteur/deploy-service.ts
- kubectl -n facteur get ksvc facteur