### PR TITLE
feat: use jangar db for memories scripts

### DIFF
--- a/services/memories/README.md
+++ b/services/memories/README.md
@@ -10,7 +10,16 @@ Note: this service is intended for local/dev agents. Production deployments shou
 bun install
 ```
 
-### Local Postgres
+### Kubernetes Postgres (Jangar)
+
+By default the `save-memory` and `retrieve-memory` helpers connect to the Jangar Postgres cluster by:
+
+- reading the connection URI from the `jangar-db-app` secret in your current kubectl namespace (override with `MEMORIES_KUBE_NAMESPACE`)
+- starting a `kubectl port-forward` to `svc/jangar-db-rw` and rewriting the URI to `127.0.0.1`
+
+If your database lives outside your current kubectl namespace, export `MEMORIES_KUBE_NAMESPACE=<namespace>` before running the scripts.
+
+### Local Postgres (optional)
 
 Bootstrapping the local Postgres schema creates a dedicated `cerebrum` role and database. Run:
 
@@ -24,11 +33,18 @@ Set `DATABASE_URL` to `postgres://cerebrum:cerebrum@localhost:5432/cerebrum?sslm
 
 ### Required environment
 
-- `DATABASE_URL` – Postgres (pgvector-enabled) endpoint with the `memories` schema.
+- `DATABASE_URL` – optional override for the Postgres endpoint (pgvector-enabled) with the `memories` schema.
 - `OPENAI_API_KEY` – key used for the embedding API calls.
 - `OPENAI_EMBEDDING_MODEL` – optional (defaults to `text-embedding-3-small`).
 - `OPENAI_EMBEDDING_DIMENSION` – optional (defaults to `1536`).
 - `OPENAI_API_BASE_URL` – optional (defaults to `https://api.openai.com/v1`).
+
+Optional Kubernetes overrides:
+
+- `MEMORIES_KUBE_NAMESPACE` – namespace to read secrets/port-forward (defaults to kubectl current namespace).
+- `MEMORIES_KUBE_SECRET` – override the secret name (defaults to `jangar-db-app`).
+- `MEMORIES_KUBE_SERVICE` – override the Postgres service (defaults to `svc/jangar-db-rw`).
+- `MEMORIES_KUBE_PORT` – override the Postgres port (defaults to `5432`).
 
 ## Scripts
 

--- a/services/memories/cli.ts
+++ b/services/memories/cli.ts
@@ -1,3 +1,7 @@
+import { Buffer } from 'node:buffer'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+
 // Lightweight helpers shared between the save and retrieve scripts.
 export type FlagMap = Record<string, string | true>
 
@@ -48,7 +52,10 @@ export function requireEnv(name: string): string {
   return value
 }
 
