### PR TITLE
fix: persist temporal es with pvc

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -274,6 +274,13 @@ spec:
             - .spec.template.spec.containers[].readinessProbe.periodSeconds
             - .spec.template.spec.containers[].readinessProbe.successThreshold
             - .spec.template.spec.containers[].readinessProbe.timeoutSeconds
+        - kind: StatefulSet
+          group: apps
+          namespace: temporal
+          name: elasticsearch-master
+          jqPathExpressions:
+            - .spec.volumeClaimTemplates[].apiVersion
+            - .spec.volumeClaimTemplates[].kind
         - kind: Service
           group: serving.knative.dev
           namespace: graf


### PR DESCRIPTION
## Summary

- enable Elasticsearch persistence in Temporal Helm values so visibility indices survive restarts
- size the Longhorn-backed PVCs to 5Gi to keep footprint small for this cluster
- add ArgoCD ignoreDifferences for elasticsearch-master StatefulSet PVC metadata to avoid noisy drift

## Related Issues

None

## Testing

- Not run (config change only)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
