### PR TITLE
feat(argocd): add codex implementation artifacts

### DIFF
--- a/apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
+++ b/apps/froussard/src/codex/cli/__tests__/codex-implement.test.ts
@@ -168,7 +168,9 @@ describe('runCodexImplementation', () => {
     await expect(stat(result.statusPath)).resolves.toEqual(expect.objectContaining({ size: expect.any(Number) }))
     await expect(stat(result.archivePath)).resolves.toEqual(expect.objectContaining({ size: expect.any(Number) }))
     const resumeMetadataPath = join(workdir, '.codex', 'implementation-resume.json')
-    await expect(stat(resumeMetadataPath)).rejects.toThrow()
+    const resumeMetadataRaw = await readFile(resumeMetadataPath, 'utf8')
+    const resumeMetadata = JSON.parse(resumeMetadataRaw) as Record<string, unknown>
+    expect(resumeMetadata.state).toBe('cleared')
   })
 
   it('throws when the event file is missing', async () => {
@@ -307,7 +309,9 @@ describe('runCodexImplementation', () => {
       expect(linkStats.isSymbolicLink()).toBe(true)
       expect(await readlink(restoredLink)).toBe('./real.ts')
       await expect(readFile(restoredFile, 'utf8')).resolves.toBe(resumeRealContent)
-      await expect(stat(resumeMetadataPath)).rejects.toThrow()
+      const resumeMetadataRaw = await readFile(resumeMetadataPath, 'utf8')
+      const resumeMetadata = JSON.parse(resumeMetadataRaw) as Record<string, unknown>
+      expect(resumeMetadata.state).toBe('cleared')
     } finally {
       await rm(resumeSourceDir, { recursive: true, force: true })
     }

--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -160,3 +160,13 @@ spec:
             path: /workspace/lab/.codex-implementation.patch
           - name: implementation-status
             path: /workspace/lab/.codex-implementation-status.txt
+          - name: implementation-log
+            path: /workspace/lab/.codex-implementation.log
+          - name: implementation-events
+            path: /workspace/lab/.codex-implementation-events.jsonl
+          - name: implementation-agent-log
+            path: /workspace/lab/.codex-implementation-agent.log
+          - name: implementation-runtime-log
+            path: /workspace/lab/.codex-implementation-runtime.log
+          - name: implementation-resume
+            path: /workspace/lab/.codex/implementation-resume.json


### PR DESCRIPTION
## Summary

- Add implementation log/event/agent/runtime artifact outputs to the Codex workflow template.
- Export resume metadata as an Argo artifact for judge resumability.
- Keep existing artifact outputs unchanged.

## Related Issues

Resolves #2109

## Testing

- scripts/argo-lint.sh
- scripts/kubeconform.sh argocd

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
