### PR TITLE
fix: ensure bun worker passes build id

### DIFF
--- a/packages/temporal-bun-sdk/bruke/src/core.zig
+++ b/packages/temporal-bun-sdk/bruke/src/core.zig
@@ -65,6 +65,8 @@ pub const WorkerVersioningStrategy = c.TemporalCoreWorkerVersioningStrategy;
 pub const WorkerVersioningStrategyTag = c.TemporalCoreWorkerVersioningStrategy_Tag;
 pub const WorkerTunerHolder = c.TemporalCoreTunerHolder;
 pub const WorkerPollerBehavior = c.TemporalCorePollerBehavior;
+pub const WorkerPollerBehaviorSimpleMaximum = c.TemporalCorePollerBehaviorSimpleMaximum;
+pub const WorkerPollerBehaviorAutoscaling = c.TemporalCorePollerBehaviorAutoscaling;
 pub const WorkerByteArrayRefArray = c.TemporalCoreByteArrayRefArray;
 
 pub const RpcService = c.TemporalCoreRpcService;

--- a/packages/temporal-bun-sdk/bruke/src/test_helpers.zig
+++ b/packages/temporal-bun-sdk/bruke/src/test_helpers.zig
@@ -37,6 +37,7 @@ var test_worker_handle = worker.WorkerHandle{
     .namespace = ""[0..0],
     .task_queue = ""[0..0],
     .identity = ""[0..0],
+    .build_id = ""[0..0],
     .core_worker = @as(?*core.WorkerOpaque, @ptrCast(&fake_worker_storage)),
     .poll_lock = .{},
     .poll_condition = .{},

--- a/packages/temporal-bun-sdk/tests/worker/build-id.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker/build-id.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test'
+import { fileURLToPath } from 'node:url'
+
+describe('createWorker buildId plumbing', () => {
+  test('passes a derived buildId to native.createWorker', async () => {
+    const previousEnv = {
+      TEMPORAL_BUN_SDK_USE_ZIG: process.env.TEMPORAL_BUN_SDK_USE_ZIG,
+      TEMPORAL_ADDRESS: process.env.TEMPORAL_ADDRESS,
+      TEMPORAL_NAMESPACE: process.env.TEMPORAL_NAMESPACE,
+      TEMPORAL_TASK_QUEUE: process.env.TEMPORAL_TASK_QUEUE,
+      TEMPORAL_ALLOW_INSECURE: process.env.TEMPORAL_ALLOW_INSECURE,
+      TEMPORAL_WORKER_BUILD_ID: process.env.TEMPORAL_WORKER_BUILD_ID,
+    }
+
+    process.env.TEMPORAL_BUN_SDK_USE_ZIG = '1'
+    process.env.TEMPORAL_ADDRESS = '127.0.0.1:7233'
+    process.env.TEMPORAL_NAMESPACE = 'default'
+    process.env.TEMPORAL_TASK_QUEUE = 'unit-test-queue'
+    process.env.TEMPORAL_ALLOW_INSECURE = '0'
+    delete process.env.TEMPORAL_WORKER_BUILD_ID
+
+    const nativeModule = await import('../../src/internal/core-bridge/native.ts')
+    const originalNative = {
+      createRuntime: nativeModule.native.createRuntime,
+      createClient: nativeModule.native.createClient,
+      createWorker: nativeModule.native.createWorker,
+      destroyWorker: nativeModule.native.destroyWorker,
+      clientShutdown: nativeModule.native.clientShutdown,
+      runtimeShutdown: nativeModule.native.runtimeShutdown,
+      workerPollWorkflowTask: nativeModule.native.worker.pollWorkflowTask,
+      workerPollActivityTask: nativeModule.native.worker.pollActivityTask,
+      workerInitiateShutdown: nativeModule.native.worker.initiateShutdown,
+      workerFinalizeShutdown: nativeModule.native.worker.finalizeShutdown,
+    } as const
+
+    const runtimeHandle = { type: 'runtime' as const, handle: 1 }
+    const clientHandle = { type: 'client' as const, handle: 2 }
+    const workerHandle = { type: 'worker' as const, handle: 3 }
+
+    let capturedConfig: Record<string, unknown> | null = null
+
+    nativeModule.native.createRuntime = () => runtimeHandle
+    nativeModule.native.createClient = async () => clientHandle
+    nativeModule.native.createWorker = (_runtime, _client, config) => {
+      capturedConfig = config
+      return workerHandle
+    }
+    nativeModule.native.destroyWorker = () => {}
+    nativeModule.native.clientShutdown = () => {}
+    nativeModule.native.runtimeShutdown = () => {}
+    nativeModule.native.worker.pollWorkflowTask = async () => new Uint8Array(0)
+    nativeModule.native.worker.pollActivityTask = async () => new Uint8Array(0)
+    nativeModule.native.worker.initiateShutdown = () => {}
+    nativeModule.native.worker.finalizeShutdown = () => {}
+
+    try {
+      const pkgUrl = new URL('../../package.json', import.meta.url)
+      const pkg = JSON.parse(await Bun.file(pkgUrl).text()) as { name?: string; version?: string }
+      const expectedBuildId = `${pkg.name}@${pkg.version}`
+
+      const { createWorker } = await import('../../src/worker.ts?build-id-test')
+      const workflowsUrl = new URL('../fixtures/workflows/simple.workflow.ts', import.meta.url)
+      const resolvedWorkflowsPath = fileURLToPath(workflowsUrl)
+
+      const handle = await createWorker({ taskQueue: 'unit-test-queue', workflowsPath: resolvedWorkflowsPath })
+
+      expect(capturedConfig).not.toBeNull()
+      expect(typeof capturedConfig?.buildId).toBe('string')
+      expect((capturedConfig?.buildId as string | undefined)?.length).toBeGreaterThan(0)
+      expect(capturedConfig?.buildId).toBe(expectedBuildId)
+
+      await handle.runtime.shutdown()
+    } finally {
+      nativeModule.native.createRuntime = originalNative.createRuntime
+      nativeModule.native.createClient = originalNative.createClient
+      nativeModule.native.createWorker = originalNative.createWorker
+      nativeModule.native.destroyWorker = originalNative.destroyWorker
+      nativeModule.native.clientShutdown = originalNative.clientShutdown
+      nativeModule.native.runtimeShutdown = originalNative.runtimeShutdown
+      nativeModule.native.worker.pollWorkflowTask = originalNative.workerPollWorkflowTask
+      nativeModule.native.worker.pollActivityTask = originalNative.workerPollActivityTask
+      nativeModule.native.worker.initiateShutdown = originalNative.workerInitiateShutdown
+      nativeModule.native.worker.finalizeShutdown = originalNative.workerFinalizeShutdown
+
+      if (previousEnv.TEMPORAL_BUN_SDK_USE_ZIG === undefined) {
+        delete process.env.TEMPORAL_BUN_SDK_USE_ZIG
+      } else {
+        process.env.TEMPORAL_BUN_SDK_USE_ZIG = previousEnv.TEMPORAL_BUN_SDK_USE_ZIG
+      }
+
+      process.env.TEMPORAL_ADDRESS = previousEnv.TEMPORAL_ADDRESS
+      process.env.TEMPORAL_NAMESPACE = previousEnv.TEMPORAL_NAMESPACE
+      process.env.TEMPORAL_TASK_QUEUE = previousEnv.TEMPORAL_TASK_QUEUE
+      if (previousEnv.TEMPORAL_ALLOW_INSECURE === undefined) {
+        delete process.env.TEMPORAL_ALLOW_INSECURE
+      } else {
+        process.env.TEMPORAL_ALLOW_INSECURE = previousEnv.TEMPORAL_ALLOW_INSECURE
+      }
+      if (previousEnv.TEMPORAL_WORKER_BUILD_ID === undefined) {
+        delete process.env.TEMPORAL_WORKER_BUILD_ID
+      } else {
+        process.env.TEMPORAL_WORKER_BUILD_ID = previousEnv.TEMPORAL_WORKER_BUILD_ID
+      }
+    }
+  })
+})

--- a/packages/temporal-bun-sdk/tests/worker/worker-runtime-shutdown.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker/worker-runtime-shutdown.test.ts
@@ -106,11 +106,13 @@ describe('WorkerRuntime.shutdown', () => {
       TEMPORAL_NAMESPACE: process.env.TEMPORAL_NAMESPACE,
       TEMPORAL_TASK_QUEUE: process.env.TEMPORAL_TASK_QUEUE,
       TEMPORAL_ALLOW_INSECURE: process.env.TEMPORAL_ALLOW_INSECURE,
+      TEMPORAL_WORKER_BUILD_ID: process.env.TEMPORAL_WORKER_BUILD_ID,
     }
     process.env.TEMPORAL_ADDRESS = '127.0.0.1:7233'
     process.env.TEMPORAL_NAMESPACE = 'default'
     process.env.TEMPORAL_TASK_QUEUE = 'unit-test-queue'
     process.env.TEMPORAL_ALLOW_INSECURE = '0'
+    process.env.TEMPORAL_WORKER_BUILD_ID = 'test-build'
 
     try {
       const { WorkerRuntime } = await import('../../src/worker/runtime.ts?shutdown-test')
@@ -119,6 +121,7 @@ describe('WorkerRuntime.shutdown', () => {
       const runtime = await WorkerRuntime.create({
         workflowsPath: resolvedWorkflowsPath,
         taskQueue: 'unit-test-queue',
+        buildId: 'test-build',
       })
 
       const runPromise = runtime.run()
@@ -151,6 +154,11 @@ describe('WorkerRuntime.shutdown', () => {
         delete process.env.TEMPORAL_ALLOW_INSECURE
       } else {
         process.env.TEMPORAL_ALLOW_INSECURE = previousEnv.TEMPORAL_ALLOW_INSECURE
+      }
+      if (previousEnv.TEMPORAL_WORKER_BUILD_ID === undefined) {
+        delete process.env.TEMPORAL_WORKER_BUILD_ID
+      } else {
+        process.env.TEMPORAL_WORKER_BUILD_ID = previousEnv.TEMPORAL_WORKER_BUILD_ID
       }
 
       if (previousFlag === undefined) {


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- ensure the Bun worker always derives and logs a non-empty build ID before creating the runtime
- plumb the build ID through WorkerRuntime into the Zig bridge and duplicate it as a null-terminated string
- set default poller behaviors in Zig so Temporal core accepts worker creation when using the native bridge
- add regression coverage to assert the derived build ID passed into native.createWorker

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- pnpm exec biome check packages/temporal-bun-sdk/src/worker.ts packages/temporal-bun-sdk/src/worker/runtime.ts
- pnpm --filter @proompteng/temporal-bun-sdk run build:native:zig
- pnpm --filter @proompteng/temporal-bun-sdk run ci:native:zig
- pnpm --filter @proompteng/temporal-bun-sdk exec bun test tests/worker/build-id.test.ts
- TEMPORAL_BUN_SDK_USE_ZIG=1 bun -e "import { createWorker } from './packages/temporal-bun-sdk/src/worker.ts'; const handle = await createWorker(); setTimeout(() => handle.worker.shutdown(), 1000); await handle.worker.run();"

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
