### PR TITLE
feat: add dorvud alpaca forwarder

### DIFF
--- a/.github/workflows/dorvud.yml
+++ b/.github/workflows/dorvud.yml
@@ -1,0 +1,30 @@
+name: dorvud-ci
+
+on:
+  push:
+    paths:
+      - 'services/dorvud/**'
+      - '.github/workflows/dorvud.yml'
+  pull_request:
+    paths:
+      - 'services/dorvud/**'
+      - '.github/workflows/dorvud.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Run tests (platform, websockets, technical-analysis)
+        run: ./gradlew :platform:test :websockets:test :technical-analysis:test
+        working-directory: services/dorvud

--- a/.github/workflows/dorvud.yml
+++ b/.github/workflows/dorvud.yml
@@ -1,11 +1,14 @@
 name: dorvud-ci
 
 on:
-  push:
+  # Run once for PRs targeting main; push runs only on main to avoid double CI for PR branches.
+  pull_request:
+    branches: [main]
     paths:
       - 'services/dorvud/**'
       - '.github/workflows/dorvud.yml'
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - 'services/dorvud/**'
       - '.github/workflows/dorvud.yml'

--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,5 @@ packages/temporal-bun-sdk/Users/
 /services/graf/.kotlin/
 /services/graf/build/
 /services/graf/gradle/wrapper/dists/
+# Kotlin Gradle build caches
+**/.gradle/

--- a/argocd/applications/kafka/kustomization.yaml
+++ b/argocd/applications/kafka/kustomization.yaml
@@ -34,6 +34,8 @@ resources:
   - load-balancer.yaml
   - strimzi-kafka-cluster.yaml
   - karapace.yaml
+  - torghut-ws-kafkauser.yaml
+  - torghut-topics.yaml
 patches:
   # Make the operator watch all namespaces
   - target:

--- a/argocd/applications/kafka/torghut-topics.yaml
+++ b/argocd/applications/kafka/torghut-topics.yaml
@@ -1,0 +1,59 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: torghut-nvda-trades-v1
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    compression.type: lz4
+    retention.ms: 604800000
+    cleanup.policy: delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: torghut-nvda-quotes-v1
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    compression.type: lz4
+    retention.ms: 604800000
+    cleanup.policy: delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: torghut-nvda-bars-1m-v1
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    compression.type: lz4
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: torghut-nvda-status-v1
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    compression.type: lz4
+    retention.ms: 604800000
+    cleanup.policy: compact,delete

--- a/argocd/applications/kafka/torghut-ws-kafkauser.yaml
+++ b/argocd/applications/kafka/torghut-ws-kafkauser.yaml
@@ -1,0 +1,37 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: torghut-ws
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: torghut.
+          patternType: prefix
+        operations:
+          - Write
+          - Create
+          - Describe
+          - DescribeConfigs
+      - resource:
+          type: group
+          name: torghut-ws
+          patternType: prefix
+        operations:
+          - Read
+          - Describe
+  template:
+    secret:
+      metadata:
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "torghut"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "torghut"

--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: torghut-ws-config
+  namespace: torghut
+data:
+  ALPACA_FEED: "iex"
+  ALPACA_BASE_URL: "https://data.alpaca.markets"
+  SYMBOLS: "NVDA"
+  ENABLE_TRADE_UPDATES: "false"
+  RECONNECT_BASE_MS: "500"
+  RECONNECT_MAX_MS: "30000"
+  DEDUP_TTL_SEC: "5"
+  DEDUP_MAX_ENTRIES: "10000"
+  KAFKA_BOOTSTRAP: "kafka-kafka-bootstrap.kafka:9093"
+  KAFKA_SECURITY_PROTOCOL: "SASL_SSL"
+  KAFKA_SASL_MECH: "SCRAM-SHA-512"
+  KAFKA_LINGER_MS: "30"
+  KAFKA_BATCH_SIZE: "32768"
+  KAFKA_ACKS: "all"
+  TOPIC_TRADES: "torghut.nvda.trades.v1"
+  TOPIC_QUOTES: "torghut.nvda.quotes.v1"
+  TOPIC_BARS_1M: "torghut.nvda.bars.1m.v1"
+  TOPIC_STATUS: "torghut.nvda.status.v1"

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: torghut-ws
+  namespace: torghut
+  labels:
+    app: torghut-ws
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: torghut-ws
+  template:
+    metadata:
+      labels:
+        app: torghut-ws
+    spec:
+      serviceAccountName: torghut-ws
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+      containers:
+        - name: torghut-ws
+          image: registry.ide-newton.ts.net/lab/torghut-ws:dev
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: torghut-ws-config
+          env:
+            - name: ALPACA_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: key_id
+            - name: ALPACA_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: secret_key
+            - name: KAFKA_SASL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-ws
+                  key: username
+            - name: KAFKA_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-ws
+                  key: password
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 9090
+              name: metrics
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      nodeSelector: {}
+      tolerations: []

--- a/argocd/applications/torghut/ws/kustomization.yaml
+++ b/argocd/applications/torghut/ws/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: torghut
 resources:
-  - postgres-cluster.yaml
-  - knative-service.yaml
-  - tailscale-service.yaml
-  - ws
+  - serviceaccount.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - pdb.yaml

--- a/argocd/applications/torghut/ws/pdb.yaml
+++ b/argocd/applications/torghut/ws/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: torghut-ws
+  namespace: torghut
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: torghut-ws

--- a/argocd/applications/torghut/ws/service.yaml
+++ b/argocd/applications/torghut/ws/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: torghut-ws
+  namespace: torghut
+  labels:
+    app: torghut-ws
+spec:
+  selector:
+    app: torghut-ws
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: metrics
+      port: 9090
+      targetPort: metrics

