### PR TITLE
docs: add kafka incident recovery report

### DIFF
--- a/docs/incidents/2025-11-01-kafka-quorum-outage.md
+++ b/docs/incidents/2025-11-01-kafka-quorum-outage.md
@@ -1,0 +1,100 @@
+# Incident Report: Kafka KRaft Quorum Corruption
+
+- **Date**: 1 Nov 2025
+- **Detected by**: Froussard readiness probes failing, lack of Codex workflow trigger after `execute plan`
+- **Reported by**: gregkonush
+- **Services Affected**: Kafka cluster (`kafka` namespace), dependent automations (Codex workflows), any producers/consumers using the shared Kafka brokers
+- **Severity**: High – Kafka cluster unavailable
+
+## Impact Summary
+
+- Kafka brokers were crash-looping and marked `Degraded`; Codex workflows relying on Kafka events were not triggered.
+- Froussard’s readiness probe failed because it could not connect to Kafka, preventing automatic Codex dispatch.
+- No message ingestion or consumption for platform topics (`github.*`, `discord.*`, Argo workflows, etc.) during the outage window.
+
+## Timeline (Pacific Time)
+
+| Time | Event |
+|------|-------|
+| 2025-11-01 14:56 | Strimzi rollout produced new revision `froussard-00062`; Kafka brokers began restarting. |
+| 2025-11-01 15:10 | Strimzi operator reported repeated reconciliation failures; brokers in `CrashLoopBackOff`. |
+| 2025-11-01 15:30 | User noticed `execute plan` comment did not trigger Codex workflow; investigation found Froussard readiness failing due to Kafka connection errors. |
+| 2025-11-01 15:35 | Confirmed Kafka brokers were unable to join the KRaft quorum; logs showed `Fatal error during broker startup` and corrupted `quorum-state`. |
+| 2025-11-01 15:40 – 15:55 | Paused ArgoCD autosync for Kafka, scaled Strimzi components down, detached broker PVCs, manually repaired quorum metadata and replication checkpoint files. |
+| 2025-11-01 15:56 | Restored quorum metadata (`quorum-state`) on all brokers, reset corrupted `replication-offset-checkpoint` files, remounted PVCs. |
+| 2025-11-01 15:57 | Scaled brokers back up; all three brokers started successfully and formed quorum. |
+| 2025-11-01 15:58 | Restarted entity operator for clean state. |
+| 2025-11-01 15:59 | Re-enabled ArgoCD autosync; Kafka application returned to `Synced/Healthy`. |
+| 2025-11-01 16:00 | Confirmed Kafka `Ready=True` and Froussard readiness probe passing. |
+
+## Root Cause
+
+During the Strimzi restart, the KRaft metadata quorum files became corrupted:
+
+- `quorum-state` on all brokers contained empty `clusterId` and stale `leaderEpoch` values (0/1163/1165 mismatches), causing brokers to fail registration.
+- `replication-offset-checkpoint` files were filled with null bytes, triggering `KafkaStorageException` when brokers attempted to become leaders.
+
+The exact trigger for the file corruption is unknown; likely caused by abrupt broker termination during disk writes while Longhorn volumes were attached.
+
+## Remediation Actions
+
+1. Suspended ArgoCD autosync (`argocd root` ApplicationSet) to prevent automated rollbacks.
+2. Scaled Strimzi operator and Kafka node pool to zero; deleted StrimziPodSet to detach PVCs.
+3. Mounted each broker PVC into privileged repair pods and:
+   - Rebuilt `__cluster_metadata-0/quorum-state` with correct `clusterId`, `leaderEpoch`, and `appliedOffset`.
+   - Reset `replication-offset-checkpoint` entries to `0\n0\n`.
+4. Unmounted PVCs, removed repair pods, and scaled brokers/operator back up.
+5. Restarted entity-operator after brokers healthy.
+6. Re-enabled ArgoCD autosync (`automation=auto`, `--sync-policy automated --self-heal --auto-prune`).
+7. Verified Kafka readiness, broker logs, and Froussard connectivity.
+
+## Follow-up Actions
+
+- **Investigate root cause**: Review Strimzi operator logs around 14:56–15:10 PT for evidence of abrupt restarts or volume issues.
+- **Add health checks**: Implement monitoring/alerting for KRaft quorum registration failures and checkpoint corruption.
+- **Document recovery runbook**: Convert this report into a formal playbook for future KRaft metadata repairs.
+- **Schedule postmortem**: Meet with platform team to determine preventive steps (e.g., backups, graceful stop hooks, filesystem checks).
+- **Verify downstream systems**: Run Kafka smoke tests (produce/consume) and confirm dependent services (Codex dispatcher, Karapace, Froussard) remain stable.
+
+## Lessons Learned
+
+- KRaft mode is sensitive to metadata file integrity; regular snapshots/backups are essential.
+- ArgoCD autosync should be paused before manual remediation to avoid unintended rollbacks.
+- Dedicated repair pods with privileged access streamline Longhorn volume debugging; keep templates ready.
+- Entity operator will continue crashing until brokers are healthy; restarting it at the end ensures CRD synchronization.
+
+## Relevant Commands
+
+```bash
+# Disable autosync and patch ApplicationSet entry
+argocd app patch-resource argocd/root --group argoproj.io --kind ApplicationSet \
+  --namespace argocd --resource-name platform \
+  --patch '[{"op":"replace","path":"/spec/generators/0/list/elements/10/automation","value":"manual"}]' \
+  --patch-type application/json-patch+json
+
+argocd app patch argocd/kafka --type json \
+  --patch '[{"op":"remove","path":"/spec/syncPolicy/automated"}]'
+
+# Scale Strimzi components down
+kubectl scale deployment strimzi-cluster-operator -n kafka --replicas=0
+kubectl patch kafkanodepool pool-a -n kafka --type merge -p '{"spec":{"replicas":0}}'
+
+# Mount PVC to repair pod (example for broker 0)
+kubectl apply -f kafka-repair-0.yaml
+kubectl exec kafka-repair-0 -n kafka -- bash -lc \
+  'printf "%s\n" "{\"clusterId\":\"…\",\"leaderId\":-1,\"leaderEpoch\":1138,\"votedId\":-1,\"appliedOffset\":2997912,\"currentVoters\":[{\"voterId\":0},{\"voterId\":1},{\"voterId\":2}],\"data_version\":0}" > /mnt/data/kafka-log0/__cluster_metadata-0/quorum-state'
+kubectl exec kafka-repair-0 -n kafka -- bash -lc \
+  'printf "0\n0\n" > /mnt/data/kafka-log0/replication-offset-checkpoint'
+
+# Restart Strimzi/Kafka
+kubectl patch kafkanodepool pool-a -n kafka --type merge -p '{"spec":{"replicas":3}}'
+kubectl scale deployment strimzi-cluster-operator -n kafka --replicas=1
+
+# Re-enable autosync
+argocd app patch-resource argocd/root --group argoproj.io --kind ApplicationSet \
+  --namespace argocd --resource-name platform \
+  --patch '[{"op":"replace","path":"/spec/generators/0/list/elements/10/automation","value":"auto"}]' \
+  --patch-type application/json-patch+json
+argocd app set argocd/kafka --sync-policy automated --self-heal --auto-prune
+```
+

