### PR TITLE
fix: handle temporal query-only tasks (#1816)

### DIFF
--- a/packages/temporal-bun-sdk/docs/production-design.md
+++ b/packages/temporal-bun-sdk/docs/production-design.md
@@ -401,6 +401,8 @@ can contribute independently without re-planning.
    - Drain in-flight work, respect `--graceful-shutdown-timeout`, expose `WorkerService` integrable with Effect layers.
 5. **Observability**
    - Structured logs (JSON), metrics (poll latency, task failures), optional tracing.
+6. **Query-only tasks (shipped)**
+   - Detect `PollWorkflowTaskQueueResponse.query` and respond with `RespondQueryTaskCompleted` in a read-only executor mode (no new commands/timers/randomness/continue-as-new). Emits `temporal_worker_query_{started,completed,failed}_total` and `temporal_worker_query_latency_ms` metrics.
 
 ### Client Library
 
@@ -413,6 +415,7 @@ can contribute independently without re-planning.
 3. **High-level APIs**
    - Convenience handles for workflow and activity results, typed search attributes,
      payload conversion hooks, streaming update support.
+   - Query helpers honour `QueryRejectCondition` and surface query failures when workers respond via `RespondQueryTaskCompleted`.
 
 ### Tooling & Automation
 

--- a/packages/temporal-bun-sdk/src/client/serialization.ts
+++ b/packages/temporal-bun-sdk/src/client/serialization.ts
@@ -274,6 +274,7 @@ export const buildQueryRequest = async (
   queryName: string,
   args: unknown[],
   dataConverter: DataConverter,
+  options?: { rejectCondition?: QueryRejectCondition },
 ): Promise<QueryWorkflowRequest> => {
   const namespace = ensureNamespace(handle.namespace, '')
   const execution = serializeWorkflowExecution(handle)
@@ -287,7 +288,7 @@ export const buildQueryRequest = async (
       queryArgs,
       header: undefined,
     },
-    queryRejectCondition: QueryRejectCondition.NONE,
+    queryRejectCondition: options?.rejectCondition ?? QueryRejectCondition.NONE,
   })
 }
 

--- a/packages/temporal-bun-sdk/src/workflow/errors.ts
+++ b/packages/temporal-bun-sdk/src/workflow/errors.ts
@@ -66,3 +66,10 @@ export class WorkflowQueryHandlerMissingError extends WorkflowError {
     this.name = 'WorkflowQueryHandlerMissingError'
   }
 }
+
+export class WorkflowQueryViolationError extends WorkflowError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WorkflowQueryViolationError'
+  }
+}

