### PR TITLE
chore: include graf openai secret in kustomization

### DIFF
--- a/argocd/applications/graf/knative-service.yaml
+++ b/argocd/applications/graf/knative-service.yaml
@@ -17,14 +17,14 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "60"
-        client.knative.dev/updateTimestamp: 2025-11-09T22:45:47.062Z
+        client.knative.dev/updateTimestamp: 2025-11-09T23:40:14.312Z
     spec:
       timeoutSeconds: 60
       containerConcurrency: 0
       serviceAccountName: graf
       containers:
         - name: user-container
-          image: registry.ide-newton.ts.net/proompteng/graf@sha256:6a3fbe5888bf09f1d7feedd3e5041a5d959697068deebbc8f0bde1e4feffccf0
+          image: registry.ide-newton.ts.net/proompteng/graf@sha256:65cf6116fc4f31b5aefbae972c7f1c7473e72a0b62132f1338766988dd53c7ec
           imagePullPolicy: Always
           ports:
             - name: http1
@@ -47,9 +47,9 @@ spec:
                   name: graf-api
                   key: bearer-tokens
             - name: GRAF_VERSION
-              value: v0.304.1-4-gdba45cd2
+              value: v0.304.1-5-g4818076d
             - name: GRAF_COMMIT
-              value: dba45cd2e2e661cd0229dc701db3874922137e75
+              value: 4818076dd5c924fb421d72348202042ea0c83446
             - name: MINIO_ENDPOINT
               value: http://observability-minio.minio.svc.cluster.local:9000
             - name: MINIO_BUCKET

--- a/argocd/applications/graf/kustomization.yaml
+++ b/argocd/applications/graf/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - knative-service.yaml
   - graf-api-secret.yaml
   - graf-auth-secret.yaml
+  - graf-openai-secret.yaml
   - neo4j-browser-service.yaml
 helmCharts:
   - name: neo4j


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- stamp the Graf Knative service with the latest Graf digest/metadata from the deployment script so Argo rolls to the new image after the failed deploy attempt
- declare the Graf OpenAI sealed secret in the kustomization so the service can consume the `AGENT_OPENAI_API_KEY` environment variable
- ensure the Graf kustomization still builds both the secrets and the Knative service together for ArgoCD

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- N/A – resource manifests only

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
