### PR TITLE
feat: upgrade Codex model to gpt-5.1-codex

### DIFF
--- a/apps/froussard/scripts/codex-config-container.toml
+++ b/apps/froussard/scripts/codex-config-container.toml
@@ -1,4 +1,4 @@
-model = "gpt-5-codex-mini"
+model = "gpt-5.1-codex"
 model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
 approval_policy = "never"

--- a/apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
+++ b/apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
@@ -130,7 +130,7 @@ describe('codex-runner', () => {
     const promptSink: string[] = []
     const sessionLog = [
       '2025-11-01T19:29:14.313728Z  INFO codex_exec: Codex initialized with event: SessionConfiguredEvent { ',
-      'session_id: ConversationId { uuid: 019a40e5-341a-7501-ad84-5ccdb240e7ff }, model: "gpt-5-codex", ',
+      'session_id: ConversationId { uuid: 019a40e5-341a-7501-ad84-5ccdb240e7ff }, model: "gpt-5.1-codex", ',
       'reasoning_effort: Some(High), history_log_id: 0, history_entry_count: 0, initial_messages: None, ',
       'rollout_path: "/root/.codex/sessions/2025/11/01/rollout-2025-11-01T19-29-14-019a40e5-341a-7501-ad84-5ccdb240e7ff.jsonl" }',
     ].join('')

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@proompteng/source",
@@ -292,6 +293,7 @@
       "devDependencies": {
         "@types/node": "^22.7.5",
         "bun-types": "^1.1.20",
+        "typescript": "^5.9.3",
       },
     },
     "packages/temporal-bun-sdk-example": {
@@ -3983,6 +3985,8 @@
 
     "@proompteng/temporal-bun-sdk/@types/node": ["@types/node@22.15.2", "", { "dependencies": { "undici-types": "6.21.0" } }, "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A=="],
 
+    "@proompteng/temporal-bun-sdk/bun-types": ["bun-types@1.3.2", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-i/Gln4tbzKNuxP70OWhJRZz1MRfvqExowP7U6JKoI8cntFrtxg7RJK3jvz7wQW54UuvNC8tbKHHri5fy74FVqg=="],
+
     "@radix-ui/react-accordion/@types/react": ["@types/react@19.1.13", "", { "dependencies": { "csstype": "3.1.3" } }, "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ=="],
 
     "@radix-ui/react-accordion/@types/react-dom": ["@types/react-dom@19.1.9", "", { "peerDependencies": { "@types/react": "19.1.13" } }, "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ=="],
@@ -5453,6 +5457,8 @@
 
     "@proompteng/bonjour/@types/node/undici-types": ["undici-types@7.14.0", "", {}, "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="],
 
+    "@proompteng/temporal-bun-sdk/bun-types/@types/node": ["@types/node@24.8.1", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q=="],
+
     "@radix-ui/react-accordion/react-dom/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "@radix-ui/react-alert-dialog/react-dom/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
@@ -6712,6 +6718,8 @@
     "@mastra/core/@opentelemetry/otlp-transformer/protobufjs/@types/node": ["@types/node@24.7.0", "", { "dependencies": { "undici-types": "7.14.0" } }, "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw=="],
 
     "@opentelemetry/otlp-transformer/protobufjs/@types/node/undici-types": ["undici-types@7.14.0", "", {}, "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="],
+
+    "@proompteng/temporal-bun-sdk/bun-types/@types/node/undici-types": ["undici-types@7.14.0", "", {}, "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="],
 
     "@tailwindcss/vite/@tailwindcss/node/enhanced-resolve/tapable": ["tapable@2.2.1", "", {}, "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="],
 

--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -104,7 +104,7 @@ Codex sessions are stored locally under `~/.codex/auth.json`. When recreating th
    - Optional flags: `--workspace <name>`, `--auth <path>`, `--config <path>`, `--remote-home <path>`, `--remote-repo <path>`.
      - The script checks for both `rsync` and the OpenSSH client locally and will exit early if either is missing.
    - By default the script consumes `scripts/codex-config-template.toml` (no MCP stanza) and renders it for the remote paths, so `/home/coder` and `/home/coder/github.com/lab` remain trusted on Ubuntu. Supply `--config <path>` if you need a different template.
-   - After syncing it installs a shell wrapper function in `~/.profile`, `~/.bashrc`, and `~/.zshrc` so running `codex …` automatically expands to `codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5-codex …` without shadowing the binary.
+  - After syncing it installs a shell wrapper function in `~/.profile`, `~/.bashrc`, and `~/.zshrc` so running `codex …` automatically expands to `codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5.1-codex …` without shadowing the binary.
    - Both files are locked down with `chmod 600` after transfer.
 3. Verify on the remote host if desired:
    ```bash

--- a/docs/codex-mcp-bridge.md
+++ b/docs/codex-mcp-bridge.md
@@ -18,7 +18,7 @@ install -d ~/.codex
 cp ~/github.com/lab/apps/froussard/scripts/codex-config-container.toml ~/.codex/config.toml
 ```
 
-The template pins `gpt-5-codex`, disables approvals, and trusts `/home/kalmyk/github.com/lab`.
+The template pins `gpt-5.1-codex`, disables approvals, and trusts `/home/kalmyk/github.com/lab`.
 
 ## Systemd service
 

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -9,7 +9,7 @@ This guide explains how the three-stage Codex automation pipeline works and how 
 3. **Argo Events** (`github-codex` EventSource/Sensor) continues to consume the JSON stream (`github.codex.tasks`) for implementation and review handoffs.
    - `github-codex-implementation` for approved plans.
    - `github-codex-review` for review/maintenance loops until the PR becomes mergeable.
-4. Each **WorkflowTemplate** runs the Codex container (`gpt-5-codex` with `--reasoning high --search --mode yolo`), orchestrated by [Argo Workflows](https://argo-workflows.readthedocs.io/en/stable/).
+4. Each **WorkflowTemplate** runs the Codex container (`gpt-5.1-codex` with `--reasoning high --search --mode yolo`), orchestrated by [Argo Workflows](https://argo-workflows.readthedocs.io/en/stable/).
    - `stage=planning`: `codex-plan.ts` (via the `facteur-dispatch` template) generates a `<!-- codex:plan -->` issue comment and logs its GH CLI output to `.codex-plan-output.md`. Facteur prefixes runs with `codex-planning-` to keep planner workflows distinct, and the Argo Events fallback reuses the same template if re-enabled.
    - `stage=implementation`: `codex-implement.ts` executes the approved plan, pushes the feature branch, opens a **draft** PR, maintains the `<!-- codex:progress -->` comment via `codex-progress-comment.ts`, and records the full interaction in `.codex-implementation.log` (uploaded as an Argo artifact).
    - `stage=review`: `codex-review.ts` consumes the review payload, synthesises the reviewer feedback plus failing checks into a new prompt, reuses the existing Codex branch, and streams the run into `.codex-review.log` for artifacts and Discord updates.

--- a/scripts/codex-config-template.toml
+++ b/scripts/codex-config-template.toml
@@ -1,4 +1,4 @@
-model = "gpt-5-codex-mini"
+model = "gpt-5.1-codex"
 model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
 approval_policy = "never"

--- a/scripts/sync-codex-cli.sh
+++ b/scripts/sync-codex-cli.sh
@@ -169,7 +169,7 @@ ssh "${ssh_opts[@]}" "$coder_host" "chmod 600 $(shell_escape "$remote_config")"
 ssh "${ssh_opts[@]}" "$coder_host" bash -s <<'REMOTE'
 set -euo pipefail
 codex_marker="# Managed by sync-codex-cli codex wrapper"
-codex_function=$'codex() {\n  command codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5-codex "$@"\n}'
+codex_function=$'codex() {\n  command codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5.1-codex "$@"\n}'
 for rc in ~/.profile ~/.bashrc ~/.zshrc; do
   touch "${rc}"
   tmp="$(mktemp)"


### PR DESCRIPTION
## Summary

- default Codex configs, wrapper scripts, docs, and tests now reference `gpt-5.1-codex`
- regenerated Codex CLI container config + bun lock metadata so the Docker image bakes the new model defaults
- rebuilt and pushed `registry.ide-newton.ts.net/lab/codex-universal:latest` via `build-codex-image.ts` with the updated config

## Related Issues

- None

## Testing

- pnpm exec biome check apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
- bun apps/froussard/src/codex/cli/build-codex-image.ts

## Screenshots (if applicable)

- None

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
