### PR TITLE
fix: disable clickhouse servicemonitor by default

### DIFF
--- a/argocd/applications/clickhouse-operator/values.yaml
+++ b/argocd/applications/clickhouse-operator/values.yaml
@@ -29,7 +29,7 @@ metrics:
       cpu: 250m
       memory: 512Mi
 serviceMonitor:
-  enabled: true
+  enabled: false
 podAnnotations:
   prometheus.io/port: "8888"
   prometheus.io/scrape: "true"


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- disable the ClickHouse operator ServiceMonitor until the Prometheus Operator CRDs are installed
- clarify the runbook so observers know metrics rely on annotations and must re-enable the ServiceMonitor once the stack is ready

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- pnpm run lint:argocd

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
