### PR TITLE
fix: avoid flink SA duplication

### DIFF
--- a/argocd/applications/flink/base/operator/kustomization.yaml
+++ b/argocd/applications/flink/base/operator/kustomization.yaml
@@ -9,6 +9,9 @@ helmCharts:
     namespace: flink
     includeCRDs: true
     valuesInline:
+      jobServiceAccount:
+        # Avoid duplicate SA with our manually managed flink serviceaccount
+        create: false
       webhook:
         create: false
       metrics:


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- disable Helm-managed job service account for Flink operator to avoid duplicate `flink` SA
- keep Argo-managed `flink` service account with existing sync-wave/annotations intact
- verified kustomize render with helm v3 to ensure manifests generate cleanly

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- kustomize build --enable-helm --helm-command /tmp/helm3/helm argocd/applications/flink/overlays/cluster

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
N/A

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
