### PR TITLE
chore: bump image updater v1.0.1

### DIFF
--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -9,10 +9,10 @@ configMapGenerator:
     options:
       disableNameSuffixHash: true
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.1.8/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.2.1/manifests/ha/install.yaml
   - base/namespace.yaml
   - base/ingressroute.yaml
-  - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/v0.16.0/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/v1.0.1/config/install.yaml
   - base/secrets.yaml
   - base/argo-workflows-sso-sealedsecret.yaml
   - base/image-updater-git-ssh.yaml
@@ -31,6 +31,7 @@ patches:
       kind: Deployment
       name: argocd-repo-server
   - path: overlays/argocd-image-updater-config.yaml
+  - path: overlays/argocd-image-updater-namespace-delete.yaml
   - path: overlays/argocd-server-deployment.yaml
     target:
       kind: Deployment

--- a/argocd/applications/argocd/overlays/argocd-image-updater-config.yaml
+++ b/argocd/applications/argocd/overlays/argocd-image-updater-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-image-updater-config
+  namespace: argocd-image-updater-system
 data:
   git.email: noreply@proompteng.ai
   git.user: Proompt Eng

--- a/argocd/applications/argocd/overlays/argocd-image-updater-namespace-delete.yaml
+++ b/argocd/applications/argocd/overlays/argocd-image-updater-namespace-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd-image-updater-system
+$patch: delete


### PR DESCRIPTION
## Summary

- bump Argo CD Image Updater to v1.0.1 and keep it alongside Argo CD
- remove upstream argocd-image-updater-system namespace to avoid creating unused namespace
- retain custom registry/git config patch for the updater against the new manifest layout

## Related Issues

None

## Testing

- kustomize build argocd/applications/argocd

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
