### PR TITLE
fix: expose graf neo4j bolt port via tailscale

### DIFF
--- a/argocd/applications/graf/neo4j-browser-service.yaml
+++ b/argocd/applications/graf/neo4j-browser-service.yaml
@@ -20,3 +20,7 @@ spec:
       protocol: TCP
       port: 443
       targetPort: 7473
+    - name: bolt
+      protocol: TCP
+      port: 7687
+      targetPort: 7687


### PR DESCRIPTION
## Summary

- add a `bolt` port on the graf Neo4j Browser LoadBalancer so tailscale clients can reach `bolt://graf:7687`
- keep the existing 80/443 HTTP/HTTPS mappings for the Browser UI unchanged
- note that this resolves the Browser connection spinner because the database port now forwards through tailscale

## Related Issues

None

## Testing

- Not run (Kubernetes manifest change only)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
