### PR TITLE
fix: strip reasoning details from command output

### DIFF
--- a/services/jangar/src/server/__tests__/chat-tool-event-renderer.test.ts
+++ b/services/jangar/src/server/__tests__/chat-tool-event-renderer.test.ts
@@ -91,4 +91,60 @@ describe('chat tool event renderer', () => {
     expect(content).toContain('**Result**')
     expect(content).toContain('"ok": true')
   })
+
+  it('strips reasoning details from command output', () => {
+    const events: ToolEvent[] = [
+      {
+        id: 'tool-5',
+        toolKind: 'command',
+        status: 'started',
+        title: 'bun install',
+      },
+      {
+        id: 'tool-5',
+        toolKind: 'command',
+        status: 'delta',
+        title: 'bun install',
+        delta:
+          'Installing\n<details type="reasoning" done="true" duration="0"><summary>Thought</summary>Waiting</details>\nDone',
+      },
+    ]
+
+    const content = collectEmittedContent(events)
+    expect(content).toContain('Installing')
+    expect(content).toContain('Done')
+    expect(content).not.toContain('<details')
+    expect(content).not.toContain('Thought')
+  })
+
+  it('removes reasoning details split across command deltas', () => {
+    const events: ToolEvent[] = [
+      {
+        id: 'tool-6',
+        toolKind: 'command',
+        status: 'started',
+        title: 'bun install',
+      },
+      {
+        id: 'tool-6',
+        toolKind: 'command',
+        status: 'delta',
+        title: 'bun install',
+        delta: 'Installing\n<details type="reasoning" done="true">',
+      },
+      {
+        id: 'tool-6',
+        toolKind: 'command',
+        status: 'delta',
+        title: 'bun install',
+        delta: '<summary>Thought</summary>\nWaiting</details>\nDone',
+      },
+    ]
+
+    const content = collectEmittedContent(events)
+    expect(content).toContain('Installing')
+    expect(content).toContain('Done')
+    expect(content).not.toContain('<details')
+    expect(content).not.toContain('Waiting')
+  })
 })


### PR DESCRIPTION
## Summary

- strip reasoning <details> blocks from command output before rendering
- ensure filtering works across split deltas in tool output
- add SSE-level regression test for the filtered output

## Related Issues

None.

## Testing

- bunx biome check services/jangar/src
- bun --cwd=services/jangar run tsc
- bun --cwd=services/jangar run test

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
