### PR TITLE
feat: add auto compaction

### DIFF
--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -82,10 +82,22 @@ const respondToTurnStart = async (child: FakeChildProcess, turnId: string) => {
   })
 }
 
-const setupClient = () => {
+const respondToThreadCompact = async (child: FakeChildProcess) => {
+  const request = await nextRequest(child)
+  expect(request.method).toBe('thread/compact')
+  writeLine(child, { id: request.id, result: {} })
+}
+
+const respondToTurnStartError = async (child: FakeChildProcess, message: string) => {
+  const request = await nextRequest(child)
+  expect(request.method).toBe('turn/start')
+  writeLine(child, { id: request.id, error: { message } })
+}
+
+const setupClient = (options: ConstructorParameters<typeof CodexAppServerClient>[0] = {}) => {
   const child = new FakeChildProcess()
   spawnMock.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
-  const client = new CodexAppServerClient({ logger: () => {} })
+  const client = new CodexAppServerClient({ logger: () => {}, ...options })
   return { child, client }
 }
 
@@ -169,6 +181,70 @@ describe('CodexAppServerClient codex/event bridging', () => {
         modelContextWindow: null,
       },
     })
+  })
+
+  it('auto-compacts before starting a new turn when usage is near the context window', async () => {
+    const { child, client } = setupClient({ autoCompaction: true })
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const firstTurnPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStart(child, 'turn-1')
+    const { threadId } = await firstTurnPromise
+
+    writeLine(child, {
+      method: 'turn/completed',
+      params: { turn: { id: 'turn-1', status: 'completed', items: [] } },
+    })
+
+    writeLine(child, {
+      method: 'thread/tokenUsage/updated',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        tokenUsage: {
+          total: {
+            totalTokens: 90,
+            inputTokens: 70,
+            cachedInputTokens: 0,
+            outputTokens: 20,
+            reasoningOutputTokens: 0,
+          },
+          last: {
+            totalTokens: 10,
+            inputTokens: 5,
+            cachedInputTokens: 0,
+            outputTokens: 5,
+            reasoningOutputTokens: 0,
+          },
+          modelContextWindow: 100,
+        },
+      },
+    })
+
+    const secondTurnPromise = client.runTurnStream('hi', { threadId })
+    await respondToThreadCompact(child)
+    await respondToTurnStart(child, 'turn-2')
+    const second = await secondTurnPromise
+
+    expect(second.threadId).toBe('thread-1')
+  })
+
+  it('compacts and retries turn/start once when it fails with a context-length error', async () => {
+    const { child, client } = setupClient({ autoCompaction: true })
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStartError(child, 'Maximum context length exceeded')
+    await respondToThreadCompact(child)
+    await respondToTurnStart(child, 'turn-1')
+
+    const result = await runPromise
+    expect(result.threadId).toBe('thread-1')
+    expect(result.turnId).toBe('turn-1')
   })
 
   it('bridges codex/event/exec_command_* into tool deltas', async () => {

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -6,6 +6,7 @@ import type {
   AgentMessageDeltaNotification,
   AskForApproval,
   CommandExecutionOutputDeltaNotification,
+  ContextCompactedNotification,
   ErrorNotification,
   FileChangeOutputDeltaNotification,
   ItemCompletedNotification,
@@ -13,9 +14,13 @@ import type {
   McpToolCallProgressNotification,
   SandboxMode,
   TerminalInteractionNotification,
+  ThreadCompactParams,
+  ThreadCompactResponse,
   ThreadItem,
   ThreadStartParams,
   ThreadStartResponse,
+  ThreadTokenUsage,
+  ThreadTokenUsageUpdatedNotification,
   Turn,
   TurnCompletedNotification,
   TurnDiffUpdatedNotification,
@@ -82,6 +87,25 @@ export type CodexAppServerOptions = {
   approval?: ApprovalModeInput
   defaultModel?: string
   defaultEffort?: ReasoningEffort
+  autoCompaction?:
+    | boolean
+    | {
+        enabled?: boolean
+        /**
+         * Trigger proactive compaction when `totalTokens / modelContextWindow >= threshold`.
+         * Defaults to `0.85`.
+         */
+        threshold?: number
+        /**
+         * Minimum time between compactions for the same thread. Defaults to `30_000`.
+         */
+        cooldownMs?: number
+        /**
+         * If `turn/start` fails with a context-length error, attempt a `thread/compact` and retry once.
+         * Defaults to `true`.
+         */
+        retryOnContextError?: boolean
+      }
   clientInfo?: ClientInfo
   logger?: (level: 'info' | 'warn' | 'error', message: string, meta?: Record<string, unknown>) => void
   bootstrapTimeoutMs?: number
@@ -104,6 +128,8 @@ const normalizeApprovalPolicy = (approval: ApprovalModeInput): AskForApproval =>
 const defaultClientInfo: ClientInfo = { name: 'lab', title: 'lab app-server client', version: '0.0.0' }
 const DEFAULT_EFFORT: ReasoningEffort = 'high'
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 10_000
+const DEFAULT_AUTO_COMPACTION_THRESHOLD = 0.85
+const DEFAULT_AUTO_COMPACTION_COOLDOWN_MS = 30_000
 
 const newId = (() => {
   let id = 1
@@ -221,6 +247,15 @@ export class CodexAppServerClient {
   private approval: AskForApproval
   private defaultModel: string
   private defaultEffort: ReasoningEffort
+  private autoCompaction: {
+    enabled: boolean
+    threshold: number
+    cooldownMs: number
+    retryOnContextError: boolean
+  }
+  private lastTokenUsageByThread = new Map<string, ThreadTokenUsage>()
+  private lastCompactionAtByThread = new Map<string, number>()
+  private compactionInFlightByThread = new Map<string, Promise<void>>()
 
   constructor({
     binaryPath = 'codex',
@@ -229,6 +264,7 @@ export class CodexAppServerClient {
     approval = 'never',
     defaultModel = 'gpt-5.1-codex-max',
     defaultEffort = DEFAULT_EFFORT,
+    autoCompaction = true,
     clientInfo = defaultClientInfo,
     logger,
     bootstrapTimeoutMs = DEFAULT_BOOTSTRAP_TIMEOUT_MS,
@@ -239,6 +275,7 @@ export class CodexAppServerClient {
     this.defaultModel = defaultModel
     this.defaultEffort = defaultEffort
     this.bootstrapTimeoutMs = bootstrapTimeoutMs
+    this.autoCompaction = this.normalizeAutoCompaction(autoCompaction)
 
     const args = ['--sandbox', this.sandbox, '--ask-for-approval', this.approval, '--model', defaultModel, 'app-server']
     this.child = spawn(binaryPath, args, {
@@ -399,6 +436,8 @@ export class CodexAppServerClient {
       activeThreadId = threadResp.thread.id
     }
 
+    await this.maybeAutoCompactThread(activeThreadId, 'pre_turn')
+
     const turnParams: TurnStartParams = {
       threadId: activeThreadId,
       input: [{ type: 'text', text: prompt }],
@@ -410,7 +449,29 @@ export class CodexAppServerClient {
       summary: null,
     }
 
-    const turnResp = (await this.request<TurnStartResponse>('turn/start', turnParams)) as TurnStartResponse
+    let turnResp: TurnStartResponse
+    try {
+      turnResp = (await this.request<TurnStartResponse>('turn/start', turnParams)) as TurnStartResponse
+    } catch (error) {
+      if (this.autoCompaction.enabled && this.autoCompaction.retryOnContextError && isContextLengthError(error)) {
+        this.log('warn', 'turn/start failed due to context length; compacting and retrying once', {
+          threadId: activeThreadId,
+          error: toErrorMessage(error),
+        })
+        try {
+          await this.compactThread(activeThreadId, { force: true, reason: 'turn_start_retry' })
+        } catch (compactError) {
+          this.log('warn', 'thread/compact failed after context-length error', {
+            threadId: activeThreadId,
+            error: toErrorMessage(compactError),
+          })
+          throw error
+        }
+        turnResp = (await this.request<TurnStartResponse>('turn/start', turnParams)) as TurnStartResponse
+      } else {
+        throw error
+      }
+    }
     const turnId = turnResp.turn.id
 
     const stream = createTurnStream()
@@ -418,6 +479,90 @@ export class CodexAppServerClient {
     this.turnItems.set(turnId, new Set())
     this.lastActiveTurnId = turnId
     return { stream: stream.iterator, turnId, threadId: activeThreadId }
+  }
+
+  async compactThread(
+    threadId: string,
+    { force = false, reason }: { force?: boolean; reason?: string } = {},
+  ): Promise<void> {
+    await this.ensureReady()
+
+    const existing = this.compactionInFlightByThread.get(threadId)
+    if (existing) {
+      await existing
+      return
+    }
+
+    const task = (async () => {
+      const startedAt = Date.now()
+      try {
+        if (!force) {
+          if (!this.autoCompaction.enabled) return
+          const usage = this.lastTokenUsageByThread.get(threadId)
+          if (!usage) return
+          if (!shouldCompactForUsage(usage, this.autoCompaction.threshold)) return
+
+          const lastCompactionAt = this.lastCompactionAtByThread.get(threadId) ?? 0
+          if (startedAt - lastCompactionAt < this.autoCompaction.cooldownMs) return
+        }
+
+        const params: ThreadCompactParams = { threadId }
+        await this.request<ThreadCompactResponse>('thread/compact', params)
+        this.lastCompactionAtByThread.set(threadId, Date.now())
+        this.log('info', 'thread compact requested', {
+          threadId,
+          reason: reason ?? null,
+          durationMs: Date.now() - startedAt,
+        })
+      } finally {
+        this.compactionInFlightByThread.delete(threadId)
+      }
+    })()
+
+    this.compactionInFlightByThread.set(threadId, task)
+    await task
+  }
+
+  private normalizeAutoCompaction(
+    value: NonNullable<CodexAppServerOptions['autoCompaction']>,
+  ): CodexAppServerClient['autoCompaction'] {
+    if (value === true) {
+      return {
+        enabled: true,
+        threshold: DEFAULT_AUTO_COMPACTION_THRESHOLD,
+        cooldownMs: DEFAULT_AUTO_COMPACTION_COOLDOWN_MS,
+        retryOnContextError: true,
+      }
+    }
+
+    if (value === false) {
+      return {
+        enabled: false,
+        threshold: DEFAULT_AUTO_COMPACTION_THRESHOLD,
+        cooldownMs: DEFAULT_AUTO_COMPACTION_COOLDOWN_MS,
+        retryOnContextError: true,
+      }
+    }
+
+    return {
+      enabled: value.enabled ?? true,
+      threshold: value.threshold ?? DEFAULT_AUTO_COMPACTION_THRESHOLD,
+      cooldownMs: value.cooldownMs ?? DEFAULT_AUTO_COMPACTION_COOLDOWN_MS,
+      retryOnContextError: value.retryOnContextError ?? true,
+    }
+  }
+
+  private async maybeAutoCompactThread(threadId: string, reason: string): Promise<void> {
+    if (!this.autoCompaction.enabled) return
+    const usage = this.lastTokenUsageByThread.get(threadId)
+    if (!usage) return
+    if (!shouldCompactForUsage(usage, this.autoCompaction.threshold)) return
+
+    try {
+      await this.compactThread(threadId, { force: false, reason })
+    } catch (error) {
+      this.log('warn', 'auto compaction failed (ignored)', { threadId, reason, error: toErrorMessage(error) })
+    }
   }
 
   async interruptTurn(turnId: string, threadId: string): Promise<void> {
@@ -1360,9 +1505,21 @@ export class CodexAppServerClient {
         break
       }
       case 'thread/tokenUsage/updated': {
-        const params = notification.params as { tokenUsage?: unknown; usage?: unknown }
-        const usage = params.tokenUsage ?? params.usage
+        const raw = (notification.params ?? null) as
+          | (Partial<ThreadTokenUsageUpdatedNotification> & { usage?: unknown })
+          | null
+        const threadId = raw && typeof raw.threadId === 'string' ? raw.threadId : null
+        const usage = raw ? (raw.tokenUsage ?? raw.usage) : null
+        if (threadId && usage && typeof usage === 'object' && !Array.isArray(usage)) {
+          this.lastTokenUsageByThread.set(threadId, usage as ThreadTokenUsage)
+        }
         if (usage) pushUsage(usage)
+        break
+      }
+      case 'thread/compacted': {
+        const params = notification.params as ContextCompactedNotification
+        this.lastCompactionAtByThread.set(params.threadId, Date.now())
+        this.log('info', 'thread compacted notification received', { threadId: params.threadId, turnId: params.turnId })
         break
       }
       case 'codex/event/stream_error':
@@ -1574,6 +1731,49 @@ export class CodexAppServerClient {
       throw err
     }
   }
+}
+
+const toErrorMessage = (error: unknown): string => {
+  if (typeof error === 'string') return error
+  if (error && typeof error === 'object' && typeof (error as { message?: unknown }).message === 'string') {
+    return (error as { message: string }).message
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return `${error}`
+  }
+}
+
+const isContextLengthError = (error: unknown): boolean => {
+  const message = toErrorMessage(error).toLowerCase()
+
+  const mentionsContext =
+    message.includes('context') ||
+    message.includes('token') ||
+    message.includes('prompt') ||
+    message.includes('request too large') ||
+    message.includes('too large')
+
+  if (!mentionsContext) return false
+
+  return (
+    message.includes('context length') ||
+    message.includes('maximum context length') ||
+    message.includes('max context length') ||
+    message.includes('context window') ||
+    message.includes('too many tokens') ||
+    message.includes('token limit') ||
+    message.includes('prompt is too long') ||
+    (message.includes('exceed') && (message.includes('context') || message.includes('token')))
+  )
+}
+
+const shouldCompactForUsage = (usage: ThreadTokenUsage, threshold: number): boolean => {
+  const modelContextWindow = usage.modelContextWindow
+  if (!modelContextWindow || modelContextWindow <= 0) return false
+  const ratio = usage.total.totalTokens / modelContextWindow
+  return ratio >= threshold
 }
 
 export { normalizeApprovalPolicy, normalizeSandboxMode, toSandboxPolicy }


### PR DESCRIPTION
## Summary

- Add `autoCompaction` to `CodexAppServerClient` (defaults enabled) to proactively compact threads when nearing the model context window.
- Track `thread/tokenUsage/updated` and compact before starting a new turn when usage crosses a threshold (with per-thread cooldown).
- Retry `turn/start` once after compaction on context-length errors; add coverage in `app-server-client.events.test.ts`.

## Related Issues

None

## Testing

- `bunx biome check packages/codex/src/app-server-client.ts packages/codex/src/app-server-client.events.test.ts`
- `bun test packages/codex/src/app-server-client.events.test.ts`

## Breaking Changes

None (behavior change: the client may issue `thread/compact` automatically; disable with `autoCompaction: false`).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
