### PR TITLE
docs: add torghut streaming design pack

### DIFF
--- a/docs/torghut/architecture.md
+++ b/docs/torghut/architecture.md
@@ -1,0 +1,128 @@
+# Torghut Streaming Architecture
+
+## Goals
+- Near real-time technical analysis (≤300–500 ms event-to-signal).
+- Reliable ingestion from Alpaca WS with automatic reconnect/dedup.
+- Exactly-once delivery in analytics path; ordering preserved per symbol.
+- Operate under Alpaca single-connection-per-account constraint.
+- Security-first: SASL/TLS to Kafka, no plaintext secrets in git, runAsNonRoot/read-only rootfs, scoped egress.
+- Observability-first: lag, reconnects, checkpoint age, sink txn failures, consumer lag.
+
+## High-level Flow
+
+```mermaid
+flowchart LR
+  A[Alpaca Market WS<br/>trades/quotes/bars] -->|JSON frames| FWD
+  FWD[Python Forwarder<br/>single Deployment] -->|Kafka producer<br/>acks=all,lz4| K1[(Kafka topics<br/>trades/quotes/bars/status)]
+  K1 --> FL[Apache Flink Job<br/>KafkaSource+Watermarks]
+  FL -->|micro-bars 1s| K2[(ta.bars.1s.v1)]
+  FL -->|EMA/RSI/MACD/VWAP/etc| K3[(ta.signals.v1)]
+  FL -->|status| K4[(ta.status.v1)]
+  K2 --> TOR[torghut main svc]
+  K3 --> TOR
+  subgraph Infra
+    OP["Flink K8s Operator"]
+    STR["Strimzi Kafka"]
+    MINIO["Checkpoint Store<br/>MinIO/S3-compatible"]
+  end
+  FL -.->|checkpoints| MINIO
+  FL -.-> OP
+  FWD -.->|status| K4
+```
+
+## Components
+- Forwarder: Python 3.11+ (alpaca-py, aiokafka); single replica; dedup on trade `i`, quote/bar `(t,symbol)`.
+- Kafka: Strimzi-managed, SASL/TLS; topics lz4, RF=3, partitions=1 per symbol.
+- Flink: 1.20.x via Operator 1.13.x; KafkaSource/Sink with exactly-once; checkpoints every 10 s to MinIO/S3.
+- torghut main service: consumes TA topics; feature flag to choose TA source.
+
+### Version matrix
+- Alpaca WS: `wss://stream.data.alpaca.markets/v2/{feed}`; one active connection per account.
+- Kafka: Strimzi 0.49.x (Kafka 4.1); Kafka connector 4.x compatible.
+- Flink: 1.20.x runtime; Operator 1.13.x.
+- Checkpoint store: MinIO/S3 via `s3a://`.
+- Python runtime: 3.11/3.12; libs alpaca-py, aiokafka.
+
+### Latency budget (p99 ≤500 ms)
+- WS frame → forwarder ingress: ~5–30 ms
+- Forwarder dedup + produce (linger 20–50 ms): ~40–80 ms
+- Kafka transit: ~5–20 ms
+- Flink watermark wait (goal 1–2 s slack): dominates tail; tune as stability improves
+- Flink compute + sink txn: ~50–120 ms
+- Downstream consume: ~10–30 ms
+
+### Failure modes & handling
+- WS disconnect: exponential backoff reconnect; status topic emits reason/attempt.
+- Duplicate frames: per-type dedup cache; metric `dedup_dropped_total`.
+- Kafka produce errors: retry with backoff; readiness fails on sustained errors.
+- Flink JM/TM crash: restore from latest checkpoint; transactional sink prevents duplicates to committed readers.
+- Checkpoint store outage: alerts on checkpoint age; job resumes from last good checkpoint after store recovers.
+
+## Contracts (envelope)
+- Fields: `ingest_ts`, `event_ts`, `feed`, `channel`, `symbol`, `seq`, `payload`, `is_final?`, `source`, `window{}`.
+- Topic retention: trades/quotes 7d; bars 30d; signals 14d; status 7d (compaction optional).
+- Schema: Avro or JSON with Karapace; subject name strategy per-topic; backward-compatible evolution.
+
+## Security
+- Kafka auth via Strimzi KafkaUser (SCRAM/TLS) mounted in torghut namespace (reflector allowed).
+- Pods runAsNonRoot, readOnlyRootFS, drop NET_RAW; scoped NetworkPolicies (egress Alpaca + Kafka + MinIO).
+
+## Observability
+- Expose Prometheus-format metrics; existing stack is Grafana Mimir/Loki/Tempo (see `argocd/applications/observability`).
+- Key metrics: WS reconnects, lag (now-event_ts), checkpoint age, sink txn failures, consumer lag.
+- Dashboards in Grafana: WS lag histogram, Kafka consumer lag, Flink watermark vs event time, checkpoint duration/age, sink txn failure rate.
+- Alerts (via Mimir/Alertmanager): reconnect rate > N/min, p99 lag > 500 ms, checkpoint age > 2× interval, sink txn failures > 0 over 5m, JM/TM restarts.
+
+## Secrets & Rotation
+- Alpaca: sealed-secret in torghut; rotate by updating SealedSecret and restarting forwarder. Avoid logging keys; env-only.
+- KafkaUser: Strimzi-managed SCRAM/TLS secret; reflect into torghut namespace if needed; rotate via Strimzi user password change (triggers secret update) then restart clients.
+- MinIO checkpoint creds: stored as Secret in torghut; rotate by updating Secret and restarting FlinkDeployment after a fresh checkpoint/savepoint.
+- Document rotations in runbook; avoid plaintext commits.
+
+## Checkpoint Bucket Provisioning
+- Create bucket (e.g., `flink-checkpoints`) in MinIO tenant; enable versioning if desired.
+- Create MinIO user with policy scoped to that bucket; store access/secret in K8s Secret (`fs.s3a.access.key`, `fs.s3a.secret.key`).
+- NetworkPolicy must allow egress from Flink pods to MinIO service; truststore must include MinIO CA if TLS.
+
+## Upgrade / Rollback (Flink TA)
+- Preferred: savepoint or last-state upgrade.
+- Steps: trigger savepoint, update image tag, deploy; verify running; if bad, redeploy prior tag with `state: last-state` or restore from savepoint.
+- Abort strategy: stop job with `--drain` to flush sink transactions before rollback when possible.
+
+## Environment / Overlay Strategy
+- Kustomize overlays per env (dev/stage/prod): endpoints (Alpaca paper vs live), MinIO endpoint/bucket, Kafka bootstrap, checkpoint URI, alert thresholds.
+- Keep topics/schemas identical across envs; vary retention/replication if needed.
+
+## Feature Flags for Consumers
+- torghut main service should gate TA consumption (enable/disable, choose topic/version).
+- Consumers should set `isolation.level=read_committed` when sinks use transactions; fallback to at-least-once profile supported via config.
+
+## Multi-symbol Scaling Plan
+- Short term: partitions=1 per symbol; add symbols by creating per-symbol topic set.
+- Medium term: shard symbols across partitions and use keyed operators; update Flink parallelism accordingly.
+- Keep watermark/idle-timeout tuned to avoid stuck watermarks on sparse symbols.
+
+## Data Quality & Monitoring
+- Track per-symbol last `event_ts`, message gaps, and count per window; alert on staleness.
+- Validate `seq` monotonicity per symbol; emit to status topic on violation.
+- Add canary consumer to compare TA output lag vs raw input lag.
+
+## Tracing / Log Correlation
+- Include `symbol`, `channel`, `event_ts`, `seq`, `source`, `trace_id` (generated) in logs to link forwarder→Flink→consumer; Loki labels on these fields.
+
+## Rollout Notes
+- Apply operator first (#1913), then forwarder (#1914), then TA job (#1915).
+- Ensure checkpoint bucket/secret provisioned before TA job sync.
+- Create KafkaTopic CRs and register schemas before enabling sinks to avoid topic/subject missing errors.
+- Keep torghut main service behind a feature flag until TA signal quality is validated.
+
+## Related docs
+- Forwarder details: `docs/torghut/alpaca-forwarder.md`
+- Flink TA job: `docs/torghut/flink-ta.md`
+- Topics & schemas: `docs/torghut/topics-and-schemas.md`
+- Low-latency tuning: `docs/torghut/low-latency-notes.md`
+- Runbooks: `docs/torghut/runbooks.md`
+- Network/RBAC: `docs/torghut/network-and-rbac.md`
+- CI/CD: `docs/torghut/ci-cd.md`
+- Argo: `docs/torghut/argo.md`
+- Test harness: `docs/torghut/test-harness.md`

--- a/docs/torghut/argo.md
+++ b/docs/torghut/argo.md
@@ -1,0 +1,36 @@
+# Argo CD / ApplicationSet Notes
+
+## Forwarder app (example)
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: torghut-forwarder
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/proompteng/lab.git
+    targetRevision: HEAD
+    path: argocd/applications/torghut/forwarder
+  destination:
+    namespace: torghut
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated: {prune: true, selfHeal: true}
+    syncOptions: [CreateNamespace=true]
+```
+
+## Flink TA app
+Similar shape, path `argocd/applications/torghut/flink-ta`. Ensure sync wave runs after operator if same namespace.
+
+## ApplicationSet hook
+- Add entries for forwarder and flink-ta in `applicationsets/product.yaml` (per issue #1914 and #1915).
+- Use generator fields (e.g., cluster list or repo path) consistent with existing Product ApplicationSet.
+
+## Sync order
+- Operator (if separate app) → forwarder → flink-ta. Use sync waves/weights if needed.
+
+## Namespaces
+- torghut: forwarder, flink-ta runtime.
+- kafka: Strimzi cluster and KafkaUser source secrets (reflected into torghut as needed).
+- minio/observability: MinIO and Mimir/Loki/Tempo; ensure NetworkPolicies allow required egress.

--- a/docs/torghut/ci-cd.md
+++ b/docs/torghut/ci-cd.md
@@ -1,0 +1,25 @@
+# CI/CD for Torghut Forwarder and Flink TA
+
+## Forwarder (Python)
+- Dockerfile: multi-stage; build with `docker build -t <registry>/torghut-forwarder:<tag> -f apps/torghut-forwarder/Dockerfile .` (path TBD).
+- Tests: `pytest` (unit/dedup/envelope), optional integration hitting Alpaca paper feed.
+- Lint/format: `bunx biome check <paths>` if TS present; `ruff`/`black` for Python if used.
+- Publish: push image to registry; update kustomization image tag under `argocd/applications/torghut/forwarder/` and Argo sync.
+
+## Flink TA job
+- Build fat jar/image: `mvn package -Pflink` or `./gradlew shadowJar` (exact module TBD) then `docker build -t <registry>/flink-ta:<tag> -f apps/flink-ta/Dockerfile .`.
+- Unit tests: indicator math (EMA/RSI/MACD/VWAP) deterministic tests.
+- Integration: local mini-kafka + embedded Flink to verify envelope and sink.
+- Publish: push image; update FlinkDeployment image tag in `argocd/applications/torghut/flink-ta/` and Argo sync.
+
+## Tag bump automation
+- Optional script: read latest image tags and patch kustomization with `yq -i` then commit.
+- Argo sync order: operator (if changed) → forwarder → Flink TA.
+
+## Schema registration
+- Keep Avro/JSON schemas in `docs/torghut/schemas/`.
+- Use script (see `scripts/register-schemas.sh`) to register with Karapace before deploying producers/consumers.
+
+## Environments
+- Overlays per env supply: Alpaca endpoint (paper/live), Kafka bootstrap, MinIO endpoint/bucket, image tags, alert thresholds.
+- Keep topic names and schemas identical across environments to simplify promotion.

--- a/docs/torghut/flink-ta.md
+++ b/docs/torghut/flink-ta.md
@@ -1,0 +1,113 @@
+# Flink Technical Analysis Job
+
+## Objective
+Produce near real-time TA outputs (≤300–500 ms p99 event-to-signal) from Alpaca-derived Kafka topics using Flink.
+
+## Inputs
+- Kafka topics (from forwarder): trades, quotes, 1m bars (`is_final` flag), status. Keyed by `symbol`, partitions=1.
+- Event time: Alpaca `t`; ingest time: forwarder `ingest_ts`.
+
+Recommended connector settings (Table API/SQL notation):
+- `scan.topic-partition-discovery.interval` = 1 min (future multi-symbol)
+- `scan.startup.mode` = latest (prod) or earliest (replay tests)
+- `properties.group.id` = flink-ta
+- `properties.isolation.level` = read_committed
+- `value.format` = avro or json; `json.ignore-parse-errors` = false
+
+## Outputs
+- `ta.bars.1s.v1`: micro-bars (O/H/L/C/V, vwap1s, count); `is_final=true`.
+- `ta.signals.v1`: EMA12/26, MACD+signal/hist, RSI14, Bollinger20/2, VWAP (session & rolling), spread/imbalance, realized vol.
+- `ta.status.v1` (optional): watermark lag, restart reason, checkpoint age.
+
+## Envelope / Schema
+Common fields: `ingest_ts`, `event_ts`, `feed`, `channel`, `symbol`, `seq`, `payload`, `is_final?`, `source`, `window{size,step,start,end}`, `version`.
+Use Avro or JSON with Karapace; backward-compatible evolution.
+
+## Flink Job Design
+- Runtime: Flink 1.20.x; Operator 1.13.x; Kafka connector 4.x (FLIP-27/143).
+- Source: `KafkaSource` with watermark `event_time - 2s` (tunable); idle timeout for idle partitions.
+- Processing:
+  - Trades -> hopping 1s/1s to micro-bars (O/H/L/C/V, vwap).
+  - Bars (1s + upstream 1m) -> EMA12/26 -> MACD; RSI14; Bollinger20/2; VWAP (session & rolling window); realized vol (30–60s); join with quotes for spread/imbalance.
+  - Dedup optional: drop duplicates by trade id and (event_ts, symbol) for quotes/bars before aggregation.
+- Sinks: `KafkaSink` to TA topics with `delivery.guarantee=exactly-once`, idempotent/transactional; partitioner fixed (key=symbol).
+
+### Window/indicator details
+- Micro-bars: hopping size=1s, step=1s (tumbling 1s equivalent) keyed by symbol; include count & vwap.
+- EMA: alpha = 2/(N+1) with N=12,26; seed with first bar close.
+- MACD: ema12-ema26; signal EMA9; hist = macd - signal.
+- RSI14: Wilder smoothing on 14-bar window using gains/losses.
+- Bollinger: mid = SMA20; upper/lower = mid ± 2*stddev20.
+- VWAP: session accumulator (reset on session boundary) + rolling window (e.g., 5m configurable).
+- Realized vol: stddev of log returns over 30–60s (configurable).
+- Spread/imbalance: bid/ask spread, (bid_sz - ask_sz)/(bid_sz + ask_sz).
+
+## State & Checkpointing
+- Checkpoints every 10 s to MinIO/S3 (s3a://flink-checkpoints/...); savepoints enabled.
+- Transaction timeout aligned with checkpoint timeout + failover budget.
+- Restart: fixed-delay 5x with 5 s backoff; backpressure monitoring on.
+
+S3A properties (example):
+- `fs.s3a.endpoint`: `http://minio.torghut.svc:9000`
+- `fs.s3a.path.style.access`: true
+- `fs.s3a.access.key` / `fs.s3a.secret.key`: from Secret
+- `fs.s3a.connection.ssl.enabled`: true|false (per MinIO TLS)
+- `fs.s3a.fast.upload`: true
+
+## Kubernetes / Argo
+- Kustomization under `argocd/applications/torghut/flink-ta/`.
+- FlinkDeployment (application mode) image includes job jar.
+- Secrets: Strimzi KafkaUser (SCRAM/TLS) in torghut namespace or reflected; optional Schema Registry creds.
+- Resources (initial): JM 1 CPU/2Gi; TM 1–2 CPU/2–4Gi; parallelism 1–2.
+- ServiceAccount with least privilege; network policy to Kafka, MinIO, registry only.
+
+### Savepoint / upgrade / rollback
+- Upgrade flow: trigger savepoint (or last-state), update image tag, redeploy; verify running and checkpointing.
+- Rollback: redeploy previous image with last-state or restore from savepoint.
+- On exactly-once sinks, prefer `--drain` or allow checkpoint to finish before shutdown to avoid in-flight txn aborts.
+
+### Sink settings (KafkaSink)
+- `deliveryGuarantee = EXACTLY_ONCE`
+- `transaction.timeout.ms` > checkpoint timeout + failover (e.g., 120s)
+- `linger.ms` 20–50; `compression.type` lz4; `enable.idempotence` true
+- `acks=all`; `max.in.flight.requests.per.connection=5` (ok with idempotence)
+
+## Observability
+- Expose Prometheus-format metrics for scrape into Mimir (existing observability stack). Key: watermark lag, checkpoint age/duration, sink txn failures, restarts.
+- Logging to Loki: JSON; include symbol, channel, event_ts, watermark, lag_ms.
+
+Alert suggestions (Mimir/Alertmanager):
+- Checkpoint age > 2× interval
+- p99 watermark lag > 1s (tune) or p99 end-to-end lag > 500 ms
+- Sink transaction failures >0 in 5m
+- JM/TM restart rate > threshold
+
+## Testing & Validation
+- Replay FAKEPACA or recorded NVDA slice into Kafka; verify micro-bars and TA signals content and ordering.
+- Lag test: p99(now - event_ts) ≤500 ms.
+- Failure test: kill JM/TM, confirm restore from last checkpoint, no duplicate outputs (read_committed consumer).
+- Schema test: evolve additive field and confirm backward compatibility.
+- Load test: sustained message rate near expected peak; observe checkpoint duration, backpressure.
+
+## Schema Registry
+- Karapace endpoint: configure in env/properties; auth if enabled.
+- Use TopicNameStrategy (default: `<topic>-value`); compatibility: backward.
+- Register subjects before deploying job to avoid startup failures.
+
+## Consumer guidance (downstream)
+- Use `isolation.level=read_committed` when TA sink runs in exactly-once mode; can switch to read_uncommitted if at-least-once profile is enabled.
+- Expect envelope fields (`event_ts`, `ingest_ts`, `seq`, `is_final`, `window`); be tolerant to additive fields.
+
+## Mermaid (processing graph)
+```mermaid
+flowchart TD
+  T[trades topic] --> MB[Build 1s micro-bars]
+  MB --> IND[Indicators
+EMA/MACD/RSI/Bollinger/VWAP/Vol]
+  Q[quotes topic] --> SP[Spread/Imbalance]
+  SP --> IND
+  B1M[1m bars topic] --> IND
+  IND --> SIG[ta.signals.v1]
+  MB --> B1S[ta.bars.1s.v1]
+  STAT[status topic] --> MON[Metrics/Alerts]
+```

--- a/docs/torghut/low-latency-notes.md
+++ b/docs/torghut/low-latency-notes.md
@@ -1,0 +1,65 @@
+# Low-Latency & Reliability Notes (Torghut Streaming)
+
+This doc captures tuning and operational guardrails to reach near-real-time behaviour while keeping correctness.
+
+## Delivery semantics vs latency
+- Exactly-once Kafka sink waits for checkpoints to commit transactions. For sub-500 ms tails, keep checkpoint interval short (e.g., 5–10 s) or allow an at-least-once profile (no transactions) when downstream can dedup.
+- Set `transaction.timeout.ms` > checkpoint timeout + failover budget to avoid aborts during recovery.
+- Consumers of TA topics should use `isolation.level=read_committed` when transactions are on.
+
+References: Flink delivery guarantees overview (Confluent): https://docs.confluent.io/cloud/current/flink/concepts/delivery-guarantees.html
+
+## Watermark & buffer tuning
+- `pipeline.auto-watermark-interval`: 50–100 ms to emit watermarks more frequently.
+- `execution.buffer-timeout`: 5–10 ms to reduce operator flush latency.
+- `table.exec.source.idle-timeout`: small (e.g., 1s) so idle partitions don’t hold back watermarks.
+
+Reference: Flink low-latency tuning guide: https://flink.apache.org/2022/05/18/getting-into-low-latency-gears-with-apache-flink-part-one/
+
+## State backend choices
+- RocksDB (with incremental checkpoints) is robust for large state; slight latency overhead.
+- Heap state can reduce tail latency but lacks incremental checkpoints; good only for small-state jobs.
+- Consider unaligned or concurrent checkpoints for faster recovery if backpressure appears.
+
+Reference: Flink state backends guide: https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/state/state_backends/
+
+## Checkpoint store (MinIO/S3A)
+- Example properties:
+  - `fs.s3a.endpoint=http://minio.torghut.svc:9000`
+  - `fs.s3a.path.style.access=true`
+  - `fs.s3a.connection.ssl.enabled=true|false` (match MinIO)
+  - `fs.s3a.access.key` / `fs.s3a.secret.key` from K8s Secret
+  - `fs.s3a.fast.upload=true`
+- Set `state.checkpoints.dir` and `state.savepoints.dir` to `s3a://<bucket>/...`.
+- Ensure NetworkPolicy allows egress to MinIO and the truststore includes the MinIO CA if TLS.
+
+MinIO how-to (policy/user/bucket): https://min.io/docs/minio/linux/administration/identity-access-management.html
+
+## Kafka client security (SCRAM/TLS)
+- Set `security.protocol=SASL_SSL`, `sasl.mechanism=SCRAM-SHA-512`.
+- Provide JAAS config from Strimzi KafkaUser secret; mount truststore, set `ssl.endpoint.identification.algorithm=HTTPS`.
+- Avoid plaintext secrets in manifests; use sealed-secret or reflector from kafka namespace.
+
+Kafka security best practices: https://www.openlogic.com/blog/apache-kafka-best-practices-security
+
+## Topic/schema readiness
+- Create KafkaTopic CRs before deploying Flink sinks to avoid unknown topic errors.
+- Register Avro/JSON subjects in Karapace ahead of job startup; use TopicNameStrategy and backward compatibility.
+
+Karapace usage: https://docs.aiven.io/docs/products/karapace/concepts/schema-registry
+
+## Low-latency profile toggle
+- Default profile: exactly-once sinks, transactions on, checkpoints 10 s.
+- Low-latency profile: at-least-once sinks (disable transactions), buffer-timeout 5 ms, watermark interval 50 ms; downstream consumers must dedup.
+
+## Alpaca WS constraints
+- One active connection per account/endpoint; exceeding limit returns HTTP 406.
+- Market stream URL: `wss://stream.data.alpaca.markets/v2/{feed}`; subscribe via JSON action `"subscribe"`.
+- Keep reconnect+resubscribe logic and emit status on disconnects.
+
+Reference: Alpaca streaming doc: https://docs.alpaca.markets/docs/streaming-market-data
+
+## Testing & load
+- Replay FAKEPACA or recorded NVDA slice into Kafka; measure end-to-end lag and consumer lag under peak expected rate.
+- Validate p99 event-to-signal latency; adjust watermark slack and buffer timeout until targets met.
+- Kill JM/TM to confirm recovery from checkpoint without duplicate committed outputs.

--- a/docs/torghut/main-service-consumer.md
+++ b/docs/torghut/main-service-consumer.md
@@ -1,0 +1,32 @@
+# torghut Main Service Consumer Guide
+
+## Purpose
+How the main torghut service should consume TA outputs and switch sources safely.
+
+## Topics to consume
+- `torghut.<symbol>.ta.signals.v1` (primary)
+- `torghut.<symbol>.ta.bars.1s.v1` (optional for charts)
+
+## Client config
+- `enable.idempotence=true` (producer, if writing responses) — not required for consumer.
+- `isolation.level=read_committed` when TA sink uses transactions (default profile).
+- `auto.offset.reset=latest` for steady state; `earliest` for backfill/replay tools.
+- SASL/TLS from Strimzi KafkaUser secret; truststore mounted; set `ssl.endpoint.identification.algorithm=HTTPS`.
+
+## Feature flag
+- Add a flag (e.g., `TA_SIGNALS_ENABLED`) to gate consumption.
+- Allow selection of topic name or schema version (v1) to ease migrations.
+
+## Payload handling
+- Expect envelope fields: `event_ts`, `ingest_ts`, `symbol`, `seq`, `is_final`, `window`, `payload`.
+- Be tolerant to additive fields (backward-compatible Avro/JSON).
+- Use `event_ts` for ordering; `seq` for monotonicity checks per symbol.
+
+## Latency and DQ checks (client-side)
+- Compute `now - event_ts` and emit metric; alert if p99 > 500 ms.
+- Validate `seq` monotonic per symbol; log anomalies.
+- Track last message timestamp per symbol; alert if stale.
+
+## Fallback path
+- If TA topics unavailable, fall back to raw bars/trades or disable TA features via flag.
+

--- a/docs/torghut/network-and-rbac.md
+++ b/docs/torghut/network-and-rbac.md
@@ -1,0 +1,105 @@
+# NetworkPolicy and RBAC Examples (torghut)
+
+## NetworkPolicy (forwarder)
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forwarder-egress
+  namespace: torghut
+spec:
+  podSelector:
+    matchLabels:
+      app: alpaca-forwarder
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: kafka}}
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: observability}}
+        - ipBlock: {cidr: 0.0.0.0/0} # replace with Alpaca IP/CIDR or FQDN via egress gateway
+      ports:
+        - port: 443
+          protocol: TCP
+    - to:
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: torghut}}
+      ports:
+        - port: 9093
+          protocol: TCP
+```
+*(Adjust for Alpaca egress allowlist; replace ipBlock with egress gateway DNS policy if available.)*
+
+## NetworkPolicy (Flink JM/TM)
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flink-egress
+  namespace: torghut
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: flink
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: kafka}}
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: torghut}}
+      ports:
+        - port: 9093
+          protocol: TCP
+    - to:
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: minio}}
+      ports:
+        - port: 9000
+          protocol: TCP
+    - to:
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: observability}}
+      ports:
+        - port: 9090
+          protocol: TCP
+```
+
+## RBAC (minimal forwarder)
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alpaca-forwarder
+  namespace: torghut
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: forwarder-basic
+  namespace: torghut
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: forwarder-basic-binding
+  namespace: torghut
+subjects:
+  - kind: ServiceAccount
+    name: alpaca-forwarder
+roleRef:
+  kind: Role
+  name: forwarder-basic
+  apiGroup: rbac.authorization.k8s.io
+```
+
+## RBAC (Flink Operator already includes)
+- Use Operator-installed roles; for the FlinkDeployment namespace, ensure the ServiceAccount used by JM/TM can read Secrets/ConfigMaps and list pods.
+
+## Truststore mounts (Kafka/MinIO)
+- Mount Strimzi-provided truststore secret and set:
+  - `ssl.truststore.location=/etc/ssl/kafka/truststore.p12`
+  - `ssl.truststore.password` from secret
+  - `ssl.endpoint.identification.algorithm=HTTPS`
+- If MinIO uses custom CA, mount it into `/etc/ssl/certs` and set `fs.s3a.connection.ssl.enabled=true`.

--- a/docs/torghut/register-schemas.sh
+++ b/docs/torghut/register-schemas.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGISTRY_URL="${KARAPACE_URL:-http://karapace.kafka.svc:8081}"
+SCHEMA_DIR="$(dirname "$0")/schemas"
+
+register() {
+  local subject=$1
+  local file=$2
+  echo "Registering $subject from $file"
+  curl -sS -X POST "${REGISTRY_URL}/subjects/${subject}/versions" \
+    -H 'Content-Type: application/vnd.schemaregistry.v1+json' \
+    --data @<(jq -n --arg schema "$(jq -c . < "$file")" '{schema: $schema}')
+}
+
+register "torghut.ta.bars.1s.v1-value" "$SCHEMA_DIR/ta-bars-1s.avsc"
+register "torghut.ta.signals.v1-value" "$SCHEMA_DIR/ta-signals.avsc"
+
+echo "Done"

--- a/docs/torghut/runbooks.md
+++ b/docs/torghut/runbooks.md
@@ -1,0 +1,44 @@
+# Torghut Runbooks (Rotations, Incidents, Upgrades)
+
+## Alpaca credential rotation
+1) Update sealed-secret manifest with new `ALPACA_KEY_ID` / `ALPACA_SECRET_KEY` in torghut namespace.
+2) Apply SealedSecret via Argo CD sync (or `kubectl apply` in emergency, then reconcile Argo).
+3) Restart forwarder Deployment to pick up keys.
+4) Verify forwarder readiness and status topic emits `healthy`; check logs for 401/403.
+
+## KafkaUser (SCRAM) rotation
+1) In Strimzi, rotate password on the KafkaUser for torghut (or create new user and update references).
+2) Allow Strimzi to update the Secret; if using reflector, ensure it copies into torghut namespace.
+3) Restart forwarder and Flink workloads to pick up new password/truststore.
+4) Confirm produce/consume success; watch for SASL auth errors.
+
+## MinIO checkpoint credential rotation
+1) Create new MinIO user/key scoped to checkpoint bucket.
+2) Update Secret in torghut with `fs.s3a.access.key` / `fs.s3a.secret.key`.
+3) Trigger a Flink savepoint (optional) and restart FlinkDeployment so the new creds are used.
+4) Verify checkpoints succeed; delete old user/key after validation.
+
+## Flink upgrade / rollback
+Upgrade (safe):
+- Trigger savepoint (or use last-state) via FlinkDeployment spec.
+- Bump job image tag in kustomization; Argo sync.
+- Verify checkpoints continue and sinks emit.
+
+Rollback:
+- Revert image tag to previous version; set `state: last-state` or point to last savepoint.
+- Sync Argo; verify job runs and outputs resume.
+
+## Alpaca WS incident (406 connection limit)
+- Ensure only one forwarder replica is running; scale down accidental extra pods.
+- Force close lingering connections by restarting the Deployment.
+- Confirm status topic transitions to `healthy` and logs show successful subscribe.
+
+## Kafka produce failures
+- Readiness should go false; inspect auth/ACL, broker reachability, and SASL secrets.
+- After fixes, rolling restart the forwarder; confirm status messages return to healthy.
+
+## Lag spike (WS → TA)
+- Check forwarder metric `ws_lag_ms` and Flink watermark lag.
+- Reconnect WS if forwarder lagged; tune watermark/idle-timeout if Flink is blocking on idle partitions.
+- If Kafka is slow, check broker health and consumer lag.
+

--- a/docs/torghut/schemas/ta-bars-1s.avsc
+++ b/docs/torghut/schemas/ta-bars-1s.avsc
@@ -1,0 +1,31 @@
+{
+  "type": "record",
+  "name": "TaBar1s",
+  "namespace": "torghut.ta",
+  "fields": [
+    {"name": "ingest_ts", "type": "string"},
+    {"name": "event_ts", "type": "string"},
+    {"name": "symbol", "type": "string"},
+    {"name": "seq", "type": "long"},
+    {"name": "is_final", "type": ["null", "boolean"], "default": null},
+    {"name": "source", "type": ["null", "string"], "default": null},
+    {"name": "window", "type": ["null", {
+      "type": "record",
+      "name": "WindowBar1s",
+      "fields": [
+        {"name": "size", "type": "string"},
+        {"name": "step", "type": ["null", "string"], "default": null},
+        {"name": "start", "type": ["null", "string"], "default": null},
+        {"name": "end", "type": ["null", "string"], "default": null}
+      ]
+    }], "default": null},
+    {"name": "o", "type": "double"},
+    {"name": "h", "type": "double"},
+    {"name": "l", "type": "double"},
+    {"name": "c", "type": "double"},
+    {"name": "v", "type": "double"},
+    {"name": "vwap", "type": ["null", "double"], "default": null},
+    {"name": "count", "type": "long"},
+    {"name": "version", "type": ["null", "int"], "default": 1}
+  ]
+}

--- a/docs/torghut/schemas/ta-signals.avsc
+++ b/docs/torghut/schemas/ta-signals.avsc
@@ -1,0 +1,77 @@
+{
+  "type": "record",
+  "name": "TaSignal",
+  "namespace": "torghut.ta",
+  "fields": [
+    {"name": "ingest_ts", "type": "string"},
+    {"name": "event_ts", "type": "string"},
+    {"name": "symbol", "type": "string"},
+    {"name": "seq", "type": "long"},
+    {"name": "is_final", "type": ["null", "boolean"], "default": null},
+    {"name": "source", "type": ["null", "string"], "default": null},
+    {"name": "window", "type": ["null", {
+      "type": "record",
+      "name": "WindowSignal",
+      "fields": [
+        {"name": "size", "type": "string"},
+        {"name": "step", "type": ["null", "string"], "default": null},
+        {"name": "start", "type": ["null", "string"], "default": null},
+        {"name": "end", "type": ["null", "string"], "default": null}
+      ]
+    }], "default": null},
+    {"name": "macd", "type": ["null", {
+      "type": "record",
+      "name": "Macd",
+      "fields": [
+        {"name": "macd", "type": "double"},
+        {"name": "signal", "type": "double"},
+        {"name": "hist", "type": "double"}
+      ]
+    }], "default": null},
+    {"name": "ema", "type": ["null", {
+      "type": "record",
+      "name": "Ema",
+      "fields": [
+        {"name": "ema12", "type": "double"},
+        {"name": "ema26", "type": "double"}
+      ]
+    }], "default": null},
+    {"name": "rsi14", "type": ["null", "double"], "default": null},
+    {"name": "boll", "type": ["null", {
+      "type": "record",
+      "name": "Bollinger",
+      "fields": [
+        {"name": "mid", "type": "double"},
+        {"name": "upper", "type": "double"},
+        {"name": "lower", "type": "double"}
+      ]
+    }], "default": null},
+    {"name": "vwap", "type": ["null", {
+      "type": "record",
+      "name": "Vwap",
+      "fields": [
+        {"name": "session", "type": "double"},
+        {"name": "w5m", "type": ["null", "double"], "default": null}
+      ]
+    }], "default": null},
+    {"name": "imbalance", "type": ["null", {
+      "type": "record",
+      "name": "Imbalance",
+      "fields": [
+        {"name": "spread", "type": "double"},
+        {"name": "bid_px", "type": "double"},
+        {"name": "ask_px", "type": "double"},
+        {"name": "bid_sz", "type": "double"},
+        {"name": "ask_sz", "type": "double"}
+      ]
+    }], "default": null},
+    {"name": "vol_realized", "type": ["null", {
+      "type": "record",
+      "name": "RealizedVol",
+      "fields": [
+        {"name": "w60s", "type": "double"}
+      ]
+    }], "default": null},
+    {"name": "version", "type": ["null", "int"], "default": 1}
+  ]
+}

--- a/docs/torghut/test-harness.md
+++ b/docs/torghut/test-harness.md
@@ -1,0 +1,35 @@
+# Test & Load Harness
+
+## Replay script (concept)
+- Use a simple producer to replay recorded Alpaca JSON lines into Kafka for trades/quotes/bars.
+- Example (kcat):
+```bash
+kcat -b $KAFKA_BOOTSTRAP \
+  -X security.protocol=SASL_SSL \
+  -X sasl.mechanisms=SCRAM-SHA-512 \
+  -X sasl.username=$USER -X sasl.password=$PASS \
+  -t torghut.nvda.trades.v1 -K: -l samples/nvda-trades.jsonl
+```
+Where `nvda-trades.jsonl` contains `<key>:<value>` JSON lines keyed by symbol.
+
+## Lag measurement
+- Consumer benchmark:
+```bash
+kcat -b $KAFKA_BOOTSTRAP -t torghut.nvda.ta.signals.v1 \
+  -C -o end -q -c 1000 -J \
+  | jq 'now*1000 - (.event_ts | fromdateiso8601*1000)'
+```
+- Or a Python script that tracks p50/p95/p99 of (ingest_ts vs now) and (event_ts vs now).
+
+## Failure drills
+- Kill JM/TM pod: `kubectl delete pod -l app.kubernetes.io/component=taskmanager -n torghut` and verify recovery from checkpoint.
+- Drop WS connection: `kubectl exec <forwarder-pod> -- pkill -f websocket` and confirm reconnect/status.
+
+## Fixtures
+- Store FAKEPACA and NVDA slices under `docs/torghut/fixtures/` (add when available) for reproducible tests.
+- Include both trades and quotes; keep event_ts fields intact for lag measurement.
+
+## Acceptance checks
+- p99(now - event_ts) ≤ 500 ms (target)
+- No duplicate seq per symbol after restart (read_committed consumer)
+- Checkpoint age < 2 × interval and sink txn failures = 0 during load

--- a/docs/torghut/topics-and-schemas.md
+++ b/docs/torghut/topics-and-schemas.md
@@ -1,0 +1,113 @@
+# Torghut Kafka Topics & Schemas (Alpaca → TA)
+
+## Topics
+
+| Topic | Purpose | Partitions | RF | Retention | Compression | Cleanup |
+| --- | --- | --- | --- | --- | --- | --- |
+| `torghut.<symbol>.trades.v1` | Alpaca trades | 1 | 3 | 7d | lz4 | delete |
+| `torghut.<symbol>.quotes.v1` | Alpaca quotes | 1 | 3 | 7d | lz4 | delete |
+| `torghut.<symbol>.bars.1m.v1` | 1m bars (+updatedBars) | 1 | 3 | 30d | lz4 | delete |
+| `torghut.<symbol>.status.v1` | forwarder status/heartbeat | 1 | 3 | 7d | lz4 | compaction optional |
+| `torghut.<symbol>.ta.bars.1s.v1` | derived micro-bars | 1 | 3 | 14d | lz4 | delete |
+| `torghut.<symbol>.ta.signals.v1` | TA indicators/signals | 1 | 3 | 14d | lz4 | delete |
+| `torghut.<symbol>.ta.status.v1` | TA job status | 1 | 3 | 7d | lz4 | compaction optional |
+
+Notes:
+- Partitions=1 preserves per-symbol ordering; scale by symbol sharding if adding more symbols later.
+- Use KafkaTopic CRs (Strimzi) for declarative management.
+
+## Envelope (shared)
+```json
+{
+  "ingest_ts": "2025-12-03T18:32:10.123Z",
+  "event_ts": "2025-12-03T18:32:10.045Z",
+  "feed": "iex",
+  "channel": "trades",
+  "symbol": "NVDA",
+  "seq": 123456,
+  "is_final": true,
+  "source": "ws",
+  "window": {"size": "PT1S", "step": "PT1S", "start": "...", "end": "..."},
+  "payload": { /* type-specific */ },
+  "version": 1
+}
+```
+
+## Payload examples
+- Trades:
+```json
+{"i":"ABC123","p":488.12,"s":100,"t":"2025-12-03T18:32:10.045Z"}
+```
+- Quotes:
+```json
+{"bp":488.10,"bs":300,"ap":488.14,"as":200,"t":"2025-12-03T18:32:10.040Z"}
+```
+- Bars (1m):
+```json
+{"o":488.0,"h":488.5,"l":487.8,"c":488.3,"v":5200,"t":"2025-12-03T18:32:00Z","is_final":false}
+```
+- Micro-bars (1s):
+```json
+{"o":488.1,"h":488.2,"l":488.0,"c":488.15,"v":320,"vwap":488.12,"count":8,"t":"2025-12-03T18:32:10Z"}
+```
+- TA signals:
+```json
+{
+  "macd": {"macd":0.42,"signal":0.35,"hist":0.07},
+  "ema": {"ema12":488.10,"ema26":487.95},
+  "rsi14": 61.2,
+  "boll": {"mid":488.0,"upper":489.2,"lower":486.8},
+  "vwap": {"session":488.05,"w5m":488.12},
+  "imbalance": {"spread":0.04,"bid_px":488.10,"ask_px":488.14,
+                 "bid_sz":300,"ask_sz":200},
+  "vol_realized": {"w60s": 0.18}
+}
+```
+
+## Avro subject naming
+- Use TopicNameStrategy (default) or per-topic subject: `<topic>-value`.
+- Compatibility: backward (recommended) to allow additive fields.
+
+Schemas stored in `docs/torghut/schemas/`:
+- `ta-bars-1s.avsc`
+- `ta-signals.avsc`
+
+Registration helper: `docs/torghut/register-schemas.sh` (uses KARAPACE_URL env, defaults to `http://karapace.kafka.svc:8081`).
+
+## Schema Registry workflow
+- Register subjects before deploying Flink sinks/consumers to avoid 404s at startup.
+- Keep schemas in repo (JSON or Avro IDL) and automate registration in CI or pre-sync script.
+- For JSON consumers, permit unknown fields to allow additive evolution.
+
+## Dedup keys
+- Trades: `i`
+- Quotes/Bars: `(event_ts, symbol)`
+- Trade updates: order id (if enabled)
+
+## Data quality monitors
+- Per-symbol staleness: alert if no events for N seconds.
+- Seq monotonicity: flag when `seq` decreases or jumps unexpectedly.
+- Window completeness: expected count of trades per micro-bar; emit to status or metrics.
+
+## Suggested KafkaTopic CR (example)
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: torghut-nvda-ta-signals-v1
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    cleanup.policy: delete
+    compression.type: lz4
+    retention.ms: 1209600000 # 14d
+    min.insync.replicas: 2
+```
+
+## Sizing & retention notes
+- Signals 14d covers operational replay while keeping storage modest.
+- Bars 30d allows backtests and recalibration of indicators.
+- Status topics may use compaction + short retention for concise health history.


### PR DESCRIPTION
## Summary
- Added torghut streaming architecture/forwarder/Flink TA design docs and diagrams.
- Documented topics/schemas with Avro artifacts plus Karapace registration helper.
- Added runbooks, CI/CD notes, network/RBAC examples, consumer guidance, and test harness outline.

## Related Issues
- Related to #1913, #1914, #1915

## Testing
- Not run — docs-only change.

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
