### PR TITLE
ci: fix publish version echo

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -216,7 +216,13 @@ jobs:
 
       - name: Confirm package version
         run: |
-          node -e "const fs=require('node:fs');const pkg=JSON.parse(fs.readFileSync('packages/temporal-bun-sdk/package.json','utf8'));console.log(\`Publishing @proompteng/temporal-bun-sdk v${pkg.version}\`);"
+          node - <<'NODE'
+          const fs = require('node:fs')
+          const pkg = JSON.parse(
+            fs.readFileSync('packages/temporal-bun-sdk/package.json', 'utf8'),
+          )
+          console.log(`Publishing @proompteng/temporal-bun-sdk v${pkg.version}`)
+          NODE
 
       - name: Build Temporal Bun SDK
         run: pnpm --filter @proompteng/temporal-bun-sdk build


### PR DESCRIPTION
## Summary

- rewrite the publish-step version check to stream node code via stdin, preventing bash from expanding `${pkg.version}`

## Related Issues

None

## Testing

- gh workflow run temporal-bun-sdk.yml -f release_mode=publish (will rerun post-merge)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
