### PR TITLE
feat: add headlamp oidc admin rbac

### DIFF
--- a/argocd/applications/headlamp/headlamp-oidc-rbac.yaml
+++ b/argocd/applications/headlamp/headlamp-oidc-rbac.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-oidc-admin
+  labels:
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/managed-by: argocd
+    app.kubernetes.io/name: headlamp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: User
+    name: oidc:gregkonush

--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: headlamp
 resources:
+  - headlamp-oidc-rbac.yaml
   - headlamp-oidc-sealedsecret.yaml
 helmCharts:
   - name: headlamp


### PR DESCRIPTION
## Summary

- Add a ClusterRoleBinding to grant cluster-admin to the Headlamp OIDC user.
- Include the RBAC manifest in the Headlamp Argo CD kustomization.

## Related Issues

None.

## Testing

- N/A (RBAC manifest update only).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
