### PR TITLE
chore: resize jangar pvc and bump longhorn

### DIFF
--- a/argocd/applications/jangar/pvc.yaml
+++ b/argocd/applications/jangar/pvc.yaml
@@ -11,5 +11,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 50Gi
   storageClassName: longhorn

--- a/argocd/applications/longhorn/kustomization.yaml
+++ b/argocd/applications/longhorn/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: longhorn-system
 helmCharts:
   - name: longhorn
     repo: https://charts.longhorn.io
-    version: 1.9.1
+    version: 1.10.1
     releaseName: longhorn
     namespace: longhorn-system
     valuesFile: longhorn-values.yaml


### PR DESCRIPTION
## Summary

- Resize Jangar PVC request to 50Gi.
- Bump Longhorn chart to 1.10.1 in Argo CD.
- Drop the now-unneeded Longhorn StorageClass expansion patch.

## Related Issues

None

## Testing

- N/A (configuration-only change)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
