### PR TITLE
feat: implement observability stack for temporal bun sdk

### DIFF
--- a/packages/temporal-bun-sdk/docs/production-design.md
+++ b/packages/temporal-bun-sdk/docs/production-design.md
@@ -197,17 +197,14 @@ can contribute independently without re-planning.
 
 ### TBS-004 – Observability
 
-- **Starting points**
-  - `src/observability/logger.ts`, `src/observability/metrics.ts` – replace console/in-memory stubs.
-  - Thread logger/metrics dependencies through worker and client constructors.
-- **Effect guidance**
-  - Provide Layers (`Effect.Layer`) for injecting logger/metrics (coordinate with TBS-010).
-  - Use structured logging JSON, integrate with OpenTelemetry API.
-- **Acceptance criteria**
-  1. Configurable logger exposing debug/info/warn/error with context.
-  2. Metrics registry exporting poll latency, command counts, retry attempts.
-  3. Optional tracing instrumentation toggled via config.
-  4. Documentation explaining how to plug custom sinks.
+- **Status**: ✅ Completed in `src/observability/*`, `src/worker/runtime.ts`, and `src/client.ts`.
+- **Highlights**
+  - Structured logger with pluggable sinks (`createLogger`) and configurable level/format via `TEMPORAL_LOG_LEVEL` / `TEMPORAL_LOG_FORMAT`.
+  - Metrics registry with in-memory snapshots (`makeInMemoryMetrics`) and OTEL bridge (`makeOpenTelemetryMetrics`); default worker metrics cover poll latency, task failures, retry attempts, and sticky-cache events.
+  - Temporal client instrumentation emits RPC latency/failure metrics and wraps WorkflowService calls in tracing spans.
+  - Optional tracing toggled through `TEMPORAL_TRACING_ENABLED` with OTEL integration (`makeOpenTelemetryTracer`).
+  - Effect layers (`LoggerLayer`, `MetricsLayer`, `TracingLayer`) expose observability services to future Effect-first runtime factories.
+  - Integration harness records metrics/logs while running CLI-driven scenarios, with tests in `tests/integration/observability.test.ts`.
 
 ### TBS-005 – Client Resilience
 

--- a/packages/temporal-bun-sdk/package.json
+++ b/packages/temporal-bun-sdk/package.json
@@ -58,6 +58,7 @@
     "bun": ">=1.1.20"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@bufbuild/protobuf": "^2.1.0",
     "@connectrpc/connect": "^2.1.0",
     "@connectrpc/connect-node": "^2.1.0",

--- a/packages/temporal-bun-sdk/src/client.ts
+++ b/packages/temporal-bun-sdk/src/client.ts
@@ -1,9 +1,9 @@
 import type { ClientSessionOptions, SecureClientSessionOptions } from 'node:http2'
 import { performance } from 'node:perf_hooks'
-import { metrics as otelMetrics } from '@opentelemetry/api'
 import { create, toBinary } from '@bufbuild/protobuf'
 import { type CallOptions, Code, ConnectError, createClient, type Transport } from '@connectrpc/connect'
 import { createGrpcTransport, type GrpcTransportOptions } from '@connectrpc/connect-node'
