### PR TITLE
fix: drop torghut-ws ACLs

### DIFF
--- a/argocd/applications/kafka/torghut-ws-kafkauser.yaml
+++ b/argocd/applications/kafka/torghut-ws-kafkauser.yaml
@@ -8,25 +8,6 @@ metadata:
 spec:
   authentication:
     type: scram-sha-512
-  authorization:
-    type: simple
-    acls:
-      - resource:
-          type: topic
-          name: torghut.
-          patternType: prefix
-        operations:
-          - Write
-          - Create
-          - Describe
-          - DescribeConfigs
-      - resource:
-          type: group
-          name: torghut-ws
-          patternType: prefix
-        operations:
-          - Read
-          - Describe
   template:
     secret:
       metadata:


### PR DESCRIPTION
## Summary

- remove unsupported simple ACL block from torghut-ws KafkaUser
- keep SCRAM auth only so Strimzi can provision secret successfully
- resolve ArgoCD degraded health on kafka app caused by KafkaUser NotReady

## Related Issues

None

## Testing

- Not run — config-only change; relying on Strimzi/ArgoCD reconciliation to regenerate the user secret

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
