### PR TITLE
chore: ignore graf statefulset/service drift

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -243,6 +243,12 @@ spec:
             - .spec.volumeClaimTemplates
         - kind: StatefulSet
           group: apps
+          namespace: graf
+          name: graf-db
+          jqPathExpressions:
+            - .spec.volumeClaimTemplates
+        - kind: StatefulSet
+          group: apps
           namespace: lgtm
           jqPathExpressions:
             - .spec.volumeClaimTemplates[].apiVersion
@@ -268,6 +274,13 @@ spec:
             - .spec.template.spec.containers[].readinessProbe.periodSeconds
             - .spec.template.spec.containers[].readinessProbe.successThreshold
             - .spec.template.spec.containers[].readinessProbe.timeoutSeconds
+        - kind: Service
+          group: serving.knative.dev
+          namespace: graf
+          name: graf
+          jqPathExpressions:
+            - .spec.template.spec.containers[].ports[].protocol
+            - .spec.template.spec.containers[].readinessProbe.successThreshold
         - kind: Deployment
           group: apps
           namespace: istio-system


### PR DESCRIPTION
## Summary

- Add Argo CD ignore rules so the Graf Neo4j StatefulSet (`apps/StatefulSet graf-db`) no longer triggers drift on volumeClaimTemplates.
- Ignore Knative-generated port/probe fields for `serving.knative.dev/Service graf` so the app stays Synced when Knative injects protocol/successThreshold.

## Related Issues

None

## Testing

- argocd app diff graf --hard-refresh

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