--- a/packages/temporal-bun-sdk/tests/integration/query-only.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/query-only.integration.test.ts
@@ -1,0 +1,212 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import crypto from 'node:crypto'
+
+import { Effect, Exit } from 'effect'
+
+import { loadTemporalConfig } from '../../src/config'
+import { EventType } from '../../src/proto/temporal/api/enums/v1/event_type_pb'
+import { WorkerRuntime } from '../../src/worker/runtime'
+import {
+  TemporalCliCommandError,
+  TemporalCliUnavailableError,
+  createIntegrationHarness,
+  type IntegrationHarness,
+  type TemporalDevServerConfig,
+  type WorkflowExecutionHandle,
+} from './harness'
+import { integrationActivities, integrationWorkflows, queryOnlyWorkflow } from './workflows'
+
+const shouldRunIntegration = process.env.TEMPORAL_INTEGRATION_TESTS === '1'
+const describeIntegration = shouldRunIntegration ? describe : describe.skip
+const scenarioTimeoutMs = 60_000
+
+const CLI_CONFIG: TemporalDevServerConfig = {
+  address: process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233',
+  namespace: process.env.TEMPORAL_NAMESPACE ?? 'default',
+  taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? 'temporal-bun-integration',
+}
+
+describeIntegration('Query-only workflow tasks', () => {
+  let harness: IntegrationHarness | null = null
+  let runtime: WorkerRuntime | null = null
+  let runtimePromise: Promise<void> | null = null
+  let cliUnavailable = false
+
+  beforeAll(async () => {
+    const harnessExit = await Effect.runPromiseExit(createIntegrationHarness(CLI_CONFIG))
+    if (Exit.isFailure(harnessExit)) {
+      if (harnessExit.cause instanceof TemporalCliUnavailableError) {
+        cliUnavailable = true
+        console.warn(`[temporal-bun-sdk] skipping query-only integration: ${harnessExit.cause.message}`)
+        return
+      }
+      throw harnessExit.cause
+    }
+    harness = harnessExit.value
+    await Effect.runPromise(harness.setup)
+
+    const runtimeConfig = await loadTemporalConfig({
+      defaults: {
+        address: CLI_CONFIG.address,
+        namespace: CLI_CONFIG.namespace,
+        taskQueue: CLI_CONFIG.taskQueue,
+      },
+    })
+    runtime = await WorkerRuntime.create({
+      config: runtimeConfig,
+      workflows: integrationWorkflows,
+      activities: integrationActivities,
+      taskQueue: CLI_CONFIG.taskQueue,
+      namespace: runtimeConfig.namespace,
+      stickyScheduling: false,
+      deployment: undefined,
+    })
+    runtimePromise = runtime.run().catch((error) => {
+      console.error('[temporal-bun-sdk] integration worker runtime exited', error)
+      throw error
+    })
+  })
+
+  afterAll(async () => {
+    if (runtime) {
+      await runtime.shutdown().catch((error) => {
+        console.error('[temporal-bun-sdk] failed to shutdown runtime', error)
+      })
+    }
+    if (runtimePromise) {
+      await runtimePromise.catch(() => {})
+    }
+    if (harness) {
+      await Effect.runPromise(harness.teardown)
+    }
+  })
+
+  const runTemporalCli = async (...args: string[]): Promise<string> => {
+    const child = Bun.spawn(['temporal', '--address', CLI_CONFIG.address, ...args], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        TEMPORAL_ADDRESS: CLI_CONFIG.address,
+        TEMPORAL_NAMESPACE: CLI_CONFIG.namespace,
+      },
+    })
+    const exitCode = await child.exited
+    const stdout = child.stdout ? await new Response(child.stdout).text() : ''
+    const stderr = child.stderr ? await new Response(child.stderr).text() : ''
+    if (exitCode !== 0) {
+      throw new TemporalCliCommandError(['temporal', ...args], exitCode, stdout, stderr)
+    }
+    return stdout.trim()
+  }
+
+  const executeWorkflow = async (workflowType: string): Promise<WorkflowExecutionHandle> => {
+    if (!harness) {
+      throw new Error('Integration harness not initialised')
+    }
+    return await Effect.runPromise(
+      harness.executeWorkflow({
+        workflowType,
+        workflowId: `query-only-${crypto.randomUUID()}`,
+        taskQueue: CLI_CONFIG.taskQueue,
+        args: [],
+        startOnly: true,
+      }),
+    )
+  }
+
+  const fetchWorkflowHistory = async (handle: WorkflowExecutionHandle) => {
+    if (!harness) {
+      throw new Error('Integration harness not initialised')
+    }
+    return await Effect.runPromise(harness.fetchWorkflowHistory(handle))
+  }
+
+  const queryWorkflow = async (handle: WorkflowExecutionHandle) => {
+    const args = [
+      'workflow',
+      'query',
+      '--workflow-id',
+      handle.workflowId,
+      '--run-id',
+      handle.runId,
+      '--namespace',
+      CLI_CONFIG.namespace,
+      '--name',
+      'status',
+      '--input',
+      '{}',
+      '--output',
+      'json',
+    ]
+
+    const extractStatus = (value: unknown): string | undefined => {
+      if (typeof value === 'string') {
+        return value
+      }
+      if (Array.isArray(value)) {
+        return value.length > 0 ? extractStatus(value[0]) : undefined
+      }
+      if (value && typeof value === 'object') {
+        const candidate = value as Record<string, unknown>
+        if (typeof candidate.status === 'string') {
+          return candidate.status
+        }
+        if (typeof candidate.message === 'string') {
+          return candidate.message
+        }
+        if (candidate.queryResult !== undefined) {
+          return extractStatus(candidate.queryResult)
+        }
+        if (candidate.result !== undefined) {
+          return extractStatus(candidate.result)
+        }
+      }
+      return undefined
+    }
+
+    const maxAttempts = 5
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        const stdout = await runTemporalCli(...args)
+        const parsed = JSON.parse(stdout)
+        return { status: extractStatus(parsed) }
+      } catch (error) {
+        if (
+          error instanceof TemporalCliCommandError &&
+          /workflow is busy/i.test(error.stderr || error.stdout || '') &&
+          attempt < maxAttempts
+        ) {
+          await Bun.sleep(300 * attempt)
+          continue
+        }
+        throw error
+      }
+    }
+    throw new Error('query retries exhausted')
+  }
+
+  const runOrSkip = async (name: string, scenario: () => Promise<void>) => {
+    if (cliUnavailable) {
+      console.warn(`[temporal-bun-sdk] CLI unavailable; skipping query-only scenario "${name}"`)
+      return
+    }
+    await scenario()
+  }
+
+  test('workflow queries resolve while execution is blocked', async () => {
+    await runOrSkip('query-only blocked workflow', async () => {
+      const handle = await executeWorkflow(queryOnlyWorkflow.name)
+      const start = Date.now()
+      const result = await queryWorkflow(handle)
+      const elapsed = Date.now() - start
+
+      expect(result.status).toBe('blocked-on-timer')
+      expect(elapsed).toBeLessThan(5_000)
+
+      const history = await fetchWorkflowHistory(handle)
+      const completed = history.find((event) => event.eventType === EventType.WORKFLOW_EXECUTION_COMPLETED)
+      expect(completed).toBeUndefined()
+    })
+  }, scenarioTimeoutMs)
+})

