### PR TITLE
fix: expose graf neo4j browser on standard ports

### DIFF
--- a/argocd/applications/graf/neo4j-browser-service.yaml
+++ b/argocd/applications/graf/neo4j-browser-service.yaml
@@ -14,9 +14,9 @@ spec:
   ports:
     - name: http
       protocol: TCP
-      port: 7474
+      port: 80
       targetPort: 7474
     - name: https
       protocol: TCP
-      port: 7473
+      port: 443
       targetPort: 7473


### PR DESCRIPTION
## Summary

- expose the graf Neo4j Browser tailscale LoadBalancer on ports 80/443
- keep the backend target ports on 7474/7473 so the chart wiring remains untouched
- add a 7687 bolt mapping so Browser logins can reach the database over Tailscale directly

## Related Issues

None

## Testing

- Not run (Kubernetes manifest change only)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
