### PR TITLE
chore: streamline temporal-bun release workflow

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Set up Node.js 22
         uses: actions/setup-node@v6
         with:
@@ -62,17 +67,13 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --recursive
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --recursive
 
       - name: Build Temporal Bun SDK
         run: pnpm --filter @proompteng/temporal-bun-sdk build
@@ -119,29 +120,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Set up Node.js 22
         uses: actions/setup-node@v6
         with:
           node-version: '22.20.0'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --recursive
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Restore pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --recursive
 
       - name: Run release-please (manifest)
         id: release_please
@@ -179,6 +176,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+          run_install: false
+
       - name: Set up Node.js 22
         uses: actions/setup-node@v6
         with:
@@ -186,11 +189,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.18.1
-          run_install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --recursive


### PR DESCRIPTION
## Summary
- cache pnpm via setup-node in test/prepare/publish jobs and use one install per job
- keep node/bun/pnpm setup in prepare/publish to ensure the build works without redundant steps

## Testing
- N/A (workflow change)
