### PR TITLE
feat: add codex sdk package

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,7 @@ jobs:
       kitty-krew: ${{ steps.filter.outputs.kitty-krew }}
       reviseur: ${{ steps.filter.outputs.reviseur }}
       bonjour: ${{ steps.filter.outputs.bonjour }}
+      codex: ${{ steps.filter.outputs.codex }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -35,6 +36,8 @@ jobs:
               - 'apps/kitty-krew/**'
             reviseur:
               - 'apps/reviseur/**'
+            codex:
+              - 'packages/codex/**'
             packages:
               - 'packages/**'
 
@@ -107,6 +110,26 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm --filter @proompteng/bonjour build
+
+  codex:
+    needs: check_changed_files
+    if: ${{ needs.check_changed_files.outputs.codex == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.20.0
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter @proompteng/codex test
+
+      - run: pnpm --filter @proompteng/codex build
 
   kitty-krew:
     needs: check_changed_files

--- a/packages/codex/README.md
+++ b/packages/codex/README.md
@@ -1,0 +1,20 @@
+# @proompteng/codex
+
+Minimal wrapper around the Codex CLI that mirrors the TypeScript SDK primitives (Codex, Thread, run/runStreamed).
+
+Usage:
+
+```ts
+import { Codex } from '@proompteng/codex'
+
+const codex = new Codex()
+const thread = codex.startThread({ workingDirectory: process.cwd(), approvalPolicy: 'never' })
+
+const { finalResponse } = await thread.run('summarize the repo')
+console.log(finalResponse)
+```
+
+Authentication is handled by the Codex CLI itself. Log in once via `codex login` (or copy `$HOME/.codex/auth.json` onto the host) and the wrapper will reuse that session. Set `codexPathOverride` if the `codex` binary is not on `PATH`.
+```
+const codex = new Codex({ codexPathOverride: '/usr/local/bin/codex' })
+```

--- a/packages/codex/examples/run-example.ts
+++ b/packages/codex/examples/run-example.ts
@@ -1,0 +1,18 @@
+import { Codex } from '../src/index'
+
+const main = async () => {
+  const codex = new Codex()
+  const thread = codex.startThread({
+    workingDirectory: process.cwd(),
+    approvalPolicy: 'never',
+  })
+
+  console.log('Starting Codex example...')
+  const { finalResponse } = await thread.run('Summarize this repository in one sentence.')
+  console.log('Codex response:', finalResponse)
+}
+
+main().catch((error) => {
+  console.error('Example failed:', error)
+  process.exit(1)
+})

--- a/packages/codex/package.json
+++ b/packages/codex/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@proompteng/codex",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "example": "bun run examples/run-example.ts",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.5",
+    "bun-types": "^1.1.20",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/codex/src/codex-exec.ts
+++ b/packages/codex/src/codex-exec.ts
@@ -1,0 +1,154 @@
+import { spawn } from 'node:child_process'
+import { createInterface } from 'node:readline'
+
+import type { ApprovalMode, SandboxMode } from './options'
+
+export interface CodexExecArgs {
+  input: string
+  threadId?: string | null
+  images?: string[]
+  model?: string
+  sandboxMode?: SandboxMode
+  workingDirectory?: string
+  skipGitRepoCheck?: boolean
+  modelReasoningEffort?: string
+  signal?: AbortSignal
+  networkAccessEnabled?: boolean
+  webSearchEnabled?: boolean
+  approvalPolicy?: ApprovalMode
+  additionalDirectories?: string[]
+  baseUrl?: string
+  apiKey?: string
+}
+
+const INTERNAL_ORIGINATOR_ENV = 'CODEX_INTERNAL_ORIGINATOR_OVERRIDE'
+const ORIGINATOR_VALUE = 'lab_codex_sdk'
+
+export class CodexExec {
+  private executablePath: string
+
+  constructor(executablePath?: string) {
+    this.executablePath = executablePath ?? process.env.CODEX_BINARY ?? 'codex'
+  }
+
+  async *run(args: CodexExecArgs): AsyncGenerator<string> {
+    const commandArgs = ['exec', '--experimental-json']
+
+    if (args.model) {
+      commandArgs.push('--model', args.model)
+    }
+
+    if (args.sandboxMode) {
+      commandArgs.push('--sandbox', args.sandboxMode)
+    }
+
+    if (args.workingDirectory) {
+      commandArgs.push('--cd', args.workingDirectory)
+    }
+
+    if (args.additionalDirectories?.length) {
+      for (const dir of args.additionalDirectories) {
+        commandArgs.push('--add-dir', dir)
+      }
+    }
+
+    if (args.skipGitRepoCheck) {
+      commandArgs.push('--skip-git-repo-check')
+    }
+
+    if (args.modelReasoningEffort) {
+      commandArgs.push('--config', `model_reasoning_effort="${args.modelReasoningEffort}"`)
+    }
+
+    if (args.networkAccessEnabled !== undefined) {
+      commandArgs.push('--config', `sandbox_workspace_write.network_access=${args.networkAccessEnabled}`)
+    }
+
+    if (args.webSearchEnabled !== undefined) {
+      commandArgs.push('--config', `features.web_search_request=${args.webSearchEnabled}`)
+    }
+
+    if (args.approvalPolicy) {
+      commandArgs.push('--config', `approval_policy="${args.approvalPolicy}"`)
+    }
+
+    if (args.images?.length) {
+      for (const image of args.images) {
+        commandArgs.push('--image', image)
+      }
+    }
+
+    if (args.threadId) {
+      commandArgs.push('resume', args.threadId)
+    }
+
+    const env = { ...process.env }
+    if (!env[INTERNAL_ORIGINATOR_ENV]) {
+      env[INTERNAL_ORIGINATOR_ENV] = ORIGINATOR_VALUE
+    }
+    if (args.baseUrl) {
+      env.OPENAI_BASE_URL = args.baseUrl
+    }
+    if (args.apiKey) {
+      env.CODEX_API_KEY = args.apiKey
+    }
+
+    const child = spawn(this.executablePath, commandArgs, {
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      signal: args.signal,
+    })
+
+    let spawnError: Error | null = null
+    child.once('error', (error) => {
+      spawnError = error instanceof Error ? error : new Error('failed to spawn codex process')
+    })
+
+    if (!child.stdin) {
+      child.kill()
+      throw new Error('codex subprocess missing stdin handle')
+    }
+    child.stdin.write(args.input)
+    child.stdin.end()
+
+    if (!child.stdout) {
+      child.kill()
+      throw new Error('codex subprocess missing stdout handle')
+    }
+
+    const stderrChunks: Buffer[] = []
+    child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+    const reader = createInterface({ input: child.stdout, crlfDelay: Infinity })
+
+    try {
+      for await (const line of reader) {
+        if (line.length === 0) {
+          continue
+        }
+        yield line
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        child.once('exit', (code) => {
+          if (spawnError) {
+            reject(spawnError)
+            return
+          }
+          if (code === 0) {
+            resolve()
+            return
+          }
+          const stderr = Buffer.concat(stderrChunks).toString('utf8')
+          reject(new Error(`codex exited with status ${code ?? 'unknown'}: ${stderr}`))
+        })
+      })
+    } finally {
+      reader.close()
+      child.removeAllListeners()
+      if (!child.killed) {
+        child.kill()
+      }
+    }
+  }
+}

--- a/packages/codex/src/codex.ts
+++ b/packages/codex/src/codex.ts
@@ -1,0 +1,25 @@
+import { CodexExec } from './codex-exec'
+import type { CodexOptions, ThreadOptions } from './options'
+import { Thread } from './thread'
+
+const defaultOptions: ThreadOptions = {
+  sandboxMode: 'workspace-write',
+}
+
+export class Codex {
+  private exec: CodexExec
+  private options: CodexOptions
+
+  constructor(options: CodexOptions = {}) {
+    this.exec = new CodexExec(options.codexPathOverride)
+    this.options = options
+  }
+
+  startThread(options: ThreadOptions = {}): Thread {
+    return new Thread(this.exec, this.options, { ...defaultOptions, ...options })
+  }
+
+  resumeThread(id: string, options: ThreadOptions = {}): Thread {
+    return new Thread(this.exec, this.options, { ...defaultOptions, ...options }, id)
+  }
+}

--- a/packages/codex/src/index.ts
+++ b/packages/codex/src/index.ts
@@ -1,0 +1,14 @@
+export { Codex } from './codex'
+export { Thread } from './thread'
+export type { RunResult, RunStreamedResult, UserInput } from './thread'
+export { CodexExec } from './codex-exec'
+export type { CodexExecArgs } from './codex-exec'
+export type {
+  CodexOptions,
+  ThreadOptions,
+  TurnOptions,
+  SandboxMode,
+  ApprovalMode,
+  ModelReasoningEffort,
+} from './options'
+export type { ThreadEvent, ThreadItem, ThreadError, Usage } from './types'

--- a/packages/codex/src/options.ts
+++ b/packages/codex/src/options.ts
@@ -1,0 +1,27 @@
+export type ApprovalMode = 'never' | 'on-request' | 'on-failure' | 'untrusted'
+
+export type SandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access'
+
+export type ModelReasoningEffort = 'minimal' | 'low' | 'medium' | 'high'
+
+export interface CodexOptions {
+  codexPathOverride?: string
+  baseUrl?: string
+  apiKey?: string
+}
+
+export interface ThreadOptions {
+  model?: string
+  sandboxMode?: SandboxMode
+  workingDirectory?: string
+  skipGitRepoCheck?: boolean
+  modelReasoningEffort?: ModelReasoningEffort
+  networkAccessEnabled?: boolean
+  webSearchEnabled?: boolean
+  approvalPolicy?: ApprovalMode
+  additionalDirectories?: string[]
+}
+
+export interface TurnOptions {
+  signal?: AbortSignal
+}

--- a/packages/codex/src/thread.test.ts
+++ b/packages/codex/src/thread.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CodexExecArgs } from './codex-exec'
+import type { CodexOptions, ThreadOptions } from './options'
+import { Thread } from './thread'
+
+const createThread = (events: string[], options?: ThreadOptions, codexOptions?: CodexOptions) => {
+  const calls: CodexExecArgs[] = []
+  const exec = {
+    run: vi.fn(async function* (args: CodexExecArgs) {
+      calls.push(args)
+      for (const event of events) {
+        yield event
+      }
+    }),
+  }
+
+  const thread = new Thread(exec as never, codexOptions ?? {}, options ?? {})
+  return { thread, calls, exec }
+}
+
+describe('Thread', () => {
+  it('collects agent messages and usage when running a turn', async () => {
+    const events = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thr_abc' }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'hello world' } }),
+      JSON.stringify({ type: 'turn.completed', usage: { output_tokens: 42 } }),
+    ]
+
+    const { thread, calls } = createThread(events, { workingDirectory: '/tmp/workspace' })
+    const result = await thread.run('Describe the repo')
+
+    expect(thread.id).toBe('thr_abc')
+    expect(result.finalResponse).toBe('hello world')
+    expect(result.usage?.output_tokens).toBe(42)
+    expect(calls[0]?.workingDirectory).toBe('/tmp/workspace')
+  })
+
+  it('streams events and updates thread id lazily', async () => {
+    const events = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thr_stream' }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'first chunk' } }),
+    ]
+
+    const { thread } = createThread(events)
+    const streamed: string[] = []
+
+    for await (const event of thread.runStreamed('Ping').events) {
+      streamed.push(event.type)
+    }
+
+    expect(streamed).toEqual(['thread.started', 'item.completed'])
+    expect(thread.id).toBe('thr_stream')
+  })
+})

