### PR TITLE
feat: add Alloy log shipper for Jangar

### DIFF
--- a/argocd/applications/jangar/alloy-configmap.yaml
+++ b/argocd/applications/jangar/alloy-configmap.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jangar-alloy
+  namespace: jangar
+data:
+  config.river: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+
+    // Jangar web app
+    discovery.kubernetes "jangar" {
+      role = "pod"
+
+      namespaces {
+        names = ["jangar"]
+      }
+
+      selectors {
+        role  = "pod"
+        label = "app=jangar"
+      }
+    }
+
+    loki.source.kubernetes "jangar" {
+      targets    = discovery.kubernetes.jangar.targets
+      forward_to = [loki.process.jangar.receiver]
+    }
+
+    loki.process "jangar" {
+      stage.labels {
+        values = {
+          namespace = "{{ .Labels.namespace }}",
+          pod       = "{{ .Labels.pod }}",
+          container = "{{ .Labels.container }}",
+        }
+      }
+
+      stage.static_labels {
+        values = {
+          app = "jangar",
+          job = "jangar",
+        }
+      }
+
+      forward_to = [loki.write.default.receiver]
+    }
+
+    // Jangar worker
+    discovery.kubernetes "jangar_worker" {
+      role = "pod"
+
+      namespaces {
+        names = ["jangar"]
+      }
+
+      selectors {
+        role  = "pod"
+        label = "app=jangar-worker"
+      }
+    }
+
+    loki.source.kubernetes "jangar_worker" {
+      targets    = discovery.kubernetes.jangar_worker.targets
+      forward_to = [loki.process.jangar_worker.receiver]
+    }
+
+    loki.process "jangar_worker" {
+      stage.labels {
+        values = {
+          namespace = "{{ .Labels.namespace }}",
+          pod       = "{{ .Labels.pod }}",
+          container = "{{ .Labels.container }}",
+        }
+      }
+
+      stage.static_labels {
+        values = {
+          app = "jangar-worker",
+          job = "jangar-worker",
+        }
+      }
+
+      forward_to = [loki.write.default.receiver]
+    }
+
+    // Jangar Open WebUI Helm release
+    discovery.kubernetes "jangar_openwebui" {
+      role = "pod"
+
+      namespaces {
+        names = ["jangar"]
+      }
+
+      selectors {
+        role  = "pod"
+        label = "app.kubernetes.io/instance=jangar-openwebui"
+      }
+    }
+
+    loki.source.kubernetes "jangar_openwebui" {
+      targets    = discovery.kubernetes.jangar_openwebui.targets
+      forward_to = [loki.process.jangar_openwebui.receiver]
+    }
+
+    loki.process "jangar_openwebui" {
+      stage.labels {
+        values = {
+          namespace = "{{ .Labels.namespace }}",
+          pod       = "{{ .Labels.pod }}",
+          container = "{{ .Labels.container }}",
+        }
+      }
+
+      stage.static_labels {
+        values = {
+          app = "jangar-openwebui",
+          job = "jangar-openwebui",
+        }
+      }
+
+      forward_to = [loki.write.default.receiver]
+    }
+
+    loki.write "default" {
+      endpoint {
+        url = "http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push"
+      }
+    }
+
+    // Future: add OTLP/metrics pipelines here once Jangar publishes telemetry.

--- a/argocd/applications/jangar/alloy-deployment.yaml
+++ b/argocd/applications/jangar/alloy-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jangar-alloy
+  namespace: jangar
+  labels:
+    app.kubernetes.io/name: jangar-alloy
+    app.kubernetes.io/component: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jangar-alloy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jangar-alloy
+        app.kubernetes.io/component: logging
+    spec:
+      serviceAccountName: jangar-alloy
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.11.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/alloy/config.river
+          ports:
+            - name: http-metrics
+              containerPort: 12345
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: jangar-alloy
+            items:
+              - key: config.river
+                path: config.river

--- a/argocd/applications/jangar/alloy-rbac.yaml
+++ b/argocd/applications/jangar/alloy-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jangar-alloy
+  namespace: jangar
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jangar-alloy
+  namespace: jangar
+rules:
+  - apiGroups: ['']
+    resources: ['pods', 'pods/log']
+    verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jangar-alloy
+  namespace: jangar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jangar-alloy
+subjects:
+  - kind: ServiceAccount
+    name: jangar-alloy
+    namespace: jangar

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
   - pvc.yaml
   - vscode-tailscale-service.yaml
   - worker-deployment.yaml
+  - alloy-rbac.yaml
+  - alloy-configmap.yaml
+  - alloy-deployment.yaml
 
 helmCharts:
   - name: open-webui


### PR DESCRIPTION
## Summary

- add Alloy RBAC, ConfigMap, and deployment for the jangar namespace with per-app pipelines
- set per-workload static `app` labels (jangar, jangar-worker, jangar-openwebui) and forward to the shared Loki gateway
- wire Alloy manifests into the jangar kustomization and validated kustomize rendering

## Related Issues

Fixes #1888

## Testing

- `kubectl kustomize --enable-helm argocd/applications/jangar`
- `kubectl kustomize --enable-helm argocd/applications/jangar | kubectl apply --dry-run=client -f -` (fails: Forbidden for identity `system:serviceaccount:argo-workflows:argo-workflows-workflow` to read resources in namespace `jangar`; unable to complete client-side apply without broader RBAC)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
