### PR TITLE
feat(jangar): add ClickHouse TA routes

### DIFF
--- a/argocd/applications/jangar/clickhouse-auth.yaml
+++ b/argocd/applications/jangar/clickhouse-auth.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: jangar-clickhouse-auth
+  namespace: jangar
+spec:
+  encryptedData:
+    username: REPLACE_WITH_SEALED_CLICKHOUSE_USERNAME
+    password: REPLACE_WITH_SEALED_CLICKHOUSE_PASSWORD
+  template:
+    metadata:
+      name: jangar-clickhouse-auth
+      namespace: jangar
+    type: Opaque

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -93,6 +93,24 @@ spec:
               value: require
             - name: JANGAR_DB_CA_CERT
               value: /etc/ssl/certs/jangar-db/ca.crt
+            - name: CH_HOST
+              value: torghut-clickhouse.torghut.svc
+            - name: CH_PORT
+              value: "8123"
+            - name: CH_DATABASE
+              value: default
+            - name: CH_SECURE
+              value: "false"
+            - name: CH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: jangar-clickhouse-auth
+                  key: username
+            - name: CH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: jangar-clickhouse-auth
+                  key: password
             - name: VSCODE_DATA_DIR
               value: /workspace/.ovscode
             - name: VSCODE_DEFAULT_FOLDER

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - github-token.yaml
+  - clickhouse-auth.yaml
   - app-tailscale-service.yaml
   - tailscale-service.yaml
   - postgres-cluster.yaml

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -28,6 +28,9 @@ import { Route as ApiTorghutSymbolsRouteImport } from './routes/api/torghut/symb
 import { Route as ApiAtlasPathsRouteImport } from './routes/api/atlas/paths'
 import { Route as ApiAtlasIndexedRouteImport } from './routes/api/atlas/indexed'
 import { Route as OpenaiV1ChatCompletionsRouteImport } from './routes/openai/v1/chat/completions'