--- a/packages/codex/src/thread.ts
+++ b/packages/codex/src/thread.ts
@@ -1,0 +1,120 @@
+import { CodexExec, type CodexExecArgs } from './codex-exec'
+import type { CodexOptions, ThreadOptions, TurnOptions } from './options'
+import type { ThreadEvent, ThreadItem, Usage } from './types'
+
+export type RunResult = {
+  items: ThreadItem[]
+  finalResponse: string
+  usage: Usage | null
+}
+
+export type RunStreamedResult = {
+  events: AsyncGenerator<ThreadEvent>
+}
+
+export type UserInput = string | Array<{ type: 'text'; text: string } | { type: 'local_image'; path: string }>
+
+const toPrompt = (input: UserInput): { prompt: string; images: string[] } => {
+  if (typeof input === 'string') {
+    return { prompt: input, images: [] }
+  }
+
+  const parts: string[] = []
+  const images: string[] = []
+  input.forEach((entry) => {
+    if (entry.type === 'text') {
+      parts.push(entry.text)
+    } else if (entry.type === 'local_image') {
+      images.push(entry.path)
+    }
+  })
+
+  return { prompt: parts.join('\n\n'), images }
+}
+
+export class Thread {
+  private exec: CodexExec
+  private options: CodexOptions
+  private threadOptions: ThreadOptions
+  private _id: string | null
+
+  constructor(exec: CodexExec, options: CodexOptions, threadOptions: ThreadOptions, id?: string | null) {
+    this.exec = exec
+    this.options = options
+    this.threadOptions = threadOptions
+    this._id = id ?? null
+  }
+
+  get id(): string | null {
+    return this._id
+  }
+
+  runStreamed(input: UserInput, turnOptions: TurnOptions = {}): RunStreamedResult {
+    const events = this.runStreamedInternal(input, turnOptions)
+    return { events }
+  }
+
+  async run(input: UserInput, turnOptions: TurnOptions = {}): Promise<RunResult> {
+    const stream = this.runStreamedInternal(input, turnOptions)
+    const items: ThreadItem[] = []
+    let finalResponse = ''
+    let usage: Usage | null = null
+
+    for await (const event of stream) {
+      if (event.type === 'item.completed' && event.item) {
+        items.push(event.item)
+        if (event.item.type === 'agent_message' && typeof event.item.text === 'string') {
+          finalResponse = event.item.text
+        }
+      }
+
+      if (event.type === 'turn.completed' && event.usage) {
+        usage = event.usage
+      }
+
+      if (event.type === 'turn.failed' && event.error) {
+        throw new Error(event.error.message)
+      }
+    }
+
+    return { items, finalResponse, usage }
+  }
+
+  private async *runStreamedInternal(input: UserInput, turnOptions: TurnOptions): AsyncGenerator<ThreadEvent> {
+    const { prompt, images } = toPrompt(input)
+    const execArgs: CodexExecArgs = {
+      input: prompt,
+      images,
+      threadId: this._id,
+      model: this.threadOptions.model,
+      sandboxMode: this.threadOptions.sandboxMode,
+      workingDirectory: this.threadOptions.workingDirectory,
+      skipGitRepoCheck: this.threadOptions.skipGitRepoCheck,
+      modelReasoningEffort: this.threadOptions.modelReasoningEffort,
+      networkAccessEnabled: this.threadOptions.networkAccessEnabled,
+      webSearchEnabled: this.threadOptions.webSearchEnabled,
+      approvalPolicy: this.threadOptions.approvalPolicy,
+      additionalDirectories: this.threadOptions.additionalDirectories,
+      baseUrl: this.options.baseUrl,
+      apiKey: this.options.apiKey,
+      signal: turnOptions.signal,
+    }
+
+    const generator = this.exec.run(execArgs)
+
+    for await (const line of generator) {
+      let parsed: ThreadEvent
+      try {
+        parsed = JSON.parse(line) as ThreadEvent
+      } catch (error) {
+        throw new Error(`failed to parse Codex event line: ${line}`, { cause: error })
+      }
+
+      if (parsed.type === 'thread.started' && parsed.thread_id) {
+        this._id = parsed.thread_id
+      }
+
+      yield parsed
+    }
+  }
+}

