### PR TITLE
fix: enable graf agent openai secret

### DIFF
--- a/argocd/applications/graf/graf-openai-secret.yaml
+++ b/argocd/applications/graf/graf-openai-secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: graf-openai
+  namespace: graf
+spec:
+  encryptedData:
+    OPENAI_API_KEY: AgCxIq9cgBxc5XwPD6U0GzI4xcEzz3wOU0eJsbnWYgkTW3huQUtxFFjnz3B+w6GBQ1F5hF3/wyoi2Vk5se3Wt3R/Wy5cdOQjW4FF2Cm3/DQQ9pOm5Mqk0BeG0lh4xf+jC/h/Jc5AG+PWDExaidlr9zJDi6sgnnFx81xEAokAFXjTV/hH26z/lGNChqhtuWO1mMHPsXbtHaAHS3eWg8j1xutMGf6IZFnGbZs3ia+aHc49juVwL39zwt5t4yv6ORQizsU3DKdEGjDqUNKwnv1hQnaCRqZSGzFpocRsAhGbVlz7eix9aVSmQ1gIqlrzjHYhe/CvzNwN0+ZM9PA/WaUgC7ICUjZs6PqFxRLSQp+3BXqj2SpzCfRfWk/Smb8+9h9TMEjOKv2bTP7w7H1EuaxYFjwnObsiC7PGiAL9wVFYgxIMr9tLG0GmVG7dzBvrhkG48ubrAVGn0H6LQfz5ekpI7axTvs50U3tHVT8Sin/jjY0HjMPLBt1M7Km1GcsKfggH6WAmtTUQv1xMaVUfTrBH16e0d7j1mUD7g52D+uwonBonwT7opiGcdiQxnWxxRonAtNXComtRhCE/fsDauOwjaPdAGwAYoif+Lkr+9Y4P7N+ASHtMxTxVC590urqsuUiXjAifoxVjPpa+so5eKctHrSXicKoZR3BZY/YpRCMWk1xnVtywXxiE1pM4iXUV3sww5MyQVBIcqnm2hXD5AuVEgzh0q+gtsOm/7mnxwzKTCuj8LuqsIyFUoDH7ptRPX6Jj1bGSN3WAZkXGQZtU5+2//FWbFBa9LAQ+ZXqYkOS+t/KVsMAE7I3l3SSQSEpi4p2cs5M6L6J/3eV6065lu1KFRE2Z1LZ9fdh1N7Drk1cpbCSyU9bSockVoX0HHq7B3wsdkwSZGamqieEmAUvUkFGG8opRYO48dg==
+  template:
+    metadata:
+      name: graf-openai
+      namespace: graf
+    type: Opaque

--- a/argocd/applications/graf/knative-service.yaml
+++ b/argocd/applications/graf/knative-service.yaml
@@ -17,14 +17,14 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "60"
-        client.knative.dev/updateTimestamp: 2025-11-09T10:38:10.270Z
+        client.knative.dev/updateTimestamp: 2025-11-09T22:45:47.062Z
     spec:
       timeoutSeconds: 60
       containerConcurrency: 0
       serviceAccountName: graf
       containers:
         - name: user-container
-          image: registry.ide-newton.ts.net/proompteng/graf@sha256:7b96ed553a8e11ef1172bdfa59f32e5418fe97c91b0fcb3ee12c839408ec6f05
+          image: registry.ide-newton.ts.net/proompteng/graf@sha256:6a3fbe5888bf09f1d7feedd3e5041a5d959697068deebbc8f0bde1e4feffccf0
           imagePullPolicy: Always
           ports:
             - name: http1
@@ -47,9 +47,9 @@ spec:
                   name: graf-api
                   key: bearer-tokens
             - name: GRAF_VERSION
-              value: v0.304.1-2-g8492ce71
+              value: v0.304.1-4-gdba45cd2
             - name: GRAF_COMMIT
-              value: 8492ce716546601d4fc1723d2fc818f45db7c649
+              value: dba45cd2e2e661cd0229dc701db3874922137e75
             - name: MINIO_ENDPOINT
               value: http://observability-minio.minio.svc.cluster.local:9000
             - name: MINIO_BUCKET
@@ -64,6 +64,13 @@ spec:
                 secretKeyRef:
                   name: observability-minio-creds
                   key: secretkey
+            - name: AGENT_ENABLED
+              value: "true"
+            - name: AGENT_OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: graf-openai
+                  key: OPENAI_API_KEY
             - name: MINIO_SECURE
               value: "false"
           securityContext:

