### PR TITLE
fix: strip shell prefixes in tool display

### DIFF
--- a/services/jangar/src/server/__tests__/chat-tool-event-renderer.test.ts
+++ b/services/jangar/src/server/__tests__/chat-tool-event-renderer.test.ts
@@ -21,8 +21,21 @@ describe('chat tool event renderer', () => {
     }
 
     const content = collectEmittedContent([started, started])
-    expect(content).toContain('/bin/bash -lc echo hi')
-    expect(content.split('/bin/bash -lc echo hi').length - 1).toBe(1)
+    expect(content).toContain('echo hi')
+    expect(content.split('echo hi').length - 1).toBe(1)
+  })
+
+  it('strips zsh prefixes from command titles', () => {
+    const started: ToolEvent = {
+      id: 'tool-4',
+      toolKind: 'command',
+      status: 'started',
+      title: '/bin/zsh -lc "rg -n \\"jangar\\""',
+    }
+
+    const content = collectEmittedContent([started])
+    expect(content).toContain('rg -n "jangar"')
+    expect(content).not.toContain('/bin/zsh -lc')
   })
 
   it('wraps file tool summaries in a code fence', () => {


### PR DESCRIPTION
## Summary

- Strip shell prefixes and unescape quoted command strings for display titles.
- Update command separator expectations to assert against sanitized output.
- Align command rendering tests with the stripped display values.

## Related Issues

None

## Testing

- bunx biome check services/jangar/src/server/chat-tool-event-renderer.ts services/jangar/src/server/__tests__/chat-completions.test.ts services/jangar/src/server/__tests__/chat-tool-event-renderer.test.ts
- cd services/jangar && bun run tsc
- cd services/jangar && bun run test

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
