### PR TITLE
fix: stabilize observability ruler and grafana

### DIFF
--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -1,5 +1,8 @@
 adminUser: admin
 adminPassword: changeme
+replicas: 1
+deploymentStrategy:
+  type: Recreate
 service:
   type: LoadBalancer
   annotations:

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -89,12 +89,28 @@ query_scheduler:
 
 ruler:
   replicas: 1
+  extraInitContainers:
+    - name: copy-graf-rules
+      image: docker.io/library/busybox:1.36
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          find /etc/mimir/rules -mindepth 1 -delete
+          cp -a /etc/mimir/rules-src/. /etc/mimir/rules/
   extraVolumes:
     - name: graf-mimir-rules
       configMap:
         name: graf-mimir-rules
+    - name: graf-mimir-rules-writable
+      emptyDir: {}
   extraVolumeMounts:
     - name: graf-mimir-rules
+      mountPath: /etc/mimir/rules-src
+      readOnly: true
+    - name: graf-mimir-rules-writable
       mountPath: /etc/mimir/rules
 
 store_gateway:


### PR DESCRIPTION
## Summary

- add writable rules mount + init container so the Mimir ruler can pass its sanity check
- force Grafana to roll out with a single replica and Recreate strategy to avoid RWO PVC contention
- document validation expectations in Testing so SREs know to sync via Argo

## Related Issues

None

## Testing

- Not run (config-only change; validation happens when Argo syncs the application)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