--- a/argocd/applications/torghut/ws/serviceaccount.yaml
+++ b/argocd/applications/torghut/ws/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: torghut-ws
+  namespace: torghut

--- a/docs/torghut/alpaca-forwarder.md
+++ b/docs/torghut/alpaca-forwarder.md
@@ -36,6 +36,7 @@ Single-replica Kotlin/JVM service (Gradle multi-project) that ingests Alpaca mar
 - `platform`: shared config (typesafe Config), logging (SLF4J), common envelope/Avro, Kafka producer factory.
 - `ws`: Ktor (or JetBrains HTTP) WebSocket client, reconnect/backoff, dedup caches, envelope builder, Kafka producers.
 - `ta`: shared TA schema/types for downstream consumers (used by ws for envelope typing and by Flink integration tests).
+- Repo path: `services/dorvud/` (multi-project). Forwarder code lives in the `websockets` module (shared code in `platform`, TA types in `technical-analysis`). Dockerfile under `services/dorvud/websockets/`; Kustomize manifests under `argocd/applications/torghut/ws/`.
 
 ## Kubernetes Design
 - Namespace: torghut. Objects: Deployment (replicas=1), ServiceAccount, ConfigMap (feeds/symbols/backoff/toggles), Secret refs, Service (health/metrics), optional PDB.

--- a/docs/torghut/ci-cd.md
+++ b/docs/torghut/ci-cd.md
@@ -1,8 +1,9 @@
 # CI/CD for Torghut Forwarder and Flink TA
 
 ## WS service (Kotlin, multi-project)
-- Build: `./gradlew :ws:shadowJar` (or `bootJar` if Spring) using JDK 21; shared code in `:platform`, TA types in `:ta`.
-- Docker: `docker build -t <registry>/torghut-ws:<tag> -f apps/torghut-ws/Dockerfile .` (image uses the shaded jar from `ws/build/libs`).
+- Build: `cd services/dorvud && ./gradlew :websockets:shadowJar` (or `bootJar` if Spring) using JDK 21; shared code in `:platform`, TA types in `:technical-analysis`.
+- Docker: `cd services/dorvud && docker build -t <registry>/torghut-ws:<tag> -f websockets/Dockerfile .` (image uses the shaded jar from `websockets/build/libs`).
+- Smoke: `bun run smoke:torghut-ws` (requires KAFKA_USERNAME/PASSWORD env, optional SYMBOL/TOPIC/NAMESPACE overrides).
 - Tests: `./gradlew :platform:test :ws:test :ta:test` (dedup/envelope, reconnect logic, Avro/JSON encoding).
 - Lint/format: `./gradlew ktlintCheck detekt` (or Spotless) depending on project plugins.
 - Publish: push image; update kustomization image tag under `argocd/applications/torghut/ws/` and Argo sync.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "convex:reseal": "bun run packages/scripts/src/convex/reseal-secrets.ts",
     "build:torghut": "bun run packages/scripts/src/torghut/build-image.ts",
     "deploy:torghut": "bun run packages/scripts/src/torghut/deploy-service.ts",
-    "flink:build": "bun run packages/scripts/src/dorvud/build-and-push.ts"
+    "flink:build": "bun run packages/scripts/src/dorvud/build-and-push.ts",
+    "smoke:torghut-ws": "bun run packages/scripts/src/torghut/ws-smoke.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",

--- a/packages/scripts/src/torghut/ws-smoke.ts
+++ b/packages/scripts/src/torghut/ws-smoke.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ensureCli, fatal, run } from '../shared/cli'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const main = async () => {
+  ensureCli('kubectl')
+  ensureCli('kafka-console-consumer')
+
+  const namespace = process.env.NAMESPACE ?? 'kafka'
+  const symbol = (process.env.SYMBOL ?? 'nvda').toLowerCase()
+  const topic = process.env.TOPIC ?? `torghut.${symbol}.trades.v1`
+  const username = process.env.KAFKA_USERNAME ?? fatal('KAFKA_USERNAME is required')
+  const password = process.env.KAFKA_PASSWORD ?? fatal('KAFKA_PASSWORD is required')
+  const securityProtocol = process.env.KAFKA_SECURITY_PROTOCOL ?? 'SASL_SSL'
+  const saslMechanism = process.env.KAFKA_SASL_MECHANISM ?? 'SCRAM-SHA-512'
+  const localPort = Number(process.env.LOCAL_KAFKA_PORT ?? '19093')
+  const remotePort = Number(process.env.REMOTE_KAFKA_PORT ?? '9093')
+
+  const tmpDir = mkdtempSync(join(tmpdir(), 'torghut-ws-smoke-'))
+  const configPath = join(tmpDir, 'client.properties')
+  writeFileSync(
+    configPath,
+    [
+      `bootstrap.servers=localhost:${localPort}`,
+      `security.protocol=${securityProtocol}`,
+      `sasl.mechanism=${saslMechanism}`,
+      `sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${username}" password="${password}";`,
+      'ssl.endpoint.identification.algorithm=HTTPS',
+    ].join('\n'),
+    'utf8',
+  )
+
+  const portForward = Bun.spawn(
+    ['kubectl', '-n', namespace, 'port-forward', 'svc/kafka-kafka-bootstrap', `${localPort}:${remotePort}`],
+    { stdout: 'pipe', stderr: 'inherit' },
+  )
+
+  await sleep(2000)
+  if (portForward.exitCode !== null) {
+    fatal('kubectl port-forward exited early; check cluster access and service name')
+  }
+
+  try {
+    await run('kafka-console-consumer', [
+      '--bootstrap-server', `localhost:${localPort}`,
+      '--topic', topic,
+      '--max-messages', process.env.MAX_MESSAGES ?? '5',
+      '--timeout-ms', process.env.TIMEOUT_MS ?? '10000',
+      '--consumer.config', configPath,
+    ])
+  } finally {
+    portForward.kill()
+    await portForward.exited
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => fatal('Smoke test failed', err))
+}

