### PR TITLE
Integrate NVIDIA supply chain Graf workflow

### DIFF
--- a/packages/temporal-bun-sdk/src/graf/client.ts
+++ b/packages/temporal-bun-sdk/src/graf/client.ts
@@ -1,0 +1,149 @@
+import { mergeHeaders } from '../client/headers'
+import { sleep } from '../common/sleep'
+import type { GrafConfig } from '../config'
+import { loadGrafConfig } from '../config'
+import type {
+  GrafBatchResponse,
+  GrafCleanRequest,
+  GrafCleanResponse,
+  GrafComplementRequest,
+  GrafComplementResponse,
+  GrafEntityBatchRequest,
+  GrafRelationshipBatchRequest,
+} from './types'
+
+export interface GrafRequestMetadata {
+  readonly artifactId: string
+  readonly workflowId: string
+  readonly workflowRunId: string
+  readonly streamId?: string
+}
+
+export interface GrafClient {
+  persistEntities(request: GrafEntityBatchRequest, metadata: GrafRequestMetadata): Promise<GrafBatchResponse>
+  persistRelationships(request: GrafRelationshipBatchRequest, metadata: GrafRequestMetadata): Promise<GrafBatchResponse>
+  complement(request: GrafComplementRequest, metadata: GrafRequestMetadata): Promise<GrafComplementResponse>
+  clean(request: GrafCleanRequest, metadata: GrafRequestMetadata): Promise<GrafCleanResponse>
+}
+
+const metadataHeaders = (metadata: GrafRequestMetadata): Record<string, string> => {
+  const headers: Record<string, string> = {
+    'x-temporal-workflow-id': metadata.workflowId,
+    'x-temporal-workflow-run-id': metadata.workflowRunId,
+    'x-temporal-artifact-id': metadata.artifactId,
+  }
+  if (metadata.streamId) {
+    headers['x-temporal-stream-id'] = metadata.streamId
+  }
+  return headers
+}
+
+const buildHeaders = (config: GrafConfig, metadata: GrafRequestMetadata): Record<string, string> =>
+  mergeHeaders({ 'content-type': 'application/json', ...config.headers }, metadataHeaders(metadata))
+
+const normalizeUrl = (serviceUrl: string): string => serviceUrl.replace(/\/+$/u, '')
+
+const ensurePath = (path: string): string => `${path.startsWith('/') ? '' : '/'}${path}`
+
+export const createGrafClient = (config?: GrafConfig): GrafClient => {
+  const resolvedConfig = config ?? loadGrafConfig()
+  const baseUrl = normalizeUrl(resolvedConfig.serviceUrl)
+
+  const sendGrafRequest = async <T>(path: string, payload: unknown, metadata: GrafRequestMetadata): Promise<T> => {
+    const url = `${baseUrl}${ensurePath(path)}`
+    const headers = buildHeaders(resolvedConfig, metadata)
+    const body = JSON.stringify(payload)
+    const retryPolicy = resolvedConfig.retryPolicy
+    let lastError: unknown
+
+    for (let attempt = 1; attempt <= retryPolicy.maxAttempts; attempt += 1) {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), resolvedConfig.requestTimeoutMs)
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers,
+          body,
+          signal: controller.signal,
+        })
+
+        if (!response.ok) {
+          const text = await response.text()
+          const error = new Error(`Graf request failed (${path}): ${response.status} ${response.statusText} - ${text}`)
+          const shouldRetry =
+            retryPolicy.retryableStatusCodes.includes(response.status) && attempt < retryPolicy.maxAttempts
+          if (!shouldRetry) {
+            throw error
+          }
+          lastError = error
+        } else {
+          const contentType = response.headers.get('content-type') ?? ''
+          if (contentType.includes('application/json')) {
+            return (await response.json()) as T
+          }
+          const text = await response.text()
+          return text as unknown as T
+        }
+      } catch (error) {
+        lastError = error
+        if (attempt === retryPolicy.maxAttempts) {
+          throw error
+        }
+      } finally {
+        clearTimeout(timer)
+      }
+
+      if (attempt < retryPolicy.maxAttempts) {
+        const delay = Math.min(
+          retryPolicy.maxDelayMs,
+          retryPolicy.initialDelayMs * retryPolicy.backoffCoefficient ** (attempt - 1),
+        )
+        await sleep(delay)
+      }
+    }
+
+    throw lastError ?? new Error(`Graf request failed (${path})`)
+  }
+
+  return {
+    async persistEntities(request, metadata) {
+      const payload = {
+        entities: request.entities.map((entity) => ({
+          ...entity,
+          artifactId: metadata.artifactId,
+          streamId: metadata.streamId,
+          researchSource: metadata.workflowRunId,
+        })),
+      }
+      return sendGrafRequest('entities', payload, metadata)
+    },
+
+    async persistRelationships(request, metadata) {
+      const payload = {
+        relationships: request.relationships.map((relationship) => ({
+          ...relationship,
+          artifactId: metadata.artifactId,
+          streamId: metadata.streamId,
+          researchSource: metadata.workflowRunId,
+        })),
+      }
+      return sendGrafRequest('relationships', payload, metadata)
+    },
+
+    complement(request, metadata) {
+      const payload: GrafComplementRequest = {
+        ...request,
+        artifactId: metadata.artifactId,
+      }
+      return sendGrafRequest('complement', payload, metadata)
+    },
+
+    clean(request, metadata) {
+      const payload: GrafCleanRequest = {
+        ...request,
+        artifactId: metadata.artifactId,
+      }
+      return sendGrafRequest('clean', payload, metadata)
+    },
+  }
+}

