### PR TITLE
feat: discord Codex bot

### DIFF
--- a/argocd/applications/discord-bot/deployment.yaml
+++ b/argocd/applications/discord-bot/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: discord-bot
+  namespace: argo-workflows
+  labels:
+    app: discord-bot
+    app.kubernetes.io/name: discord-bot
+    app.kubernetes.io/part-of: lab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: discord-bot
+  template:
+    metadata:
+      labels:
+        app: discord-bot
+        app.kubernetes.io/name: discord-bot
+        app.kubernetes.io/part-of: lab
+    spec:
+      containers:
+        - name: app
+          image: registry.ide-newton.ts.net/lab/discord-bot:latest
+          imagePullPolicy: Always
+          env:
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: discord-codex-bot
+                  key: bot-token
+            - name: DISCORD_ALLOWED_GUILD_IDS
+              valueFrom:
+                secretKeyRef:
+                  name: discord-codex-bot
+                  key: guild-id
+                  optional: true
+            - name: JANGAR_BASE_URL
+              value: http://jangar.jangar.svc.cluster.local
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi

--- a/argocd/applications/discord-bot/kustomization.yaml
+++ b/argocd/applications/discord-bot/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argo-workflows
+resources:
+  - deployment.yaml

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -155,6 +155,13 @@ spec:
                   - /metadata/annotations
             automation: manual
             enabled: true
+          - name: discord-bot
+            path: argocd/applications/discord-bot
+            namespace: argo-workflows
+            annotations:
+              argocd.argoproj.io/sync-wave: "6"
+            automation: manual
+            enabled: true
       selector:
         matchExpressions:
           - key: enabled

--- a/bun.lock
+++ b/bun.lock
@@ -424,6 +424,20 @@
         "bun-types": "^1.1.20",
       },
     },
