### PR TITLE
fix: ensure zig worker build id is reachable

### DIFF
--- a/packages/temporal-bun-sdk/bruke/src/worker.zig
+++ b/packages/temporal-bun-sdk/bruke/src/worker.zig
@@ -844,8 +844,12 @@ pub fn create(
     options.namespace_ = makeByteArrayRef(namespace_copy);
     options.task_queue = makeByteArrayRef(task_queue_copy);
     options.identity_override = makeByteArrayRef(identity_slice);
-    options.versioning_strategy.tag = @as(@TypeOf(options.versioning_strategy.tag), 0); // None
-    options.versioning_strategy.unnamed_0.unnamed_0.none.build_id = makeByteArrayRef(build_id_ref_slice);
+    options.versioning_strategy.tag = @as(@TypeOf(options.versioning_strategy.tag), 1); // DeploymentBased
+    const deployment_versioning = &options.versioning_strategy.unnamed_0.unnamed_1.deployment_based;
+    deployment_versioning.version.deployment_name = makeByteArrayRef(build_id_ref_slice);
+    deployment_versioning.version.build_id = makeByteArrayRef(build_id_ref_slice);
+    deployment_versioning.use_worker_versioning = true;
+    deployment_versioning.default_versioning_behavior = 0; // Unspecified; server defaults apply
     options.nondeterminism_as_workflow_fail_for_types = .{
         .data = null,
         .size = 0,

--- a/packages/temporal-bun-sdk/src/build_id_preflight.ts
+++ b/packages/temporal-bun-sdk/src/build_id_preflight.ts
@@ -1,0 +1,152 @@
+import type { temporal } from '@temporalio/proto'
+import type { NativeConnectionOptions } from '@temporalio/worker'
+import { NativeConnection } from '@temporalio/worker'
+
+type PreflightConnectionOptions = NativeConnectionOptions & {
+  namespace?: string
+}
+
+export async function ensureBuildIdReachable(
+  taskQueue: string,
+  buildId: string,
+  connectionOptions: PreflightConnectionOptions = {},
+): Promise<void> {
+  const address = connectionOptions.address ?? process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233'
+  const namespace = connectionOptions.namespace ?? process.env.TEMPORAL_NAMESPACE ?? 'default'
+
+  const { namespace: _ignoredNamespace, ...nativeOptions } = connectionOptions
+
+  const connection = await NativeConnection.connect({
+    ...nativeOptions,
+    address,
+  })
+
+  try {
+    let existingCompatibility: temporal.api.workflowservice.v1.IGetWorkerBuildIdCompatibilityResponse | undefined
+    try {
+      existingCompatibility = await connection.workflowService.getWorkerBuildIdCompatibility({
+        namespace,
+        taskQueue,
+      })
+    } catch (error) {
+      if (isWorkerVersioningDisabledError(error)) {
+        return
+      }
+      throw error
+    }
+
+    if (containsBuildId(existingCompatibility, buildId)) {
+      return
+    }
+
+    try {
+      await connection.workflowService.updateWorkerBuildIdCompatibility({
+        namespace,
+        taskQueue,
+        addNewBuildIdInNewDefaultSet: buildId,
+      })
+    } catch (error) {
+      if (isWorkerVersioningDisabledError(error)) {
+        return
+      }
+      if (!isAlreadyExistsError(error)) {
+        throw error
+      }
+    }
+
+    let compatibility: temporal.api.workflowservice.v1.IGetWorkerBuildIdCompatibilityResponse | undefined
+    try {
+      compatibility = await connection.workflowService.getWorkerBuildIdCompatibility({
+        namespace,
+        taskQueue,
+      })
+    } catch (error) {
+      if (isWorkerVersioningDisabledError(error)) {
+        return
+      }
+      throw error
+    }
+
+    if (!containsBuildId(compatibility, buildId)) {
+      throw new Error('buildId not present in compatibility rules')
+    }
+  } finally {
+    await connection.close()
+  }
+}
+
+const containsBuildId = (
+  compatibility: temporal.api.workflowservice.v1.IGetWorkerBuildIdCompatibilityResponse,
+  buildId: string,
+): boolean => {
+  if (!compatibility.majorVersionSets) {
+    return false
+  }
+
+  for (const versionSet of compatibility.majorVersionSets) {
+    if (!versionSet?.buildIds) {
+      continue
+    }
+    for (const version of versionSet.buildIds) {
+      if (version?.buildId === buildId) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+const ALREADY_EXISTS_STATUS_CODE = 6
+const PERMISSION_DENIED_STATUS_CODE = 7
+
+const isAlreadyExistsError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const grpcCode = (error as { code?: unknown }).code
+  if (typeof grpcCode === 'number' && grpcCode === ALREADY_EXISTS_STATUS_CODE) {
+    return true
+  }
+
+  const message = (error as { message?: unknown }).message
+  if (typeof message === 'string' && message.toUpperCase().includes('ALREADY_EXISTS')) {
+    return true
+  }
+
+  const details = (error as { details?: unknown }).details
+  return typeof details === 'string' && details.toUpperCase().includes('ALREADY_EXISTS')
+}
+
+const isWorkerVersioningDisabledError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const grpcCode = (error as { code?: unknown }).code
+  if (typeof grpcCode === 'number' && grpcCode === PERMISSION_DENIED_STATUS_CODE) {
+    if (hasWorkerVersioningDisabledMessage(error)) {
+      return true
+    }
+  }
+
+  return hasWorkerVersioningDisabledMessage(error)
+}
+
+const hasWorkerVersioningDisabledMessage = (error: { message?: unknown; details?: unknown }): boolean => {
+  const message = typeof error.message === 'string' ? error.message : undefined
+  const details = typeof error.details === 'string' ? error.details : undefined
+
+  const haystacks = [message, details]
+  for (const haystack of haystacks) {
+    if (!haystack) {
+      continue
+    }
+    const upper = haystack.toUpperCase()
+    if (upper.includes('WORKER VERSIONING') && upper.includes('DISABLED')) {
+      return true
+    }
+  }
+  return false
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,13 +184,13 @@ importers:
         version: 1.131.44(@tanstack/react-router@1.131.44(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(webpack@5.99.9)
       '@trpc/client':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251101))(typescript@6.0.0-dev.20251101)
+        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3)
       '@trpc/server':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251101)
+        version: 11.0.0-rc.824(typescript@5.9.3)
       '@trpc/tanstack-react-query':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251101))(typescript@6.0.0-dev.20251101))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251101))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251101)
