### PR TITLE
test: add Codex intake/orchestration coverage

### DIFF
--- a/services/facteur/internal/knowledge/store_test.go
+++ b/services/facteur/internal/knowledge/store_test.go
@@ -206,6 +206,26 @@ func TestIngestCodexTask(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestIngestCodexTaskRejectsNilPayload(t *testing.T) {
+	store := knowledge.NewStore(nil)
+
+	_, _, _, err := store.IngestCodexTask(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "payload is required")
+}
+
+func TestIngestCodexTaskRejectsMissingDeliveryID(t *testing.T) {
+	store := knowledge.NewStore(nil)
+
+	_, _, _, err := store.IngestCodexTask(context.Background(), &froussardpb.CodexTask{
+		Stage:       froussardpb.CodexTaskStage_CODEX_TASK_STAGE_IMPLEMENTATION,
+		Repository:  "proompteng/lab",
+		IssueNumber: 1635,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing delivery_id")
+}
+
 func expectTaskLifecycle(mock sqlmock.Sqlmock, ideaID, stage, taskID, runID string, queuedAt time.Time, deliveryID string, created time.Time) {
 	mock.ExpectBegin()
 

--- a/services/facteur/internal/orchestrator/implementation_test.go
+++ b/services/facteur/internal/orchestrator/implementation_test.go
@@ -274,6 +274,25 @@ func TestImplementer_RunnerFailure(t *testing.T) {
 	require.Equal(t, 2, runner.calls)
 }
 
+func TestImplementer_MissingDeliveryID(t *testing.T) {
+	store := &fakeStore{}
+	runner := &fakeRunner{}
+
+	implementerInstance, err := NewImplementer(store, runner, Config{})
+	require.NoError(t, err)
+
+	_, err = implementerInstance.Implement(context.Background(), &froussardpb.CodexTask{
+		Stage:       froussardpb.CodexTaskStage_CODEX_TASK_STAGE_IMPLEMENTATION,
+		Repository:  "proompteng/lab",
+		IssueNumber: 1636,
+		DeliveryId:  " ",
+	})
+	require.ErrorIs(t, err, ErrImplementationMissingDeliveryID)
+	require.Equal(t, 0, runner.calls)
+	require.Equal(t, 0, store.ideaCalls)
+	require.Equal(t, 0, store.lifecycleCalls)
+}
+
 func TestImplementer_UnsupportedStage(t *testing.T) {
 	store := &fakeStore{}
 	runner := &fakeRunner{}

--- a/services/facteur/internal/server/server_test.go
+++ b/services/facteur/internal/server/server_test.go
@@ -193,6 +193,30 @@ func TestCodexTasksImplementationDisabled(t *testing.T) {
 	require.Equal(t, 503, resp.StatusCode)
 }
 
+func TestCodexTasksRejectsEmptyPayload(t *testing.T) {
+	srv, err := server.New(server.Options{})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/codex/tasks", bytes.NewReader(nil))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	resp, err := srv.App().Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 400, resp.StatusCode)
+}
+
+func TestCodexTasksRejectsInvalidPayload(t *testing.T) {
+	srv, err := server.New(server.Options{})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/codex/tasks", bytes.NewReader([]byte("not-proto")))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	resp, err := srv.App().Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 400, resp.StatusCode)
+}
+
 func TestCodexTasksUnsupportedStage(t *testing.T) {
 	srv, err := server.New(server.Options{
 		Dispatcher: &stubDispatcher{},


### PR DESCRIPTION
## Summary

- add Codex task intake tests for empty/invalid protobuf payloads
- cover missing delivery_id validation in orchestrator + knowledge intake
- keep Codex orchestration dispatch tests hermetic (no external calls)

## Related Issues

Closes #2023

## Testing

- go test ./... (in services/facteur)
- go build ./... (in services/facteur)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. (N/A — tests only)
