### PR TITLE
fix(temporal-bun-sdk): avoid child workflow id collisions

### DIFF
--- a/packages/temporal-bun-sdk/src/workflow/context.ts
+++ b/packages/temporal-bun-sdk/src/workflow/context.ts
@@ -617,12 +617,16 @@ const buildStartChildWorkflowIntent = (
   options: StartChildWorkflowOptions,
 ): StartChildWorkflowCommandIntent => {
   const sequence = ctx.nextSequence()
+  const previous = ctx.previousIntent(sequence)
+  const replayWorkflowId = previous && previous.kind === 'start-child-workflow' ? previous.workflowId : undefined
+  const workflowId =
+    options.workflowId ?? replayWorkflowId ?? `${ctx.info.workflowId}-child-${ctx.info.runId}-${sequence}`
   return {
     id: `start-child-workflow-${sequence}`,
     kind: 'start-child-workflow',
     sequence,
     workflowType,
-    workflowId: options.workflowId ?? `${ctx.info.workflowId}-child-${sequence}`,
+    workflowId,
     namespace: options.namespace ?? ctx.info.namespace,
     taskQueue: options.taskQueue ?? ctx.info.taskQueue,
     input: args,


### PR DESCRIPTION
## Summary
- ensure default child workflow IDs include runId to prevent collisions across continue-as-new runs
- preserve replayed child workflow IDs for determinism compatibility
- reduce bumba repo fanout size and worker concurrency to protect self-hosted model capacity
- add workflow context tests for unique IDs and replay behavior

## Related Issues
None

## Testing
- bun test packages/temporal-bun-sdk/tests/workflow/primitives.test.ts
- not run (bumba workflow/deployment tuning only)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.