### PR TITLE
ci: fix pnpm setup for publish

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -175,7 +175,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.1
           run_install: false
 
       - name: Set up Node.js 22


### PR DESCRIPTION
## Summary

- drop the redundant `version` input from pnpm/action-setup in the publish job to satisfy packageManager pinning

## Related Issues

None

## Testing

- gh workflow run temporal-bun-sdk.yml -f release_mode=publish (will rerun after merge per instructions)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
