### PR TITLE
docs: capture codex mcp bridge setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - Run backend workflows through `go test ./...` and `go build ./...`.
 - Infra flow: `pnpm run tf:plan` (review), `pnpm run tf:apply` (approved), and `pnpm run ansible` for playbooks. Use the deployment helper scripts when touching automation services:
   - `bun apps/froussard/src/codex/cli/build-codex-image.ts` to rebuild/push the Codex runner image.
+    - Script defaults to the `tuslagch` GitHub CLI account; override with `GH_TOKEN_USER=<other>` if needed. Container git commits use `tuslagch@proompteng.ai`.
   - `bun packages/scripts/src/froussard/deploy-service.ts` to build and roll the Froussard Knative service (sets `FROUSSARD_VERSION/FROUSSARD_COMMIT` automatically).
   - `bun packages/scripts/src/facteur/deploy-service.ts` to build, push, and redeploy Facteur (applies the kustomize overlay and `kn service apply`).
 - Whenever you change any TypeScript/JavaScript files, run the relevant Biome check command (e.g. `pnpm exec biome check <paths>`) and resolve every diagnostic before pushing or opening a PR; mention the run in your PR description if manual fixes were required.

--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -92,8 +92,8 @@ RUN --mount=type=secret,id=github_token,target=/tmp/gh_token \
     gh auth login --with-token < /tmp/gh_token \
     && gh auth setup-git
 
-RUN git config --global user.name "codex-automation" \
-    && git config --global user.email "codex-automation@users.noreply.github.com"
+RUN git config --global user.name "tuslagch" \
+    && git config --global user.email "tuslagch@proompteng.ai"
 
 COPY apps/froussard/src/codex/cli/codex-bootstrap.ts /usr/local/bin/codex-bootstrap
 COPY apps/froussard/src/codex/cli/codex-plan.ts /usr/local/bin/codex-plan

