### PR TITLE
fix: prevent turn diff suppressing tool calls

### DIFF
--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -732,6 +732,64 @@ describe('CodexAppServerClient codex/event bridging', () => {
     ])
   })
 
+  it('does not let turn diffs suppress command tool deltas', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStart(child, 'turn-1')
+    const { stream } = await runPromise
+
+    writeLine(child, {
+      method: 'turn/diff/updated',
+      params: { turnId: 'turn-1', diff: 'diff --git a/a b/a\nindex 1..2\n--- a/a\n+++ b/a\n@@\n' },
+    })
+
+    writeLine(child, {
+      method: 'codex/event/exec_command_begin',
+      params: {
+        id: 'turn-1',
+        msg: {
+          type: 'exec_command_begin',
+          call_id: 'call-1',
+          turn_id: 'turn-1',
+          command: ['bash', '-lc', 'echo hi'],
+          cwd: '/tmp',
+          parsed_cmd: [],
+          source: 'Agent',
+        },
+      },
+    })
+
+    writeLine(child, {
+      method: 'turn/completed',
+      params: { turn: { id: 'turn-1', status: 'completed', items: [] } },
+    })
+
+    const deltas = await drainStream(stream as unknown as AsyncGenerator<unknown, unknown, void>)
+    expect(deltas).toEqual([
+      {
+        type: 'tool',
+        toolKind: 'file',
+        id: 'turn-1:diff',
+        status: 'delta',
+        title: 'turn diff',
+        data: { changes: [{ path: 'turn.diff', diff: 'diff --git a/a b/a\nindex 1..2\n--- a/a\n+++ b/a\n@@\n' }] },
+      },
+      {
+        type: 'tool',
+        toolKind: 'command',
+        id: 'call-1',
+        status: 'started',
+        title: 'bash -lc echo hi',
+        detail: '/tmp',
+        data: { processId: undefined, source: 'Agent' },
+      },
+    ])
+  })
+
   it('emits agent message deltas from only one source (legacy then v2)', async () => {
     const { child, client } = setupClient()
     await respondToInitialize(child)


### PR DESCRIPTION
## Summary

- Prevent v2 `turn/diff/updated` deltas from suppressing legacy command tool deltas.
- Track tool-delta source per tool kind and isolate `turn diff` streaming from real tool calls.
- Add a regression test covering “turn diff first, then command tool begin”.

## Related Issues

None

## Testing

- `bunx biome check packages/codex/src/app-server-client.ts packages/codex/src/app-server-client.events.test.ts`
- `bun run --cwd packages/codex test`

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
