### PR TITLE
fix: restore convex-db storage size

### DIFF
--- a/argocd/applications/convex/postgres-cluster.yaml
+++ b/argocd/applications/convex/postgres-cluster.yaml
@@ -6,7 +6,7 @@ spec:
   instances: 1
   primaryUpdateStrategy: unsupervised
   storage:
-    size: 5Gi
+    size: 30Gi
   bootstrap:
     initdb:
       database: convex_self_hosted


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- Reverted CNPG cluster `convex-db` storage size back to 30Gi after shrink denial.
- Kept unrelated `bun.lock` diff out of the commit to focus on the manifest fix.
- Ready for ArgoCD sync to reapply the restored storage spec.

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- Not run — manifest-only change; no local CNPG cluster available.

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
N/A

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
