### PR TITLE
fix: harden docs docker build

### DIFF
--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.2
+ARG BUN_VERSION=1.3.3
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION
@@ -7,11 +7,14 @@ WORKDIR /app
 ENV BUN_INSTALL="/root/.bun"
 ENV PATH="$BUN_INSTALL/bin:$PATH"
 
+RUN apk add --no-cache bash curl
 RUN curl -fsSL https://bun.sh/install | bash -s -- bun-v${BUN_VERSION}
 
-COPY package.json bun.lock .npmrc* ./
+COPY package.json bun.lock .npmrc* turbo.json tsconfig.base.json tsconfig.json ./
 COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
-COPY apps/docs ./apps/docs
+COPY apps ./apps
+COPY packages ./packages
+COPY services ./services
 
 ENV HUSKY=0
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Install bash/curl and bump Bun to 1.3.3 in the docs Docker deps stage.
- Copy apps/packages/services plus root configs into the deps layer so bun install sees the full workspace.
- Confirm docs image builds end-to-end inside Docker with frozen lockfile and Next.js build.

## Related Issues

None

## Testing

- docker build -f apps/docs/Dockerfile .

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
