### PR TITLE
perf: raise openwebui resources

### DIFF
--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -60,11 +60,11 @@ volumeMounts:
 
 resources:
   requests:
-    cpu: "2"
-    memory: 4Gi
+    cpu: "4"
+    memory: 8Gi
   limits:
-    cpu: "2"
-    memory: 4Gi
+    cpu: "4"
+    memory: 8Gi
 
 # Increase OpenWebUI verbosity for debugging streaming issues
 logging:


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- Increase OpenWebUI CPU requests/limits from 2 to 4 cores for jangar.
- Raise memory requests/limits from 4Gi to 8Gi to avoid throttling during streams.
- Keep debugging-friendly logging note in place; no other values changed.

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- Not run — config-only change; Argo CD will reconcile and surface any apply errors.

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
N/A

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