+    "services/discord-bot": {
+      "name": "@proompteng/discord-bot",
+      "version": "0.1.0",
+      "dependencies": {
+        "@proompteng/discord": "file:../../packages/discord",
+        "discord.js": "^14.22.1",
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.2",
+        "bun-types": "latest",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.15",
+      },
+    },
     "services/golink": {
       "name": "@proompteng/golink",
       "dependencies": {
@@ -755,6 +769,18 @@
     "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
+
+    "@discordjs/builders": ["@discordjs/builders@1.13.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.33", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w=="],
+
+    "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
+
+    "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
+
+    "@discordjs/rest": ["@discordjs/rest@2.6.0", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.1.1", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.3", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.16", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w=="],
+
+    "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
+
+    "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
@@ -1382,6 +1408,8 @@
 
     "@proompteng/discord": ["@proompteng/discord@workspace:packages/discord"],
 
+    "@proompteng/discord-bot": ["@proompteng/discord-bot@workspace:services/discord-bot"],
+
     "@proompteng/golink": ["@proompteng/golink@workspace:services/golink"],
 
     "@proompteng/jangar": ["@proompteng/jangar@workspace:services/jangar"],
@@ -1635,6 +1663,12 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ=="],
+
+    "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
+
+    "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
+
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
@@ -2033,6 +2067,8 @@
     "@vitest/spy": ["@vitest/spy@4.0.15", "", {}, "sha512-+EIjOJmnY6mIfdXtE/bnozKEvTC4Uczg19yeZ2vtCz5Yyb0QQ31QWVQ8hswJ3Ysx/K2EqaNsVanjr//2+P3FHw=="],
 
     "@vitest/utils": ["@vitest/utils@4.0.15", "", { "dependencies": { "@vitest/pretty-format": "4.0.15", "tinyrainbow": "^3.0.3" } }, "sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA=="],
+
+    "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 
     "@webcontainer/env": ["@webcontainer/env@1.1.1", "", {}, "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng=="],
 
@@ -2506,7 +2542,11 @@
 
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
 
+    "discord-api-types": ["discord-api-types@0.38.37", "", {}, "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w=="],
+
     "discord-interactions": ["discord-interactions@4.4.0", "", {}, "sha512-jjJx8iwAeJcj8oEauV43fue9lNqkf38fy60aSs2+G8D1nJmDxUIrk08o3h0F3wgwuBWWJUZO+X/VgfXsxpCiJA=="],
+
+    "discord.js": ["discord.js@14.25.1", "", { "dependencies": { "@discordjs/builders": "^1.13.0", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.0", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.33", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g=="],
 
     "docs": ["docs@workspace:apps/docs"],
 
@@ -3273,6 +3313,8 @@
     "lucide-react": ["lucide-react@0.555.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-bytes.js": ["magic-bytes.js@1.12.1", "", {}, "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -4164,6 +4206,8 @@
 
     "ts-jest": ["ts-jest@29.4.5", "", { "dependencies": { "bs-logger": "^0.2.6", "fast-json-stable-stringify": "^2.1.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "lodash.memoize": "^4.1.2", "make-error": "^1.3.6", "semver": "^7.7.3", "type-fest": "^4.41.0", "yargs-parser": "^21.1.1" }, "peerDependencies": { "@babel/core": ">=7.0.0-beta.0 <8", "@jest/transform": "^29.0.0 || ^30.0.0", "@jest/types": "^29.0.0 || ^30.0.0", "babel-jest": "^29.0.0 || ^30.0.0", "jest": "^29.0.0 || ^30.0.0", "jest-util": "^29.0.0 || ^30.0.0", "typescript": ">=4.3 <6" }, "optionalPeers": ["@babel/core", "@jest/transform", "@jest/types", "babel-jest", "jest-util"], "bin": { "ts-jest": "cli.js" } }, "sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q=="],
 
+    "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
+
     "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-script": "dist/bin-script-deprecated.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
 
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
@@ -4224,7 +4268,7 @@
 
     "unctx": ["unctx@2.4.1", "", { "dependencies": { "acorn": "^8.14.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.17", "unplugin": "^2.1.0" } }, "sha512-AbaYw0Nm4mK4qjhns67C+kgxR2YWiwlDBPzxrN8h8C6VtAdCgditAY5Dezu3IJy4XVqAnbrXt9oQJvsn3fyozg=="],
 
-    "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
+    "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -4468,6 +4512,10 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
     "@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
@@ -4704,6 +4752,8 @@
 
     "@proompteng/discord/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
+    "@proompteng/discord-bot/@types/node": ["@types/node@24.10.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA=="],
+
     "@proompteng/golink/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@proompteng/golink/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
@@ -4931,6 +4981,8 @@
     "cdk8s-plus-28/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "cheerio/undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
     "cli-truncate/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
@@ -5191,6 +5243,8 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "nitro/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "nitro/undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
     "nitropack/@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@28.0.9", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA=="],
 
@@ -5825,6 +5879,8 @@
     "@proompteng/codex/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@proompteng/cx-tools/bun-types/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
+    "@proompteng/discord-bot/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@proompteng/discord/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/services/discord-bot/Dockerfile
+++ b/services/discord-bot/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7
+
+ARG BUN_VERSION=1.3.4
+
+FROM oven/bun:${BUN_VERSION} AS base
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY bun.lock ./bun.lock
+
+COPY packages/discord ./packages/discord
+COPY services/discord-bot ./services/discord-bot
+
+WORKDIR /app/services/discord-bot
+RUN --mount=type=cache,target=/root/.cache/bun bun install --frozen-lockfile --production
+
+CMD ["bun", "run", "start"]

--- a/services/discord-bot/README.md
+++ b/services/discord-bot/README.md
@@ -1,0 +1,55 @@
+# @proompteng/discord-bot
+
+A small Discord gateway bot that streams chat completions from **Jangar** (the existing Codex app-server proxy) into Discord messages.
+
+## Trigger mode
+
+The bot responds **only** when the first token of a message is a mention of the bot:
+
+```
+<@BOT_ID> summarize this PR…
+```
+
+Everything after the mention is treated as the prompt.
+
+## Threading (`x-openwebui-chat-id`)
+
+Each prompt is sent to Jangar with a stable chat id:
+
+```
+discord:<guildId>:<channelId>:<authorId>
+```
+
+This keeps conversation state stable per-user, per-channel.
+
+## Environment variables
+
+- `DISCORD_BOT_TOKEN` (required): Discord bot token.
+- `JANGAR_BASE_URL` (required): Base URL to Jangar (example: `http://127.0.0.1:3000`).
+- `CODEX_MODEL` (optional): Overrides the model sent to Jangar. Default: `gpt-5.1-codex-max`.
+- `DISCORD_ALLOWED_GUILD_IDS` (optional): Comma-separated allowlist of guild IDs.
+- `DISCORD_ALLOWED_CHANNEL_IDS` (optional): Comma-separated allowlist of channel IDs.
+
+## Discord configuration
+
+The bot requires these gateway intents:
+
+- `Guilds`
+- `GuildMessages`
+- `MessageContent` (privileged)
+
+## Local development
+
+```bash
+cd services/discord-bot
+DISCORD_BOT_TOKEN=... \
+JANGAR_BASE_URL=http://127.0.0.1:3000 \
+bun run dev
+```
+
+## Tests
+
+```bash
+cd services/discord-bot
+bun run test
+```

--- a/services/discord-bot/package.json
+++ b/services/discord-bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@proompteng/discord-bot",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun src/main.ts",
+    "start": "bun src/main.ts",
+    "test": "bunx vitest run --config vitest.config.ts",
+    "lint": "bunx biome check src"
+  },
+  "dependencies": {
+    "@proompteng/discord": "file:../../packages/discord",
+    "discord.js": "^14.22.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.2",
+    "bun-types": "latest",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.15"
+  },
+  "packageManager": "bun@1.3.4"
+}

--- a/services/discord-bot/src/__tests__/discord-output.test.ts
+++ b/services/discord-bot/src/__tests__/discord-output.test.ts
@@ -1,0 +1,74 @@
+import { DISCORD_MESSAGE_LIMIT } from '@proompteng/discord'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createStreamingReply } from '../discord-output'
+
+describe('createStreamingReply', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('splits overflow into follow-up messages', async () => {
+    const edits: string[] = []
+    const sends: string[] = []
+
+    const makeSentMessage = () => ({
+      edit: vi.fn(async (content: string) => {
+        edits.push(content)
+      }),
+    })
+
+    const message = {
+      reply: vi.fn(async () => makeSentMessage()),
+      channel: {
+        send: vi.fn(async (content: string) => {
+          sends.push(content)
+          return makeSentMessage()
+        }),
+      },
+    }
+
+    const streamer = await createStreamingReply({ message })
+    await streamer.pushDelta('a'.repeat(DISCORD_MESSAGE_LIMIT + 50))
+    await streamer.finalize()
+
+    expect(message.channel.send).toHaveBeenCalled()
+    expect(sends.length).toBeGreaterThan(0)
+    expect(edits.length).toBeGreaterThan(0)
+  })
+
+  it('throttles edits to at most 1/sec for fast deltas', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    const editTimes: number[] = []
+    const makeSentMessage = () => ({
+      edit: vi.fn(async () => {
+        editTimes.push(Date.now())
+      }),
+    })
+
+    const message = {
+      reply: vi.fn(async () => makeSentMessage()),
+      channel: {
+        send: vi.fn(async () => makeSentMessage()),
+      },
+    }
+
+    const streamer = await createStreamingReply({ message })
+    await streamer.pushDelta('a')
+    await streamer.pushDelta('b')
+    await streamer.pushDelta('c')
+
+    expect(editTimes.length).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await streamer.finalize()
+
+    expect(editTimes.length).toBeLessThanOrEqual(2)
+    if (editTimes.length === 2) {
+      expect(editTimes[1] - editTimes[0]).toBeGreaterThanOrEqual(1_000)
+    }
+  })
+})

--- a/services/discord-bot/src/__tests__/jangar-sse.test.ts
+++ b/services/discord-bot/src/__tests__/jangar-sse.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { streamChatCompletionsFromJangar } from '../jangar'
+
+const streamFromChunks = (chunks: string[]) => {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk))
+      }
+      controller.close()
+    },
+  })
+}
+
+describe('streamChatCompletionsFromJangar (SSE parsing)', () => {
+  it('yields deltas and terminates on [DONE]', async () => {
+    const usagePayload = { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 }
+    const sse = [
+      'data: {"choices":[{"delta":{"content":"Hello "}}]}\n',
+      'data: {"choices":[{"delta":{"content":"world"}}]}\n',
+      `data: ${JSON.stringify({ usage: usagePayload })}\n`,
+      'data: [DONE]\n',
+    ].join('')
+
+    const stream = streamFromChunks([sse.slice(0, 25), sse.slice(25)])
+
+    let capturedUsage: unknown
+    const fetchImpl: typeof fetch = async () =>
+      new Response(stream, {
+        headers: { 'content-type': 'text/event-stream' },
+        status: 200,
+      })
+
+    let text = ''
+    for await (const delta of streamChatCompletionsFromJangar({
+      baseUrl: 'http://example.test',
+      chatId: 'discord:test',
+      prompt: 'hi',
+      fetchImpl,
+      onUsage: (value) => {
+        capturedUsage = value
+      },
+    })) {
+      text += delta
+    }
+
+    expect(text).toBe('Hello world')
+    expect(capturedUsage).toEqual(usagePayload)
+  })
+})

