### PR TITLE
feat: seed NVIDIA Graf prompts and coverage

### DIFF
--- a/docs/graf-codex-research/prompts/README.md
+++ b/docs/graf-codex-research/prompts/README.md
@@ -1,0 +1,25 @@
+# Graf Codex research prompt catalog
+
+This directory stores the NVIDIA Graf research prompt catalog referenced by `packages/scripts/src/graf/run-prompts.ts`. The catalog ensures each stream (foundries, ODM/EMS, logistics/ports, research partners, financing/risk, instrumentation vendors) has structured metadata, scoring heuristics, and citation guidance.
+
+## Layout
+
+- `prompt-schema.json`: JSON Schema describing every property a prompt definition must expose.
+- `catalog.json`: Index of the active prompt files, catalog metadata (version, schema), and stream-level routing hints.
+- `*.json`: One prompt definition per stream. Promote the schema before editing by running the validation commands below.
+
+## Editing workflow
+
+1. Update the stream-specific JSON file (e.g., `foundries.json`) with the required fields: `promptId`, `streamId`, `objective`, `inputs`, `expectedJsonEnvelope`, `scoringHeuristics`, and `citationPolicy`.
+2. Run `pnpm exec biome check packages/scripts/src/graf` and `bun test packages/scripts/src/graf/**/__tests__/*.test.ts` to confirm the shared TypeScript schema still parses the updated structure.
+3. If the schema changes, update `prompt-schema.json` and the TypeScript `zod` schema (`packages/scripts/src/graf/schema.ts`), then rerun Biome and the tests.
+4. Add or refresh the corresponding entry in `catalog.json` (include `promptId`, `streamId`, `file`, `priority`, `cadence`, and any metadata your workflows need).
+5. Reference the updated prompts in `docs/graf-codex-research.md` so Temporal/Argo operators know how to interpret the new fields.
+
+## Validation
+
+- `pnpm exec biome check packages/scripts/src/graf`
+- `bun test packages/scripts/src/graf/**/__tests__/*.test.ts`
+- `bun packages/scripts/src/graf/run-prompts.ts --dry-run` (ensures the driver can read every prompt and report what would be sent)
+
+Run these commands from the repository root whenever you modify the catalog or driver logic.

--- a/docs/graf-codex-research/prompts/catalog.json
+++ b/docs/graf-codex-research/prompts/catalog.json
@@ -1,0 +1,77 @@
+{
+  "catalogId": "nvidia-graf-research-prompts",
+  "name": "NVIDIA Graf research prompt catalog",
+  "description": "Structured definitions for the NVIDIA Graf Codex research streams; each entry enumerates inputs, metadata, scoring heuristics, and citation policy references drawn from docs/nvidia-supply-chain-graph-design.md.",
+  "version": "2025.11.09",
+  "schema": "prompt-schema.json",
+  "updatedAt": "2025-11-09T10:00:00Z",
+  "documentation": "README.md",
+  "streams": [
+    {
+      "promptId": "nvidia-foundries",
+      "streamId": "foundries",
+      "file": "foundries.json",
+      "priority": "high",
+      "cadence": "biweekly",
+      "metadata": {
+        "catalogPosition": "1",
+        "topicGroup": "manufacturing"
+      }
+    },
+    {
+      "promptId": "nvidia-odm-ems",
+      "streamId": "odm-ems",
+      "file": "odm-ems.json",
+      "priority": "high",
+      "cadence": "monthly",
+      "metadata": {
+        "catalogPosition": "2",
+        "topicGroup": "integration"
+      }
+    },
+    {
+      "promptId": "nvidia-logistics-ports",
+      "streamId": "logistics-ports",
+      "file": "logistics-ports.json",
+      "priority": "medium",
+      "cadence": "weekly",
+      "metadata": {
+        "catalogPosition": "3",
+        "topicGroup": "logistics"
+      }
+    },
+    {
+      "promptId": "nvidia-research-partners",
+      "streamId": "research-partners",
+      "file": "research-partners.json",
+      "priority": "medium",
+      "cadence": "monthly",
+      "metadata": {
+        "catalogPosition": "4",
+        "topicGroup": "research"
+      }
+    },
+    {
+      "promptId": "nvidia-financing-risk",
+      "streamId": "financing-risk",
+      "file": "financing-risk.json",
+      "priority": "high",
+      "cadence": "monthly",
+      "metadata": {
+        "catalogPosition": "5",
+        "topicGroup": "risk"
+      }
+    },
+    {
+      "promptId": "nvidia-instrumentation-vendors",
+      "streamId": "instrumentation-vendors",
+      "file": "instrumentation-vendors.json",
+      "priority": "medium",
+      "cadence": "monthly",
+      "metadata": {
+        "catalogPosition": "6",
+        "topicGroup": "auxiliary"
+      }
+    }
+  ]
+}

--- a/docs/graf-codex-research/prompts/financing-risk.json
+++ b/docs/graf-codex-research/prompts/financing-risk.json
@@ -1,0 +1,107 @@
+{
+  "promptId": "nvidia-financing-risk",
+  "title": "Financing & risk posture research",
+  "streamId": "financing-risk",
+  "objective": "Capture financing shifts, insurance coverage, and macro risk indicators that could reweight NVIDIA's supply commitments.",
+  "description": "Track capital availability, hedging, geopolitical risk, sanctions, and insurance or warranty exposures along the supply graph.",
+  "promptTemplate": "You are the risk intelligence analyst for NVIDIA's financing stream. Use the Inputs below (financialSignals, riskAlerts, policySignals) to produce EXACT JSON matching the expected envelope with streamId \"financing-risk\". Include net exposures, risk migration, and mitigation plans. Reference docs/nvidia-supply-chain-graph-design.md (RiskTag, Graph fidelity, Architecture Overview) plus credible sources for each claim. Leave artifactId/workflowId null and fill generatedAt with the current RFC 3339 timestamp. Apply the scoring heuristics and citation policy tied to this stream when scoring confidence or labeling risk severity.\n\nInputs:\n- financialSignals: statements about budget shifts, financing approvals, or currency hedges relevant to NVIDIA supply partners.\n- riskAlerts: insurance claims, political risk warnings, sanctions chatter, or macro indicators affecting suppliers.\n- policySignals: new legislation, embargoes, or export changes that alter risk footprints.\n\nReturn only the JSON object described in expectedJsonEnvelope; append no prose afterwards.",
+  "metadata": {
+    "priority": "high",
+    "cadence": "monthly"
+  },
+  "inputs": [
+    {
+      "name": "financialSignals",
+      "type": "array",
+      "description": "Capital commitments, credit lines, or liquidity events tied to NVIDIA supply partners or their financiers.",
+      "required": true,
+      "example": "[\"Tier-1 supplier secured a bonded financing facility\", \"Currency hedging desk increased exposure to KRW\"]"
+    },
+    {
+      "name": "riskAlerts",
+      "type": "array",
+      "description": "Insurance claims, credit downgrades, sanctions, or audit outcomes that change the risk posture of nodes in the graph.",
+      "required": true,
+      "example": "[\"Sanctions tightening around a logistics provider in the region\", \"Insurance payout triggered by warehouse fire\"]"
+    },
+    {
+      "name": "policySignals",
+      "type": "array",
+      "description": "Export control updates, legislative reviews, or compliance reminders that could constrain financing or sourcing.",
+      "required": false,
+      "example": "[\"New export licensing rules for advanced packaging equipment to Taiwan\"]"
+    }
+  ],
+  "expectedJsonEnvelope": {
+    "summary": "Risk and financing object for Neo4j risk scoring.",
+    "fields": [
+      {
+        "name": "streamId",
+        "type": "string",
+        "description": "Set to \"financing-risk\" for accurate lineage.",
+        "required": true
+      },
+      {
+        "name": "workflowId",
+        "type": "string",
+        "description": "Temporal workflow identifier (null placeholder).",
+        "required": false
+      },
+      {
+        "name": "artifactId",
+        "type": "string",
+        "description": "Graf artifact reference (null until Graf fills).",
+        "required": false
+      },
+      {
+        "name": "generatedAt",
+        "type": "string",
+        "description": "RFC 3339 timestamp of artifact generation.",
+        "required": true
+      },
+      {
+        "name": "findings",
+        "type": "array",
+        "description": "Findings should describe financing posture, risk likelihood, and mitigation moves.",
+        "required": true
+      },
+      {
+        "name": "risks",
+        "type": "array",
+        "description": "Detailed risk tags (financial, geopolitical, insurance).",
+        "required": true
+      },
+      {
+        "name": "nextSteps",
+        "type": "array",
+        "description": "Actions for compliance, hedging, or financial teams.",
+        "required": false
+      },
+      {
+        "name": "citations",
+        "type": "array",
+        "description": "Citations referencing docs/nvidia-supply-chain-graph-design.md and finance/regulatory sources.",
+        "required": true
+      },
+      {
+        "name": "confidence",
+        "type": "number",
+        "description": "Score between 0.0 and 1.0 guided by the scoring heuristics.",
+        "required": true
+      }
+    ]
+  },
+  "scoringHeuristics": [
+    "Confidence should be ≥0.7 when citing multiple financial/risk data points that align with the Neo4j RiskTag schema.",
+    "Lower confidence by 0.25 when deductions rely on predictive models or indirect signals.",
+    "Boost confidence when multiple sources (financial regulators, partner filings) corroborate a risk migration."
+  ],
+  "citationPolicy": {
+    "summary": "Cite docs/nvidia-supply-chain-graph-design.md (RiskTag, Graph Platform, Neo4j Schema Highlights) plus regulatory or industry disclosures for each risk callout.",
+    "references": [
+      "docs/nvidia-supply-chain-graph-design.md (Neo4j Schema Highlights, RiskTag nodes, Concurrent Codex Stream Considerations)",
+      "docs/nvidia-supply-chain-graph-design.md (Temporal → Argo → Codex → Service Flow, Architecture Overview)"
+    ],
+    "enforcement": "Each risk finding must have at least two citations (one canonical doc reference and one external source) and include the section or url used for verification."
+  }
+}

