### PR TITLE
docs(jangar): add judge proof marker

### DIFF
--- a/docs/jangar/judge-proof.md
+++ b/docs/jangar/judge-proof.md
@@ -1,0 +1,5 @@
+# Judge Pipeline Proof Run
+
+- Automated Codex proof run triggered via Facteur -> Argo workflow.
+- Output validates that artifacts, PR gating, and judge ingestion are wired.
+- Created for end-to-end verification; safe to edit/remove after validation.


### PR DESCRIPTION
## Summary

- add a judge proof marker doc under docs/jangar
- provide a small proof payload for the Codex judge pipeline
- keep change isolated to a single new file

## Related Issues

- Refs #2109

## Testing

- N/A (documentation-only proof marker)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