-export const DEFAULT_DATABASE_URL = 'postgres://cerebrum:cerebrum@localhost:5432/cerebrum?sslmode=disable'
+export const LOCAL_DATABASE_URL = 'postgres://cerebrum:cerebrum@localhost:5432/cerebrum?sslmode=disable'
+const DEFAULT_KUBE_SECRET = 'jangar-db-app'
+const DEFAULT_KUBE_SERVICE = 'svc/jangar-db-rw'
+const DEFAULT_KUBE_PORT = 5432
 
 export function toPgTextArray(values: string[]) {
   if (!values.length) {
@@ -96,4 +103,166 @@ export function vectorToPgArray(values: number[]) {
 
 export async function readFile(path: string) {
   return await Bun.file(path).text()
+}
+
+type PortForwardHandle = {
+  localPort: number
+  stop: () => Promise<void>
+}
+
+export type DatabaseSession = {
+  databaseUrl: string
+  stop: () => Promise<void>
+}
+
+const namespaceArgs = () => {
+  const namespace = process.env.MEMORIES_KUBE_NAMESPACE
+  if (!namespace) {
+    return [] as string[]
+  }
+  return ['-n', namespace]
+}
+
+const capture = async (args: string[]): Promise<string> => {
+  const subprocess = Bun.spawn(['kubectl', ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const stdout = subprocess.stdout ? await new Response(subprocess.stdout).text() : ''
+  const stderr = subprocess.stderr ? await new Response(subprocess.stderr).text() : ''
+  const exitCode = await subprocess.exited
+
+  if (exitCode !== 0) {
+    throw new Error(stderr.trim() || `kubectl ${args.join(' ')} failed with exit code ${exitCode}`)
+  }
+
+  return stdout
+}
+
+const decodeDatabaseSecret = async () => {
+  const secretName = process.env.MEMORIES_KUBE_SECRET ?? DEFAULT_KUBE_SECRET
+  const output = await capture(['get', 'secret', secretName, ...namespaceArgs(), '-o', 'jsonpath={.data.uri}'])
+  const encoded = output.trim()
+  if (!encoded) {
+    throw new Error(`Secret ${secretName} does not contain a uri key`)
+  }
+  return Buffer.from(encoded, 'base64').toString('utf8')
+}
+
+const startPortForward = async (): Promise<PortForwardHandle> => {
+  const service = process.env.MEMORIES_KUBE_SERVICE ?? DEFAULT_KUBE_SERVICE
+  const portRaw = process.env.MEMORIES_KUBE_PORT ?? String(DEFAULT_KUBE_PORT)
+  const port = Number(portRaw)
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error(`Invalid MEMORIES_KUBE_PORT: ${portRaw}`)
+  }
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(
+      'kubectl',
+      ['port-forward', ...namespaceArgs(), service, `0:${port}`, '--address', '127.0.0.1'],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+
+    let resolved = false
+    const timeout = setTimeout(() => {
+      if (!resolved) {
+        resolved = true
+        child.kill('SIGINT')
+        reject(new Error('Timed out establishing kubectl port-forward'))
+      }
+    }, 15_000)
+
+    const buffer: string[] = []
+    const handleForwardingLine = (text: string) => {
+      const match = text.match(/Forwarding from (?:127\.0\.0\.1|\[::1\]):(\d+)/)
+      if (match && !resolved) {
+        resolved = true
+        clearTimeout(timeout)
+        const localPort = Number(match[1])
+        console.log(`kubectl port-forward established on 127.0.0.1:${localPort}`)
+        const killOnExit = () => {
+          if (child.exitCode === null) {
+            child.kill('SIGINT')
+          }
+        }
+        const teardownHooks = () => {
+          process.off('exit', killOnExit)
+          process.off('SIGINT', killOnExit)
+          process.off('SIGTERM', killOnExit)
+        }
+        process.on('exit', killOnExit)
+        process.on('SIGINT', killOnExit)
+        process.on('SIGTERM', killOnExit)
+        const stop = async () => {
+          teardownHooks()
+          if (child.exitCode !== null || child.signalCode) {
+            return
+          }
+          child.kill('SIGINT')
+          await once(child, 'exit')
+        }
+        resolve({ localPort, stop })
+      }
+    }
+
+    const logStream = (data: Buffer) => {
+      const text = data.toString()
+      buffer.push(text)
+      handleForwardingLine(text)
+      if (/error/i.test(text) && !resolved) {
+        clearTimeout(timeout)
+        resolved = true
+        if (child.exitCode === null) {
+          child.kill('SIGINT')
+        }
+        reject(new Error(text.trim()))
+      }
+    }
+
+    child.stdout?.on('data', (data) => logStream(data))
+    child.stderr?.on('data', (data) => logStream(data))
+
+    child.once('exit', (code) => {
+      clearTimeout(timeout)
+      if (!resolved) {
+        resolved = true
+        reject(new Error(`kubectl port-forward exited with code ${code ?? 0}`))
+      }
+    })
+
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      if (!resolved) {
+        resolved = true
+        reject(error)
+      }
+    })
+  })
+}
+
+const rewriteDatabaseUrl = (databaseUrl: string, localPort: number): string => {
+  let parsed: URL
+  try {
+    parsed = new URL(databaseUrl)
+  } catch (error) {
+    throw new Error(`Invalid database URL; unable to parse for port-forwarding: ${String(error)}`)
+  }
+  parsed.hostname = '127.0.0.1'
+  parsed.port = String(localPort)
+  return parsed.toString()
+}
+
+export const resolveDatabaseSession = async (): Promise<DatabaseSession> => {
+  if (process.env.DATABASE_URL) {
+    return { databaseUrl: process.env.DATABASE_URL, stop: async () => {} }
+  }
+
+  const databaseUrl = await decodeDatabaseSecret()
+  const forward = await startPortForward()
+  const localUrl = rewriteDatabaseUrl(databaseUrl, forward.localPort)
+  return { databaseUrl: localUrl, stop: forward.stop }
 }


### PR DESCRIPTION
## Summary

- Update memories CLI helpers to connect via kubectl port-forward to Jangar Postgres using the jangar-db-app secret
- Support MEMORIES_KUBE_* overrides and document the Kubernetes connection behavior
- Remove writes to memories.events from save/retrieve to avoid missing-table failures

## Related Issues

None

## Testing

- bunx biome check services/memories/cli.ts
- bunx biome check services/memories/save.ts services/memories/retrieve.ts

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
