### PR TITLE
fix: build discord workspace package

### DIFF
--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepare": "pnpm run build",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -1,1 +1,1 @@
-export * from './channel'
+export * from './channel.js'

--- a/packages/discord/tsconfig.json
+++ b/packages/discord/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
     "types": ["node"],
     "module": "ESNext",
     "target": "ESNext"


### PR DESCRIPTION
<!-- codex:progress -->
## Summary
- build @proompteng/discord during installs via a prepare script and emit declarations with a rootDir-aligned TS config
- align ESM entrypoints to compiled .js outputs to restore runtime resolution for Bun/Node consumers
- verified the Discord helper runs (dry-run) and ensured the package's Vitest suite passes

## Related Issues
- proompteng/lab#1840

## Testing
- pnpm --filter @proompteng/discord run build
- pnpm --filter @proompteng/discord test
- pnpm exec biome check packages/discord/src
- echo "demo message" | bun apps/froussard/scripts/discord-channel.ts --dry-run --repo proompteng/lab --issue 1840 --stage test --run-id demo

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
