### PR TITLE
chore(vecteur): default build script to arm64

### DIFF
--- a/scripts/build-vecteur.ts
+++ b/scripts/build-vecteur.ts
@@ -4,14 +4,15 @@ const imageName = process.env.VECTEUR_IMAGE_NAME ?? 'registry.ide-newton.ts.net/
 const dockerfile = process.env.VECTEUR_DOCKERFILE ?? 'services/vecteur/Dockerfile'
 const contextPath = process.env.VECTEUR_CONTEXT_PATH ?? 'services/vecteur'
 const defaultTag = process.env.VECTEUR_DEFAULT_TAG ?? '18-trixie'
-const targetArch = process.env.VECTEUR_TARGET_ARCH ?? 'arm64'
+const platforms = process.env.VECTEUR_PLATFORMS ?? 'linux/arm64'
+const pgMajor = process.env.VECTEUR_PG_MAJOR ?? '18'
 
 const [tagArg] = Bun.argv.slice(2)
 const tag = tagArg ?? defaultTag
 const fullImageName = `${imageName}:${tag}`
 
 function configSummary() {
-  return { fullImageName, dockerfile, contextPath, targetArch }
+  return { fullImageName, dockerfile, contextPath, platforms, pgMajor }
 }
 
 async function run(cmd: string, args: string[]) {
@@ -29,7 +30,9 @@ async function main() {
     'buildx',
     'build',
     '--platform',
-    `linux/${targetArch}`,
+    platforms,
+    '--build-arg',
+    `PG_MAJOR=${pgMajor}`,
     '-t',
     fullImageName,
     '-f',


### PR DESCRIPTION
## Summary

- default vecteur build script to arm64 via `VECTEUR_PLATFORMS` (overrideable)
- pass `PG_MAJOR` build arg (default 18) into the Docker build
- surface platform + PG major in the config summary output

## Related Issues

None

## Testing

- `bun scripts/build-vecteur.ts 18-trixie`

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
