### PR TITLE
chore: bump codex tooling versions

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -26,7 +26,7 @@ RUN apt-get update \
 RUN CODEX_ENV_NODE_VERSION="$CODEX_ENV_NODE_VERSION" CODEX_ENV_GO_VERSION="$CODEX_ENV_GO_VERSION" /opt/codex/setup_universal.sh
 
 RUN mise use --global "bun@${BUN_VERSION}" \
-    && (mise cache clear || true) \
+    && mise cache clear \
     && rm -rf "$HOME/.cache/mise" "$HOME/.local/share/mise/downloads"
 
 RUN set -eux; \


### PR DESCRIPTION
## Summary

- Pin Codex runner image to Bun 1.3.2 via mise with fatal install (no masked failures) to override the base 1.2.x toolchain.
- Upgrade Temporal CLI download to v1.5.1 and Go toolchain to 1.25.4 in the Codex Dockerfile.
- Keep Node 22 configured through the universal setup for reproducible builds.

## Related Issues

None

## Testing

- bun apps/froussard/src/codex/cli/build-codex-image.ts
- docker run --rm --entrypoint /bin/bash registry.ide-newton.ts.net/lab/codex-universal:latest -lc "go version; bun -v; temporal --version | head -n1; node -v"
- docker run --rm --entrypoint /bin/bash registry.ide-newton.ts.net/lab/codex-universal:latest -lc "codex exec --skip-git-repo-check 'Say hi in one short sentence'"

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