--- a/packages/codex/src/types.ts
+++ b/packages/codex/src/types.ts
@@ -1,0 +1,27 @@
+export type ThreadItem = {
+  type: string
+  text?: string
+  [key: string]: unknown
+}
+
+export type ThreadError = {
+  message: string
+  code?: string
+  [key: string]: unknown
+}
+
+export type Usage = {
+  input_tokens?: number
+  output_tokens?: number
+  total_tokens?: number
+  [key: string]: unknown
+}
+
+export type ThreadEvent = {
+  type: string
+  thread_id?: string
+  item?: ThreadItem
+  usage?: Usage
+  error?: ThreadError
+  [key: string]: unknown
+}

--- a/packages/codex/tsconfig.json
+++ b/packages/codex/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["bun-types", "node"]
+  },
+  "include": ["src"]
+}

--- a/packages/codex/vitest.config.ts
+++ b/packages/codex/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,18 @@ importers:
         specifier: ^5.8.2
         version: 5.8.2
 
+  packages/codex:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.7.5
+        version: 22.15.2
+      bun-types:
+        specifier: ^1.1.20
+        version: 1.3.2(@types/react@19.2.2)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+
   packages/scripts:
     dependencies:
       yaml:
@@ -9755,8 +9767,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20251112:
-    resolution: {integrity: sha512-t9fwupCY/vxrHyZR+m3BOwvXdnpuq9Yp0I8ZWFneE5PICANlM4Qgfps3prhzhtiFXPMxfBy5+UEFkynOFybIlg==}
+  typescript@6.0.0-dev.20251113:
+    resolution: {integrity: sha512-z+uimGhCCWMugvUGPrqMRikJpx8weV3zZr7lxvxt8D/IGdmO3w/XDCaKtXCTyFE9zJG6lm2Ci90j2TQtaht39g==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10866,7 +10878,7 @@ snapshots:
       '@babel/types': 7.28.4
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -11992,14 +12004,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.15.2)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@24.8.1)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -12134,7 +12146,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -15947,7 +15959,7 @@ snapshots:
 
   '@types/bunyan@1.8.9':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
 
   '@types/chai@5.2.2':
     dependencies:
