### PR TITLE
chore: bump bun to 1.3.4

### DIFF
--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -19,7 +19,7 @@ jobs:
   test-and-build:
     uses: ./.github/workflows/common-monorepo.yml
     with:
-      bun-version: 1.3.3
+      bun-version: 1.3.4
       node-version: 24.11.1
       install-command: bun install --frozen-lockfile
       lint-command: bunx biome check packages/codex

--- a/.github/workflows/common-monorepo.yml
+++ b/.github/workflows/common-monorepo.yml
@@ -10,7 +10,7 @@ on:
       bun-version:
         required: false
         type: string
-        default: '1.3.3'
+        default: '1.3.4'
       install-command:
         required: true
         type: string

--- a/.github/workflows/jangar-ci.yml
+++ b/.github/workflows/jangar-ci.yml
@@ -16,7 +16,7 @@ jobs:
   lint-and-typecheck:
     uses: ./.github/workflows/common-monorepo.yml
     with:
-      bun-version: 1.3.3
+      bun-version: 1.3.4
       node-version: 24.11.1
       install-command: bun install --frozen-lockfile && cd services/jangar && bun install --frozen-lockfile
       lint-command: bunx biome check services/jangar packages/scripts/src/jangar argocd/applications/jangar

--- a/.github/workflows/jangar-deploy.yml
+++ b/.github/workflows/jangar-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - name: Install deps (workspace)
         run: bun install --frozen-lockfile

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,14 +65,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - run: bun install --frozen-lockfile
 
@@ -102,14 +102,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - run: bun install --frozen-lockfile
 
@@ -128,14 +128,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - run: bun install --frozen-lockfile
 
@@ -162,14 +162,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - run: bun install --frozen-lockfile
 
@@ -186,7 +186,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - name: Install dependencies
         working-directory: apps/kitty-krew
@@ -221,14 +221,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - run: bun install --frozen-lockfile
         working-directory: apps/reviseur

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -16,7 +16,7 @@ jobs:
   lint-and-test:
     uses: ./.github/workflows/common-monorepo.yml
     with:
-      bun-version: 1.3.3
+      bun-version: 1.3.4
       node-version: 24.11.1
       install-command: bun install --frozen-lockfile
       lint-command: bun run --filter @proompteng/scripts lint

--- a/.github/workflows/temporal-bun-sdk-protos.yml
+++ b/.github/workflows/temporal-bun-sdk-protos.yml
@@ -22,15 +22,15 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - name: Cache Bun install
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - name: Install Buf CLI
         uses: bufbuild/buf-setup-action@v1

--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -61,15 +61,15 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - name: Cache Bun install
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -127,15 +127,15 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - name: Cache Bun install
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -196,15 +196,15 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.4
 
       - name: Cache Bun install
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.4-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
+            ${{ runner.os }}-bun-1.3.4-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Build, Test & Development Commands
 
