### PR TITLE
chore: update bun lockfile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -395,7 +395,7 @@
     },
     "packages/temporal-bun-sdk": {
       "name": "@proompteng/temporal-bun-sdk",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "bin": {
         "temporal-bun-worker": "./dist/bin/start-worker.js",
         "temporal-bun": "./dist/bin/temporal-bun.js",
@@ -4757,6 +4757,8 @@
     "@proompteng/discord/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
     "@proompteng/golink/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@proompteng/jangar/@proompteng/temporal-bun-sdk": ["@proompteng/temporal-bun-sdk@0.3.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.1.0", "@connectrpc/connect": "^2.1.0", "@connectrpc/connect-node": "^2.1.0", "@effect/schema": "^0.75.5", "effect": "^3.2.0" }, "bin": { "temporal-bun-worker": "dist/bin/start-worker.js", "temporal-bun": "dist/bin/temporal-bun.js" } }, "sha512-gAh8SFBSlG9LWEtERKCvsrlPScQe7GR7Er+4O/TKvk3OifHdurXlyEdxqBhNDGs261ytp6b7NiIRq40/Y4HaaQ=="],
 
     "@proompteng/jangar/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 


### PR DESCRIPTION
## Summary

- Update bun.lock to reflect current dependency resolution.
- Unblock Temporal Bun SDK CI/publish jobs that choke on frozen lockfile drift.
- No source changes; lockfile-only update.

## Related Issues

None

## Testing

- Not run — lockfile-only change; CI will cover install/build.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
