### PR TITLE
fix: use headlamp FQDN in tailscale ingress

### DIFF
--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -18,10 +18,10 @@ ingress:
   enabled: true
   ingressClassName: tailscale
   hosts:
-    - host: headlamp
+    - host: headlamp.ide-newton.ts.net
       paths:
         - path: /
           type: Prefix
   tls:
     - hosts:
-        - headlamp
+        - headlamp.ide-newton.ts.net


### PR DESCRIPTION
## Summary

- set Headlamp ingress host to full MagicDNS FQDN

## Related Issues

None

## Testing

- N/A (values-only change)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
