### PR TITLE
feat: add deterministic workflow context

### DIFF
--- a/packages/temporal-bun-sdk/docs/production-design.md
+++ b/packages/temporal-bun-sdk/docs/production-design.md
@@ -124,7 +124,7 @@ Effect integration: workflows run inside the Effect runtime with schemas enforci
 
 ## Next Steps
 
-1. Implement workflow command builders and context API.
+1. ✅ Implement workflow command builders and context API (Effect-based context, command intents, determinism guardrails).
 2. Build history replay engine with determinism checks.
 3. Add activity scheduling/heartbeat/cancellation support.
 4. Introduce worker concurrency controls and sticky queue handling.

--- a/packages/temporal-bun-sdk/src/config.ts
+++ b/packages/temporal-bun-sdk/src/config.ts
@@ -22,6 +22,7 @@ interface TemporalEnvironment {
   ALLOW_INSECURE_TLS?: string
   TEMPORAL_WORKER_IDENTITY_PREFIX?: string
   TEMPORAL_SHOW_STACK_SOURCES?: string
+  TEMPORAL_DISABLE_WORKFLOW_CONTEXT?: string
 }
 
 const truthyValues = new Set(['1', 'true', 't', 'yes', 'y', 'on'])
@@ -52,6 +53,7 @@ const sanitizeEnvironment = (env: NodeJS.ProcessEnv): TemporalEnvironment => {
     ALLOW_INSECURE_TLS: read('ALLOW_INSECURE_TLS'),
     TEMPORAL_WORKER_IDENTITY_PREFIX: read('TEMPORAL_WORKER_IDENTITY_PREFIX'),
     TEMPORAL_SHOW_STACK_SOURCES: read('TEMPORAL_SHOW_STACK_SOURCES'),
+    TEMPORAL_DISABLE_WORKFLOW_CONTEXT: read('TEMPORAL_DISABLE_WORKFLOW_CONTEXT'),
   }
 }
 
