### PR TITLE
feat: add CNPG cluster for Jangar (JNG-080a)

### DIFF
--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: jangar
 resources:
+  - postgres-cluster.yaml
   - kservice.yaml
   - tailscale-service.yaml
 

--- a/argocd/applications/jangar/postgres-cluster.yaml
+++ b/argocd/applications/jangar/postgres-cluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: jangar-db
+spec:
+  instances: 1
+  primaryUpdateStrategy: unsupervised
+  storage:
+    storageClass: longhorn
+    size: 10Gi
+  bootstrap:
+    initdb:
+      database: jangar
+      owner: jangar
+      encoding: "UTF8"
+      dataChecksums: true
+  monitoring:
+    enablePodMonitor: true
+# CNPG defaults generate application credentials in `jangar-db-app` (uri, user, password, host, port, dbname)
+# and the CA bundle in `jangar-db-ca` (ca.crt). JNG-080b will wire DATABASE_URL and PGSSLROOTCERT from these.

--- a/docs/jangar/implementation-plan.md
+++ b/docs/jangar/implementation-plan.md
@@ -62,6 +62,10 @@ Context: use this plan to split work across Codex agents/Argo jobs. Markers use 
 
 ### JNG-080 Infra/Build
 - TODO(jng-080a): Add CNPG manifest `argocd/applications/jangar/postgres-cluster.yaml` and include in kustomization.
+- NOTE(jng-080a): CNPG Cluster `jangar-db` (10Gi longhorn PVC, instances: 1, `primaryUpdateStrategy: unsupervised`,
+  PodMonitor enabled) auto-generates `jangar-db-app` (uri, user, password, host, port, dbname) and `jangar-db-ca`
+  (ca.crt). The service should read `DATABASE_URL` from `jangar-db-app:uri` and `PGSSLROOTCERT` from
+  `jangar-db-ca:ca.crt`.
 - TODO(jng-080b): Extend `argocd/applications/jangar/kservice.yaml` with env/secret mounts (DATABASE_URL, CODEX_API_KEY, GITHUB_TOKEN, CA mount) and add OpenWebUI sidecar.
 - TODO(jng-080c): Update `packages/scripts/src/jangar/build-image.ts` & `deploy-service.ts` to bundle `packages/cx-tools/dist`, UI dist, and stamp `JANGAR_VERSION/JANGAR_COMMIT`.
 


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- Add CloudNativePG cluster manifest for Jangar with 10Gi longhorn storage, initdb owner/database `jangar`, and PodMonitor enabled.
- Include the new Postgres cluster in `argocd/applications/jangar` kustomization resources.
- Document generated secrets (`jangar-db-app`, `jangar-db-ca`) and how the service should consume `DATABASE_URL`/`PGSSLROOTCERT`.

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
Closes #1871

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- `kustomize build argocd/applications/jangar`
- `kubectl -n jangar create --dry-run=client -k argocd/applications/jangar` (client-side validation; `apply --dry-run=client` was blocked by cluster RBAC for the current service account)

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