--- a/docs/graf-codex-research/prompts/foundries.json
+++ b/docs/graf-codex-research/prompts/foundries.json
@@ -1,0 +1,107 @@
+{
+  "promptId": "nvidia-foundries",
+  "title": "Foundry capacity & resilience research",
+  "streamId": "foundries",
+  "objective": "Capture wafer fabrication capacity, node readiness, and risk for NVIDIA's Tier-0 foundries so the Neo4j model reflects the latest supply constraints.",
+  "description": "Focus on capacity planning, certification upgrades, location risk, alternative sources, and how these impact NVIDIA's multi-node design roadmaps.",
+  "promptTemplate": "You are the NVIDIA supply chain research analyst for the foundries stream. Ingest the latest market signals, wafer fab announcements, and policy risk indicators (see the Inputs section below). Your job is to emit EXACT JSON that matches the expected envelope and tags each finding with the streamId \"foundries\". Every finding should include `summary`, `confidence` (0.0-1.0), and `evidence` that cites docs/nvidia-supply-chain-graph-design.md plus any other verifiable sources you referenced. Set `artifactId`/`workflowId` to `null` (Graf will attach the real values later) and populate `generatedAt` with the current RFC 3339 timestamp. Use the scoring heuristics and citation policy defined in this catalog entry when deciding the confidence score and when to flag risk or mitigation steps.\n\nInputs:\n- capacitySignals: statements about wafer starts, node yields, new tool orders, or fab expansion cadence.\n- fabEvents: alerts on maintenance, regulatory reviews, or disruptions (power, workers, water) affecting the fabs identified in docs/nvidia-supply-chain-graph-design.md.\n- riskIndicators: policy shifts, sanctions updates, or supplier audits that change the resilience posture of each fab.\n\nReturn only the JSON object described in expectedJsonEnvelope; do not append prose outside the object.",
+  "metadata": {
+    "priority": "high",
+    "cadence": "biweekly"
+  },
+  "inputs": [
+    {
+      "name": "capacitySignals",
+      "type": "array",
+      "description": "Statements describing wafer starts, yield changes, node certifications, or intake volume commitments for major fabs (TSMC, Samsung, etc.).",
+      "required": true,
+      "example": "[\"TSMC Q4 wafer bookings climbed 8%\", \"Samsung 3nm line delayed by six weeks\"]"
+    },
+    {
+      "name": "fabEvents",
+      "type": "array",
+      "description": "Events such as maintenance windows, regulatory inspections, or raw material shortages that can constrain production slots.",
+      "required": true,
+      "example": "[\"Power curtailment notice for TSMC Hsinchu plants\", \"Samsung certification for HVM EUV nodes\"]"
+    },
+    {
+      "name": "riskIndicators",
+      "type": "array",
+      "description": "Policy, geopolitical, or downstream demand shifts that may increase the failure probability for each fab relationship.",
+      "required": false,
+      "example": "[\"New export control guidance impacts EUV tool deployment to Taiwan\"]"
+    }
+  ],
+  "expectedJsonEnvelope": {
+    "summary": "Structured insight object that Neo4j can ingest for foundry relationships.",
+    "fields": [
+      {
+        "name": "streamId",
+        "type": "string",
+        "description": "Must equal \"foundries\" to keep lineage correct.",
+        "required": true
+      },
+      {
+        "name": "workflowId",
+        "type": "string",
+        "description": "Temporal workflow identifier (leave null when drafting).",
+        "required": false
+      },
+      {
+        "name": "artifactId",
+        "type": "string",
+        "description": "Graf artifact key (set to null in the prompt output).",
+        "required": false
+      },
+      {
+        "name": "generatedAt",
+        "type": "string",
+        "description": "RFC 3339 timestamp of when the artifact was generated.",
+        "required": true
+      },
+      {
+        "name": "findings",
+        "type": "array",
+        "description": "Array of findings with {summary, confidence, evidence, impact}.",
+        "required": true
+      },
+      {
+        "name": "risks",
+        "type": "array",
+        "description": "Binary or tiered risk buckets (capacity, certifications, sanctions).",
+        "required": false
+      },
+      {
+        "name": "nextSteps",
+        "type": "array",
+        "description": "Recommended nudges for Temporal (refresh cadence, manual validation, supplier outreach).",
+        "required": false
+      },
+      {
+        "name": "citations",
+        "type": "array",
+        "description": "Every major claim must cite docs/nvidia-supply-chain-graph-design.md or another citable source with {source, url, excerpt}.",
+        "required": true
+      },
+      {
+        "name": "confidence",
+        "type": "number",
+        "description": "Normalized 0.0-1.0 score that mirrors the scoring heuristics below.",
+        "required": true
+      }
+    ]
+  },
+  "scoringHeuristics": [
+    "Confidence should start at 0.7 when multiple citations reference docs/nvidia-supply-chain-graph-design.md before weighting others.",
+    "Lower the confidence by at least 0.15 when a signal is purely speculative or lacks an industry announcement.",
+    "Elevate confidence (≥0.85) when you can tie capacity changes to confirmed fab commitments and cite the exact section that describes the stream catalog or graph fidelity."
+  ],
+  "citationPolicy": {
+    "summary": "Always cite docs/nvidia-supply-chain-graph-design.md (Purpose, Graph fidelity, and Stream catalog sections) when describing the canonical model; add source URLs for any external signal.",
+    "references": [
+      "docs/nvidia-supply-chain-graph-design.md (Purpose, Graph fidelity, Temporal → Argo → Codex → Service Flow)",
+      "docs/nvidia-supply-chain-graph-design.md (Concurrent Codex Stream Considerations, Stream catalog)"
+    ],
+    "enforcement": "Every finding and risk callout must cite at least one reference, and citations must include a url or document section identifier. Use the streamId to align this evidence with Neo4j's ResearchSource nodes."
+  }
+}