--- a/services/dorvud/build.gradle.kts
+++ b/services/dorvud/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 plugins {
   kotlin("jvm") version "2.2.21" apply false
+  kotlin("plugin.serialization") version "2.2.21" apply false
 }
 
 subprojects {

--- a/services/dorvud/platform/build.gradle.kts
+++ b/services/dorvud/platform/build.gradle.kts
@@ -1,1 +1,24 @@
-description = "Platform foundation components for Dorvud"
+plugins {
+  kotlin("plugin.serialization")
+}
+
+dependencies {
+  val serializationVersion = "1.7.3"
+  val coroutinesVersion = "1.9.0"
+  val kafkaVersion = "4.1.0"
+  val micrometerVersion = "1.13.5"
+  val logbackVersion = "1.5.12"
+  val kotlinLoggingVersion = "3.0.5"
+
+  api("org.apache.kafka:kafka-clients:$kafkaVersion")
+  api("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
+  api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+  api("io.micrometer:micrometer-core:$micrometerVersion")
+  api("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
+
+  implementation("com.typesafe:config:1.4.3")
+  implementation("io.github.microutils:kotlin-logging-jvm:$kotlinLoggingVersion")
+  implementation("ch.qos.logback:logback-classic:$logbackVersion")
+
+  testImplementation("io.mockk:mockk:1.13.12")
+}

--- a/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/DedupCache.kt
+++ b/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/DedupCache.kt
@@ -1,0 +1,41 @@
+package ai.proompteng.dorvud.platform
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * TTL + size bounded dedup cache. Returns true when the key is already present (i.e., duplicate).
+ */
+class DedupCache<K>(
+  private val ttl: Duration,
+  private val maxEntries: Int,
+) {
+  private val entries = ConcurrentHashMap<K, Instant>()
+  private val order = ConcurrentLinkedQueue<K>()
+
+  fun isDuplicate(key: K, now: Instant = Instant.now()): Boolean {
+    evictExpired(now)
+    val existing = entries.putIfAbsent(key, now)
+    if (existing != null) return true
+
+    order.add(key)
+    if (entries.size > maxEntries) {
+      val victim = order.poll()
+      if (victim != null) entries.remove(victim)
+    }
+    return false
+  }
+
+  private fun evictExpired(now: Instant) {
+    val cutoff = now.minus(ttl)
+    val iterator = entries.entries.iterator()
+    while (iterator.hasNext()) {
+      val entry = iterator.next()
+      if (entry.value.isBefore(cutoff)) {
+        iterator.remove()
+      }
+    }
+  }
+}

--- a/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Envelope.kt
+++ b/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Envelope.kt
@@ -1,0 +1,48 @@
+package ai.proompteng.dorvud.platform
+
+import java.time.Instant
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/** Shared envelope used for all forwarder outputs. */
+@Serializable
+data class Envelope<T>(
+  @Serializable(with = InstantIsoSerializer::class)
+  val ingestTs: Instant,
+  @Serializable(with = InstantIsoSerializer::class)
+  val eventTs: Instant,
+  val feed: String,
+  val channel: String,
+  val symbol: String,
+  val seq: Long,
+  val payload: T,
+  val isFinal: Boolean = true,
+  val source: String = "ws",
+  val window: Window? = null,
+  val version: Int = 1,
+)
+
+@Serializable
+data class Window(
+  val size: String,
+  val step: String,
+  val start: String,
+  val end: String,
+)
+
+/** Simple ISO-8601 serializer for java.time.Instant. */
+object InstantIsoSerializer : KSerializer<Instant> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("Instant", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: Instant) {
+    encoder.encodeString(value.toString())
+  }
+
+  override fun deserialize(decoder: Decoder): Instant = Instant.parse(decoder.decodeString())
+}

--- a/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Kafka.kt
+++ b/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Kafka.kt
@@ -1,0 +1,57 @@
+package ai.proompteng.dorvud.platform
+
+import java.util.Properties
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.serialization.StringSerializer
+
+data class KafkaAuth(
+  val username: String,
+  val password: String,
+  val mechanism: String = "SCRAM-SHA-512",
+)
+
+data class KafkaTls(
+  val truststorePath: String? = null,
+  val truststorePassword: String? = null,
+  val endpointIdentification: String = "HTTPS",
+)
+
+data class KafkaProducerSettings(
+  val bootstrapServers: String,
+  val clientId: String = "dorvud-ws",
+  val lingerMs: Int = 30,
+  val batchSize: Int = 32768,
+  val acks: String = "all",
+  val enableIdempotence: Boolean = true,
+  val compressionType: String = "lz4",
+  val securityProtocol: String = "SASL_SSL",
+  val auth: KafkaAuth,
+  val tls: KafkaTls = KafkaTls(),
+)
+
+fun KafkaProducerSettings.toProperties(): Properties = Properties().also { props ->
+  props[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
+  props[ProducerConfig.CLIENT_ID_CONFIG] = clientId
+  props[ProducerConfig.ACKS_CONFIG] = acks
+  props[ProducerConfig.LINGER_MS_CONFIG] = lingerMs
+  props[ProducerConfig.BATCH_SIZE_CONFIG] = batchSize
+  props[ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG] = enableIdempotence
+  props[ProducerConfig.COMPRESSION_TYPE_CONFIG] = compressionType
+  props[ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION] = 5
+  props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+  props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+
+  props["security.protocol"] = securityProtocol
+  props[SaslConfigs.SASL_MECHANISM] = auth.mechanism
+  props[SaslConfigs.SASL_JAAS_CONFIG] =
+    "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${auth.username}\" password=\"${auth.password}\";"
+  props[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = tls.endpointIdentification
+  tls.truststorePath?.let { props[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = it }
+  tls.truststorePassword?.let { props[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = it }
+}
+
+fun buildProducer(settings: KafkaProducerSettings): KafkaProducer<String, String> =
+  KafkaProducer(settings.toProperties())

--- a/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Metrics.kt
+++ b/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/Metrics.kt
@@ -1,0 +1,9 @@
+package ai.proompteng.dorvud.platform
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+
+object Metrics {
+  val registry: MeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+}

--- a/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/SeqTracker.kt
+++ b/services/dorvud/platform/src/main/kotlin/ai/proompteng/dorvud/platform/SeqTracker.kt
@@ -1,0 +1,11 @@
+package ai.proompteng.dorvud.platform
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/** Maintains per-symbol monotonic sequence numbers. */
+class SeqTracker {
+  private val counters = ConcurrentHashMap<String, AtomicLong>()
+
+  fun next(symbol: String): Long = counters.computeIfAbsent(symbol) { AtomicLong(0) }.incrementAndGet()
+}

--- a/services/dorvud/platform/src/test/kotlin/ai/proompteng/dorvud/platform/DedupCacheTest.kt
+++ b/services/dorvud/platform/src/test/kotlin/ai/proompteng/dorvud/platform/DedupCacheTest.kt
@@ -1,0 +1,27 @@
+package ai.proompteng.dorvud.platform
+
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DedupCacheTest {
+  @Test
+  fun `marks duplicates within ttl`() {
+    val cache = DedupCache<String>(Duration.ofSeconds(5), maxEntries = 2)
+    val now = Instant.parse("2025-12-03T00:00:00Z")
+
+    assertFalse(cache.isDuplicate("k1", now))
+    assertTrue(cache.isDuplicate("k1", now.plusSeconds(1)))
+  }
+
+  @Test
+  fun `evicts after ttl`() {
+    val cache = DedupCache<String>(Duration.ofSeconds(1), maxEntries = 2)
+    val start = Instant.parse("2025-12-03T00:00:00Z")
+
+    assertFalse(cache.isDuplicate("k1", start))
+    assertFalse(cache.isDuplicate("k1", start.plusSeconds(2)))
+  }
+}

--- a/services/dorvud/technical-analysis/build.gradle.kts
+++ b/services/dorvud/technical-analysis/build.gradle.kts
@@ -1,1 +1,8 @@
-description = "Technical analysis placeholder for Dorvud"
+plugins {
+  kotlin("plugin.serialization")
+}
+
+dependencies {
+  val serializationVersion = "1.7.3"
+  api("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
+}

--- a/services/dorvud/technical-analysis/src/main/kotlin/ai/proompteng/dorvud/ta/Indicators.kt
+++ b/services/dorvud/technical-analysis/src/main/kotlin/ai/proompteng/dorvud/ta/Indicators.kt
@@ -1,0 +1,26 @@
+package ai.proompteng.dorvud.ta
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MicroBar(
+  val o: Double,
+  val h: Double,
+  val l: Double,
+  val c: Double,
+  val v: Long,
+  val t: String,
+)
+
+@Serializable
+data class SignalSnapshot(
+  val rsi14: Double? = null,
+  val macd: Macd? = null,
+  val ema: Ema? = null,
+)
+
+@Serializable
+data class Macd(val macd: Double, val signal: Double, val hist: Double)
+
+@Serializable
+data class Ema(val ema12: Double? = null, val ema26: Double? = null)

--- a/services/dorvud/websockets/Dockerfile
+++ b/services/dorvud/websockets/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+
+COPY gradlew gradle.properties settings.gradle.kts build.gradle.kts ./
+COPY gradle ./gradle
+COPY platform ./platform
+COPY websockets ./websockets
+COPY technical-analysis ./technical-analysis
+
+RUN chmod +x ./gradlew
+RUN ./gradlew :websockets:installDist --no-daemon
+
+FROM gcr.io/distroless/java21:nonroot
+WORKDIR /app
+COPY --from=build /workspace/websockets/build/install/websockets /app
+ENTRYPOINT ["/app/bin/websockets"]

--- a/services/dorvud/websockets/build.gradle.kts
+++ b/services/dorvud/websockets/build.gradle.kts
@@ -1,1 +1,31 @@
-description = "Websockets gateway placeholder for Dorvud"
+plugins {
+  kotlin("plugin.serialization")
+  application
+}
+
+dependencies {
+  val ktorVersion = "2.3.12"
+  val coroutinesVersion = "1.9.0"
+  val kotlinLoggingVersion = "3.0.5"
+
+  implementation(project(":platform"))
+  implementation("io.ktor:ktor-client-core:$ktorVersion")
+  implementation("io.ktor:ktor-client-cio:$ktorVersion")
+  implementation("io.ktor:ktor-client-websockets:$ktorVersion")
+  implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+  implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+  implementation("io.ktor:ktor-server-core:$ktorVersion")
+  implementation("io.ktor:ktor-server-cio:$ktorVersion")
+  implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
+  implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+  implementation("io.github.microutils:kotlin-logging-jvm:$kotlinLoggingVersion")
+
+  testImplementation("io.mockk:mockk:1.13.12")
+  testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+}
+
+application {
+  mainClass.set("ai.proompteng.dorvud.ws.ForwarderAppKt")
+}

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMapper.kt
@@ -1,0 +1,82 @@
+package ai.proompteng.dorvud.ws
+
+import ai.proompteng.dorvud.platform.Envelope
+import ai.proompteng.dorvud.platform.InstantIsoSerializer
+import java.time.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+
+/** Maps raw Alpaca JSON message into our envelope + channel name. */
+object AlpacaMapper {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  fun decode(raw: String): AlpacaMessage = json.decodeFromString(AlpacaMessageSerializer, raw)
+
+  fun toEnvelope(message: AlpacaMessage, seqProvider: (String) -> Long): Envelope<JsonElement>? =
+    when (message) {
+      is AlpacaTrade -> envelope(
+        message.symbol,
+        channel = "trades",
+        eventTs = message.timestamp,
+        seq = seqProvider(message.symbol),
+        payload = json.encodeToJsonElement(AlpacaTrade.serializer(), message),
+        isFinal = true,
+      )
+      is AlpacaQuote -> envelope(
+        message.symbol,
+        channel = "quotes",
+        eventTs = message.timestamp,
+        seq = seqProvider(message.symbol),
+        payload = json.encodeToJsonElement(AlpacaQuote.serializer(), message),
+        isFinal = true,
+      )
+      is AlpacaBar -> envelope(
+        message.symbol,
+        channel = "bars",
+        eventTs = message.timestamp,
+        seq = seqProvider(message.symbol),
+        payload = json.encodeToJsonElement(AlpacaBar.serializer(), message),
+        isFinal = true,
+      )
+      is AlpacaUpdatedBar -> envelope(
+        message.symbol,
+        channel = "updatedBars",
+        eventTs = message.timestamp,
+        seq = seqProvider(message.symbol),
+        payload = json.encodeToJsonElement(AlpacaUpdatedBar.serializer(), message),
+        isFinal = false,
+        source = "ws",
+      )
+      is AlpacaStatus -> envelope(
+        message.symbol,
+        channel = "status",
+        eventTs = message.timestamp,
+        seq = seqProvider(message.symbol),
+        payload = json.encodeToJsonElement(AlpacaStatus.serializer(), message),
+        isFinal = true,
+      )
+      else -> null
+    }
+
+  private fun envelope(
+    symbol: String,
+    channel: String,
+    eventTs: String,
+    seq: Long,
+    payload: JsonElement,
+    isFinal: Boolean,
+    source: String = "ws",
+  ): Envelope<JsonElement> = Envelope(
+    ingestTs = Instant.now(),
+    eventTs = Instant.parse(eventTs),
+    feed = "alpaca",
+    channel = channel,
+    symbol = symbol,
+    seq = seq,
+    payload = payload,
+    isFinal = isFinal,
+    source = source,
+  )
+}

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMessageSerializer.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaMessageSerializer.kt
@@ -1,0 +1,39 @@
+package ai.proompteng.dorvud.ws
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** Polymorphic dispatch on Alpaca market data field `T`. */
+object AlpacaMessageSerializer : KSerializer<AlpacaMessage> {
+  override val descriptor: SerialDescriptor = buildClassSerialDescriptor("AlpacaMessage")
+
+  override fun serialize(encoder: Encoder, value: AlpacaMessage) {
+    throw SerializationException("encoding not supported")
+  }
+
+  override fun deserialize(decoder: Decoder): AlpacaMessage {
+    val input = decoder as? JsonDecoder ?: error("JSON decoder required")
+    val element = input.decodeJsonElement()
+    val type = element.jsonObject["T"]?.jsonPrimitive?.content
+      ?: throw SerializationException("missing T field")
+    return when (type) {
+      "t" -> input.json.decodeFromJsonElement(AlpacaTrade.serializer(), element)
+      "q" -> input.json.decodeFromJsonElement(AlpacaQuote.serializer(), element)
+      "b" -> input.json.decodeFromJsonElement(AlpacaBar.serializer(), element)
+      "u" -> input.json.decodeFromJsonElement(AlpacaUpdatedBar.serializer(), element)
+      "s" -> input.json.decodeFromJsonElement(AlpacaStatus.serializer(), element)
+      "subscription" -> input.json.decodeFromJsonElement(AlpacaSubscription.serializer(), element)
+      "success" -> input.json.decodeFromJsonElement(AlpacaSuccess.serializer(), element)
+      else -> throw SerializationException("unknown message type: $type")
+    }
+  }
+}

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaModels.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaModels.kt
@@ -1,0 +1,97 @@
+package ai.proompteng.dorvud.ws
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Alpaca market data frames (v2 streaming). */
+@Serializable
+sealed interface AlpacaMessage { val type: String }
+
+@Serializable
+@SerialName("success")
+data class AlpacaSuccess(
+  @SerialName("T") override val type: String = "success",
+  val msg: String,
+) : AlpacaMessage
+
+@Serializable
+@SerialName("subscription")
+data class AlpacaSubscription(
+  @SerialName("T") override val type: String = "subscription",
+  val trades: List<String> = emptyList(),
+  val quotes: List<String> = emptyList(),
+  @SerialName("bars") val bars1m: List<String> = emptyList(),
+  @SerialName("updatedBars") val updatedBars: List<String> = emptyList(),
+  val dailyBars: List<String> = emptyList(),
+  val statuses: List<String> = emptyList(),
+) : AlpacaMessage
+
+@Serializable
+@SerialName("t")
+data class AlpacaTrade(
+  @SerialName("T") override val type: String = "t",
+  @SerialName("S") val symbol: String,
+  @SerialName("i") val id: Long,
+  @SerialName("x") val exchange: String? = null,
+  @SerialName("p") val price: Double,
+  @SerialName("s") val size: Long,
+  @SerialName("c") val conditions: List<String>? = null,
+  @SerialName("t") val timestamp: String,
+  @SerialName("z") val tape: String? = null,
+) : AlpacaMessage
+
+@Serializable
+@SerialName("q")
+data class AlpacaQuote(
+  @SerialName("T") override val type: String = "q",
+  @SerialName("S") val symbol: String,
+  @SerialName("bx") val bidExchange: String? = null,
+  @SerialName("bp") val bidPrice: Double,
+  @SerialName("bs") val bidSize: Long,
+  @SerialName("ax") val askExchange: String? = null,
+  @SerialName("ap") val askPrice: Double,
+  @SerialName("as") val askSize: Long,
+  @SerialName("c") val conditions: List<String>? = null,
+  @SerialName("t") val timestamp: String,
+  @SerialName("z") val tape: String? = null,
+) : AlpacaMessage
+
+@Serializable
+@SerialName("b")
+data class AlpacaBar(
+  @SerialName("T") override val type: String = "b",
+  @SerialName("S") val symbol: String,
+  @SerialName("o") val open: Double,
+  @SerialName("h") val high: Double,
+  @SerialName("l") val low: Double,
+  @SerialName("c") val close: Double,
+  @SerialName("v") val volume: Long,
+  @SerialName("vw") val vwap: Double? = null,
+  @SerialName("n") val tradeCount: Long? = null,
+  @SerialName("t") val timestamp: String,
+) : AlpacaMessage
+
+@Serializable
+@SerialName("u")
+data class AlpacaUpdatedBar(
+  @SerialName("T") override val type: String = "u",
+  @SerialName("S") val symbol: String,
+  @SerialName("o") val open: Double,
+  @SerialName("h") val high: Double,
+  @SerialName("l") val low: Double,
+  @SerialName("c") val close: Double,
+  @SerialName("v") val volume: Long,
+  @SerialName("vw") val vwap: Double? = null,
+  @SerialName("n") val tradeCount: Long? = null,
+  @SerialName("t") val timestamp: String,
+) : AlpacaMessage
+
+@Serializable
+@SerialName("s")
+data class AlpacaStatus(
+  @SerialName("T") override val type: String = "s",
+  @SerialName("S") val symbol: String,
+  val statusCode: String? = null,
+  val statusMessage: String? = null,
+  @SerialName("t") val timestamp: String,
+) : AlpacaMessage

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -1,0 +1,182 @@
+package ai.proompteng.dorvud.ws
+
+import ai.proompteng.dorvud.platform.DedupCache
+import ai.proompteng.dorvud.platform.Envelope
+import ai.proompteng.dorvud.platform.Metrics
+import ai.proompteng.dorvud.platform.SeqTracker
+import ai.proompteng.dorvud.platform.buildProducer
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.system.exitProcess
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import io.ktor.websocket.readBytes
+import io.ktor.websocket.WebSocketSession
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+
+private val logger = KotlinLogging.logger {}
+
+class ForwarderApp(
+  private val config: ForwarderConfig,
+  private val producerFactory: (ForwarderConfig) -> KafkaProducer<String, String> = { cfg -> buildProducer(cfg.kafka) },
+  private val json: Json = Json { encodeDefaults = true; ignoreUnknownKeys = true },
+) {
+  private val scope = CoroutineScope(Dispatchers.Default)
+  private val ready = AtomicBoolean(false)
+  private val httpClient = HttpClient(CIO) {
+    install(WebSockets)
+    install(ContentNegotiation) { json() }
+  }
+
+  fun start(): Job {
+    val job = scope.launch {
+      logger.info { "dorvud-ws starting with symbols=${config.symbols}" }
+      val producer = producerFactory(config)
+      val seq = SeqTracker()
+
+      val tradesDedup = DedupCache<String>(Duration.ofSeconds(config.dedupTtlSeconds), config.dedupMaxEntries)
+      val quotesDedup = DedupCache<String>(Duration.ofSeconds(config.dedupTtlSeconds), config.dedupMaxEntries)
+      val barsDedup = DedupCache<String>(Duration.ofSeconds(config.dedupTtlSeconds), config.dedupMaxEntries)
+
+      ready.set(true)
+      streamAlpaca(producer, seq, tradesDedup, quotesDedup, barsDedup)
+    }
+    return job
+  }
+
+  fun stop() {
+    ready.set(false)
+    scope.cancel()
+  }
+
+  fun isReady(): Boolean = ready.get()
+
+  fun isAlive(): Boolean = scope.coroutineContext.isActive
+
+  private suspend fun streamAlpaca(
+    producer: KafkaProducer<String, String>,
+    seq: SeqTracker,
+    tradesDedup: DedupCache<String>,
+    quotesDedup: DedupCache<String>,
+    barsDedup: DedupCache<String>,
+  ) {
+    val url = "wss://stream.data.alpaca.markets/v2/${config.alpacaFeed}"
+    httpClient.webSocket(urlString = url) {
+      // auth
+      val auth = mapOf("action" to "auth", "key" to config.alpacaKeyId, "secret" to config.alpacaSecretKey)
+      sendSerialized(auth)
+      val subscribe = mapOf(
+        "action" to "subscribe",
+        "trades" to config.symbols,
+        "quotes" to config.symbols,
+        "bars" to config.symbols,
+        "updatedBars" to config.symbols,
+      )
+      sendSerialized(subscribe)
+
+      for (frame in incoming) {
+        val text = when (frame) {
+          is Frame.Text -> frame.readText()
+          is Frame.Binary -> frame.readBytes().decodeToString()
+          else -> continue
+        }
+        val elements = json.parseToJsonElement(text)
+        val messages: List<JsonElement> =
+          if (elements is JsonArray) elements.toList() else listOf(elements)
+        messages.forEach { el ->
+          val msg = json.decodeFromJsonElement(AlpacaMessageSerializer, el)
+          handleMessage(msg, producer, seq, tradesDedup, quotesDedup, barsDedup)
+        }
+      }
+    }
+  }
+
+  private suspend fun handleMessage(
+    msg: AlpacaMessage,
+    producer: KafkaProducer<String, String>,
+    seq: SeqTracker,
+    tradesDedup: DedupCache<String>,
+    quotesDedup: DedupCache<String>,
+    barsDedup: DedupCache<String>,
+  ) {
+    when (msg) {
+      is AlpacaTrade -> {
+        if (tradesDedup.isDuplicate(msg.id.toString())) return
+      }
+      is AlpacaQuote -> {
+        if (quotesDedup.isDuplicate("${msg.timestamp}-${msg.symbol}")) return
+      }
+      is AlpacaBar, is AlpacaUpdatedBar -> {
+        val symbol = when (msg) {
+          is AlpacaBar -> msg.symbol
+          is AlpacaUpdatedBar -> msg.symbol
+          else -> ""
+        }
+        val ts = when (msg) {
+          is AlpacaBar -> msg.timestamp
+          is AlpacaUpdatedBar -> msg.timestamp
+          else -> ""
+        }
+        if (barsDedup.isDuplicate("$ts-$symbol")) return
+      }
+      else -> {}
+    }
+
+    val env = AlpacaMapper.toEnvelope(msg) { symbol -> seq.next(symbol) } ?: return
+    val topic = when (env.channel) {
+      "trades" -> config.topics.trades
+      "quotes" -> config.topics.quotes
+      "bars", "updatedBars" -> config.topics.bars1m
+      "status" -> config.topics.status
+      else -> null
+    } ?: return
+
+    val payload = json.encodeToString(env)
+    producer.send(ProducerRecord(topic, env.symbol, payload))
+  }
+
+  private suspend fun DefaultClientWebSocketSession.sendSerialized(payload: Any) {
+    val text = json.encodeToString(payload)
+    send(Frame.Text(text))
+  }
+}
+
+fun main() = runBlocking {
+  try {
+    val cfg = ForwarderConfig.fromEnv()
+    val app = ForwarderApp(cfg)
+    val health = HealthServer(app, cfg)
+    health.start()
+    val job = app.start()
+    Runtime.getRuntime().addShutdownHook(Thread {
+      health.stop()
+      app.stop()
+    })
+    job.join()
+  } catch (e: Exception) {
+    logger.error(e) { "forwarder failed to start" }
+    exitProcess(1)
+  }
+}

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderConfig.kt
@@ -1,0 +1,81 @@
+package ai.proompteng.dorvud.ws
+
+import ai.proompteng.dorvud.platform.KafkaAuth
+import ai.proompteng.dorvud.platform.KafkaProducerSettings
+import ai.proompteng.dorvud.platform.KafkaTls
+
+data class TopicConfig(
+  val trades: String,
+  val quotes: String,
+  val bars1m: String,
+  val status: String,
+  val tradeUpdates: String?,
+)
+
+data class ForwarderConfig(
+  val alpacaKeyId: String,
+  val alpacaSecretKey: String,
+  val alpacaFeed: String,
+  val alpacaBaseUrl: String,
+  val symbols: List<String>,
+  val enableTradeUpdates: Boolean,
+  val reconnectBaseMs: Long,
+  val reconnectMaxMs: Long,
+  val dedupTtlSeconds: Long,
+  val dedupMaxEntries: Int,
+  val kafka: KafkaProducerSettings,
+  val topics: TopicConfig,
+  val healthPort: Int = 8080,
+  val metricsPort: Int = 9090,
+) {
+  companion object {
+    fun fromEnv(env: Map<String, String> = System.getenv()): ForwarderConfig {
+      val symbols = env["SYMBOLS"]?.split(',')?.map { it.trim() }?.filter { it.isNotEmpty() }
+        ?: listOf("NVDA")
+      val topics = TopicConfig(
+        trades = env["TOPIC_TRADES"] ?: "torghut.nvda.trades.v1",
+        quotes = env["TOPIC_QUOTES"] ?: "torghut.nvda.quotes.v1",
+        bars1m = env["TOPIC_BARS_1M"] ?: "torghut.nvda.bars.1m.v1",
+        status = env["TOPIC_STATUS"] ?: "torghut.nvda.status.v1",
+        tradeUpdates = env["TOPIC_TRADE_UPDATES"],
+      )
+
+      val kafka = KafkaProducerSettings(
+        bootstrapServers = env["KAFKA_BOOTSTRAP"] ?: "kafka-kafka-bootstrap.kafka:9092",
+        clientId = env["KAFKA_CLIENT_ID"] ?: "dorvud-ws",
+        lingerMs = env["KAFKA_LINGER_MS"]?.toIntOrNull() ?: 30,
+        batchSize = env["KAFKA_BATCH_SIZE"]?.toIntOrNull() ?: 32768,
+        acks = env["KAFKA_ACKS"] ?: "all",
+        compressionType = env["KAFKA_COMPRESSION"] ?: "lz4",
+        securityProtocol = env["KAFKA_SECURITY_PROTOCOL"] ?: "SASL_SSL",
+        auth = KafkaAuth(
+          username = env["KAFKA_SASL_USER"] ?: "dorvud-ws",
+          password = env["KAFKA_SASL_PASSWORD"] ?: "changeme",
+          mechanism = env["KAFKA_SASL_MECH"] ?: "SCRAM-SHA-512",
+        ),
+        tls = KafkaTls(
+          truststorePath = env["KAFKA_TRUSTSTORE_PATH"],
+          truststorePassword = env["KAFKA_TRUSTSTORE_PASSWORD"],
+          endpointIdentification = env["KAFKA_SSL_ENDPOINT_IDENTIFICATION"] ?: "HTTPS",
+        ),
+      )
+
+      return ForwarderConfig(
+        alpacaKeyId = env.getValue("ALPACA_KEY_ID"),
+        alpacaSecretKey = env.getValue("ALPACA_SECRET_KEY"),
+        alpacaFeed = env["ALPACA_FEED"] ?: "iex",
+        alpacaBaseUrl = env["ALPACA_BASE_URL"] ?: "https://data.alpaca.markets",
+        symbols = symbols,
+        enableTradeUpdates = env["ENABLE_TRADE_UPDATES"]?.toBooleanStrictOrNull() ?: false,
+        reconnectBaseMs = env["RECONNECT_BASE_MS"]?.toLongOrNull() ?: 500,
+        reconnectMaxMs = env["RECONNECT_MAX_MS"]?.toLongOrNull() ?: 30_000,
+        dedupTtlSeconds = env["DEDUP_TTL_SEC"]?.toLongOrNull() ?: 5,
+        dedupMaxEntries = env["DEDUP_MAX_ENTRIES"]?.toIntOrNull() ?: 10_000,
+        kafka = kafka,
+        topics = topics,
+        healthPort = env["HEALTH_PORT"]?.toIntOrNull() ?: 8080,
+        metricsPort = env["METRICS_PORT"]?.toIntOrNull() ?: 9090,
+      )
+    }
+  }
+}

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/HealthServer.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/HealthServer.kt
@@ -1,0 +1,58 @@
+package ai.proompteng.dorvud.ws
+
+import ai.proompteng.dorvud.platform.Metrics
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.callloging.CallLogging
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+class HealthServer(
+  private val app: ForwarderApp,
+  private val config: ForwarderConfig,
+) {
+  private var engine: ApplicationEngine? = null
+
+  fun start() {
+    if (engine != null) return
+    engine = embeddedServer(CIO, port = config.healthPort) {
+      install(CallLogging)
+      install(ContentNegotiation) {
+        json(Json { encodeDefaults = true })
+      }
+      metricsRoutes()
+    }.start(wait = false)
+    logger.info { "health server listening on ${config.healthPort}" }
+  }
+
+  fun stop() {
+    engine?.stop()
+    engine = null
+  }
+
+  private fun Application.metricsRoutes() {
+    routing {
+      get("/healthz") { call.respondText("ok") }
+      get("/readyz") {
+        if (app.isReady()) call.respondText("ready") else call.respondText("not-ready", status = HttpStatusCode.ServiceUnavailable)
+      }
+      get("/metrics") {
+        val scrape = (Metrics.registry as? PrometheusMeterRegistry)?.scrape() ?: ""
+        call.respondText(scrape)
+      }
+    }
+  }
+}

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
@@ -1,0 +1,22 @@
+package ai.proompteng.dorvud.ws
+
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class AlpacaMapperTest {
+  @Test
+  fun `maps trade to envelope`() {
+    val msg =
+      """{"T":"t","S":"AAPL","i":123,"p":190.5,"s":10,"t":"2025-12-05T00:00:00Z"}"""
+    val decoded = AlpacaMapper.decode(msg)
+    val env = AlpacaMapper.toEnvelope(decoded) { 1 }
+    assertNotNull(env)
+    assertEquals("AAPL", env.symbol)
+    assertEquals("trades", env.channel)
+    assertEquals(true, env.isFinal)
+    val payloadSymbol = env.payload.jsonObject["S"]?.toString()?.trim('"')
+    assertEquals("AAPL", payloadSymbol)
+  }
+}

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderConfigTest.kt
@@ -1,0 +1,21 @@
+package ai.proompteng.dorvud.ws
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ForwarderConfigTest {
+  @Test
+  fun `loads defaults when optional envs missing`() {
+    val cfg = ForwarderConfig.fromEnv(
+      mapOf(
+        "ALPACA_KEY_ID" to "key",
+        "ALPACA_SECRET_KEY" to "secret",
+      ),
+    )
+
+    assertEquals(listOf("NVDA"), cfg.symbols)
+    assertFalse(cfg.enableTradeUpdates)
+    assertEquals("torghut.nvda.trades.v1", cfg.topics.trades)
+  }
+}


### PR DESCRIPTION
## Summary
- implement Alpaca WS → Kafka forwarder in services/dorvud (Alpaca models, mapper, Ktor WS client, Kafka producer, Dockerfile)
- add Argo/Kafka manifests for torghut-ws (Deployment/ConfigMap/SA/PDB, KafkaUser, topics) and CI workflow for dorvud
- add Bun smoke helper and docs updates; structure Kafka settings with nested auth/tls

## Related Issues
- closes #1914

## Testing
- ./gradlew :platform:test :websockets:test
- smoke:torghut-ws (not run here; requires kafka-console-consumer in PATH)

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
