### PR TITLE
feat: add reestr image details route (#2060)

### DIFF
--- a/apps/reestr/src/lib/registry.ts
+++ b/apps/reestr/src/lib/registry.ts
@@ -1,0 +1,342 @@
+type RegistryManifest = {
+  config?: { size?: number; digest?: string }
+  layers?: Array<{ size?: number }>
+}
+
+type ManifestDescriptor = {
+  digest: string
+  platform?: { architecture?: string; os?: string }
+}
+
+type ManifestList = {
+  manifests?: ManifestDescriptor[]
+}
+
+type TagDetails = {
+  tag: string
+  sizeBytes?: number
+  createdAt?: string
+  error?: string
+}
+
+type TagManifestPlatform = {
+  digest: string
+  platformLabel: string
+  sizeBytes?: number
+  error?: string
+}
+
+type TagManifestBreakdown = {
+  tag: string
+  manifestType: 'single' | 'list'
+  sizeBytes?: number
+  createdAt?: string
+  error?: string
+  manifests?: TagManifestPlatform[]
+}
+
+const registryBaseUrl = 'https://registry.ide-newton.ts.net'
+const registryAcceptHeader = [
+  'application/vnd.oci.image.index.v1+json',
+  'application/vnd.docker.distribution.manifest.list.v2+json',
+  'application/vnd.oci.image.manifest.v1+json',
+  'application/vnd.docker.distribution.manifest.v2+json',
+].join(', ')
+
+const decodeRepositoryParam = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+const encodeRepositoryParam = (value: string): string => encodeURIComponent(value)
+
+const formatPlatformLabel = (descriptor: ManifestDescriptor): string => {
+  const os = descriptor.platform?.os
+  const arch = descriptor.platform?.architecture
+  if (os && arch) {
+    return `${os}/${arch}`
+  }
+
+  return os ?? arch ?? 'unknown'
+}
+
+const pickManifestDescriptor = (manifests: ManifestDescriptor[]): ManifestDescriptor | undefined => {
+  const linuxArm64 = manifests.find(
+    (manifest) => manifest.platform?.os === 'linux' && manifest.platform?.architecture === 'arm64',
+  )
+  if (linuxArm64) {
+    return linuxArm64
+  }
+
+  const linuxAmd64 = manifests.find(
+    (manifest) => manifest.platform?.os === 'linux' && manifest.platform?.architecture === 'amd64',
+  )
+  if (linuxAmd64) {
+    return linuxAmd64
+  }
+
+  return manifests[0]
+}
+
+const isManifestList = (payload: RegistryManifest | ManifestList): payload is ManifestList =>
+  Array.isArray((payload as ManifestList).manifests)
+
+const calculateManifestSize = (manifest: RegistryManifest): number => {
+  const configSize = manifest.config?.size ?? 0
+  const layerSize = manifest.layers?.reduce((total, layer) => total + (layer.size ?? 0), 0) ?? 0
+
+  return configSize + layerSize
+}
+
+const fetchManifest = async (
+  repository: string,
+  reference: string,
+): Promise<{ payload?: RegistryManifest | ManifestList; error?: string }> => {
+  try {
+    const response = await fetch(new URL(`/v2/${repository}/manifests/${reference}`, registryBaseUrl), {
+      headers: {
+        Accept: registryAcceptHeader,
+      },
+    })
+    if (!response.ok) {
+      return { error: `Manifest request failed (${response.status})` }
+    }
+
+    return { payload: (await response.json()) as RegistryManifest | ManifestList }
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Failed to load manifest' }
+  }
+}
+
+const fetchTagCreatedAt = async (
+  repository: string,
+  configDigest: string,
+): Promise<{ createdAt?: string; error?: string }> => {
+  try {
+    const response = await fetch(new URL(`/v2/${repository}/blobs/${configDigest}`, registryBaseUrl))
+    if (!response.ok) {
+      return { error: `Config request failed (${response.status})` }
+    }
+
+    const payload = (await response.json()) as { created?: string }
+    return { createdAt: payload.created }
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Failed to load config' }
+  }
+}
+
+const fetchRegistryCatalog = async (): Promise<{ repositories: string[]; error?: string }> => {
+  try {
+    const catalogResponse = await fetch(new URL('/v2/_catalog', registryBaseUrl))
+    if (!catalogResponse.ok) {
+      return {
+        repositories: [],
+        error: `Registry catalog request failed (${catalogResponse.status})`,
+      }
+    }
+
+    const catalog = (await catalogResponse.json()) as { repositories?: string[] }
+    return { repositories: catalog.repositories ?? [] }
+  } catch (error) {
+    return {
+      repositories: [],
+      error: error instanceof Error ? error.message : 'Failed to load registry',
+    }
+  }
+}
+
+const fetchRepositoryTags = async (repository: string): Promise<{ tags: string[]; error?: string }> => {
+  try {
+    const tagsResponse = await fetch(new URL(`/v2/${repository}/tags/list`, registryBaseUrl))
+    if (!tagsResponse.ok) {
+      return {
+        tags: [],
+        error: `Tags request failed (${tagsResponse.status})`,
+      }
+    }
+
+    const tagsPayload = (await tagsResponse.json()) as { tags?: string[] }
+    return { tags: tagsPayload.tags ?? [] }
+  } catch (error) {
+    return {
+      tags: [],
+      error: error instanceof Error ? error.message : 'Failed to load tags',
+    }
+  }
+}
+
+const fetchRepositorySize = async (
+  repository: string,
+  reference: string,
+): Promise<{ sizeBytes?: number; manifest?: RegistryManifest; error?: string }> => {
+  const manifestResult = await fetchManifest(repository, reference)
+  if (!manifestResult.payload) {
+    return { error: manifestResult.error }
+  }
+
+  if (isManifestList(manifestResult.payload)) {
+    const descriptor = pickManifestDescriptor(manifestResult.payload.manifests ?? [])
+    if (!descriptor) {
+      return { error: 'No manifest entries returned' }
+    }
+
+    const nestedManifestResult = await fetchManifest(repository, descriptor.digest)
+    if (!nestedManifestResult.payload || isManifestList(nestedManifestResult.payload)) {
+      return { error: nestedManifestResult.error ?? 'Manifest payload was not an image manifest' }
+    }
+
+    return {
+      sizeBytes: calculateManifestSize(nestedManifestResult.payload),
+      manifest: nestedManifestResult.payload,
+    }
+  }
+
+  return {
+    sizeBytes: calculateManifestSize(manifestResult.payload),
+    manifest: manifestResult.payload,
+  }
+}
+
+const fetchTagDetails = async (repository: string, tag: string): Promise<TagDetails> => {
+  const sizeResult = await fetchRepositorySize(repository, tag)
+  if (!sizeResult.manifest) {
+    return { tag, error: sizeResult.error ?? 'Manifest not available' }
+  }
+
+  const configDigest = sizeResult.manifest.config?.digest
+  if (!configDigest) {
+    return {
+      tag,
+      sizeBytes: sizeResult.sizeBytes,
+      error: 'Manifest missing config digest',
+    }
+  }
+
+  const createdResult = await fetchTagCreatedAt(repository, configDigest)
+
+  return {
+    tag,
+    sizeBytes: sizeResult.sizeBytes,
+    createdAt: createdResult.createdAt,
+    error: createdResult.error,
+  }
+}
+
+const fetchTagManifestBreakdown = async (repository: string, tag: string): Promise<TagManifestBreakdown> => {
+  const manifestResult = await fetchManifest(repository, tag)
+  if (!manifestResult.payload) {
+    return {
+      tag,
+      manifestType: 'single',
+      error: manifestResult.error ?? 'Manifest not available',
+    }
+  }
+
+  if (isManifestList(manifestResult.payload)) {
+    const descriptors = manifestResult.payload.manifests ?? []
+    if (!descriptors.length) {
+      return {
+        tag,
+        manifestType: 'list',
+        error: 'No manifest entries returned',
+        manifests: [],
+      }
+    }
+
+    const manifestEntries = await Promise.all(
+      descriptors.map(async (descriptor) => {
+        const platformLabel = formatPlatformLabel(descriptor)
+        const nestedResult = await fetchManifest(repository, descriptor.digest)
+        if (!nestedResult.payload || isManifestList(nestedResult.payload)) {
+          return {
+            digest: descriptor.digest,
+            platformLabel,
+            error: nestedResult.error ?? 'Manifest payload was not an image manifest',
+          }
+        }
+
+        return {
+          digest: descriptor.digest,
+          platformLabel,
+          sizeBytes: calculateManifestSize(nestedResult.payload),
+          configDigest: nestedResult.payload.config?.digest,
+        }
+      }),
+    )
+
+    const selectedDescriptor = pickManifestDescriptor(descriptors)
+    const selectedEntry = selectedDescriptor
+      ? manifestEntries.find((entry) => entry.digest === selectedDescriptor.digest)
+      : undefined
+    const configDigest = selectedEntry?.configDigest
+    const createdResult = configDigest ? await fetchTagCreatedAt(repository, configDigest) : undefined
+    const manifests = manifestEntries.map(({ configDigest: _configDigest, ...entry }) => entry)
+    const sizes = manifests.map((entry) => entry.sizeBytes).filter((size): size is number => typeof size === 'number')
+    const sizeBytes = sizes.length ? sizes.reduce((total, size) => total + size, 0) : undefined
+    const error = createdResult?.error ?? (sizeBytes ? undefined : 'Manifest sizes unavailable')
+
+    return {
+      tag,
+      manifestType: 'list',
+      sizeBytes,
+      createdAt: createdResult?.createdAt,
+      error,
+      manifests,
+    }
+  }
+
+  const sizeBytes = calculateManifestSize(manifestResult.payload)
+  const configDigest = manifestResult.payload.config?.digest
+  const createdResult = configDigest ? await fetchTagCreatedAt(repository, configDigest) : undefined
+  const error = createdResult?.error ?? (!configDigest ? 'Manifest missing config digest' : undefined)
+
+  return {
+    tag,
+    manifestType: 'single',
+    sizeBytes,
+    createdAt: createdResult?.createdAt,
+    error,
+  }
+}
+
+const formatSize = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0\u00A0B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let unitIndex = 0
+  let value = bytes
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  const formatted = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: unitIndex === 0 ? 0 : 1,
+  }).format(value)
+
+  return `${formatted}\u00A0${units[unitIndex]}`
+}
+
+export type {
+  ManifestDescriptor,
+  ManifestList,
+  RegistryManifest,
+  TagDetails,
+  TagManifestBreakdown,
+  TagManifestPlatform,
+}
+export {
+  decodeRepositoryParam,
+  encodeRepositoryParam,
+  fetchRegistryCatalog,
+  fetchRepositoryTags,
+  fetchTagDetails,
+  fetchTagManifestBreakdown,
+  formatSize,
+}

