### PR TITLE
fix: make codex bootstrap tolerate lock diffs

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 ENV CODEX_ENV_NODE_VERSION=24.11.1 \
     CODEX_ENV_GO_VERSION=1.25.4 \
-    BUN_VERSION=1.3.2
+    BUN_VERSION=1.3.4
 
 # Preinstall requested Node version to avoid nvm cache misses during setup.
 RUN bash -lc 'source /root/.nvm/nvm.sh && nvm install ${CODEX_ENV_NODE_VERSION}'

--- a/apps/froussard/src/codex/cli/__tests__/codex-bootstrap.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-bootstrap.test.ts
@@ -105,6 +105,18 @@ describe('runCodexBootstrap', () => {
     expect(commands).toContain(`git -C ${workdir} reset --hard origin/main`)
   })
 
+  it('retries bun install without frozen lockfile when frozen install fails', async () => {
+    await mkdir(join(workdir, '.git'), { recursive: true })
+    exitCodeOverrides.set('bun install --frozen-lockfile', 1)
+
+    const exitCode = await runCodexBootstrap()
+
+    expect(exitCode).toBe(0)
+    const commands = execMock.mock.calls.map((call) => call[0]?.command)
+    expect(commands).toContain('bun install --frozen-lockfile')
+    expect(commands).toContain('bun install')
+  })
+
   it('clones the repository when the worktree is missing', async () => {
     const repoDir = join(workdir, 'repo')
     process.env.WORKTREE = repoDir

--- a/apps/froussard/src/codex/cli/codex-bootstrap.ts
+++ b/apps/froussard/src/codex/cli/codex-bootstrap.ts
@@ -71,7 +71,16 @@ const bootstrapWorkspace = async () => {
 
   const bunExecutable = (await which('bun')) ?? 'bun'
   console.log('Installing workspace dependencies via Bun...')
-  await $`${bunExecutable} install --frozen-lockfile`
+  const installResult = await $`${bunExecutable} install --frozen-lockfile`.nothrow()
+
+  if (installResult.exitCode !== 0) {
+    console.warn('bun install --frozen-lockfile failed; retrying without frozen lockfile')
+    const retryResult = await $`${bunExecutable} install`.nothrow()
+
+    if (retryResult.exitCode !== 0) {
+      throw new Error('Bun install failed even after retry without --frozen-lockfile')
+    }
+  }
 }
 
 const waitForDocker = async () => {


### PR DESCRIPTION
## Summary

- Make codex bootstrap retry `bun install` without `--frozen-lockfile` so lockfile diffs do not fail workflows
- Add test coverage for the non-frozen bun install fallback
- Bump Codex image Bun runtime to 1.3.4 and rebuild/push latest

## Related Issues

None

## Testing

- bunx vitest apps/froussard/src/codex/cli/__tests__/codex-bootstrap.test.ts
- bun apps/froussard/src/codex/cli/build-codex-image.ts

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
