### PR TITLE
fix: persist temporal elasticsearch data

### DIFF
--- a/argocd/applications/temporal/kustomization.yaml
+++ b/argocd/applications/temporal/kustomization.yaml
@@ -26,7 +26,7 @@ helmCharts:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 20Gi
+              storage: 5Gi
           storageClassName: longhorn
       web:
         # https://docs.temporal.io/references/web-ui-environment-variables


### PR DESCRIPTION
## Summary

- enable Elasticsearch persistence in Temporal Helm values to keep visibility indices across node restarts
- provision 5Gi Longhorn-backed PVCs for the ES master StatefulSet
- document intent in values for future operators

## Related Issues

None

## Testing

- Not run (config change only)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
