### PR TITLE
feat: pool pending handles in temporal-bun-sdk

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Build and test Zig bridge
         run: pnpm --filter @proompteng/temporal-bun-sdk run ci:native:zig
 
+      - name: Stress pending executor
+        run: zig run packages/temporal-bun-sdk/bruke/src/pending_executor_stress.zig
+
       - name: Start Temporal CLI dev server
         run: |
           cd packages/temporal-bun-sdk

--- a/packages/scripts/src/codex/recover-workflow-artifacts.ts
+++ b/packages/scripts/src/codex/recover-workflow-artifacts.ts
@@ -1,0 +1,539 @@
+#!/usr/bin/env bun
+
+import { existsSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+import process from 'node:process'
+
+import type { Subprocess } from 'bun'
+import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
+
+type Options = {
+  workflow: string
+  namespace: string
+  bucket?: string
+  alias: string
+  destination: string
+  applyChanges: boolean
+  portForward: boolean
+  minioNamespace: string
+  minioService: string
+  minioPort: number
+  localPort: number
+}
+
+type WorkflowJson = {
+  spec?: unknown
+  status?: {
+    nodes?: Record<
+      string,
+      {
+        outputs?: {
+          artifacts?: ArtifactJson[]
+        }
+      }
+    >
+  }
+}
+
+type ArtifactJson = {
+  name?: string
+  path?: string
+  s3?: {
+    bucket?: string
+    key?: string
+  }
+}
+
+type ParsedArtifact = {
+  name: string
+  key: string
+}
+
+type WorkflowTemplate = {
+  outputs?: {
+    artifacts?: Array<{
+      s3?: { bucket?: string }
+    }>
+  }
+}
+
+type PortForwardHandle = {
+  stop: () => void
+}
+
+const PORT_FORWARD_TIMEOUT_MS = 15_000
+
+const textDecoder = new TextDecoder()
+
+const parseArgs = (): Options => {
+  const args = process.argv.slice(2)
+  const options: Partial<Options> = {
+    namespace: 'argo-workflows',
+    alias: process.env.MINIO_ALIAS?.trim()?.length ? process.env.MINIO_ALIAS.trim() : 'argo',
+    applyChanges: true,
+    portForward: true,
+    minioNamespace: 'minio',
+    minioService: 'observability-minio',
+    minioPort: 9000,
+    localPort: 9000,
+  }
+
+  const positional: string[] = []
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (!arg.startsWith('-')) {
+      positional.push(arg)
+      continue
+    }
+
+    switch (arg) {
+      case '--namespace':
+      case '-n': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal(`${arg} requires a value`)
+        options.namespace = value
+        break
+      }
+      case '--bucket': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--bucket requires a value')
+        options.bucket = value
+        break
+      }
+      case '--alias': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--alias requires a value')
+        options.alias = value
+        break
+      }
+      case '--dest':
+      case '--destination': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal(`${arg} requires a value`)
+        options.destination = value
+        break
+      }
+      case '--minio-namespace': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--minio-namespace requires a value')
+        options.minioNamespace = value
+        break
+      }
+      case '--minio-service': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--minio-service requires a value')
+        options.minioService = value
+        break
+      }
+      case '--minio-port': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--minio-port requires a value')
+        const parsed = Number.parseInt(value, 10)
+        if (Number.isNaN(parsed) || parsed <= 0) fatal('--minio-port must be a positive integer')
+        options.minioPort = parsed
+        break
+      }
+      case '--local-port': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--local-port requires a value')
+        const parsed = Number.parseInt(value, 10)
+        if (Number.isNaN(parsed) || parsed <= 0) fatal('--local-port must be a positive integer')
+        options.localPort = parsed
+        break
+      }
+      case '--no-apply': {
+        options.applyChanges = false
+        break
+      }
+      case '--no-port-forward': {
+        options.portForward = false
+        break
+      }
+      case '--help':
+      case '-h': {
+        printHelp()
+        process.exit(0)
+        break
+      }
+      default:
+        fatal(`Unknown option: ${arg}`)
+    }
+  }
+
+  if (positional.length === 0) {
+    fatal('Usage: recover-workflow-artifacts <workflow> [options]. Use --help for details.')
+  }
+
+  if (positional.length > 1) {
+    fatal('Only one workflow name may be specified')
+  }
+
+  const workflow = positional[0]
+  const destination = options.destination
+    ? resolve(process.cwd(), options.destination)
+    : resolve(repoRoot, '.codex', 'recovery', workflow)
+
+  return {
+    workflow,
+    namespace: options.namespace ?? 'argo-workflows',
+    bucket: options.bucket,
+    alias: options.alias ?? 'argo',
+    destination,
+    applyChanges: options.applyChanges ?? true,
+    portForward: options.portForward ?? true,
+    minioNamespace: options.minioNamespace ?? 'minio',
+    minioService: options.minioService ?? 'observability-minio',
+    minioPort: options.minioPort ?? 9000,
+    localPort: options.localPort ?? 9000,
+  }
+}
+
+const printHelp = () => {
+  console.log(`Usage: recover-workflow-artifacts <workflow> [options]
+
+Download Codex workflow artifacts from MinIO and restore the recorded changes locally.
+
+Options:
+  -n, --namespace <value>    Kubernetes namespace for the workflow (default: argo-workflows)
+      --bucket <value>       MinIO bucket name (auto-detected when possible)
+      --alias <value>        MinIO client alias to use with mc (default: $MINIO_ALIAS or 'argo')
+      --dest <path>          Directory to store downloaded artifacts
+      --minio-namespace      Namespace containing the MinIO service (default: minio)
+      --minio-service        Service name to port-forward (default: observability-minio)
+      --minio-port           Target port on the MinIO service (default: 9000)
+      --local-port           Local port to bind for the port-forward (default: 9000)
+      --no-apply             Skip applying the captured changes to the current worktree
+      --no-port-forward      Skip establishing a kubectl port-forward
+  -h, --help                 Show this help message
+`)
+}
+
+const execJson = (command: string, args: string[]): unknown => {
+  const result = Bun.spawnSync([command, ...args], { stdout: 'pipe', stderr: 'pipe' })
+  if (result.exitCode !== 0) {
+    const stderr = textDecoder.decode(result.stderr)
+    fatal(`Command failed: ${command} ${args.join(' ')}\n${stderr.trim()}`)
+  }
+  try {
+    return JSON.parse(textDecoder.decode(result.stdout))
+  } catch (error) {
+    fatal(`Failed to parse JSON from ${command} ${args.join(' ')}`, error)
+  }
+}
+
+const collectArtifacts = (workflowJson: WorkflowJson): ParsedArtifact[] => {
+  const nodes = workflowJson.status?.nodes ?? {}
+  const artifacts: ParsedArtifact[] = []
+
+  for (const node of Object.values(nodes)) {
+    for (const artifact of node?.outputs?.artifacts ?? []) {
+      if (!artifact?.name || !artifact?.s3?.key) {
+        continue
+      }
+
+      // Deduplicate by artifact name (latest entry wins).
+      const existingIndex = artifacts.findIndex((entry) => entry.name === artifact.name)
+      const parsed: ParsedArtifact = {
+        name: artifact.name,
+        key: artifact.s3.key,
+      }
+      if (existingIndex >= 0) {
+        artifacts[existingIndex] = parsed
+      } else {
+        artifacts.push(parsed)
+      }
+    }
+  }
+
+  return artifacts
+}
+
+const detectBucket = (workflowJson: WorkflowJson): string | undefined => {
+  const nodes = workflowJson.status?.nodes ?? {}
+  for (const node of Object.values(nodes)) {
+    for (const artifact of node?.outputs?.artifacts ?? []) {
+      const bucket = artifact?.s3?.bucket?.trim()
+      if (bucket) return bucket
+    }
+  }
+
+  const specTemplates = (workflowJson as { spec?: { templates?: WorkflowTemplate[] } }).spec?.templates
+  const templates = Array.isArray(specTemplates) ? specTemplates : []
+
+  for (const template of templates) {
+    for (const artifact of template?.outputs?.artifacts ?? []) {
+      const bucket = artifact?.s3?.bucket?.trim()
+      if (bucket) return bucket
+    }
+  }
+
+  // Attempt to read archiveLocation fallback.
+  const archiveLocation = (workflowJson as { spec?: { archiveLocation?: { s3?: { bucket?: string } } } }).spec
+    ?.archiveLocation?.s3?.bucket
+  if (archiveLocation && archiveLocation.trim().length > 0) {
+    return archiveLocation.trim()
+  }
+
+  return undefined
+}
+
+const ensureDestination = async (path: string) => {
+  if (!existsSync(path)) {
+    await mkdir(path, { recursive: true })
+  }
+}
+
+const downloadArtifact = async ({
+  alias,
+  bucket,
+  artifact,
+  destination,
+}: {
+  alias: string
+  bucket: string
+  artifact: ParsedArtifact
+  destination: string
+}) => {
+  const filename = basename(artifact.key)
+  const target = join(destination, filename)
+
+  await run('mc', ['cp', `${alias}/${bucket}/${artifact.key}`, target])
+  return target
+}
+
+const extractArchive = async (archive: string, directory: string) => {
+  await run('tar', ['-xzf', archive, '-C', directory])
+}
+
+const recoverChanges = async ({ artifactsDir }: { artifactsDir: string }) => {
+  const changesArchive = join(artifactsDir, '.codex-implementation-changes.tar.gz')
+  if (existsSync(changesArchive)) {
+    console.log('Extracting recorded filesystem changes into the repository...')
+    await run('tar', ['-xzf', changesArchive, '-C', repoRoot])
+  } else {
+    console.warn('Changes archive not found; skipping filesystem extraction.')
+  }
+
+  const patchPath = join(artifactsDir, '.codex-implementation.patch')
+  if (existsSync(patchPath)) {
+    console.log('Applying git patch...')
+    await run('git', ['apply', '--3way', '--whitespace=nowarn', patchPath], { cwd: repoRoot })
+  } else {
+    console.warn('Patch file not found; skipping git apply.')
+  }
+}
+
+const showStatus = async ({ artifactsDir }: { artifactsDir: string }) => {
+  const statusPath = join(artifactsDir, '.codex-implementation-status.txt')
+  if (!existsSync(statusPath)) {
+    console.warn('Status file not found; skipping status output.')
+    return
+  }
+
+  const content = await Bun.file(statusPath).text()
+  console.log('\n=== Codex Implementation Status ===')
+  console.log(content.trim())
+  console.log('=== End Status ===\n')
+}
+
+const waitForPortForwardReady = async (subprocess: Subprocess, options: Options) => {
+  const decoder = new TextDecoder()
+  let resolved = false
+
+  const createReadPromise = (stream: ReadableStream<Uint8Array> | null | undefined) => {
+    if (!stream) return null
+    const reader = stream.getReader()
+
+    const read = (async () => {
+      let buffer = ''
+      try {
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          if (resolved) return
+
+          const chunk = decoder.decode(value)
+          buffer += chunk
+          buffer = buffer.length > 4096 ? buffer.slice(-4096) : buffer
+          process.stderr.write(chunk)
+
+          if (chunk.includes('address already in use')) {
+            throw new Error(`Local port ${options.localPort} is already in use`)
+          }
+
+          if (buffer.includes('Forwarding from')) {
+            resolved = true
+            return
+          }
+
+          if (!resolved && chunk.toLowerCase().includes('error')) {
+            throw new Error(`kubectl port-forward error: ${chunk.trim()}`)
+          }
+        }
+
+        if (!resolved) {
+          throw new Error('kubectl port-forward closed before reporting readiness')
+        }
+      } finally {
+        reader.releaseLock()
+      }
+    })()
+
+    return read
+  }
+
+  const readPromises = [createReadPromise(subprocess.stdout), createReadPromise(subprocess.stderr)].filter(
+    (value): value is Promise<void> => value !== null,
+  )
+
+  if (readPromises.length === 0) {
+    throw new Error('kubectl port-forward did not expose readable streams')
+  }
+
+  const exitPromise = subprocess.exited.then((code) => {
+    if (!resolved) {
+      throw new Error(`kubectl port-forward exited early with code ${code}`)
+    }
+  })
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<void>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      if (!resolved) {
+        reject(new Error('Timed out waiting for kubectl port-forward to become ready'))
+      }
+    }, PORT_FORWARD_TIMEOUT_MS)
+  })
+
+  try {
+    await Promise.race([...readPromises, exitPromise, timeoutPromise])
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
+const startPortForward = async (options: Options): Promise<PortForwardHandle> => {
+  console.log(
+    `Establishing kubectl port-forward for ${options.minioNamespace}/svc/${options.minioService} -> 127.0.0.1:${options.localPort}...`,
+  )
+
+  const args = [
+    '-n',
+    options.minioNamespace,
+    'port-forward',
+    `svc/${options.minioService}`,
+    `${options.localPort}:${options.minioPort}`,
+    '--address',
+    '127.0.0.1',
+  ]
+
+  const subprocess = Bun.spawn(['kubectl', ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  try {
+    await waitForPortForwardReady(subprocess, options)
+  } catch (error) {
+    subprocess.kill()
+    throw error
+  }
+
+  return {
+    stop: () => {
+      if (subprocess.exitCode === null) {
+        subprocess.kill()
+      }
+    },
+  }
+}
+
+export const main = async () => {
+  const options = parseArgs()
+
+  ensureCli('argo')
+  ensureCli('mc')
+  ensureCli('tar')
+  ensureCli('git')
+  if (options.portForward) {
+    ensureCli('kubectl')
+  }
+
+  let portForwardHandle: PortForwardHandle | undefined
+
+  const workflowJson = execJson('argo', [
+    'get',
+    options.workflow,
+    '--namespace',
+    options.namespace,
+    '-o',
+    'json',
+  ]) as WorkflowJson
+
+  const bucket = options.bucket ?? detectBucket(workflowJson) ?? 'argo-workflows'
+  if (!bucket) {
+    fatal('Unable to determine artifact bucket. Provide one with --bucket <name>.')
+  }
+
+  const artifacts = collectArtifacts(workflowJson)
+  if (artifacts.length === 0) {
+    fatal('No artifacts with S3 keys found on this workflow.')
+  }
+
+  await ensureDestination(options.destination)
+
+  try {
+    if (options.portForward) {
+      portForwardHandle = await startPortForward(options)
+    } else {
+      console.log('Skipping port-forward (--no-port-forward supplied).')
+    }
+
+    console.log(`Downloading artifacts for workflow '${options.workflow}' into ${options.destination}...`)
+    const downloadedPaths: string[] = []
+    for (const artifact of artifacts) {
+      const archivePath = await downloadArtifact({
+        alias: options.alias,
+        bucket,
+        artifact,
+        destination: options.destination,
+      })
+
+      if (archivePath.endsWith('.tgz')) {
+        await extractArchive(archivePath, options.destination)
+      } else {
+        downloadedPaths.push(archivePath)
+      }
+    }
+
+    if (options.applyChanges) {
+      await recoverChanges({ artifactsDir: options.destination })
+    } else {
+      console.log('Skipping worktree modification (--no-apply supplied).')
+    }
+
+    await showStatus({ artifactsDir: options.destination })
+
+    console.log('Recovery artifacts ready. Inspect main.log for workflow output if needed.')
+    for (const path of downloadedPaths) {
+      console.log(` - ${path}`)
+    }
+  } finally {
+    portForwardHandle?.stop()
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => fatal('Failed to recover artifacts', error))
+}

--- a/packages/temporal-bun-sdk/bruke/src/client/workflows/query.zig
+++ b/packages/temporal-bun-sdk/bruke/src/client/workflows/query.zig
@@ -370,6 +370,12 @@ fn queryWorkflowWorker(task: *QueryWorkflowTask) void {
     context.wait_group.wait();
 }
 
+fn runQueryWorkflowTask(context: ?*anyopaque) void {
+    const raw = context orelse return;
+    const task_ptr = @as(*QueryWorkflowTask, @ptrCast(@alignCast(raw)));
+    queryWorkflowWorker(task_ptr);
+}
+
 pub fn queryWorkflow(client_ptr: ?*common.ClientHandle, payload: []const u8) ?*pending.PendingByteArray {
     if (client_ptr == null) {
         return common.createByteArrayError(grpc.invalid_argument, "temporal-bun-bridge-zig: queryWorkflow received null client");
@@ -420,21 +426,39 @@ pub fn queryWorkflow(client_ptr: ?*common.ClientHandle, payload: []const u8) ?*p
         return @as(?*pending.PendingByteArray, pending_handle);
     }
 
-    const thread = std.Thread.spawn(.{}, queryWorkflowWorker, .{task}) catch |err| {
+    const runtime_handle = client_ptr.?.runtime orelse {
         allocator.destroy(task);
         allocator.free(copy);
         pending.release(pending_handle_ptr);
-        pending.free(pending_handle_ptr);
-        var scratch: [128]u8 = undefined;
-        const message = std.fmt.bufPrint(
-            &scratch,
-            "temporal-bun-bridge-zig: failed to spawn queryWorkflow worker: {}",
-            .{err},
-        ) catch "temporal-bun-bridge-zig: failed to spawn queryWorkflow worker";
-        _ = pending.rejectByteArray(pending_handle, grpc.internal, message);
+        const message = "temporal-bun-bridge-zig: queryWorkflow missing runtime handle";
+        errors.setStructuredError(.{ .code = grpc.failed_precondition, .message = message });
+        _ = pending.rejectByteArray(pending_handle, grpc.failed_precondition, message);
         return @as(?*pending.PendingByteArray, pending_handle);
     };
 
-    thread.detach();
+    const context_any: ?*anyopaque = @as(?*anyopaque, @ptrCast(@alignCast(task)));
+    runtime.schedulePendingTask(runtime_handle, .{
+        .run = runQueryWorkflowTask,
+        .context = context_any,
+    }) catch |err| switch (err) {
+        runtime.SchedulePendingTaskError.ShuttingDown => blk: {
+            allocator.destroy(task);
+            allocator.free(copy);
+            pending.release(pending_handle_ptr);
+            const message = "temporal-bun-bridge-zig: runtime is shutting down";
+            errors.setStructuredError(.{ .code = grpc.failed_precondition, .message = message });
+            _ = pending.rejectByteArray(pending_handle, grpc.failed_precondition, message);
+            break :blk;
+        },
+        runtime.SchedulePendingTaskError.ExecutorUnavailable => blk: {
+            allocator.destroy(task);
+            allocator.free(copy);
+            pending.release(pending_handle_ptr);
+            const message = "temporal-bun-bridge-zig: pending executor unavailable";
+            errors.setStructuredError(.{ .code = grpc.internal, .message = message });
+            _ = pending.rejectByteArray(pending_handle, grpc.internal, message);
+            break :blk;
+        },
+    };
     return @as(?*pending.PendingByteArray, pending_handle);
 }

--- a/packages/temporal-bun-sdk/bruke/src/lib.zig
+++ b/packages/temporal-bun-sdk/bruke/src/lib.zig
@@ -61,6 +61,14 @@ pub export fn temporal_bun_runtime_test_get_attach_service_name(handle: ?*runtim
     return if (runtime.telemetryAttachServiceNameForTest(handle)) 1 else 0;
 }
 
+pub export fn temporal_bun_runtime_test_get_pending_worker_count(handle: ?*runtime.RuntimeHandle) usize {
+    return runtime.pendingExecutorWorkerCountForTest(handle);
+}
+
+pub export fn temporal_bun_runtime_test_get_pending_queue_capacity(handle: ?*runtime.RuntimeHandle) usize {
+    return runtime.pendingExecutorQueueCapacityForTest(handle);
+}
+
 pub export fn temporal_bun_runtime_test_register_client(handle: ?*runtime.RuntimeHandle) i32 {
     return if (runtime.registerClientForTest(handle)) 1 else 0;
 }

--- a/packages/temporal-bun-sdk/bruke/src/pending.zig
+++ b/packages/temporal-bun-sdk/bruke/src/pending.zig
@@ -12,6 +12,186 @@ pub const Status = enum(i32) {
 
 const CleanupFn = ?*const fn (?*anyopaque) void;
 
+pub const PendingTaskFn = *const fn (?*anyopaque) void;
+
+pub const PendingTask = struct {
+    run: PendingTaskFn,
+    context: ?*anyopaque,
+};
+
+pub const PendingExecutorOptions = struct {
+    worker_count: usize,
+    queue_capacity: usize,
+};
+
+pub const PendingExecutorSubmitError = error{
+    ShuttingDown,
+};
+
+pub const PendingExecutor = struct {
+    allocator: std.mem.Allocator = std.heap.c_allocator,
+    mutex: std.Thread.Mutex = .{},
+    not_empty: std.Thread.Condition = .{},
+    not_full: std.Thread.Condition = .{},
+    queue: []PendingTask = &[_]PendingTask{},
+    head: usize = 0,
+    tail: usize = 0,
+    count: usize = 0,
+    worker_count: usize = 0,
+    shutting_down: bool = false,
+    initialized: bool = false,
+    workers: []std.Thread = &[_]std.Thread{},
+
+    pub fn init(self: *PendingExecutor, allocator: std.mem.Allocator, options: PendingExecutorOptions) !void {
+        if (options.worker_count == 0 or options.queue_capacity == 0) {
+            return error.InvalidExecutorConfiguration;
+        }
+
+        self.allocator = allocator;
+        self.queue = try allocator.alloc(PendingTask, options.queue_capacity);
+        errdefer allocator.free(self.queue);
+
+        self.workers = try allocator.alloc(std.Thread, options.worker_count);
+        errdefer allocator.free(self.workers);
+
+        self.worker_count = options.worker_count;
+        self.head = 0;
+        self.tail = 0;
+        self.count = 0;
+        self.shutting_down = false;
+        self.initialized = true;
+
+        var spawned: usize = 0;
+        errdefer {
+            self.mutex.lock();
+            self.shutting_down = true;
+            self.not_empty.broadcast();
+            self.not_full.broadcast();
+            self.mutex.unlock();
+
+            var idx: usize = 0;
+            while (idx < spawned) : (idx += 1) {
+                self.workers[idx].join();
+            }
+            allocator.free(self.workers);
+            allocator.free(self.queue);
+            self.workers = &[_]std.Thread{};
+            self.queue = &[_]PendingTask{};
+            self.worker_count = 0;
+            self.initialized = false;
+        }
+
+        while (spawned < options.worker_count) : (spawned += 1) {
+            const thread = try std.Thread.spawn(.{}, pendingExecutorWorker, .{self});
+            self.workers[spawned] = thread;
+        }
+    }
+
+    pub fn submit(self: *PendingExecutor, task: PendingTask) PendingExecutorSubmitError!void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        if (!self.initialized or self.shutting_down) {
+            return PendingExecutorSubmitError.ShuttingDown;
+        }
+
+        while (self.count == self.queue.len) {
+            self.not_full.wait(&self.mutex);
+            if (self.shutting_down) {
+                return PendingExecutorSubmitError.ShuttingDown;
+            }
+        }
+
+        self.queue[self.tail] = task;
+        self.tail = (self.tail + 1) % self.queue.len;
+        self.count += 1;
+        self.not_empty.signal();
+    }
+
+    pub fn shutdown(self: *PendingExecutor) void {
+        self.mutex.lock();
+        if (!self.initialized or self.shutting_down) {
+            self.shutting_down = true;
+            self.mutex.unlock();
+        } else {
+            self.shutting_down = true;
+            self.not_empty.broadcast();
+            self.not_full.broadcast();
+            self.mutex.unlock();
+        }
+
+        // Join workers outside the mutex to avoid deadlocks.
+        var idx: usize = 0;
+        while (idx < self.worker_count) : (idx += 1) {
+            self.workers[idx].join();
+        }
+
+        self.mutex.lock();
+        self.count = 0;
+        self.head = 0;
+        self.tail = 0;
+        self.initialized = false;
+        self.mutex.unlock();
+
+        if (self.workers.len != 0) {
+            self.allocator.free(self.workers);
+        }
+        if (self.queue.len != 0) {
+            self.allocator.free(self.queue);
+        }
+        self.workers = &[_]std.Thread{};
+        self.queue = &[_]PendingTask{};
+        self.worker_count = 0;
+    }
+
+    pub fn workerCount(self: *const PendingExecutor) usize {
+        return self.worker_count;
+    }
+
+    pub fn queueCapacity(self: *const PendingExecutor) usize {
+        return self.queue.len;
+    }
+
+    fn workerLoop(self: *PendingExecutor) void {
+        while (true) {
+            self.mutex.lock();
+            while (self.count == 0) {
+                if (self.shutting_down) {
+                    self.mutex.unlock();
+                    return;
+                }
+                self.not_empty.wait(&self.mutex);
+            }
+
+            const task = self.queue[self.head];
+            self.head = (self.head + 1) % self.queue.len;
+            self.count -= 1;
+            self.not_full.signal();
+            self.mutex.unlock();
+
+            task.run(task.context);
+        }
+    }
+};
+
+pub fn recommendedExecutorWorkerCount() usize {
+    const cpu_count_result = std.Thread.getCpuCount() catch 4;
+    const cpu_count: usize = @intCast(cpu_count_result);
+    return math.clamp(cpu_count, 2, 8);
+}
+
+pub fn recommendedExecutorQueueCapacity(worker_count: usize) usize {
+    if (worker_count == 0) {
+        return 0;
+    }
+    const per_worker: usize = 16;
+    return worker_count * per_worker;
+}
+
+fn pendingExecutorWorker(executor: *PendingExecutor) void {
+    executor.workerLoop();
+}
+
 pub const GrpcStatus = struct {
     pub const ok: i32 = 0;
     pub const cancelled: i32 = 1;
@@ -116,8 +296,6 @@ fn destroyHandle(handle: *PendingHandle) void {
 pub const PendingClient = PendingHandle;
 pub const PendingByteArray = PendingHandle;
 
-// TODO(codex, zig-runtime-04): Explore pooling or reusing worker threads so pending handles avoid
-// the overhead of `std.Thread.spawn` per RPC once benchmarks justify the complexity.
 fn assignError(handle: *PendingHandle, code: i32, message: []const u8, duplicate: bool) void {
     destroyMessage(handle.fault.message, handle.fault.owns_message);
     handle.fault.code = code;
@@ -611,4 +789,150 @@ test "retain increments reference count" {
 
     release(handle_ptr);
     release(handle_ptr);
+}
+
+const ExecutorTestContext = struct {
+    counter: *std.atomic.Value(u32),
+};
+
+fn executorIncrementTask(context: ?*anyopaque) void {
+    const raw = context orelse return;
+    const ctx = @as(*ExecutorTestContext, @ptrCast(@alignCast(raw)));
+    _ = ctx.counter.fetchAdd(1, .seq_cst);
+}
+
+const ExecutorBlockingContext = struct {
+    gate: *std.atomic.Value(bool),
+    counter: *std.atomic.Value(u32),
+};
+
+fn executorBlockingTask(context: ?*anyopaque) void {
+    const raw = context orelse return;
+    const ctx = @as(*ExecutorBlockingContext, @ptrCast(@alignCast(raw)));
+    while (!ctx.gate.load(.seq_cst)) {
+        std.Thread.sleep(100_000);
+    }
+    _ = ctx.counter.fetchAdd(1, .seq_cst);
+}
+
+const ExecutorSimpleContext = struct {
+    counter: *std.atomic.Value(u32),
+    completed: *std.atomic.Value(bool),
+};
+
+fn executorSimpleTask(context: ?*anyopaque) void {
+    const raw = context orelse return;
+    const ctx = @as(*ExecutorSimpleContext, @ptrCast(@alignCast(raw)));
+    _ = ctx.counter.fetchAdd(1, .seq_cst);
+    ctx.completed.store(true, .seq_cst);
+}
+
+const SubmitThreadArgs = struct {
+    executor: *PendingExecutor,
+    context: *ExecutorSimpleContext,
+};
+
+fn submitSimpleTaskWorker(args: SubmitThreadArgs) void {
+    args.executor.submit(.{
+        .run = executorSimpleTask,
+        .context = @as(?*anyopaque, @ptrCast(@alignCast(args.context))),
+    }) catch unreachable;
+}
+
+const ExecutorSleepContext = struct {
+    counter: *std.atomic.Value(u32),
+};
+
+fn executorSleepTask(context: ?*anyopaque) void {
+    const raw = context orelse return;
+    const ctx = @as(*ExecutorSleepContext, @ptrCast(@alignCast(raw)));
+    std.Thread.sleep(2 * std.time.ns_per_ms);
+    _ = ctx.counter.fetchAdd(1, .seq_cst);
+}
+
+fn waitForCounter(counter: *std.atomic.Value(u32), expected: u32) void {
+    var attempts: usize = 0;
+    while (counter.load(.seq_cst) != expected and attempts < 20000) {
+        std.Thread.sleep(100_000);
+        attempts += 1;
+    }
+}
+
+test "pending executor processes submitted tasks" {
+    var executor = PendingExecutor{};
+    defer executor.shutdown();
+    try executor.init(std.heap.c_allocator, .{ .worker_count = 2, .queue_capacity = 4 });
+
+    var counter = std.atomic.Value(u32).init(0);
+    const contexts = [_]ExecutorTestContext{
+        .{ .counter = &counter },
+        .{ .counter = &counter },
+        .{ .counter = &counter },
+        .{ .counter = &counter },
+    };
+
+    for (contexts[0..]) |*ctx| {
+        try executor.submit(.{
+            .run = executorIncrementTask,
+            .context = @as(?*anyopaque, @ptrCast(@alignCast(@constCast(ctx)))),
+        });
+    }
+
+    waitForCounter(&counter, @intCast(contexts.len));
+    try testing.expectEqual(@as(u32, contexts.len), counter.load(.seq_cst));
+}
+
+test "pending executor waits for queue availability" {
+    var executor = PendingExecutor{};
+    defer executor.shutdown();
+    try executor.init(std.heap.c_allocator, .{ .worker_count = 1, .queue_capacity = 1 });
+
+    var gate = std.atomic.Value(bool).init(false);
+    var counter = std.atomic.Value(u32).init(0);
+    var submit_completed = std.atomic.Value(bool).init(false);
+
+    var blocking_ctx = ExecutorBlockingContext{ .gate = &gate, .counter = &counter };
+    try executor.submit(.{
+        .run = executorBlockingTask,
+        .context = @as(?*anyopaque, @ptrCast(@alignCast(&blocking_ctx))),
+    });
+
+    var simple_ctx = ExecutorSimpleContext{ .counter = &counter, .completed = &submit_completed };
+    const args = SubmitThreadArgs{ .executor = &executor, .context = &simple_ctx };
+    var submit_thread = try std.Thread.spawn(.{}, submitSimpleTaskWorker, .{args});
+    var joined = false;
+    defer if (!joined) submit_thread.join();
+
+    std.Thread.sleep(2 * std.time.ns_per_ms);
+    try testing.expect(!submit_completed.load(.seq_cst));
+
+    gate.store(true, .seq_cst);
+    submit_thread.join();
+    joined = true;
+
+    waitForCounter(&counter, 2);
+    try testing.expectEqual(@as(u32, 2), counter.load(.seq_cst));
+    try testing.expect(submit_completed.load(.seq_cst));
+}
+
+test "pending executor shutdown waits for tasks to finish" {
+    var executor = PendingExecutor{};
+    try executor.init(std.heap.c_allocator, .{ .worker_count = 2, .queue_capacity = 4 });
+
+    var counter = std.atomic.Value(u32).init(0);
+    const contexts = [_]ExecutorSleepContext{
+        .{ .counter = &counter },
+        .{ .counter = &counter },
+        .{ .counter = &counter },
+    };
+
+    for (contexts[0..]) |*ctx| {
+        try executor.submit(.{
+            .run = executorSleepTask,
+            .context = @as(?*anyopaque, @ptrCast(@alignCast(@constCast(ctx)))),
+        });
+    }
+
+    executor.shutdown();
+    try testing.expectEqual(@as(u32, contexts.len), counter.load(.seq_cst));
 }

--- a/packages/temporal-bun-sdk/bruke/src/pending_executor_stress.zig
+++ b/packages/temporal-bun-sdk/bruke/src/pending_executor_stress.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const pending = @import("pending.zig");
+
+const StressContext = struct {
+    counter: *std.atomic.Value(u32),
+};
+
+fn stressTask(context_any: ?*anyopaque) void {
+    const raw = context_any orelse return;
+    const ctx = @as(*StressContext, @ptrCast(@alignCast(raw)));
+    std.Thread.sleep(100 * std.time.ns_per_ms);
+    _ = ctx.counter.fetchAdd(1, .seq_cst);
+}
+
+pub fn main() !void {
+    const pid = std.c.getpid();
+    std.debug.print("stress-start pid={d}\n", .{pid});
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var executor = pending.PendingExecutor{};
+    try executor.init(allocator, .{
+        .worker_count = pending.recommendedExecutorWorkerCount(),
+        .queue_capacity = pending.recommendedExecutorWorkerCount() * 8,
+    });
+    defer executor.shutdown();
+
+    const worker_count = executor.workerCount();
+    const queue_capacity = executor.queueCapacity();
+
+    var counter = std.atomic.Value(u32).init(0);
+    const total: usize = queue_capacity * 2;
+    const contexts = try allocator.alloc(StressContext, total);
+    defer allocator.free(contexts);
+
+    for (contexts) |*ctx| {
+        ctx.* = .{ .counter = &counter };
+    }
+
+    std.debug.print(
+        "stress-dispatch total={d} workers={d} queue={d}\n",
+        .{ total, worker_count, queue_capacity },
+    );
+
+    for (contexts) |*ctx| {
+        executor.submit(.{
+            .run = stressTask,
+            .context = @as(?*anyopaque, @ptrCast(@alignCast(ctx))),
+        }) catch unreachable;
+    }
+
+    const expected: u32 = @intCast(total);
+    var attempts: usize = 0;
+    while (counter.load(.seq_cst) != expected and attempts < 5000) : (attempts += 1) {
+        std.Thread.sleep(50 * std.time.ns_per_ms);
+    }
+
+    const completed = counter.load(.seq_cst);
+    std.debug.print("stress-complete executed={d} attempts={d}\n", .{ completed, attempts });
+
+    if (completed != expected) {
+        return error.IncompleteExecution;
+    }
+}

--- a/packages/temporal-bun-sdk/docs/zig-bridge-scaffold-checklist.md
+++ b/packages/temporal-bun-sdk/docs/zig-bridge-scaffold-checklist.md
@@ -39,7 +39,7 @@ The items below slice the Zig bridge effort into PR-sized TODOs. Every ID maps b
 |----|-------------|-------------|------------|
 | zig-buf-01 | Swap stub allocator for zero-copy handling of Temporal-owned buffers. | `src/byte_array.zig` | Roundtrip tests prove no leaks and zero-copy when possible. |
 | zig-buf-02 | Add guardrails + telemetry counters for buffer allocations. | `src/byte_array.zig` | Metrics surfaced to TS layer; unit tests cover failure cases. |
-| zig-pend-01 | Implement reusable pending handle state machine for clients + byte arrays. | `src/pending.zig` | Concurrent stress test passes; TS polling logic unchanged. |
+| zig-pend-01 | Implement reusable pending handle state machine for clients + byte arrays. | `src/pending.zig` | ✅ Concurrent stress test passes; bounded executor replaces per-request threads and TS polling logic remains unchanged. |
 
 ### Worker Lifecycle
 

--- a/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
+++ b/packages/temporal-bun-sdk/src/internal/core-bridge/native.ts
@@ -272,6 +272,14 @@ function buildBridgeSymbolMap() {
       args: [FFIType.ptr],
       returns: FFIType.int32_t,
     },
+    temporal_bun_runtime_test_get_pending_worker_count: {
+      args: [FFIType.ptr],
+      returns: FFIType.uint64_t,
+    },
+    temporal_bun_runtime_test_get_pending_queue_capacity: {
+      args: [FFIType.ptr],
+      returns: FFIType.uint64_t,
+    },
     temporal_bun_runtime_test_register_client: {
       args: [FFIType.ptr],
       returns: FFIType.int32_t,
@@ -470,6 +478,8 @@ const {
     temporal_bun_runtime_test_get_metric_prefix,
     temporal_bun_runtime_test_get_socket_addr,
     temporal_bun_runtime_test_get_attach_service_name,
+    temporal_bun_runtime_test_get_pending_worker_count,
+    temporal_bun_runtime_test_get_pending_queue_capacity,
     temporal_bun_runtime_test_register_client,
     temporal_bun_runtime_test_unregister_client,
     temporal_bun_runtime_test_register_worker,
@@ -588,6 +598,14 @@ export const native = {
     if (result !== 0) {
       throw buildNativeBridgeError()
     }
+  },
+
+  pendingExecutorWorkerCount(runtime: Runtime): number {
+    return Number(temporal_bun_runtime_test_get_pending_worker_count(runtime.handle))
+  },
+
+  pendingExecutorQueueCapacity(runtime: Runtime): number {
+    return Number(temporal_bun_runtime_test_get_pending_queue_capacity(runtime.handle))
   },
 
   installLogger(runtime: Runtime, callback: TemporalCoreLogger, onDetach?: () => void): void {

--- a/packages/temporal-bun-sdk/tests/fixtures/stub_temporal_bridge.c
+++ b/packages/temporal-bun-sdk/tests/fixtures/stub_temporal_bridge.c
@@ -34,6 +34,78 @@ void temporal_bun_runtime_free(void *handle) {
   (void)handle;
 }
 
+int32_t temporal_bun_runtime_update_telemetry(void *handle, void *payload, uint64_t len) {
+  (void)handle;
+  (void)payload;
+  (void)len;
+  return 0;
+}
+
+int32_t temporal_bun_runtime_set_logger(void *handle, void *callback) {
+  (void)handle;
+  (void)callback;
+  return 0;
+}
+
+uint32_t temporal_bun_runtime_test_get_mode(void *handle) {
+  (void)handle;
+  return 0;
+}
+
+void *temporal_bun_runtime_test_get_metric_prefix(void *handle) {
+  (void)handle;
+  return NULL;
+}
+
+void *temporal_bun_runtime_test_get_socket_addr(void *handle) {
+  (void)handle;
+  return NULL;
+}
+
+int32_t temporal_bun_runtime_test_get_attach_service_name(void *handle) {
+  (void)handle;
+  return 1;
+}
+
+int32_t temporal_bun_runtime_test_register_client(void *handle) {
+  (void)handle;
+  return 1;
+}
+
+void temporal_bun_runtime_test_unregister_client(void *handle) {
+  (void)handle;
+}
+
+int32_t temporal_bun_runtime_test_register_worker(void *handle) {
+  (void)handle;
+  return 1;
+}
+
+void temporal_bun_runtime_test_unregister_worker(void *handle) {
+  (void)handle;
+}
+
+void temporal_bun_runtime_test_emit_log(uint32_t level, const char *target_ptr, uint64_t target_len, const char *message_ptr, uint64_t message_len, uint64_t timestamp_millis, const char *fields_ptr, uint64_t fields_len) {
+  (void)level;
+  (void)target_ptr;
+  (void)target_len;
+  (void)message_ptr;
+  (void)message_len;
+  (void)timestamp_millis;
+  (void)fields_ptr;
+  (void)fields_len;
+}
+
+uint64_t temporal_bun_runtime_test_get_pending_worker_count(void *handle) {
+  (void)handle;
+  return 4;
+}
+
+uint64_t temporal_bun_runtime_test_get_pending_queue_capacity(void *handle) {
+  (void)handle;
+  return 64;
+}
+
 const char *temporal_bun_error_message(uint64_t *len_out) {
   if (len_out) {
     *len_out = (uint64_t)strlen(kNoError);


### PR DESCRIPTION
- Resolves #1652
- Implements bounded pending executor, wires runtime/client/worker scheduling, and updates docs/tests
- Adds Bun recovery helper and CI stress harness to ensure executor stays bounded

## Testing
- pnpm --filter @proompteng/temporal-bun-sdk run build:native:zig
- cd packages/temporal-bun-sdk/bruke && zig build test
- pnpm --filter @proompteng/temporal-bun-sdk test
- TEMPORAL_BUN_SDK_USE_ZIG=1 pnpm --filter temporal-bun-sdk-example run test
- zig run packages/temporal-bun-sdk/bruke/src/pending_executor_stress.zig