--- a/docs/postman/graf-autoresearch.postman_collection.json
+++ b/docs/postman/graf-autoresearch.postman_collection.json
@@ -1,0 +1,424 @@
+{
+  "info": {
+    "name": "proompteng",
+    "description": "Graf CRUD, complement, clean, and automation routes keyed for the lab platform. Import this collection into Postman, set the base URL + bearer token variables, and run the requests in order to prime the Neo4j persistence layer and automation workflows.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0
+    },
+    "_postman_id": "bf5e7016-b5a6-4c6d-aa67-3f7abe7f8531"
+  },
+  "item": [
+    {
+      "name": "Upsert entities",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text",
+            "description": "Token from graf-api secret (e.g., graf-api/bearer-tokens entry)."
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"entities\": [\n    {\n      \"id\": \"nvidia\",\n      \"label\": \"Company\",\n      \"properties\": {\n        \"name\": \"NVIDIA\",\n        \"focus\": \"AI research\",\n        \"hq\": \"Santa Clara\"\n      },\n      \"streamId\": \"ecosystem-west\",\n      \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-09\"\n    },\n    {\n      \"id\": \"openai\",\n      \"label\": \"ResearchLab\",\n      \"properties\": {\n        \"name\": \"OpenAI\",\n        \"focus\": \"general intelligence\"\n      },\n      \"streamId\": \"ecosystem-west\",\n      \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-09\"\n    }\n  ]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/entities",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "entities"
+          ]
+        },
+        "description": "Creates or updates the nodes that the autoresearch agent and downstream services will inspect. Returns 200 OK with batch results."
+      },
+      "response": []
+    },
+    {
+      "name": "Upsert relationships",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"relationships\": [\n    {\n      \"id\": \"nvidia-openai\",\n      \"type\": \"PARTNER_WITH\",\n      \"fromId\": \"nvidia\",\n      \"toId\": \"openai\",\n      \"properties\": {\n        \"since\": \"2023\",\n        \"notes\": \"Research collaboration on multimodal models\"\n      },\n      \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-09\"\n    }\n  ]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/relationships",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "relationships"
+          ]
+        },
+        "description": "Heartbeats a relationship or installs a new edge between nodes; returns 200 OK with batch IDs."
+      },
+      "response": []
+    },
+    {
+      "name": "Patch entity",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"set\": {\n    \"hq\": \"Santa Clara, CA\",\n    \"sector\": \"Semiconductors\"\n  },\n  \"remove\": [\"deprecatedTag\"],\n  \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-10\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/entities/nvidia",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "entities",
+            "nvidia"
+          ]
+        },
+        "description": "Updates `nvidia` properties by merging `set` and pruning keys listed in `remove`; returns 200 OK."
+      },
+      "response": []
+    },
+    {
+      "name": "Patch relationship",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"set\": {\n    \"confidence\": \"high\",\n    \"evidence\": \"NVIDIA/ OpenAI 2024 memo\"\n  },\n  \"remove\": [],\n  \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-10\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/relationships/nvidia-openai",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "relationships",
+            "nvidia-openai"
+          ]
+        },
+        "description": "Patch metadata on an existing relationship ID `nvidia-openai`; returns 200 OK indicating success."
+      },
+      "response": []
+    },
+    {
+      "name": "Delete entity",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-11\",\n  \"reason\": \"Retiring stale vendor record\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/entities/obsolete-node",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "entities",
+            "obsolete-node"
+          ]
+        },
+        "description": "Soft deletes a node by adding metadata; response is 200 OK and preserves Neo4j audit fields."
+      },
+      "response": []
+    },
+    {
+      "name": "Delete relationship",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-11\",\n  \"reason\": \"Relationship no longer relevant\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/relationships/obsolete-edge",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "relationships",
+            "obsolete-edge"
+          ]
+        },
+        "description": "Marks the relationship record as deleted without dropping it; response is 200 OK."
+      },
+      "response": []
+    },
+    {
+      "name": "Complement entity",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"id\": \"nvidia\",\n  \"hints\": {\n    \"goal\": \"Surface new research partners for AI\",\n    \"confidence\": \"draft\"\n  },\n  \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-11\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/complement",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "complement"
+          ]
+        },
+        "description": "Asks the complement helper to add hints for the entity before an autoresearch run; returns 200 OK with complement details."
+      },
+      "response": []
+    },
+    {
+      "name": "Run clean",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"artifactId\": \"temporal://streams/cleanup/2025-11-11\",\n  \"olderThanHours\": 72\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/clean",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "clean"
+          ]
+        },
+        "description": "Cleans stale records or artifacts, returning 200 OK and the `affected` count."
+      },
+      "response": []
+    },
+    {
+      "name": "Codex research workflow",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"prompt\": \"Summarize the February release notes for the NVIDIA partner graph\",\n  \"metadata\": {\n    \"source\": \"ops-dashboard\"\n  }\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/codex-research",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "codex-research"
+          ]
+        },
+        "description": "Starts the Codex research Argo workflow; returns 202 Accepted with workflow/run IDs and MinIO artifact reference."
+      },
+      "response": []
+    },
+    {
+      "name": "Autoresearch workflow",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{graf_token}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"objective\": \"Map NVIDIA's 2025 AI research alliances across universities and vendors\",\n  \"focus\": \"research\",\n  \"streamId\": \"ecosystem-west\",\n  \"metadata\": {\n    \"artifactId\": \"temporal://streams/ecosystem-west/2025-11-09\"\n  }\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{graf_base_url}}/v1/autoresearch",
+          "host": [
+            "{{graf_base_url}}"
+          ],
+          "path": [
+            "v1",
+            "autoresearch"
+          ]
+        },
+        "description": "Triggers the GPT-5 autoresearch planner; returns 202 Accepted with Temporal workflow metadata while the agent runs asynchronously."
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    {
+      "key": "graf_base_url",
+      "value": "https://graf.proompteng.ai",
+      "type": "string",
+      "description": "Graf service ingress (override when targeting local/alternate clusters)."
+    },
+    {
+      "key": "graf_token",
+      "value": "",
+      "type": "string",
+      "description": "Bearer token from the graf-api secret (matches graf-api/bearer-tokens)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- update the Graf Knative service with the latest image/metadata and enable the agent using an OpenAI key reference
- add a sealed secret that supplies the agent with the OpenAI API key from Kubernetes
- include the Graf autoresearch Postman collection for manual testing of the agent workflow

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- N/A – configuration and asset-only changes

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