@@ -92,6 +94,7 @@ export interface TemporalConfig {
   workerIdentity: string
   workerIdentityPrefix: string
   showStackTraceSources?: boolean
+  workflowContextBypass: boolean
 }
 
 export interface TLSCertPair {
@@ -161,6 +164,8 @@ export const loadTemporalConfig = async (options: LoadTemporalConfigOptions = {}
   const tls = await buildTlsConfig(env, options)
   const showStackTraceSources =
     coerceBoolean(env.TEMPORAL_SHOW_STACK_SOURCES) ?? options.defaults?.showStackTraceSources ?? false
+  const workflowContextBypass =
+    coerceBoolean(env.TEMPORAL_DISABLE_WORKFLOW_CONTEXT) ?? options.defaults?.workflowContextBypass ?? false
 
   return {
     host,
@@ -174,6 +179,7 @@ export const loadTemporalConfig = async (options: LoadTemporalConfigOptions = {}
     workerIdentity,
     workerIdentityPrefix,
     showStackTraceSources,
+    workflowContextBypass,
   }
 }
 
@@ -183,4 +189,8 @@ export const temporalDefaults = {
   namespace: DEFAULT_NAMESPACE,
   taskQueue: DEFAULT_TASK_QUEUE,
   workerIdentityPrefix: DEFAULT_IDENTITY_PREFIX,
-} satisfies Pick<TemporalConfig, 'host' | 'port' | 'namespace' | 'taskQueue' | 'workerIdentityPrefix'>
+  workflowContextBypass: false,
+} satisfies Pick<
+  TemporalConfig,
+  'host' | 'port' | 'namespace' | 'taskQueue' | 'workerIdentityPrefix' | 'workflowContextBypass'
+>

--- a/packages/temporal-bun-sdk/src/workflow/commands.ts
+++ b/packages/temporal-bun-sdk/src/workflow/commands.ts
@@ -1,0 +1,327 @@
+import { create } from '@bufbuild/protobuf'
+import type { Duration } from '@bufbuild/protobuf/wkt'
+
+import type { DataConverter } from '../common/payloads'
+import { encodeValuesToPayloads } from '../common/payloads/converter'
+import {
+  type Command,
+  CommandSchema,
+  ContinueAsNewWorkflowExecutionCommandAttributesSchema,
+  ScheduleActivityTaskCommandAttributesSchema,
+  SignalExternalWorkflowExecutionCommandAttributesSchema,
+  StartChildWorkflowExecutionCommandAttributesSchema,
+  StartTimerCommandAttributesSchema,
+} from '../proto/temporal/api/command/v1/message_pb'
+import {
+  type ActivityType,
+  ActivityTypeSchema,
+  type Header,
+  type Memo,
+  PayloadsSchema,
+  type RetryPolicy,
+  RetryPolicySchema,
+  type SearchAttributes,
+  WorkflowExecutionSchema,
+  type WorkflowType,
+  WorkflowTypeSchema,
+} from '../proto/temporal/api/common/v1/message_pb'
+import { CommandType } from '../proto/temporal/api/enums/v1/command_type_pb'
+import { TaskQueueSchema } from '../proto/temporal/api/taskqueue/v1/message_pb'
+import type { WorkflowCommandIntentId } from './context'
+import type { WorkflowRetryPolicyInput } from './determinism'
+
+export type WorkflowCommandKind =
+  | 'schedule-activity'
+  | 'start-timer'
+  | 'start-child-workflow'
+  | 'signal-external-workflow'
+  | 'continue-as-new'
+
+export interface WorkflowCommandIntentBase {
+  readonly id: WorkflowCommandIntentId
+  readonly kind: WorkflowCommandKind
+  readonly sequence: number
+}
+
+export interface ScheduleActivityCommandIntent extends WorkflowCommandIntentBase {
+  readonly kind: 'schedule-activity'
+  readonly activityType: string
+  readonly activityId: string
+  readonly taskQueue: string
+  readonly input: unknown[]
+  readonly header?: Header
+  readonly timeouts: {
+    readonly scheduleToCloseTimeoutMs?: number
+    readonly scheduleToStartTimeoutMs?: number
+    readonly startToCloseTimeoutMs?: number
+    readonly heartbeatTimeoutMs?: number
+  }
+  readonly retry?: WorkflowRetryPolicyInput
+  readonly requestEagerExecution?: boolean
+}
+
+export interface StartTimerCommandIntent extends WorkflowCommandIntentBase {
+  readonly kind: 'start-timer'
+  readonly timerId: string
+  readonly timeoutMs: number
+}
+
+export interface StartChildWorkflowCommandIntent extends WorkflowCommandIntentBase {
+  readonly kind: 'start-child-workflow'
+  readonly workflowType: string
+  readonly workflowId: string
+  readonly namespace: string
+  readonly taskQueue: string
+  readonly input: unknown[]
+  readonly timeouts: {
+    readonly workflowExecutionTimeoutMs?: number
+    readonly workflowRunTimeoutMs?: number
+    readonly workflowTaskTimeoutMs?: number
+  }
+  readonly parentClosePolicy?: number
+  readonly workflowIdReusePolicy?: number
+  readonly retry?: WorkflowRetryPolicyInput
+  readonly cronSchedule?: string
+  readonly header?: Header
+  readonly memo?: Memo
+  readonly searchAttributes?: SearchAttributes
+}
+
+export interface SignalExternalWorkflowCommandIntent extends WorkflowCommandIntentBase {
+  readonly kind: 'signal-external-workflow'
+  readonly namespace: string
+  readonly workflowId: string
+  readonly runId?: string
+  readonly signalName: string
+  readonly input: unknown[]
+  readonly childWorkflowOnly: boolean
+  readonly header?: Header
+}
+
+export interface ContinueAsNewWorkflowCommandIntent extends WorkflowCommandIntentBase {
+  readonly kind: 'continue-as-new'
+  readonly workflowType: string
+  readonly taskQueue: string
+  readonly input: unknown[]
+  readonly timeouts: {
+    readonly workflowRunTimeoutMs?: number
+    readonly workflowTaskTimeoutMs?: number
+  }
+  readonly backoffStartIntervalMs?: number
+  readonly retry?: WorkflowRetryPolicyInput
+  readonly memo?: Memo
+  readonly searchAttributes?: SearchAttributes
+  readonly header?: Header
+  readonly cronSchedule?: string
+}
+
+export type WorkflowCommandIntent =
+  | ScheduleActivityCommandIntent
+  | StartTimerCommandIntent
+  | StartChildWorkflowCommandIntent
+  | SignalExternalWorkflowCommandIntent
+  | ContinueAsNewWorkflowCommandIntent
+
+export interface WorkflowCommandMaterializationOptions {
+  readonly dataConverter: DataConverter
+}
+
+export const materializeCommands = async (
+  intents: readonly WorkflowCommandIntent[],
+  options: WorkflowCommandMaterializationOptions,
+): Promise<Command[]> => {
+  const commands: Command[] = []
+
+  for (const intent of intents) {
+    switch (intent.kind) {
+      case 'schedule-activity': {
+        commands.push(await buildScheduleActivityCommand(intent, options))
+        break
+      }
+      case 'start-timer': {
+        commands.push(buildStartTimerCommand(intent))
+        break
+      }
+      case 'start-child-workflow': {
+        commands.push(await buildStartChildWorkflowCommand(intent, options))
+        break
+      }
+      case 'signal-external-workflow': {
+        commands.push(await buildSignalExternalWorkflowCommand(intent, options))
+        break
+      }
+      case 'continue-as-new': {
+        commands.push(await buildContinueAsNewCommand(intent, options))
+        break
+      }
+      default: {
+        // Exhaustive check
+        const exhaustive: never = intent
+        throw new Error(`Unsupported workflow command intent: ${(exhaustive as WorkflowCommandIntent).kind}`)
+      }
+    }
+  }
+
+  return commands
+}
+
+const buildScheduleActivityCommand = async (
+  intent: ScheduleActivityCommandIntent,
+  options: WorkflowCommandMaterializationOptions,
+): Promise<Command> => {
+  const payloads = await encodeValuesToPayloads(options.dataConverter, intent.input)
+
+  const attributes = create(ScheduleActivityTaskCommandAttributesSchema, {
+    activityId: intent.activityId,
+    activityType: buildActivityType(intent.activityType),
+    taskQueue: create(TaskQueueSchema, { name: intent.taskQueue }),
+    input: payloads.length > 0 ? create(PayloadsSchema, { payloads }) : undefined,
+    scheduleToCloseTimeout: durationFromMillis(intent.timeouts.scheduleToCloseTimeoutMs),
+    scheduleToStartTimeout: durationFromMillis(intent.timeouts.scheduleToStartTimeoutMs),
+    startToCloseTimeout: durationFromMillis(intent.timeouts.startToCloseTimeoutMs),
+    heartbeatTimeout: durationFromMillis(intent.timeouts.heartbeatTimeoutMs),
+    retryPolicy: intent.retry ? buildRetryPolicy(intent.retry) : undefined,
+    requestEagerExecution: intent.requestEagerExecution ?? false,
+    header: intent.header,
+  })
+
+  return create(CommandSchema, {
+    commandType: CommandType.SCHEDULE_ACTIVITY_TASK,
+    attributes: {
+      case: 'scheduleActivityTaskCommandAttributes',
+      value: attributes,
+    },
+  })
+}
+
+const buildStartTimerCommand = (intent: StartTimerCommandIntent): Command => {
+  const attributes = create(StartTimerCommandAttributesSchema, {
+    timerId: intent.timerId,
+    startToFireTimeout: durationFromMillis(intent.timeoutMs),
+  })
+
+  return create(CommandSchema, {
+    commandType: CommandType.START_TIMER,
+    attributes: {
+      case: 'startTimerCommandAttributes',
+      value: attributes,
+    },
+  })
+}
+
+const buildStartChildWorkflowCommand = async (
+  intent: StartChildWorkflowCommandIntent,
+  options: WorkflowCommandMaterializationOptions,
+): Promise<Command> => {
+  const payloads = await encodeValuesToPayloads(options.dataConverter, intent.input)
+
+  const attributes = create(StartChildWorkflowExecutionCommandAttributesSchema, {
+    namespace: intent.namespace,
+    workflowId: intent.workflowId,
+    workflowType: buildWorkflowType(intent.workflowType),
+    taskQueue: create(TaskQueueSchema, { name: intent.taskQueue }),
+    input: payloads.length > 0 ? create(PayloadsSchema, { payloads }) : undefined,
+    workflowExecutionTimeout: durationFromMillis(intent.timeouts.workflowExecutionTimeoutMs),
+    workflowRunTimeout: durationFromMillis(intent.timeouts.workflowRunTimeoutMs),
+    workflowTaskTimeout: durationFromMillis(intent.timeouts.workflowTaskTimeoutMs),
+    parentClosePolicy: intent.parentClosePolicy ?? 0,
+    workflowIdReusePolicy: intent.workflowIdReusePolicy ?? 0,
+    retryPolicy: intent.retry ? buildRetryPolicy(intent.retry) : undefined,
+    cronSchedule: intent.cronSchedule ?? '',
+    header: intent.header,
+    memo: intent.memo,
+    searchAttributes: intent.searchAttributes,
+  })
+
+  return create(CommandSchema, {
+    commandType: CommandType.START_CHILD_WORKFLOW_EXECUTION,
+    attributes: {
+      case: 'startChildWorkflowExecutionCommandAttributes',
+      value: attributes,
+    },
+  })
+}
+
+const buildSignalExternalWorkflowCommand = async (
+  intent: SignalExternalWorkflowCommandIntent,
+  options: WorkflowCommandMaterializationOptions,
+): Promise<Command> => {
+  const payloads = await encodeValuesToPayloads(options.dataConverter, intent.input)
+
+  const execution = create(WorkflowExecutionSchema, {
+    workflowId: intent.workflowId,
+    runId: intent.runId ?? '',
+  })
+
+  const attributes = create(SignalExternalWorkflowExecutionCommandAttributesSchema, {
+    namespace: intent.namespace,
+    execution,
+    signalName: intent.signalName,
+    input: payloads.length > 0 ? create(PayloadsSchema, { payloads }) : undefined,
+    control: '',
+    childWorkflowOnly: intent.childWorkflowOnly,
+    header: intent.header,
+  })
+
+  return create(CommandSchema, {
+    commandType: CommandType.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION,
+    attributes: {
+      case: 'signalExternalWorkflowExecutionCommandAttributes',
+      value: attributes,
+    },
+  })
+}
+
+const buildContinueAsNewCommand = async (
+  intent: ContinueAsNewWorkflowCommandIntent,
+  options: WorkflowCommandMaterializationOptions,
+): Promise<Command> => {
+  const payloads = await encodeValuesToPayloads(options.dataConverter, intent.input)
+
+  const attributes = create(ContinueAsNewWorkflowExecutionCommandAttributesSchema, {
+    workflowType: buildWorkflowType(intent.workflowType),
+    taskQueue: create(TaskQueueSchema, { name: intent.taskQueue }),
+    input: payloads.length > 0 ? create(PayloadsSchema, { payloads }) : undefined,
+    workflowRunTimeout: durationFromMillis(intent.timeouts.workflowRunTimeoutMs),
+    workflowTaskTimeout: durationFromMillis(intent.timeouts.workflowTaskTimeoutMs),
+    backoffStartInterval: durationFromMillis(intent.backoffStartIntervalMs),
+    retryPolicy: intent.retry ? buildRetryPolicy(intent.retry) : undefined,
+    cronSchedule: intent.cronSchedule ?? '',
+    header: intent.header,
+    memo: intent.memo,
+    searchAttributes: intent.searchAttributes,
+  })
+
+  return create(CommandSchema, {
+    commandType: CommandType.CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+    attributes: {
+      case: 'continueAsNewWorkflowExecutionCommandAttributes',
+      value: attributes,
+    },
+  })
+}
+
+export const durationFromMillis = (ms?: number): Duration | undefined => {
+  if (typeof ms !== 'number' || Number.isNaN(ms) || ms <= 0) {
+    return undefined
+  }
+  const seconds = BigInt(Math.trunc(ms / 1_000))
+  const nanos = Math.trunc(ms % 1_000) * 1_000_000
+  return {
+    seconds,
+    nanos,
+  } as Duration
+}
+
+const buildRetryPolicy = (input: WorkflowRetryPolicyInput): RetryPolicy =>
+  create(RetryPolicySchema, {
+    initialInterval: durationFromMillis(input.initialIntervalMs),
+    backoffCoefficient: input.backoffCoefficient ?? 2,
+    maximumInterval: durationFromMillis(input.maximumIntervalMs),
+    maximumAttempts: input.maximumAttempts ?? 0,
+    nonRetryableErrorTypes: input.nonRetryableErrorTypes ?? [],
+  })
+
+const buildActivityType = (name: string): ActivityType => create(ActivityTypeSchema, { name })
+
+const buildWorkflowType = (name: string): WorkflowType => create(WorkflowTypeSchema, { name })

--- a/packages/temporal-bun-sdk/src/workflow/context.ts
+++ b/packages/temporal-bun-sdk/src/workflow/context.ts
@@ -1,0 +1,353 @@
+import { Effect } from 'effect'
+
+import type {
+  ContinueAsNewWorkflowCommandIntent,
+  ScheduleActivityCommandIntent,
+  SignalExternalWorkflowCommandIntent,
+  StartChildWorkflowCommandIntent,
+  StartTimerCommandIntent,
+  WorkflowCommandIntent,
+} from './commands'
+import type { DeterminismGuard, WorkflowRetryPolicyInput } from './determinism'
+import { ContinueAsNewWorkflowError, WorkflowBlockedError } from './errors'
+
+export type WorkflowCommandIntentId = string
+
+export interface WorkflowInfo {
+  readonly namespace: string
+  readonly taskQueue: string
+  readonly workflowId: string
+  readonly runId: string
+  readonly workflowType: string
+}
+
+export interface ScheduleActivityOptions {
+  readonly activityId?: string
+  readonly taskQueue?: string
+  readonly scheduleToCloseTimeoutMs?: number
+  readonly scheduleToStartTimeoutMs?: number
+  readonly startToCloseTimeoutMs?: number
+  readonly heartbeatTimeoutMs?: number
+  readonly retry?: WorkflowRetryPolicyInput
+  readonly requestEagerExecution?: boolean
+}
+
+export interface StartTimerOptions {
+  readonly timerId?: string
+  readonly timeoutMs: number
+}
+
+export interface StartChildWorkflowOptions {
+  readonly workflowId?: string
+  readonly namespace?: string
+  readonly taskQueue?: string
+  readonly workflowExecutionTimeoutMs?: number
+  readonly workflowRunTimeoutMs?: number
+  readonly workflowTaskTimeoutMs?: number
+  readonly parentClosePolicy?: number
+  readonly workflowIdReusePolicy?: number
+  readonly retry?: WorkflowRetryPolicyInput
+  readonly cronSchedule?: string
+}
+
+export interface SignalExternalWorkflowOptions {
+  readonly namespace?: string
+  readonly workflowId?: string
+  readonly runId?: string
+  readonly childWorkflowOnly?: boolean
+}
+
+export interface ContinueAsNewOptions {
+  readonly workflowType?: string
+  readonly taskQueue?: string
+  readonly input?: unknown[]
+  readonly workflowRunTimeoutMs?: number
+  readonly workflowTaskTimeoutMs?: number
+  readonly backoffStartIntervalMs?: number
+  readonly retry?: WorkflowRetryPolicyInput
+  readonly cronSchedule?: string
+}
+
+export interface WorkflowScheduledCommandRef {
+  readonly id: WorkflowCommandIntentId
+  readonly kind: WorkflowCommandIntent['kind']
+  readonly sequence: number
+  readonly activityId?: string
+  readonly timerId?: string
+}
+
+export interface WorkflowActivities {
+  schedule(
+    activityType: string,
+    args?: unknown[],
+    options?: ScheduleActivityOptions,
+  ): Effect.Effect<WorkflowScheduledCommandRef, never, never>
+}
+
+export interface WorkflowTimers {
+  start(options: StartTimerOptions): Effect.Effect<WorkflowScheduledCommandRef, never, never>
+}
+
+export interface WorkflowChildWorkflows {
+  start(
+    workflowType: string,
+    args?: unknown[],
+    options?: StartChildWorkflowOptions,
+  ): Effect.Effect<WorkflowScheduledCommandRef, never, never>
+}
+
+export interface WorkflowSignalClient {
+  signal(
+    signalName: string,
+    args?: unknown[],
+    options?: SignalExternalWorkflowOptions,
+  ): Effect.Effect<WorkflowScheduledCommandRef, never, never>
+}
+
+export interface WorkflowDeterminismHelpers {
+  now(): number
+  random(): number
+}
+
+export interface WorkflowRuntimeServices {
+  readonly activities: WorkflowActivities
+  readonly timers: WorkflowTimers
+  readonly childWorkflows: WorkflowChildWorkflows
+  readonly signals: WorkflowSignalClient
+  readonly determinism: WorkflowDeterminismHelpers
+  continueAsNew(options?: ContinueAsNewOptions): Effect.Effect<never, ContinueAsNewWorkflowError, never>
+}
+
+export interface WorkflowContext<I> extends WorkflowRuntimeServices {
+  readonly input: I
+  readonly info: WorkflowInfo
+}
+
+export interface CreateWorkflowContextParams<I> {
+  readonly input: I
+  readonly info: WorkflowInfo
+  readonly determinismGuard: DeterminismGuard
+}
+
+export class WorkflowCommandContext {
+  readonly #info: WorkflowInfo
+  readonly #guard: DeterminismGuard
+  readonly #intents: WorkflowCommandIntent[] = []
+  #sequence = 0
+
+  constructor(params: { info: WorkflowInfo; guard: DeterminismGuard }) {
+    this.#info = params.info
+    this.#guard = params.guard
+  }
+
+  get intents(): readonly WorkflowCommandIntent[] {
+    return this.#intents
+  }
+
+  addIntent(intent: WorkflowCommandIntent): void {
+    this.#guard.recordCommand(intent)
+    this.#intents.push(intent)
+  }
+
+  nextSequence(): number {
+    const seq = this.#sequence
+    this.#sequence += 1
+    return seq
+  }
+
+  get info(): WorkflowInfo {
+    return this.#info
+  }
+}
+
+export const createWorkflowContext = <I>(
+  params: CreateWorkflowContextParams<I>,
+): { context: WorkflowContext<I>; commandContext: WorkflowCommandContext } => {
+  const commandContext = new WorkflowCommandContext({ info: params.info, guard: params.determinismGuard })
+
+  const activities: WorkflowActivities = {
+    schedule(activityType, args = [], options = {}) {
+      return Effect.sync(() => {
+        const intent = buildScheduleActivityIntent(commandContext, activityType, args, options)
+        commandContext.addIntent(intent)
+        return createCommandRef(intent, { activityId: intent.activityId })
+      })
+    },
+  }
+
+  const timers: WorkflowTimers = {
+    start(options) {
+      return Effect.sync(() => {
+        if (!options || typeof options.timeoutMs !== 'number' || options.timeoutMs <= 0) {
+          throw new WorkflowBlockedError('Timer timeoutMs must be a positive number')
+        }
+        const intent = buildStartTimerIntent(commandContext, options)
+        commandContext.addIntent(intent)
+        return createCommandRef(intent, { timerId: intent.timerId })
+      })
+    },
+  }
+
+  const childWorkflows: WorkflowChildWorkflows = {
+    start(workflowType, args = [], options = {}) {
+      return Effect.sync(() => {
+        const intent = buildStartChildWorkflowIntent(commandContext, workflowType, args, options)
+        commandContext.addIntent(intent)
+        return createCommandRef(intent)
+      })
+    },
+  }
+
+  const signals: WorkflowSignalClient = {
+    signal(signalName, args = [], options = {}) {
+      return Effect.sync(() => {
+        const intent = buildSignalExternalWorkflowIntent(commandContext, signalName, args, options)
+        commandContext.addIntent(intent)
+        return createCommandRef(intent)
+      })
+    },
+  }
+
+  const determinism: WorkflowDeterminismHelpers = {
+    now: () => params.determinismGuard.nextTime(() => Date.now()),
+    random: () => params.determinismGuard.nextRandom(() => Math.random()),
+  }
+
+  const context: WorkflowContext<I> = {
+    input: params.input,
+    info: params.info,
+    activities,
+    timers,
+    childWorkflows,
+    signals,
+    determinism,
+    continueAsNew(options) {
+      return Effect.sync(() => {
+        const intent = buildContinueAsNewIntent(commandContext, options)
+        commandContext.addIntent(intent)
+        return intent
+      }).pipe(Effect.flatMap(() => Effect.fail(new ContinueAsNewWorkflowError())))
+    },
+  }
+
+  return { context, commandContext }
+}
+
+const createCommandRef = (
+  intent: WorkflowCommandIntent,
+  extras?: Partial<Pick<WorkflowScheduledCommandRef, 'activityId' | 'timerId'>>,
+): WorkflowScheduledCommandRef => ({
+  id: intent.id,
+  kind: intent.kind,
+  sequence: intent.sequence,
+  ...extras,
+})
+
+const buildScheduleActivityIntent = (
+  ctx: WorkflowCommandContext,
+  activityType: string,
+  args: unknown[],
+  options: ScheduleActivityOptions,
+): ScheduleActivityCommandIntent => {
+  const sequence = ctx.nextSequence()
+  const activityId = options.activityId ?? `activity-${sequence}`
+  const taskQueue = options.taskQueue ?? ctx.info.taskQueue
+  return {
+    id: `schedule-activity-${sequence}`,
+    kind: 'schedule-activity',
+    sequence,
+    activityType,
+    activityId,
+    taskQueue,
+    input: args,
+    timeouts: {
+      scheduleToCloseTimeoutMs: options.scheduleToCloseTimeoutMs,
+      scheduleToStartTimeoutMs: options.scheduleToStartTimeoutMs,
+      startToCloseTimeoutMs: options.startToCloseTimeoutMs,
+      heartbeatTimeoutMs: options.heartbeatTimeoutMs,
+    },
+    retry: options.retry,
+    requestEagerExecution: options.requestEagerExecution,
+  }
+}
+
+const buildStartTimerIntent = (ctx: WorkflowCommandContext, options: StartTimerOptions): StartTimerCommandIntent => {
+  const sequence = ctx.nextSequence()
+  return {
+    id: `start-timer-${sequence}`,
+    kind: 'start-timer',
+    sequence,
+    timerId: options.timerId ?? `timer-${sequence}`,
+    timeoutMs: options.timeoutMs,
+  }
+}
+
+const buildStartChildWorkflowIntent = (
+  ctx: WorkflowCommandContext,
+  workflowType: string,
+  args: unknown[],
+  options: StartChildWorkflowOptions,
+): StartChildWorkflowCommandIntent => {
+  const sequence = ctx.nextSequence()
+  return {
+    id: `start-child-workflow-${sequence}`,
+    kind: 'start-child-workflow',
+    sequence,
+    workflowType,
+    workflowId: options.workflowId ?? `${ctx.info.workflowId}-child-${sequence}`,
+    namespace: options.namespace ?? ctx.info.namespace,
+    taskQueue: options.taskQueue ?? ctx.info.taskQueue,
+    input: args,
+    timeouts: {
+      workflowExecutionTimeoutMs: options.workflowExecutionTimeoutMs,
+      workflowRunTimeoutMs: options.workflowRunTimeoutMs,
+      workflowTaskTimeoutMs: options.workflowTaskTimeoutMs,
+    },
+    parentClosePolicy: options.parentClosePolicy,
+    workflowIdReusePolicy: options.workflowIdReusePolicy,
+    retry: options.retry,
+    cronSchedule: options.cronSchedule,
+  }
+}
+
+const buildSignalExternalWorkflowIntent = (
+  ctx: WorkflowCommandContext,
+  signalName: string,
+  args: unknown[],
+  options: SignalExternalWorkflowOptions,
+): SignalExternalWorkflowCommandIntent => {
+  const sequence = ctx.nextSequence()
+  return {
+    id: `signal-external-${sequence}`,
+    kind: 'signal-external-workflow',
+    sequence,
+    namespace: options.namespace ?? ctx.info.namespace,
+    workflowId: options.workflowId ?? ctx.info.workflowId,
+    runId: options.runId,
+    signalName,
+    input: args,
+    childWorkflowOnly: options.childWorkflowOnly ?? false,
+  }
+}
+
+const buildContinueAsNewIntent = (
+  ctx: WorkflowCommandContext,
+  options: ContinueAsNewOptions = {},
+): ContinueAsNewWorkflowCommandIntent => {
+  const sequence = ctx.nextSequence()
+  return {
+    id: `continue-as-new-${sequence}`,
+    kind: 'continue-as-new',
+    sequence,
+    workflowType: options.workflowType ?? ctx.info.workflowType,
+    taskQueue: options.taskQueue ?? ctx.info.taskQueue,
+    input: options.input ?? [],
+    timeouts: {
+      workflowRunTimeoutMs: options.workflowRunTimeoutMs,
+      workflowTaskTimeoutMs: options.workflowTaskTimeoutMs,
+    },
+    backoffStartIntervalMs: options.backoffStartIntervalMs,
+    retry: options.retry,
+    cronSchedule: options.cronSchedule,
+  }
+}

--- a/packages/temporal-bun-sdk/src/workflow/definition.ts
+++ b/packages/temporal-bun-sdk/src/workflow/definition.ts
@@ -1,13 +1,11 @@
 import type { Effect } from 'effect'
 import * as Schema from 'effect/Schema'
 
+import type { WorkflowContext } from './context'
+
 export type WorkflowSchema<I> = Schema.Schema<I>
 
 const defaultWorkflowSchema = Schema.Array(Schema.Unknown) as Schema.Schema<readonly unknown[]>
-
-export interface WorkflowContext<I> {
-  readonly input: I
-}
 
 export type WorkflowHandler<I, O> = (context: WorkflowContext<I>) => Effect.Effect<O, unknown, never>
 

--- a/packages/temporal-bun-sdk/src/workflow/determinism.ts
+++ b/packages/temporal-bun-sdk/src/workflow/determinism.ts
@@ -1,0 +1,178 @@
+import type { WorkflowCommandIntent } from './commands'
+import { WorkflowNondeterminismError } from './errors'
+
+export interface WorkflowRetryPolicyInput {
+  readonly initialIntervalMs?: number
+  readonly backoffCoefficient?: number
+  readonly maximumIntervalMs?: number
+  readonly maximumAttempts?: number
+  readonly nonRetryableErrorTypes?: string[]
+}
+
+export interface WorkflowCommandHistoryEntry {
+  readonly intent: WorkflowCommandIntent
+}
+
+export interface WorkflowDeterminismState {
+  readonly commandHistory: readonly WorkflowCommandHistoryEntry[]
+  readonly randomValues: readonly number[]
+  readonly timeValues: readonly number[]
+}
+
+export interface DeterminismGuardOptions {
+  readonly allowBypass?: boolean
+  readonly previousState?: WorkflowDeterminismState
+}
+
+export type DeterminismGuardSnapshot = {
+  commandHistory: WorkflowCommandHistoryEntry[]
+  randomValues: number[]
+  timeValues: number[]
+}
+
+export const snapshotToDeterminismState = (snapshot: DeterminismGuardSnapshot): WorkflowDeterminismState => ({
+  commandHistory: snapshot.commandHistory.map((entry) => ({ intent: entry.intent })),
+  randomValues: [...snapshot.randomValues],
+  timeValues: [...snapshot.timeValues],
+})
+
+export class DeterminismGuard {
+  readonly #allowBypass: boolean
+  readonly #previous: WorkflowDeterminismState | undefined
+  readonly snapshot: DeterminismGuardSnapshot
+  #commandIndex = 0
+  #randomIndex = 0
+  #timeIndex = 0
+
+  constructor(options: DeterminismGuardOptions = {}) {
+    this.#allowBypass = options.allowBypass ?? false
+    this.#previous = options.previousState
+    this.snapshot = {
+      commandHistory: [],
+      randomValues: [],
+      timeValues: [],
+    }
+  }
+
+  recordCommand(intent: WorkflowCommandIntent): void {
+    if (!this.#allowBypass && this.#previous) {
+      const expected = this.#previous.commandHistory[this.#commandIndex]?.intent
+      if (!expected) {
+        throw new WorkflowNondeterminismError('Workflow emitted new command on replay', {
+          hint: `commandIndex=${this.#commandIndex}`,
+          received: intent,
+        })
+      }
+      if (!intentsEqual(expected, intent)) {
+        throw new WorkflowNondeterminismError('Workflow command intent mismatch during replay', {
+          hint: `commandIndex=${this.#commandIndex}`,
+          expected,
+          received: intent,
+        })
+      }
+    }
+    this.snapshot.commandHistory.push({ intent })
+    this.#commandIndex += 1
+  }
+
+  nextRandom(generate: () => number): number {
+    if (!this.#allowBypass && this.#previous) {
+      const expected = this.#previous.randomValues[this.#randomIndex]
+      if (expected === undefined) {
+        throw new WorkflowNondeterminismError('Workflow generated new random value during replay', {
+          hint: `randomIndex=${this.#randomIndex}`,
+        })
+      }
+      this.snapshot.randomValues.push(expected)
+      this.#randomIndex += 1
+      return expected
+    }
+    const value = generate()
+    if (!Number.isFinite(value)) {
+      throw new WorkflowNondeterminismError('Random value must be a finite number', {
+        received: value,
+      })
+    }
+    this.snapshot.randomValues.push(value)
+    this.#randomIndex += 1
+    return value
+  }
+
+  nextTime(generate: () => number): number {
+    if (!this.#allowBypass && this.#previous) {
+      const expected = this.#previous.timeValues[this.#timeIndex]
+      if (expected === undefined) {
+        throw new WorkflowNondeterminismError('Workflow generated new time value during replay', {
+          hint: `timeIndex=${this.#timeIndex}`,
+        })
+      }
+      this.snapshot.timeValues.push(expected)
+      this.#timeIndex += 1
+      return expected
+    }
+    const value = generate()
+    if (!Number.isFinite(value)) {
+      throw new WorkflowNondeterminismError('Time value must be a finite number', {
+        received: value,
+      })
+    }
+    this.snapshot.timeValues.push(value)
+    this.#timeIndex += 1
+    return value
+  }
+}
+
+export const intentsEqual = (a: WorkflowCommandIntent | undefined, b: WorkflowCommandIntent | undefined): boolean => {
+  if (!a || !b) {
+    return a === b
+  }
+  if (a.kind !== b.kind) {
+    return false
+  }
+  if (a.sequence !== b.sequence) {
+    return false
+  }
+  const signatureA = stableIntentSignature(a)
+  const signatureB = stableIntentSignature(b)
+  return signatureA === signatureB
+}
+
+const stableIntentSignature = (intent: WorkflowCommandIntent): string =>
+  stableStringify(intent, (_key, value) => {
+    if (typeof value === 'bigint') {
+      return value.toString()
+    }
+    if (value instanceof Uint8Array) {
+      return Buffer.from(value).toString('base64')
+    }
+    if (value && typeof value === 'object' && 'kind' in value && 'sequence' in value) {
+      return value
+    }
+    return value
+  })
+
+type JsonReplacer = (this: unknown, key: string, value: unknown) => unknown
+
+const stableStringify = (value: unknown, replacer?: JsonReplacer): string => {
+  const seen = new WeakSet<object>()
+  const stable = (key: string, input: unknown): unknown => {
+    if (replacer) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      input = replacer.call(this, key, input)
+    }
+    if (!input || typeof input !== 'object') {
+      return input
+    }
+    if (seen.has(input as object)) {
+      return '[Circular]'
+    }
+    seen.add(input as object)
+    if (Array.isArray(input)) {
+      return input.map((item, index) => stable(String(index), item))
+    }
+    const entries = Object.entries(input as Record<string, unknown>).map(([k, v]) => [k, stable(k, v)] as const)
+    entries.sort(([lhs], [rhs]) => lhs.localeCompare(rhs))
+    return Object.fromEntries(entries)
+  }
+  return JSON.stringify(stable('', value))
+}

