### PR TITLE
chore: deploy bumba image

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: bumba
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2025-12-23T06:35:19.230Z"
+        kubectl.kubernetes.io/restartedAt: "2025-12-23T23:23:48.236Z"
     spec:
       containers:
         - name: bumba

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: "da785320"
+    newTag: "bc473027"


### PR DESCRIPTION
## Summary

- Update bumba image tag to bc473027 in ArgoCD manifests.
- Refresh the bumba deployment rollout annotation.
- Deploy the updated bumba image via the bumba kustomization.

## Related Issues

None

## Testing

- kubectl -n jangar rollout status deployment/bumba --timeout=120s

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
