### PR TITLE
fix: default memories namespace and embedding dimensions

### DIFF
--- a/services/memories/cli.ts
+++ b/services/memories/cli.ts
@@ -116,10 +116,7 @@ export type DatabaseSession = {
 }
 
 const namespaceArgs = () => {
-  const namespace = process.env.MEMORIES_KUBE_NAMESPACE
-  if (!namespace) {
-    return [] as string[]
-  }
+  const namespace = process.env.MEMORIES_KUBE_NAMESPACE ?? 'jangar'
   return ['-n', namespace]
 }
 

--- a/services/memories/save.ts
+++ b/services/memories/save.ts
@@ -49,7 +49,17 @@ const encoderModel = getFlagValue(flags, 'model') ?? process.env.OPENAI_EMBEDDIN
 const encoderVersion = getFlagValue(flags, 'encoder-version')
 const openAiBaseUrl = process.env.OPENAI_API_BASE_URL ?? process.env.OPENAI_API_BASE ?? 'https://api.openai.com/v1'
 const apiKey = requireEnv('OPENAI_API_KEY')
-const expectedDimension = parseInt(process.env.OPENAI_EMBEDDING_DIMENSION ?? '1536', 10)
+const dimensionsRaw = process.env.OPENAI_EMBEDDING_DIMENSION
+const expectedDimension = parseInt(dimensionsRaw ?? '1536', 10)
+
+const embedBody: Record<string, unknown> = {
+  model: encoderModel,
+  input: content,
+}
+
+if (dimensionsRaw) {
+  embedBody.dimensions = expectedDimension
+}
 
 const embedResponse = await fetch(`${openAiBaseUrl}/embeddings`, {
   method: 'POST',
@@ -57,7 +67,7 @@ const embedResponse = await fetch(`${openAiBaseUrl}/embeddings`, {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${apiKey}`,
   },
-  body: JSON.stringify({ model: encoderModel, input: content }),
+  body: JSON.stringify(embedBody),
 })
 
 if (!embedResponse.ok) {


### PR DESCRIPTION
## Summary

- Default memories kubectl namespace to `jangar` when none is provided.
- Pass embedding `dimensions` when `OPENAI_EMBEDDING_DIMENSION` is set to align with DB expectations.
- Reduce memory save failures caused by missing namespace or mismatched embedding sizes.

## Related Issues

None

## Testing

- bunx biome check services/memories/cli.ts services/memories/save.ts
- Manual: bun run save-memory (10 entries) with OPENAI_EMBEDDING_DIMENSION=1024

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
