### PR TITLE
fix: add flink sa kustomization

### DIFF
--- a/argocd/applications/flink/base/serviceaccount/kustomization.yaml
+++ b/argocd/applications/flink/base/serviceaccount/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flink-serviceaccount.yaml


### PR DESCRIPTION
## Summary

- add kustomization for flink base serviceaccount so Argo CD can resolve the path
- keep helm-driven operator config unchanged; only structural fix to kustomize tree
- note: bun.lock remains untouched/uncommitted and out of scope for this PR

## Related Issues

None

## Testing

- Not run — local `kustomize build --enable-helm argocd/applications/flink/overlays/cluster` is blocked by Helm v4 rejecting `--client`; Argo CD plugin uses Helm v3 so generation should succeed in-cluster.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
