### PR TITLE
chore: align graf image naming

### DIFF
--- a/.github/workflows/graf-build-push.yaml
+++ b/.github/workflows/graf-build-push.yaml
@@ -23,7 +23,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: registry.ide-newton.ts.net/proompteng/graf-service
+          images: registry.ide-newton.ts.net/proompteng/graf
           tags: |
             type=ref,event=branch
             type=sha
@@ -44,5 +44,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/proompteng/graf-service:latest
-          cache-to: type=inline
+          cache-from: |
+            type=registry,ref=registry.ide-newton.ts.net/proompteng/graf:latest
+            type=registry,ref=registry.ide-newton.ts.net/proompteng/graf:cache
+          cache-to: |
+            type=registry,ref=registry.ide-newton.ts.net/proompteng/graf:cache,mode=max
+            type=inline

--- a/argocd/applications/graf/README.md
+++ b/argocd/applications/graf/README.md
@@ -3,7 +3,7 @@
 - Managed through the platform `ApplicationSet` (`argocd/applicationsets/platform.yaml`).
 - This directory exposes a `kustomization.yaml` that renders the latest Neo4j Helm chart (2025.10.1) via the Kustomize `helmCharts` plugin. The chart now installs its CRDs and uses the `longhorn` storage class for the data volume.
 - The Argo CD `graf` application deploys the chart into the `graf` namespace and creates the Helm release named `graf`. It also applies `knative-service.yaml`, which registers the Kotlin persistence service in the same namespace so Temporal/Knative can reach the graph API.
-- The Knative service pulls its image from the shared Tailscale registry host `registry.ide-newton.ts.net`.
+- The Knative service pulls its image from the shared Tailscale registry host `registry.ide-newton.ts.net/proompteng/graf:latest`.
 - A `graf-neo4j-browser` LoadBalancer service is applied alongside the Helm release; it carries `tailscale.com/hostname=graf` so operators can reach the Neo4j Browser via that tailnet DNS name.
 
 Check status:

--- a/argocd/applications/graf/knative-service.yaml
+++ b/argocd/applications/graf/knative-service.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: graf-service
       containers:
         - name: graf-service
-          image: registry.ide-newton.ts.net/proompteng/graf-service:latest
+          image: registry.ide-newton.ts.net/proompteng/graf:latest
           imagePullPolicy: Always
           ports:
             - name: http1

--- a/services/graf/README.md
+++ b/services/graf/README.md
@@ -31,6 +31,6 @@ tail -n +1 build/logs/*
 ## Container image
 Build from the provided multi-stage `Dockerfile`:
 ```bash
-docker build -t graf-service:latest .
+docker build -t graf:latest .
 ```
 The entrypoint is `bin/graf` from Gradle's `installDist`, and the runtime image is a distroless Java 21 runtime.


### PR DESCRIPTION
## Summary

- rename the Graf Knative service image to `registry.ide-newton.ts.net/proompteng/graf:latest` so Kubernetes pulls the same artifact that was pushed
- document the registry path and local `graf` tag throughout the Graf README, and keep the Graf build workflow's metadata/cache references consistent with that name
- ensure the local README build instructions reference the `graf:latest` tag that matches the shared registry entry

## Related Issues

- None

## Testing

- `cd services/graf && ./gradlew clean test`

## Screenshots (if applicable)

- None

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed (`./gradlew clean test`).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and follow-up notes were updated where necessary.
