### PR TITLE
chore: set codex model to gpt-5.1-codex-max

### DIFF
--- a/apps/froussard/scripts/codex-config-container.toml
+++ b/apps/froussard/scripts/codex-config-container.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.1-codex"
+model = "gpt-5.1-codex-max"
 model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
 approval_policy = "never"

--- a/apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
+++ b/apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
@@ -130,7 +130,7 @@ describe('codex-runner', () => {
     const promptSink: string[] = []
     const sessionLog = [
       '2025-11-01T19:29:14.313728Z  INFO codex_exec: Codex initialized with event: SessionConfiguredEvent { ',
-      'session_id: ConversationId { uuid: 019a40e5-341a-7501-ad84-5ccdb240e7ff }, model: "gpt-5.1-codex", ',
+      'session_id: ConversationId { uuid: 019a40e5-341a-7501-ad84-5ccdb240e7ff }, model: "gpt-5.1-codex-max", ',
       'reasoning_effort: Some(High), history_log_id: 0, history_entry_count: 0, initial_messages: None, ',
       'rollout_path: "/root/.codex/sessions/2025/11/01/rollout-2025-11-01T19-29-14-019a40e5-341a-7501-ad84-5ccdb240e7ff.jsonl" }',
     ].join('')

--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -104,7 +104,7 @@ Codex sessions are stored locally under `~/.codex/auth.json`. When recreating th
    - Optional flags: `--workspace <name>`, `--auth <path>`, `--config <path>`, `--remote-home <path>`, `--remote-repo <path>`.
      - The script checks for both `rsync` and the OpenSSH client locally and will exit early if either is missing.
    - By default the script consumes `scripts/codex-config-template.toml` (no MCP stanza) and renders it for the remote paths, so `/home/coder` and `/home/coder/github.com/lab` remain trusted on Ubuntu. Supply `--config <path>` if you need a different template.
-  - After syncing it installs a shell wrapper function in `~/.profile`, `~/.bashrc`, and `~/.zshrc` so running `codex …` automatically expands to `codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5.1-codex …` without shadowing the binary.
+  - After syncing it installs a shell wrapper function in `~/.profile`, `~/.bashrc`, and `~/.zshrc` so running `codex …` automatically expands to `codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5.1-codex-max …` without shadowing the binary.
    - Both files are locked down with `chmod 600` after transfer.
 3. Verify on the remote host if desired:
    ```bash

--- a/docs/codex-mcp-bridge.md
+++ b/docs/codex-mcp-bridge.md
@@ -18,7 +18,7 @@ install -d ~/.codex
 cp ~/github.com/lab/apps/froussard/scripts/codex-config-container.toml ~/.codex/config.toml
 ```
 
-The template pins `gpt-5.1-codex`, disables approvals, and trusts `/home/kalmyk/github.com/lab`.
+The template pins `gpt-5.1-codex-max`, disables approvals, and trusts `/home/kalmyk/github.com/lab`.
 
 ## Systemd service
 

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -9,7 +9,7 @@ This guide explains how the three-stage Codex automation pipeline works and how 
 3. **Argo Events** (`github-codex` EventSource/Sensor) continues to consume the JSON stream (`github.codex.tasks`) for implementation and review handoffs.
    - `github-codex-implementation` for approved plans.
    - `github-codex-review` for review/maintenance loops until the PR becomes mergeable.
-4. Each **WorkflowTemplate** runs the Codex container (`gpt-5.1-codex` with `--reasoning high --search --mode yolo`), orchestrated by [Argo Workflows](https://argo-workflows.readthedocs.io/en/stable/).
+4. Each **WorkflowTemplate** runs the Codex container (`gpt-5.1-codex-max` with `--reasoning high --search --mode yolo`), orchestrated by [Argo Workflows](https://argo-workflows.readthedocs.io/en/stable/).
    - `stage=planning`: `codex-plan.ts` (via the `facteur-dispatch` template) generates a `<!-- codex:plan -->` issue comment and logs its GH CLI output to `.codex-plan-output.md`. Facteur prefixes runs with `codex-planning-` to keep planner workflows distinct, and the Argo Events fallback reuses the same template if re-enabled.
    - `stage=implementation`: `codex-implement.ts` executes the approved plan, pushes the feature branch, opens a **draft** PR, maintains the `<!-- codex:progress -->` comment via `codex-progress-comment.ts`, and records the full interaction in `.codex-implementation.log` (uploaded as an Argo artifact).
    - `stage=review`: `codex-review.ts` consumes the review payload, synthesises the reviewer feedback plus failing checks into a new prompt, reuses the existing Codex branch, and streams the run into `.codex-review.log` for artifacts and Discord updates.

--- a/scripts/codex-config-template.toml
+++ b/scripts/codex-config-template.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.1-codex"
+model = "gpt-5.1-codex-max"
 model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
 approval_policy = "never"

--- a/scripts/sync-codex-cli.sh
+++ b/scripts/sync-codex-cli.sh
@@ -169,7 +169,7 @@ ssh "${ssh_opts[@]}" "$coder_host" "chmod 600 $(shell_escape "$remote_config")"
 ssh "${ssh_opts[@]}" "$coder_host" bash -s <<'REMOTE'
 set -euo pipefail
 codex_marker="# Managed by sync-codex-cli codex wrapper"
-codex_function=$'codex() {\n  command codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5.1-codex "$@"\n}'
+codex_function=$'codex() {\n  command codex --full-auto --dangerously-bypass-approvals-and-sandbox --search --model gpt-5.1-codex-max "$@"\n}'
 for rc in ~/.profile ~/.bashrc ~/.zshrc; do
   touch "${rc}"
   tmp="$(mktemp)"


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- default Codex model set to `gpt-5.1-codex-max` across CLI configs and wrapper
- container config and documentation references updated to match the new model default
- Codex runner test fixture adjusted to expect the `gpt-5.1-codex-max` identifier

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- pnpm exec biome check apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
- Not run (config/doc updates only)

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