--- a/packages/temporal-bun-sdk/src/workflow/errors.ts
+++ b/packages/temporal-bun-sdk/src/workflow/errors.ts
@@ -1,0 +1,46 @@
+export class WorkflowError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WorkflowError'
+  }
+}
+
+export interface WorkflowNondeterminismDetails {
+  readonly expected?: unknown
+  readonly received?: unknown
+  readonly hint?: string
+}
+
+export class WorkflowNondeterminismError extends WorkflowError {
+  readonly details?: WorkflowNondeterminismDetails
+
+  constructor(message: string, details?: WorkflowNondeterminismDetails) {
+    super(message)
+    this.name = 'WorkflowNondeterminismError'
+    this.details = details
+  }
+}
+
+export class WorkflowBlockedError extends WorkflowError {
+  readonly reason: string
+
+  constructor(reason: string) {
+    super(`Workflow blocked: ${reason}`)
+    this.name = 'WorkflowBlockedError'
+    this.reason = reason
+  }
+}
+
+export class WorkflowDeterminismGuardError extends WorkflowError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WorkflowDeterminismGuardError'
+  }
+}
+
+export class ContinueAsNewWorkflowError extends WorkflowError {
+  constructor() {
+    super('Workflow requested continue-as-new')
+    this.name = 'ContinueAsNewWorkflowError'
+  }
+}

