### PR TITLE
fix: avoid removing pvc mount point

### DIFF
--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -100,7 +100,7 @@ spec:
             "${WORKTREE_DIR}/apps/froussard/src/codex/cli/codex-implement.ts" "$EVENT_FILE"
         volumeMounts:
           - name: workdir
-            mountPath: /workspace/lab
+            mountPath: /workspace
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
## Summary

- cherry-pick the PVC mount-point fix onto latest `main` so the workdir volume lives at `/workspace`
- prevent `codex-bootstrap` from trying to delete the PVC root, eliminating the `EBUSY: rm '/workspace/lab'` failures during implementation retries

## Related Issues

None

## Testing

- kubectl apply -k argocd/applications/froussard

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
