### PR TITLE
fix: disable client-side compaction in codex client

### DIFF
--- a/services/jangar/scripts/codex-config-container.toml
+++ b/services/jangar/scripts/codex-config-container.toml
@@ -13,6 +13,7 @@ rmcp_client = true
 shell_snapshot = true
 skills = true
 tui2 = true
+remote_compaction = true
 
 [mcp_servers.memories]
 url = "http://127.0.0.1:8080/mcp"


### PR DESCRIPTION
## Summary

- remove client-side auto-compaction logic from the Codex app-server client
- drop compaction retry/tests tied to client-side behavior
- enable remote compaction in Jangar's codex config

## Related Issues

None

## Testing

- bunx biome check packages/codex/src/app-server-client.ts packages/codex/src/app-server-client.events.test.ts

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
