### PR TITLE
feat(jangar): add codex judge run history + stats

### DIFF
--- a/services/jangar/src/data/memories.ts
+++ b/services/jangar/src/data/memories.ts
@@ -23,7 +23,7 @@ export type CountMemoriesInput = {
   namespace?: string
 }
 
-type MemoryRecordJson = Omit<MemoryRecord, 'metadata'> & { metadata: Record<string, {}> }
+type MemoryRecordJson = Omit<MemoryRecord, 'metadata'> & { metadata: Record<string, unknown> }
 
 export type PersistNoteResult = { ok: true; memory: MemoryRecordJson } | { ok: false; message: string }
 export type RetrieveNotesResult = { ok: true; memories: MemoryRecordJson[] } | { ok: false; message: string }
@@ -33,7 +33,7 @@ const handlerRuntime = ManagedRuntime.make(Layer.mergeAll(MemoriesLive))
 
 const toJsonMemoryRecord = (record: MemoryRecord): MemoryRecordJson => ({
   ...record,
-  metadata: record.metadata as Record<string, {}>,
+  metadata: record.metadata,
 })
 
 const persistNoteServer = createServerFn({ method: 'POST' })

--- a/services/jangar/src/routes/api/codex/runs.tsx
+++ b/services/jangar/src/routes/api/codex/runs.tsx
@@ -1,0 +1,115 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { type CodexJudgeStore, createCodexJudgeStore } from '~/server/codex-judge-store'
+
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 50
+
+type RunsQuery = {
+  repository: string
+  issueNumber: number
+  branch?: string
+  limit: number
+}
+
+export const Route = createFileRoute('/api/codex/runs')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getCodexRunsHandler(request),
+      POST: async () => new Response('Method Not Allowed', { status: 405 }),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const errorResponse = (message: string, status = 500) => jsonResponse({ ok: false, error: message }, status)
+
+const resolveServiceError = (message: string) => {
+  if (message.includes('DATABASE_URL')) return errorResponse(message, 503)
+  return errorResponse(message, 500)
+}
+
+const clampLimit = (raw: string | null) => {
+  if (!raw) return DEFAULT_LIMIT
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return DEFAULT_LIMIT
+  return Math.max(1, Math.min(MAX_LIMIT, parsed))
+}
+
+const parseIssueNumber = (raw: string | null) => {
+  if (!raw) return null
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) return null
+  return parsed
+}
+
+const parseRunsQuery = (request: Request): { ok: true; value: RunsQuery } | { ok: false; message: string } => {
+  try {
+    const url = new URL(request.url)
+    const repository = (url.searchParams.get('repository') ?? '').trim()
+    if (!repository) {
+      return { ok: false, message: 'Repository is required.' }
+    }
+
+    const issueNumber =
+      parseIssueNumber(url.searchParams.get('issueNumber')) ?? parseIssueNumber(url.searchParams.get('issue_number'))
+    if (!issueNumber) {
+      return { ok: false, message: 'Issue number is required.' }
+    }
+
+    const branch = (url.searchParams.get('branch') ?? '').trim() || undefined
+    const limit = clampLimit(url.searchParams.get('limit'))
+
+    return { ok: true, value: { repository, issueNumber, branch, limit } }
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : 'Invalid query parameters.' }
+  }
+}
+
+let defaultStore: CodexJudgeStore | null = null
+
+const getDefaultStore = () => {
+  if (!defaultStore) {
+    defaultStore = createCodexJudgeStore()
+  }
+  return defaultStore
+}
+
+export const getCodexRunsHandler = async (request: Request, store?: CodexJudgeStore) => {
+  const parsed = parseRunsQuery(request)
+  if (!parsed.ok) return errorResponse(parsed.message, 400)
+
+  try {
+    const resolvedStore = store ?? getDefaultStore()
+    const { repository, issueNumber, branch, limit } = parsed.value
+    const [runs, stats] = await Promise.all([
+      resolvedStore.listRunHistory({ repository, issueNumber, branch, limit }),
+      resolvedStore.getRunStats({ repository, issueNumber, branch }),
+    ])
+
+    return jsonResponse({
+      ok: true,
+      runs,
+      stats: {
+        completion_rate: stats.completionRate,
+        avg_attempts_per_issue: stats.avgAttemptsPerIssue,
+        failure_reason_counts: stats.failureReasonCounts,
+        avg_ci_duration: stats.avgCiDuration,
+        avg_judge_confidence: stats.avgJudgeConfidence,
+      },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return resolveServiceError(message)
+  }
+}

--- a/services/jangar/src/server/__tests__/codex-judge-ci.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-ci.test.ts
@@ -55,6 +55,8 @@ if (!globalState.__codexJudgeStoreMock) {
     getRunByWorkflow: vi.fn(),
     getRunById: vi.fn(),
     listRunsByIssue: vi.fn(),
+    listRunHistory: vi.fn(),
+    getRunStats: vi.fn(),
     createPromptTuning: vi.fn(),
     close: vi.fn(),
   }
@@ -102,21 +104,34 @@ if (!globalState.__codexJudgeMemoryStoreMock) {
   }
 }
 
+const requireMock = <T>(value: T | undefined, name: string): T => {
+  if (!value) {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+const getConfigMock = () => requireMock(globalState.__codexJudgeConfigMock, 'codex judge config mock')
+const getStoreMock = () => requireMock(globalState.__codexJudgeStoreMock, 'codex judge store mock')
+const getGithubMock = () => requireMock(globalState.__codexJudgeGithubMock, 'codex judge github mock')
+const getMemoriesStoreMock = () =>
+  requireMock(globalState.__codexJudgeMemoryStoreMock, 'codex judge memories store mock')
+
 vi.mock('../codex-judge-config', () => ({
-  loadCodexJudgeConfig: () => globalState.__codexJudgeConfigMock!,
+  loadCodexJudgeConfig: () => getConfigMock(),
 }))
 
 vi.mock('../codex-judge-store', () => ({
   __private: storePrivate,
-  createCodexJudgeStore: () => globalState.__codexJudgeStoreMock!,
+  createCodexJudgeStore: () => getStoreMock(),
 }))
 
 vi.mock('../github-client', () => ({
-  createGitHubClient: () => globalState.__codexJudgeGithubMock!,
+  createGitHubClient: () => getGithubMock(),
 }))
 
 vi.mock('../memories-store', () => ({
-  createPostgresMemoriesStore: () => globalState.__codexJudgeMemoryStoreMock!,
+  createPostgresMemoriesStore: () => getMemoriesStoreMock(),
 }))
 
 let __private: Awaited<typeof import('../codex-judge')>['__private'] | null = null
@@ -184,8 +199,8 @@ describe('codex-judge CI fallback', () => {
   beforeEach(async () => {
     getRefSha.mockReset()
     getCheckRuns.mockReset()
-    Object.assign(globalState.__codexJudgeGithubMock!, github)
-    Object.assign(globalState.__codexJudgeConfigMock!, config)
+    Object.assign(getGithubMock(), github)
+    Object.assign(getConfigMock(), config)
     if (!__private) {
       __private = (await import('../codex-judge')).__private
     }
@@ -196,7 +211,10 @@ describe('codex-judge CI fallback', () => {
     getCheckRuns.mockResolvedValueOnce({ status: 'pending' })
 
     const run = buildRun()
-    const result = await __private!.resolveCiContext(run, null)
+    if (!__private) {
+      throw new Error('codex judge private helpers not loaded')
+    }
+    const result = await __private.resolveCiContext(run, null)
 
     expect(getRefSha).toHaveBeenCalledWith('owner', 'repo', 'heads/codex/issue-123')
     expect(getCheckRuns).toHaveBeenCalledWith('owner', 'repo', 'branchsha1234567890')
@@ -222,7 +240,10 @@ describe('codex-judge CI fallback', () => {
       },
     })
 
-    const result = await __private!.resolveCiContext(run, null)
+    if (!__private) {
+      throw new Error('codex judge private helpers not loaded')
+    }
+    const result = await __private.resolveCiContext(run, null)
 
     expect(getRefSha).not.toHaveBeenCalled()
     expect(getCheckRuns).toHaveBeenCalledWith('owner', 'repo', manifestSha)
@@ -242,7 +263,10 @@ describe('codex-judge CI fallback', () => {
       },
     })
 
-    const result = await __private!.resolveCiContext(run, null)
+    if (!__private) {
+      throw new Error('codex judge private helpers not loaded')
+    }
+    const result = await __private.resolveCiContext(run, null)
 
     expect(getRefSha).toHaveBeenCalledWith('owner', 'repo', 'heads/codex/issue-123')
     expect(getCheckRuns).toHaveBeenCalledWith('owner', 'repo', branchSha)
@@ -256,7 +280,10 @@ describe('codex-judge CI fallback', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const run = buildRun()
-    const result = await __private!.resolveCiContext(run, null)
+    if (!__private) {
+      throw new Error('codex judge private helpers not loaded')
+    }
+    const result = await __private.resolveCiContext(run, null)
 
     expect(getRefSha).toHaveBeenCalledWith('owner', 'repo', 'heads/codex/issue-123')
     expect(getCheckRuns).toHaveBeenCalledWith('owner', 'repo', branchSha)

--- a/services/jangar/src/server/__tests__/codex-judge-runs-route.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-runs-route.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getCodexRunsHandler } from '~/routes/api/codex/runs'
+import type { CodexJudgeStore, CodexRunHistoryRecord, CodexRunStats } from '../codex-judge-store'
+
+const buildRun = (overrides: Partial<CodexRunHistoryRecord> = {}): CodexRunHistoryRecord => ({
+  id: 'run-1',
+  repository: 'proompteng/lab',
+  issueNumber: 2137,
+  branch: 'codex/issue-2137',
+  attempt: 1,
+  workflowName: 'workflow-1',
+  workflowUid: null,
+  workflowNamespace: null,
+  stage: 'implementation',
+  status: 'completed',
+  phase: null,
+  prompt: null,
+  nextPrompt: null,
+  commitSha: null,
+  prNumber: null,
+  prUrl: null,
+  ciStatus: null,
+  ciUrl: null,
+  reviewStatus: null,
+  reviewSummary: {},
+  notifyPayload: null,
+  runCompletePayload: null,
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  startedAt: null,
+  finishedAt: null,
+  artifacts: [],
+  latestEvaluation: null,
+  ...overrides,
+})
+
+const buildStore = (overrides: Partial<CodexJudgeStore> = {}): CodexJudgeStore => {
+  const store = {
+    upsertRunComplete: vi.fn(),
+    attachNotify: vi.fn(),
+    updateCiStatus: vi.fn(),
+    updateReviewStatus: vi.fn(),
+    updateDecision: vi.fn(),
+    updateRunStatus: vi.fn(),
+    updateRunPrompt: vi.fn(),
+    updateRunPrInfo: vi.fn(),
+    upsertArtifacts: vi.fn(),
+    getRunByWorkflow: vi.fn(),
+    getRunById: vi.fn(),
+    listRunsByIssue: vi.fn(),
+    listRunHistory: vi.fn(),
+    getRunStats: vi.fn(),
+    createPromptTuning: vi.fn(),
+    close: vi.fn(),
+    ...overrides,
+  } satisfies CodexJudgeStore
+
+  return store
+}
+
+describe('codex runs API', () => {
+  it('returns 400 when repository is missing', async () => {
+    const request = new Request('http://localhost/api/codex/runs?issueNumber=2137')
+    const response = await getCodexRunsHandler(request, buildStore())
+
+    expect(response.status).toBe(400)
+    const json = await response.json()
+    expect(json.error).toContain('Repository')
+  })
+
+  it('returns run history and stats', async () => {
+    const runs = [
+      buildRun({
+        id: 'run-2',
+        artifacts: [
+          {
+            id: 'artifact-1',
+            runId: 'run-2',
+            name: 'implementation-changes',
+            key: 'artifact-key',
+            bucket: 'codex',
+            url: 'https://example.com/artifact',
+            metadata: {},
+            createdAt: '2025-01-01T00:00:00Z',
+          },
+        ],
+        latestEvaluation: {
+          id: 'eval-1',
+          runId: 'run-2',
+          decision: 'pass',
+          confidence: 0.8,
+          reasons: {},
+          missingItems: {},
+          suggestedFixes: {},
+          nextPrompt: null,
+          promptTuning: {},
+          systemSuggestions: {},
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+      }),
+    ]
+
+    const stats: CodexRunStats = {
+      completionRate: 1,
+      avgAttemptsPerIssue: 1,
+      failureReasonCounts: {},
+      avgCiDuration: 0,
+      avgJudgeConfidence: 0.8,
+    }
+
+    const store = buildStore({
+      listRunHistory: vi.fn().mockResolvedValue(runs),
+      getRunStats: vi.fn().mockResolvedValue(stats),
+    })
+
+    const request = new Request('http://localhost/api/codex/runs?repository=proompteng/lab&issueNumber=2137&limit=5')
+    const response = await getCodexRunsHandler(request, store)
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.ok).toBe(true)
+    expect(json.runs).toHaveLength(1)
+    expect(json.stats.completion_rate).toBe(1)
+    expect(store.listRunHistory).toHaveBeenCalledWith({
+      repository: 'proompteng/lab',
+      issueNumber: 2137,
+      branch: undefined,
+      limit: 5,
+    })
+  })
+})

--- a/services/jangar/src/server/__tests__/codex-judge-runs-store.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-runs-store.test.ts
@@ -1,0 +1,327 @@
+import {
+  type CompiledQuery,
+  type DatabaseConnection,
+  type Driver,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type QueryResult,
+} from 'kysely'
+import { describe, expect, it } from 'vitest'
+
+import { createCodexJudgeStore } from '../codex-judge-store'
+import type { Database } from '../db'
+
+type SqlCall = { sql: string; params: readonly unknown[] }
+
+type FakeDbOptions = {
+  runs?: Array<Record<string, unknown>>
+  artifacts?: Array<Record<string, unknown>>
+  evaluations?: Array<Record<string, unknown>>
+}
+
+const makeFakeDb = (options: FakeDbOptions = {}) => {
+  const calls: SqlCall[] = []
+
+  class TestConnection implements DatabaseConnection {
+    async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
+      const params = (compiledQuery.parameters ?? []) as readonly unknown[]
+      calls.push({ sql: compiledQuery.sql, params })
+
+      const normalized = compiledQuery.sql.toLowerCase()
+
+      if (normalized.includes('select extname from pg_extension')) {
+        return { rows: [{ extname: 'vector' }, { extname: 'pgcrypto' }] as R[] }
+      }
+
+      if (normalized.includes('from "codex_judge"."runs"')) {
+        return { rows: (options.runs ?? []) as R[] }
+      }
+
+      if (normalized.includes('from "codex_judge"."artifacts"')) {
+        return { rows: (options.artifacts ?? []) as R[] }
+      }
+
+      if (normalized.includes('from "codex_judge"."evaluations"')) {
+        return { rows: (options.evaluations ?? []) as R[] }
+      }
+
+      return { rows: [] as R[] }
+    }
+
+    async *streamQuery<R>(): AsyncIterableIterator<QueryResult<R>> {
+      yield* []
+    }
+  }
+
+  class TestDriver implements Driver {
+    async init() {}
+
+    async acquireConnection(): Promise<DatabaseConnection> {
+      return new TestConnection()
+    }
+
+    async beginTransaction() {}
+
+    async commitTransaction() {}
+
+    async rollbackTransaction() {}
+
+    async releaseConnection() {}
+
+    async destroy() {}
+  }
+
+  const db = new Kysely<Database>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new TestDriver(),
+      createIntrospector: (dbInstance) => new PostgresIntrospector(dbInstance),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  })
+
+  return { db, calls }
+}
+
+describe('codex judge store run history', () => {
+  it('returns runs with artifacts and latest evaluations', async () => {
+    const { db } = makeFakeDb({
+      runs: [
+        {
+          id: 'run-1',
+          repository: 'proompteng/lab',
+          issue_number: 2137,
+          branch: 'codex/issue-2137',
+          attempt: 1,
+          workflow_name: 'workflow-1',
+          workflow_uid: null,
+          workflow_namespace: null,
+          stage: 'implementation',
+          status: 'completed',
+          phase: null,
+          prompt: null,
+          next_prompt: null,
+          commit_sha: null,
+          pr_number: null,
+          pr_url: null,
+          ci_status: null,
+          ci_url: null,
+          review_status: null,
+          review_summary: {},
+          notify_payload: null,
+          run_complete_payload: null,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          started_at: '2025-01-01T00:00:00Z',
+          finished_at: '2025-01-01T00:10:00Z',
+        },
+        {
+          id: 'run-2',
+          repository: 'proompteng/lab',
+          issue_number: 2137,
+          branch: 'codex/issue-2137',
+          attempt: 2,
+          workflow_name: 'workflow-2',
+          workflow_uid: null,
+          workflow_namespace: null,
+          stage: 'implementation',
+          status: 'needs_iteration',
+          phase: null,
+          prompt: null,
+          next_prompt: null,
+          commit_sha: null,
+          pr_number: null,
+          pr_url: null,
+          ci_status: null,
+          ci_url: null,
+          review_status: null,
+          review_summary: {},
+          notify_payload: null,
+          run_complete_payload: null,
+          created_at: '2025-01-02T00:00:00Z',
+          updated_at: '2025-01-02T00:00:00Z',
+          started_at: '2025-01-02T00:00:00Z',
+          finished_at: '2025-01-02T00:20:00Z',
+        },
+      ],
+      artifacts: [
+        {
+          id: 'artifact-1',
+          run_id: 'run-1',
+          name: 'implementation-changes',
+          key: 'artifact-key',
+          bucket: 'codex',
+          url: 'https://example.com/artifact',
+          metadata: { size: 123 },
+          created_at: '2025-01-01T00:00:00Z',
+        },
+      ],
+      evaluations: [
+        {
+          id: 'eval-1',
+          run_id: 'run-1',
+          decision: 'pass',
+          confidence: 0.1,
+          reasons: { error: 'old_error' },
+          missing_items: {},
+          suggested_fixes: {},
+          next_prompt: null,
+          prompt_tuning: {},
+          system_suggestions: {},
+          created_at: '2025-01-01T00:05:00Z',
+        },
+        {
+          id: 'eval-2',
+          run_id: 'run-1',
+          decision: 'pass',
+          confidence: 0.9,
+          reasons: {},
+          missing_items: {},
+          suggested_fixes: {},
+          next_prompt: null,
+          prompt_tuning: {},
+          system_suggestions: {},
+          created_at: '2025-01-01T00:06:00Z',
+        },
+        {
+          id: 'eval-3',
+          run_id: 'run-2',
+          decision: 'needs_iteration',
+          confidence: 0.3,
+          reasons: { error: 'ci_failed' },
+          missing_items: {},
+          suggested_fixes: {},
+          next_prompt: null,
+          prompt_tuning: {},
+          system_suggestions: {},
+          created_at: '2025-01-02T00:05:00Z',
+        },
+      ],
+    })
+
+    const store = createCodexJudgeStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    const runs = await store.listRunHistory({
+      repository: 'proompteng/lab',
+      issueNumber: 2137,
+      limit: 10,
+    })
+
+    const runOne = runs.find((run) => run.id === 'run-1')
+    expect(runOne?.artifacts).toHaveLength(1)
+    expect(runOne?.latestEvaluation?.id).toBe('eval-2')
+
+    const runTwo = runs.find((run) => run.id === 'run-2')
+    expect(runTwo?.artifacts).toHaveLength(0)
+    expect(runTwo?.latestEvaluation?.id).toBe('eval-3')
+  })
+
+  it('computes stats from latest evaluations and run attempts', async () => {
+    const { db } = makeFakeDb({
+      runs: [
+        {
+          id: 'run-1',
+          repository: 'proompteng/lab',
+          issue_number: 2137,
+          branch: 'codex/issue-2137',
+          attempt: 1,
+          workflow_name: 'workflow-1',
+          workflow_uid: null,
+          workflow_namespace: null,
+          stage: 'implementation',
+          status: 'completed',
+          phase: null,
+          prompt: null,
+          next_prompt: null,
+          commit_sha: null,
+          pr_number: null,
+          pr_url: null,
+          ci_status: null,
+          ci_url: null,
+          review_status: null,
+          review_summary: {},
+          notify_payload: null,
+          run_complete_payload: null,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+          started_at: '2025-01-01T00:00:00Z',
+          finished_at: '2025-01-01T00:10:00Z',
+        },
+        {
+          id: 'run-2',
+          repository: 'proompteng/lab',
+          issue_number: 2137,
+          branch: 'codex/issue-2137',
+          attempt: 2,
+          workflow_name: 'workflow-2',
+          workflow_uid: null,
+          workflow_namespace: null,
+          stage: 'implementation',
+          status: 'needs_iteration',
+          phase: null,
+          prompt: null,
+          next_prompt: null,
+          commit_sha: null,
+          pr_number: null,
+          pr_url: null,
+          ci_status: null,
+          ci_url: null,
+          review_status: null,
+          review_summary: {},
+          notify_payload: null,
+          run_complete_payload: null,
+          created_at: '2025-01-02T00:00:00Z',
+          updated_at: '2025-01-02T00:00:00Z',
+          started_at: '2025-01-02T00:00:00Z',
+          finished_at: '2025-01-02T00:20:00Z',
+        },
+      ],
+      evaluations: [
+        {
+          id: 'eval-2',
+          run_id: 'run-1',
+          decision: 'pass',
+          confidence: 0.9,
+          reasons: {},
+          missing_items: {},
+          suggested_fixes: {},
+          next_prompt: null,
+          prompt_tuning: {},
+          system_suggestions: {},
+          created_at: '2025-01-01T00:06:00Z',
+        },
+        {
+          id: 'eval-3',
+          run_id: 'run-2',
+          decision: 'needs_iteration',
+          confidence: 0.3,
+          reasons: { error: 'ci_failed' },
+          missing_items: {},
+          suggested_fixes: {},
+          next_prompt: null,
+          prompt_tuning: {},
+          system_suggestions: {},
+          created_at: '2025-01-02T00:05:00Z',
+        },
+      ],
+    })
+
+    const store = createCodexJudgeStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    const stats = await store.getRunStats({ repository: 'proompteng/lab', issueNumber: 2137 })
+
+    expect(stats.completionRate).toBeCloseTo(0.5)
+    expect(stats.avgAttemptsPerIssue).toBe(2)
+    expect(stats.failureReasonCounts).toEqual({ ci_failed: 1 })
+    expect(stats.avgCiDuration).toBe(900000)
+    expect(stats.avgJudgeConfidence).toBeCloseTo(0.6)
+  })
+})


### PR DESCRIPTION
## Summary
- add codex judge run history + stats queries (artifacts + latest evaluation) in store
- add internal GET /api/codex/runs with repository/issue filters and stats payload
- add store/route unit tests and clean up codex judge test mocks for lint

## Related Issues
Resolves #2137

## Testing
- bun run --cwd services/jangar lint
- bun run --cwd services/jangar test

## Screenshots (if applicable)
None.

## Breaking Changes
None.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
