### PR TITLE
fix: align chat streaming usage and web search output

### DIFF
--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -29,6 +29,11 @@ npm run test
 
 This project uses [Tailwind CSS](https://tailwindcss.com/) for styling.
 
+## API Notes
+
+- `/openai/v1/chat/completions` is **streaming-only**; requests must set `stream: true`. Non-streaming responses are not implemented.
+- Authentication and rate limiting are intentionally disabled because this endpoint is for internal use only; place it behind your own network guardrails when exposing it.
+- Usage totals are emitted only when the request includes `stream_options: { include_usage: true }`. The final SSE chunk (empty `choices` array) carries the normalized OpenAI-style `usage`, even when a turn ends with an upstream error or client abort.
 
 
 


### PR DESCRIPTION
## Summary
- Format Codex web-search deltas as plain backticked queries so OpenWebUI renders them.
- Gate usage emission on `stream_options.include_usage` and prefer per-turn totals; emit even on abort/error.
- Document streaming-only scope plus intentional lack of auth/rate limits for the internal endpoint.

## Related Issues
None

## Testing
- cd services/jangar && bun test src/server/__tests__/chat-completions.test.ts

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
