### PR TITLE
feat: persist codex implementation workdir

### DIFF
--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -14,6 +14,16 @@ spec:
         value: '{}'
       - name: eventBody
         value: '{}'
+  volumeClaimTemplates:
+    - metadata:
+        name: workdir
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 30Gi
+        storageClassName: longhorn
   templates:
     - name: implement
       inputs:
@@ -88,6 +98,9 @@ spec:
 
             echo "Executing implementation workflow" >&2
             "${WORKTREE_DIR}/apps/froussard/src/codex/cli/codex-implement.ts" "$EVENT_FILE"
+        volumeMounts:
+          - name: workdir
+            mountPath: /workspace/lab
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
## Summary

- add a per-run Longhorn-backed PVC to the implementation workflow template
- mount the persistent workdir into the Codex container so git state and logs survive `argo retry`
- applied the updated manifest so Argo now provisions the volume in cluster

## Related Issues

None

## Testing

- kubectl apply -k argocd/applications/froussard

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