--- a/docs/local-llm-deepseek-coder.md
+++ b/docs/local-llm-deepseek-coder.md
@@ -1,0 +1,129 @@
+# Local DeepSeek Coder on docker-host (RTX 3090)
+
+Date: 1 Nov 2025
+
+## Goal
+Run a coding-tuned LLM locally on the `docker-host` VM (Ubuntu 24.04, RTX 3090 24 GB) and expose it through Ollama + Open WebUI for interactive use.
+
+## Prerequisites
+- `docker-host` accessible via SSH (`kalmyk@192.168.1.190`).
+- NVIDIA 580.95 driver + CUDA 13.0 installed (see “GPU passthrough & driver notes”).
+- Ollama service running under systemd `/etc/systemd/system/ollama.service`.
+- Open WebUI container deployed from `~/ollama-stack/docker-compose.yml`.
+
+## GPU passthrough & driver notes
+1. **Enable passthrough in Harvester**: Select the GA102 device (`altra-000c01000`) and turn passthrough on.
+2. **Bind both GPU + audio functions to `vfio-pci`** (PCIs `000c:01:00.0` & `000c:01:00.1`). If the audio function stays on `snd_hda_intel`, the passthrough toggle hangs in “In Progress”.
+3. **Install NVIDIA driver + CUDA toolkit inside the VM**:
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y nvidia-driver-550 nvidia-cuda-toolkit
+   ```
+   `nvidia-smi` should show the RTX 3090 with driver 580.95.
+4. **Typical issues**
+   - `modprobe nvidia: No such device` → GPU not bound to VM; recheck Harvester claim/binding.
+   - Passthrough stuck → unbind the audio device, bind both functions to `vfio-pci`, restart `harvester-pcidevices-controller` pod.
+
+## Install Ollama
+Use the official script to install the binary and unit:
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+sudo systemctl enable --now ollama
+```
+
+This places the binary at `/usr/local/bin/ollama`, creates `/etc/systemd/system/ollama.service`, and starts the service.
+
+## Configure Ollama for remote clients
+Ollama defaults to 127.0.0.1. Allow container access by editing the unit:
+
+```bash
+sudo tee /etc/systemd/system/ollama.service <<'EOF_UNIT'
+[Unit]
+Description=Ollama Service
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/ollama serve
+User=ollama
+Group=ollama
+Restart=always
+RestartSec=3
+Environment=OLLAMA_HOST=0.0.0.0
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
+
+[Install]
+WantedBy=default.target
+EOF_UNIT
+
+sudo systemctl daemon-reload
+sudo systemctl restart ollama
+```
+
+## Deploy Open WebUI
+`~/ollama-stack/docker-compose.yml` contains:
+
+```yaml
+services:
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:latest
+    container_name: open-webui
+    restart: unless-stopped
+    environment:
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "3000:8080"
+    volumes:
+      - openwebui-data:/app/backend/data
+
+volumes:
+  openwebui-data:
+    driver: local
+```
+
+Start/stop the stack:
+
+```bash
+cd ~/ollama-stack
+docker compose up -d      # start
+docker compose down       # stop
+```
+
+## Pull DeepSeek Coder
+Select the 6.7 B model (fits in VRAM with good speed):
+
+```bash
+ollama pull deepseek-coder:6.7b
+```
+
+Smoke-test the model:
+
+```bash
+ollama list
+printf 'Write a Python function that returns True if a number is prime.' | \
+  ollama run deepseek-coder:6.7b
+```
+
+## Register models in Open WebUI
+Restart the compose stack after pulling new models so WebUI refreshes `/api/tags`:
+
+```bash
+cd ~/ollama-stack
+docker compose restart
+```
+
+Browse to `http://192.168.1.190:3000`, sign in, and pick **deepseek-coder:6.7b** from the dropdown (use “Set as default” for coding sessions).
+
+## Runtime notes
+- DeepSeek Coder download size: ~3.8 GB in `/usr/share/ollama/.ollama/models`.
+- Expected throughput on the 3090: ~30 tokens/s.
+- Keep one heavy model resident at a time to avoid VRAM thrash.
+- Always restart the WebUI container after adding new Ollama models.
+
+## Troubleshooting checklist
+- **Model dropdown empty / 500 errors** → ensure `OLLAMA_HOST=0.0.0.0` in the unit; restart `ollama` and `docker compose restart`.
+- **`nvidia-smi` missing** → rebind passthrough devices and reinstall driver/toolkit.
+- **Passthrough toggle stuck** → unbind audio function, bind both to `vfio-pci`, bounce `harvester-pcidevices-controller`.
+- Logs: `journalctl -u ollama -f`, `docker logs open-webui`.

