### PR TITLE
chore(codex): tune prompt and disable tui2

### DIFF
--- a/apps/froussard/scripts/codex-config-container.toml
+++ b/apps/froussard/scripts/codex-config-container.toml
@@ -12,7 +12,6 @@ apply_patch_freeform = true
 rmcp_client = true
 shell_snapshot = true
 skills = true
-tui2 = true
 
 [shell_environment_policy]
 ignore_default_excludes = true

--- a/apps/froussard/src/codex.ts
+++ b/apps/froussard/src/codex.ts
@@ -69,6 +69,7 @@ const buildImplementationPrompt = ({
     '- Run all required formatters/linters/tests per repo instructions; fix and rerun until green.',
     `- Commit in logical units referencing #${issueNumber}; push the branch.`,
     '- Open the PR using the default template per repo instructions; link the issue.',
+    '- Finish only when required CI is green; fix failures and re-run the smallest necessary checks until it is.',
     '- Do not stop until the PR is opened and all required checks are green.',
     '- Use relevant repo skills in `skills/` when applicable; do not restate their instructions.',
     '',

--- a/services/jangar/scripts/codex-config-container.toml
+++ b/services/jangar/scripts/codex-config-container.toml
@@ -12,7 +12,6 @@ apply_patch_freeform = true
 rmcp_client = true
 shell_snapshot = true
 skills = true
-tui2 = true
 remote_compaction = true
 
 [mcp_servers.memories]


### PR DESCRIPTION
## Summary
- Remove experimental `tui2` from Codex container configs.
- Add CI-green gating and minimal re-run guidance to the Codex implementation prompt.

## Related Issues
None.

## Testing
- N/A (prompt/config text changes only).

## Breaking Changes
None.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
