### PR TITLE
fix: guard release branch checkout in prepare

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -153,11 +153,18 @@ jobs:
         id: release_branch
         run: |
           branch="release-please--branches--main--components--temporal-bun-sdk"
-          git fetch origin "$branch":"$branch"
-          git checkout "$branch"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          if git ls-remote --exit-code origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "$branch":"$branch"
+            git checkout "$branch"
+            echo "branch=$branch" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release-please branch $branch not found; nothing to build yet"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build Temporal Bun SDK
+        if: steps.release_branch.outputs.found == 'true'
         run: pnpm --filter @proompteng/temporal-bun-sdk build
 
   publish-release:


### PR DESCRIPTION
## Summary

- guard release branch fetch in temporal-bun-sdk prepare workflow, skipping checkout when the release-please branch doesn't exist yet
- keep the build step conditional on that branch so prepare runs don't fail after a merged release PR

## Related Issues

None

## Testing

- Not run (workflow-only change)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
