### PR TITLE
fix: allow grafana rollout without pvc conflict

### DIFF
--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -2,7 +2,10 @@ adminUser: admin
 adminPassword: changeme
 replicas: 1
 deploymentStrategy:
-  type: Recreate
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 0
+    maxUnavailable: 1
 service:
   type: LoadBalancer
   annotations:


### PR DESCRIPTION
## Summary

- switch Grafana back to a RollingUpdate strategy with `maxSurge: 0`/`maxUnavailable: 1` so Kubernetes accepts the spec
- keep replicas at 1, guaranteeing the PVC is never attached to more than one pod during upgrades
- unblock the Argo CD sync that was failing with `spec.strategy.rollingUpdate: Forbidden`

## Related Issues

None

## Testing

- Not run (config-only change; validation happens when Argo syncs the application)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
