### PR TITLE
fix: mount istio gateway secrets

### DIFF
--- a/argocd/applications/istio-system/knative-local-gateway-deployment.yaml
+++ b/argocd/applications/istio-system/knative-local-gateway-deployment.yaml
@@ -73,6 +73,26 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          volumeMounts:
+            - name: workload-socket
+              mountPath: /var/run/secrets/workload-spiffe-uds
+            - name: credential-socket
+              mountPath: /var/run/secrets/credential-uds
+            - name: workload-certs
+              mountPath: /var/run/secrets/workload-spiffe-credentials
+            - name: istio-envoy
+              mountPath: /etc/istio/proxy
+            - name: config-volume
+              mountPath: /etc/istio/config
+            - name: istiod-ca-cert
+              mountPath: /var/run/secrets/istio
+            - name: istio-token
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+            - name: istio-data
+              mountPath: /var/lib/istio/data
+            - name: podinfo
+              mountPath: /etc/istio/pod
           resources:
             limits:
               cpu: "2"
@@ -94,3 +114,38 @@ spec:
         sysctls:
           - name: net.ipv4.ip_unprivileged_port_start
             value: "0"
+      volumes:
+        - name: workload-socket
+          emptyDir: {}
+        - name: credential-socket
+          emptyDir: {}
+        - name: workload-certs
+          emptyDir: {}
+        - name: istio-envoy
+          emptyDir: {}
+        - name: istio-data
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: istio
+            optional: true
+        - name: podinfo
+          downwardAPI:
+            items:
+              - path: "labels"
+                fieldRef:
+                  fieldPath: metadata.labels
+              - path: "annotations"
+                fieldRef:
+                  fieldPath: metadata.annotations
+        - name: istiod-ca-cert
+          configMap:
+            name: istio-ca-root-cert
+            optional: true
+        - name: istio-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: istio-token
+                  expirationSeconds: 43200
+                  audience: istio-ca


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- mount the Istio‑provided config, token, and certificate volumes so the knative-local-gateway SDS stack can find `root-cert.pem`
- add the workload sockets, pods info, and proxy artifact mounts that the upstream Istio ingress gateway expects for Envoy/pilot-agent initialization
- keep the existing args/env while layering the Istio volumes to ensure the gateway can authenticate to `istiod` without needing extra configs in the cluster

## Related Issues

None

## Testing

- N/A (not requested)

## Screenshots (if applicable)

- None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
