### PR TITLE
feat: expose observability OTLP via tailscale

### DIFF
--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -5,6 +5,9 @@ namespace: observability
 resources:
   - minio-secret.yaml
   - minio-buckets-job.yaml
+  - loki-tailscale-service.yaml
+  - tempo-tailscale-service.yaml
+  - mimir-tailscale-service.yaml
   - graf-mimir-rules.yaml
   - graf-graf-dashboard-configmap.yaml
 

--- a/argocd/applications/observability/loki-tailscale-service.yaml
+++ b/argocd/applications/observability/loki-tailscale-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: observability-loki-tailscale
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: loki
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: observability-loki
+    app.kubernetes.io/name: loki-distributed
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/argocd/applications/observability/mimir-tailscale-service.yaml
+++ b/argocd/applications/observability/mimir-tailscale-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: observability-mimir-tailscale
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: mimir
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/instance: observability-mimir
+    app.kubernetes.io/name: mimir
+  ports:
+    - name: http
+      port: 80
+      targetPort: http-metric

--- a/argocd/applications/observability/tempo-tailscale-service.yaml
+++ b/argocd/applications/observability/tempo-tailscale-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: observability-tempo-tailscale
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: tempo
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: observability-tempo
+    app.kubernetes.io/name: tempo
+  ports:
+    - name: http
+      port: 80
+      targetPort: http-metrics


### PR DESCRIPTION
## Summary

- Expose observability Loki/Tempo/Mimir gateways via Tailscale LBs (hostnames: loki, tempo, mimir)
- Add Tailscale service manifests to the observability kustomization
- Enable OTLP access for local Alloy forwarding over tailnet

## Related Issues

None

## Testing

- Not run (config-only changes)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