-- Install dependencies with `bun install` (Node 24.11.1) and run `go mod tidy` inside each Go service.
+- Install dependencies with `bun install` (Node 24.11.1, Bun 1.3.4) and run `go mod tidy` inside each Go service.
 - Start UIs with `bun run dev:proompteng`; swap the suffix for sibling apps.
 - Build and smoke test via `bun run build:<app>` then `bun run start:<app>`.
 - Format and lint using `bun run format` and `bun run lint:<app>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ kubectl --kubeconfig ~/.kube/altra.yaml apply -f ./tofu/harvester/templates
 - **Backend**: Go 1.24, Node.js 22.20, Python 3.9-3.13
 - **Data**: Dagster, Temporal, PostgreSQL, Kafka, Milvus
 - **Infrastructure**: Kubernetes (K3s), ArgoCD, Harvester, Ansible
-- **Tooling**: Bun 1.3.x, Biome, Turbo, Docker, UV
+- **Tooling**: Bun 1.3.4, Biome, Turbo, Docker, UV
 
 ### Application Patterns
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A multi-language monorepo for experimenting with conversational tooling, data pi
 ## Quick Start
 
 1. **Prerequisites**
-   - Node.js 24.11.x and Bun 1.3.x
+   - Node.js 24.11.x and Bun 1.3.4
    - Go 1.24+
    - Docker / Kubernetes tooling if you plan to run services or apply manifests locally
 2. **Install workspace dependencies**

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.3
+ARG BUN_VERSION=1.3.4
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION

--- a/apps/froussard/Dockerfile
+++ b/apps/froussard/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG NODE_VERSION=24.11.1
-ARG BUN_VERSION=1.3.2
+ARG BUN_VERSION=1.3.4
 
 FROM node:${NODE_VERSION}-bookworm AS base
 ARG BUN_VERSION

--- a/apps/kitty-krew/Dockerfile
+++ b/apps/kitty-krew/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.2
+ARG BUN_VERSION=1.3.4
 
 FROM oven/bun:${BUN_VERSION}-alpine AS builder
 

--- a/apps/proompteng/Dockerfile
+++ b/apps/proompteng/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.2
+ARG BUN_VERSION=1.3.4
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION

--- a/apps/reestr/Dockerfile
+++ b/apps/reestr/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM oven/bun:1.3.3 AS builder
+FROM oven/bun:1.3.4 AS builder
 WORKDIR /app
 
 COPY bun.lock package.json tsconfig.base.json tsconfig.json turbo.json biome.json ./
@@ -15,7 +15,7 @@ WORKDIR /app/apps/reestr
 RUN bun run build
 
 # Runtime (bun)
-FROM oven/bun:1.3.3 AS runner
+FROM oven/bun:1.3.4 AS runner
 WORKDIR /app/apps/reestr
 ENV NODE_ENV=production
 ENV PORT=4173

--- a/apps/reviseur/Dockerfile
+++ b/apps/reviseur/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.2
+ARG BUN_VERSION=1.3.4
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION

--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -49,7 +49,7 @@ This document explains how to maintain the single `k8s-arm64` template in Coder,
 
 - Waits up to three minutes for `module.nodejs` to finish publishing `~/.nvm/nvm.sh` and Node 24. If the module misses that window, the script installs `nvm` and Node 24 itself.
 - After `nvm use 22`, the script refreshes the shell hash table and blocks until `npm` is reachable to avoid race conditions that previously produced exit code 127.
-- Installs Bun 1.3.x (via the official shell script) alongside Node so package scripts use the same runtime locally and in automation.
+- Installs Bun 1.3.4 (via the official shell script) alongside Node so package scripts use the same runtime locally and in automation.
 - Installs CLI dependencies in this order: `bun`, `convex@1.27.0`, `@openai/codex`, `kubectl`, `argocd`.
 - Appends `BUN_INSTALL/bin` and `~/.local/bin` to the login shells (`.profile`, `.bashrc`, `.zshrc`) so future shells inherit the toolchain.
 - Dependency install runs only when a manifest exists: `bun install --frozen-lockfile` when a Bun lockfile is present, otherwise `bun install` when only `package.json` is present.
@@ -130,6 +130,6 @@ Following this loop keeps the template lineage clean and ensures future Codex ru
 ## Latest Findings (September 28, 2025)
 
 - Bootstrap script v1.0.17 now tolerates the node module’s nested `~/.nvm/nvm` layout, waits for Node 24, and re-installs nvm if the module lags.
-- Tooling validated inside `greg/proompteng` on template version `xenodochial_jackson9` (Node v24.11.1, Bun 1.3.x, Convex 1.27.0, codex-cli 0.42.0, kubectl v1.34.1, Argo CD v3.1.7).
+- Tooling validated inside `greg/proompteng` on template version `xenodochial_jackson9` (Node v24.11.1, Bun 1.3.4, Convex 1.27.0, codex-cli 0.42.0, kubectl v1.34.1, Argo CD v3.1.7).
 - Repository auto-detection fixes the previous `/home/coder/github.com/workspace` miss; `bun install --frozen-lockfile` now runs automatically when a Bun lockfile is present.
 - `kubectl` and `argocd` binaries are symlinked into `/tmp/coder-script-data/bin`, so `coder ssh workspace -- <command>` works without shell init files.

--- a/kubernetes/coder/README.md
+++ b/kubernetes/coder/README.md
@@ -49,7 +49,7 @@ coder workspaces create sutro --template "kubernetes/coder"
 - `coder/cursor@1.3.2` to expose Cursor Desktop
 - `thezoker/nodejs@1.0.11` to install Node.js via nvm
 - `coder_script.bootstrap_tools` runs on start to:
-  - Install Node.js LTS (fallback to 22) and Bun 1.3.x
+  - Install Node.js LTS (fallback to 22) and Bun 1.3.4
   - Install Convex CLI, OpenAI Codex CLI, kubectl, and Argo CD CLI when missing
   - Expand the repository path, then run `bun install --frozen-lockfile` or `bun install` based on repo files
   - Persist Bun environment variables in `.profile` and `.zshrc`

--- a/package.json
+++ b/package.json
@@ -69,5 +69,5 @@
     "@headlessui/react": "^2.2.9",
     "xstate": "^5.24.0"
   },
-  "packageManager": "bun@1.3.3"
+  "packageManager": "bun@1.3.4"
 }

--- a/packages/bonjour/Dockerfile
+++ b/packages/bonjour/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG BUN_VERSION=1.3.2
+ARG BUN_VERSION=1.3.4
 
 FROM node:24.11.1-bullseye-slim AS builder
 ARG BUN_VERSION

--- a/packages/schematic/src/docker/index.ts
+++ b/packages/schematic/src/docker/index.ts
@@ -1,5 +1,5 @@
 export const dockerfile = (name: string) => `# syntax=docker/dockerfile:1.7
