### PR TITLE
fix: update kubectl installation again

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2025-11-30T04:52:34.399Z"
+    deploy.knative.dev/rollout: "2025-11-30T09:38:40.534Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -27,5 +27,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: f9aba0e3
-    digest: sha256:0812014cc7cf9bcc262c04437893d48ca7e0dbfd01cf55f9292f66af24be7df0
+    newTag: 039eed4b
+    digest: sha256:85e2557da081676464e124379cc7d6f6d0b4dbbfde347021960bc1eb5a177493

--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -24,22 +24,22 @@ RUN --mount=type=cache,target=/var/cache/apt \
   export DEBIAN_FRONTEND=noninteractive; \
   apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20; \
   apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    curl \
-    git \
-    gnupg \
-    ripgrep \
-    tini; \
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  gnupg \
+  ripgrep \
+  tini; \
   rm -rf /var/lib/apt/lists/*
 
 # Lightweight GitHub CLI install (no apt repo)
 RUN set -eux; \
   ARCH="$(uname -m)"; \
   case "$ARCH" in \
-    amd64|x86_64) GH_ARCH=amd64 ;; \
-    arm64|aarch64) GH_ARCH=arm64 ;; \
-    *) echo "Unsupported arch for gh: $ARCH" >&2; exit 1 ;; \
+  amd64|x86_64) GH_ARCH=amd64 ;; \
+  arm64|aarch64) GH_ARCH=arm64 ;; \
+  *) echo "Unsupported arch for gh: $ARCH" >&2; exit 1 ;; \
   esac; \
   curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" -o /tmp/gh.tar.gz; \
   tar -xzf /tmp/gh.tar.gz -C /tmp; \
@@ -50,11 +50,11 @@ RUN set -eux; \
 RUN set -eux; \
   ARCH="${TARGETARCH:-$(uname -m)}"; \
   case "$ARCH" in \
-    amd64|x86_64) NODE_ARCH=x64 ;; \
-    arm64|aarch64) NODE_ARCH=arm64 ;; \
-    ppc64le) NODE_ARCH=ppc64le ;; \
-    s390x) NODE_ARCH=s390x ;; \
-    *) NODE_ARCH="$ARCH" ;; \
+  amd64|x86_64) NODE_ARCH=x64 ;; \
+  arm64|aarch64) NODE_ARCH=arm64 ;; \
+  ppc64le) NODE_ARCH=ppc64le ;; \
+  s390x) NODE_ARCH=s390x ;; \
+  *) NODE_ARCH="$ARCH" ;; \
   esac; \
   curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://nodejs.org/dist/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz; \
   tar -xJf /tmp/node.tar.xz -C /tmp; \
@@ -69,15 +69,22 @@ RUN set -eux; \
 RUN set -eux; \
   ARCH="${TARGETARCH:-$(uname -m)}"; \
   case "$ARCH" in \
-    amd64|x86_64) K_ARCH=amd64 ;; \
-    arm64|aarch64) K_ARCH=arm64 ;; \
-    *) echo "Unsupported arch for kubectl: $ARCH" >&2; exit 1 ;; \
+  amd64|x86_64) K_ARCH=amd64 ;; \
+  arm64|aarch64) K_ARCH=arm64 ;; \
+  *) echo "Unsupported arch for kubectl: $ARCH" >&2; exit 1 ;; \
   esac; \
-  curl -fsSLo /tmp/kubectl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${K_ARCH}/kubectl"; \
-  curl -fsSLo /tmp/kubectl.sha256 "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${K_ARCH}/kubectl.sha256"; \
-  echo "$(< /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum --check; \
-  install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl; \
-  rm /tmp/kubectl /tmp/kubectl.sha256; \
+  cd /tmp; \
+  curl -fsSLO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${K_ARCH}/kubectl"; \
+  curl -fsSLO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${K_ARCH}/kubectl.sha256"; \
+  # sanity check: ensure checksum file looks like a single SHA-256
+  if ! grep -Eq '^[0-9a-f]{64}$' kubectl.sha256; then \
+  echo "kubectl.sha256 has unexpected contents:" >&2; \
+  cat kubectl.sha256 >&2; \
+  exit 1; \
+  fi; \
+  printf '%s  %s\n' "$(cat kubectl.sha256)" kubectl | sha256sum -c -; \
+  install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl; \
+  rm kubectl kubectl.sha256; \
   kubectl version --client --output=yaml
 
 # Base tsconfig for workspace packages
@@ -119,9 +126,9 @@ RUN bun add -g @openai/codex@latest
 RUN set -eux; \
   ARCH="$(uname -m)"; \
   case "$ARCH" in \
-    aarch64|arm64) OVS_ARCH=arm64 ;; \
-    x86_64|amd64)  OVS_ARCH=x64 ;; \
-    *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;; \
+  aarch64|arm64) OVS_ARCH=arm64 ;; \
+  x86_64|amd64)  OVS_ARCH=x64 ;; \
+  *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;; \
   esac; \
   curl -fL --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v${OPENVSCODE_VERSION}/openvscode-server-v${OPENVSCODE_VERSION}-linux-${OVS_ARCH}.tar.gz" -o /tmp/ovscode.tar.gz; \
   mkdir -p /opt/openvscode-server; \


### PR DESCRIPTION
## Summary

- Replace kubectl checksum verification with a deterministic, Kubernetes-docs-compliant implementation.
- Switch from `echo` to `printf` to avoid malformed checksum lines.
- Add a sanity check ensuring `kubectl.sha256` contains a valid 64-character hex digest.
- Use the official file layout (`cd /tmp`, `kubectl`, `kubectl.sha256`) for consistent verification.
- Improve diagnostics for corrupted or intercepted checksum downloads.

## Related Issues

None.

## Testing

- Built container using:

```sh
  docker buildx build --progress=plain .
```
- Verified checksum file format:

```sh
grep -Eq '^[0-9a-f]{64}$' kubectl.sha256
```

- Verified SHA256 matches:

```sh
printf '%s  %s\n' "$(cat kubectl.sha256)" kubectl | sha256sum -c -
```

- Verified kubectl runs:

```sh
kubectl version --client --output=yaml
```

Screenshots

N/A

Breaking Changes

None.

Checklist

- Testing section documents the exact validation performed.
- Screenshots and Breaking Changes sections are handled correctly.
- Documentation, release notes, or follow-ups tracked as needed.

