### PR TITLE
fix: pass tempo env expansion args

### DIFF
--- a/argocd/applications/observability/tempo-values.yaml
+++ b/argocd/applications/observability/tempo-values.yaml
@@ -13,8 +13,6 @@ global:
         secretKeyRef:
           name: observability-minio-credentials
           key: tempoSecretKey
-  extraArgs:
-    - -config.expand-env=true
 
 traces:
   otlp:
@@ -25,11 +23,15 @@ traces:
 
 distributor:
   replicas: 1
+  extraArgs:
+    - -config.expand-env=true
 
 ingester:
   replicas: 2
   persistence:
     enabled: false
+  extraArgs:
+    - -config.expand-env=true
 
 compactor:
   replicas: 1
@@ -37,12 +39,18 @@ compactor:
     enabled: true
     size: 20Gi
     storageClass: longhorn
+  extraArgs:
+    - -config.expand-env=true
 
 querier:
   replicas: 1
+  extraArgs:
+    - -config.expand-env=true
 
 queryFrontend:
   replicas: 1
+  extraArgs:
+    - -config.expand-env=true
 
 storage:
   trace:


### PR DESCRIPTION
## Summary

- pass -config.expand-env=true to Tempo deployments that consume env placeholders
- ensure S3 credentials in tempo.yaml are expanded at startup

## Related Issues

None

## Testing

- kubectl -n observability get deployment observability-tempo-query-frontend -o jsonpath='{.spec.template.spec.containers[0].args}' (confirmed args include -config.expand-env)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
