### PR TITLE
fix: harden torghut ws alpaca decoding

### DIFF
--- a/argocd/applications/torghut/role.yaml
+++ b/argocd/applications/torghut/role.yaml
@@ -13,3 +13,6 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]

--- a/argocd/applications/torghut/ta/configmap.yaml
+++ b/argocd/applications/torghut/ta/configmap.yaml
@@ -16,6 +16,7 @@ data:
   TA_SIGNALS_TOPIC: "torghut.nvda.ta.signals.v1"
   TA_GROUP_ID: "torghut-ta-nvda"
   TA_CLIENT_ID: "torghut-ta-nvda"
+  TA_AUTO_OFFSET_RESET: "latest"
   TA_CHECKPOINT_DIR: "s3a://flink-checkpoints/torghut/technical-analysis"
   TA_SAVEPOINT_DIR: "s3a://flink-checkpoints/torghut/technical-analysis/savepoints"
   TA_CHECKPOINT_INTERVAL_MS: "10000"

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:8628d930b706ff17b493f6b2b5332e79a8644e3098e8c5d7aea45e3b714d30fa
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:574956b501e45d6ad9fd25b4024ce759c48ed9b5adfa1d874db3e70be1207a49
   imagePullPolicy: IfNotPresent
   flinkVersion: v1_20
   serviceAccount: torghut-runtime
@@ -54,10 +54,30 @@ spec:
                 secretKeyRef:
                   name: observability-minio-creds
                   key: secretkey
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-creds
+                  key: accesskey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-creds
+                  key: secretkey
+            - name: AWS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-creds
+                  key: accesskey
+            - name: AWS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: observability-minio-creds
+                  key: secretkey
             - name: TORGHUT_TA_VERSION
-              value: v0.336.0-2-g56c56630
+              value: v0.342.1-1-g32907c81
             - name: TORGHUT_TA_COMMIT
-              value: 56c56630a96c57efef24da55ff6bf52544e0bb18
+              value: 32907c81669dff3baa00393b0050c43c6e1a1200
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2025-12-09T07:31:34.667Z
+        kubectl.kubernetes.io/restartedAt: 2025-12-18T21:25:57Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:
@@ -25,7 +25,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:70a24bb7f1c27d8697a1e021349193a0616473a050e5eb8b095f6fea62490a69
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:59250615262c544067f77afb1b27f6ef5ec76d99c842c815bb9c984cd3146cef
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -49,9 +49,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: v0.336.0-2-g56c56630
+              value: hotfix-20251218-212459-32907c81
             - name: TORGHUT_WS_COMMIT
-              value: 56c56630a96c57efef24da55ff6bf52544e0bb18
+              value: 32907c81669dff3baa00393b0050c43c6e1a1200
           ports:
             - containerPort: 8080
               name: http

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2025-12-18T21:25:57Z
+        kubectl.kubernetes.io/restartedAt: 2025-12-18T21:49:59Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:
@@ -49,9 +49,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: hotfix-20251218-212459-32907c81
+              value: hotfix-20251218-214959-9bae3d8a
             - name: TORGHUT_WS_COMMIT
-              value: 32907c81669dff3baa00393b0050c43c6e1a1200
+              value: 9bae3d8ade52d6973a28617c29430cebf89843e5
           ports:
             - containerPort: 8080
               name: http

--- a/docs/torghut/flink-ta.md
+++ b/docs/torghut/flink-ta.md
@@ -65,7 +65,7 @@ S3A properties (example):
 - Jar: `cd services/dorvud && ./gradlew :technical-analysis-flink:uberJar`
 - Image (amd64): `docker buildx build --platform linux/amd64 -f services/dorvud/technical-analysis-flink/Dockerfile -t registry.ide-newton.ts.net/lab/torghut-ta:<tag> services/dorvud --push`
 - Apply: `kubectl -n torghut apply -k argocd/applications/torghut/ta/` or run `bun packages/scripts/src/torghut/deploy-service.ts` to build, push, and wait for `flinkdeployment/torghut-ta` Ready.
-- Checkpoint/Savepoint bucket: `s3a://flink-checkpoints/torghut/technical-analysis/`; provide `TA_S3_ACCESS_KEY/TA_S3_SECRET_KEY` from the MinIO secret.
+- Checkpoint/Savepoint bucket: `s3a://flink-checkpoints/torghut/technical-analysis/`; provide MinIO creds via `TA_S3_ACCESS_KEY/TA_S3_SECRET_KEY` and `AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY` (S3A credential providers look for AWS env vars).
 
 ### Savepoint / upgrade / rollback
 - Upgrade flow: trigger savepoint (or last-state), update image tag, redeploy; verify running and checkpointing.

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaModels.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/AlpacaModels.kt
@@ -2,10 +2,24 @@ package ai.proompteng.dorvud.ws
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 /** Alpaca market data frames (v2 streaming). */
 @Serializable
 sealed interface AlpacaMessage { val type: String }
+
+@Serializable
+@SerialName("error")
+data class AlpacaError(
+  @SerialName("T") override val type: String = "error",
+  val code: Int? = null,
+  val msg: String? = null,
+) : AlpacaMessage
+
+data class AlpacaUnknownMessage(
+  override val type: String,
+  val raw: JsonElement,
+) : AlpacaMessage
 
 @Serializable
 @SerialName("success")

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/AlpacaMapperTest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.fail
 
 class AlpacaMapperTest {
   @Test
@@ -18,5 +19,25 @@ class AlpacaMapperTest {
     assertEquals(true, env.isFinal)
     val payloadSymbol = env.payload.jsonObject["S"]?.toString()?.trim('"')
     assertEquals("AAPL", payloadSymbol)
+  }
+
+  @Test
+  fun `decoding unknown message types does not crash`() {
+    val msg = """{"T":"n","foo":"bar"}"""
+    try {
+      AlpacaMapper.decode(msg)
+    } catch (e: Exception) {
+      fail("expected decode to succeed, got ${e::class.simpleName}: ${e.message}")
+    }
+  }
+
+  @Test
+  fun `decoding messages without T does not crash`() {
+    val msg = """{"foo":"bar"}"""
+    try {
+      AlpacaMapper.decode(msg)
+    } catch (e: Exception) {
+      fail("expected decode to succeed, got ${e::class.simpleName}: ${e.message}")
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Drop malformed Alpaca WS frames/messages instead of crashing the forwarder.
- Log and ignore Alpaca `error` / unknown message types.
- Update Torghut TA + WS manifests (offset reset, AWS env creds, image/version/commit metadata) and RBAC.
- Refresh Flink TA docs for credential env var expectations.

## Related Issues

None

## Testing

- `cd services/dorvud && ./gradlew :websockets:test --no-daemon`
- `cd services/dorvud && ./gradlew test --no-daemon`
- `kubectl apply --dry-run=client --validate=true -f argocd/applications/torghut/ws/deployment.yaml`
- `kubectl apply --dry-run=client --validate=true -f argocd/applications/torghut/ta/flinkdeployment.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
