### PR TITLE
ci: wire npm token

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -232,6 +232,7 @@ jobs:
         env:
           NPM_DIST_TAG: ${{ steps.release_meta.outputs.npm_tag }}
           DRY_RUN: ${{ steps.release_meta.outputs.dry_run }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           if [[ "${DRY_RUN}" == "true" ]]; then


### PR DESCRIPTION
## Summary

- pass `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN` to the publish step so npm accepts the release

## Related Issues

None

## Testing

- gh workflow run temporal-bun-sdk.yml -f release_mode=publish (to run after merge)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