--- a/docs/graf-codex-research/prompts/instrumentation-vendors.json
+++ b/docs/graf-codex-research/prompts/instrumentation-vendors.json
@@ -1,0 +1,107 @@
+{
+  "promptId": "nvidia-instrumentation-vendors",
+  "title": "Instrumentation vendors and metrology readiness",
+  "streamId": "instrumentation-vendors",
+  "objective": "Document the instrumentation, metrology, and test tooling vendors that NVIDIA relies on so the Neo4j graph includes auxiliary hypothesis that support physical testing.",
+  "description": "Capture availability, certification cycles, service-level impacts, and strategic investments by instrumentation partners (metrology tools, test racks, etc.).",
+  "promptTemplate": "You are the instrumentation analyst for NVIDIA's supply chain graph. Use the Inputs below to reason about tooling availability, service contracts, and calibration needs. Output EXACT JSON per expectedJsonEnvelope and set streamId to \"instrumentation-vendors\". Each finding should note tooling backlog, calibration status, or service coverage, citing docs/nvidia-supply-chain-graph-design.md (Instrumentation/auxiliary industries sections) plus any vendor statements. Keep artifactId/workflowId null and write generatedAt in RFC 3339 format. Follow the scoring heuristics and citation policy in this entry for confidence assignments.\n\nInputs:\n- vendorSignals: vendor announcements about shipments, calibration, or support windows.\n- testCoverage: signals about test rack throughput, certification runs, or new metrology equipment.\n- serviceRequests: service calls, replacement orders, or maintenance visits that may delay instrumentation.\n\nReturn no prose outside the JSON object defined by expectedJsonEnvelope.",
+  "metadata": {
+    "priority": "medium",
+    "cadence": "monthly"
+  },
+  "inputs": [
+    {
+      "name": "vendorSignals",
+      "type": "array",
+      "description": "Messages from instrumentation vendors about delivery slots, calibration cycles, or new tool orders.",
+      "required": true,
+      "example": "[\"Vendor A allocated four EUV metrology units to Nvidia labs\", \"Vendor B reported shipment delay for high-speed test racks\"]"
+    },
+    {
+      "name": "testCoverage",
+      "type": "array",
+      "description": "Updates on test-floor coverage, throughput, and certification runs for NVIDIA hardware.",
+      "required": false,
+      "example": "[\"Test floor reports 12-hour calibration backlog\", \"New automation scripts cleared subsystem validation\"]"
+    },
+    {
+      "name": "serviceRequests",
+      "type": "array",
+      "description": "Service visits, spare part orders, or maintenance narratives that affect instrumentation uptime.",
+      "required": false,
+      "example": "[\"Requested vendor engineer to recalibrate double-sided reflow oven\"]"
+    }
+  ],
+  "expectedJsonEnvelope": {
+    "summary": "Instrumentation vendor insight object for auxiliary industries.",
+    "fields": [
+      {
+        "name": "streamId",
+        "type": "string",
+        "description": "Should read \"instrumentation-vendors\" for this stream.",
+        "required": true
+      },
+      {
+        "name": "workflowId",
+        "type": "string",
+        "description": "Temporal workflow ID placeholder.",
+        "required": false
+      },
+      {
+        "name": "artifactId",
+        "type": "string",
+        "description": "Graf artifact reference (null in the prompt).",
+        "required": false
+      },
+      {
+        "name": "generatedAt",
+        "type": "string",
+        "description": "RFC 3339 timestamp of artifact creation.",
+        "required": true
+      },
+      {
+        "name": "findings",
+        "type": "array",
+        "description": "Findings describing tool availability, calibration, and risk.",
+        "required": true
+      },
+      {
+        "name": "risks",
+        "type": "array",
+        "description": "Risks introduced by instrument downtime, calibration slips, or vendor liquidity.",
+        "required": false
+      },
+      {
+        "name": "nextSteps",
+        "type": "array",
+        "description": "Recommendations for scheduling, buffer stock, or manual verification.",
+        "required": false
+      },
+      {
+        "name": "citations",
+        "type": "array",
+        "description": "Citations referencing docs/nvidia-supply-chain-graph-design.md and vendor notes for each claim.",
+        "required": true
+      },
+      {
+        "name": "confidence",
+        "type": "number",
+        "description": "Confidence score between 0.0 and 1.0 guided by the scoring heuristics.",
+        "required": true
+      }
+    ]
+  },
+  "scoringHeuristics": [
+    "Confidence should read ≥0.7 when multiple vendor/test-floor inputs converge on a single readiness state.",
+    "Reduce confidence when the signal is from a single analyst or lacks confirmed instrumentation data.",
+    "Increase confidence when vendor updates tie directly to the auxiliary industries described in docs/nvidia-supply-chain-graph-design.md."
+  ],
+  "citationPolicy": {
+    "summary": "Cite docs/nvidia-supply-chain-graph-design.md (auxiliary industries, instrumentation vendor context) plus vendor release notes or maintenance logs.",
+    "references": [
+      "docs/nvidia-supply-chain-graph-design.md (Purpose, Architecture Overview, Neo4j Schema Highlights for auxiliary industries)",
+      "docs/nvidia-supply-chain-graph-design.md (Concurrent Codex Stream Considerations, Stream catalog)"
+    ],
+    "enforcement": "Each finding should provide the doc section or url that grounds the instrumentation claim; pair it with a vendor note when discussing availability."
+  }
+}