--- a/packages/temporal-bun-sdk/src/graf/types.ts
+++ b/packages/temporal-bun-sdk/src/graf/types.ts
@@ -1,0 +1,61 @@
+export type JsonProperties = Record<string, unknown>
+
+export interface GrafEntityRequest {
+  readonly id?: string
+  readonly label: string
+  readonly properties?: JsonProperties
+  readonly artifactId?: string
+  readonly researchSource?: string
+  readonly streamId?: string
+}
+
+export interface GrafEntityBatchRequest {
+  readonly entities: GrafEntityRequest[]
+}
+
+export interface GrafRelationshipRequest {
+  readonly id?: string
+  readonly type: string
+  readonly fromId: string
+  readonly toId: string
+  readonly properties?: JsonProperties
+  readonly artifactId?: string
+  readonly researchSource?: string
+  readonly streamId?: string
+}
+
+export interface GrafRelationshipBatchRequest {
+  readonly relationships: GrafRelationshipRequest[]
+}
+
+export interface GrafComplementRequest {
+  readonly id: string
+  readonly hints?: JsonProperties
+  readonly artifactId?: string
+}
+
+export interface GrafCleanRequest {
+  readonly artifactId?: string
+  readonly olderThanHours?: number
+}
+
+export interface GrafResponse {
+  readonly id: string
+  readonly message: string
+  readonly artifactId?: string
+}
+
+export interface GrafBatchResponse {
+  readonly results: GrafResponse[]
+}
+
+export interface GrafComplementResponse {
+  readonly id: string
+  readonly message: string
+  readonly artifactId?: string
+}
+
+export interface GrafCleanResponse {
+  readonly affected: number
+  readonly message: string
+}

--- a/packages/temporal-bun-sdk/src/index.ts
+++ b/packages/temporal-bun-sdk/src/index.ts
@@ -10,5 +10,13 @@ export type {
   TerminateWorkflowOptions,
   WorkflowHandle,
 } from './client/types'
-export type { TemporalConfig, TLSConfig } from './config'
-export { loadTemporalConfig } from './config'
+export type { GrafConfig, GrafRetryPolicy, TemporalConfig, TLSConfig } from './config'
+export { loadGrafConfig, loadTemporalConfig } from './config'
+export type { GrafClient, GrafRequestMetadata } from './graf/client'
+export { createGrafClient } from './graf/client'
+export type {
+  GrafCleanRequest,
+  GrafComplementRequest,
+  GrafEntityBatchRequest,
+  GrafRelationshipBatchRequest,
+} from './graf/types'

