### PR TITLE
fix(codex): harden docker sidecar bootstrap

### DIFF
--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -82,6 +82,8 @@ spec:
             value: ""
           - name: DOCKER_ENABLED
             value: "1"
+          - name: DOCKER_WAIT_ATTEMPTS
+            value: "12"
         command: ["/usr/local/bin/codex-bootstrap"]
         args:
           - "/bin/bash"
@@ -125,11 +127,10 @@ spec:
             memory: 12Gi
       sidecars:
         - name: docker
-          image: docker:25.0-dind
+          image: docker:25.0-dind-rootless
           command: ["dockerd-entrypoint.sh"]
           args:
             - "--host=tcp://0.0.0.0:2375"
-            - "--host=unix:///var/run/docker.sock"
           env:
             - name: DOCKER_TLS_CERTDIR
               value: ""

--- a/docs/autonomous-codex-design.md
+++ b/docs/autonomous-codex-design.md
@@ -274,7 +274,7 @@ This design builds directly on the current codebase, evolving Froussard and Fact
 
 ## 16. Docker-Enabled Codex Workflows
 
-- **Image tooling:** `apps/froussard/Dockerfile.codex` now bakes Docker CLI, Buildx, and Compose with defaults `DOCKER_HOST=tcp://localhost:2375` and `DOCKER_TLS_VERIFY=0`. `DOCKER_ENABLED` defaults to `0` in the image and is set to `1` only on WorkflowTemplates that attach the Docker sidecar so non-docker workflows stay untouched.
+- **Image tooling:** `apps/froussard/Dockerfile.codex` now bakes Docker CLI, Buildx, and Compose with default `DOCKER_HOST=tcp://localhost:2375`. `DOCKER_TLS_VERIFY` should be unset for the in-pod daemon (bootstrap treats `0`/`false` as unset). `DOCKER_ENABLED` defaults to `0` in the image and is set to `1` only on WorkflowTemplates that attach the Docker sidecar so non-docker workflows stay untouched.
 - **Rootless sidecar:** Every GitHub Codex WorkflowTemplate attaches a `docker:25.0-dind-rootless` sidecar listening on 2375, backed by an `emptyDir` at `/var/lib/docker` that is mounted read-only into the main Codex container to make image layers visible across steps without exposing write access.
 - **Bootstrap changes:** `codex-bootstrap` skips redundant `bun install` when `DOCKER_ENABLED=1` and cached modules exist, and it waits for `docker info` only when `DOCKER_ENABLED=1` so docker-ready workflows fail fast while other workflows proceed without delay.
 - **Policy guardrails:** A dedicated RBAC binding (`codex-docker-privileged` role in `argocd/applications/argo-workflows/codex-docker-policy.yaml`) scopes privileged pod usage to the Codex workflow service account; review namespace pod-security posture before promotion.

--- a/docs/runbooks/codex-docker.md
+++ b/docs/runbooks/codex-docker.md
@@ -3,7 +3,7 @@
 ## Overview
 - Codex workflow pods now ship with a rootless Docker sidecar (`docker:25.0-dind-rootless`) exposing `tcp://localhost:2375` with TLS disabled.
 - The sidecar owns `/var/lib/docker` on an `emptyDir` volume; the main Codex container mounts it read-only to reuse layers without permitting mutation.
-- `DOCKER_HOST=tcp://localhost:2375` and `DOCKER_TLS_VERIFY=0` are baked into the Codex image; `DOCKER_ENABLED=1` is set by the docker-enabled WorkflowTemplates so bootstrap waits for the sidecar. Image default for `DOCKER_ENABLED` remains `0` to avoid blocking workflows without a daemon.
+- `DOCKER_HOST=tcp://localhost:2375` is baked into the Codex image; `DOCKER_TLS_VERIFY` should be unset for the in-pod daemon (bootstrap treats `0`/`false` as unset). `DOCKER_ENABLED=1` is set by the docker-enabled WorkflowTemplates so bootstrap waits for the sidecar. Image default for `DOCKER_ENABLED` remains `0` to avoid blocking workflows without a daemon.
 
 ## Validate the daemon
 1) Confirm connectivity:


### PR DESCRIPTION
## Summary
- use the rootless Docker sidecar for the GitHub Codex implementation workflow and extend the docker wait window
- normalize docker TLS env handling in codex-bootstrap to avoid sidecar connection failures
- update docker runbook/design notes to reflect the in-pod TLS expectations

## Related Issues
None

## Testing
- Not run (config change; requires Argo workflow run / cluster validation).

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