+import { metrics as otelMetrics } from '@opentelemetry/api'
 import { Effect } from 'effect'
 import { createDefaultHeaders, mergeHeaders, normalizeMetadataHeaders } from './client/headers'
 import {
@@ -68,9 +68,8 @@ const resolveMetricsRegistry = async (
   if (metricsConfig.exporter === 'otel') {
     const meter =
       metricsConfig.meter ??
-      otelMetrics.getMeter(metricsConfig.meterName ?? 'temporal-bun-sdk', {
+      otelMetrics.getMeter(metricsConfig.meterName ?? 'temporal-bun-sdk', metricsConfig.meterVersion, {
         schemaUrl: metricsConfig.schemaUrl,
-        version: metricsConfig.meterVersion,
       })
     return makeOpenTelemetryMetrics(meter)
   }

--- a/packages/temporal-bun-sdk/src/config.ts
+++ b/packages/temporal-bun-sdk/src/config.ts
@@ -201,9 +201,9 @@ const normalizeTracingExporter = (value: string | undefined): TracingExporter =>
   value?.toLowerCase() === 'otel' ? 'otel' : 'none'
 
 const buildObservabilityConfig = (env: TemporalEnvironment, defaults?: ObservabilityDefaults): ObservabilityConfig => {
-  const loggerDefaults = defaults?.logger ?? {}
-  const metricsDefaults = defaults?.metrics ?? {}
-  const tracingDefaults = defaults?.tracing ?? {}
+  const loggerDefaults: Partial<LoggerConfig> = defaults?.logger ?? {}
+  const metricsDefaults: Partial<MetricsConfig> = defaults?.metrics ?? {}
+  const tracingDefaults: Partial<TracingConfig> = defaults?.tracing ?? {}
 
   const level = normalizeLogLevel(env.TEMPORAL_LOG_LEVEL ?? loggerDefaults.level)
   const format = normalizeLogFormat(env.TEMPORAL_LOG_FORMAT ?? loggerDefaults.format)

--- a/packages/temporal-bun-sdk/src/observability/logger.ts
+++ b/packages/temporal-bun-sdk/src/observability/logger.ts
@@ -6,29 +6,197 @@ export interface LogFields {
   readonly [key: string]: unknown
 }
 
-export interface Logger {
-  readonly log: (level: LogLevel, message: string, fields?: LogFields) => Effect.Effect<void, never, never>
+export interface LogRecord {
+  readonly timestamp: string
+  readonly level: LogLevel
+  readonly message: string
+  readonly fields: LogFields
 }
 
-export const makeConsoleLogger = (): Logger => ({
-  log(level, message, fields) {
-    // TODO(TBS-004): Integrate with structured logging sinks and add bunyan/pino compatible adapters.
+export interface LoggerSink {
+  readonly write: (record: LogRecord) => Effect.Effect<void, never, never>
+}
+
+export interface LoggerOptions {
+  /**
+   * Minimum severity that should be written to sinks. Defaults to `info`.
+   */
+  readonly level?: LogLevel
+  /**
+   * Console formatter. `json` produces a single-line JSON payload, `pretty` produces a human-readable string.
+   */
+  readonly format?: 'json' | 'pretty'
+  /**
+   * Additional fields appended to every log entry.
+   */
+  readonly fields?: LogFields
+  /**
+   * Custom sinks for structured log consumption (e.g. pino transport, Loki, etc.).
+   * When omitted the logger writes to `process.stdout` / `process.stderr`.
+   */
+  readonly sinks?: ReadonlyArray<LoggerSink>
+  /**
+   * Override timestamp factory – primarily for tests.
+   */
+  readonly timestamp?: () => string
+}
+
+export interface Logger {
+  readonly level: LogLevel
+  readonly log: (level: LogLevel, message: string, fields?: LogFields) => Effect.Effect<void, never, never>
+  readonly debug: (message: string, fields?: LogFields) => Effect.Effect<void, never, never>
+  readonly info: (message: string, fields?: LogFields) => Effect.Effect<void, never, never>
+  readonly warn: (message: string, fields?: LogFields) => Effect.Effect<void, never, never>
+  readonly error: (message: string, fields?: LogFields) => Effect.Effect<void, never, never>
+  /**
+   * Returns a derived logger that automatically appends `fields` to every entry.
+   */
+  readonly with: (fields: LogFields) => Logger
+}
+
+const LOG_LEVEL_ORDER: readonly LogLevel[] = ['debug', 'info', 'warn', 'error']
+const LOG_LEVEL_WEIGHT: Readonly<Record<LogLevel, number>> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+}
+
+export const DEFAULT_LOG_LEVEL: LogLevel = 'info'
+
+export const normalizeLogLevel = (value: string | undefined | null): LogLevel => {
+  if (!value) {
+    return DEFAULT_LOG_LEVEL
+  }
+  const normalized = value.trim().toLowerCase()
+  if (LOG_LEVEL_ORDER.includes(normalized as LogLevel)) {
+    return normalized as LogLevel
+  }
+  return DEFAULT_LOG_LEVEL
+}
+
+interface LoggerContext {
+  readonly level: LogLevel
+  readonly baseFields: LogFields
+  readonly sinks: ReadonlyArray<LoggerSink>
+  readonly timestamp: () => string
+}
+
+class LoggerImpl implements Logger {
+  readonly #context: LoggerContext
+
+  constructor(context: LoggerContext) {
+    this.#context = context
+  }
+
+  get level(): LogLevel {
+    return this.#context.level
+  }
+
+  log(level: LogLevel, message: string, fields?: LogFields): Effect.Effect<void, never, never> {
+    if (!shouldLog(level, this.#context.level)) {
+      return Effect.void
+    }
+
+    const record: LogRecord = {
+      level,
+      message,
+      timestamp: this.#context.timestamp(),
+      fields: mergeFields(this.#context.baseFields, fields),
+    }
+
+    return Effect.forEach(this.#context.sinks, (sink) => sink.write(record), {
+      concurrency: 'inherit',
+      discard: true,
+    })
+  }
+
+  debug(message: string, fields?: LogFields): Effect.Effect<void, never, never> {
+    return this.log('debug', message, fields)
+  }
+
+  info(message: string, fields?: LogFields): Effect.Effect<void, never, never> {
+    return this.log('info', message, fields)
+  }
+
+  warn(message: string, fields?: LogFields): Effect.Effect<void, never, never> {
+    return this.log('warn', message, fields)
+  }
+
+  error(message: string, fields?: LogFields): Effect.Effect<void, never, never> {
+    return this.log('error', message, fields)
+  }
+
+  with(fields: LogFields): Logger {
+    return new LoggerImpl({
+      ...this.#context,
+      baseFields: mergeFields(this.#context.baseFields, fields),
+    })
+  }
+}
+
+const shouldLog = (entryLevel: LogLevel, threshold: LogLevel): boolean =>
+  LOG_LEVEL_WEIGHT[entryLevel] >= LOG_LEVEL_WEIGHT[threshold]
+
+const mergeFields = (base: LogFields, patch?: LogFields): LogFields => {
+  if (!patch || Object.keys(patch).length === 0) {
+    return { ...base }
+  }
+  return { ...base, ...patch }
+}
+
+const defaultTimestamp = (): string => new Date().toISOString()
+
+const makeConsoleSink = (format: 'json' | 'pretty'): LoggerSink => ({
+  write(record) {
     return Effect.sync(() => {
-      const payload = fields ? `${message} ${JSON.stringify(fields)}` : message
-      switch (level) {
-        case 'debug':
-          console.debug(payload)
-          break
-        case 'info':
-          console.info(payload)
-          break
-        case 'warn':
-          console.warn(payload)
-          break
-        case 'error':
-          console.error(payload)
-          break
+      const payload = {
+        timestamp: record.timestamp,
+        level: record.level,
+        message: record.message,
+        ...record.fields,
       }
+
+      if (format === 'json') {
+        const serialized = JSON.stringify(payload)
+        forwardToConsole(record.level, serialized)
+        return
+      }
+
+      const { message, level, timestamp, ...rest } = payload
+      const fields = Object.keys(rest).length > 0 ? JSON.stringify(rest) : ''
+      const formatted = `[${timestamp}] ${level.toUpperCase()} ${message}${fields ? ` ${fields}` : ''}`
+      forwardToConsole(record.level, formatted)
     })
   },
 })
+
+const forwardToConsole = (level: LogLevel, payload: string) => {
+  switch (level) {
+    case 'debug':
+    case 'info':
+      console.log(payload)
+      break
+    case 'warn':
+      console.warn(payload)
+      break
+    case 'error':
+      console.error(payload)
+      break
+  }
+}
+
+export const createLogger = (options: LoggerOptions = {}): Logger => {
+  const level = options.level ?? DEFAULT_LOG_LEVEL
+  const sinkList =
+    options.sinks && options.sinks.length > 0 ? options.sinks : [makeConsoleSink(options.format ?? 'json')]
+
+  return new LoggerImpl({
+    level,
+    sinks: sinkList,
+    baseFields: { ...(options.fields ?? {}) },
+    timestamp: options.timestamp ?? defaultTimestamp,
+  })
+}
+
+export const makeConsoleLogger = (options?: LoggerOptions): Logger => createLogger(options)

--- a/packages/temporal-bun-sdk/src/observability/metrics.ts
+++ b/packages/temporal-bun-sdk/src/observability/metrics.ts
@@ -1,47 +1,250 @@
 import { Effect, Ref } from 'effect'
 
+export type MetricAttributes = Readonly<Record<string, string | number | boolean>>
+
+export interface MetricMetadata {
+  readonly description?: string
+  readonly unit?: string
+}
+
+export interface HistogramMetadata extends MetricMetadata {}
+
 export interface Counter {
-  readonly inc: (value?: number) => Effect.Effect<void, never, never>
+  readonly inc: (value?: number, attributes?: MetricAttributes) => Effect.Effect<void, never, never>
 }
 
 export interface Histogram {
-  readonly observe: (value: number) => Effect.Effect<void, never, never>
+  readonly observe: (value: number, attributes?: MetricAttributes) => Effect.Effect<void, never, never>
+}
+
+export interface MetricsSnapshot {
+  readonly counters: ReadonlyArray<{
+    readonly name: string
+    readonly description?: string
+    readonly unit?: string
+    readonly points: ReadonlyArray<{
+      readonly value: number
+      readonly attributes: MetricAttributes
+    }>
+  }>
+  readonly histograms: ReadonlyArray<{
+    readonly name: string
+    readonly description?: string
+    readonly unit?: string
+    readonly points: ReadonlyArray<{
+      readonly values: ReadonlyArray<number>
+      readonly attributes: MetricAttributes
+    }>
+  }>
 }
 
 export interface MetricsRegistry {
-  readonly counter: (name: string, description?: string) => Effect.Effect<Counter, never, never>
-  readonly histogram: (name: string, description?: string) => Effect.Effect<Histogram, never, never>
+  readonly counter: (name: string, metadata?: MetricMetadata) => Effect.Effect<Counter, never, never>
+  readonly histogram: (name: string, metadata?: HistogramMetadata) => Effect.Effect<Histogram, never, never>
+  readonly collect?: () => Effect.Effect<MetricsSnapshot, never, never>
+}
+
+const cloneMetadata = (metadata?: MetricMetadata): MetricMetadata => (metadata ? { ...metadata } : {}) as MetricMetadata
+
+interface CounterPoint {
+  value: number
+  attributes: MetricAttributes
+}
+
+interface CounterState {
+  metadata: MetricMetadata
+  points: Map<string, CounterPoint>
+}
+
+interface HistogramPoint {
+  values: number[]
+  attributes: MetricAttributes
+}
+
+interface HistogramState {
+  metadata: HistogramMetadata
+  points: Map<string, HistogramPoint>
+}
+
+const attributesKey = (attributes: MetricAttributes): string => {
+  const entries = Object.entries(attributes).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+  return JSON.stringify(entries)
+}
+
+const cloneAttributes = (attributes: MetricAttributes): MetricAttributes => ({ ...attributes })
+
+const mergeMetadata = (existing: MetricMetadata, next?: MetricMetadata): MetricMetadata => ({
+  description: existing.description ?? next?.description,
+  unit: existing.unit ?? next?.unit,
+})
+
+const normalizeAttributes = (attributes?: MetricAttributes): MetricAttributes => {
+  if (!attributes) {
+    return {} as MetricAttributes
+  }
+  const normalized: Record<string, string | number | boolean> = {}
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined) {
+      continue
+    }
+    normalized[key] = value
+  }
+  return normalized as MetricAttributes
 }
 
 export const makeInMemoryMetrics = (): Effect.Effect<MetricsRegistry, never, never> =>
   Effect.gen(function* () {
-    const counters = yield* Ref.make(new Map<string, number>())
-    const histograms = yield* Ref.make(new Map<string, number[]>())
+    const counters = yield* Ref.make(new Map<string, CounterState>())
+    const histograms = yield* Ref.make(new Map<string, HistogramState>())
 
-    const counter: MetricsRegistry['counter'] = (name) =>
-      Effect.sync(() => ({
-        inc: (value = 1) =>
-          Ref.update(counters, (map) => {
-            map.set(name, (map.get(name) ?? 0) + value)
-            return map
-          }),
-      }))
+    const registerCounter = (name: string, metadata?: MetricMetadata): Effect.Effect<CounterState, never, never> =>
+      Ref.modify(counters, (map) => {
+        const current = map.get(name)
+        if (current) {
+          current.metadata = mergeMetadata(current.metadata, metadata)
+          return [current, map]
+        }
+        const state: CounterState = {
+          metadata: cloneMetadata(metadata),
+          points: new Map(),
+        }
+        map.set(name, state)
+        return [state, map]
+      })
 
-    const histogram: MetricsRegistry['histogram'] = (name) =>
-      Effect.sync(() => ({
-        observe: (value) =>
-          Ref.update(histograms, (map) => {
-            const bucket = map.get(name) ?? []
-            bucket.push(value)
-            map.set(name, bucket)
-            return map
-          }),
-      }))
+    const registerHistogram = (
+      name: string,
+      metadata?: HistogramMetadata,
+    ): Effect.Effect<HistogramState, never, never> =>
+      Ref.modify(histograms, (map) => {
+        const current = map.get(name)
+        if (current) {
+          current.metadata = mergeMetadata(current.metadata, metadata)
+          return [current, map]
+        }
+        const state: HistogramState = {
+          metadata: cloneMetadata(metadata),
+          points: new Map(),
+        }
+        map.set(name, state)
+        return [state, map]
+      })
 
-    // TODO(TBS-004): Export metrics via OpenTelemetry / Prometheus integrations.
+    const counter: MetricsRegistry['counter'] = (name, metadata) =>
+      Effect.gen(function* () {
+        const state = yield* registerCounter(name, metadata)
+        return {
+          inc: (value = 1, attributes) => {
+            const normalized = normalizeAttributes(attributes)
+            return Ref.update(counters, (map) => {
+              const current = map.get(name) ?? state
+              const key = attributesKey(normalized)
+              const existing = current.points.get(key)
+              if (existing) {
+                existing.value += value
+              } else {
+                current.points.set(key, { value, attributes: normalized })
+              }
+              map.set(name, current)
+              return map
+            })
+          },
+        }
+      })
+
+    const histogram: MetricsRegistry['histogram'] = (name, metadata) =>
+      Effect.gen(function* () {
+        const state = yield* registerHistogram(name, metadata)
+        return {
+          observe: (value, attributes) => {
+            const normalized = normalizeAttributes(attributes)
+            return Ref.update(histograms, (map) => {
+              const current = map.get(name) ?? state
+              const key = attributesKey(normalized)
+              const existing = current.points.get(key)
+              if (existing) {
+                existing.values.push(value)
+              } else {
+                current.points.set(key, { values: [value], attributes: normalized })
+              }
+              map.set(name, current)
+              return map
+            })
+          },
+        }
+      })
+
+    const collect = (): Effect.Effect<MetricsSnapshot, never, never> =>
+      Effect.gen(function* () {
+        const [counterMap, histogramMap] = yield* Effect.all([Ref.get(counters), Ref.get(histograms)])
+
+        const countersSnapshot = Array.from(counterMap.entries()).map(([name, state]) => ({
+          name,
+          description: state.metadata.description,
+          unit: state.metadata.unit,
+          points: Array.from(state.points.values()).map((point) => ({
+            value: point.value,
+            attributes: cloneAttributes(point.attributes),
+          })),
+        }))
+
+        const histogramsSnapshot = Array.from(histogramMap.entries()).map(([name, state]) => ({
+          name,
+          description: state.metadata.description,
+          unit: state.metadata.unit,
+          points: Array.from(state.points.values()).map((point) => ({
+            values: [...point.values],
+            attributes: cloneAttributes(point.attributes),
+          })),
+        }))
+
+        return {
+          counters: countersSnapshot,
+          histograms: histogramsSnapshot,
+        }
+      })
 
     return {
       counter,
       histogram,
+      collect,
     }
   })
+
+export interface OtelMeter {
+  readonly createCounter: (name: string, options?: MetricMetadata) => OtelCounter
+  readonly createHistogram: (name: string, options?: HistogramMetadata) => OtelHistogram
+}
+
+export interface OtelCounter {
+  readonly add: (value: number, attributes?: MetricAttributes) => void
+}
+
+export interface OtelHistogram {
+  readonly record: (value: number, attributes?: MetricAttributes) => void
+}
+
+export const makeOpenTelemetryMetrics = (meter: OtelMeter): MetricsRegistry => ({
+  counter(name, metadata) {
+    return Effect.sync(() => {
+      const counter = meter.createCounter(name, metadata)
+      return {
+        inc: (value = 1, attributes) =>
+          Effect.sync(() => {
+            counter.add(value, attributes)
+          }),
+      }
+    })
+  },
+  histogram(name, metadata) {
+    return Effect.sync(() => {
+      const histogram = meter.createHistogram(name, metadata)
+      return {
+        observe: (value, attributes) =>
+          Effect.sync(() => {
+            histogram.record(value, attributes)
+          }),
+      }
+    })
+  },
+})

--- a/packages/temporal-bun-sdk/src/observability/tracing.ts
+++ b/packages/temporal-bun-sdk/src/observability/tracing.ts
@@ -1,0 +1,59 @@
+import { SpanStatusCode, trace } from '@opentelemetry/api'
+
+import type { MetricAttributes } from './metrics'
+
+export interface Span {
+  end(): void
+  recordException(error: unknown): void
+  setAttribute(key: string, value: string | number | boolean): void
+  setAttributes(attributes: MetricAttributes): void
+}
+
+export interface Tracer {
+  startSpan(name: string, attributes?: MetricAttributes): Span
+}
+
+export const makeNoopTracer = (): Tracer => ({
+  startSpan() {
+    return {
+      end() {},
+      recordException() {},
+      setAttribute() {},
+      setAttributes() {},
+    }
+  },
+})
+
+export interface OpenTelemetryTracerOptions {
+  serviceName?: string
+}
+
+export const makeOpenTelemetryTracer = (options: OpenTelemetryTracerOptions = {}): Tracer => {
+  const otelTracer = trace.getTracer(options.serviceName ?? 'temporal-bun-sdk')
+
+  return {
+    startSpan(name, attributes) {
+      const span = otelTracer.startSpan(name, { attributes })
+      return {
+        end() {
+          span.end()
+        },
+        recordException(error: unknown) {
+          span.recordException(error instanceof Error ? error : { name: 'Error', message: String(error) })
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          })
+        },
+        setAttribute(key, value) {
+          span.setAttribute(key, value)
+        },
+        setAttributes(attrs) {
+          for (const [key, value] of Object.entries(attrs)) {
+            span.setAttribute(key, value)
+          }
+        },
+      }
+    },
+  }
+}

--- a/packages/temporal-bun-sdk/src/runtime/effect-layers.ts
+++ b/packages/temporal-bun-sdk/src/runtime/effect-layers.ts
@@ -1,24 +1,28 @@
-import { Context, Effect, Layer } from 'effect'
+import { metrics as otelMetrics } from '@opentelemetry/api'
+import { Effect, Layer } from 'effect'
 
 import { loadTemporalConfig, type TemporalConfig } from '../config'
-import { type Logger, makeConsoleLogger } from '../observability/logger'
+import { createLogger, type Logger } from '../observability/logger'
 import type { MetricsRegistry } from '../observability/metrics'
-import { makeInMemoryMetrics } from '../observability/metrics'
+import { makeInMemoryMetrics, makeOpenTelemetryMetrics } from '../observability/metrics'
+import { makeNoopTracer, makeOpenTelemetryTracer, type Tracer } from '../observability/tracing'
 import type { WorkflowServiceClient } from '../worker/runtime'
 
-export class TemporalConfigService extends Context.Tag('@proompteng/temporal-bun-sdk/TemporalConfig')<
+export class TemporalConfigService extends Effect.Tag('@proompteng/temporal-bun-sdk/TemporalConfig')<
   TemporalConfigService,
   TemporalConfig
 >() {}
 
-export class LoggerService extends Context.Tag('@proompteng/temporal-bun-sdk/Logger')<LoggerService, Logger>() {}
+export class LoggerService extends Effect.Tag('@proompteng/temporal-bun-sdk/Logger')<LoggerService, Logger>() {}
 
-export class MetricsService extends Context.Tag('@proompteng/temporal-bun-sdk/Metrics')<
+export class MetricsService extends Effect.Tag('@proompteng/temporal-bun-sdk/Metrics')<
   MetricsService,
   MetricsRegistry
 >() {}
 
-export class WorkflowServiceClientService extends Context.Tag('@proompteng/temporal-bun-sdk/WorkflowServiceClient')<
+export class TracingService extends Effect.Tag('@proompteng/temporal-bun-sdk/Tracing')<TracingService, Tracer>() {}
+
+export class WorkflowServiceClientService extends Effect.Tag('@proompteng/temporal-bun-sdk/WorkflowServiceClient')<
   WorkflowServiceClientService,
   WorkflowServiceClient
 >() {}
@@ -31,11 +35,58 @@ export const ConfigLayer: Layer.Layer<never, unknown, TemporalConfigService> = L
   }),
 )
 
-export const LoggerLayer: Layer.Layer<never, never, LoggerService> = Layer.succeed(LoggerService, makeConsoleLogger())
+export const LoggerLayer: Layer.Layer<TemporalConfigService, never, LoggerService> = Layer.effect(
+  LoggerService,
+  Effect.gen(function* () {
+    const config = yield* TemporalConfigService
+    const observability = config.observability ?? {}
+    const loggerConfig = observability.logger ?? {}
 
-export const MetricsLayer: Layer.Layer<never, never, MetricsService> = Layer.effect(
+    return createLogger({
+      level: loggerConfig.level,
+      format: loggerConfig.format ?? 'json',
+      fields: {
+        component: 'temporal-bun-sdk',
+        namespace: config.namespace,
+        taskQueue: config.taskQueue,
+      },
+    })
+  }),
+)
+
+export const MetricsLayer: Layer.Layer<TemporalConfigService, never, MetricsService> = Layer.effect(
   MetricsService,
-  makeInMemoryMetrics(),
+  Effect.gen(function* () {
+    const config = yield* TemporalConfigService
+    const observability = config.observability ?? {}
+    const metricsConfig = observability.metrics ?? {}
+
+    if (metricsConfig.exporter === 'otel') {
+      const meter =
+        metricsConfig.meter ??
+        otelMetrics.getMeter(metricsConfig.meterName ?? 'temporal-bun-sdk', {
+          schemaUrl: metricsConfig.schemaUrl,
+          version: metricsConfig.meterVersion,
+        })
+      return makeOpenTelemetryMetrics(meter)
+    }
+
+    return yield* makeInMemoryMetrics()
+  }),
+)
+
+export const TracingLayer: Layer.Layer<TemporalConfigService, never, TracingService> = Layer.effect(
+  TracingService,
+  Effect.gen(function* () {
+    const config = yield* TemporalConfigService
+    const tracingConfig = config.observability?.tracing
+
+    if (!tracingConfig || !tracingConfig.enabled || tracingConfig.exporter === 'none') {
+      return makeNoopTracer()
+    }
+
+    return makeOpenTelemetryTracer({ serviceName: tracingConfig.serviceName })
+  }),
 )
 
 export const WorkflowServiceLayer: Layer.Layer<never, unknown, WorkflowServiceClientService> = Layer.effect(

--- a/packages/temporal-bun-sdk/tests/integration/observability.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/observability.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'bun:test'
+import { Effect } from 'effect'
+
+import { createLogger, type LogRecord, type LoggerSink } from '../../src/observability/logger'
+import { makeInMemoryMetrics } from '../../src/observability/metrics'
+import { createIntegrationHarness } from './harness'
+
+const createCaptureLogger = () => {
+  const records: LogRecord[] = []
+  const sink: LoggerSink = {
+    write(record) {
+      records.push(record)
+      return Effect.void
+    },
+  }
+
+  const logger = createLogger({
+    level: 'debug',
+    sinks: [sink],
+  })
+
+  return { logger, records }
+}
+
+test('integration harness records logs and metrics for scenarios', async () => {
+  const { logger, records } = createCaptureLogger()
+  const metrics = await Effect.runPromise(makeInMemoryMetrics())
+
+  const harness = await Effect.runPromise(
+    createIntegrationHarness(
+      {
+        address: '127.0.0.1:7233',
+        namespace: 'default',
+      },
+      { logger, metrics },
+    ),
+  )
+
+  await Effect.runPromise(harness.setup)
+
+  const successResult = await Effect.runPromise(
+    harness.runScenario('success-case', () => Effect.succeed('ok')),
+  )
+  expect(successResult).toBe('ok')
+
+  await expect(
+    Effect.runPromise(harness.runScenario('failing-case', () => Effect.fail(new Error('boom')))),
+  ).rejects.toThrow('boom')
+
+  await Effect.runPromise(harness.teardown)
+
+  const snapshot = await Effect.runPromise(harness.metrics.collect!())
+  const scenariosMetric = snapshot.counters.find((counter) => counter.name === 'temporal_integration_scenarios_total')
+  expect(scenariosMetric?.points).toBeDefined()
+  const successPoint = scenariosMetric?.points?.find((point) => point.attributes.scenario === 'success-case')
+  const failureScenarioPoint = scenariosMetric?.points?.find((point) => point.attributes.scenario === 'failing-case')
+  expect(successPoint?.value).toBe(1)
+  expect(failureScenarioPoint?.value).toBe(1)
+
+  const failureMetric = snapshot.counters.find((counter) => counter.name === 'temporal_integration_failures_total')
+  const failurePoint = failureMetric?.points?.find((point) => point.attributes.scenario === 'failing-case')
+  expect(failurePoint?.value).toBe(1)
+
+  const labels = records.map((record) => record.message)
+  expect(labels).toContain('integration harness setup')
+  expect(labels).toContain('integration harness teardown')
+  expect(labels).toContain('integration scenario start')
+  expect(labels).toContain('integration scenario completed')
+  expect(labels).toContain('integration scenario failed')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,13 +184,13 @@ importers:
         version: 1.131.44(@tanstack/react-router@1.131.44(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(webpack@5.99.9)
       '@trpc/client':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105)
+        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3)
       '@trpc/server':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251105)
+        version: 11.0.0-rc.824(typescript@5.9.3)
       '@trpc/tanstack-react-query':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251105)
+        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -239,7 +239,7 @@ importers:
         version: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.0-dev.20251105)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 5.1.4(typescript@5.9.3)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
 
   apps/nata:
     dependencies:
@@ -581,7 +581,7 @@ importers:
         version: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2))
       ts-jest:
         specifier: ^29
-        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.2.6(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
       ts-node:
         specifier: ^10
         version: 10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)
@@ -613,6 +613,9 @@ importers:
       '@connectrpc/connect-node':
         specifier: ^2.1.0
         version: 2.1.0(@bufbuild/protobuf@2.10.0)(@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.10.0))
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       effect:
         specifier: ^3.2.0
         version: 3.18.4
@@ -9752,8 +9755,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20251105:
-    resolution: {integrity: sha512-1qXzjLkr7/FSYqHvV5GyP/16Y4bJyO4OcboOVBOGcorurTfB2Gf0Vya/3nPVcAunSPBq/VM9hzVPsFX1M9buZg==}
+  typescript@6.0.0-dev.20251106:
+    resolution: {integrity: sha512-5+HwV8o70G9ot/VDVYQwklYFxN3lk8sfu/NGOMzqxDKThrOhyMZ7DaXd89g7kNCSd8yPJmwzsSMVgfRdtV4I2g==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -11019,35 +11022,77 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.9)':
     dependencies:
@@ -11064,40 +11109,88 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
+
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.26.5
+    optional: true
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.9)':
     dependencies:
@@ -15781,23 +15874,23 @@ snapshots:
       long: 5.3.1
       protobufjs: 7.4.0
 
-  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105)':
+  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251105)
-      typescript: 6.0.0-dev.20251105
+      '@trpc/server': 11.0.0-rc.824(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105)':
+  '@trpc/server@11.0.0-rc.824(typescript@5.9.3)':
     dependencies:
