### PR TITLE
chore: move graf helm overrides to file

### DIFF
--- a/argocd/applications/graf/kustomization.yaml
+++ b/argocd/applications/graf/kustomization.yaml
@@ -11,17 +11,4 @@ helmCharts:
     releaseName: graf
     namespace: graf
     includeCRDs: true
-    values:
-      disableLookups: true
-      neo4j:
-        name: graf
-        password: ""
-      volumes:
-        data:
-          mode: dynamic
-          dynamic:
-            storageClassName: longhorn
-            accessModes:
-              - ReadWriteOnce
-            requests:
-              storage: 20Gi
+    valuesFile: neo4j-values.yaml

--- a/argocd/applications/graf/neo4j-values.yaml
+++ b/argocd/applications/graf/neo4j-values.yaml
@@ -1,0 +1,13 @@
+disableLookups: true
+neo4j:
+  name: graf
+  password: ""
+volumes:
+  data:
+    mode: dynamic
+    dynamic:
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      requests:
+        storage: 20Gi


### PR DESCRIPTION
## Summary

- split the Graf Helm chart overrides into `neo4j-values.yaml` and reference that file from `kustomization.yaml` so the lovely plugin no longer rejects the unsupported `values` field

## Related Issues

- None

## Testing

- not run (manifest-only change)

## Screenshots (if applicable)

- None

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and follow-up notes were updated where necessary.