--- a/docs/graf-codex-research/prompts/logistics-ports.json
+++ b/docs/graf-codex-research/prompts/logistics-ports.json
@@ -1,0 +1,107 @@
+{
+  "promptId": "nvidia-logistics-ports",
+  "title": "Logistics & ports routing intelligence",
+  "streamId": "logistics-ports",
+  "objective": "Document major shipping lanes, port congestion, and logistics providers so the graph captures Visa-level movement constraints for NVIDIA hardware.",
+  "description": "Focus on carriers, terminals, transshipment points, customs delays, and their impact on downstream builds/shipments.",
+  "promptTemplate": "You are the transportation intelligence analyst for NVIDIA's logistics & ports stream. Synthesize the Inputs below to reason about port availability, carrier reliability, and emergent delays that might reroute NVIDIA shipments. Produce EXACT JSON matching the expected envelope and set streamId to \"logistics-ports\". List shipment events, congestion snapshots, and resilience actions, citing docs/nvidia-supply-chain-graph-design.md (LogisticsProvider, Logistics, and Graph fidelity sections) plus any authority reporting the event. Leave artifactId/workflowId null and emit generatedAt as the current RFC 3339 timestamp. Apply the scoring heuristics and citation policy in this entry to determine confidence and risk severity.\n\nInputs:\n- laneSignals: new or rerouted lanes, rerouting approvals, or carrier capacity shifts for NVIDIA-relevant cargo.\n- portAlerts: congestion metrics, berth availability, customs queues, or terminal closures affecting the target ports.\n- transitCapacity: freight rate changes, warehouse constraints, or trucking/rail availability that feeds into port throughput.\n\nReturn only the JSON object described in expectedJsonEnvelope; append no prose afterwards.",
+  "metadata": {
+    "priority": "medium",
+    "cadence": "weekly"
+  },
+  "inputs": [
+    {
+      "name": "laneSignals",
+      "type": "array",
+      "description": "Updates about ocean/air/rail lanes used by NVIDIA for finished goods or components, including forced diversions.",
+      "required": true,
+      "example": "[\"Maersk rerouted Asia-Pacific trans-shipments away from Ningbo\", \"Air freight space tightened between Seattle and Taipei\"]"
+    },
+    {
+      "name": "portAlerts",
+      "type": "array",
+      "description": "Terminal congestion, customs processes, berth shortages, or weather closures that hamper throughput.",
+      "required": false,
+      "example": "[\"Key port reports 6+ day berth delay due to Typhoon\", \"Customs flagged documentation gap for first-party transloading\"]"
+    },
+    {
+      "name": "transitCapacity",
+      "type": "array",
+      "description": "Carrier capacity adjustments, trucking pools, or rail link statuses that inform lead-time changes.",
+      "required": false,
+      "example": "[\"Rail operator advising 40% decline in locomotive availability\", \"Trucking pool limiting hazardous rate loads\"]"
+    }
+  ],
+  "expectedJsonEnvelope": {
+    "summary": "Structured logistics & ports insight object for the Graf graph.",
+    "fields": [
+      {
+        "name": "streamId",
+        "type": "string",
+        "description": "Must be \"logistics-ports\" for this stream.",
+        "required": true
+      },
+      {
+        "name": "workflowId",
+        "type": "string",
+        "description": "Temporal workflow id (null in practice).",
+        "required": false
+      },
+      {
+        "name": "artifactId",
+        "type": "string",
+        "description": "Placeholder for Graf's artifact key.",
+        "required": false
+      },
+      {
+        "name": "generatedAt",
+        "type": "string",
+        "description": "Timestamp in RFC 3339 format.",
+        "required": true
+      },
+      {
+        "name": "findings",
+        "type": "array",
+        "description": "Each finding should include {summary, confidence, evidence, impact, affectedPorts}.",
+        "required": true
+      },
+      {
+        "name": "risks",
+        "type": "array",
+        "description": "List of short-term or systemic logistics risks.",
+        "required": false
+      },
+      {
+        "name": "nextSteps",
+        "type": "array",
+        "description": "Suggestions for re-routing, stockpile moves, or manual review.",
+        "required": false
+      },
+      {
+        "name": "citations",
+        "type": "array",
+        "description": "Citations describing each claim; reference docs/nvidia-supply-chain-graph-design.md and logistics providers.",
+        "required": true
+      },
+      {
+        "name": "confidence",
+        "type": "number",
+        "description": "Confidence score derived from the heuristics in this catalog entry.",
+        "required": true
+      }
+    ]
+  },
+  "scoringHeuristics": [
+    "Confidence should remain ≥0.6 when you cite port capacity reports or verified carrier notices.",
+    "Reduce confidence when the signal is anecdotal or derived from a single unverified terminal update.",
+    "Elevate confidence (≥0.8) for multi-provider consensus (e.g., both port and carrier confirm a reroute) and when referencing docs/nvidia-supply-chain-graph-design.md."
+  ],
+  "citationPolicy": {
+    "summary": "Cite docs/nvidia-supply-chain-graph-design.md (LogisticsProvider, Graph Platform, and Concurrent Codex Stream Considerations) plus carrier or port press releases.",
+    "references": [
+      "docs/nvidia-supply-chain-graph-design.md (Graph fidelity, Concurrent Codex Stream Considerations, Temporal → Argo → Codex Flow)",
+      "docs/nvidia-supply-chain-graph-design.md (Neo4j Schema Highlights for LogisticsProvider nodes)"
+    ],
+    "enforcement": "Every finding should include both the canonical doc reference and an independent carrier/port source with url/excerpt. For risks, cite at least two sources when possible."
+  }
+}

--- a/docs/graf-codex-research/prompts/odm-ems.json
+++ b/docs/graf-codex-research/prompts/odm-ems.json
@@ -1,0 +1,107 @@
+{
+  "promptId": "nvidia-odm-ems",
+  "title": "ODM/EMS execution & integration research",
+  "streamId": "odm-ems",
+  "objective": "Track the ODM/EMS partners that assemble and integrate NVIDIA systems so the graph knows which integrators back which product families.",
+  "description": "Highlight contract status, integration readiness, yield performance, and co-engineering risks while correlating those facts with NVIDIA's planned product launch windows.",
+  "promptTemplate": "You are the NVIDIA supply chain research analyst for the ODM/EMS stream. Use the Inputs section below to reason about assembly partners, integration line readiness, and quality escapes. Emit EXACT JSON that matches the expected envelope and sets streamId to \"odm-ems\". Capture contract remarks, backlog risks, and integration signals, and cite docs/nvidia-supply-chain-graph-design.md plus any OEM/EMS statements. Keep artifactId/workflowId null for now and write generatedAt with the current RFC 3339 timestamp. Apply the scoring heuristics and citation policy in this catalog entry when assigning confidence and flagging follow-up actions or mitigations.\n\nInputs:\n- contractSignals: new contract awards, ramp schedules, or exclusivity clauses affecting ODM/EMS partners.\n- integrationRequests: system-level integration requirements, test coverage updates, or co-design dependencies that impact MOS trust.\n- qualityAlerts: failure modes, recall watchlists, or inspection outcomes reported by labor or partners.\n\nReturn only the JSON object described in expectedJsonEnvelope; append nothing else.",
+  "metadata": {
+    "priority": "high",
+    "cadence": "monthly"
+  },
+  "inputs": [
+    {
+      "name": "contractSignals",
+      "type": "array",
+      "description": "Announcements describing new or amended ODM/EMS contracts, ramp schedules, or changes to assembly volume commitments.",
+      "required": true,
+      "example": "[\"ODM partner X to assemble Blackwell prototypes in Q1\", \"EMS supplier Y adding a dedicated Nvidia line\"]"
+    },
+    {
+      "name": "integrationRequests",
+      "type": "array",
+      "description": "Integration/update requests such as firmware dependencies, validation labs, or shared tooling that must align with NVIDIA's reference designs.",
+      "required": true,
+      "example": "[\"EMS integration lab seeking access to NVLink test rig\", \"ODM claims board-level cooling redesign\"]"
+    },
+    {
+      "name": "qualityAlerts",
+      "type": "array",
+      "description": "Post-production issues, inspections, yield anomalies, or recalls that could affect assembly continuity or release timing.",
+      "required": false,
+      "example": "[\"Operational audit flagged inconsistency in chassis sealing\", \"EMS reported 1.2% yield drop linked to double-sided reflow\"]"
+    }
+  ],
+  "expectedJsonEnvelope": {
+    "summary": "Graph-friendly ODM/EMS intelligence object.",
+    "fields": [
+      {
+        "name": "streamId",
+        "type": "string",
+        "description": "Must equal \"odm-ems\" for stream alignment.",
+        "required": true
+      },
+      {
+        "name": "workflowId",
+        "type": "string",
+        "description": "Temporal workflow identifier (set to null in the prompt output).",
+        "required": false
+      },
+      {
+        "name": "artifactId",
+        "type": "string",
+        "description": "Graf artifact key placeholder.",
+        "required": false
+      },
+      {
+        "name": "generatedAt",
+        "type": "string",
+        "description": "RFC 3339 timestamp of artifact creation.",
+        "required": true
+      },
+      {
+        "name": "findings",
+        "type": "array",
+        "description": "List of {summary, confidence, evidence, impact} describing the current ODM/EMS posture.",
+        "required": true
+      },
+      {
+        "name": "risks",
+        "type": "array",
+        "description": "Risks tied to ramp timing, integration gaps, or quality events.",
+        "required": false
+      },
+      {
+        "name": "nextSteps",
+        "type": "array",
+        "description": "Recommended follow-up actions for Temporal or procurement.",
+        "required": false
+      },
+      {
+        "name": "citations",
+        "type": "array",
+        "description": "Evidence for each claim; reference docs/nvidia-supply-chain-graph-design.md and vendor communications.",
+        "required": true
+      },
+      {
+        "name": "confidence",
+        "type": "number",
+        "description": "Confidence score from 0.0 to 1.0 informed by scoring heuristics.",
+        "required": true
+      }
+    ]
+  },
+  "scoringHeuristics": [
+    "Confidence should lean ≥0.75 when two or more inputs describe the same integration or quality milestone.",
+    "Drop confidence by at least 0.2 when a signal is based on unverified rumors or single-source speculation.",
+    "Raise confidence when OEM/EMS statements align with the Temporal-managed stream catalog described in docs/nvidia-supply-chain-graph-design.md."
+  ],
+  "citationPolicy": {
+    "summary": "Cite docs/nvidia-supply-chain-graph-design.md (Graph fidelity and Stream catalog sections) for canonical metadata and include partner statements for operational claims.",
+    "references": [
+      "docs/nvidia-supply-chain-graph-design.md (Graph fidelity, Stream catalog, Temporal → Argo → Codex → Service Flow)",
+      "docs/nvidia-supply-chain-graph-design.md (Concurrent Codex Stream Considerations)"
+    ],
+    "enforcement": "Every finding should include at least one citation; cite section names or paragraph numbers when possible and pair them with supporting URLs from partner or news statements."
+  }
+}

