### PR TITLE
fix: use supported release-please action

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Run release-please (manifest)
         id: release_please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           command: manifest
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- switch temporal-bun-sdk workflow to the supported `googleapis/release-please-action@v4`
- keep manifest mode inputs intact so prepare runs can open/update the release PR
- unblock prepare release workflow that was failing with 403 from the deprecated action

## Related Issues

None

## Testing

- Not run (YAML-only change to GitHub Actions workflow)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