--- a/apps/froussard/src/codex/cli/build-codex-image.ts
+++ b/apps/froussard/src/codex/cli/build-codex-image.ts
@@ -37,7 +37,8 @@ const loadGitHubToken = async (): Promise<string> => {
     if (!ghCli) {
       throw new Error('gh CLI not found; please install gh or export GH_TOKEN')
     }
-    const output = await $`${ghCli} auth token`.text()
+    const ghUser = process.env.GH_TOKEN_USER ?? process.env.GH_AUTH_USER ?? 'tuslagch'
+    const output = ghUser ? await $`${ghCli} auth token --user ${ghUser}`.text() : await $`${ghCli} auth token`.text()
     const trimmed = output.trim()
     if (trimmed) {
       return trimmed

--- a/docs/codex-mcp-bridge.md
+++ b/docs/codex-mcp-bridge.md
@@ -1,0 +1,111 @@
+# Codex MCP Bridge on docker-host
+
+This playbook captures how we expose the Codex CLI as an MCP server on `docker-host` and surface it inside Open WebUI.
+
+## Prerequisites
+
+- `codex` CLI installed globally (`sudo npm install -g @openai/codex`).
+- `mcpo` installed via `pipx` (`pipx install mcpo`).
+- Tailscale agent running on the host.
+- The repository cloned to `/home/kalmyk/github.com/lab`.
+
+## Configure Codex
+
+Copy the repo’s template config so Codex runs with the expected defaults (model, sandbox, trusted workspace):
+
+```bash
+install -d ~/.codex
+cp ~/github.com/lab/apps/froussard/scripts/codex-config-container.toml ~/.codex/config.toml
+```
+
+The template pins `gpt-5-codex`, disables approvals, and trusts `/home/kalmyk/github.com/lab`.
+
+## Systemd service
+
+`codex-mcp.service` lives at `/etc/systemd/system/codex-mcp.service` and wraps Codex with mcpo:
+
+```ini
+[Unit]
+Description=Codex MCP server bridged by mcpo
+After=network.target
+
+[Service]
+User=kalmyk
+Group=kalmyk
+WorkingDirectory=/home/kalmyk/github.com/lab
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/kalmyk/.local/bin:/home/kalmyk/.local/npm-global/bin
+ExecStart=/home/kalmyk/.local/bin/mcpo --host 0.0.0.0 --port 8200 --name codex --api-key CODEx_MCP_KEY -- codex mcp-server
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and verify:
+
+```bash
+sudo systemctl enable --now codex-mcp.service
+sudo systemctl status codex-mcp.service
+curl http://192.168.1.190:8200/openapi.json | jq '.info.title'
+```
+
+The last command should print `codex-mcp-server`. Use the `Authorization: Bearer CODEx_MCP_KEY` header when calling POST endpoints.
+
+## Expose through Tailscale
+
+Open WebUI’s frontend also needs to reach the MCP endpoint *and* the chat UI over HTTPS. Proxy both through Tailscale:
+
+```bash
+sudo tailscale set --operator=$USER                   # allow non-root serve commands
+tailscale serve --bg --set-path /codex http://127.0.0.1:8200
+tailscale serve --bg --set-path /      http://127.0.0.1:3000
+```
+
+This exposes:
+
+- `https://docker.ide-newton.ts.net/codex` → Codex MCP (requires the bearer token)
+- `https://docker.ide-newton.ts.net/` → Open WebUI chat
+
+Validate from your laptop (with Tailscale connected):
+
+```bash
+curl -I https://docker.ide-newton.ts.net/
+curl -H 'Authorization: Bearer CODEx_MCP_KEY' \
+  https://docker.ide-newton.ts.net/codex/openapi.json | jq '.info.title'
+```
+
+## Wire up Open WebUI
+
+1. Edit `~/ollama-stack/docker-compose.yml` and add the tool server connection:
+
+   ```yaml
+   environment:
+     - MCP_ENABLE=true
+     - TOOL_SERVER_CONNECTIONS=[{"name":"codex-mcp","url":"https://docker.ide-newton.ts.net/codex/mcp","api_key":"CODEx_MCP_KEY"}]
+   ```
+
+2. Restart the stack:
+
+   ```bash
+   cd ~/ollama-stack
+   docker compose down
+   docker compose up -d
+   ```
+
+3. Import the helper JSON (see `~/Downloads/codex-mcp-tool.json`) via **Settings → External Tools → Import**, then toggle the tool on. Codex commands run inside `/home/kalmyk/github.com/lab`.
+
+## Smoke test
+
+Run a simple Codex call against the bridge:
+
+```bash
+curl -s -m 30 -X POST http://192.168.1.190:8200/codex \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer CODEx_MCP_KEY' \
+  -d '{"prompt":"Say hello","cwd":"/home/kalmyk/github.com/lab"}'
+```
+
+Expected output: `"Hey there!"`
+
+If you see 401/500 errors, recheck the bearer token, the config template, and the service status (`sudo systemctl status codex-mcp.service`).


### PR DESCRIPTION
## Summary

- add a dedicated Codex MCP bridge guide and cross-link it from the local LLM runbook
- document tailscale layering so the MCP endpoint and Open WebUI are both reachable at https://docker.ide-newton.ts.net
- tweak codex automation defaults (Dockerfile + build script) to use the tuslagch account and harden Discord relay chunking logic

## Related Issues

None

## Testing

- curl -I https://docker.ide-newton.ts.net/
- curl -H 'Authorization: Bearer CODEx_MCP_KEY' https://docker.ide-newton.ts.net/codex/openapi.json | jq '.info.title'
- curl -s -m 30 -X POST http://192.168.1.190:8200/codex -H 'Content-Type: application/json' -H 'Authorization: Bearer CODEx_MCP_KEY' -d '{"prompt":"Say hello","cwd":"/home/kalmyk/github.com/lab"}'

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