--- a/packages/temporal-bun-sdk/docs/client-runtime.md
+++ b/packages/temporal-bun-sdk/docs/client-runtime.md
@@ -4,7 +4,7 @@
 - DONE: `createTemporalClient` threads a configurable `dataConverter` through request serialization, query decoding, and signal hashing.  
 - DONE: Serialization helpers now encode memo, headers, search attributes, and failure details via `encodeValuesToJson` / `encodeMapToJson`, preserving codec metadata for the Zig bridge.  
 - DONE: `cancelWorkflow` now delegates to the Zig bridge implementation (`temporal_bun_client_cancel_workflow`), returning structured Temporal core errors through pending handles.  
-- TODO: Telemetry/logging hooks from the upstream SDK remain unimplemented pending additional Zig exports.
+- DONE: Telemetry configuration and logger registration are exposed via `Runtime.configureTelemetry` / `Runtime.installLogger` and backed by Zig exports.
 
 Keep this document aligned with the current source so new work can focus on the remaining gaps rather than rediscovering the existing surface.
 

--- a/packages/temporal-bun-sdk/docs/zig-bridge-scaffold-checklist.md
+++ b/packages/temporal-bun-sdk/docs/zig-bridge-scaffold-checklist.md
@@ -62,7 +62,7 @@ The items below slice the Zig bridge effort into PR-sized TODOs. Every ID maps b
 | zig-pack-01 | Link Zig build against Temporal static libraries emitted by Cargo. | `build.zig` | `build:native:zig` links successfully on macOS/Linux. |
 | zig-pack-02 | Ship Zig artifacts in npm package (`zig-out/lib` per target). | `package.json`, publish pipeline | Pack command includes Zig binaries (Rust fallback removed). |
 | zig-pack-03 | Document Zig toolchain requirements + installation flow referencing the official Zig install guide. | `README.md`, docs | README section updated, CI job references version. |
