### PR TITLE
fix: align memories MCP naming

### DIFF
--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -72,7 +72,7 @@ bun --cwd services/jangar run tsc
 
 ## MCP (memories)
 
-Jangar exposes an MCP endpoint at `POST /mcp` (see `services/jangar/src/routes/mcp.ts`). The Codex app-server is configured to use it via `threadConfig.mcp_servers.jangar` (see `services/jangar/src/server/codex-client.ts`).
+The memories MCP endpoint is available at `POST /mcp` (see `services/jangar/src/routes/mcp.ts`). The Codex app-server is configured to use it via `threadConfig.mcp_servers.memories` (see `services/jangar/src/server/codex-client.ts`).
 
 The MCP server provides:
 

--- a/services/jangar/src/server/__tests__/mcp.test.ts
+++ b/services/jangar/src/server/__tests__/mcp.test.ts
@@ -50,13 +50,13 @@ const post = async (service: MemoriesService, body: unknown, headers: Record<str
   return { response, json }
 }
 
-describe('Jangar MCP handler', () => {
+describe('Memories MCP handler', () => {
   it('supports initialize + tools/list', async () => {
     const { service } = makeService()
 
     const init = await post(service, { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
     expect(init.response.status).toBe(200)
-    expect(init.json?.result?.serverInfo?.name).toBe('jangar')
+    expect(init.json?.result?.serverInfo?.name).toBe('memories')
 
     const list = await post(service, { jsonrpc: '2.0', id: 2, method: 'tools/list' })
     expect(list.response.status).toBe(200)
@@ -181,7 +181,7 @@ describe('Jangar MCP handler', () => {
     expect(batch.response.headers.get('Mcp-Session-Id')).toBe('session-1')
     expect(Array.isArray(batch.json)).toBe(true)
     expect(batch.json?.map((item: { id: number }) => item.id)).toEqual([1, 2, 3])
-    expect(batch.json?.find((item: { id: number }) => item.id === 1)?.result?.serverInfo?.name).toBe('jangar')
+    expect(batch.json?.find((item: { id: number }) => item.id === 1)?.result?.serverInfo?.name).toBe('memories')
     expect(batch.json?.find((item: { id: number }) => item.id === 2)?.error?.code).toBe(-32000)
     expect(batch.json?.find((item: { id: number }) => item.id === 3)?.error?.code).toBe(-32000)
   })

--- a/services/jangar/src/server/codex-client.ts
+++ b/services/jangar/src/server/codex-client.ts
@@ -18,7 +18,7 @@ const defaultFactory: Factory = (options) =>
       'features.rmcp_client': true,
       'features.web_search_request': true,
       mcp_servers: {
-        jangar: {
+        memories: {
           url: resolveMcpUrl(),
         },
       },

--- a/services/jangar/src/server/mcp.ts
+++ b/services/jangar/src/server/mcp.ts
@@ -142,7 +142,7 @@ const handleJsonRpcMessageEffect = (request: Request, raw: unknown) =>
         return asJsonRpcResponse(id, {
           protocolVersion: '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'jangar', version: '0.1.0' },
+          serverInfo: { name: 'memories', version: '0.1.0' },
         })
       }
       case 'notifications/initialized': {

--- a/services/jangar/src/server/memories-store.ts
+++ b/services/jangar/src/server/memories-store.ts
@@ -312,7 +312,7 @@ export const createPostgresMemoriesStore = (options: PostgresMemoriesStoreOption
     const encoderModel = process.env.OPENAI_EMBEDDING_MODEL ?? 'text-embedding-3-small'
     const derivedSummary = resolvedSummary ?? resolvedContent.slice(0, 300)
     const metadata = JSON.stringify({ namespace: resolvedNamespace })
-    const source = 'jangar.mcp'
+    const source = 'memories.mcp'
 
     const rows = (await db`
 	      INSERT INTO memories.entries (task_name, content, summary, tags, metadata, source, embedding, encoder_model)

--- a/skills/memories/SKILL.md
+++ b/skills/memories/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: memories
+description: Use the memories MCP tools with the default namespace.
+---
+
+## Scope
+- Memories MCP tools: `persist_memory` and `retrieve_memory`.
+- Always store and query memories in the `default` namespace.
+
+## Persisting Memories
+- Required fields: `{ namespace: 'default', content }`.
+- Optional fields: `summary`, `tags`.
+- Never write to any namespace other than `default`.
+
+## Retrieving Memories
+- Use `{ namespace: 'default', query, limit? }`.
+- Prefer small `limit` values (e.g. 5–10) unless the task demands more.


### PR DESCRIPTION
## Summary

- Rename the MCP server identifier from `jangar` to `memories` in config and responses.
- Align tests and metadata source values with the new MCP name.
- Add a `skills/memories` skill definition for MCP usage guidance.

## Related Issues

None

## Testing

- `bunx biome check services/jangar/src/server/__tests__/mcp.test.ts services/jangar/src/server/codex-client.ts services/jangar/src/server/mcp.ts services/jangar/src/server/memories-store.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
