### PR TITLE
fix: harden codex bootstrap env

### DIFF
--- a/apps/froussard/src/codex/cli/__tests__/codex-bootstrap.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-bootstrap.test.ts
@@ -117,4 +117,27 @@ describe('runCodexBootstrap', () => {
     )
     expect(exitCode).toBe(7)
   })
+
+  it('configures non-interactive env defaults without overriding explicit values', async () => {
+    await mkdir(join(workdir, '.git'), { recursive: true })
+    delete process.env.PAGER
+    delete process.env.GIT_PAGER
+    delete process.env.GIT_TERMINAL_PROMPT
+    process.env.LESS = '-R'
+    process.env.MANPAGER = 'more'
+
+    await runCodexBootstrap()
+
+    expect(process.env.PAGER).toBe('cat')
+    expect(process.env.GIT_PAGER).toBe('cat')
+    expect(process.env.GIT_TERMINAL_PROMPT).toBe('0')
+    expect(process.env.KUBECTL_PAGER).toBe('cat')
+    expect(process.env.SYSTEMD_PAGER).toBe('cat')
+    expect(process.env.BAT_PAGER).toBe('cat')
+    expect(process.env.MANPAGER).toBe('more')
+    expect(process.env.LESS).toContain('R')
+    expect(process.env.LESS).toContain('F')
+    expect(process.env.LESS).toContain('S')
+    expect(process.env.LESS).toContain('X')
+  })
 })


### PR DESCRIPTION
## Summary

- force codex bootstrap to disable interactive pagers/prompts so git/diff/apply_patch don't hang workflows
- add targeted vitest coverage confirming env shaping without clobbering overrides
- document validation via biome/vitest to keep CI parity

## Related Issues

None

## Testing

- pnpm --filter froussard exec vitest src/codex/cli/__tests__/codex-bootstrap.test.ts
- pnpm exec biome check apps/froussard/src/codex/cli/codex-bootstrap.ts apps/froussard/src/codex/cli/__tests__/codex-bootstrap.test.ts

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