-| zig-pack-04 | CI executes `zig build test` in addition to existing Rust bridge smoke tests. | CI configs | Pipeline green with dual bridge verification (see `.github/workflows/temporal-bun-sdk-zig.yml`). |
+| zig-pack-04 | CI executes `zig build test` alongside Bun suites. | CI configs | `.github/workflows/temporal-bun-sdk.yml` runs `pnpm --filter @proompteng/temporal-bun-sdk run ci:native:zig` (release + debug `zig build test`) on every push / PR. |
 
 Grab a single ID, replace the matching TODO in code, and keep scope bounded so each merge delivers
 an incremental capability.

--- a/packages/temporal-bun-sdk/docs/zig-production-readiness.md
+++ b/packages/temporal-bun-sdk/docs/zig-production-readiness.md
@@ -11,8 +11,7 @@
   end-to-end coverage.
 
 ## 2. Automated Verification
-- [ ] Dedicated Zig CI workflow (e.g. `.github/workflows/temporal-bun-sdk-zig.yml`) runs `zig build test` plus Bun
-  smoke tests on every PR.
+- [x] Zig CI coverage lives in `.github/workflows/temporal-bun-sdk.yml`, which runs `pnpm --filter @proompteng/temporal-bun-sdk run ci:native:zig` (Release + Debug `zig build` tests) alongside Bun suites on every push/PR.
 - [ ] Nightly Temporal CLI smoke (`scripts/start-temporal-cli.ts` + `TEMPORAL_TEST_SERVER=1` suites) exercises the
   Zig bridge path and reports separately from the Rust bridge.
 - [ ] Flaky Zig tests, if any, are triaged with documented owners and follow-ups.


### PR DESCRIPTION
## Summary
- Document the 1 Nov 2025 Kafka KRaft quorum outage and remediation steps under `docs/incidents`.
- Add local DeepSeek Coder notes for the LLM workflow.
- Carry forward the staged Temporal Bun SDK doc tweaks present in the workspace.

## Related Issues
- None

## Testing
- N/A (documentation-only changes)

## Screenshots (if applicable)
- None

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
