### PR TITLE
fix: robust kubectl install and rollout

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2025-11-29T10:55:44.302Z"
+    deploy.knative.dev/rollout: "2025-11-29T23:26:48.945Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -27,5 +27,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 39f56007
-    digest: sha256:4ab13111a8ef4d5edebcabc0b2550b89f52085d22d9f78ab3591148e6e4d5efa
+    newTag: 5e29ad61
+    digest: sha256:73ec96624d27560165eae9b277a3866b04e49e16485d4356cb608634de4249ae

--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -39,15 +39,20 @@ RUN set -eux; \
 RUN set -eux; \
   ARCH="${TARGETARCH:-$(uname -m)}"; \
   case "$ARCH" in \
-    amd64|x86_64) BIN_ARCH=amd64 ;; \
-    arm64|aarch64) BIN_ARCH=arm64 ;; \
+    amd64|x86_64) BIN_ARCH=amd64; DOCKER_ARCH=x86_64 ;; \
+    arm64|aarch64) BIN_ARCH=arm64; DOCKER_ARCH=aarch64 ;; \
     *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;; \
   esac; \
-  # kubectl
-  curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux-${BIN_ARCH}/kubectl"; \
-  chmod +x /usr/local/bin/kubectl; \
+  # kubectl via apt.k8s.io (new repository scheme); derive minor series (e.g., v1.30)
+  KUBE_SERIES="${KUBECTL_VERSION%.*}"; \
+  KUBE_REPO="https://pkgs.k8s.io/core:/stable:/${KUBE_SERIES}/deb"; \
+  install -m 0755 -d /etc/apt/keyrings; \
+  curl -fSLs --noproxy '*' "$KUBE_REPO/Release.key" | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg; \
+  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] $KUBE_REPO/ /" > /etc/apt/sources.list.d/kubernetes.list; \
+  apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20; \
+  apt-get install -y --no-install-recommends kubectl; \
   # docker CLI
-  curl -fsSLo /tmp/docker.tgz "https://download.docker.com/linux/static/stable/${BIN_ARCH}/docker-${DOCKER_CLI_VERSION}.tgz"; \
+  curl -fSLs -o /tmp/docker.tgz "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_CLI_VERSION}.tgz"; \
   tar -xz -C /usr/local/bin --strip-components=1 -f /tmp/docker.tgz docker/docker; \
   rm /tmp/docker.tgz
 


### PR DESCRIPTION
## Summary

- Install kubectl from signed pkgs.k8s.io repo to stop arm64 build 404s.
- Map Docker CLI download archs correctly (aarch64/x86_64) in Jangar image build.
- Rebuilt/pushed Jangar image and updated Argo CD kustomization tag and rollout annotation; Convex deploy ran as part of deploy script.

## Related Issues

None

## Testing

- bun run packages/scripts/src/jangar/deploy-service.ts

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
