### PR TITLE
chore: allow argo sso log viewing

### DIFF
--- a/argocd/applications/argo-workflows/rbac.yaml
+++ b/argocd/applications/argo-workflows/rbac.yaml
@@ -128,6 +128,37 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: argo-events-controller-manager
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-workflows-sso-logs
+  namespace: argo-workflows
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflows-sso-logs
+  namespace: argo-workflows
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflows-sso-admin
+    namespace: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-workflows-sso-logs
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
## Summary
- add a dedicated role/binding so the `argo-workflows-sso-admin` service account can `get/list/watch` pods and `pods/log` inside `argo-workflows`
- this lets the Argo UI stream logs for SSO-authenticated viewers without touching the global admin binding
- update the Git-managed RBAC manifest so Argo CD can reconcile the new permissions automatically

## Related Issues
None

## Testing
- N/A

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