--- a/packages/temporal-bun-sdk/src/workflow/index.ts
+++ b/packages/temporal-bun-sdk/src/workflow/index.ts
@@ -1,3 +1,7 @@
+export * from './commands'
+export * from './context'
 export * from './definition'
+export * from './determinism'
+export * from './errors'
 export { WorkflowExecutor } from './executor'
 export { WorkflowRegistry } from './registry'

--- a/packages/temporal-bun-sdk/src/workflows/index.ts
+++ b/packages/temporal-bun-sdk/src/workflows/index.ts
@@ -4,13 +4,17 @@ import * as Schema from 'effect/Schema'
 import { defineWorkflow } from '../workflow'
 
 export const workflows = [
-  defineWorkflow('helloTemporal', Schema.Array(Schema.String), ({ input }) =>
-    Effect.sync(() => {
-      const [rawName] = input
-      const name = typeof rawName === 'string' && rawName.length > 0 ? rawName : 'Temporal'
-      return `Hello, ${name}!`
-    }),
-  ),
+  defineWorkflow('helloTemporal', Schema.Array(Schema.String), ({ input, activities, determinism }) => {
+    const [rawName] = input
+    const name = typeof rawName === 'string' && rawName.length > 0 ? rawName : 'Temporal'
+
+    return Effect.flatMap(activities.schedule('recordGreeting', [name]), () =>
+      Effect.sync(() => {
+        const timestamp = new Date(determinism.now()).toISOString()
+        return `Greeting enqueued for ${name} at ${timestamp}`
+      }),
+    )
+  }),
 ]
 
 export default workflows

