### PR TITLE
docs: document jangar current state

### DIFF
--- a/docs/jangar/current-state.md
+++ b/docs/jangar/current-state.md
@@ -1,0 +1,26 @@
+# Jangar current state (2025-11-30)
+
+Source code is the source of truth; this note captures what is actually implemented today.
+
+## Working
+- OpenAI-compatible proxy endpoints `/openai/v1/chat/completions` (streaming-only) and `/openai/v1/models` backed by the Codex app-server (`gpt-5.1-codex-*`).
+- Convex schema and mutations for conversations, turns, messages, reasoning sections, commands (+ chunks), usage, rate limits, and events. The proxy writes via `src/services/db`.
+- App server wrapper auto-clones the lab repo into `CODEX_CWD` when missing; runs Codex with sandbox `danger-full-access`, approval `never` by default.
+
+## Not yet implemented
+- Activities: `run-codex-turn`, `run-worker-task`, and `publish-event` are stubs; no repo cloning, lint/test, PR creation, or SSE fan-out.
+- Workflow: `codexOrchestrationWorkflow` schedules a single stub turn; signals/queries/loop/guardrails are missing.
+- Toolbelt: `packages/cx-tools` contains only scaffolding—no `cx-codex-run` or `cx-workflow-*` binaries are built.
+- UI: only a welcome page and `/health`; mission list/detail, chat, timeline, and SSE wiring are absent.
+- Convex read-side queries are absent; UI cannot fetch history/state.
+- Manifests lack secrets for `CODEX_API_KEY`, `GITHUB_TOKEN`, and Convex deploy/admin keys; app deployment disables the Temporal worker (`ENABLE_TEMPORAL_WORKER=0`).
+
+## Behavioral notes
+- `/v1/models` exposes four Codex variants (`gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1`). Adjust `src/services/models.ts` if only one should appear.
+- Worker and app share the same image; worker command is `bun run src/worker.ts`. App entrypoint `src/index.ts` can start the worker if `ENABLE_TEMPORAL_WORKER` is set.
+- Env helper `buildCodexEnv` sets `CX_DEPTH` and `CODEX_HOME` but does not yet wire `CODEX_API_KEY/CODEX_PATH`.
+
+## Quick smoke
+- From `services/jangar`: `bun run start:dev` (UI) and `curl -N -X POST http://localhost:3000/openai/v1/chat/completions ...` with `stream=true` to confirm SSE proxy + Convex writes.
+
+Keep this file in sync with code changes until the planned features land.

--- a/docs/jangar/openwebui.md
+++ b/docs/jangar/openwebui.md
@@ -18,7 +18,7 @@ OpenWebUI is installed via the upstream Helm chart (`open-webui` v8.18.0, app v0
 - Auth/signup remain disabled (`WEBUI_AUTH=false`, `ENABLE_SIGNUP=false`).
 - Websockets: `WEBSOCKET_MANAGER=redis`, `WEBSOCKET_REDIS_URL=redis://jangar-openwebui-redis:6379/0` (Redis provided by the operator, not the chart).
 - Database: `DATABASE_URL` from CNPG secret `jangar-db-app`; TLS root cert from `jangar-db-ca`.
-- Only the orchestrator model is exposed in `/v1/models` (mapped to `gpt-5.1-codex-max`).
+- Current code returns four models from `/v1/models` (`gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1`); if OpenWebUI should show a single orchestrator entry, narrow the list in `services/jangar/src/services/models.ts` or filter in values.
 
 ## Image pin
 - `ghcr.io/open-webui/open-webui:v0.6.40` (managed by the Helm chart)

--- a/services/jangar/src/README.md
+++ b/services/jangar/src/README.md
@@ -1,17 +1,30 @@
-# Jangar Start UI
+# Jangar service
 
-TanStack Start scaffold for the Jangar operator UI. OpenWebUI now ships as its own Helm release; Jangar connects to it via
-the configured host instead of an in-app banner.
+This directory hosts the Bun app that serves the OpenAI-compatible proxy, the TanStack Start UI scaffold, and the Temporal worker (same image). As of November 30, 2025 the implementation is partial; see “Current state” below.
 
-## Commands
+## Current state
 
-- `bun run start:dev` (from `services/jangar`) – boots the Start dev server.
-- `bun run start:build` – produces a production build under `services/jangar/dist/ui/`.
+- ✅ OpenAI proxy endpoints `/openai/v1/chat/completions` (streaming only) and `/openai/v1/models` backed by the Codex app-server.
+- ✅ Convex mutations for telemetry are called by the proxy; schema lives in `convex/schema.ts`.
+- ⚠️ Workflow/activities are stubs: `run-codex-turn`, `run-worker-task`, `publish-event` and the `codexOrchestrationWorkflow` loop do not perform real work yet.
+- ⚠️ Toolbelt (`packages/cx-tools`) is unimplemented, so activities cannot shell out via `cx-*` CLIs.
+- ⚠️ UI is a minimal shell (`/_index`, `/health`); mission/chat/SSE views are not present.
+- `/v1/models` returns four Codex variants; narrow this list in `src/services/models.ts` if you need a single orchestrator model.
+- The app Deployment disables the Temporal worker by default (`ENABLE_TEMPORAL_WORKER=0`); the worker Deployment runs the same image with `bun run src/worker.ts`.
 
-The follow-up image work (JNG-080c) will package the Start dist output from `dist/ui` alongside the server.
+## Running locally
 
-## Notes
+- UI/dev + worker watch: `bun run dev:all` (or `bun run start:dev` for UI only). Default ports: UI 3000, OpenWebUI 8080 (Docker compose).
+- Prod-style entrypoint: `bun run src/index.ts` (spawns app-server, UI server, optional worker based on `ENABLE_TEMPORAL_WORKER`).
+- OpenWebUI link: use `VITE_OPENWEBUI_URL` to point the UI at an external host; defaults to `http://localhost:8080` in dev.
 
-- Data is mocked in `src/app/lib/mocks.ts` and mirrored in the UI as loading/error shells.
-- UI dev server listens on port 3000 by default; OpenWebUI defaults to http://localhost:8080 for local dev and uses the
-  external host in production via `VITE_OPENWEBUI_URL`.
+## Build
+
+- `bun run start:build` produces the TanStack Start output in `dist/ui/`. Image assembly is handled by `packages/scripts/src/jangar/build-image.ts` (bundles dist + Codex binary); bundling `packages/cx-tools/dist` will be required once the toolbelt exists.
+
+## Missing pieces (tracked in docs/jangar/implementation-plan.md)
+
+- Real implementations for activities and workflow loop.
+- Worker repo clone/branch/push helpers in `src/services/git.ts`.
+- Mission REST/SSE endpoints and UI views for orchestrations.
+- Toolbelt CLIs and bundling into the image.


### PR DESCRIPTION
## Summary

- Documented the current Jangar implementation snapshot (as of 2025-11-30) in design docs and added a concise current-state reference.
- Clarified OpenWebUI wiring and model exposure to match the code (four Codex models, external host usage).
- Updated the service README to reflect what runs today, how to start locally, and what is still missing.

## Related Issues

None

## Testing

- N/A (docs-only changes)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