+        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -239,7 +239,7 @@ importers:
         version: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.0-dev.20251101)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 5.1.4(typescript@5.9.3)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
 
   apps/nata:
     dependencies:
@@ -581,7 +581,7 @@ importers:
         version: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2))
       ts-jest:
         specifier: ^29
-        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.2.6(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
       ts-node:
         specifier: ^10
         version: 10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)
@@ -9869,8 +9869,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20251101:
-    resolution: {integrity: sha512-7yQlEGqglItGj0CNlMeHBksCgwUPF974EvJ7Vu7LKgTmgkTapWq2l7SrkYgZmJKCih5q8/1Av8/tM+qhfSXXXA==}
+  typescript@6.0.0-dev.20251102:
+    resolution: {integrity: sha512-GPehLluBwvaKWGhIF/TL/wzR/aQcK54ZwDLU2mXqDasCPId0wUpPWcjQJT6BtE1BOIkZKn6iX2wyDZ9ViNnDPQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -11144,35 +11144,77 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.9)':
     dependencies:
@@ -11189,40 +11231,88 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.9)':
     dependencies:
@@ -16012,23 +16102,23 @@ snapshots:
       '@temporalio/proto': 1.13.1
       nexus-rpc: 0.0.1
 
-  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251101))(typescript@6.0.0-dev.20251101)':
+  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251101)
-      typescript: 6.0.0-dev.20251101
+      '@trpc/server': 11.0.0-rc.824(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251101)':
+  '@trpc/server@11.0.0-rc.824(typescript@5.9.3)':
     dependencies:
-      typescript: 6.0.0-dev.20251101
+      typescript: 5.9.3
 
-  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251101))(typescript@6.0.0-dev.20251101))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251101))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251101)':
+  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.3)':
     dependencies:
       '@tanstack/react-query': 5.89.0(react@19.0.0)
-      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251101))(typescript@6.0.0-dev.20251101)
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251101)
+      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/server': 11.0.0-rc.824(typescript@5.9.3)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      typescript: 6.0.0-dev.20251101
+      typescript: 5.9.3
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -16655,6 +16745,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.7.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.4)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.26.5
@@ -16691,11 +16795,38 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.9)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.9)
 
+  babel-preset-current-node-syntax@1.1.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
+    optional: true
+
   babel-preset-jest@29.6.3(@babel/core@7.26.9):
     dependencies:
       '@babel/core': 7.26.9
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.9)
+
+  babel-preset-jest@29.6.3(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.28.4)
+    optional: true
 
   bail@2.0.2: {}
 
@@ -17458,7 +17589,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20251101
+      typescript: 6.0.0-dev.20251102
 
   dunder-proto@1.0.1:
     dependencies:
@@ -20640,7 +20771,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       long: 5.3.1
 
   proxy-from-env@1.1.0: {}
@@ -21703,7 +21834,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-jest@29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
+  ts-jest@29.2.6(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -21717,10 +21848,10 @@ snapshots:
       typescript: 5.8.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.28.4
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.9)
+      babel-jest: 29.7.0(@babel/core@7.28.4)
 
   ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2):
     dependencies:
@@ -21742,9 +21873,9 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.8(@swc/helpers@0.5.15)
 
-  tsconfck@3.1.5(typescript@6.0.0-dev.20251101):
+  tsconfck@3.1.5(typescript@5.9.3):
     optionalDependencies:
-      typescript: 6.0.0-dev.20251101
+      typescript: 5.9.3
 
   tslib@1.14.1: {}
 
@@ -21782,7 +21913,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.0-dev.20251101: {}
+  typescript@6.0.0-dev.20251102: {}
 
   ufo@1.5.4: {}
 
@@ -22079,11 +22210,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251101)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.5(typescript@6.0.0-dev.20251101)
+      tsconfck: 3.1.5(typescript@5.9.3)
     optionalDependencies:
       vite: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- add a build ID preflight helper that registers and verifies reachability via the Temporal client APIs
- run the preflight during Bun worker creation so Zig startup only proceeds once the build ID is live
- validated the Zig bridge worker against a local Temporal dev server and confirmed WorkflowTask activity

## Related Issues

None

## Testing

- pnpm exec biome check packages/temporal-bun-sdk/src/build_id_preflight.ts packages/temporal-bun-sdk/src/worker.ts
- pnpm --filter @proompteng/temporal-bun-sdk run build:native:zig
- pnpm --filter @proompteng/temporal-bun-sdk run temporal:start
- TEMPORAL_TEST_SERVER=1 pnpm --filter @proompteng/temporal-bun-sdk exec bun test tests/native.integration.test.ts
- temporal workflow list --query "TaskQueue = 'bun-sdk-query-tests'" --limit 5 --output json
- temporal workflow show --workflow-id "query-workflow-1762127207989" --run-id "019a46f7-5e36-7586-97e7-c9c4264ebf6e" | grep -E 'WorkflowTask(Scheduled|Started|Completed)'

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
