### PR TITLE
fix(jangar): complete codex judge deterministic gates (#2122)

### DIFF
--- a/services/jangar/src/server/__tests__/codex-judge-gates.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-gates.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { evaluateDeterministicGates } from '~/server/codex-judge-gates'
+
+describe('codex judge deterministic gates', () => {
+  it('flags empty diff when no noop override is present', () => {
+    const result = evaluateDeterministicGates({
+      diff: '',
+      issueTitle: 'Implement gating',
+      issueBody: 'Ensure behavior matches requirements.',
+      prompt: 'Do the work.',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.decision).toBe('needs_iteration')
+    expect(result?.reason).toBe('empty_diff')
+  })
+
+  it('detects merge conflicts from diff markers', () => {
+    const diff = [
+      'diff --git a/file.txt b/file.txt',
+      '@@',
+      '+<<<<<<< HEAD',
+      '+conflict',
+      '+=======',
+      '+resolution',
+      '+>>>>>>> branch',
+    ].join('\n')
+
+    const result = evaluateDeterministicGates({
+      diff,
+      issueTitle: 'Resolve issue',
+      issueBody: '',
+      prompt: 'Update the file.',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.decision).toBe('needs_human')
+    expect(result?.reason).toBe('merge_conflict')
+  })
+
+  it('detects patch apply failures from logs', () => {
+    const result = evaluateDeterministicGates({
+      diff: 'diff --git a/file.txt b/file.txt\n+change',
+      issueTitle: 'Apply patch',
+      issueBody: '',
+      prompt: 'Apply changes.',
+      logExcerpt: { output: 'error: patch failed: file.txt' },
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.decision).toBe('needs_iteration')
+    expect(result?.reason).toBe('patch_apply_failed')
+  })
+})

--- a/services/jangar/src/server/codex-judge-gates.ts
+++ b/services/jangar/src/server/codex-judge-gates.ts
@@ -1,0 +1,177 @@
+export type CodexLogExcerpt = {
+  output?: string | null
+  events?: string | null
+  agent?: string | null
+  runtime?: string | null
+  status?: string | null
+}
+
+export type DeterministicGateFailure = {
+  decision: 'needs_human' | 'needs_iteration'
+  reason: string
+  detail?: string
+  suggestedFix: string
+  nextPrompt: string | null
+}
+
+type NoopContext = {
+  issueTitle?: string | null
+  issueBody?: string | null
+  prompt?: string | null
+  runCompletePayload?: Record<string, unknown> | null
+}
+
+type GateContext = NoopContext & {
+  diff: string
+  logExcerpt?: CodexLogExcerpt | null
+}
+
+const NOOP_MARKERS = [
+  'codex:allow-noop',
+  'codex:allow-no-op',
+  '#codex-allow-noop',
+  '#codex-allow-no-op',
+  '[codex:allow-noop]',
+  '[codex:allow-no-op]',
+]
+
+const CONFLICT_STATUS_CODES = ['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']
+
+const CONFLICT_MARKER_REGEX = /^[+\- ]?(<{7}|={7}|>{7})/
+
+const LOG_CONFLICT_REGEX = /(merge conflict|unmerged paths|\bCONFLICT\b)/i
+const PATCH_FAILURE_REGEX =
+  /(patch failed|apply failed|failed to apply|could not apply|error:.*patch failed|3-way merge failed)/i
+
+const normalizeText = (value?: string | null) => (typeof value === 'string' ? value.trim() : '')
+
+const hasNoopMarker = (text: string) => {
+  if (!text) return false
+  const lowered = text.toLowerCase()
+  return NOOP_MARKERS.some((marker) => lowered.includes(marker))
+}
+
+const readNoopFlag = (payload?: Record<string, unknown> | null) => {
+  if (!payload) return false
+  const candidates = [
+    payload.allowNoop,
+    payload.allow_noop,
+    payload.allowNoOp,
+    payload.noop,
+    payload.noopAllowed,
+    payload.no_op_allowed,
+    payload.noOpAllowed,
+  ]
+
+  for (const candidate of candidates) {
+    if (candidate === true) return true
+    if (typeof candidate === 'string' && candidate.trim().toLowerCase() === 'true') return true
+  }
+
+  return false
+}
+
+export const isNoopAllowed = ({ issueTitle, issueBody, prompt, runCompletePayload }: NoopContext) => {
+  if (readNoopFlag(runCompletePayload)) return true
+  const combined = [issueTitle, issueBody, prompt].map((value) => normalizeText(value)).join('\n')
+  return hasNoopMarker(combined)
+}
+
+const extractStatusConflicts = (status: string) => {
+  const lines = status
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0)
+  const conflictLines = lines.filter((line) => CONFLICT_STATUS_CODES.some((code) => line.startsWith(`${code} `)))
+  return conflictLines.slice(0, 3)
+}
+
+const extractConflictMarkers = (diff: string) => {
+  const lines = diff
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0)
+  const markers = lines.filter((line) => CONFLICT_MARKER_REGEX.test(line))
+  return markers.slice(0, 3)
+}
+
+const collectLogText = (logExcerpt?: CodexLogExcerpt | null) => {
+  if (!logExcerpt) return ''
+  return [logExcerpt.output, logExcerpt.events, logExcerpt.agent, logExcerpt.runtime, logExcerpt.status]
+    .map((value) => normalizeText(value))
+    .filter((value) => value.length > 0)
+    .join('\n')
+}
+
+const detectConflictSignals = ({ diff, logExcerpt }: Pick<GateContext, 'diff' | 'logExcerpt'>) => {
+  const details: string[] = []
+  const statusText = normalizeText(logExcerpt?.status ?? null)
+  const conflictLines = statusText ? extractStatusConflicts(statusText) : []
+  if (conflictLines.length > 0) {
+    details.push(`git status reports unmerged entries (${conflictLines.join(', ')})`)
+  }
+
+  const diffMarkers = extractConflictMarkers(diff)
+  if (diffMarkers.length > 0) {
+    details.push('diff contains conflict markers')
+  }
+
+  const logText = collectLogText(logExcerpt)
+  const logHasConflict = logText.length > 0 && LOG_CONFLICT_REGEX.test(logText)
+  if (logHasConflict) {
+    details.push('log excerpt mentions merge conflicts')
+  }
+
+  const logHasPatchFailure = logText.length > 0 && PATCH_FAILURE_REGEX.test(logText)
+  if (logHasPatchFailure) {
+    details.push('log excerpt indicates patch apply failure')
+  }
+
+  const mergeConflict = conflictLines.length > 0 || diffMarkers.length > 0 || logHasConflict
+
+  return { mergeConflict, patchApplyFailure: logHasPatchFailure, details }
+}
+
+export const evaluateDeterministicGates = ({
+  diff,
+  logExcerpt,
+  issueTitle,
+  issueBody,
+  prompt,
+  runCompletePayload,
+}: GateContext): DeterministicGateFailure | null => {
+  const normalizedDiff = typeof diff === 'string' ? diff : ''
+  const conflictSignals = detectConflictSignals({ diff: normalizedDiff, logExcerpt })
+  if (conflictSignals.mergeConflict) {
+    return {
+      decision: 'needs_human',
+      reason: 'merge_conflict',
+      detail: conflictSignals.details.slice(0, 2).join('; '),
+      suggestedFix: 'Resolve merge conflicts on the branch and update the PR.',
+      nextPrompt: 'Resolve merge conflicts on the branch and update the PR.',
+    }
+  }
+
+  if (conflictSignals.patchApplyFailure) {
+    return {
+      decision: 'needs_iteration',
+      reason: 'patch_apply_failed',
+      detail: conflictSignals.details.slice(0, 2).join('; '),
+      suggestedFix: 'Reapply the patch cleanly and ensure the working tree is consistent.',
+      nextPrompt: 'Reapply the patch cleanly and ensure the working tree is consistent.',
+    }
+  }
+
+  const diffEmpty = normalizedDiff.trim().length === 0
+  const noopAllowed = isNoopAllowed({ issueTitle, issueBody, prompt, runCompletePayload })
+  if (diffEmpty && !noopAllowed) {
+    return {
+      decision: 'needs_iteration',
+      reason: 'empty_diff',
+      suggestedFix: 'Produce a non-empty diff or explicitly mark the task as a no-op.',
+      nextPrompt: 'Make the required code changes so the PR includes a non-empty diff.',
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

- add deterministic gate checks for empty diffs and conflict/patch failures before LLM judging
- wire gate failures to needs_iteration/needs_human decisions with rerun/escalation handling
- add vitest coverage for empty diff, conflict markers, and patch apply failures

## Related Issues

- Closes #2122

## Testing

- bunx biome check services/jangar/src/server/codex-judge.ts services/jangar/src/server/codex-judge-gates.ts services/jangar/src/server/__tests__/codex-judge-gates.test.ts
- bun run --cwd services/jangar test

## Screenshots (if applicable)

- N/A

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