@@ -15955,11 +15967,11 @@ snapshots:
 
   '@types/connect@3.4.36':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -16055,11 +16067,11 @@ snapshots:
 
   '@types/mysql@2.15.26':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       form-data: 4.0.2
 
   '@types/node@16.18.126': {}
@@ -16094,7 +16106,7 @@ snapshots:
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       pg-protocol: 1.7.1
       pg-types: 2.2.0
 
@@ -16122,11 +16134,11 @@ snapshots:
 
   '@types/stream-buffers@3.0.7':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       minipass: 4.2.8
 
   '@types/tedious@4.0.14':
@@ -16143,7 +16155,7 @@ snapshots:
 
   '@types/ws@8.18.0':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -16210,6 +16222,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.5(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.5(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/mocker@3.2.4(vite@7.1.5(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
@@ -16691,12 +16711,12 @@ snapshots:
 
   bun-types@1.2.23(@types/react@19.2.2):
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       '@types/react': 19.2.2
 
   bun-types@1.3.0(@types/react@19.2.2):
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       '@types/react': 19.2.2
 
   bun-types@1.3.2(@types/react@19.1.13):
@@ -17380,7 +17400,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20251112
+      typescript: 6.0.0-dev.20251113
 
   dunder-proto@1.0.1:
     dependencies:
@@ -18601,7 +18621,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.15.2)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@24.8.1)(ts-node@10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.26.9
       '@jest/test-sequencer': 29.7.0
@@ -18626,7 +18646,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       ts-node: 10.9.2(@swc/core@1.11.8(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -18814,7 +18834,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.2
+      '@types/node': 24.8.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -21657,7 +21677,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.0-dev.20251112: {}
+  typescript@6.0.0-dev.20251113: {}
 
   ufo@1.5.4: {}
 
@@ -21929,6 +21949,27 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.5(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
@@ -21960,6 +22001,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  vite@7.1.5(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.0
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.50.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.15.2
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.1
+      terser: 5.39.0
+      tsx: 4.20.6
+      yaml: 2.8.1
 
   vite@7.1.5(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
@@ -21998,6 +22056,48 @@ snapshots:
   vitefu@1.1.1(vite@7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)):
     optionalDependencies:
       vite: 7.1.5(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.5(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.15.2
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.7.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:


### PR DESCRIPTION
## Summary

- add internal `@proompteng/codex` package so automation can spawn Codex threads without vendoring upstream sources
- expose build/test scripts, example runner, and Vitest coverage to keep the wrapper verified in CI
- wire GitHub Actions to run the new package’s tests/build whenever `packages/codex/**` changes

## Related Issues

None

## Testing

- pnpm --filter @proompteng/codex test
- pnpm --filter @proompteng/codex build

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
