### PR TITLE
fix: avoid tempo ingester pvc change

### DIFF
--- a/argocd/applications/observability/tempo-values.yaml
+++ b/argocd/applications/observability/tempo-values.yaml
@@ -29,9 +29,7 @@ distributor:
 ingester:
   replicas: 2
   persistence:
-    enabled: true
-    size: 20Gi
-    storageClass: longhorn
+    enabled: false
 
 compactor:
   replicas: 1


### PR DESCRIPTION
## Summary

- disable tempo ingester PVC toggles to avoid immutable StatefulSet replacements
- let OTLP + S3 config apply cleanly in ArgoCD

## Related Issues

None

## Testing

- kubectl -n argocd get applications.argoproj.io observability (checked ArgoCD error cause)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