--- a/docs/graf-codex-research/prompts/prompt-schema.json
+++ b/docs/graf-codex-research/prompts/prompt-schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Graf research prompt definition",
+  "type": "object",
+  "required": [
+    "promptId",
+    "title",
+    "streamId",
+    "objective",
+    "promptTemplate",
+    "inputs",
+    "expectedJsonEnvelope",
+    "scoringHeuristics",
+    "citationPolicy"
+  ],
+  "properties": {
+    "promptId": {
+      "type": "string",
+      "description": "Globally unique key for the prompt."
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable title for this stream."
+    },
+    "streamId": {
+      "type": "string",
+      "description": "Temporal stream identifier stored on artifacts."
+    },
+    "objective": {
+      "type": "string",
+      "description": "High-level research goal."
+    },
+    "description": {
+      "type": "string",
+      "description": "Extended explanation for maintainers."
+    },
+    "promptTemplate": {
+      "type": "string",
+      "description": "Instructional text sent to Graf/Codex."
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Optional tags (priority, cadence, etc.)."
+    },
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/inputDefinition"
+      }
+    },
+    "expectedJsonEnvelope": {
+      "type": "object",
+      "required": [
+        "summary",
+        "fields"
+      ],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "Overview of the JSON layout."
+        },
+        "fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/fieldDefinition"
+          }
+        }
+      }
+    },
+    "scoringHeuristics": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "citationPolicy": {
+      "$ref": "#/$defs/citationPolicy"
+    }
+  },
+  "definitions": {
+    "inputDefinition": {
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "description"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "example": {
+          "type": "string"
+        }
+      }
+    },
+    "fieldDefinition": {
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "description"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "citationPolicy": {
+      "type": "object",
+      "required": [
+        "summary",
+        "references"
+      ],
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "references": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "enforcement": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/graf-codex-research/prompts/research-partners.json
+++ b/docs/graf-codex-research/prompts/research-partners.json
@@ -1,0 +1,107 @@
+{
+  "promptId": "nvidia-research-partners",
+  "title": "Research partners collaboration intelligence",
+  "streamId": "research-partners",
+  "objective": "Surface research partner programs, academic relationships, and joint technology experiments that feed NVIDIA's innovations.",
+  "description": "Describe collaboration status, mutual deliverables, intellectual property guardrails, and how these partnerships intersect with NVIDIA research goals.",
+  "promptTemplate": "You are the research partnership analyst for NVIDIA's supply chain graph. Leverage the Inputs below to reason about the strength of each partnership, open deliverables, and research confidences. Return EXACT JSON matching the expected envelope and set streamId to \"research-partners\". Document the relevance to the research graph, cite docs/nvidia-supply-chain-graph-design.md (ResearchSource, Research Partners, Architecture Overview) and external technical disclosures, and keep artifactId/workflowId null while populating generatedAt with the current RFC 3339 timestamp. Follow the scoring heuristics and citation policy defined here when deciding confidence or flagging uncertainty.\n\nInputs:\n- partnerUpdates: program updates, memorandum of understanding, or research deliveries in progress.\n- capabilitySignals: breakthrough publications, lab expansions, or equipment acquisitions by a partner.\n- engagementRequests: outstanding requests for tooling, data, or verification from NVIDIA research teams.\n\nDo not append prose outside the JSON object described in expectedJsonEnvelope.",
+  "metadata": {
+    "priority": "medium",
+    "cadence": "monthly"
+  },
+  "inputs": [
+    {
+      "name": "partnerUpdates",
+      "type": "array",
+      "description": "Progress updates from academic or research partners, including contract renewals and joint lab statuses.",
+      "required": true,
+      "example": "[\"University lab X delivered early benchmarking data\", \"Partner Y signed a new data-sharing agreement\"]"
+    },
+    {
+      "name": "capabilitySignals",
+      "type": "array",
+      "description": "Published papers, patents, or prototype test results that show a partner's capability in GPU/AI research.",
+      "required": false,
+      "example": "[\"Partner Z published an AI system optimization for tensor cores\"]"
+    },
+    {
+      "name": "engagementRequests",
+      "type": "array",
+      "description": "Requests for instrumentation, datasets, or point-of-contact support from NVIDIA research leads.",
+      "required": false,
+      "example": "[\"Request for NVSwitch testbeds in Singapore lab\"]"
+    }
+  ],
+  "expectedJsonEnvelope": {
+    "summary": "Research partner insight object that can seed ResearchSource nodes and partnership edges.",
+    "fields": [
+      {
+        "name": "streamId",
+        "type": "string",
+        "description": "Set to \"research-partners\" for this catalog entry.",
+        "required": true
+      },
+      {
+        "name": "workflowId",
+        "type": "string",
+        "description": "Temporal workflow id (left null in the prompt output).",
+        "required": false
+      },
+      {
+        "name": "artifactId",
+        "type": "string",
+        "description": "Placeholder for Graf artifact reference.",
+        "required": false
+      },
+      {
+        "name": "generatedAt",
+        "type": "string",
+        "description": "The RFC 3339 timestamp for this artifact.",
+        "required": true
+      },
+      {
+        "name": "findings",
+        "type": "array",
+        "description": "Findings should describe program status, capability, and alignment to NVIDIA research goals.",
+        "required": true
+      },
+      {
+        "name": "risks",
+        "type": "array",
+        "description": "Risks related to IP, shared tooling, or partner bandwidth.",
+        "required": false
+      },
+      {
+        "name": "nextSteps",
+        "type": "array",
+        "description": "Actions for mentorship, testing, or documentation to fortify the partnership.",
+        "required": false
+      },
+      {
+        "name": "citations",
+        "type": "array",
+        "description": "Each claim must include a citation referencing docs/nvidia-supply-chain-graph-design.md or partner documents.",
+        "required": true
+      },
+      {
+        "name": "confidence",
+        "type": "number",
+        "description": "Normalized confidence derived from the scoring heuristics.",
+        "required": true
+      }
+    ]
+  },
+  "scoringHeuristics": [
+    "Confidence should be ≥0.7 when referencing signed agreements or published joint results.",
+    "Reduce confidence when discussing speculative pipeline items or unsanctioned collaborations.",
+    "Boost confidence when you can tie partner signals to artifacts already stored in the ResearchSource node schema described in docs/nvidia-supply-chain-graph-design.md."
+  ],
+  "citationPolicy": {
+    "summary": "Cite docs/nvidia-supply-chain-graph-design.md (ResearchSource, Research Partners, Architecture Overview) plus partner disclosures or journal publications.",
+    "references": [
+      "docs/nvidia-supply-chain-graph-design.md (Architecture Overview, Neo4j Schema Highlights, Research stream component diagram)",
+      "docs/nvidia-supply-chain-graph-design.md (Concurrent Codex Stream Considerations, Stream catalog)"
+    ],
+    "enforcement": "Record citations that include document titles or urls; pair them with doc references when you discuss how the data should seed ResearchSource nodes in Neo4j."
+  }
+}

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -14,6 +14,7 @@ Utility Bun/TypeScript scripts that automate common platform workflows. Use `bun
 | Script | Description | Required CLIs | Example |
 | --- | --- | --- | --- |
 | `src/codex/trigger-review-workflow.ts` | Collects unresolved review threads and failing checks for a pull request and submits the `github-codex-review` Argo workflow when action is needed. | `gh`, `argo` | `bun run packages/scripts/src/codex/trigger-review-workflow.ts --pr=1529` (also accepts full PR URLs) |
+| `src/graf/run-prompts.ts` | Validates the NVIDIA Graf prompt catalog, optionally filters by prompt/stream, and POSTs each prompt to `/v1/codex-research`, logging the Graf `workflowId`/`runId` output. Supports `--graf-url`, token flags, and `--dry-run`. | none (fetch-built-in) | `bun run packages/scripts/src/graf/run-prompts.ts --graf-url http://localhost:8080 --dry-run` |
 | `src/froussard/deploy-service.ts` | Builds/pushes the Froussard image via `pnpm --filter froussard run deploy` and exports the live Knative Service for GitOps. | `pnpm`, `kubectl` | `bun run packages/scripts/src/froussard/deploy-service.ts` |
 | `src/froussard/reseal-secrets.ts` | Reseals the Froussard SealedSecrets using the cluster cert bundle. | `kubectl`, `openssl`, `kubeseal` | `bun run packages/scripts/src/froussard/reseal-secrets.ts` |
 | `src/facteur/build-image.ts` | Builds the Facteur container image and pushes to the configured registry. | `docker`/`podman` | `bun run packages/scripts/src/facteur/build-image.ts` |
@@ -31,6 +32,8 @@ pnpm --filter @proompteng/scripts lint
 
 # Execute Bun tests
 bun test packages/scripts/src/**/__tests__/*.test.ts
+# Validate the Graf prompt catalog driver (dry run only)
+bun packages/scripts/src/graf/run-prompts.ts --graf-url http://localhost:8080 --dry-run
 ```
 
 These commands are also executed in CI (see `.github/workflows/scripts-ci.yml`).

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -7,7 +7,8 @@
     "lint": "biome lint"
   },
   "dependencies": {
-    "yaml": "^2.8.0"
+    "yaml": "^2.8.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "bun-types": "^1.1.20",

--- a/packages/scripts/src/graf/__tests__/prompt-schema.test.ts
+++ b/packages/scripts/src/graf/__tests__/prompt-schema.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test'
+
+import { promptDefinitionSchema } from '../schema'
+
+const minimalPrompt = {
+  promptId: 'test-prompt',
+  title: 'Test prompt',
+  streamId: 'test-stream',
+  objective: 'Confirm the schema exports validation helpers.',
+  promptTemplate: 'Please return JSON.',
+  inputs: [
+    {
+      name: 'context',
+      type: 'string',
+      description: 'Any contextual payload.',
+    },
+  ],
+  expectedJsonEnvelope: {
+    summary: 'A summary field',
+    fields: [
+      {
+        name: 'testField',
+        type: 'string',
+        description: 'A test field.',
+      },
+    ],
+  },
+  scoringHeuristics: ['Score high when metadata is referenced.'],
+  citationPolicy: {
+    summary: 'Cite docs/nvidia-supply-chain-graph-design.md when referencing context.',
+    references: ['docs/nvidia-supply-chain-graph-design.md (Purpose)'],
+  },
+}
+
+describe('promptDefinitionSchema', () => {
+  it('rejects a definition without streamId', () => {
+    const { streamId: _, ...broken } = minimalPrompt
+    const result = promptDefinitionSchema.safeParse(broken)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const hasStreamIdIssue = result.error.issues.some((issue) => issue.path.includes('streamId'))
+      expect(hasStreamIdIssue).toBe(true)
+    }
+  })
+
+  it('accepts a minimal valid definition', () => {
+    const parsed = promptDefinitionSchema.parse(minimalPrompt)
+    expect(parsed.promptId).toBe('test-prompt')
+  })
+})

--- a/packages/scripts/src/graf/run-prompts.ts
+++ b/packages/scripts/src/graf/run-prompts.ts
@@ -1,0 +1,190 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { promptCatalogSchema, promptDefinitionSchema } from './schema'
+import type { PromptCatalog, PromptDefinition } from './types'
+
+type DriverOptions = {
+  catalogPath: string
+  grafUrl: string
+  promptId?: string
+  streamId?: string
+  token?: string
+  tokenFile?: string
+  dryRun: boolean
+}
+
+const DEFAULT_CATALOG = resolve(process.cwd(), 'docs/graf-codex-research/prompts/catalog.json')
+const DEFAULT_GRAF_URL = 'http://localhost:8080'
+
+const usage = () => {
+  console.log(`Usage: run-prompts [options]
+
+Options:
+  --catalog <path>         Path to the prompt catalog JSON (defaults to ${DEFAULT_CATALOG})
+  --prompt-id <id>         Submit only the prompt with this ID
+  --stream-id <id>         Submit prompts associated with this stream
+  --graf-url <url>         Graf base URL (default ${DEFAULT_GRAF_URL})
+  --token <token>          Bearer token for Graf
+  --token-file <path>      File containing the bearer token
+  --dry-run                Only validate prompts and log what would be posted
+  -h, --help               Show this help message`)
+}
+
+const parseArgs = (argv: string[]): DriverOptions => {
+  const options: DriverOptions = {
+    catalogPath: DEFAULT_CATALOG,
+    grafUrl: DEFAULT_GRAF_URL,
+    dryRun: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--catalog':
+        options.catalogPath = argv[++i]
+        break
+      case '--prompt-id':
+        options.promptId = argv[++i]
+        break
+      case '--stream-id':
+        options.streamId = argv[++i]
+        break
+      case '--graf-url':
+        options.grafUrl = argv[++i]
+        break
+      case '--token':
+        options.token = argv[++i]
+        break
+      case '--token-file':
+        options.tokenFile = argv[++i]
+        break
+      case '--dry-run':
+        options.dryRun = true
+        break
+      case '-h':
+        usage()
+        process.exit(0)
+        break
+      case '--help':
+        usage()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+const loadCatalog = async (path: string): Promise<PromptCatalog> => {
+  const raw = await readFile(path, 'utf8')
+  return promptCatalogSchema.parse(JSON.parse(raw))
+}
+
+const loadPrompt = async (baseDir: string, entryFile: string): Promise<PromptDefinition> => {
+  const fullPath = resolve(baseDir, entryFile)
+  const raw = await readFile(fullPath, 'utf8')
+  return promptDefinitionSchema.parse(JSON.parse(raw))
+}
+
+const shouldSubmit = (options: DriverOptions, entry: PromptDefinition): boolean => {
+  if (options.promptId && entry.promptId !== options.promptId) {
+    return false
+  }
+  if (options.streamId && entry.streamId !== options.streamId) {
+    return false
+  }
+  return true
+}
+
+const resolveToken = async (options: DriverOptions): Promise<string | undefined> => {
+  if (options.token) {
+    return options.token
+  }
+  if (options.tokenFile) {
+    const raw = await readFile(options.tokenFile, 'utf8')
+    return raw.trim()
+  }
+  return process.env.GRAF_API_TOKEN ?? process.env.GRAF_TOKEN
+}
+
+const postPrompt = async (
+  grafUrl: string,
+  definition: PromptDefinition,
+  metadata: Record<string, string>,
+  token?: string,
+) => {
+  const url = `${grafUrl.replace(/\/$/, '')}/v1/codex-research`
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      prompt: definition.promptTemplate,
+      metadata,
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Graf responded ${response.status}: ${body}`)
+  }
+
+  const payload = await response.json()
+  const workflowId = payload.workflowId ?? payload.argoWorkflowName ?? 'unknown'
+  const runId = payload.runId ?? 'unknown'
+  console.log(`prompt=${definition.promptId} workflowId=${workflowId} runId=${runId}`)
+}
+
+const run = async () => {
+  const options = parseArgs(process.argv.slice(2))
+  const catalog = await loadCatalog(options.catalogPath)
+  const catalogDir = dirname(options.catalogPath)
+  const token = await resolveToken(options)
+
+  const entries: Array<{ prompt: PromptDefinition; stream: PromptCatalog['streams'][number] }> = []
+  for (const stream of catalog.streams) {
+    const prompt = await loadPrompt(catalogDir, stream.file)
+    if (shouldSubmit(options, prompt)) {
+      entries.push({ prompt, stream })
+    }
+  }
+
+  if (entries.length === 0) {
+    console.warn('No prompts matched the filter criteria; nothing to submit.')
+    return
+  }
+
+  for (const { prompt, stream } of entries) {
+    const metadata: Record<string, string> = {
+      promptId: prompt.promptId,
+      streamId: prompt.streamId,
+      catalogVersion: catalog.version,
+      priority: stream.priority ?? 'normal',
+      cadence: stream.cadence ?? 'unknown',
+      citationPolicy: prompt.citationPolicy.summary,
+    }
+    if (stream.metadata) {
+      Object.assign(metadata, stream.metadata)
+    }
+
+    if (options.dryRun) {
+      console.log(`dry-run prompt=${prompt.promptId} metadata=${JSON.stringify(metadata)}`)
+      continue
+    }
+
+    await postPrompt(options.grafUrl, prompt, metadata, token)
+  }
+}
+
+run().catch((error) => {
+  console.error('run-prompts failed:', error)
+  process.exit(1)
+})

--- a/packages/scripts/src/graf/schema.ts
+++ b/packages/scripts/src/graf/schema.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod'
+
+const promptInputSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  description: z.string(),
+  required: z.boolean().optional(),
+  example: z.string().optional(),
+})
+
+const envelopeFieldSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  description: z.string(),
+  required: z.boolean().optional(),
+})
+
+const expectedJsonEnvelopeSchema = z.object({
+  summary: z.string(),
+  fields: z.array(envelopeFieldSchema).min(1),
+})
+
+const citationPolicySchema = z.object({
+  summary: z.string(),
+  references: z.array(z.string()).min(1),
+  enforcement: z.string().optional(),
+})
+
+export const promptDefinitionSchema = z.object({
+  promptId: z.string(),
+  title: z.string(),
+  streamId: z.string(),
+  objective: z.string(),
+  description: z.string().optional(),
+  promptTemplate: z.string(),
+  metadata: z.record(z.string()).optional(),
+  inputs: z.array(promptInputSchema).min(1),
+  expectedJsonEnvelope: expectedJsonEnvelopeSchema,
+  scoringHeuristics: z.array(z.string()).min(1),
+  citationPolicy: citationPolicySchema,
+})
+
+const catalogEntrySchema = z.object({
+  promptId: z.string(),
+  streamId: z.string(),
+  file: z.string(),
+  priority: z.string().optional(),
+  cadence: z.string().optional(),
+  metadata: z.record(z.string()).optional(),
+})
+
+export const promptCatalogSchema = z.object({
+  catalogId: z.string(),
+  name: z.string(),
+  description: z.string(),
+  version: z.string(),
+  schema: z.string(),
+  updatedAt: z.string(),
+  documentation: z.string().optional(),
+  streams: z.array(catalogEntrySchema).min(1),
+})

--- a/packages/scripts/src/graf/types.ts
+++ b/packages/scripts/src/graf/types.ts
@@ -1,0 +1,7 @@
+import type { z } from 'zod'
+import type { promptCatalogSchema, promptDefinitionSchema } from './schema'
+
+export type PromptDefinition = z.infer<typeof promptDefinitionSchema>
+export type PromptCatalog = z.infer<typeof promptCatalogSchema>
+export type PromptCatalogEntry = PromptCatalog['streams'][number]
+export type PromptMetadata = PromptDefinition['metadata']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,13 +184,13 @@ importers:
         version: 1.131.44(@tanstack/react-router@1.131.44(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(webpack@5.99.9)
       '@trpc/client':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105)
+        version: 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251109))(typescript@6.0.0-dev.20251109)
       '@trpc/server':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251105)
+        version: 11.0.0-rc.824(typescript@6.0.0-dev.20251109)
       '@trpc/tanstack-react-query':
         specifier: ^11.0.0-rc.818
-        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251105)
+        version: 11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251109))(typescript@6.0.0-dev.20251109))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251109))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251109)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -239,7 +239,7 @@ importers:
         version: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.0-dev.20251105)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 5.1.4(typescript@6.0.0-dev.20251109)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
 
   apps/nata:
     dependencies:
@@ -594,6 +594,9 @@ importers:
       yaml:
         specifier: ^2.8.0
         version: 2.8.1
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
     devDependencies:
       bun-types:
         specifier: ^1.1.20
@@ -9752,8 +9755,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20251105:
-    resolution: {integrity: sha512-1qXzjLkr7/FSYqHvV5GyP/16Y4bJyO4OcboOVBOGcorurTfB2Gf0Vya/3nPVcAunSPBq/VM9hzVPsFX1M9buZg==}
+  typescript@6.0.0-dev.20251109:
+    resolution: {integrity: sha512-kRfs6Op05piLPd5Vdpyciv2lDS2UYN0WnKPiyygNwGtzy9Xj8afUIkze0BIer5+7E12ANb0pZkk9e4XMIuq2mg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -15781,23 +15784,23 @@ snapshots:
       long: 5.3.1
       protobufjs: 7.4.0
 
-  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105)':
+  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251109))(typescript@6.0.0-dev.20251109)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251105)
-      typescript: 6.0.0-dev.20251105
+      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251109)
+      typescript: 6.0.0-dev.20251109
 
-  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105)':
+  '@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251109)':
     dependencies:
-      typescript: 6.0.0-dev.20251105
+      typescript: 6.0.0-dev.20251109
 
-  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251105)':
+  '@trpc/tanstack-react-query@11.0.0-rc.824(@tanstack/react-query@5.89.0(react@19.0.0))(@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251109))(typescript@6.0.0-dev.20251109))(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251109))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@6.0.0-dev.20251109)':
     dependencies:
       '@tanstack/react-query': 5.89.0(react@19.0.0)
-      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251105))(typescript@6.0.0-dev.20251105)
-      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251105)
+      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@6.0.0-dev.20251109))(typescript@6.0.0-dev.20251109)
+      '@trpc/server': 11.0.0-rc.824(typescript@6.0.0-dev.20251109)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      typescript: 6.0.0-dev.20251105
+      typescript: 6.0.0-dev.20251109
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -17246,7 +17249,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20251105
+      typescript: 6.0.0-dev.20251109
 
   dunder-proto@1.0.1:
     dependencies:
@@ -21483,9 +21486,9 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.8(@swc/helpers@0.5.15)
 
-  tsconfck@3.1.5(typescript@6.0.0-dev.20251105):
+  tsconfck@3.1.5(typescript@6.0.0-dev.20251109):
     optionalDependencies:
-      typescript: 6.0.0-dev.20251105
+      typescript: 6.0.0-dev.20251109
 
   tslib@1.14.1: {}
 
@@ -21523,7 +21526,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.0-dev.20251105: {}
+  typescript@6.0.0-dev.20251109: {}
 
   ufo@1.5.4: {}
 
@@ -21816,11 +21819,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251105)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-tsconfig-paths@5.1.4(typescript@6.0.0-dev.20251109)(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.5(typescript@6.0.0-dev.20251105)
+      tsconfck: 3.1.5(typescript@6.0.0-dev.20251109)
     optionalDependencies:
       vite: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:

--- a/services/graf/src/test/kotlin/ai/proompteng/graf/codex/CodexResearchActivitiesImplTest.kt
+++ b/services/graf/src/test/kotlin/ai/proompteng/graf/codex/CodexResearchActivitiesImplTest.kt
@@ -2,71 +2,105 @@ package ai.proompteng.graf.codex
 
 import ai.proompteng.graf.model.ArtifactReference
 import ai.proompteng.graf.model.BatchResponse
+import ai.proompteng.graf.model.EntityBatchRequest
+import ai.proompteng.graf.model.GraphResponse
+import ai.proompteng.graf.model.RelationshipBatchRequest
 import ai.proompteng.graf.services.GraphPersistence
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.slot
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import java.io.ByteArrayInputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class CodexResearchActivitiesImplTest {
-  private val graphPersistence = mockk<GraphPersistence>(relaxed = true)
-  private val artifactFetcher = mockk<MinioArtifactFetcher>()
-  private val activities =
-    CodexResearchActivitiesImpl(
-      argoClient = mockk(relaxed = true),
-      graphPersistence = graphPersistence,
-      artifactFetcher = artifactFetcher,
-      json = Json { ignoreUnknownKeys = true },
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun activities(
+    argo: ArgoWorkflowClient = mockk(),
+    persistence: GraphPersistence = mockk(),
+    fetcher: MinioArtifactFetcher = mockk(),
+  ) =
+    CodexResearchActivitiesImpl(argo, persistence, fetcher, json)
+
+  @Test
+  fun `downloadArtifact returns streamed content`() = runBlocking {
+    val fetcher = mockk<MinioArtifactFetcher>()
+    val reference = ArtifactReference("bucket", "key", "endpoint")
+    every { fetcher.open(reference) } returns "payload".byteInputStream()
+
+    val activities = activities(fetcher = fetcher)
+    val content = activities.downloadArtifact(reference)
+    assertEquals("payload", content)
+  }
+
+  @Test
+  fun `persistCodexArtifact throws when payload is malformed`() {
+    val activities = activities()
+    val input = CodexResearchWorkflowInput(
+      prompt = "test",
+      metadata = emptyMap(),
+      argoWorkflowName = "workflow",
+      artifactKey = "artifact-key",
+      argoPollTimeoutSeconds = 10,
     )
 
-  @Test
-  fun `downloadArtifact returns payload`() =
-    runBlocking {
-      val reference = ArtifactReference("bucket", "key", "https://minio", null)
-      val payload = """{"data":"value"}"""
-      val stream = ByteArrayInputStream(payload.toByteArray())
-      every { artifactFetcher.open(reference) } returns stream
-
-      val result = activities.downloadArtifact(reference)
-
-      assertEquals(payload, result)
-      verify {
-        artifactFetcher.open(reference)
-      }
-    }
+    assertFailsWith<SerializationException> { activities.persistCodexArtifact("not json", input) }
+  }
 
   @Test
-  fun `persistCodexArtifact writes entities and relationships`() =
-    runBlocking {
-      val payload = """{
-            "entities": [
-                {"label": "Node", "properties": {"id": "node:1"}}
-            ],
-            "relationships": [
-                {"type": "LINKS", "fromId": "node:1", "toId": "node:2"}
-            ]
-        }"""
-      coEvery { graphPersistence.upsertEntities(any()) } returns BatchResponse(emptyList())
-      coEvery { graphPersistence.upsertRelationships(any()) } returns BatchResponse(emptyList())
+  fun `persistCodexArtifact upserts entities and relationships`() {
+    val persistence = mockk<GraphPersistence>()
+    val entitySlot = slot<EntityBatchRequest>()
+    val relationshipSlot = slot<RelationshipBatchRequest>()
+    coEvery { persistence.upsertEntities(capture(entitySlot)) } returns BatchResponse(emptyList())
+    coEvery { persistence.upsertRelationships(capture(relationshipSlot)) } returns BatchResponse(emptyList())
 
-      activities.persistCodexArtifact(
-        payload,
-        CodexResearchWorkflowInput(
-          prompt = "prompt",
-          metadata = emptyMap(),
-          argoWorkflowName = "name",
-          artifactKey = "key",
-          argoPollTimeoutSeconds = 7200,
-        ),
-      )
+    val activities = activities(persistence = persistence)
+    val payload =
+      """
+        {
+          "entities": [
+            {
+              "id": "entity-1",
+              "label": "Company",
+              "properties": {},
+              "artifactId": "artifact",
+              "streamId": "test-stream"
+            }
+          ],
+          "relationships": [
+            {
+              "id": "rel-1",
+              "type": "PARTNERS_WITH",
+              "fromId": "entity-1",
+              "toId": "entity-2",
+              "properties": {},
+              "artifactId": "artifact",
+              "streamId": "test-stream"
+            }
+          ]
+        }
+      """.trimIndent()
 
-      coVerify { graphPersistence.upsertEntities(match { it.entities.size == 1 }) }
-      coVerify { graphPersistence.upsertRelationships(match { it.relationships.size == 1 }) }
-    }
+    val input = CodexResearchWorkflowInput(
+      prompt = "test",
+      metadata = emptyMap(),
+      argoWorkflowName = "workflow",
+      artifactKey = "artifact-key",
+      argoPollTimeoutSeconds = 10,
+    )
+
+    activities.persistCodexArtifact(payload, input)
+
+    coVerify(exactly = 1) { persistence.upsertEntities(any()) }
+    coVerify(exactly = 1) { persistence.upsertRelationships(any()) }
+    assertEquals("entity-1", entitySlot.captured.entities.first().id)
+    assertEquals("PARTNERS_WITH", relationshipSlot.captured.relationships.first().type)
+  }
 }


### PR DESCRIPTION
## Summary
- add the NVIDIA Graf research prompt catalog (schema, README, catalog.json, and one JSON file per stream) so Temporal stream metadata and citation rules are anchored in docs/nvidia-supply-chain-graph-design.md.
- introduce the Bun driver in packages/scripts/src/graf/run-prompts.ts plus shared Zod schema/types, a schema unit test, and README guidance for running/validating the catalog.
- update docs/graf-codex-research.md and services/graf/README.md while expanding CodexResearchActivitiesImplTest coverage so Codex artifact ingestion exercises GraphPersistence and downstream tests run via ./gradlew test/kover.

## Related Issues
- closes #1728

## Testing
- Checked 6 files in 12ms. No fixes applied.
- bun test v1.2.14 (6a363a38)
- dry-run prompt=nvidia-foundries metadata={"promptId":"nvidia-foundries","streamId":"foundries","catalogVersion":"2025.11.09","priority":"high","cadence":"biweekly","citationPolicy":"Always cite docs/nvidia-supply-chain-graph-design.md (Purpose, Graph fidelity, and Stream catalog sections) when describing the canonical model; add source URLs for any external signal.","catalogPosition":"1","topicGroup":"manufacturing"}
dry-run prompt=nvidia-odm-ems metadata={"promptId":"nvidia-odm-ems","streamId":"odm-ems","catalogVersion":"2025.11.09","priority":"high","cadence":"monthly","citationPolicy":"Cite docs/nvidia-supply-chain-graph-design.md (Graph fidelity and Stream catalog sections) for canonical metadata and include partner statements for operational claims.","catalogPosition":"2","topicGroup":"integration"}
dry-run prompt=nvidia-logistics-ports metadata={"promptId":"nvidia-logistics-ports","streamId":"logistics-ports","catalogVersion":"2025.11.09","priority":"medium","cadence":"weekly","citationPolicy":"Cite docs/nvidia-supply-chain-graph-design.md (LogisticsProvider, Graph Platform, and Concurrent Codex Stream Considerations) plus carrier or port press releases.","catalogPosition":"3","topicGroup":"logistics"}
dry-run prompt=nvidia-research-partners metadata={"promptId":"nvidia-research-partners","streamId":"research-partners","catalogVersion":"2025.11.09","priority":"medium","cadence":"monthly","citationPolicy":"Cite docs/nvidia-supply-chain-graph-design.md (ResearchSource, Research Partners, Architecture Overview) plus partner disclosures or journal publications.","catalogPosition":"4","topicGroup":"research"}
dry-run prompt=nvidia-financing-risk metadata={"promptId":"nvidia-financing-risk","streamId":"financing-risk","catalogVersion":"2025.11.09","priority":"high","cadence":"monthly","citationPolicy":"Cite docs/nvidia-supply-chain-graph-design.md (RiskTag, Graph Platform, Neo4j Schema Highlights) plus regulatory or industry disclosures for each risk callout.","catalogPosition":"5","topicGroup":"risk"}
dry-run prompt=nvidia-instrumentation-vendors metadata={"promptId":"nvidia-instrumentation-vendors","streamId":"instrumentation-vendors","catalogVersion":"2025.11.09","priority":"medium","cadence":"monthly","citationPolicy":"Cite docs/nvidia-supply-chain-graph-design.md (auxiliary industries, instrumentation vendor context) plus vendor release notes or maintenance logs.","catalogPosition":"6","topicGroup":"auxiliary"}
- 
- 

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
