### PR TITLE
chore: slim temporal-bun prepare job

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -124,12 +124,6 @@ jobs:
           command: manifest
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Ensure release PR exists
-        if: steps.release_please.outputs.pr == ''
-        run: |
-          echo 'No release PR created. Ensure there are Conventional Commit entries since the last release.'
-          exit 1
-
       - name: Fetch release branch
         id: release_branch
         run: |


### PR DESCRIPTION
## Summary

- Remove duplicated setup (Node, pnpm, Bun, Temporal CLI) from the prepare-release job since CI already ran those steps
- Keep release-please + validation on the release branch so the release PR still gets rebuilt/verified

## Related Issues

- Follow-up to #1788 validation

## Testing

- N/A (workflow-only change)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked (not needed).
