### PR TITLE
docs: add headlamp oidc setup runbook

### DIFF
--- a/docs/headlamp-setup.md
+++ b/docs/headlamp-setup.md
@@ -1,0 +1,119 @@
+# Headlamp Setup (OIDC + RBAC)
+
+This runbook covers Headlamp deployment, OIDC wiring with Keycloak, control-plane OIDC args, and RBAC.
+
+## Deployment layout
+
+- Argo CD app path: `argocd/applications/headlamp`
+- Namespace: `headlamp`
+- Helm release: `headlamp` (chart from https://kubernetes-sigs.github.io/headlamp)
+- OIDC secret (SealedSecret): `argocd/applications/headlamp/headlamp-oidc-sealedsecret.yaml`
+- RBAC manifest: `argocd/applications/headlamp/headlamp-oidc-rbac.yaml`
+
+## Keycloak client (OIDC)
+
+Create a confidential OpenID Connect client (e.g., `kubernetes`) and use it for both Headlamp and the kube-apiserver.
+
+Capabilities:
+- Client authentication: **On**
+- Standard flow: **On**
+- Direct access grants: Off
+- Implicit flow: Off
+- Service accounts roles: Off
+- PKCE: None
+
+Login settings:
+- Root URL: `https://headlamp.ide-newton.ts.net`
+- Home URL: `https://headlamp.ide-newton.ts.net`
+- Valid redirect URIs: `https://headlamp.ide-newton.ts.net/oidc-callback`
+- Web origins: `https://headlamp.ide-newton.ts.net`
+- Valid post logout redirect URIs: `https://headlamp.ide-newton.ts.net`
+
+OIDC values:
+- Issuer: `https://auth.proompteng.ai/realms/master`
+- Scopes: `openid profile email`
+
+Optional (recommended) group mapper:
+- Mapper type: **Group Membership**
+- Token claim name: `groups`
+- Add to ID token: On
+- Add to access token: On
+
+## Reseal Headlamp OIDC secret
+
+Update `argocd/applications/headlamp/headlamp-oidc-sealedsecret.yaml` whenever the client ID/secret changes.
+
+```bash
+kubectl -n headlamp create secret generic headlamp-oidc \
+  --from-literal=OIDC_CLIENT_ID=kubernetes \
+  --from-literal=OIDC_CLIENT_SECRET='<client-secret>' \
+  --from-literal=OIDC_ISSUER_URL='https://auth.proompteng.ai/realms/master' \
+  --from-literal=OIDC_SCOPES='openid profile email' \
+  --from-literal=OIDC_CALLBACK_URL='https://headlamp.ide-newton.ts.net/oidc-callback' \
+  --dry-run=client -o yaml \
+  | kubeseal --controller-name sealed-secrets \
+  --controller-namespace sealed-secrets -o yaml \
+  > argocd/applications/headlamp/headlamp-oidc-sealedsecret.yaml
+```
+
+Commit and sync the Headlamp Argo CD app.
+
+## Apply OIDC to the control plane (k3s)
+
+Headlamp tokens are validated by the kube-apiserver, so OIDC settings must be applied on all control-plane nodes.
+
+Playbook:
+- `ansible/playbooks/k3s-oidc.yml`
+- Writes `/etc/rancher/k3s/config.yaml.d/oidc.yaml` and restarts k3s **serially**.
+- Defaults to `remote_user: kalmyk`.
+
+Run:
+
+```bash
+ANSIBLE_HOST_KEY_CHECKING=False \
+  ansible-playbook -i ansible/inventory/hosts.ini \
+  ansible/playbooks/k3s-oidc.yml \
+  --ssh-extra-args='-o StrictHostKeyChecking=accept-new'
+```
+
+Optional overrides:
+
+```bash
+ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/k3s-oidc.yml \
+  --extra-vars 'k3s_oidc_client_id=kubernetes k3s_oidc_issuer_url=https://auth.proompteng.ai/realms/master'
+```
+
+If Keycloak uses a private CA, provide:
+
+```
+--extra-vars 'k3s_oidc_ca_file=/etc/ssl/certs/your-ca.pem'
+```
+
+## RBAC (GitOps)
+
+Grant permissions using a ClusterRoleBinding in GitOps.
+
+Default binding (user-based):
+- `argocd/applications/headlamp/headlamp-oidc-rbac.yaml`
+- Binds `User: oidc:gregkonush` to `cluster-admin`.
+
+If you prefer group-based RBAC, change the subject to:
+
+```yaml
+subjects:
+  - kind: Group
+    name: oidc:<your-group>
+```
+
+Make sure the Keycloak groups mapper is configured so the `groups` claim is present.
+
+## Troubleshooting
+
+- **401 Unauthorized**: kube-apiserver OIDC config missing or mismatched (issuer/client-id/CA).
+- **403 Forbidden**: RBAC missing. Add/update `headlamp-oidc-rbac.yaml` and sync Argo CD.
+- **Old config in Headlamp**: sync the Argo CD app and restart the deployment:
+
+```bash
+argocd app sync headlamp
+kubectl -n headlamp rollout restart deploy/headlamp
+```

--- a/docs/keycloak-oidc.md
+++ b/docs/keycloak-oidc.md
@@ -10,6 +10,9 @@ This runbook covers the in-cluster Keycloak deployment used for OIDC, plus the i
 - Database: CloudNativePG cluster `keycloak-db` (Longhorn, 5Gi)
 - Public hostname: `auth.proompteng.ai`
 - Traefik route: `argocd/applications/keycloak/ingressroute.yaml`
+- Uses plain manifests (no Helm) under `argocd/applications/keycloak/`.
+
+For Headlamp-specific wiring (OIDC secret, RBAC, control-plane OIDC args), see `docs/headlamp-setup.md`.
 
 ## Admin UI
 
@@ -28,6 +31,35 @@ Keycloak warns if you are still using the bootstrap admin. Create a permanent ad
 4) Delete the temporary bootstrap admin user.
 
 Note: In this Keycloak build, the realm-level admin role is named **admin** under Realm roles (not `realm-admin`).
+
+## OIDC client for Kubernetes/Headlamp
+
+Use a single confidential OIDC client for both the kube-apiserver and Headlamp (example client ID: `kubernetes`).
+
+Capabilities:
+- Client authentication: **On**
+- Standard flow: **On**
+- Direct access grants: Off
+- Implicit flow: Off
+- Service accounts roles: Off
+- PKCE: None
+
+Login settings (Headlamp):
+- Root URL: `https://headlamp.ide-newton.ts.net`
+- Home URL: `https://headlamp.ide-newton.ts.net`
+- Valid redirect URIs: `https://headlamp.ide-newton.ts.net/oidc-callback`
+- Web origins: `https://headlamp.ide-newton.ts.net`
+- Valid post logout redirect URIs: `https://headlamp.ide-newton.ts.net`
+
+Issuer and scopes:
+- Issuer: Realm → **Realm settings** → **Endpoints** → **OpenID Endpoint Configuration** (`issuer`)
+- Scopes: `openid profile email`
+
+Optional (recommended) group mapper:
+- Mapper type: **Group Membership**
+- Token claim name: `groups`
+- Add to ID token: On
+- Add to access token: On
 
 ## Proxy (Nginx Proxy Manager)
 


### PR DESCRIPTION
## Summary

- Add a Headlamp setup runbook covering OIDC, control-plane config, and RBAC.
- Extend Keycloak OIDC doc with client creation guidance and issuer/scopes lookup.

## Related Issues

None.

## Testing

- N/A (documentation changes only).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
