### PR TITLE
chore: namespace temporal-bun-sdk tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "package-name": "@proompteng/temporal-bun-sdk",
       "changelog-path": "packages/temporal-bun-sdk/CHANGELOG.md",
       "extra-files": ["packages/temporal-bun-sdk/package.json"],
-      "include-component-in-tag": false,
+      "include-component-in-tag": true,
       "versioning": "default"
     }
   }


### PR DESCRIPTION
## Summary

- set `include-component-in-tag` to true for temporal-bun-sdk so release tags are namespaced (e.g., `temporal-bun-sdk-v0.2.1`)
- avoids collisions with existing global `v0.2.0` tag and lets release-please detect the last version correctly

## Related Issues

None

## Testing

- Not run (config-only change)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