--- a/services/discord-bot/src/discord-output.ts
+++ b/services/discord-bot/src/discord-output.ts
@@ -1,0 +1,142 @@
+import { chunkContent, DISCORD_MESSAGE_LIMIT } from '@proompteng/discord'
+
+export interface DiscordSentMessageLike {
+  edit: (content: string) => Promise<unknown>
+}
+
+export interface DiscordIncomingMessageLike {
+  reply: (content: string) => Promise<DiscordSentMessageLike>
+  channel: {
+    send: (content: string) => Promise<DiscordSentMessageLike>
+  }
+}
+
+export interface StreamingReply {
+  pushDelta: (delta: string) => Promise<void>
+  finalize: () => Promise<void>
+}
+
+interface CreateStreamingReplyParams {
+  message: DiscordIncomingMessageLike
+  limit?: number
+}
+
+const EDIT_THROTTLE_MS = 1_000
+
+export const createStreamingReply = async ({ message, limit = DISCORD_MESSAGE_LIMIT }: CreateStreamingReplyParams) => {
+  const sentMessages: DiscordSentMessageLike[] = []
+  let buffer = ''
+  let lastEditAt = -EDIT_THROTTLE_MS
+  let _pendingEditTimer: ReturnType<typeof setTimeout> | undefined
+  let pendingEditPromise: Promise<void> | undefined
+  let pendingEditContent = ''
+  let lastEditedContent = ''
+  let finalized = false
+
+  const base = await message.reply('Working…')
+  sentMessages.push(base)
+
+  const editLatest = async (content: string) => {
+    const latest = sentMessages[sentMessages.length - 1]
+    if (!latest) {
+      return
+    }
+    await latest.edit(content)
+    lastEditAt = Date.now()
+    lastEditedContent = content
+  }
+
+  const flush = async () => {
+    if (finalized) {
+      return
+    }
+
+    const chunks = chunkContent(buffer, limit)
+    const normalized = chunks.length > 0 ? chunks : ['']
+
+    while (normalized.length > sentMessages.length) {
+      const previousIndex = sentMessages.length - 1
+      const previousChunk = normalized[previousIndex]
+      if (previousChunk !== undefined) {
+        await sentMessages[previousIndex]?.edit(previousChunk)
+        lastEditedContent = previousChunk
+      }
+
+      const nextChunk = normalized[sentMessages.length]
+      if (nextChunk === undefined) {
+        break
+      }
+      const followup = await message.channel.send(nextChunk)
+      sentMessages.push(followup)
+      lastEditedContent = nextChunk
+    }
+
+    const latestChunk = normalized[normalized.length - 1] ?? ''
+    const now = Date.now()
+    const remaining = Math.max(0, EDIT_THROTTLE_MS - (now - lastEditAt))
+
+    if (remaining === 0) {
+      await editLatest(latestChunk)
+      return
+    }
+
+    pendingEditContent = latestChunk
+
+    if (!pendingEditPromise) {
+      pendingEditPromise = new Promise((resolve) => {
+        _pendingEditTimer = setTimeout(() => {
+          _pendingEditTimer = undefined
+          pendingEditPromise = undefined
+          void editLatest(pendingEditContent).then(resolve)
+        }, remaining)
+      })
+    }
+  }
+
+  const reply: StreamingReply = {
+    pushDelta: async (delta: string) => {
+      buffer += delta
+      await flush()
+    },
+    finalize: async () => {
+      finalized = true
+      const chunks = chunkContent(buffer, limit)
+      const normalized = chunks.length > 0 ? chunks : ['']
+
+      while (normalized.length > sentMessages.length) {
+        const previousIndex = sentMessages.length - 1
+        const previousChunk = normalized[previousIndex]
+        if (previousChunk !== undefined) {
+          await sentMessages[previousIndex]?.edit(previousChunk)
+          lastEditedContent = previousChunk
+        }
+
+        const nextChunk = normalized[sentMessages.length]
+        if (nextChunk === undefined) {
+          break
+        }
+
+        const followup = await message.channel.send(nextChunk)
+        sentMessages.push(followup)
+        lastEditedContent = nextChunk
+      }
+
+      const latest = sentMessages[sentMessages.length - 1]
+      const latestChunk = normalized[normalized.length - 1] ?? ''
+      if (latest) {
+        pendingEditContent = latestChunk
+
+        if (pendingEditPromise) {
+          await pendingEditPromise
+        }
+
+        if (latestChunk !== lastEditedContent) {
+          await latest.edit(latestChunk)
+          lastEditedContent = latestChunk
+        }
+      }
+    },
+  }
+
+  return reply
+}

