### PR TITLE
docs: document Zig toolchain requirements (#1515)

### DIFF
--- a/packages/temporal-bun-sdk/docs/zig-bridge-migration-plan.md
+++ b/packages/temporal-bun-sdk/docs/zig-bridge-migration-plan.md
@@ -117,14 +117,24 @@ Bun (bun:ffi) ──▶ Zig Bridge (libtemporal_bun_bridge.zig)
 
 ## 6. Build & Tooling Updates
 
-1. **Zig Toolchain Version** — Standardize on Zig 0.15.1 (matches `services/galette`). Document installation in README.  
+1. **Zig Toolchain Version** — Standardize on Zig 0.15.1 (matches `services/galette`) and follow the install guidance in [`README.md#zig-toolchain`](../README.md#zig-toolchain).  
+   - When bumping Zig, update `.github/workflows/temporal-bun-sdk.yml`, `packages/temporal-bun-sdk/Dockerfile`, and the README section in the same PR so CI, local docs, and our container image stay aligned.  
+   - Re-run `pnpm --filter @proompteng/temporal-bun-sdk run build:native:zig` plus `pnpm exec biome check packages/temporal-bun-sdk/README.md` after the upgrade to confirm local builds pass and docs stay formatted.  
+   - Debian/Ubuntu developers must install `xz-utils` before unpacking official tarballs; macOS users should `brew pin zig` after installing 0.15.1 to avoid automatic upgrades that break parity with CI.
 2. **Package Scripts** — ✅ **COMPLETED** - Replaced `cargo build` scripts with pre-built library downloads:
    ```json
    "build:native": "bun run libs:download && zig build -Doptimize=ReleaseFast --build-file bruke/build.zig"
    ```
-3. **CI Images** — ✅ **COMPLETED** - Removed Rust from Docker images, using only Zig with pre-built libraries.  
-4. **Prebuilt Artifacts** — Use `zig build install` to stage artifacts under `native/artifacts/<platform>/`.  
+3. **CI Images** — ✅ **COMPLETED** - Removed Rust from Docker images, using only Zig with pre-built libraries.
+4. **Prebuilt Artifacts** — Use `zig build install` to stage artifacts under `native/artifacts/<platform>/`.
 5. **NPM Packaging** — Update publish step to copy Zig binaries into `dist/native/<platform>/`.
+
+### Toolchain troubleshooting
+
+- Run `zig version` and `zig env` whenever `build:native:zig` fails; a missing `zig` binary on `PATH` or the wrong version (≠0.15.1) is the most common issue.
+- Verify Temporal libraries downloaded via `bun run scripts/download-temporal-libs.ts` before rebuilding; stale caches surface as linker errors.
+- Windows/MSVC support remains deferred—call it out in release notes and onboarding docs until we publish compatible artifacts.
+- Capture upgrade steps in the issue checklist: update workflow + Dockerfile + README, regenerate release notes, and notify Bun SDK maintainers.
 
 ---
 

--- a/packages/temporal-bun-sdk/docs/zig-bridge-scaffold-checklist.md
+++ b/packages/temporal-bun-sdk/docs/zig-bridge-scaffold-checklist.md
@@ -61,7 +61,7 @@ The items below slice the Zig bridge effort into PR-sized TODOs. Every ID maps b
 |----|-------------|-------------|------------|
 | zig-pack-01 | Link Zig build against Temporal static libraries emitted by Cargo. | `build.zig` | `build:native:zig` links successfully on macOS/Linux. |
 | zig-pack-02 | Ship Zig artifacts in npm package (`zig-out/lib` per target). | `package.json`, publish pipeline | Pack command includes Zig binaries (Rust fallback removed). |
-| zig-pack-03 | Document Zig toolchain requirements + installation flow referencing the official Zig install guide. | `README.md`, docs | README section updated, CI job references version. |
+| zig-pack-03 | Document Zig toolchain requirements + installation flow referencing the official Zig install guide. | `README.md`, docs | README `#Zig Toolchain` section stays in sync with `.github/workflows/temporal-bun-sdk.yml` and `packages/temporal-bun-sdk/Dockerfile`; docs link back to the section. |
 | zig-pack-04 | CI executes `zig build test` alongside Bun suites. | CI configs | `.github/workflows/temporal-bun-sdk.yml` runs `pnpm --filter @proompteng/temporal-bun-sdk run ci:native:zig` (release + debug `zig build test`) on every push / PR. |
 
 Grab a single ID, replace the matching TODO in code, and keep scope bounded so each merge delivers

--- a/packages/temporal-bun-sdk/docs/zig-production-readiness.md
+++ b/packages/temporal-bun-sdk/docs/zig-production-readiness.md
@@ -21,7 +21,7 @@
   artifacts into `dist/native/<platform>/<arch>/`. Prebuilt archives ship via `.github/workflows/temporal-static-libraries.yml`
   and `scripts/download-temporal-libs.ts` pulls them into `.temporal-libs-cache` before each build.
 - [ ] Release automation publishes Zig binaries (macOS arm64, Linux arm64/x64) with signatures/provenance. (Windows/MSVC and Intel macOS remain unsupported.)
-- [ ] README and publish notes explain how SDK consumers opt into/out of the Zig bridge and which platforms are supported.
+- [ ] README and publish notes explain how SDK consumers opt into/out of the Zig bridge and which platforms are supported (`README.md#zig-toolchain` documents the current version and install paths).
 
 ## 4. Security & Compliance
 - [ ] Supply-chain review covers the Zig toolchain, vendored headers, and build scripts.


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- document the Zig 0.15.1 toolchain requirements in the Temporal Bun SDK README
- add install/verification guidance (Homebrew, asdf, tarball) and remove the zig-pack-03 TODO marker
- sync migration/readiness docs so they reference the README section and capture troubleshooting/upgrade steps

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
Closes #1515

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- `pnpm exec biome check packages/temporal-bun-sdk/README.md packages/temporal-bun-sdk/docs/zig-bridge-migration-plan.md packages/temporal-bun-sdk/docs/zig-bridge-scaffold-checklist.md packages/temporal-bun-sdk/docs/zig-production-readiness.md` (skipped: Biome config ignores markdown paths)
- `pnpm exec biome check packages/temporal-bun-sdk` (fails on generated .temporal-libs-cache JSON; no repo files changed)

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Zig 0.15.1 toolchain install/verification guide to the README and aligns migration, checklist, and readiness docs to reference it and capture troubleshooting/upgrade steps.
> 
> - **README (`packages/temporal-bun-sdk/README.md`)**
>   - Add **Zig Toolchain** section: standardize on Zig `0.15.1`, provide install options (Homebrew, asdf, official tarball), verification commands, and notes (`xz-utils`, `brew pin`, Windows unsupported).
>   - Clarify build expectations and failure remediation for `build:native:zig`.
> - **Docs**
>   - `docs/zig-bridge-migration-plan.md`:
>     - Reference `README.md#zig-toolchain`; add upgrade/troubleshooting steps and keep CI/Dockerfile/README in sync.
>     - Minor formatting/numbering fixes; clarify prebuilt artifacts staging.
>   - `docs/zig-bridge-scaffold-checklist.md`:
>     - Update `zig-pack-03` acceptance to require README/CI/Dockerfile alignment and link back to README section.
>   - `docs/zig-production-readiness.md`:
>     - Update packaging checklist to point to `README.md#zig-toolchain` for version/install paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8483fd04456742d473adf5af9e39f0bed90c68ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->