### PR TITLE
fix: use proxy image for knative local gateway

### DIFF
--- a/argocd/applications/istio-system/knative-local-gateway-deployment.yaml
+++ b/argocd/applications/istio-system/knative-local-gateway-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: istio-proxy
-          image: auto
+          image: docker.io/istio/proxyv2:1.28.0
           imagePullPolicy: Always
           ports:
             - containerPort: 15090


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- Pin the `knative-local-gateway` deployment to the released `docker.io/istio/proxyv2:1.28.0` image so it can be pulled successfully.
- Align the ArgoCD manifest with the working ingress gateway deployment that already uses the same image, avoiding the placeholder `auto` tag.
- Ensure the knative-local-gateway pod stays Pending only until ArgoCD replaces it with the stable proxy image rather than failing with `ImagePullBackOff`.

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- N/A – manifest-only change (no runnable artifacts).

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked (not required for this manifest-only fix).
