### PR TITLE
fix: allow graf workflow SA to create workflowtaskresults

### DIFF
--- a/argocd/applications/graf/graf-workflows-clusterrolebinding.yaml
+++ b/argocd/applications/graf/graf-workflows-clusterrolebinding.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: ServiceAccount
     name: graf
     namespace: graf
+  - kind: ServiceAccount
+    name: graf
+    namespace: argo-workflows


### PR DESCRIPTION
## Summary

- allow the `argo-workflows:graf` service account to use the existing `argo-workflows-edit` cluster role so the executor can manage `workflowtaskresults.argoproj.io`
- keep the original `graf` SA in the `graf` namespace anchored to the same ClusterRole so both producers share the permission and the Codex workflow can finish
- this is the sole change required to unblock the `workflowtaskresults` permission errors that blocked artifact persistence

## Related Issues

None

## Testing

- N/A (RBAC manifest-only change; no automated test run needed)

## Screenshots (if applicable)

- N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
