### PR TITLE
chore: manage graf neo4j credentials via sealed secret

### DIFF
--- a/argocd/applications/graf/README.md
+++ b/argocd/applications/graf/README.md
@@ -5,6 +5,7 @@
 - The Argo CD `graf` application deploys the chart into the `graf` namespace and creates the Helm release named `graf`. It also applies `knative-service.yaml`, which registers the Kotlin persistence service in the same namespace so Temporal/Knative can reach the graph API.
 - The Knative service pulls its image from the shared Tailscale registry host `registry.ide-newton.ts.net/proompteng/graf:latest`.
 - A `graf-neo4j-browser` LoadBalancer service is applied alongside the Helm release; it carries `tailscale.com/hostname=graf` so operators can reach the Neo4j Browser via that tailnet DNS name.
+- Neo4j credentials live in the `graf-auth` SealedSecret checked in as `graf-auth-secret.yaml`; the Helm values reference it via `neo4j.passwordFromSecret`. Rotate them by generating a new password, updating the sealed secret, and applying it before syncing Argo CD.
 - The `/v1` graph APIs now require a bearer token. The Knative service reads `GRAF_API_BEARER_TOKENS` from the `graf-api` SealedSecret defined in `graf-api-secret.yaml` (`bearer-tokens` key, comma or newline separated). The checked-in manifest currently contains a placeholder (`REPLACE_WITH_ACTUAL_TOKENS`), so re-seal it with the real tokens before the next sync:
 - The Codex workflow template and its RBAC helpers live in `argocd/applications/argo-workflows` because they must stay in the `argo-workflows` namespace; they are no longer rendered through this `graf` kustomization.
 

--- a/argocd/applications/graf/graf-auth-secret.yaml
+++ b/argocd/applications/graf/graf-auth-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: graf-auth
+  namespace: graf
+spec:
+  encryptedData:
+    NEO4J_AUTH: AgCZCrh4eTOnksc4X4DJ9slSZ8Gxg/SbHhj2f5IPixErPlC+lUidejO63D8tw+Hq55YmN0fIt7aTf2Yj3mwLHzbIRq4uziqutGHLc0+HXB5ukiBgvfWabOreo6TbOUTKb7cUgKl7x92eW4o9O9HGUOB1fkMFwibmzpZ2OZMk2Kua1mLLz0Xfp37Zbp8Cyge0hxMlIealSPT1g4i6WZ0YC2auW1kAVc0TSbQI2oPlMfWSxTDKZcMKIQ3bKsjq7K7DaWH2h4uX5OR9nAc6UUiBtCh1d7Vk27/ufcqGOJVx3Qk3qmrrdV/whHOJU2OYG2HOvC89bELFwSL4t68gKXbEvDBQMeyXFCOM7PE232+azfcnkiqMaKSR47dDOsTFFQxLJyHtjcdbuJf5t99VO9uamfP6/ACse9arXO3W+xp4Rc837AXG09w+8h8mkseVoqNoDUZpMtu0hnXiSRM9YFBwu6fcyx4jVXt3V1y6LwWlv06NxtvbMipmn50OxxjXZiYgBslWeL8lUItp2Z2JuaI0XypOvgMgUFBb2Ax+8R8ULx8hpheOjVzdFae8+nc3QaVqwjHjKhRIizSMOpyhYhLLEYyrKSJ9YE81GUqgWTBg1RwKvGabKDycL06VML4wxwAAEARQBbhAnvownZFJo3uhGjp7/yiTrde4G2rtA/qbw9nax25wZmVoCLoAUalNXT9VNidAjPrpfxsGDWVMK8PVpNTH7wKncEQLmX3q0g==
+  template:
+    metadata:
+      name: graf-auth
+      namespace: graf

--- a/argocd/applications/graf/knative-service.yaml
+++ b/argocd/applications/graf/knative-service.yaml
@@ -17,14 +17,14 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "60"
-        client.knative.dev/updateTimestamp: 2025-11-09T09:32:40.512Z
+        client.knative.dev/updateTimestamp: 2025-11-09T10:38:10.270Z
     spec:
       timeoutSeconds: 60
       containerConcurrency: 0
       serviceAccountName: graf
       containers:
         - name: user-container
-          image: registry.ide-newton.ts.net/proompteng/graf@sha256:0383a7677d70129530802213e5779828290eee135a553e2ccf467bae2ea44069
+          image: registry.ide-newton.ts.net/proompteng/graf@sha256:7b96ed553a8e11ef1172bdfa59f32e5418fe97c91b0fcb3ee12c839408ec6f05
           imagePullPolicy: Always
           ports:
             - name: http1
@@ -47,9 +47,9 @@ spec:
                   name: graf-api
                   key: bearer-tokens
             - name: GRAF_VERSION
-              value: v0.304.0-2-ga1963833
+              value: v0.304.1-2-g8492ce71
             - name: GRAF_COMMIT
-              value: a1963833f20580f153b2e7f584895825a9729011
+              value: 8492ce716546601d4fc1723d2fc818f45db7c649
             - name: MINIO_ENDPOINT
               value: http://observability-minio.minio.svc.cluster.local:9000
             - name: MINIO_BUCKET

--- a/argocd/applications/graf/kustomization.yaml
+++ b/argocd/applications/graf/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - service-account.yaml
   - knative-service.yaml
   - graf-api-secret.yaml
+  - graf-auth-secret.yaml
   - neo4j-browser-service.yaml
 helmCharts:
   - name: neo4j

--- a/argocd/applications/graf/neo4j-values.yaml
+++ b/argocd/applications/graf/neo4j-values.yaml
@@ -2,6 +2,7 @@ disableLookups: true
 neo4j:
   name: graf
   password: ""
+  passwordFromSecret: graf-auth
 volumes:
   data:
     mode: dynamic


### PR DESCRIPTION
## Summary

- add a sealed `graf-auth` secret and wire `neo4j.passwordFromSecret` so Neo4j + Graf consume repo-managed credentials
- refresh the Graf Knative service manifest with the newly built image digest and version metadata
- document the rotation workflow in the Graf README and prune the unsupported tls reload config knob

## Related Issues

None

## Testing

- bun packages/scripts/src/graf/deploy-service.ts

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
