### PR TITLE
fix: keep prepare release-please in manifest mode

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -144,7 +144,9 @@ jobs:
         id: release_please
         uses: googleapis/release-please-action@v4
         with:
-          command: manifest
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch release branch


### PR DESCRIPTION
## Summary

- run release-please action in manifest mode by pointing at config/manifest files
- skip GitHub release creation during prepare runs; only open/update the release PR
- keep temporal-bun-sdk prepare workflow unblocked after action input changes

## Related Issues

None

## Testing

- Not run (GitHub Actions workflow-only change)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
