### PR TITLE
fix: dedupe reasoning content in Codex SSE

### DIFF
--- a/services/jangar/src/server/__tests__/chat-completions.test.ts
+++ b/services/jangar/src/server/__tests__/chat-completions.test.ts
@@ -52,6 +52,39 @@ describe('chat completions handler', () => {
     expect(response.headers.get('content-type')).toContain('text/event-stream')
   })
 
+  it('deduplicates reasoning deltas and streams incremental reasoning_content', async () => {
+    const mockClient = {
+      runTurnStream: async () => ({
+        turnId: 'turn-1',
+        threadId: 'thread-1',
+        stream: (async function* () {
+          yield { type: 'reasoning', delta: 'Thinking' }
+          yield { type: 'reasoning', delta: 'Thinking' }
+          yield { type: 'reasoning', delta: 'Thinking harder' }
+          yield { type: 'message', delta: 'final answer' }
+          yield { type: 'usage', usage: { input_tokens: 3, output_tokens: 4 } }
+        })(),
+      }),
+      stop: vi.fn(),
+      ensureReady: vi.fn(),
+    }
+    setCodexClientFactory(() => mockClient as unknown as CodexAppServerClient)
+
+    const request = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'gpt-5.1-codex', messages: [{ role: 'user', content: 'hi' }], stream: true }),
+    })
+
+    const response = await chatCompletionsHandler(request)
+    const text = await response.text()
+
+    const firstReasoningMatches = text.match(/"reasoning_content":"Thinking"/g) ?? []
+    expect(firstReasoningMatches).toHaveLength(1)
+    expect(text).toContain('"reasoning_content":" harder"')
+    expect(text).toContain('final answer')
+    expect(text).toContain('"usage"')
+  })
+
   it('returns validation error when messages missing', async () => {
     const request = new Request('http://localhost', {
       method: 'POST',
@@ -84,6 +117,35 @@ describe('chat completions handler', () => {
     expect(response.status).toBe(200)
     const text = await response.text()
     expect(text).toContain('"code":"codex_error"')
+    expect(text).not.toContain('"finish_reason":"stop"')
+    expect(text.trim().endsWith('[DONE]')).toBe(true)
+  })
+
+  it('does not emit stop chunk when codex stream reports error delta', async () => {
+    const mockClient = {
+      runTurnStream: async () => ({
+        turnId: 'turn-1',
+        threadId: 'thread-1',
+        stream: (async function* () {
+          yield { type: 'message', delta: 'partial' }
+          yield { type: 'error', error: { message: 'stream exploded', code: 'oops' } }
+        })(),
+      }),
+      stop: vi.fn(),
+      ensureReady: vi.fn(),
+    }
+    setCodexClientFactory(() => mockClient as unknown as CodexAppServerClient)
+
+    const request = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'gpt-5.1-codex', messages: [{ role: 'user', content: 'hi' }], stream: true }),
+    })
+
+    const response = await chatCompletionsHandler(request)
+    const text = await response.text()
+
+    expect(text).toContain('stream exploded')
+    expect(text).not.toContain('"finish_reason":"stop"')
     expect(text.trim().endsWith('[DONE]')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Deduplicate Codex reasoning deltas and stream incremental `reasoning_content` to OpenAI-compatible SSE clients.
- Handle Codex error deltas without emitting misleading stop chunks while preserving normal usage streaming.
- Extend chat completions SSE tests to cover reasoning dedup, usage, and error paths.

## Related Issues
- Closes #1952

## Testing
- bunx biome check services/jangar/src/server services/jangar/src/server/__tests__
- cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/chat-completions.test.ts

## Screenshots (if applicable)
- None

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