--- a/packages/temporal-bun-sdk/src/workflows/index.ts
+++ b/packages/temporal-bun-sdk/src/workflows/index.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect'
 import * as Schema from 'effect/Schema'
 
 import { defineWorkflow } from '../workflow'
+import { nvidiaSupplyChainWorkflow } from './nvidia-supply-chain'
 
 export const workflows = [
   defineWorkflow('helloTemporal', Schema.Array(Schema.String), ({ input, activities, determinism }) => {
@@ -15,6 +16,7 @@ export const workflows = [
       }),
     )
   }),
+  nvidiaSupplyChainWorkflow,
 ]
 
 export default workflows

--- a/packages/temporal-bun-sdk/src/workflows/nvidia-supply-chain.ts
+++ b/packages/temporal-bun-sdk/src/workflows/nvidia-supply-chain.ts
@@ -1,0 +1,188 @@
+import { Effect } from 'effect'
+import * as Schema from 'effect/Schema'
+
+import { type GrafConfig, loadGrafConfig } from '../config'
+import { createGrafClient, type GrafClient, type GrafRequestMetadata } from '../graf/client'
+import type {
+  GrafCleanRequest,
+  GrafComplementRequest,
+  GrafEntityBatchRequest,
+  GrafRelationshipBatchRequest,
+} from '../graf/types'
+import { defineWorkflow } from '../workflow'
+
+const JsonPropertiesSchema = Schema.Record({
+  key: Schema.String,
+  value: Schema.Unknown,
+})
+
+const EntityInputSchema = Schema.Struct({
+  label: Schema.String,
+  properties: Schema.optional(JsonPropertiesSchema),
+})
+
+const RelationshipInputSchema = Schema.Struct({
+  type: Schema.String,
+  fromId: Schema.String,
+  toId: Schema.String,
+  properties: Schema.optional(JsonPropertiesSchema),
+})
+
+const ComplementInputSchema = Schema.Struct({
+  id: Schema.String,
+  hints: Schema.optional(JsonPropertiesSchema),
+})
+
+const CleanInputSchema = Schema.Struct({
+  olderThanHours: Schema.optional(Schema.Number),
+})
+
+const ArtifactInputSchema = Schema.Struct({
+  artifactId: Schema.String,
+  streamId: Schema.String,
+  confidence: Schema.Number,
+  entities: Schema.Array(EntityInputSchema),
+  relationships: Schema.Array(RelationshipInputSchema),
+  complement: Schema.optional(ComplementInputSchema),
+  clean: Schema.optional(CleanInputSchema),
+})
+
+const WorkflowInputSchema = Schema.Struct({
+  artifact: ArtifactInputSchema,
+})
+
+export interface NvidiaArtifactEntityInput {
+  readonly label: string
+  readonly properties?: Record<string, unknown>
+}
+
+export interface NvidiaArtifactRelationshipInput {
+  readonly type: string
+  readonly fromId: string
+  readonly toId: string
+  readonly properties?: Record<string, unknown>
+}
+
+export interface NvidiaArtifactComplementInput {
+  readonly id: string
+  readonly hints?: Record<string, unknown>
+}
+
+export interface NvidiaArtifactCleanInput {
+  readonly olderThanHours?: number
+}
+
+export interface NvidiaArtifactPayload {
+  readonly artifactId: string
+  readonly streamId: string
+  readonly confidence: number
+  readonly entities: ReadonlyArray<NvidiaArtifactEntityInput>
+  readonly relationships: ReadonlyArray<NvidiaArtifactRelationshipInput>
+  readonly complement?: NvidiaArtifactComplementInput
+  readonly clean?: NvidiaArtifactCleanInput
+}
+
+export interface NvidiaSupplyChainWorkflowInput {
+  readonly artifact: NvidiaArtifactPayload
+}
+
+export interface NvidiaSupplyChainWorkflowResult {
+  readonly artifactId: string
+  readonly workflowId: string
+  readonly workflowRunId: string
+  readonly status: 'skipped' | 'ingested'
+  readonly detail?: string
+}
+
+export interface NvidiaSupplyChainWorkflowDependencies {
+  readonly grafClient?: GrafClient
+  readonly grafConfig?: GrafConfig
+}
+
+const entityBatchFromArtifact = (artifact: NvidiaArtifactPayload): GrafEntityBatchRequest => ({
+  entities: artifact.entities.map((entity) => ({
+    label: entity.label,
+    properties: entity.properties,
+  })),
+})
+
+const relationshipBatchFromArtifact = (artifact: NvidiaArtifactPayload): GrafRelationshipBatchRequest => ({
+  relationships: artifact.relationships.map((relationship) => ({
+    type: relationship.type,
+    fromId: relationship.fromId,
+    toId: relationship.toId,
+    properties: relationship.properties,
+  })),
+})
+
+const complementRequestFromArtifact = (artifact: NvidiaArtifactPayload): GrafComplementRequest | undefined =>
+  artifact.complement
+    ? {
+        id: artifact.complement.id,
+        hints: artifact.complement.hints,
+      }
+    : undefined
+
+const cleanRequestFromArtifact = (artifact: NvidiaArtifactPayload): GrafCleanRequest | undefined =>
+  artifact.clean
+    ? {
+        olderThanHours: artifact.clean.olderThanHours,
+      }
+    : undefined
+
+const buildMetadata = (
+  artifact: NvidiaArtifactPayload,
+  workflowId: string,
+  workflowRunId: string,
+): GrafRequestMetadata => ({
+  artifactId: artifact.artifactId,
+  streamId: artifact.streamId,
+  workflowId,
+  workflowRunId,
+})
+
+export const createNvidiaSupplyChainWorkflow = (dependencies: NvidiaSupplyChainWorkflowDependencies = {}) => {
+  const grafConfig = dependencies.grafConfig ?? loadGrafConfig()
+  const grafClient = dependencies.grafClient ?? createGrafClient(grafConfig)
+
+  return defineWorkflow('ingestCodexArtifact', WorkflowInputSchema, ({ input, info, determinism }) =>
+    Effect.gen(function* ($) {
+      const artifact = input.artifact
+      const metadata = buildMetadata(artifact, info.workflowId, info.runId)
+
+      if (artifact.confidence < grafConfig.confidenceThreshold) {
+        return {
+          artifactId: artifact.artifactId,
+          workflowId: metadata.workflowId,
+          workflowRunId: metadata.workflowRunId,
+          status: 'skipped',
+          detail: `confidence ${artifact.confidence.toFixed(2)} < ${grafConfig.confidenceThreshold.toFixed(2)}`,
+        }
+      }
+
+      yield* $(Effect.promise(() => grafClient.persistEntities(entityBatchFromArtifact(artifact), metadata)))
+
+      yield* $(Effect.promise(() => grafClient.persistRelationships(relationshipBatchFromArtifact(artifact), metadata)))
+
+      const complementRequest = complementRequestFromArtifact(artifact)
+      if (complementRequest) {
+        yield* $(Effect.promise(() => grafClient.complement(complementRequest, metadata)))
+      }
+
+      const cleanRequest = cleanRequestFromArtifact(artifact)
+      if (cleanRequest) {
+        yield* $(Effect.promise(() => grafClient.clean(cleanRequest, metadata)))
+      }
+
+      return {
+        artifactId: artifact.artifactId,
+        workflowId: metadata.workflowId,
+        workflowRunId: metadata.workflowRunId,
+        status: 'ingested',
+        detail: new Date(determinism.now()).toISOString(),
+      }
+    }),
+  )
+}
+
+export const nvidiaSupplyChainWorkflow = createNvidiaSupplyChainWorkflow()