--- a/packages/temporal-bun-sdk/tests/workflow.executor.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow.executor.test.ts
@@ -2,69 +2,232 @@ import { expect, test } from 'bun:test'
 import { Effect } from 'effect'
 import * as Schema from 'effect/Schema'
 
-import { createDefaultDataConverter } from '../src/common/payloads'
+import { createDefaultDataConverter, decodePayloadsToValues } from '../src/common/payloads'
+import type { ExecuteWorkflowInput, WorkflowExecutionOutput } from '../src/workflow/executor'
 import { WorkflowExecutor } from '../src/workflow/executor'
 import { defineWorkflow } from '../src/workflow/definition'
 import { WorkflowRegistry } from '../src/workflow/registry'
+import { WorkflowNondeterminismError } from '../src/workflow/errors'
+import type { WorkflowDeterminismState } from '../src/workflow/determinism'
 import { CommandType } from '../src/proto/temporal/api/enums/v1/command_type_pb'
 
 const makeExecutor = () => {
   const registry = new WorkflowRegistry()
   const dataConverter = createDefaultDataConverter()
-  return { registry, executor: new WorkflowExecutor({ registry, dataConverter }), dataConverter }
+  const executor = new WorkflowExecutor({ registry, dataConverter })
+  return { registry, executor, dataConverter }
 }
 
