### PR TITLE
feat: guard workflow imports for determinism

### DIFF
--- a/packages/temporal-bun-sdk/src/bin/start-worker.ts
+++ b/packages/temporal-bun-sdk/src/bin/start-worker.ts
@@ -5,7 +5,47 @@ import { Cause, Effect, Exit, Fiber } from 'effect'
 import { runWorkerApp } from '../runtime/worker-app'
 import { resolveWorkerActivities, resolveWorkerWorkflowsPath } from '../worker/defaults'
 
+const applyImportFlagsToEnv = (argv: string[]) => {
+  const normalize = (value: string | undefined) => value?.trim()
+  const flagValue = (flag: string): string | undefined => {
+    const prefixed = `--${flag}`
+    for (let index = 0; index < argv.length; index++) {
+      const candidate = argv[index]
+      if (!candidate.startsWith(prefixed)) {
+        continue
+      }
+      const equalsIndex = candidate.indexOf('=')
+      if (equalsIndex !== -1) {
+        return normalize(candidate.slice(equalsIndex + 1))
+      }
+      const next = argv[index + 1]
+      if (next && !next.startsWith('--')) {
+        return normalize(next)
+      }
+    }
+    return undefined
+  }
+
+  const allow = flagValue('workflow-import-allow')
+  const block = flagValue('workflow-import-block')
+  const ignore = flagValue('workflow-import-ignore')
+  if (allow) {
+    process.env.TEMPORAL_WORKFLOW_IMPORT_ALLOW = allow
+  }
+  if (block) {
+    process.env.TEMPORAL_WORKFLOW_IMPORT_BLOCK = block
+  }
+  if (ignore) {
+    process.env.TEMPORAL_WORKFLOW_IMPORT_IGNORE = ignore
+  }
+  if (argv.includes('--workflow-import-unsafe-ok')) {
+    process.env.TEMPORAL_WORKFLOW_IMPORT_UNSAFE_OK = '1'
+  }
+}
+
 const main = async () => {
+  applyImportFlagsToEnv(process.argv.slice(2))
+
   const workerLayerOptions = {
     worker: {
       activities: resolveWorkerActivities(undefined),

--- a/packages/temporal-bun-sdk/src/index.ts
+++ b/packages/temporal-bun-sdk/src/index.ts
@@ -31,9 +31,10 @@ export type {
   WorkflowUpdateResult,
   WorkflowUpdateStage,
 } from './client/types'
-export type { TemporalConfig, TLSConfig } from './config'
+export type { TemporalConfig, TLSConfig, WorkflowImportPolicy } from './config'
 export {
   applyTemporalConfigOverrides,
+  defaultWorkflowImportPolicy,
   loadTemporalConfig,
   loadTemporalConfigEffect,
   TemporalConfigError,

--- a/packages/temporal-bun-sdk/src/worker/runtime.ts
+++ b/packages/temporal-bun-sdk/src/worker/runtime.ts
@@ -91,6 +91,7 @@ import type {
 import { WorkflowNondeterminismError } from '../workflow/errors'
 import type { WorkflowQueryEvaluationResult, WorkflowUpdateInvocation } from '../workflow/executor'
 import { WorkflowExecutor } from '../workflow/executor'
+import { guardWorkflowImports } from '../workflow/import-guard'
 import type { WorkflowQueryRequest, WorkflowSignalDeliveryInput } from '../workflow/inbound'
 import { WorkflowRegistry } from '../workflow/registry'
 import {
@@ -257,7 +258,11 @@ export class WorkerRuntime {
     }
 
     const identity = options.identity ?? config.workerIdentity
-    const workflows = await loadWorkflows(options.workflowsPath, options.workflows)
+    const workflowsPath = options.workflowsPath
+    if (!options.workflows && workflowsPath) {
+      await guardWorkflowImports(workflowsPath, config.workflowImportPolicy)
+    }
+    const workflows = await loadWorkflows(workflowsPath, options.workflows)
     if (workflows.length === 0) {
       throw new Error('No workflow definitions were registered; provide workflows or workflowsPath')
     }

--- a/packages/temporal-bun-sdk/src/workflow/import-guard.ts
+++ b/packages/temporal-bun-sdk/src/workflow/import-guard.ts
@@ -1,0 +1,145 @@
+import { builtinModules } from 'node:module'
+import path from 'node:path'
+
+import type { WorkflowImportPolicy } from '../config'
+
+const normalizeSpecifier = (specifier: string): string =>
+  specifier
+    .replace(/^node:/, '')
+    .replace(/^bun:/, '')
+    .trim()
+
+const BUN_BUILTINS = ['bun', 'bun:ffi', 'bun:sqlite', 'bun:sqlite3', 'bun:jsc']
+const BUILTIN_SET = new Set<string>([...builtinModules, ...BUN_BUILTINS].map(normalizeSpecifier))
+
+const transpilers = new Map<Bun.Transpiler['loader'], Bun.Transpiler>()
+
+const getTranspiler = (loader: Bun.Transpiler['loader']): Bun.Transpiler => {
+  const cached = transpilers.get(loader)
+  if (cached) {
+    return cached
+  }
+  const created = new Bun.Transpiler({ loader })
+  transpilers.set(loader, created)
+  return created
+}
+
+const resolveLoader = (filePath: string): Bun.Transpiler['loader'] => {
+  const ext = path.extname(filePath).toLowerCase()
+  if (ext === '.tsx') return 'tsx'
+  if (ext === '.jsx') return 'jsx'
+  if (ext === '.ts' || ext === '.mts' || ext === '.cts') return 'ts'
+  return 'js'
+}
+
+const matchesPolicy = (specifier: string, entries: readonly string[]): boolean => {
+  if (!entries.length) return false
+  const base = specifier.split('/')[0] ?? specifier
+  return entries.some((entry) => {
+    const normalized = normalizeSpecifier(entry)
+    return normalized === base || specifier === normalized || specifier.startsWith(`${normalized}/`)
+  })
+}
+
+const isBuiltinSpecifier = (specifier: string): boolean =>
+  BUILTIN_SET.has(normalizeSpecifier(specifier).split('/')[0] ?? '')
+
+const resolveImport = (specifier: string, fromFile: string): { builtin?: string; path?: string } | undefined => {
+  try {
+    const resolved = Bun.resolveSync(specifier, path.dirname(fromFile))
+    if (resolved.startsWith('node:') || resolved.startsWith('bun:')) {
+      return { builtin: resolved }
+    }
+    return { path: path.resolve(resolved) }
+  } catch {
+    return undefined
+  }
+}
+
+const scanImports = async (filePath: string): Promise<{ path: string }[]> => {
+  const file = Bun.file(filePath)
+  if (!(await file.exists())) {
+    return []
+  }
+  const source = await file.text()
+  const loader = resolveLoader(filePath)
+  const transpiler = getTranspiler(loader)
+  return transpiler.scanImports(source)
+}
+
+export class WorkflowImportGuardError extends Error {
+  constructor(
+    message: string,
+    readonly specifiers: string[],
+  ) {
+    super(message)
+    this.name = 'WorkflowImportGuardError'
+  }
+}
+
+export const guardWorkflowImports = async (entrypoint: string, policy: WorkflowImportPolicy): Promise<void> => {
+  if (policy.unsafeImportsAllowed) {
+    return
+  }
+
+  const visited = new Set<string>()
+  const queue = [path.resolve(entrypoint)]
+  const violations = new Set<string>()
+
+  while (queue.length > 0) {
+    const current = queue.pop()
+    if (!current || visited.has(current)) {
+      continue
+    }
+    visited.add(current)
+
+    const imports = await scanImports(current)
+
+    for (const record of imports) {
+      const rawSpecifier = record.path
+      const normalized = normalizeSpecifier(rawSpecifier)
+      const builtin = isBuiltinSpecifier(rawSpecifier)
+      const ignored = matchesPolicy(normalized, policy.ignore)
+      if (ignored) {
+        continue
+      }
+      const allowed = matchesPolicy(normalized, policy.allow)
+      const blocked = matchesPolicy(normalized, policy.block)
+
+      if (!allowed && (blocked || builtin)) {
+        violations.add(normalized || rawSpecifier)
+        continue
+      }
+
+      const resolved = resolveImport(rawSpecifier, current)
+      if (!resolved) {
+        continue
+      }
+      if (resolved.builtin) {
+        const builtinSpecifier = normalizeSpecifier(resolved.builtin)
+        const builtinAllowed = matchesPolicy(builtinSpecifier, policy.allow)
+        const builtinIgnored = matchesPolicy(builtinSpecifier, policy.ignore)
+        const builtinBlocked = matchesPolicy(builtinSpecifier, policy.block)
+        if (!builtinIgnored && !builtinAllowed && (builtinBlocked || isBuiltinSpecifier(builtinSpecifier))) {
+          violations.add(builtinSpecifier)
+        }
+        continue
+      }
+
+      if (resolved.path) {
+        queue.push(resolved.path)
+      }
+    }
+  }
+
+  if (violations.size > 0) {
+    const specifiers = [...violations].sort()
+    const hints = [
+      'Remove nondeterministic built-in imports from workflows or move them to activities.',
+      'Allow a module explicitly via TEMPORAL_WORKFLOW_IMPORT_ALLOW or ignore it with TEMPORAL_WORKFLOW_IMPORT_IGNORE.',
+      'For debugging only, TEMPORAL_WORKFLOW_IMPORT_UNSAFE_OK=1 skips the guard.',
+    ]
+    const message = `Workflow import guard blocked nondeterministic modules: ${specifiers.join(', ')}. ${hints.join(' ')}`
+    throw new WorkflowImportGuardError(message, specifiers)
+  }
+}

--- a/packages/temporal-bun-sdk/tests/fixtures/workflows/import-guard/allowed.ts
+++ b/packages/temporal-bun-sdk/tests/fixtures/workflows/import-guard/allowed.ts
@@ -1,0 +1,6 @@
+import assert from 'node:assert'
+import { URL } from 'node:url'
+import util from 'node:util'
+
+export const workflows = []
+export default workflows

--- a/packages/temporal-bun-sdk/tests/fixtures/workflows/import-guard/disallowed-fs.ts
+++ b/packages/temporal-bun-sdk/tests/fixtures/workflows/import-guard/disallowed-fs.ts
@@ -1,0 +1,6 @@
+import { readFile } from 'fs/promises'
+
+export const workflows = []
+export default workflows
+
+void readFile // keep import referenced

--- a/packages/temporal-bun-sdk/tests/fixtures/workflows/import-guard/nested-entry.ts
+++ b/packages/temporal-bun-sdk/tests/fixtures/workflows/import-guard/nested-entry.ts
@@ -1,0 +1,4 @@
+import './nested/uses-path.ts'
+
+export const workflows = []
+export default workflows

--- a/packages/temporal-bun-sdk/tests/fixtures/workflows/import-guard/nested/uses-path.ts
+++ b/packages/temporal-bun-sdk/tests/fixtures/workflows/import-guard/nested/uses-path.ts
@@ -1,0 +1,4 @@
+import path from 'node:path'
+
+export const value = path.join('a', 'b')
+export default value

--- a/packages/temporal-bun-sdk/tests/worker.import-guard.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker.import-guard.test.ts
@@ -1,0 +1,52 @@
+import { join } from 'node:path'
+
+import { expect, test } from 'bun:test'
+
+import { defaultWorkflowImportPolicy, type WorkflowImportPolicy } from '../src/config'
+import { guardWorkflowImports } from '../src/workflow/import-guard'
+
+const fixture = (file: string) =>
+  join(import.meta.dir, 'fixtures', 'workflows', 'import-guard', file)
+
+const clonePolicy = (policy: WorkflowImportPolicy): WorkflowImportPolicy => ({
+  allow: [...policy.allow],
+  block: [...policy.block],
+  ignore: [...policy.ignore],
+  unsafeImportsAllowed: policy.unsafeImportsAllowed,
+})
+
+test('fails fast on blocked built-in imports', async () => {
+  await expect(guardWorkflowImports(fixture('disallowed-fs.ts'), defaultWorkflowImportPolicy)).rejects.toThrow(
+    /fs/,
+  )
+})
+
+test('allows safe built-ins by default', async () => {
+  await expect(guardWorkflowImports(fixture('allowed.ts'), defaultWorkflowImportPolicy)).resolves.toBeUndefined()
+})
+
+test('honors allow list overrides', async () => {
+  const policy = clonePolicy(defaultWorkflowImportPolicy)
+  policy.allow.push('fs')
+  policy.block = policy.block.filter((entry) => entry !== 'fs')
+
+  await expect(guardWorkflowImports(fixture('disallowed-fs.ts'), policy)).resolves.toBeUndefined()
+})
+
+test('ignores specifiers on the ignore list', async () => {
+  const policy = clonePolicy(defaultWorkflowImportPolicy)
+  policy.ignore.push('fs')
+
+  await expect(guardWorkflowImports(fixture('disallowed-fs.ts'), policy)).resolves.toBeUndefined()
+})
+
+test('recursively scans nested workflow imports', async () => {
+  await expect(guardWorkflowImports(fixture('nested-entry.ts'), defaultWorkflowImportPolicy)).rejects.toThrow(/path/)
+})
+
+test('escape hatch bypasses the guard', async () => {
+  const policy = clonePolicy(defaultWorkflowImportPolicy)
+  policy.unsafeImportsAllowed = true
+
+  await expect(guardWorkflowImports(fixture('disallowed-fs.ts'), policy)).resolves.toBeUndefined()
+})

--- a/packages/temporal-bun-sdk/tests/workflow/globals-guard.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow/globals-guard.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from 'bun:test'
+import { Effect } from 'effect'
+import * as Schema from 'effect/Schema'
+
+import { createDefaultDataConverter } from '../../src/common/payloads'
+import { defineWorkflow } from '../../src/workflow/definition'
+import { WorkflowExecutor } from '../../src/workflow/executor'
+import { WorkflowNondeterminismError } from '../../src/workflow/errors'
+import { WorkflowRegistry } from '../../src/workflow/registry'
+
+const makeExecutor = () => {
+  const registry = new WorkflowRegistry()
+  const dataConverter = createDefaultDataConverter()
+  const executor = new WorkflowExecutor({ registry, dataConverter })
+  return { registry, executor }
+}
+
+const execute = (
+  executor: WorkflowExecutor,
+  workflowType: string,
+  args: unknown[] = [],
+) =>
+  executor.execute({
+    workflowType,
+    arguments: args,
+    workflowId: 'wf-id',
+    runId: 'run-id',
+    namespace: 'default',
+    taskQueue: 'test-queue',
+  })
+
+test('throws when workflow touches WeakRef', async () => {
+  const { registry, executor } = makeExecutor()
+  registry.register(
+    defineWorkflow(
+      'usesWeakRef',
+      Schema.Array(Schema.Unknown),
+      () =>
+        Effect.sync(() => {
+          // @ts-expect-error WeakRef override should throw inside workflows
+          const ref = new WeakRef({ value: 1 })
+          return ref.deref()
+        }),
+    ),
+  )
+
+  await expect(execute(executor, 'usesWeakRef')).rejects.toThrow(WorkflowNondeterminismError)
+})
+
+test('throws when workflow registers FinalizationRegistry', async () => {
+  const { registry, executor } = makeExecutor()
+  registry.register(
+    defineWorkflow(
+      'usesFinalizationRegistry',
+      Schema.Array(Schema.Unknown),
+      () =>
+        Effect.sync(() => {
+          // @ts-expect-error FinalizationRegistry override should throw inside workflows
+          new FinalizationRegistry(() => {})
+          return 'ok'
+        }),
+    ),
+  )
+
+  await expect(execute(executor, 'usesFinalizationRegistry')).rejects.toThrow(WorkflowNondeterminismError)
+})
+
+test('restores global constructors after execution', async () => {
+  const originalWeakRef = globalThis.WeakRef
+  const originalFinalizationRegistry = globalThis.FinalizationRegistry
+  const { registry, executor } = makeExecutor()
+
+  registry.register(
+    defineWorkflow(
+      'no-op',
+      Schema.Array(Schema.Unknown),
+      () => Effect.sync(() => 'ok'),
+    ),
+  )
+
+  await expect(execute(executor, 'no-op')).resolves.toBeDefined()
+  expect(globalThis.WeakRef).toBe(originalWeakRef)
+  expect(globalThis.FinalizationRegistry).toBe(originalFinalizationRegistry)
+})


### PR DESCRIPTION
## Summary

- add workflow import policy config with default safe allowlist and env overrides
- run a startup import guard plus CLI flags and runtime WeakRef/FinalizationRegistry shims for workflow determinism
- add fixtures/tests for import/global guards and document the determinism guard defaults and escape hatch

## Related Issues

Closes #1862

## Testing

- pnpm --filter @proompteng/temporal-bun-sdk exec biome check src tests
- pnpm --filter @proompteng/temporal-bun-sdk exec bun test

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
