### PR TITLE
chore: bump openwebui to 0.6.41

### DIFF
--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 helmCharts:
   - name: open-webui
     repo: https://helm.openwebui.com
-    version: 8.18.0
+    version: 8.19.0
     releaseName: jangar-openwebui
     namespace: jangar
     valuesFile: openwebui-values.yaml

--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -15,7 +15,7 @@ websocket:
     enabled: false
 
 image:
-  tag: v0.6.40
+  tag: v0.6.41
 
 openaiApiKey: ""
 


### PR DESCRIPTION
## Summary

- bump helm chart to open-webui 8.19.0 (app v0.6.41)
- update values to use image tag v0.6.41 for jangar deployment
- leave ArgoCD apply to controllers; no manual rollout run locally

## Related Issues

None

## Testing

- Not run — chart upgrade only; avoided local kubectl apply per request

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