+import { Route as ApiTorghutTaSignalsRouteImport } from './routes/api/torghut/ta/signals'
+import { Route as ApiTorghutTaLatestRouteImport } from './routes/api/torghut/ta/latest'
+import { Route as ApiTorghutTaBarsRouteImport } from './routes/api/torghut/ta/bars'
 import { Route as ApiTorghutSymbolsSymbolRouteImport } from './routes/api/torghut/symbols/$symbol'
 
 const MemoriesRoute = MemoriesRouteImport.update({
@@ -125,6 +128,21 @@ const OpenaiV1ChatCompletionsRoute = OpenaiV1ChatCompletionsRouteImport.update({
   path: '/openai/v1/chat/completions',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiTorghutTaSignalsRoute = ApiTorghutTaSignalsRouteImport.update({
+  id: '/api/torghut/ta/signals',
+  path: '/api/torghut/ta/signals',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiTorghutTaLatestRoute = ApiTorghutTaLatestRouteImport.update({
+  id: '/api/torghut/ta/latest',
+  path: '/api/torghut/ta/latest',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiTorghutTaBarsRoute = ApiTorghutTaBarsRouteImport.update({
+  id: '/api/torghut/ta/bars',
+  path: '/api/torghut/ta/bars',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiTorghutSymbolsSymbolRoute = ApiTorghutSymbolsSymbolRouteImport.update({
   id: '/$symbol',
   path: '/$symbol',
@@ -151,6 +169,9 @@ export interface FileRoutesByFullPath {
   '/api/torghut/symbols': typeof ApiTorghutSymbolsRouteWithChildren
   '/openai/v1/models': typeof OpenaiV1ModelsRoute
   '/api/torghut/symbols/$symbol': typeof ApiTorghutSymbolsSymbolRoute
+  '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
+  '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
+  '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
 }
 export interface FileRoutesByTo {
@@ -173,6 +194,9 @@ export interface FileRoutesByTo {
   '/api/torghut/symbols': typeof ApiTorghutSymbolsRouteWithChildren
   '/openai/v1/models': typeof OpenaiV1ModelsRoute
   '/api/torghut/symbols/$symbol': typeof ApiTorghutSymbolsSymbolRoute
+  '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
+  '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
+  '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
 }
 export interface FileRoutesById {
@@ -196,6 +220,9 @@ export interface FileRoutesById {
   '/api/torghut/symbols': typeof ApiTorghutSymbolsRouteWithChildren
   '/openai/v1/models': typeof OpenaiV1ModelsRoute
   '/api/torghut/symbols/$symbol': typeof ApiTorghutSymbolsSymbolRoute
+  '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
+  '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
+  '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
 }
 export interface FileRouteTypes {
@@ -220,6 +247,9 @@ export interface FileRouteTypes {
     | '/api/torghut/symbols'
     | '/openai/v1/models'
     | '/api/torghut/symbols/$symbol'
+    | '/api/torghut/ta/bars'
+    | '/api/torghut/ta/latest'
+    | '/api/torghut/ta/signals'
     | '/openai/v1/chat/completions'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -242,6 +272,9 @@ export interface FileRouteTypes {
     | '/api/torghut/symbols'
     | '/openai/v1/models'
     | '/api/torghut/symbols/$symbol'
+    | '/api/torghut/ta/bars'
+    | '/api/torghut/ta/latest'
+    | '/api/torghut/ta/signals'
     | '/openai/v1/chat/completions'
   id:
     | '__root__'
@@ -264,6 +297,9 @@ export interface FileRouteTypes {
     | '/api/torghut/symbols'
     | '/openai/v1/models'
     | '/api/torghut/symbols/$symbol'
+    | '/api/torghut/ta/bars'
+    | '/api/torghut/ta/latest'
+    | '/api/torghut/ta/signals'
     | '/openai/v1/chat/completions'
   fileRoutesById: FileRoutesById
 }
@@ -286,6 +322,9 @@ export interface RootRouteChildren {
   ApiAtlasPathsRoute: typeof ApiAtlasPathsRoute
   ApiTorghutSymbolsRoute: typeof ApiTorghutSymbolsRouteWithChildren
   OpenaiV1ModelsRoute: typeof OpenaiV1ModelsRoute
+  ApiTorghutTaBarsRoute: typeof ApiTorghutTaBarsRoute
+  ApiTorghutTaLatestRoute: typeof ApiTorghutTaLatestRoute
+  ApiTorghutTaSignalsRoute: typeof ApiTorghutTaSignalsRoute
   OpenaiV1ChatCompletionsRoute: typeof OpenaiV1ChatCompletionsRoute
 }
 
@@ -424,6 +463,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OpenaiV1ChatCompletionsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/torghut/ta/signals': {
+      id: '/api/torghut/ta/signals'
+      path: '/api/torghut/ta/signals'
+      fullPath: '/api/torghut/ta/signals'
+      preLoaderRoute: typeof ApiTorghutTaSignalsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/ta/latest': {
+      id: '/api/torghut/ta/latest'
+      path: '/api/torghut/ta/latest'
+      fullPath: '/api/torghut/ta/latest'
+      preLoaderRoute: typeof ApiTorghutTaLatestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/ta/bars': {
+      id: '/api/torghut/ta/bars'
+      path: '/api/torghut/ta/bars'
+      fullPath: '/api/torghut/ta/bars'
+      preLoaderRoute: typeof ApiTorghutTaBarsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/torghut/symbols/$symbol': {
       id: '/api/torghut/symbols/$symbol'
       path: '/$symbol'
@@ -464,6 +524,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAtlasPathsRoute: ApiAtlasPathsRoute,
   ApiTorghutSymbolsRoute: ApiTorghutSymbolsRouteWithChildren,
   OpenaiV1ModelsRoute: OpenaiV1ModelsRoute,
+  ApiTorghutTaBarsRoute: ApiTorghutTaBarsRoute,
+  ApiTorghutTaLatestRoute: ApiTorghutTaLatestRoute,
+  ApiTorghutTaSignalsRoute: ApiTorghutTaSignalsRoute,
   OpenaiV1ChatCompletionsRoute: OpenaiV1ChatCompletionsRoute,
 }
 export const routeTree = rootRouteImport

--- a/services/jangar/src/routes/api/torghut/ta/bars.ts
+++ b/services/jangar/src/routes/api/torghut/ta/bars.ts
@@ -1,0 +1,59 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { resolveClickHouseClient } from '~/server/clickhouse'
+import { parseTaRangeParams } from '~/server/torghut-ta'
+
+export const Route = createFileRoute('/api/torghut/ta/bars')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getBarsHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const errorResponse = (message: string, status = 500) => jsonResponse({ ok: false, message, error: message }, status)
+
+export const getBarsHandler = async (request: Request) => {
+  const url = new URL(request.url)
+  const parsed = parseTaRangeParams(url)
+  if (!parsed.ok) return errorResponse(parsed.message, 400)
+
+  const clientResult = resolveClickHouseClient()
+  if (!clientResult.ok) return errorResponse(clientResult.message, 503)
+
+  const { symbol, from, to, limit } = parsed.value
+
+  const query = `
+    SELECT *
+    FROM ta_microbars
+    WHERE symbol = {symbol:String}
+      AND event_ts >= {from:DateTime64(3)}
+      AND event_ts <= {to:DateTime64(3)}
+    ORDER BY event_ts ASC
+    LIMIT {limit:UInt32}
+  `
+
+  try {
+    const items = await clientResult.client.queryJson(query, {
+      symbol,
+      from,
+      to,
+      limit,
+    })
+
+    return jsonResponse({ ok: true, symbol, items })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'ClickHouse query failed'
+    return errorResponse(message, 500)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/ta/latest.ts
+++ b/services/jangar/src/routes/api/torghut/ta/latest.ts
@@ -1,0 +1,68 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { resolveClickHouseClient } from '~/server/clickhouse'
+import { parseTaLatestParams } from '~/server/torghut-ta'
+
+export const Route = createFileRoute('/api/torghut/ta/latest')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getLatestHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const errorResponse = (message: string, status = 500) => jsonResponse({ ok: false, message, error: message }, status)
+
+export const getLatestHandler = async (request: Request) => {
+  const url = new URL(request.url)
+  const parsed = parseTaLatestParams(url)
+  if (!parsed.ok) return errorResponse(parsed.message, 400)
+
+  const clientResult = resolveClickHouseClient()
+  if (!clientResult.ok) return errorResponse(clientResult.message, 503)
+
+  const { symbol } = parsed.value
+
+  const barsQuery = `
+    SELECT *
+    FROM ta_microbars
+    WHERE symbol = {symbol:String}
+    ORDER BY event_ts DESC
+    LIMIT 1
+  `
+
+  const signalsQuery = `
+    SELECT *
+    FROM ta_signals
+    WHERE symbol = {symbol:String}
+    ORDER BY event_ts DESC
+    LIMIT 1
+  `
+
+  try {
+    const [bars, signals] = await Promise.all([
+      clientResult.client.queryJson(barsQuery, { symbol }),
+      clientResult.client.queryJson(signalsQuery, { symbol }),
+    ])
+
+    return jsonResponse({
+      ok: true,
+      symbol,
+      bars: bars[0] ?? null,
+      signals: signals[0] ?? null,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'ClickHouse query failed'
+    return errorResponse(message, 500)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/ta/signals.ts
+++ b/services/jangar/src/routes/api/torghut/ta/signals.ts
@@ -1,0 +1,59 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { resolveClickHouseClient } from '~/server/clickhouse'
+import { parseTaRangeParams } from '~/server/torghut-ta'
+
+export const Route = createFileRoute('/api/torghut/ta/signals')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getSignalsHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const errorResponse = (message: string, status = 500) => jsonResponse({ ok: false, message, error: message }, status)
+
+export const getSignalsHandler = async (request: Request) => {
+  const url = new URL(request.url)
+  const parsed = parseTaRangeParams(url)
+  if (!parsed.ok) return errorResponse(parsed.message, 400)
+
+  const clientResult = resolveClickHouseClient()
+  if (!clientResult.ok) return errorResponse(clientResult.message, 503)
+
+  const { symbol, from, to, limit } = parsed.value
+
+  const query = `
+    SELECT *
+    FROM ta_signals
+    WHERE symbol = {symbol:String}
+      AND event_ts >= {from:DateTime64(3)}
+      AND event_ts <= {to:DateTime64(3)}
+    ORDER BY event_ts ASC
+    LIMIT {limit:UInt32}
+  `
+
+  try {
+    const items = await clientResult.client.queryJson(query, {
+      symbol,
+      from,
+      to,
+      limit,
+    })
+
+    return jsonResponse({ ok: true, symbol, items })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'ClickHouse query failed'
+    return errorResponse(message, 500)
+  }
+}

--- a/services/jangar/src/server/clickhouse.ts
+++ b/services/jangar/src/server/clickhouse.ts
@@ -1,0 +1,159 @@
+export type ClickHouseConfig = {
+  host: string
+  port: number
+  user: string
+  password: string
+  database: string
+  secure: boolean
+  timeoutMs: number
+}
+
+type ValidationResult<T> = { ok: true; value: T } | { ok: false; message: string }
+
+const DEFAULT_PORT = 8123
+const DEFAULT_DATABASE = 'default'
+const DEFAULT_TIMEOUT_MS = 15000
+
+const normalizeEnv = (value: string | undefined) => (value ?? '').trim()
+
+const parseBoolean = (value: string | undefined) => {
+  const normalized = normalizeEnv(value).toLowerCase()
+  if (!normalized) return false
+  if (['true', '1', 'yes', 'on'].includes(normalized)) return true
+  if (['false', '0', 'no', 'off'].includes(normalized)) return false
+  throw new Error('CH_SECURE must be true or false')
+}
+
+const parsePositiveInt = (value: string | undefined, field: string, fallback: number) => {
+  if (value === undefined) return fallback
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${field} must be a positive integer`)
+  }
+  return parsed
+}
+
+export const resolveClickHouseConfig = (): ValidationResult<ClickHouseConfig> => {
+  try {
+    const host = normalizeEnv(process.env.CH_HOST)
+    if (!host) return { ok: false, message: 'CH_HOST is not configured' }
+
+    const user = normalizeEnv(process.env.CH_USER)
+    if (!user) return { ok: false, message: 'CH_USER is not configured' }
+
+    const password = process.env.CH_PASSWORD ?? ''
+    if (!password) return { ok: false, message: 'CH_PASSWORD is not configured' }
+
+    const port = parsePositiveInt(process.env.CH_PORT, 'CH_PORT', DEFAULT_PORT)
+    const database = normalizeEnv(process.env.CH_DATABASE) || DEFAULT_DATABASE
+    const secure = parseBoolean(process.env.CH_SECURE)
+    const timeoutMs = parsePositiveInt(process.env.CH_TIMEOUT_MS, 'CH_TIMEOUT_MS', DEFAULT_TIMEOUT_MS)
+
+    return {
+      ok: true,
+      value: {
+        host,
+        port,
+        user,
+        password,
+        database,
+        secure,
+        timeoutMs,
+      },
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : 'Invalid ClickHouse configuration',
+    }
+  }
+}
+
+export type ClickHouseParamValue = string | number | boolean | Date
+export type ClickHouseParams = Record<string, ClickHouseParamValue>
+
+export type ClickHouseClient = {
+  queryJson: <T = Record<string, unknown>>(query: string, params?: ClickHouseParams) => Promise<T[]>
+}
+
+const encodeParamValue = (value: ClickHouseParamValue) => {
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'boolean') return value ? '1' : '0'
+  return String(value)
+}
+
+const ensureJsonFormat = (query: string) => {
+  const trimmed = query.trim().replace(/;$/, '')
+  if (/\bformat\s+json\b/i.test(trimmed)) return trimmed
+  return `${trimmed}\nFORMAT JSON`
+}
+
+export const createClickHouseClient = (config: ClickHouseConfig): ClickHouseClient => {
+  const protocol = config.secure ? 'https' : 'http'
+  const baseUrl = `${protocol}://${config.host}:${config.port}/`
+  const headers: Record<string, string> = {
+    'content-type': 'text/plain; charset=utf-8',
+    'x-clickhouse-user': config.user,
+    'x-clickhouse-key': config.password,
+  }
+
+  const queryJson = async <T = Record<string, unknown>>(query: string, params?: ClickHouseParams) => {
+    const searchParams = new URLSearchParams()
+    searchParams.set('database', config.database)
+
+    if (params) {
+      for (const [name, param] of Object.entries(params)) {
+        if (param === undefined) continue
+        searchParams.set(`param_${name}`, encodeParamValue(param))
+      }
+    }
+
+    const url = `${baseUrl}?${searchParams.toString()}`
+    const controller = new AbortController()
+    const timeoutHandle = setTimeout(() => controller.abort(), config.timeoutMs)
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: ensureJsonFormat(query),
+        signal: controller.signal,
+      })
+
+      const bodyText = await response.text()
+      if (!response.ok) {
+        throw new Error(`ClickHouse request failed (${response.status}): ${bodyText}`)
+      }
+
+      let parsed: { data?: T[] }
+      try {
+        parsed = JSON.parse(bodyText) as { data?: T[] }
+      } catch (_error) {
+        throw new Error('ClickHouse response was not valid JSON')
+      }
+
+      if (!parsed.data || !Array.isArray(parsed.data)) {
+        throw new Error('ClickHouse response missing data payload')
+      }
+
+      return parsed.data
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(`ClickHouse request timed out after ${config.timeoutMs}ms`)
+      }
+      throw error
+    } finally {
+      clearTimeout(timeoutHandle)
+    }
+  }
+
+  return { queryJson }
+}
+
+export type ClickHouseClientResult = { ok: true; client: ClickHouseClient } | { ok: false; message: string }
+
+export const resolveClickHouseClient = (): ClickHouseClientResult => {
+  const configResult = resolveClickHouseConfig()
+  if (!configResult.ok) return { ok: false, message: configResult.message }
+  return { ok: true, client: createClickHouseClient(configResult.value) }
+}

--- a/services/jangar/src/server/torghut-ta.ts
+++ b/services/jangar/src/server/torghut-ta.ts
@@ -1,0 +1,114 @@
+import { normalizeTorghutSymbol } from '~/server/torghut-symbols'
+
+type ValidationResult<T> = { ok: true; value: T } | { ok: false; message: string }
+
+const SYMBOL_PATTERN = /^[A-Z0-9._:-]{1,32}$/
+
+export const TA_DEFAULT_LIMIT = 1000
+export const TA_MAX_LIMIT = 5000
+export const TA_MAX_RANGE_MS = 1000 * 60 * 60 * 24 * 7
+
+export type TaRangeQuery = {
+  symbol: string
+  from: string
+  to: string
+  limit: number
+}
+
+const parseSymbol = (value: string | null) => {
+  const raw = value?.trim() ?? ''
+  if (!raw) return null
+  const normalized = normalizeTorghutSymbol(raw)
+  if (!SYMBOL_PATTERN.test(normalized)) {
+    throw new Error('symbol must be uppercase letters, numbers, or . _ : -')
+  }
+  return normalized
+}
+
+const parseDateInput = (value: string | null, field: string) => {
+  const raw = value?.trim() ?? ''
+  if (!raw) return null
+
+  let date: Date
+  if (/^\d+$/.test(raw)) {
+    const numeric = Number(raw)
+    if (!Number.isFinite(numeric)) {
+      throw new Error(`${field} must be a valid timestamp`)
+    }
+    const millis = raw.length <= 10 ? numeric * 1000 : numeric
+    date = new Date(millis)
+  } else {
+    date = new Date(raw)
+  }
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${field} must be a valid timestamp`)
+  }
+
+  return date
+}
+
+const parseLimit = (value: string | null, fallback: number) => {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) {
+    throw new Error('limit must be a number')
+  }
+  if (parsed <= 0 || parsed > TA_MAX_LIMIT) {
+    throw new Error(`limit must be between 1 and ${TA_MAX_LIMIT}`)
+  }
+  return parsed
+}
+
+export const parseTaRangeParams = (url: URL): ValidationResult<TaRangeQuery> => {
+  try {
+    const symbol = parseSymbol(url.searchParams.get('symbol'))
+    if (!symbol) return { ok: false, message: 'symbol is required' }
+
+    const fromDate = parseDateInput(url.searchParams.get('from'), 'from')
+    if (!fromDate) return { ok: false, message: 'from is required' }
+
+    const toDate = parseDateInput(url.searchParams.get('to'), 'to')
+    if (!toDate) return { ok: false, message: 'to is required' }
+
+    const fromMs = fromDate.getTime()
+    const toMs = toDate.getTime()
+    if (toMs < fromMs) return { ok: false, message: 'to must be after from' }
+
+    const rangeMs = toMs - fromMs
+    if (rangeMs > TA_MAX_RANGE_MS) {
+      const maxDays = Math.floor(TA_MAX_RANGE_MS / (1000 * 60 * 60 * 24))
+      return { ok: false, message: `range must be ${maxDays} days or less` }
+    }
+
+    const limit = parseLimit(url.searchParams.get('limit'), TA_DEFAULT_LIMIT)
+
+    return {
+      ok: true,
+      value: {
+        symbol,
+        from: fromDate.toISOString(),
+        to: toDate.toISOString(),
+        limit,
+      },
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : 'Invalid query parameters',
+    }
+  }
+}
+
+export const parseTaLatestParams = (url: URL): ValidationResult<{ symbol: string }> => {
+  try {
+    const symbol = parseSymbol(url.searchParams.get('symbol'))
+    if (!symbol) return { ok: false, message: 'symbol is required' }
+    return { ok: true, value: { symbol } }
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : 'Invalid query parameters',
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add ClickHouse HTTP client helper + TA query validation for Jangar
- add /api/torghut/ta bars, signals, latest routes backed by ClickHouse
- wire CH env vars in Jangar deployment and add sealed secret manifest (placeholder encrypted values; reseal before sync)

## Related Issues

Resolves #2090

## Testing

- bun run --filter @proompteng/jangar build
- bunx biome check services/jangar/src/server/clickhouse.ts services/jangar/src/server/torghut-ta.ts services/jangar/src/routes/api/torghut/ta

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