--- a/packages/temporal-bun-sdk/tests/graf/client.test.ts
+++ b/packages/temporal-bun-sdk/tests/graf/client.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createGrafClient, type GrafRequestMetadata } from '../../src/graf/client'
+import type { GrafConfig } from '../../src/config'
+
+const makeConfig = (): GrafConfig => ({
+  serviceUrl: 'http://graf.test',
+  headers: { authorization: 'Bearer test' },
+  confidenceThreshold: 0.7,
+  requestTimeoutMs: 1_000,
+  retryPolicy: {
+    maxAttempts: 3,
+    initialDelayMs: 1,
+    maxDelayMs: 1,
+    backoffCoefficient: 1,
+    retryableStatusCodes: [500],
+  },
+})
+
+const metadata: GrafRequestMetadata = {
+  artifactId: 'artifact-abc',
+  workflowId: 'wf-1',
+  workflowRunId: 'run-1',
+  streamId: 'stream-foo',
+}
+
+describe('Graf client', () => {
+  test('persistEntities posts metadata to /entities', async () => {
+    const client = createGrafClient(makeConfig())
+    const requests: Array<{ url: string; init: RequestInit }> = []
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = (url: string | URL, init?: RequestInit) => {
+      requests.push({ url: String(url), init: init ?? {} })
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    try {
+      await client.persistEntities(
+        { entities: [{ label: 'Company', properties: { name: 'Acme' } }] },
+        metadata,
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(requests).toHaveLength(1)
+    const payload = JSON.parse((requests[0].init.body as string) ?? '{}')
+    expect(payload.entities[0]).toEqual({
+      label: 'Company',
+      properties: { name: 'Acme' },
+      artifactId: metadata.artifactId,
+      streamId: metadata.streamId,
+      researchSource: metadata.workflowRunId,
+    })
+    const headers = requests[0].init.headers as Record<string, string>
+    expect(headers['x-temporal-workflow-id']).toBe(metadata.workflowId)
+    expect(headers['x-temporal-workflow-run-id']).toBe(metadata.workflowRunId)
+    expect(headers['x-temporal-artifact-id']).toBe(metadata.artifactId)
+    expect(headers['x-temporal-stream-id']).toBe(metadata.streamId)
+    expect(requests[0].url).toBe('http://graf.test/entities')
+  })
+
+  test('persistRelationships posts to /relationships with metadata', async () => {
+    const client = createGrafClient(makeConfig())
+    const requests: Array<{ url: string; init: RequestInit }> = []
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = (url: string | URL, init?: RequestInit) => {
+      requests.push({ url: String(url), init: init ?? {} })
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    try {
+      await client.persistRelationships(
+        {
+          relationships: [
+            {
+              type: 'PARTNERS_WITH',
+              fromId: 'Acme',
+              toId: 'Nvidia',
+            },
+          ],
+        },
+        metadata,
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0].url).toBe('http://graf.test/relationships')
+    const payload = JSON.parse((requests[0].init.body as string) ?? '{}')
+    expect(payload.relationships[0]).toMatchObject({
+      type: 'PARTNERS_WITH',
+      artifactId: metadata.artifactId,
+      streamId: metadata.streamId,
+      researchSource: metadata.workflowRunId,
+    })
+  })
+
+  test('retries on retryable failures', async () => {
+    const config = makeConfig()
+    config.retryPolicy = { ...config.retryPolicy, maxAttempts: 2 }
+    const client = createGrafClient(config)
+    const attempts: Array<number> = []
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = async () => {
+      attempts.push(attempts.length + 1)
+      if (attempts.length === 1) {
+        return new Response('boom', { status: 500 })
+      }
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    try {
+      await client.persistEntities({ entities: [{ label: 'Company' }] }, metadata)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(attempts).toEqual([1, 2])
+  })
+})

--- a/packages/temporal-bun-sdk/tests/graf/fixtures/artifact.json
+++ b/packages/temporal-bun-sdk/tests/graf/fixtures/artifact.json
@@ -1,0 +1,30 @@
+{
+  "artifactId": "artifact-123",
+  "streamId": "stream-foo",
+  "confidence": 0.85,
+  "entities": [
+    {
+      "label": "Company",
+      "properties": {
+        "name": "Acme"
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "type": "PARTNERS_WITH",
+      "fromId": "Acme",
+      "toId": "Nvidia",
+      "properties": {}
+    }
+  ],
+  "complement": {
+    "id": "acme-geo",
+    "hints": {
+      "country": "USA"
+    }
+  },
+  "clean": {
+    "olderThanHours": 24
+  }
+}

--- a/packages/temporal-bun-sdk/tests/workflow/fixtures/artifact.json
+++ b/packages/temporal-bun-sdk/tests/workflow/fixtures/artifact.json
@@ -1,0 +1,34 @@
+{
+  "artifact": {
+    "artifactId": "artifact-123",
+    "streamId": "stream-foo",
+    "confidence": 0.92,
+    "entities": [
+      {
+        "label": "Facility",
+        "properties": {
+          "name": "Fab 1"
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "type": "MANUFACTURES_AT",
+        "fromId": "Company:Acme",
+        "toId": "Facility:Fab 1",
+        "properties": {
+          "capacity": "5k"
+        }
+      }
+    ],
+    "complement": {
+      "id": "fab-geo",
+      "hints": {
+        "region": "US"
+      }
+    },
+    "clean": {
+      "olderThanHours": 48
+    }
+  }
+}

--- a/packages/temporal-bun-sdk/tests/workflow/nvidia-ingest.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/nvidia-ingest.test.ts
@@ -1,0 +1,119 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+
+import { createWorkflowContext, type WorkflowInfo } from '../../src/workflow/context'
+import { DeterminismGuard } from '../../src/workflow/determinism'
+import { createNvidiaSupplyChainWorkflow, type NvidiaSupplyChainWorkflowInput } from '../../src/workflows/nvidia-supply-chain'
+import type { GrafRequestMetadata } from '../../src/graf/client'
+import type { GrafConfig } from '../../src/config'
+
+const loadFixture = async (): Promise<NvidiaSupplyChainWorkflowInput> => {
+  const raw = await readFile(new URL('./fixtures/artifact.json', import.meta.url), 'utf8')
+  return JSON.parse(raw)
+}
+
+const makeInfo = (): WorkflowInfo => ({
+  namespace: 'default',
+  taskQueue: 'nvidia-supply-chain',
+  workflowId: 'wf-1',
+  runId: 'run-1',
+  workflowType: 'ingestCodexArtifact',
+})
+
+const makeContext = (input: NvidiaSupplyChainWorkflowInput) => {
+  const guard = new DeterminismGuard()
+  const info = makeInfo()
+  const { context } = createWorkflowContext({ input, info, determinismGuard: guard })
+  return { context, info }
+}
+
+const makeGrafConfig = (overrides: Partial<GrafConfig> = {}): GrafConfig => ({
+  serviceUrl: 'http://graf.test',
+  headers: {},
+  confidenceThreshold: 0.5,
+  requestTimeoutMs: 1_000,
+  retryPolicy: {
+    maxAttempts: 2,
+    initialDelayMs: 1,
+    maxDelayMs: 2,
+    backoffCoefficient: 1,
+    retryableStatusCodes: [500],
+  },
+  ...overrides,
+})
+
+describe('NVIDIA supply chain workflow', () => {
+  test('persists high-confidence artifacts and passes metadata', async () => {
+    const fixture = await loadFixture()
+    const { context } = makeContext(fixture)
+    const grafConfig = makeGrafConfig()
+    const calls: string[] = []
+    const metadataRecords: GrafRequestMetadata[] = []
+
+    const grafClient = {
+      async persistEntities(_request: unknown, metadata: GrafRequestMetadata) {
+        metadataRecords.push(metadata)
+        calls.push('entities')
+        return { results: [] }
+      },
+      async persistRelationships(_request: unknown, metadata: GrafRequestMetadata) {
+        metadataRecords.push(metadata)
+        calls.push('relationships')
+        return { results: [] }
+      },
+      async complement(_request: unknown, metadata: GrafRequestMetadata) {
+        metadataRecords.push(metadata)
+        calls.push('complement')
+        return { id: 'hint', message: 'ok', artifactId: metadata.artifactId }
+      },
+      async clean(_request: unknown, metadata: GrafRequestMetadata) {
+        metadataRecords.push(metadata)
+        calls.push('clean')
+        return { affected: 0, message: 'ok' }
+      },
+    }
+
+    const workflow = createNvidiaSupplyChainWorkflow({ grafClient, grafConfig })
+    const result = await Effect.runPromise(workflow.handler(context))
+
+    expect(result.status).toBe('ingested')
+    expect(calls).toEqual(['entities', 'relationships', 'complement', 'clean'])
+    expect(metadataRecords.every((meta) => meta.artifactId === fixture.artifact.artifactId)).toBe(true)
+    expect(metadataRecords.every((meta) => meta.workflowId === 'wf-1')).toBe(true)
+  })
+
+  test('skips persistence when confidence is below threshold', async () => {
+    const fixture = await loadFixture()
+    fixture.artifact.confidence = 0.1
+    const { context } = makeContext(fixture)
+    const grafConfig = makeGrafConfig({ confidenceThreshold: 0.9 })
+    const calls: string[] = []
+
+    const grafClient = {
+      async persistEntities() {
+        calls.push('entities')
+        return { results: [] }
+      },
+      async persistRelationships() {
+        calls.push('relationships')
+        return { results: [] }
+      },
+      async complement() {
+        calls.push('complement')
+        return { id: 'hint', message: 'ok', artifactId: 'artifact-123' }
+      },
+      async clean() {
+        calls.push('clean')
+        return { affected: 0, message: 'ok' }
+      },
+    }
+
+    const workflow = createNvidiaSupplyChainWorkflow({ grafClient, grafConfig })
+    const result = await Effect.runPromise(workflow.handler(context))
+
+    expect(result.status).toBe('skipped')
+    expect(result.detail).toContain('confidence')
+    expect(calls).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- add Graf client/types/config plumbing, register the new `ingestCodexArtifact` workflow, and export the helpers alongside the existing Temporal SDK entry points
- gate artifacts using `SUPPLY_CHAIN_ARTIFACT_CONFIDENCE_THRESHOLD`, annotate Graf requests with artifact/stream/workflow metadata, and emit complementary cleanup hints
- cover the new paths with fixtures/tests and update the README/design doc so operators know how to start the workflow and tune Graf/TLS settings

## Related Issues

- closes #1712

## Testing

- `bun test` (monorepo) – fails in the existing `deploy script` sanitized manifest test (same failure happens on `main`)
- `bun test tests/graf/client.test.ts tests/workflow/nvidia-ingest.test.ts`
- `pnpm exec biome check packages/temporal-bun-sdk/src`
- `cd packages/temporal-bun-sdk && bun run build`
- `curl -sf http://graf-service.graf.svc.cluster.local:8080/healthz` (fails with exit 6 because the hostname is not reachable inside this workspace)
- `temporal workflow execute --workflow-id smoke-1 --type ingestCodexArtifact --task-queue nvidia-supply-chain --input '{"artifact":{"artifactId":"smoke","streamId":"stream-smoke","confidence":0.9,"entities":[],"relationships":[]}}'` (run started with id `019a656c-f9a8-7e94-aea6-ee827f0baf51` while CLI was running locally; command had to be interrupted because no worker finished the execution)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed
- [x] Screenshots and Breaking Changes sections are handled appropriately
- [x] Documentation, release notes, and follow-ups are updated or tracked