--- a/apps/reestr/src/routeTree.gen.ts
+++ b/apps/reestr/src/routeTree.gen.ts
@@ -10,33 +10,43 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ImageImageIdRouteImport } from './routes/image.$imageId'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ImageImageIdRoute = ImageImageIdRouteImport.update({
+  id: '/image/$imageId',
+  path: '/image/$imageId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/image/$imageId': typeof ImageImageIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/image/$imageId': typeof ImageImageIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/image/$imageId': typeof ImageImageIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/image/$imageId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/image/$imageId'
+  id: '__root__' | '/' | '/image/$imageId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ImageImageIdRoute: typeof ImageImageIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -48,21 +58,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/image/$imageId': {
+      id: '/image/$imageId'
+      path: '/image/$imageId'
+      fullPath: '/image/$imageId'
+      preLoaderRoute: typeof ImageImageIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ImageImageIdRoute: ImageImageIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/apps/reestr/src/routes/image.$imageId.tsx
+++ b/apps/reestr/src/routes/image.$imageId.tsx
@@ -1,0 +1,192 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+
+import { ScrollArea } from '~/components/ui/scroll-area'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui/table'
+import {
+  decodeRepositoryParam,
+  fetchRepositoryTags,
+  fetchTagManifestBreakdown,
+  formatSize,
+  type TagManifestBreakdown,
+} from '~/lib/registry'
+
+type ImageDetailsLoaderData = {
+  repository: string
+  tags: TagManifestBreakdown[]
+  totalSizeBytes?: number
+  hasTotalSize: boolean
+  fetchedAt: string
+  error?: string
+}
+
+const formatTimestamp = (value?: string) => {
+  if (!value) {
+    return null
+  }
+
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(parsed))
+}
+
+const buildTotalSize = (tags: TagManifestBreakdown[]) => {
+  const sizes = tags.map((tag) => tag.sizeBytes).filter((size): size is number => typeof size === 'number')
+  return {
+    total: sizes.reduce((total, size) => total + size, 0),
+    hasTotal: sizes.length > 0,
+  }
+}
+
+export const Route = createFileRoute('/image/$imageId')({
+  loader: async ({ params }): Promise<ImageDetailsLoaderData> => {
+    const fetchedAt = new Date().toISOString()
+    const repository = decodeRepositoryParam(params.imageId)
+    const tagsResult = await fetchRepositoryTags(repository)
+    if (tagsResult.error) {
+      return {
+        repository,
+        tags: [],
+        totalSizeBytes: undefined,
+        hasTotalSize: false,
+        fetchedAt,
+        error: tagsResult.error,
+      }
+    }
+
+    const tagBreakdowns = await Promise.all(tagsResult.tags.map((tag) => fetchTagManifestBreakdown(repository, tag)))
+    const { total, hasTotal } = buildTotalSize(tagBreakdowns)
+
+    return {
+      repository,
+      tags: tagBreakdowns,
+      totalSizeBytes: hasTotal ? total : undefined,
+      hasTotalSize: hasTotal,
+      fetchedAt,
+    }
+  },
+  component: ImageDetails,
+})
+
+function ImageDetails() {
+  const { repository, tags, totalSizeBytes, hasTotalSize, fetchedAt, error } = Route.useLoaderData()
+  const formattedTime = new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(fetchedAt))
+
+  return (
+    <div className="flex h-dvh w-full justify-center">
+      <section className="flex h-dvh w-full max-w-6xl flex-col px-6 py-6 text-neutral-100">
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
+          <header className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex flex-col gap-2">
+              <Link to="/" className="text-xs font-medium text-neutral-400 transition hover:text-neutral-100">
+                ← Back to registry
+              </Link>
+              <div className="space-y-1">
+                <h1 className="text-xl font-semibold text-neutral-100">{repository}</h1>
+                <p className="text-xs text-neutral-500">Last refreshed {formattedTime}</p>
+              </div>
+            </div>
+            <div className="rounded-sm border border-neutral-800/80 bg-neutral-950 px-4 py-3 text-right">
+              <p className="text-[11px] uppercase tracking-wide text-neutral-500">Total size</p>
+              <p className="text-lg font-semibold text-neutral-100">
+                {hasTotalSize && totalSizeBytes !== undefined ? formatSize(totalSizeBytes) : 'Unknown'}
+              </p>
+              <p className="text-xs text-neutral-500">{tags.length} tags</p>
+            </div>
+          </header>
+
+          <div className="flex min-h-0 flex-1 flex-col rounded-sm border border-neutral-800/80 bg-neutral-950 shadow-[0_0_0_1px_rgba(10,10,10,0.6)]">
+            {error ? (
+              <p role="alert" className="mt-4 px-6 text-sm text-rose-400">
+                {error}
+              </p>
+            ) : null}
+            <ScrollArea className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]]:overflow-y-auto [&_[data-slot=scroll-area-viewport]]:overscroll-contain [&_[data-slot=table-container]]:overflow-x-visible">
+              <Table className="table-fixed text-sm">
+                <colgroup>
+                  <col className="w-[22%]" />
+                  <col className="w-[48%]" />
+                  <col className="w-[14%]" />
+                  <col className="w-[16%]" />
+                </colgroup>
+                <TableHeader>
+                  <TableRow className="h-12 border-neutral-800/80 text-xs uppercase tracking-wide text-neutral-400">
+                    <TableHead className="sticky top-0 z-10 bg-neutral-950 px-4 py-0 font-semibold">Tag</TableHead>
+                    <TableHead className="sticky top-0 z-10 bg-neutral-950 px-4 py-0 font-semibold">
+                      Manifest breakdown
+                    </TableHead>
+                    <TableHead className="sticky top-0 z-10 bg-neutral-950 px-4 py-0 font-semibold">Size</TableHead>
+                    <TableHead className="sticky top-0 z-10 bg-neutral-950 px-4 py-0 font-semibold">Updated</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {tags.length === 0 ? (
+                    <TableRow className="h-12 border-neutral-800/80">
+                      <TableCell colSpan={4} className="px-4 py-0 text-center text-sm text-neutral-300">
+                        No tags found for this repository.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    tags.map((tag) => (
+                      <TableRow key={tag.tag} className="border-neutral-800/80">
+                        <TableCell className="px-4 py-3 align-top">
+                          <div className="flex flex-col gap-1">
+                            <span className="text-sm font-semibold text-neutral-100">{tag.tag}</span>
+                            {tag.error ? <span className="text-xs text-rose-400">{tag.error}</span> : null}
+                          </div>
+                        </TableCell>
+                        <TableCell className="px-4 py-3">
+                          {tag.manifestType === 'list' ? (
+                            tag.manifests?.length ? (
+                              <div className="flex flex-col gap-2">
+                                {tag.manifests.map((manifest) => (
+                                  <div key={manifest.digest} className="flex flex-wrap items-center gap-2 text-xs">
+                                    <span className="rounded-full border border-neutral-700/70 bg-neutral-900/70 px-2 py-0.5 text-neutral-200">
+                                      {manifest.platformLabel}
+                                    </span>
+                                    <span className="text-neutral-300">
+                                      {typeof manifest.sizeBytes === 'number'
+                                        ? formatSize(manifest.sizeBytes)
+                                        : 'Unknown'}
+                                    </span>
+                                    {manifest.error ? <span className="text-rose-400">{manifest.error}</span> : null}
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <span className="text-xs text-neutral-500">No manifest entries</span>
+                            )
+                          ) : (
+                            <span className="text-xs text-neutral-500">Single manifest</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-xs text-neutral-300">
+                          {typeof tag.sizeBytes === 'number' ? (
+                            <span className="text-sm font-medium text-neutral-100">{formatSize(tag.sizeBytes)}</span>
+                          ) : (
+                            <span className="text-xs text-neutral-500">Unknown</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-xs text-neutral-300">
+                          {tag.createdAt ? formatTimestamp(tag.createdAt) : '—'}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/reestr/src/routes/index.tsx
+++ b/apps/reestr/src/routes/index.tsx
@@ -1,8 +1,16 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import type { KeyboardEvent } from 'react'
 
 import { ScrollArea } from '~/components/ui/scroll-area'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui/table'
-import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip'
+import {
+  encodeRepositoryParam,
+  fetchRegistryCatalog,
+  fetchRepositoryTags,
+  fetchTagDetails,
+  formatSize,
+  type TagDetails,
+} from '~/lib/registry'
 
 type RegistryImage = {
   name: string
@@ -12,179 +20,6 @@ type RegistryImage = {
   sizeTimestamp?: string
   error?: string
   sizeError?: string
-}
-
-const registryBaseUrl = 'https://registry.ide-newton.ts.net'
-const registryAcceptHeader = [
-  'application/vnd.oci.image.index.v1+json',
-  'application/vnd.docker.distribution.manifest.list.v2+json',
-  'application/vnd.oci.image.manifest.v1+json',
-  'application/vnd.docker.distribution.manifest.v2+json',
-].join(', ')
-
-type RegistryManifest = {
-  config?: { size?: number; digest?: string }
-  layers?: Array<{ size?: number }>
-}
-
-type ManifestDescriptor = {
-  digest: string
-  platform?: { architecture?: string; os?: string }
-}
-
-type ManifestList = {
-  manifests?: ManifestDescriptor[]
-}
-
-function pickManifestDescriptor(manifests: ManifestDescriptor[]): ManifestDescriptor | undefined {
-  const linuxArm64 = manifests.find(
-    (manifest) => manifest.platform?.os === 'linux' && manifest.platform?.architecture === 'arm64',
-  )
-  if (linuxArm64) {
-    return linuxArm64
-  }
-
-  const linuxAmd64 = manifests.find(
-    (manifest) => manifest.platform?.os === 'linux' && manifest.platform?.architecture === 'amd64',
-  )
-  if (linuxAmd64) {
-    return linuxAmd64
-  }
-
-  return manifests[0]
-}
-
-function isManifestList(payload: RegistryManifest | ManifestList): payload is ManifestList {
-  return Array.isArray((payload as ManifestList).manifests)
-}
-
-function calculateManifestSize(manifest: RegistryManifest): number {
-  const configSize = manifest.config?.size ?? 0
-  const layerSize = manifest.layers?.reduce((total, layer) => total + (layer.size ?? 0), 0) ?? 0
-
-  return configSize + layerSize
-}
-
-async function fetchManifest(
-  repository: string,
-  reference: string,
-): Promise<{ payload?: RegistryManifest | ManifestList; error?: string }> {
-  try {
-    const response = await fetch(new URL(`/v2/${repository}/manifests/${reference}`, registryBaseUrl), {
-      headers: {
-        Accept: registryAcceptHeader,
-      },
-    })
-    if (!response.ok) {
-      return { error: `Manifest request failed (${response.status})` }
-    }
-
-    return { payload: (await response.json()) as RegistryManifest | ManifestList }
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Failed to load manifest' }
-  }
-}
-
-async function fetchRepositorySize(
-  repository: string,
-  reference: string,
-): Promise<{ sizeBytes?: number; manifest?: RegistryManifest; error?: string }> {
-  const manifestResult = await fetchManifest(repository, reference)
-  if (!manifestResult.payload) {
-    return { error: manifestResult.error }
-  }
-
-  if (isManifestList(manifestResult.payload)) {
-    const descriptor = pickManifestDescriptor(manifestResult.payload.manifests ?? [])
-    if (!descriptor) {
-      return { error: 'No manifest entries returned' }
-    }
-
-    const nestedManifestResult = await fetchManifest(repository, descriptor.digest)
-    if (!nestedManifestResult.payload || isManifestList(nestedManifestResult.payload)) {
-      return { error: nestedManifestResult.error ?? 'Manifest payload was not an image manifest' }
-    }
-
-    return {
-      sizeBytes: calculateManifestSize(nestedManifestResult.payload),
-      manifest: nestedManifestResult.payload,
-    }
-  }
-
-  return {
-    sizeBytes: calculateManifestSize(manifestResult.payload),
-    manifest: manifestResult.payload,
-  }
-}
-
-function formatSize(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) {
-    return '0\u00A0B'
-  }
-
-  const units = ['B', 'KB', 'MB', 'GB', 'TB']
-  let unitIndex = 0
-  let value = bytes
-
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024
-    unitIndex += 1
-  }
-
-  const formatted = new Intl.NumberFormat(undefined, {
-    maximumFractionDigits: unitIndex === 0 ? 0 : 1,
-  }).format(value)
-
-  return `${formatted}\u00A0${units[unitIndex]}`
-}
-
-type TagDetails = {
-  tag: string
-  sizeBytes?: number
-  createdAt?: string
-  error?: string
-}
-
-async function fetchTagCreatedAt(
-  repository: string,
-  configDigest: string,
-): Promise<{ createdAt?: string; error?: string }> {
-  try {
-    const response = await fetch(new URL(`/v2/${repository}/blobs/${configDigest}`, registryBaseUrl))
-    if (!response.ok) {
-      return { error: `Config request failed (${response.status})` }
-    }
-
-    const payload = (await response.json()) as { created?: string }
-    return { createdAt: payload.created }
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Failed to load config' }
-  }
-}
-
-async function fetchTagDetails(repository: string, tag: string): Promise<TagDetails> {
-  const sizeResult = await fetchRepositorySize(repository, tag)
-  if (!sizeResult.manifest) {
-    return { tag, error: sizeResult.error ?? 'Manifest not available' }
-  }
-
-  const configDigest = sizeResult.manifest.config?.digest
-  if (!configDigest) {
-    return {
-      tag,
-      sizeBytes: sizeResult.sizeBytes,
-      error: 'Manifest missing config digest',
-    }
-  }
-
-  const createdResult = await fetchTagCreatedAt(repository, configDigest)
-
-  return {
-    tag,
-    sizeBytes: sizeResult.sizeBytes,
-    createdAt: createdResult.createdAt,
-    error: createdResult.error,
-  }
 }
 
 function pickLatestTag(details: TagDetails[]): TagDetails | undefined {
@@ -208,64 +43,54 @@ async function fetchRegistryImages(): Promise<{
   const fetchedAt = new Date().toISOString()
 
   try {
-    const catalogResponse = await fetch(new URL('/v2/_catalog', registryBaseUrl))
-    if (!catalogResponse.ok) {
+    const catalogResult = await fetchRegistryCatalog()
+    if (catalogResult.error) {
       return {
         images: [],
-        error: `Registry catalog request failed (${catalogResponse.status})`,
+        error: catalogResult.error,
         fetchedAt,
       }
     }
 
-    const catalog = (await catalogResponse.json()) as { repositories?: string[] }
-    const repositories = catalog.repositories ?? []
+    const repositories = catalogResult.repositories
 
     const images = await Promise.all(
       repositories.map(async (repository) => {
-        try {
-          const tagsResponse = await fetch(new URL(`/v2/${repository}/tags/list`, registryBaseUrl))
-          if (!tagsResponse.ok) {
-            return {
-              name: repository,
-              tags: [],
-              error: `Tags request failed (${tagsResponse.status})`,
-            }
-          }
-
-          const tagsPayload = (await tagsResponse.json()) as { tags?: string[] }
-          const tags = tagsPayload.tags ?? []
-          let sizeBytes: number | undefined
-          let sizeTag: string | undefined
-          let sizeTimestamp: string | undefined
-          let sizeError: string | undefined
-
-          if (tags.length) {
-            const tagDetails = await Promise.all(tags.map((tag) => fetchTagDetails(repository, tag)))
-            const latestTag = pickLatestTag(tagDetails)
-            sizeBytes = latestTag?.sizeBytes
-            sizeTag = latestTag?.tag
-            sizeTimestamp = latestTag?.createdAt
-            if (!sizeBytes) {
-              sizeError = latestTag?.error ?? 'No valid manifest found'
-            }
-          } else {
-            sizeError = 'No tags available'
-          }
-
-          return {
-            name: repository,
-            tags,
-            sizeTag,
-            sizeBytes,
-            sizeTimestamp,
-            sizeError,
-          }
-        } catch (error) {
+        const tagsResult = await fetchRepositoryTags(repository)
+        if (tagsResult.error) {
           return {
             name: repository,
             tags: [],
-            error: error instanceof Error ? error.message : 'Failed to load tags',
+            error: tagsResult.error,
           }
+        }
+
+        const tags = tagsResult.tags
+        let sizeBytes: number | undefined
+        let sizeTag: string | undefined
+        let sizeTimestamp: string | undefined
+        let sizeError: string | undefined
+
+        if (tags.length) {
+          const tagDetails = await Promise.all(tags.map((tag) => fetchTagDetails(repository, tag)))
+          const latestTag = pickLatestTag(tagDetails)
+          sizeBytes = latestTag?.sizeBytes
+          sizeTag = latestTag?.tag
+          sizeTimestamp = latestTag?.createdAt
+          if (!sizeBytes) {
+            sizeError = latestTag?.error ?? 'No valid manifest found'
+          }
+        } else {
+          sizeError = 'No tags available'
+        }
+
+        return {
+          name: repository,
+          tags,
+          sizeTag,
+          sizeBytes,
+          sizeTimestamp,
+          sizeError,
         }
       }),
     )
@@ -308,6 +133,13 @@ function App() {
     }).format(new Date(parsed))
   }
 
+  const handleRowLinkKeyDown = (event: KeyboardEvent<HTMLAnchorElement>) => {
+    if (event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault()
+      event.currentTarget.click()
+    }
+  }
+
   return (
     <div className="flex h-dvh w-full justify-center">
       <section className="flex h-dvh w-full max-w-6xl flex-col px-6 py-6 text-neutral-100">
@@ -343,62 +175,82 @@ function App() {
                 ) : (
                   images.map((image) => {
                     const extraTags = Math.max(0, image.tags.length - 3)
+                    const imageId = encodeRepositoryParam(image.name)
+                    const linkProps = {
+                      to: '/image/$imageId',
+                      params: { imageId },
+                    } as const
 
                     return (
-                      <TableRow key={image.name} className="h-12 border-neutral-800/80">
-                        <TableCell className="px-4 py-0 font-medium text-neutral-100">{image.name}</TableCell>
-                        <TableCell className="min-w-0 px-4 py-0">
-                          {image.tags.length ? (
-                            <div className="flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden">
-                              {image.tags.slice(0, 3).map((tag) => (
-                                <span
-                                  key={tag}
-                                  className="h-6 max-w-[120px] truncate whitespace-nowrap rounded-full border border-neutral-700/70 bg-neutral-900/70 px-2 py-0.5 text-xs text-neutral-200"
-                                >
-                                  {tag}
-                                </span>
-                              ))}
-                              {extraTags > 0 ? (
-                                <>
-                                  <span className="text-xs text-neutral-500">…</span>
-                                  <Tooltip>
-                                    <TooltipTrigger
-                                      type="button"
-                                      aria-label={`Show ${extraTags} more tags`}
+                      <TableRow
+                        key={image.name}
+                        className="h-12 border-neutral-800/80 transition-colors hover:bg-neutral-900/50 focus-within:bg-neutral-900/50"
+                      >
+                        <TableCell className="px-0 py-0 font-medium text-neutral-100">
+                          <Link
+                            {...linkProps}
+                            onKeyDown={handleRowLinkKeyDown}
+                            className="flex h-full w-full items-center px-4 py-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/80 focus-visible:ring-inset"
+                          >
+                            {image.name}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="min-w-0 px-0 py-0">
+                          <Link
+                            {...linkProps}
+                            onKeyDown={handleRowLinkKeyDown}
+                            className="flex min-w-0 items-center px-4 py-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/80 focus-visible:ring-inset"
+                          >
+                            {image.tags.length ? (
+                              <div className="flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden">
+                                {image.tags.slice(0, 3).map((tag) => (
+                                  <span
+                                    key={tag}
+                                    className="h-6 max-w-[120px] truncate whitespace-nowrap rounded-full border border-neutral-700/70 bg-neutral-900/70 px-2 py-0.5 text-xs text-neutral-200"
+                                  >
+                                    {tag}
+                                  </span>
+                                ))}
+                                {extraTags > 0 ? (
+                                  <>
+                                    <span className="text-xs text-neutral-500">…</span>
+                                    <span
                                       className="flex h-6 min-w-6 items-center justify-center rounded-full border border-neutral-700/70 bg-neutral-900/70 px-2 text-[11px] text-neutral-200"
+                                      title={image.tags.slice(3).join(', ')}
                                     >
                                       +{extraTags}
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                      side="top"
-                                      align="start"
-                                      className="border border-neutral-700/80 bg-neutral-950 text-neutral-100 shadow-lg [&>*:last-child]:hidden"
-                                    >
-                                      <p className="max-w-xs text-xs text-neutral-100">
-                                        {image.tags.slice(3).join(', ')}
-                                      </p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </>
-                              ) : null}
-                            </div>
-                          ) : (
-                            <span className="text-xs text-neutral-500">No tags</span>
-                          )}
+                                    </span>
+                                  </>
+                                ) : null}
+                              </div>
+                            ) : (
+                              <span className="text-xs text-neutral-500">No tags</span>
+                            )}
+                          </Link>
                         </TableCell>
-                        <TableCell className="px-4 py-0 text-xs text-neutral-300">
-                          {image.sizeBytes ? (
-                            <div className="flex flex-col gap-1">
+                        <TableCell className="px-0 py-0 text-xs text-neutral-300">
+                          <Link
+                            {...linkProps}
+                            onKeyDown={handleRowLinkKeyDown}
+                            className="flex h-full w-full flex-col justify-center px-4 py-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/80 focus-visible:ring-inset"
+                          >
+                            {image.sizeBytes ? (
                               <span className="text-sm font-medium text-neutral-100">
                                 {formatSize(image.sizeBytes)}
                               </span>
-                            </div>
-                          ) : (
-                            <span className="text-xs text-neutral-500">Unknown</span>
-                          )}
+                            ) : (
+                              <span className="text-xs text-neutral-500">Unknown</span>
+                            )}
+                          </Link>
                         </TableCell>
-                        <TableCell className="px-4 py-0 text-xs text-neutral-300">
-                          {image.sizeTimestamp ? formatTimestamp(image.sizeTimestamp) : '—'}
+                        <TableCell className="px-0 py-0 text-xs text-neutral-300">
+                          <Link
+                            {...linkProps}
+                            onKeyDown={handleRowLinkKeyDown}
+                            className="flex h-full w-full items-center px-4 py-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/80 focus-visible:ring-inset"
+                          >
+                            {image.sizeTimestamp ? formatTimestamp(image.sizeTimestamp) : '—'}
+                          </Link>
                         </TableCell>
                       </TableRow>
                     )


### PR DESCRIPTION
## Summary

- extract registry fetch helpers into `apps/reestr/src/lib/registry.ts` for shared manifest/tag sizing logic
- add `/image/$imageId` details route with per-tag and per-platform size breakdowns plus totals
- make index table rows keyboard-accessible links into the new image details view

## Related Issues

Closes #2060

## Testing

- bunx biome check apps/reestr/src/routes apps/reestr/src/lib (ran `bunx biome format --write apps/reestr/src/lib/registry.ts 'apps/reestr/src/routes/image.$imageId.tsx'` to fix formatting)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
