### PR TITLE
chore(jangar): update deploy image and optional clickhouse secret

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2025-12-28T06:10:35.144Z"
+    deploy.knative.dev/rollout: "2025-12-28T22:47:56.915Z"
 spec:
   replicas: 1
   strategy:
@@ -136,11 +136,13 @@ spec:
                 secretKeyRef:
                   name: jangar-clickhouse-auth
                   key: username
+                  optional: true
             - name: CH_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: jangar-clickhouse-auth
                   key: password
+                  optional: true
             - name: VSCODE_DATA_DIR
               value: /workspace/.ovscode
             - name: VSCODE_DEFAULT_FOLDER

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -33,5 +33,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "8aecd143"
-    digest: sha256:1ab60f980f2b0b751eaa3f099f6d1a3abf3ed3594eee92055b47edfc0599f006
+    newTag: "97ad1e3b"
+    digest: sha256:37ac58524b80fe0a35de3a5ce386db586a1be9cdfa96f3ae3dda15b82099a474


### PR DESCRIPTION
## Summary

- Bump Jangar image tag/digest to the latest judge run history build.
- Allow ClickHouse secret keys to be optional so the service can start without sealed values.
- Refresh rollout annotation for the deployment.

## Related Issues

None

## Testing

- `kubectl -n jangar rollout status deploy/jangar`
- `curl -s http://127.0.0.1:8085/health` (via `kubectl -n jangar port-forward svc/jangar 8085:80`)
- `curl -s -H "accept: application/json" "http://127.0.0.1:8085/api/codex/runs?repository=proompteng/lab&issueNumber=2137&limit=1"`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