-ARG BUN_VERSION=1.3.3
+ARG BUN_VERSION=1.3.4
 
 FROM oven/bun:${'$'}{BUN_VERSION} AS builder
 WORKDIR /workspace

--- a/packages/scripts/src/torghut/ws-smoke.ts
+++ b/packages/scripts/src/torghut/ws-smoke.ts
@@ -47,11 +47,16 @@ const main = async () => {
 
   try {
     await run('kafka-console-consumer', [
-      '--bootstrap-server', `localhost:${localPort}`,
-      '--topic', topic,
-      '--max-messages', process.env.MAX_MESSAGES ?? '5',
-      '--timeout-ms', process.env.TIMEOUT_MS ?? '10000',
-      '--consumer.config', configPath,
+      '--bootstrap-server',
+      `localhost:${localPort}`,
+      '--topic',
+      topic,
+      '--max-messages',
+      process.env.MAX_MESSAGES ?? '5',
+      '--timeout-ms',
+      process.env.TIMEOUT_MS ?? '10000',
+      '--consumer.config',
+      configPath,
     ])
   } finally {
     portForward.kill()

--- a/services/golink/Dockerfile
+++ b/services/golink/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-ARG BUN_VERSION=1.3.3
+ARG BUN_VERSION=1.3.4
 
 FROM oven/bun:${BUN_VERSION} AS builder
 WORKDIR /workspace

--- a/services/golink/README.md
+++ b/services/golink/README.md
@@ -4,7 +4,7 @@ Internal Knative service that powers `http://go/<slug>` redirects with a small a
 
 ## Prerequisites
 - `.env.local` in `services/golink` (copy `.env.example`) with `GOLINK_DATABASE_URL` set. Defaults point to the local compose Postgres on port 15433.
-- Bun 1.3.x and Node 24.11.1 (workspace defaults).
+- Bun 1.3.4 and Node 24.11.1 (workspace defaults).
 
 ## Scripts
 All commands run from the repo root unless noted.

--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 # Bun image for jangar worker + UI + Codex app-server
-ARG BUN_VERSION=1.3.3
+ARG BUN_VERSION=1.3.4
 ARG OPENVSCODE_VERSION=1.105.1
 ARG GH_VERSION=2.65.0
 ARG KUBECTL_VERSION=1.31.0


### PR DESCRIPTION
## Summary
- bump package metadata and docs to Bun 1.3.4 so local dev and guidance match the new runtime
- align GitHub Actions and all Bun-based Docker builds/ARGs to 1.3.4 (apps, services, shared templates)
- regenerate lockfiles with Bun 1.3.4 and rerun the repo validation suite on the new version (proompteng build run with convex codegen stub due to missing deployment token; script restored afterward)

## Related Issues
- closes #1943

## Testing
- bun install --frozen-lockfile
- (cd services/memories && bun install --frozen-lockfile)
- bunx biome check packages apps services scripts
- bun run lint:proompteng
- bun run build:proompteng *(convex codegen stubbed to skip missing deployment token; original script restored afterward)*
- bun run build:reviseur
- bun run build:docs
- bun run lint:golink
- bun test packages/scripts/src
- bun test services/memories

## Screenshots (if applicable)
- None

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