--- a/packages/temporal-bun-sdk/tests/worker.query-task.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker.query-task.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from 'bun:test'
+import { Effect } from 'effect'
+import * as Schema from 'effect/Schema'
+
+import { createObservabilityStub, createTestTemporalConfig } from './helpers/observability'
+import type { TemporalConfig } from '../src/config'
+import { QueryResultType } from '../src/proto/temporal/api/enums/v1/query_pb'
+import type { RespondQueryTaskCompletedRequest } from '../src/proto/temporal/api/workflowservice/v1/request_response_pb'
+import type { WorkflowServiceClient } from '../src/worker/runtime'
+import { WorkerRuntime } from '../src/worker/runtime'
+import { defineWorkflow } from '../src/workflow/definition'
+import { defineWorkflowQueries } from '../src/workflow/inbound'
+
+const waitFor = async (predicate: () => boolean, timeoutMs = 2_000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error('waitFor timed out')
+}
+
+test('worker runtime responds to legacy query-only tasks with query completion RPC', async () => {
+  const config: TemporalConfig = createTestTemporalConfig({ taskQueue: 'query-runtime-test' })
+  const observability = createObservabilityStub()
+
+  const queryHandles = defineWorkflowQueries({
+    status: {
+      input: Schema.Unknown,
+      output: Schema.Struct({ value: Schema.String }),
+    },
+  })
+
+  const workflows = [
+    defineWorkflow({
+      name: 'queryRuntimeWorkflow',
+      queries: queryHandles,
+      handler: ({ queries }) =>
+        Effect.gen(function* () {
+          let value = 'booting'
+          yield* queries.register(queryHandles.status, () => Effect.sync(() => ({ value })))
+          value = 'ready'
+          return value
+        }),
+    }),
+  ]
+
+  const respondQueryCalls: RespondQueryTaskCompletedRequest[] = []
+  let respondWorkflowTaskCompletedCalls = 0
+  let historyCalls = 0
+
+  let pollCount = 0
+  const pollResponse = {
+    taskToken: new Uint8Array([1, 2, 3]),
+    workflowExecution: { workflowId: 'wf-query', runId: 'run-query' },
+    workflowType: { name: 'queryRuntimeWorkflow' },
+    query: { queryType: 'status', queryArgs: { payloads: [] } },
+  }
+
+  const workflowService: WorkflowServiceClient = {
+    pollWorkflowTaskQueue: async (_request, { signal }: { signal?: AbortSignal }) => {
+      pollCount += 1
+      if (pollCount === 1) {
+        return pollResponse
+      }
+      return await new Promise((_, reject) => {
+        const abortError = new Error('aborted')
+        abortError.name = 'AbortError'
+        if (signal?.aborted) {
+          reject(abortError)
+          return
+        }
+        signal?.addEventListener('abort', () => reject(abortError), { once: true })
+      })
+    },
+    getWorkflowExecutionHistory: async () => {
+      historyCalls += 1
+      return { history: { events: [] }, nextPageToken: new Uint8Array() }
+    },
+    respondQueryTaskCompleted: async (request: RespondQueryTaskCompletedRequest) => {
+      respondQueryCalls.push(request)
+      return {}
+    },
+    respondWorkflowTaskCompleted: async () => {
+      respondWorkflowTaskCompletedCalls += 1
+      return {}
+    },
+    respondWorkflowTaskFailed: async () => ({}),
+    pollActivityTaskQueue: async () => ({ taskToken: new Uint8Array() }),
+    respondActivityTaskCompleted: async () => ({}),
+    respondActivityTaskFailed: async () => ({}),
+    respondActivityTaskCanceled: async () => ({}),
+    requestCancelWorkflowExecution: async () => ({}),
+    pollWorkflowExecutionUpdate: async () => ({ messages: [] }),
+  } as unknown as WorkflowServiceClient
+
+  const runtime = await WorkerRuntime.create({
+    config,
+    taskQueue: config.taskQueue,
+    namespace: config.namespace,
+    workflows,
+    workflowService,
+    logger: observability.services.logger,
+    metrics: observability.services.metricsRegistry,
+    metricsExporter: observability.services.metricsExporter,
+    stickyScheduling: false,
+    pollers: { workflow: 1 },
+    concurrency: { workflow: 1, activity: 0 },
+  })
+
+  const runPromise = runtime.run()
+  await waitFor(() => respondQueryCalls.length > 0)
+  await runtime.shutdown()
+  await runPromise
+
+  expect(respondWorkflowTaskCompletedCalls).toBe(0)
+  expect(historyCalls).toBeGreaterThanOrEqual(1)
+  expect(respondQueryCalls).toHaveLength(1)
+  const [request] = respondQueryCalls
+  expect(request.completedType).toBe(QueryResultType.ANSWERED)
+  const payloads = request.queryResult?.payloads ?? []
+  expect(payloads.length).toBe(1)
+})


### PR DESCRIPTION
## Summary

- Detect Temporal query-only tasks and respond via `RespondQueryTaskCompleted`, adding query latency/success/failure metrics.
- Add a read-only query execution path with `WorkflowQueryViolationError`, plus client QueryRejectCondition support and refreshed docs.
- Expand coverage with executor/runtime unit tests and a CLI integration test exercising query-only workflows.

## Related Issues

Fixes #1816

## Testing

- pnpm exec biome check packages/temporal-bun-sdk
- pnpm --filter @proompteng/temporal-bun-sdk exec bun test ./tests/workflow.executor.test.ts
- pnpm --filter @proompteng/temporal-bun-sdk exec bun test ./tests/worker.query-task.test.ts
- TEMPORAL_INTEGRATION_TESTS=1 pnpm --filter @proompteng/temporal-bun-sdk exec bun test ./tests/integration/query-only.integration.test.ts

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
