### PR TITLE
chore: enable openwebui debug logging

### DIFF
--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -66,6 +66,13 @@ resources:
     cpu: "2"
     memory: 4Gi
 
+# Increase OpenWebUI verbosity for debugging streaming issues
+logging:
+  level: debug
+  components:
+    openai: debug
+    main: debug
+
 persistence:
   storageClass: longhorn
   size: 5Gi

--- a/services/jangar/docker-compose.yml
+++ b/services/jangar/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - DEFAULT_USER_ROLE=admin
       - WEBUI_AUTH=false
       - ENABLE_LOGIN_FORM=false
+      - GLOBAL_LOG_LEVEL=DEBUG
+      - UVICORN_LOG_LEVEL=debug
     volumes:
       - openwebui-data:/app/backend/data
     extra_hosts:


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- Raised OpenWebUI global logging to DEBUG with component overrides for main/openai in cluster values.
- Enabled DEBUG and uvicorn debug logging for local docker-compose OpenWebUI service.
- Preparing to capture more verbose traces for streaming/TransferEncodingError investigations.

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
- None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- Not run — config-only logging verbosity change.

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
- N/A

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
- None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
