### PR TITLE
fix: unblock facteur knative rollout

### DIFF
--- a/argocd/applications/facteur/overlays/cluster/facteur-service.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-service.yaml
@@ -11,8 +11,7 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "100"
-        deploy.knative.dev/rollout: "2025-11-23T20:36:24.795Z"
-        networking.knative.dev/visibility: cluster-local
+        deploy.knative.dev/rollout: "2025-11-23T21:06:31.691Z"
     spec:
       serviceAccountName: facteur
       containers:

--- a/argocd/applications/facteur/overlays/cluster/kustomization.yaml
+++ b/argocd/applications/facteur/overlays/cluster/kustomization.yaml
@@ -21,4 +21,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/facteur
-    newTag: 09ad0084
+    newTag: 21c518bc

--- a/docs/knative/best-practices.md
+++ b/docs/knative/best-practices.md
@@ -1,0 +1,18 @@
+# Knative deployment best practices
+
+## Visibility
+- Prefer the `networking.knative.dev/visibility` **label** on the Service metadata to scope a service to `cluster-local`; do **not** set it as a revision template annotation because the serving webhook rejects it and blocks SKS creation.
+
+## Revision health & rollouts
+- Keep only required annotations on `spec.template.metadata.annotations`; unknown keys can block revisions from becoming Ready.
+- If you use `autoscaling.knative.dev/minScale`, ensure new revisions reach Ready (check `kubectl get ksvc -n <ns>`) to avoid multiple always-on deployments accumulating.
+- Verify traffic targets after deploys (`kubectl get ksvc -n <ns> -o wide`) and clean stale revisions if they remain NotReady.
+
+## Configuration hygiene
+- Set rollout timestamps (`deploy.knative.dev/rollout`) and image digests via automation scripts; avoid manual edits that desynchronize Argo CD and Knative state.
+- Keep readiness probes lightweight; failing probes stall promotion and leave old revisions serving traffic.
+
+## Troubleshooting checklist
+- Look at the PodAutoscaler (`kubectl describe kpa <rev> -n <ns>`) for admission or SKS errors.
+- Check Route/Service events for validation errors, especially after manifest changes.
+- Confirm only the Service-level label defines visibility; absence of SKS usually points to webhook validation failures.


### PR DESCRIPTION
## Summary
- remove invalid Knative visibility annotation from Facteur revision template to allow SKS creation
- roll out new Facteur revision (21c518bc) and document Knative best practices
- clean up stuck prior revision and add guidance for future deployments

## Related Issues
- None

## Testing
- bun packages/scripts/src/facteur/deploy-service.ts
- kubectl get ksvc facteur -n facteur
- kubectl get revisions -n facteur

## Screenshots (if applicable)
- None (no UI changes)

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