-test('completes workflow and returns completion command', async () => {
-  const { registry, executor } = makeExecutor()
+const execute = async (
+  executor: WorkflowExecutor,
+  overrides: Partial<ExecuteWorkflowInput> & Pick<ExecuteWorkflowInput, 'workflowType' | 'arguments'>,
+): Promise<WorkflowExecutionOutput> =>
+  await executor.execute({
+    workflowType: overrides.workflowType,
+    arguments: overrides.arguments,
+    workflowId: overrides.workflowId ?? 'test-workflow-id',
+    runId: overrides.runId ?? 'test-run-id',
+    namespace: overrides.namespace ?? 'default',
+    taskQueue: overrides.taskQueue ?? 'test-task-queue',
+    determinismState: overrides.determinismState,
+    bypassDeterministicContext: overrides.bypassDeterministicContext,
+  })
+
+test('schedules an activity command and completes with result', async () => {
+  const { registry, executor, dataConverter } = makeExecutor()
   registry.register(
     defineWorkflow(
-      'helloWorkflow',
+      'scheduleActivity',
       Schema.Array(Schema.String),
-      ({ input }) => Effect.sync(() => `Hello, ${input[0] ?? 'Temporal'}!`),
+      ({ input, activities }) =>
+        Effect.flatMap(activities.schedule('sendEmail', input), () => Effect.sync(() => 'scheduled')),
     ),
   )
 
-  const commands = await executor.execute({ workflowType: 'helloWorkflow', arguments: ['Temporal'] })
+  const output = await execute(executor, { workflowType: 'scheduleActivity', arguments: ['hello@acme.test'] })
 
-  expect(commands).toHaveLength(1)
-  const [command] = commands
-  expect(command.commandType).toBe(CommandType.COMPLETE_WORKFLOW_EXECUTION)
-  expect(command.attributes?.case).toBe('completeWorkflowExecutionCommandAttributes')
-  expect(command.attributes?.value.result?.payloads).toBeDefined()
+  expect(output.commands).toHaveLength(2)
+  const [schedule, completion] = output.commands
+  expect(schedule.commandType).toBe(CommandType.SCHEDULE_ACTIVITY_TASK)
+  expect(schedule.attributes?.case).toBe('scheduleActivityTaskCommandAttributes')
+  const attrs = schedule.attributes?.value
+  expect(attrs?.activityType?.name).toBe('sendEmail')
+  expect(attrs?.activityId).toBe('activity-0')
+  const decoded = await decodePayloadsToValues(dataConverter, attrs?.input?.payloads ?? [])
+  expect(decoded).toEqual(['hello@acme.test'])
+
+  expect(completion.commandType).toBe(CommandType.COMPLETE_WORKFLOW_EXECUTION)
+  expect(output.completion).toBe('completed')
 })
 
-test('fails workflow when handler raises', async () => {
+test('emits start timer command', async () => {
   const { registry, executor } = makeExecutor()
   registry.register(
     defineWorkflow(
-      'failingWorkflow',
+      'startTimer',
+      Schema.Array(Schema.Number),
+      ({ timers, input }) =>
+        Effect.flatMap(timers.start({ timeoutMs: input[0] ?? 1000 }), () => Effect.sync(() => 'done')),
+    ),
+  )
+
+  const output = await execute(executor, { workflowType: 'startTimer', arguments: [2500] })
+
+  expect(output.commands).toHaveLength(2)
+  const timerCommand = output.commands[0]
+  expect(timerCommand.commandType).toBe(CommandType.START_TIMER)
+  expect(timerCommand.attributes?.case).toBe('startTimerCommandAttributes')
+  expect(timerCommand.attributes?.value.timerId).toBe('timer-0')
+})
+
+test('schedules a child workflow command', async () => {
+  const { registry, executor, dataConverter } = makeExecutor()
+  registry.register(
+    defineWorkflow(
+      'childStarter',
       Schema.Array(Schema.String),
+      ({ childWorkflows, input }) =>
+        Effect.flatMap(
+          childWorkflows.start('childWorkflow', input, {
+            workflowId: 'child-1',
+            taskQueue: 'child-queue',
+          }),
+          () => Effect.sync(() => null),
+        ),
+    ),
+  )
+
+  const output = await execute(executor, { workflowType: 'childStarter', arguments: ['payload'] })
+
+  expect(output.commands).toHaveLength(2)
+  const startChildCommand = output.commands[0]
+  expect(startChildCommand.commandType).toBe(CommandType.START_CHILD_WORKFLOW_EXECUTION)
+  expect(startChildCommand.attributes?.case).toBe('startChildWorkflowExecutionCommandAttributes')
+  const attrs = startChildCommand.attributes?.value
+  expect(attrs?.workflowType?.name).toBe('childWorkflow')
+  expect(attrs?.workflowId).toBe('child-1')
+  expect(attrs?.taskQueue?.name).toBe('child-queue')
+  const decoded = await decodePayloadsToValues(dataConverter, attrs?.input?.payloads ?? [])
+  expect(decoded).toEqual(['payload'])
+})
+
+test('signals an external workflow', async () => {
+  const { registry, executor, dataConverter } = makeExecutor()
+  registry.register(
+    defineWorkflow(
+      'signaller',
+      Schema.Array(Schema.Unknown),
+      ({ signals }) =>
+        Effect.flatMap(
+          signals.signal(
+            'notify',
+            ['value'],
+            { workflowId: 'target', namespace: 'alt', runId: 'run-target', childWorkflowOnly: true },
+          ),
+          () => Effect.sync(() => 'ok'),
+        ),
+    ),
+  )
+
+  const output = await execute(executor, { workflowType: 'signaller', arguments: [] })
+
+  const signalCommand = output.commands[0]
+  expect(signalCommand.commandType).toBe(CommandType.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION)
+  const attrs = signalCommand.attributes?.value
+  expect(attrs?.namespace).toBe('alt')
+  expect(attrs?.execution?.workflowId).toBe('target')
+  expect(attrs?.execution?.runId).toBe('run-target')
+  expect(attrs?.childWorkflowOnly).toBe(true)
+  const decoded = await decodePayloadsToValues(dataConverter, attrs?.input?.payloads ?? [])
+  expect(decoded).toEqual(['value'])
+})
+
+test('continue-as-new produces continue command without completion', async () => {
+  const { registry, executor } = makeExecutor()
+  registry.register(
+    defineWorkflow(
+      'continuer',
+      Schema.Array(Schema.Number),
+      ({ continueAsNew }) => continueAsNew({ input: [42], taskQueue: 'replay-queue' }),
+    ),
+  )
+
+  const output = await execute(executor, { workflowType: 'continuer', arguments: [] })
+  expect(output.commands).toHaveLength(1)
+  const [continueCmd] = output.commands
+  expect(continueCmd.commandType).toBe(CommandType.CONTINUE_AS_NEW_WORKFLOW_EXECUTION)
+  expect(continueCmd.attributes?.value.taskQueue?.name).toBe('replay-queue')
+  expect(output.completion).toBe('continued-as-new')
+})
+
+test('workflow failure returns failure command', async () => {
+  const { registry, executor } = makeExecutor()
+  registry.register(
+    defineWorkflow(
+      'fails',
+      Schema.Array(Schema.Unknown),
       () => Effect.fail(new Error('boom')),
     ),
   )
 
-  const commands = await executor.execute({ workflowType: 'failingWorkflow', arguments: [] })
-
-  expect(commands).toHaveLength(1)
-  const [command] = commands
-  expect(command.commandType).toBe(CommandType.FAIL_WORKFLOW_EXECUTION)
-  expect(command.attributes?.case).toBe('failWorkflowExecutionCommandAttributes')
+  const output = await execute(executor, { workflowType: 'fails', arguments: [] })
+  expect(output.commands).toHaveLength(1)
+  const [failCmd] = output.commands
+  expect(failCmd.commandType).toBe(CommandType.FAIL_WORKFLOW_EXECUTION)
+  expect(output.completion).toBe('failed')
 })
 
-test('schema violations surface as failure commands', async () => {
+test('replay with matching determinism state succeeds', async () => {
   const { registry, executor } = makeExecutor()
   registry.register(
     defineWorkflow(
-      'arrayWorkflow',
-      Schema.Array(Schema.String),
-      ({ input }) => Effect.sync(() => input.join(':')),
+      'deterministic',
+      Schema.Array(Schema.Unknown),
+      ({ determinism }) =>
+        Effect.map(Effect.sync(() => determinism.random()), (value) => (value > 0 ? 'ok' : 'nope')),
     ),
   )
 
-  const commands = await executor.execute({ workflowType: 'arrayWorkflow', arguments: [123] as unknown[] })
+  const first = await execute(executor, { workflowType: 'deterministic', arguments: [] })
+  expect(first.completion).toBe('completed')
 
-  expect(commands).toHaveLength(1)
-  const [command] = commands
-  expect(command.commandType).toBe(CommandType.FAIL_WORKFLOW_EXECUTION)
-  expect(command.attributes?.case).toBe('failWorkflowExecutionCommandAttributes')
+  const second = await execute(executor, {
+    workflowType: 'deterministic',
+    arguments: [],
+    determinismState: cloneState(first.determinismState),
+  })
+  expect(second.completion).toBe('completed')
+})
+
+test('tampered determinism state throws WorkflowNondeterminismError', async () => {
+  const { registry, executor } = makeExecutor()
+  registry.register(
+    defineWorkflow(
+      'randomWorkflow',
+      Schema.Array(Schema.Unknown),
+      ({ determinism }) =>
+        Effect.sync(() => determinism.random()),
+    ),
+  )
+
+  const first = await execute(executor, { workflowType: 'randomWorkflow', arguments: [] })
+  expect(first.completion).toBe('completed')
+  expect(first.determinismState.randomValues.length).toBe(1)
+
+  const tampered = cloneState(first.determinismState)
+  tampered.randomValues = []
+
+  await expect(
+    execute(executor, {
+      workflowType: 'randomWorkflow',
+      arguments: [],
+      determinismState: tampered,
+    }),
+  ).rejects.toBeInstanceOf(WorkflowNondeterminismError)
+})
+
+const cloneState = (state: WorkflowDeterminismState): WorkflowDeterminismState => ({
+  commandHistory: state.commandHistory.map((entry) => ({ intent: entry.intent })),
+  randomValues: [...state.randomValues],
+  timeValues: [...state.timeValues],
 })


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- add workflow command intent modules with deterministic guardrails and context helpers for activities, timers, child workflows, signals, and continue-as-new
- extend `WorkflowExecutor`/worker runtime to translate intents into Temporal commands, store replay state, and surface nondeterminism errors; add `TEMPORAL_DISABLE_WORKFLOW_CONTEXT` rollback flag
- update docs/examples and expand executor test suite to cover command translation and replay determinism

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
- closes #1689

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- pnpm exec biome check packages/temporal-bun-sdk
- pnpm --filter @proompteng/temporal-bun-sdk exec bun test
- pnpm --filter @proompteng/temporal-bun-sdk exec bun run build

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
