### PR TITLE
fix: add idle timeout guard to codex sessions

### DIFF
--- a/apps/froussard/src/codex/cli/lib/codex-runner.ts
+++ b/apps/froussard/src/codex/cli/lib/codex-runner.ts
@@ -408,12 +408,15 @@ export const runCodexSession = async ({
   }
 
   const codexExitCode = await codexProcess.exited
-  if (codexExitCode !== 0) {
-    throw new Error(`Codex exited with status ${codexExitCode}`)
-  }
 
   if (forcedTermination) {
-    log.warn('Codex subprocess was terminated due to idle timeout')
+    if (codexExitCode !== 0) {
+      log.warn(`Codex subprocess was terminated due to idle timeout (exit ${codexExitCode})`)
+    } else {
+      log.warn('Codex subprocess was terminated due to idle timeout')
+    }
+  } else if (codexExitCode !== 0) {
+    throw new Error(`Codex exited with status ${codexExitCode}`)
   }
 
   if (discordProcess) {


### PR DESCRIPTION
## Summary
- Add idle/grace timeout guards to Codex stdout streaming so hung execs are force-killed after silence.
- Track `turn.completed` to shorten the grace window and log forced terminations; clear/unref timers after successful reads so they don’t keep the loop alive.
- Accept non-zero exits when a forced idle timeout kills Codex; only throw for unexpected non-zero exits.
- Make idle/grace thresholds configurable via `CODEX_IDLE_TIMEOUT_MS` and `CODEX_EXIT_GRACE_MS` env vars.
- Add unit tests covering idle timeout, post–turn.completed grace, and forced-kill non-zero exit behavior in `codex-runner`.

## Related Issues
None

## Testing
- pnpm exec biome check apps/froussard/src/codex/cli/lib/codex-runner.ts
- pnpm exec biome check apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts
- pnpm exec vitest run apps/froussard/src/codex/cli/lib/__tests__/codex-runner.test.ts

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
