### PR TITLE
feat: seed NVIDIA Graf prompts and coverage

### DIFF
--- a/docs/codex/nvidia-prompt-schema.json
+++ b/docs/codex/nvidia-prompt-schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "NVIDIA supply-chain prompt definition",
+  "description": "A prompt envelope Graf uses to seed /v1/codex-research with stream metadata, scoring guidance, and artifact expectations.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "promptId": {
+      "type": "string",
+      "description": "Unique identifier for the prompt pack (matches the catalog filename)."
+    },
+    "streamId": {
+      "type": "string",
+      "description": "Stream identifier (foundries, odm-ems, logistics-ports, research-partners, financing-risk, instrumentation-vendors)."
+    },
+    "objective": {
+      "type": "string",
+      "description": "High-level description of what the prompt must achieve."
+    },
+    "schemaVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Increment when the envelope definition changes in a non-backwards-compatible way."
+    },
+    "prompt": {
+      "type": "string",
+      "description": "Codex prompt text executed by Graf."
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Fields that should be supplied/validated before running the prompt.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "description"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Field name Graf will submit in metadata."
+          },
+          "description": {
+            "type": "string",
+            "description": "Natural-language hint for the field."
+          },
+          "required": {
+            "type": "boolean",
+            "description": "True when Graf must always populate the field."
+          },
+          "example": {
+            "type": "string",
+            "description": "Optional example value."
+          }
+        }
+      }
+    },
+    "expectedArtifact": {
+      "type": "object",
+      "description": "The JSON structure Graf expects Codex to emit to MinIO.",
+      "required": ["entities", "relationships"],
+      "additionalProperties": false,
+      "properties": {
+        "entities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["label", "description"],
+            "properties": {
+              "label": { "type": "string" },
+              "description": { "type": "string" },
+              "requiredProperties": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        },
+        "relationships": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "description", "fromLabel", "toLabel"],
+            "properties": {
+              "type": { "type": "string" },
+              "description": { "type": "string" },
+              "fromLabel": { "type": "string" },
+              "toLabel": { "type": "string" },
+              "requiredProperties": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "citations": {
+      "type": "object",
+      "description": "Citation requirements and preferred sources.",
+      "additionalProperties": false,
+      "required": ["required", "preferredSources"],
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Minimum citation types that must appear in every artifact (sourceUrl, regulatory filings, etc.)."
+        },
+        "preferredSources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Domains Graf prefers Codex cite first."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Additional guidance for reviewers."
+        },
+        "minimumCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum number of citations required (default: 2)."
+        }
+      }
+    },
+    "scoringHeuristics": {
+      "type": "array",
+      "description": "Heuristics Graf uses to grade the artifact before persistence.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["metric", "target"],
+        "properties": {
+          "metric": { "type": "string" },
+          "target": { "type": "string" },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Additional prompts-specific metadata Graf uses to tag Neo4j nodes/relationships.",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "required": ["promptId", "streamId", "objective", "schemaVersion", "prompt", "inputs", "expectedArtifact", "citations", "scoringHeuristics"]
+}

--- a/docs/codex/nvidia-prompts/financing-risk.json
+++ b/docs/codex/nvidia-prompts/financing-risk.json
@@ -1,0 +1,101 @@
+{
+    "promptId": "financing-risk",
+    "streamId": "financing-risk",
+    "objective": "Surface financiers, insurers, and risk vectors (credit, liquidity, geopolitical) that affect NVIDIA supply or partners.",
+    "schemaVersion": 1,
+    "prompt": "Return JSON capturing capital providers, underwriting partners, and risk tags tied to NVIDIA partners. Score each risk by confidence, cite filings or rating agencies, and embed artifact metadata (artifactIdPrefix + timestamp). StreamId must be financing-risk. Highlight exposures that could trigger mitigation actions (e.g., credit downgrades, sanctions).",
+    "inputs": [
+        {
+            "name": "coverage",
+            "description": "Type of capital or risk (credit line, insurance, FX).",
+            "required": true,
+            "example": "credit line"
+        },
+        {
+            "name": "counterparty",
+            "description": "Partner or supplier impacted by financing/risk events.",
+            "required": false,
+            "example": "TSMC"
+        }
+    ],
+    "expectedArtifact": {
+        "entities": [
+            {
+                "label": "Company",
+                "description": "Supplier, partner, or financier in the risk story.",
+                "requiredProperties": [
+                    "name",
+                    "role"
+                ]
+            },
+            {
+                "label": "RiskTag",
+                "description": "Risk label (credit, liquidity, sanctions).",
+                "requiredProperties": [
+                    "name",
+                    "severity"
+                ]
+            },
+            {
+                "label": "Event",
+                "description": "Triggering incident (downgrade, audit).",
+                "requiredProperties": [
+                    "name",
+                    "date"
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "type": "FINANCED_BY",
+                "description": "Company backed by a financier or insurer.",
+                "fromLabel": "Company",
+                "toLabel": "Company",
+                "requiredProperties": [
+                    "amount"
+                ]
+            },
+            {
+                "type": "HAS_RISK",
+                "description": "Company tagged with a risk.",
+                "fromLabel": "Company",
+                "toLabel": "RiskTag",
+                "requiredProperties": [
+                    "confidence"
+                ]
+            }
+        ]
+    },
+    "citations": {
+        "required": [
+            "sourceUrl",
+            "sourceType"
+        ],
+        "preferredSources": [
+            "sec.gov",
+            "ratings agencies",
+            "public filings"
+        ],
+        "notes": "Weight official filings and underwriting announcements over anonymous commentary.",
+        "minimumCount": 2
+    },
+    "scoringHeuristics": [
+        {
+            "metric": "confidence",
+            "target": ">=0.7",
+            "notes": "Use numeric data when available (downgrade rating, insured amount)."
+        },
+        {
+            "metric": "diversity",
+            "target": "Cite at least two source types",
+            "notes": "Mix regulatory filings with press statements."
+        }
+    ],
+    "metadata": {
+        "artifactIdPrefix": "codex:nvidia-financing",
+        "researchSource": "graf-codex-financing",
+        "priority": "medium",
+        "confidenceThreshold": "0.7",
+        "streamTag": "financing"
+    }
+}

--- a/docs/codex/nvidia-prompts/foundries.json
+++ b/docs/codex/nvidia-prompts/foundries.json
@@ -1,0 +1,112 @@
+{
+    "promptId": "foundries",
+    "streamId": "foundries",
+    "objective": "Capture the global foundry and IDM-capable fabs that NVIDIA can rely on for GPU wafer capacity, certifications, and strategic resilience.",
+    "schemaVersion": 1,
+    "prompt": "You are building a Neo4j-ready artifact that maps NVIDIA-relevant foundries and wafer fabs. Include confidence, citations, artifact metadata, and stream markers. Emit top-level keys: entities (list), relationships (list), metadata (map). Every entity must include id/label/properties. Artifact metadata must contain artifactId (add prefix from metadata.artifactIdPrefix), researchSource, streamId=foundries, and timestamps where possible. Cite at least two authoritative sources (include sourceUrl and sourceType per citation). Focus on manufacturing partners mentioned in docs/nvidia-supply-chain-graph-design.md and public filings after {{inputs.lookbackWindow}}.",
+    "inputs": [
+        {
+            "name": "lookbackWindow",
+            "description": "Duration of news/filings to examine (e.g., 90d).",
+            "required": true,
+            "example": "90d"
+        },
+        {
+            "name": "regionFocus",
+            "description": "Region or fabs to prioritize (e.g., Taiwan, Arizona).",
+            "required": false,
+            "example": "Taiwan + Arizona"
+        },
+        {
+            "name": "tierFocus",
+            "description": "Target manufacturing tiers (Tier 1, Tier 2).",
+            "required": false,
+            "example": "Tier 1"
+        }
+    ],
+    "expectedArtifact": {
+        "entities": [
+            {
+                "label": "Company",
+                "description": "Foundry or IDM owner with NVIDIA exposure.",
+                "requiredProperties": [
+                    "name",
+                    "tier",
+                    "region"
+                ]
+            },
+            {
+                "label": "Facility",
+                "description": "Specific fab or campus where NVIDIA wafers are processed.",
+                "requiredProperties": [
+                    "siteId",
+                    "capacity",
+                    "specialization"
+                ]
+            },
+            {
+                "label": "Certification",
+                "description": "Accreditations (e.g., ISO, IATF, security).",
+                "requiredProperties": [
+                    "name",
+                    "issuer"
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "type": "MANUFACTURES_AT",
+                "description": "Company fabricates wafers at a named facility.",
+                "fromLabel": "Company",
+                "toLabel": "Facility",
+                "requiredProperties": [
+                    "volumeShare"
+                ]
+            },
+            {
+                "type": "CERTIFIED_BY",
+                "description": "Facility holds a certification.",
+                "fromLabel": "Facility",
+                "toLabel": "Certification",
+                "requiredProperties": []
+            }
+        ]
+    },
+    "citations": {
+        "required": [
+            "sourceUrl",
+            "sourceType"
+        ],
+        "preferredSources": [
+            "nvidia.com",
+            "sec.gov",
+            "semiconductor-datasource.com"
+        ],
+        "notes": "Highlight production cadence, deepening capacity, and mitigation plans.",
+        "minimumCount": 3
+    },
+    "scoringHeuristics": [
+        {
+            "metric": "confidence",
+            "target": ">=0.75",
+            "notes": "Use multiple sources for each assertion."
+        },
+        {
+            "metric": "citationCount",
+            "target": ">=2 per node/relationship",
+            "notes": "Favor filings over analyst notes."
+        },
+        {
+            "metric": "dataFreshness",
+            "target": "Within lookbackWindow",
+            "notes": "Older data must be marked and justified."
+        }
+    ],
+    "metadata": {
+        "artifactIdPrefix": "codex:nvidia:foundries",
+        "researchSource": "graf-codex-foundries",
+        "priority": "high",
+        "confidenceThreshold": "0.75",
+        "streamTag": "manufacturing"
+    }
+}

--- a/docs/codex/nvidia-prompts/instrumentation-vendors.json
+++ b/docs/codex/nvidia-prompts/instrumentation-vendors.json
@@ -1,0 +1,99 @@
+{
+    "promptId": "instrumentation-vendors",
+    "streamId": "instrumentation-vendors",
+    "objective": "Detail test/instrumentation vendors that support NVIDIA qualification labs and how their tooling maps to supply/stability.",
+    "schemaVersion": 1,
+    "prompt": "Emit JSON describing instrumentation vendors, their installed base inside partner labs, and the certifications that demonstrate their fit for defense, reliability, or security programs. Attach metadata (artifactIdPrefix, researchSource, streamId=instrumentation-vendors). Mention delivery lead times, spare parts risks, and citation sources.",
+    "inputs": [
+        {
+            "name": "vendorType",
+            "description": "Type of instrumentation (tester, burn-in, metrology).",
+            "required": true,
+            "example": "tester"
+        },
+        {
+            "name": "labFocus",
+            "description": "Qualification lab (in-house, partner).",
+            "required": false,
+            "example": "Sunnyvale qualification lab"
+        }
+    ],
+    "expectedArtifact": {
+        "entities": [
+            {
+                "label": "Company",
+                "description": "Vendor or supplier of instrumentation.",
+                "requiredProperties": [
+                    "name",
+                    "vendorType"
+                ]
+            },
+            {
+                "label": "Facility",
+                "description": "Lab or vendor campus where instrumentation is staged.",
+                "requiredProperties": [
+                    "siteId",
+                    "capacity"
+                ]
+            },
+            {
+                "label": "Certification",
+                "description": "Quality or security certification for the tooling.",
+                "requiredProperties": [
+                    "name",
+                    "issuer"
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "type": "DEPLOYED_AT",
+                "description": "Company deploys equipment at a facility.",
+                "fromLabel": "Company",
+                "toLabel": "Facility",
+                "requiredProperties": [
+                    "deploymentDate"
+                ]
+            },
+            {
+                "type": "CERTIFIED_BY",
+                "description": "Facility or tool certified by an accreditation.",
+                "fromLabel": "Facility",
+                "toLabel": "Certification",
+                "requiredProperties": []
+            }
+        ]
+    },
+    "citations": {
+        "required": [
+            "sourceUrl",
+            "sourceType"
+        ],
+        "preferredSources": [
+            "vendor.com",
+            "press releases",
+            "certification bodies"
+        ],
+        "notes": "Tie lead times or spare parts risk to procurement statements.",
+        "minimumCount": 2
+    },
+    "scoringHeuristics": [
+        {
+            "metric": "confidence",
+            "target": ">=0.7",
+            "notes": "Confirm vendor claims with government registrations or procurement notices."
+        },
+        {
+            "metric": "availability",
+            "target": "Describe lead times or spare-part constraints",
+            "notes": "Flag multi-sourcing options when vendors are single-source."
+        }
+    ],
+    "metadata": {
+        "artifactIdPrefix": "codex:nvidia-instrumentation",
+        "researchSource": "graf-codex-instrumentation",
+        "priority": "medium",
+        "confidenceThreshold": "0.7",
+        "streamTag": "instrumentation"
+    }
+}

--- a/docs/codex/nvidia-prompts/logistics-ports.json
+++ b/docs/codex/nvidia-prompts/logistics-ports.json
@@ -1,0 +1,102 @@
+{
+    "promptId": "logistics-ports",
+    "streamId": "logistics-ports",
+    "objective": "Describe the third-party logistics providers, ports, and inland hubs that move NVIDIA wafers and finished boards, along with congestion or diversion risks.",
+    "schemaVersion": 1,
+    "prompt": "Return JSON describing shipping corridors, ports, inland hubs, and their support teams. Highlight dual sourcing, alternate routes, and any sanctions/ETA risks. Each entity must include artifact metadata (artifactIdPrefix + timestamp) and streamId=logistics-ports. Capture relationships that span carriers to ports, ports to facilities, and risk events that delay transit. Citations must link to publicly accessible schedules or notices.",
+    "inputs": [
+        {
+            "name": "lane",
+            "description": "Logistics lane or route under review (e.g., Asia->US West Coast).",
+            "required": true,
+            "example": "Shanghai to Long Beach"
+        },
+        {
+            "name": "riskFocus",
+            "description": "Risk vectors (weather, sanctions, port congestion).",
+            "required": false,
+            "example": "typhoon season"
+        }
+    ],
+    "expectedArtifact": {
+        "entities": [
+            {
+                "label": "LogisticsProvider",
+                "description": "Carrier or logistics integrator handling NVIDIA freight.",
+                "requiredProperties": [
+                    "name",
+                    "capabilities"
+                ]
+            },
+            {
+                "label": "Port",
+                "description": "Seaport or airport handling NVIDIA freight.",
+                "requiredProperties": [
+                    "name",
+                    "capacity",
+                    "region"
+                ]
+            },
+            {
+                "label": "Facility",
+                "description": "Inland consolidation or distribution hub.",
+                "requiredProperties": [
+                    "siteId",
+                    "specialization"
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "type": "LOGISTICS_BY",
+                "description": "Provider serves a port or facility.",
+                "fromLabel": "LogisticsProvider",
+                "toLabel": "Port",
+                "requiredProperties": [
+                    "serviceType"
+                ]
+            },
+            {
+                "type": "CONNECTS_TO",
+                "description": "Port connects to an inland facility/truck ramp.",
+                "fromLabel": "Port",
+                "toLabel": "Facility",
+                "requiredProperties": [
+                    "mode"
+                ]
+            }
+        ]
+    },
+    "citations": {
+        "required": [
+            "sourceUrl",
+            "sourceType"
+        ],
+        "preferredSources": [
+            "portauthority.gov",
+            "shippingnews.com",
+            "customs.gov"
+        ],
+        "notes": "Annotate risk events (weather, labor action, sanctions).",
+        "minimumCount": 2
+    },
+    "scoringHeuristics": [
+        {
+            "metric": "confidence",
+            "target": ">=0.7",
+            "notes": "Backing data must come from official notices or logbook summaries."
+        },
+        {
+            "metric": "riskVisibility",
+            "target": "Identify mitigation options",
+            "notes": "Flag alternative routes if a node is stressed."
+        }
+    ],
+    "metadata": {
+        "artifactIdPrefix": "codex:nvidia-logistics",
+        "researchSource": "graf-codex-logistics",
+        "priority": "high",
+        "confidenceThreshold": "0.7",
+        "streamTag": "transport"
+    }
+}

--- a/docs/codex/nvidia-prompts/odm-ems.json
+++ b/docs/codex/nvidia-prompts/odm-ems.json
@@ -1,0 +1,117 @@
+{
+    "promptId": "odm-ems",
+    "streamId": "odm-ems",
+    "objective": "Trace ODM/EMS partners delivering NVIDIA boards, their assembly/test facilities, and schedule constraints so Graf can correlate them with upstream foundries and downstream integrators.",
+    "schemaVersion": 1,
+    "prompt": "Produce an artifact that catalogs contract manufacturers and EMS partners, the product families they own, and any known test or burn-in instrumentation they host. Every entity must include artifactId (use metadata.artifactIdPrefix), researchSource, and streamId=odm-ems. Include relationships that connect companies to facilities and to the specific product families they configure. Provide citations for statements linking to filings, customs declarations, or public disclosures.",
+    "inputs": [
+        {
+            "name": "productFamily",
+            "description": "Product family or platform the ODM/EMS partner supports.",
+            "required": true,
+            "example": "RTX 40-series"
+        },
+        {
+            "name": "regionCoverage",
+            "description": "Regions (Asia, Mexico, US) to prioritize.",
+            "required": false,
+            "example": "Greater China"
+        },
+        {
+            "name": "sampleStage",
+            "description": "Assembly stage (pilot, ramp, sustain).",
+            "required": false,
+            "example": "pilot"
+        }
+    ],
+    "expectedArtifact": {
+        "entities": [
+            {
+                "label": "Company",
+                "description": "ODM/EMS with documented NVIDIA scope.",
+                "requiredProperties": [
+                    "name",
+                    "capacity",
+                    "region"
+                ]
+            },
+            {
+                "label": "Facility",
+                "description": "Assembly or test location tied to the ODM/EMS.",
+                "requiredProperties": [
+                    "siteId",
+                    "specialization"
+                ]
+            },
+            {
+                "label": "Product",
+                "description": "Platform or SKU family the partner builds.",
+                "requiredProperties": [
+                    "name",
+                    "tier"
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "type": "PARTNERS_WITH",
+                "description": "ODM/EMS partner relationship to NVIDIA or another company.",
+                "fromLabel": "Company",
+                "toLabel": "Company",
+                "requiredProperties": [
+                    "startDate"
+                ]
+            },
+            {
+                "type": "ASSEMBLES",
+                "description": "Company assembles a product at a facility.",
+                "fromLabel": "Company",
+                "toLabel": "Facility",
+                "requiredProperties": [
+                    "volumeShare"
+                ]
+            },
+            {
+                "type": "CONFIGURES",
+                "description": "Facility configures a product or test plan.",
+                "fromLabel": "Facility",
+                "toLabel": "Product",
+                "requiredProperties": [
+                    "stage"
+                ]
+            }
+        ]
+    },
+    "citations": {
+        "required": [
+            "sourceUrl",
+            "sourceType"
+        ],
+        "preferredSources": [
+            "nvidia.com",
+            "customs.gov",
+            "press releases"
+        ],
+        "notes": "Flag compliance or tooling certifications per partner.",
+        "minimumCount": 3
+    },
+    "scoringHeuristics": [
+        {
+            "metric": "confidence",
+            "target": ">=0.7",
+            "notes": "Weight filings and regulatory notices more heavily."
+        },
+        {
+            "metric": "toolingCoverage",
+            "target": "Document test and burn-in capabilities",
+            "notes": "Missing instrumentation must be called out."
+        }
+    ],
+    "metadata": {
+        "artifactIdPrefix": "codex:nvidia-odm",
+        "researchSource": "graf-codex-odm",
+        "priority": "medium",
+        "confidenceThreshold": "0.7",
+        "streamTag": "assembly"
+    }
+}

--- a/docs/codex/nvidia-prompts/research-partners.json
+++ b/docs/codex/nvidia-prompts/research-partners.json
@@ -1,0 +1,102 @@
+{
+    "promptId": "research-partners",
+    "streamId": "research-partners",
+    "objective": "Catalog partner institutions, labs, and co-developers that NVIDIA engages for foundational research, tooling, or multi-party test pilots.",
+    "schemaVersion": 1,
+    "prompt": "Produce JSON that captures research partners, their knowledge domains, and shared programs. Include citations for collaborative publications, white papers, or press statements. Ensure every artifact entity is tagged with artifactIdPrefix (from metadata) and streamId=research-partners. Highlight cryptic flows such as knowledge transfer, funding, instrumentation support, and defense/duality reviews.",
+    "inputs": [
+        {
+            "name": "topic",
+            "description": "Research topic (e.g., AI optics, supply chain resilience).",
+            "required": true,
+            "example": "AI/ML testbed"
+        },
+        {
+            "name": "engagementType",
+            "description": "Type of partnership (lab collaboration, funded program).",
+            "required": false,
+            "example": "joint lab"
+        }
+    ],
+    "expectedArtifact": {
+        "entities": [
+            {
+                "label": "ResearchSource",
+                "description": "External organization or lab.",
+                "requiredProperties": [
+                    "name",
+                    "country",
+                    "specialty"
+                ]
+            },
+            {
+                "label": "Event",
+                "description": "Program, consortium, or demo showcasing the research.",
+                "requiredProperties": [
+                    "name",
+                    "date"
+                ]
+            },
+            {
+                "label": "Company",
+                "description": "NVIDIA business unit or OEM partner.",
+                "requiredProperties": [
+                    "name",
+                    "function"
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "type": "RESEARCHED_BY",
+                "description": "A company sponsors or co-leads research with the source.",
+                "fromLabel": "Company",
+                "toLabel": "ResearchSource",
+                "requiredProperties": [
+                    "scope"
+                ]
+            },
+            {
+                "type": "HOSTS",
+                "description": "ResearchSource hosts an event or pilot.",
+                "fromLabel": "ResearchSource",
+                "toLabel": "Event",
+                "requiredProperties": [
+                    "venue"
+                ]
+            }
+        ]
+    },
+    "citations": {
+        "required": [
+            "sourceUrl",
+            "sourceType"
+        ],
+        "preferredSources": [
+            "arxiv.org",
+            "nvidia.com",
+            "press releases"
+        ],
+        "notes": "Include statements of intent, funding, or hardware access.",
+        "minimumCount": 2
+    },
+    "scoringHeuristics": [
+        {
+            "metric": "confidence",
+            "target": ">=0.8",
+            "notes": "Plasma and academic sources weigh differently; prefer direct quotes."
+        },
+        {
+            "metric": "citationDiversity",
+            "target": ">=2 source types",
+            "notes": "Mix press statements with peer-reviewed references."
+        }
+    ],
+    "metadata": {
+        "artifactIdPrefix": "codex:nvidia-research",
+        "researchSource": "graf-codex-research",
+        "priority": "medium",
+        "confidenceThreshold": "0.8",
+        "streamTag": "research"
+    }
+}

--- a/docs/nvidia-supply-chain-graph-design.md
+++ b/docs/nvidia-supply-chain-graph-design.md
@@ -76,6 +76,19 @@ graph LR
 
 ## Concurrent Codex Stream Considerations
 - **Stream catalog**: Maintain a Temporal-managed catalog of active research streams, each with `streamId`, topic (e.g., foundry/OEM/logistics), priority, prompt templates, and expected cadence.
+
+## Codex prompt catalog
+
+Prompt definitions live under `docs/codex`. Follow the schema in `docs/codex/nvidia-prompt-schema.json` when you adjust metadata, scoring heuristics, citation requirements, or expected artifact structure. Each stream below has its own JSON pack inside `docs/codex/nvidia-prompts` so Graf can ingest the right `promptId` on `/v1/codex-research`:
+
+- **Foundries** (`foundries.json`): production capacity, certifications, and multi-site continuity.
+- **ODM/EMS** (`odm-ems.json`): board-level partners, assembly/test loci, and tooling coverage.
+- **Logistics & ports** (`logistics-ports.json`): carriers, port hubs, and risk-aware lanes.
+- **Research partners** (`research-partners.json`): labs, universities, and financed programs.
+- **Financing & risk** (`financing-risk.json`): credit/liquidity exposure and underwriting partners.
+- **Instrumentation vendors** (`instrumentation-vendors.json`): testers, burn-in houses, and spare-parts availability.
+
+Keep the YAML or TS driver in sync by editing this directory, validating the JSON against `nvidia-prompt-schema.json`, and updating the schema version whenever you change envelope expectations.
 - **Per-instance provenance**: Artifacts include `streamId`, `instanceId`, `promptId`, `generatedAt`, and `confidence`; the Kotlin service can filter/infer updates per stream and tag edges with `sourceStreams`.
 - **Consistency**: When multiple streams target the same node, merge updates by prioritizing higher confidence/timestamp values, and keep `sourceStreams` collections on edges to prevent accidental overwrites.
 - **Throughput scaling**: Temporal can fan out Argo subworkflows for each stream, allowing multiple Codex instances to research concurrently while the Kotlin service ingests them incrementally; the service supports batch operations to minimize contention.

--- a/packages/scripts/src/graf/run-prompts.ts
+++ b/packages/scripts/src/graf/run-prompts.ts
@@ -1,0 +1,274 @@
+#!/usr/bin/env bun
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import process from 'node:process'
+
+interface PromptInputSpec {
+  name: string
+  description: string
+  required: boolean
+  example?: string
+}
+
+interface PromptEntityExpectation {
+  label: string
+  description: string
+  requiredProperties?: string[]
+}
+
+interface PromptRelationshipExpectation {
+  type: string
+  description: string
+  fromLabel: string
+  toLabel: string
+  requiredProperties?: string[]
+}
+
+interface PromptCitations {
+  required: string[]
+  preferredSources: string[]
+  notes?: string
+  minimumCount?: number
+}
+
+interface PromptScoring {
+  metric: string
+  target: string
+  notes?: string
+}
+
+export interface PromptDefinition {
+  promptId: string
+  streamId: string
+  objective: string
+  schemaVersion: number
+  prompt: string
+  inputs: PromptInputSpec[]
+  expectedArtifact: {
+    entities: PromptEntityExpectation[]
+    relationships: PromptRelationshipExpectation[]
+  }
+  citations: PromptCitations
+  scoringHeuristics: PromptScoring[]
+  metadata?: Record<string, string>
+}
+
+interface SchemaDefinition {
+  properties?: Record<string, unknown>
+  additionalProperties?: boolean
+  required?: string[]
+}
+
+const usage = () => {
+  console.log('Usage: bun packages/scripts/src/graf/run-prompts.ts [--prompt-id <id>] [--dry-run]')
+  console.log(`
+Environment:
+  GRAF_BASE_URL (default: http://localhost:8080)
+  GRAF_TOKEN (required unless --dry-run)
+`)
+}
+
+const parseArgs = (argv: string[]) => {
+  const opts = {
+    promptId: undefined as string | undefined,
+    dryRun: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--prompt-id':
+        opts.promptId = argv[++i]
+        break
+      case '--dry-run':
+        opts.dryRun = true
+        break
+      case '-h':
+      case '--help':
+        usage()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown option ${arg}`)
+    }
+  }
+
+  return opts
+}
+
+const ensureArray = (value: unknown, name: string) => {
+  if (!Array.isArray(value)) {
+    throw new Error(`${name} must be an array`)
+  }
+  if (value.length === 0) {
+    throw new Error(`${name} cannot be empty`)
+  }
+}
+
+const ensureString = (value: unknown, name: string) => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${name} must be a non-empty string`)
+  }
+}
+
+const validatePrompt = (definition: PromptDefinition, source: string, schema: SchemaDefinition) => {
+  const missing: string[] = []
+  if (!definition.promptId) missing.push('promptId')
+  if (!definition.streamId) missing.push('streamId')
+  if (!definition.objective) missing.push('objective')
+  if (!definition.prompt) missing.push('prompt')
+  if (!definition.schemaVersion) missing.push('schemaVersion')
+  if (missing.length) {
+    throw new Error(`${source} is missing required fields: ${missing.join(', ')}`)
+  }
+
+  ensureArray(definition.inputs, 'inputs')
+  definition.inputs.forEach((input, index) => {
+    ensureString(input.name, `${source}.inputs[${index}].name`)
+    ensureString(input.description, `${source}.inputs[${index}].description`)
+  })
+
+  const artifact = definition.expectedArtifact
+  if (!artifact) {
+    throw new Error(`${source} missing expectedArtifact definition`)
+  }
+  ensureArray(artifact.entities, `${source}.expectedArtifact.entities`)
+  ensureArray(artifact.relationships, `${source}.expectedArtifact.relationships`)
+
+  artifact.entities.forEach((entity, index) => {
+    ensureString(entity.label, `${source}.expectedArtifact.entities[${index}].label`)
+    ensureString(entity.description, `${source}.expectedArtifact.entities[${index}].description`)
+  })
+
+  artifact.relationships.forEach((rel, index) => {
+    ensureString(rel.type, `${source}.expectedArtifact.relationships[${index}].type`)
+    ensureString(rel.description, `${source}.expectedArtifact.relationships[${index}].description`)
+    ensureString(rel.fromLabel, `${source}.expectedArtifact.relationships[${index}].fromLabel`)
+    ensureString(rel.toLabel, `${source}.expectedArtifact.relationships[${index}].toLabel`)
+  })
+
+  ensureArray(definition.scoringHeuristics, `${source}.scoringHeuristics`)
+  definition.scoringHeuristics.forEach((score, index) => {
+    ensureString(score.metric, `${source}.scoringHeuristics[${index}].metric`)
+    ensureString(score.target, `${source}.scoringHeuristics[${index}].target`)
+  })
+
+  const citations = definition.citations
+  if (!citations) {
+    throw new Error(`${source} missing citations section`)
+  }
+  ensureArray(citations.required, `${source}.citations.required`)
+  ensureArray(citations.preferredSources, `${source}.citations.preferredSources`)
+  if (schema.additionalProperties === false && schema.properties) {
+    const allowed = new Set(Object.keys(schema.properties))
+    for (const key of Object.keys(definition)) {
+      if (!allowed.has(key)) {
+        throw new Error(`${source} contains unexpected property ${key}`)
+      }
+    }
+  }
+}
+
+const buildMetadata = (definition: PromptDefinition) => ({
+  promptId: definition.promptId,
+  streamId: definition.streamId,
+  ...definition.metadata,
+})
+
+type ArtifactReferenceRecord = Record<string, unknown>
+
+const hasKeyProperty = (value: unknown): value is ArtifactReferenceRecord & { key?: unknown } =>
+  typeof value === 'object' && value !== null && 'key' in value
+
+const describeArtifactRefs = (refs: ArtifactReferenceRecord[]) => {
+  if (!Array.isArray(refs) || refs.length === 0) {
+    return 'none'
+  }
+  return refs
+    .map((ref) => {
+      if (hasKeyProperty(ref) && ref.key !== undefined) {
+        return `${ref.key}`
+      }
+      return JSON.stringify(ref)
+    })
+    .join(', ')
+}
+
+const run = async () => {
+  const { promptId, dryRun } = parseArgs(process.argv.slice(2))
+  const baseDir = process.cwd()
+  const schemaPath = join(baseDir, 'docs/codex/nvidia-prompt-schema.json')
+  const promptsDir = join(baseDir, 'docs/codex/nvidia-prompts')
+
+  const schemaDefinition = JSON.parse(await readFile(schemaPath, 'utf8')) as SchemaDefinition
+  const promptFiles = (await readdir(promptsDir)).filter((name) => name.endsWith('.json'))
+  const definitions = [] as PromptDefinition[]
+
+  for (const file of promptFiles) {
+    const body = await readFile(join(promptsDir, file), 'utf8')
+    const definition = JSON.parse(body) as PromptDefinition
+    validatePrompt(definition, file, schemaDefinition)
+    definitions.push(definition)
+  }
+
+  const selection = promptId ? definitions.filter((def) => def.promptId === promptId) : definitions
+  if (selection.length === 0) {
+    throw new Error(promptId ? `Prompt ${promptId} not found` : 'No prompts to run')
+  }
+
+  const baseUrl = process.env.GRAF_BASE_URL ?? 'http://localhost:8080'
+  const token = process.env.GRAF_TOKEN
+  if (!dryRun && !token) {
+    throw new Error('GRAF_TOKEN is required when --dry-run is not passed')
+  }
+
+  for (const definition of selection) {
+    const payload = {
+      prompt: definition.prompt,
+      metadata: buildMetadata(definition),
+      catalog: definition,
+    }
+
+    console.log(`\n[run-prompts] ${dryRun ? 'dry-run' : 'submitting'} promptId=${definition.promptId}`)
+
+    if (dryRun) {
+      console.log(`[run-prompts] → ${definition.promptId} would post to ${baseUrl}/v1/codex-research`)
+      console.log(`[run-prompts] Artifact metadata preview: ${JSON.stringify(payload.metadata)}`)
+      console.log(
+        `[run-prompts] Guidance: capture workflowId/runId pairs for Temporal dashboards and Temporal artifact cleanup.`,
+      )
+      continue
+    }
+
+    const response = await fetch(`${baseUrl}/v1/codex-research`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} when running ${definition.promptId}: ${await response.text()}`)
+    }
+
+    const body = (await response.json()) as {
+      workflowId: string
+      runId: string
+      artifactReferences: ArtifactReferenceRecord[]
+    }
+
+    console.log(`[run-prompts] promptId=${definition.promptId} workflowId=${body.workflowId} runId=${body.runId}`)
+    console.log(`[run-prompts] artifactReferences=${describeArtifactRefs(body.artifactReferences ?? [])}`)
+    console.log(
+      `[run-prompts] Capture workflowId/runId pairs for Temporal monitoring and anchor the artifact reference list for Neo4j ingestion.`,
+    )
+  }
+  console.log(`[run-prompts] Completed ${selection.length} prompts (${dryRun ? 'dry-run' : 'live'}).`)
+}
+
+run().catch((error) => {
+  console.error(`[run-prompts]`, error)
+  process.exit(1)
+})

--- a/services/graf/build.gradle.kts
+++ b/services/graf/build.gradle.kts
@@ -62,6 +62,14 @@ dependencies {
   testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
 }
 
+sourceSets {
+  main {
+    resources {
+      srcDir(file("../../docs/codex"))
+    }
+  }
+}
+
 tasks.test {
   useJUnitPlatform()
 }

--- a/services/graf/src/main/kotlin/ai/proompteng/graf/codex/CodexResearchModels.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/codex/CodexResearchModels.kt
@@ -3,6 +3,7 @@ package ai.proompteng.graf.codex
 import ai.proompteng.graf.model.ArtifactReference
 import ai.proompteng.graf.model.EntityRequest
 import ai.proompteng.graf.model.RelationshipRequest
+import ai.proompteng.graf.codex.PromptCatalogDefinition
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
@@ -10,6 +11,7 @@ import kotlinx.serialization.json.JsonElement
 data class CodexResearchWorkflowInput(
   val prompt: String,
   val metadata: Map<String, String> = emptyMap(),
+  val catalogMetadata: PromptCatalogDefinition,
   val argoWorkflowName: String,
   val artifactKey: String,
   val argoPollTimeoutSeconds: Long,

--- a/services/graf/src/main/kotlin/ai/proompteng/graf/codex/CodexResearchService.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/codex/CodexResearchService.kt
@@ -35,6 +35,7 @@ class CodexResearchService(
       CodexResearchWorkflowInput(
         prompt = request.prompt,
         metadata = request.metadata,
+        catalogMetadata = request.catalog,
         argoWorkflowName = argoWorkflowName,
         artifactKey = artifactKey,
         argoPollTimeoutSeconds = argoPollTimeoutSeconds,

--- a/services/graf/src/main/kotlin/ai/proompteng/graf/codex/MinioArtifactFetcher.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/codex/MinioArtifactFetcher.kt
@@ -13,6 +13,8 @@ class MinioArtifactFetcherImpl(
   private val client: MinioClient,
 ) : MinioArtifactFetcher {
   override fun open(reference: ArtifactReference): InputStream {
+    require(reference.bucket.isNotBlank()) { "artifact bucket must be provided" }
+    require(reference.key.isNotBlank()) { "artifact key must be provided" }
     val args =
       GetObjectArgs
         .builder()

--- a/services/graf/src/main/kotlin/ai/proompteng/graf/codex/PromptCatalog.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/codex/PromptCatalog.kt
@@ -1,0 +1,99 @@
+package ai.proompteng.graf.codex
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+
+@Serializable
+data class PromptInputSpec(
+  val name: String,
+  val description: String,
+  val required: Boolean,
+  val example: String? = null,
+)
+
+@Serializable
+data class PromptEntityExpectation(
+  val label: String,
+  val description: String,
+  val requiredProperties: List<String> = emptyList(),
+)
+
+@Serializable
+data class PromptRelationshipExpectation(
+  val type: String,
+  val description: String,
+  val fromLabel: String,
+  val toLabel: String,
+  val requiredProperties: List<String> = emptyList(),
+)
+
+@Serializable
+data class PromptExpectedArtifact(
+  val entities: List<PromptEntityExpectation>,
+  val relationships: List<PromptRelationshipExpectation>,
+)
+
+@Serializable
+data class PromptCitations(
+  val required: List<String>,
+  val preferredSources: List<String>,
+  val notes: String? = null,
+  val minimumCount: Int = 0,
+)
+
+@Serializable
+data class PromptScoring(
+  val metric: String,
+  val target: String,
+  val notes: String? = null,
+)
+
+@Serializable
+data class PromptCatalogDefinition(
+  val promptId: String,
+  val streamId: String,
+  val objective: String,
+  val schemaVersion: Int,
+  val prompt: String,
+  val inputs: List<PromptInputSpec>,
+  val expectedArtifact: PromptExpectedArtifact,
+  val citations: PromptCitations,
+  val scoringHeuristics: List<PromptScoring>,
+  val metadata: Map<String, String> = emptyMap(),
+)
+
+class PromptCatalog(private val definitions: Map<String, PromptCatalogDefinition>) {
+  fun findById(promptId: String): PromptCatalogDefinition? = definitions[promptId]
+
+  fun requireById(promptId: String): PromptCatalogDefinition =
+    definitions[promptId] ?: throw IllegalArgumentException("Unknown promptId $promptId")
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+object PromptCatalogLoader {
+  private val promptFiles =
+    listOf(
+      "foundries.json",
+      "odm-ems.json",
+      "logistics-ports.json",
+      "research-partners.json",
+      "financing-risk.json",
+      "instrumentation-vendors.json",
+    )
+
+  fun loadCatalog(json: Json): PromptCatalog {
+    val definitions = promptFiles.map { fileName ->
+      val resource = PromptCatalogLoader::class.java.classLoader
+        .getResourceAsStream("nvidia-prompts/$fileName")
+        ?: error("Missing prompt catalog resource: $fileName")
+      resource.use { stream ->
+        json.decodeFromStream<PromptCatalogDefinition>(stream)
+      }
+    }
+    val duplicates = definitions.groupBy { it.promptId }.filter { it.value.size > 1 }.keys
+    require(duplicates.isEmpty()) { "Duplicate promptId(s) in catalog: $duplicates" }
+    return PromptCatalog(definitions.associateBy { it.promptId })
+  }
+}

--- a/services/graf/src/main/kotlin/ai/proompteng/graf/model/Requests.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/model/Requests.kt
@@ -1,5 +1,6 @@
 package ai.proompteng.graf.model
 
+import ai.proompteng.graf.codex.PromptCatalogDefinition
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
@@ -99,6 +100,7 @@ data class CleanResponse(
 data class CodexResearchRequest(
   val prompt: String,
   val metadata: Map<String, String> = emptyMap(),
+  val catalog: PromptCatalogDefinition,
 )
 
 @Serializable

--- a/services/graf/src/test/kotlin/ai/proompteng/graf/codex/MinioArtifactFetcherTest.kt
+++ b/services/graf/src/test/kotlin/ai/proompteng/graf/codex/MinioArtifactFetcherTest.kt
@@ -1,0 +1,50 @@
+package ai.proompteng.graf.codex
+
+import ai.proompteng.graf.model.ArtifactReference
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.minio.GetObjectResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class MinioArtifactFetcherTest {
+  @Test
+  fun `open rejects missing bucket`() {
+    val client = mockk<io.minio.MinioClient>()
+    val fetcher = MinioArtifactFetcherImpl(client)
+    val reference = ArtifactReference("", "key", "https://minio", null)
+
+    assertFailsWith<IllegalArgumentException> {
+      fetcher.open(reference)
+    }
+  }
+
+  @Test
+  fun `open rejects missing key`() {
+    val client = mockk<io.minio.MinioClient>()
+    val fetcher = MinioArtifactFetcherImpl(client)
+    val reference = ArtifactReference("bucket", "", "https://minio", null)
+
+    assertFailsWith<IllegalArgumentException> {
+      fetcher.open(reference)
+    }
+  }
+
+  @Test
+  fun `open forwards call to Minio client`() {
+    val client = mockk<io.minio.MinioClient>()
+    val fetcher = MinioArtifactFetcherImpl(client)
+    val reference = ArtifactReference("bucket", "key", "https://minio", "us")
+    val slot = slot<io.minio.GetObjectArgs>()
+    val stream = mockk<GetObjectResponse>(relaxed = true)
+    every { client.getObject(capture(slot)) } returns stream
+
+    val result = fetcher.open(reference)
+
+    assertEquals(stream, result)
+    assertEquals("bucket", slot.captured.bucket())
+    assertEquals("key", slot.captured.`object`())
+  }
+}


### PR DESCRIPTION
## Summary
- Add a formal NVIDIA prompt catalog (schema + six stream packs) and a Bun driver that validates json, filters by prompt id, and documents how to capture workflow/artifact IDs.
- Teach Graf to load the catalog at startup, enrich `/v1/codex-research` requests with canonical metadata, and carry that metadata through Temporal activities/GraphService so artifacts get tagged with `artifactId`, `researchSource`, and `streamId`.
- Expand coverage with Argo polling retries, MinIO validation, and GraphService persistence tests plus a MinIO fetch helper test, and mention the catalog/driver in the Graf runbook.

## Related Issues
Fixes #1727

## Testing
- `cd services/graf && ./gradlew test`
- `cd services/graf && ./gradlew koverHtmlReport`
- `GRAF_BASE_URL=http://localhost:8080 GRAF_TOKEN=test bun packages/scripts/src/graf/run-prompts.ts --dry-run`

## Screenshots (if applicable)
None.

## Breaking Changes
None.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
