### PR TITLE
fix: align knative local gateway args

### DIFF
--- a/argocd/applications/istio-system/knative-local-gateway-deployment.yaml
+++ b/argocd/applications/istio-system/knative-local-gateway-deployment.yaml
@@ -36,10 +36,43 @@ spec:
         - name: istio-proxy
           image: docker.io/istio/proxyv2:1.28.0
           imagePullPolicy: Always
+          args:
+            - proxy
+            - router
+            - --domain
+            - $(POD_NAMESPACE).svc.cluster.local
+            - --proxyLogLevel=warning
+            - --proxyComponentLogLevel=misc:error
+            - --log_output_level=default:info
+            - --serviceCluster
+            - knative-local-gateway
+            - --proxyAdminPort
+            - "15000"
+            - --controlPlaneAuthPolicy
+            - NONE
+            - --discoveryAddress
+            - istiod.istio-system.svc.cluster.local:15012
           ports:
             - containerPort: 15090
               name: http-envoy-prom
               protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: ISTIO_META_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           resources:
             limits:
               cpu: "2"


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- align the knative-local-gateway args/env with the standard Istio ingress deployment so the proxy runs `pilot-agent proxy router` instead of the default command that crashed without xDS identity values
- add the metadata-facing env vars (namespace, pod name, pod IP, ISTIO_META_POD_NAME) the agent expects so pilot can bootstrap with a stable service cluster identity
- keep the resources/security context unchanged so the deployment still matches the documented gateway profile while supporting the new CLI setup

## Related Issues

None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- N/A (not requested)

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
- None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