-      typescript: 6.0.0-dev.20251105
+      typescript: 5.9.3
 
-  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251105)':
+  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.3)':
     dependencies:
       '@tanstack/react-query': 5.89.0(react@19.0.0)
-      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105)
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251105)
+      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/server': 11.0.0-rc.824(typescript@5.9.3)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      typescript: 6.0.0-dev.20251105
+      typescript: 5.9.3
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -16444,6 +16537,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.7.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.4)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.26.5
@@ -16480,11 +16587,38 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.9)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.9)
 
+  babel-preset-current-node-syntax@1.1.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
+    optional: true
+
   babel-preset-jest@29.6.3(@babel/core@7.26.9):
     dependencies:
       '@babel/core': 7.26.9
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.9)
+
+  babel-preset-jest@29.6.3(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.28.4)
+    optional: true
 
   bail@2.0.2: {}
 
@@ -17246,7 +17380,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20251105
+      typescript: 6.0.0-dev.20251106
 
   dunder-proto@1.0.1:
     dependencies:
@@ -21444,7 +21578,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-jest@29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
+  ts-jest@29.2.6(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -21458,10 +21592,10 @@ snapshots:
       typescript: 5.8.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.28.4
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.9)
+      babel-jest: 29.7.0(@babel/core@7.28.4)
 
   ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2):
     dependencies:
@@ -21483,9 +21617,9 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.8(@swc/helpers@0.5.15)
 
-  tsconfck@3.1.5(typescript@6.0.0-dev.20251105):
+  tsconfck@3.1.5(typescript@5.9.3):
     optionalDependencies:
-      typescript: 6.0.0-dev.20251105
+      typescript: 5.9.3
 
   tslib@1.14.1: {}
 
@@ -21523,7 +21657,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.0-dev.20251105: {}
+  typescript@6.0.0-dev.20251106: {}
 
   ufo@1.5.4: {}
 
@@ -21816,11 +21950,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251105)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.5(typescript@6.0.0-dev.20251105)
+      tsconfck: 3.1.5(typescript@5.9.3)
     optionalDependencies:
       vite: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- add structured logging, metrics registry, and optional tracing services to the Temporal Bun SDK
- thread observability services through Effect layers, worker runtime, and client configuration knobs
- document new environment variables and add integration harness coverage for observability signals

## Related Issues

Closes #1697

## Testing

- pnpm --filter @proompteng/temporal-bun-sdk test

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