--- a/services/discord-bot/src/jangar.ts
+++ b/services/discord-bot/src/jangar.ts
@@ -1,0 +1,116 @@
+export interface StreamChatCompletionsFromJangarParams {
+  baseUrl: string
+  chatId: string
+  prompt: string
+  model?: string
+  fetchImpl?: typeof fetch
+  onUsage?: (usage: unknown) => void
+  signal?: AbortSignal
+}
+
+interface JangarSseDeltaPayload {
+  choices?: Array<{
+    delta?: {
+      content?: unknown
+    }
+  }>
+  usage?: unknown
+}
+
+const parseAllowedJson = (value: string): JangarSseDeltaPayload | undefined => {
+  try {
+    return JSON.parse(value) as JangarSseDeltaPayload
+  } catch {
+    return undefined
+  }
+}
+
+export async function* streamChatCompletionsFromJangar({
+  baseUrl,
+  chatId,
+  prompt,
+  model = process.env.CODEX_MODEL ?? 'gpt-5.1-codex-max',
+  fetchImpl = fetch,
+  onUsage,
+  signal,
+}: StreamChatCompletionsFromJangarParams): AsyncIterable<string> {
+  const response = await fetchImpl(`${baseUrl.replace(/\/$/, '')}/openai/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-openwebui-chat-id': chatId,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      stream: true,
+      stream_options: { include_usage: true },
+    }),
+    signal,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`Jangar request failed (${response.status}): ${text || response.statusText}`)
+  }
+
+  if (!response.body) {
+    throw new Error('Jangar response body missing (expected SSE stream)')
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let usage: unknown
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) {
+        break
+      }
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+
+      for (const rawLine of lines) {
+        const line = rawLine.trimEnd()
+        if (!line.startsWith('data: ')) {
+          continue
+        }
+
+        const payload = line.slice('data: '.length).trim()
+        if (!payload) {
+          continue
+        }
+        if (payload === '[DONE]') {
+          if (onUsage && usage !== undefined) {
+            onUsage(usage)
+          }
+          return
+        }
+
+        const parsed = parseAllowedJson(payload)
+        if (!parsed) {
+          continue
+        }
+
+        if (parsed.usage !== undefined) {
+          usage = parsed.usage
+        }
+
+        const delta = parsed.choices?.[0]?.delta?.content
+        if (typeof delta === 'string' && delta.length > 0) {
+          yield delta
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  if (onUsage && usage !== undefined) {
+    onUsage(usage)
+  }
+}

--- a/services/discord-bot/src/main.ts
+++ b/services/discord-bot/src/main.ts
@@ -1,0 +1,105 @@
+import { Client, GatewayIntentBits } from 'discord.js'
+
+import { createStreamingReply } from './discord-output'
+import { streamChatCompletionsFromJangar } from './jangar'
+
+const parseAllowlist = (value: string | undefined): Set<string> | undefined => {
+  if (!value) {
+    return undefined
+  }
+  const items = value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+  if (items.length === 0) {
+    return undefined
+  }
+  return new Set(items)
+}
+
+const requiredEnv = (key: string) => {
+  const value = process.env[key]
+  if (!value) {
+    throw new Error(`Missing required env var: ${key}`)
+  }
+  return value
+}
+
+const DISCORD_BOT_TOKEN = requiredEnv('DISCORD_BOT_TOKEN')
+const JANGAR_BASE_URL = requiredEnv('JANGAR_BASE_URL')
+
+const allowedGuildIds = parseAllowlist(process.env.DISCORD_ALLOWED_GUILD_IDS)
+const allowedChannelIds = parseAllowlist(process.env.DISCORD_ALLOWED_CHANNEL_IDS)
+
+const client = new Client({
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
+})
+
+client.on('ready', () => {
+  if (!client.user) {
+    console.log('Logged in (missing user)')
+    return
+  }
+  console.log(`Logged in as ${client.user.tag}`)
+})
+
+client.on('messageCreate', async (message) => {
+  if (!client.user) {
+    return
+  }
+
+  if (message.author.bot) {
+    return
+  }
+
+  if (!message.guildId || !message.channelId) {
+    return
+  }
+
+  if (allowedGuildIds && !allowedGuildIds.has(message.guildId)) {
+    return
+  }
+
+  if (allowedChannelIds && !allowedChannelIds.has(message.channelId)) {
+    return
+  }
+
+  const mentionRegex = new RegExp(`^<@!?${client.user.id}>(\\s+|$)`, 'i')
+  const trimmed = message.content.trim()
+  if (!mentionRegex.test(trimmed)) {
+    return
+  }
+
+  const prompt = trimmed.replace(mentionRegex, '').trim()
+  if (!prompt) {
+    await message.reply('Send a prompt after mentioning me, e.g. `<@BOT_ID> hello`.')
+    return
+  }
+
+  const chatId = `discord:${message.guildId}:${message.channelId}:${message.author.id}`
+  const streaming = await createStreamingReply({ message })
+  let usage: unknown
+
+  try {
+    for await (const delta of streamChatCompletionsFromJangar({
+      baseUrl: JANGAR_BASE_URL,
+      chatId,
+      prompt,
+      onUsage: (value) => {
+        usage = value
+      },
+    })) {
+      await streaming.pushDelta(delta)
+    }
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : String(error)
+    await streaming.pushDelta(`\n\nError: ${messageText}`)
+  } finally {
+    await streaming.finalize()
+    if (usage !== undefined) {
+      console.log('Usage', usage)
+    }
+  }
+})
+
+await client.login(DISCORD_BOT_TOKEN)

--- a/services/discord-bot/tsconfig.json
+++ b/services/discord-bot/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun-types"],
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "vitest.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/services/discord-bot/vitest.config.ts
+++ b/services/discord-bot/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vitest/config'
+
+const root = fileURLToPath(new URL('./src', import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': root,
+      '@': root,
+    },
+  },
+  test: {
+    environment: 'node',
+    alias: {
+      '~': root,
+      '@': root,
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- Adds new Bun-based `services/discord-bot` gateway bot that streams Codex responses from Jangar into Discord.
- Implements mention-first-token ingestion, per-user/per-channel threading via `x-openwebui-chat-id`, SSE parsing, and Discord-safe streaming output (edit throttling + chunking).
- Adds unit tests for SSE delta parsing and Discord chunking/throttling, plus Docker + ArgoCD deployment scaffolding.

## Related Issues

Resolves #1967.

## Testing

- `bunx biome check services/discord-bot/src` (exit 0)
- `cd services/discord-bot && bun run test` (exit 0)
- `bun run test:discord` (exit 0)

## Screenshots (if applicable)

None (bot service only).

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections handled appropriately.
- [x] Documentation and follow-ups updated/tracked.
