### PR TITLE
ci: enable npm trusted publishing

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -185,6 +185,11 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@11.5.1
+          npm --version
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --recursive
 
@@ -232,7 +237,6 @@ jobs:
         env:
           NPM_DIST_TAG: ${{ steps.release_meta.outputs.npm_tag }}
           DRY_RUN: ${{ steps.release_meta.outputs.dry_run }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           if [[ "${DRY_RUN}" == "true" ]]; then


### PR DESCRIPTION
## Summary

- upgrade npm to 11.5.1 inside the publish job so GitHub's OIDC-based trusted publishing is supported
- drop the legacy `NODE_AUTH_TOKEN` usage in favor of npm's trusted workflow authentication

## Related Issues

None

## Testing

- N/A (GitHub Actions workflow change; publish job only runs on `refs/heads/main`. Will rerun `temporal-bun-sdk.yml` with `release_mode=publish` after merge.)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
