### PR TITLE
fix(argo-events): unblock workflow completion events

### DIFF
--- a/argocd/applications/froussard/workflow-completions-eventsource.yaml
+++ b/argocd/applications/froussard/workflow-completions-eventsource.yaml
@@ -15,17 +15,3 @@ spec:
       resource: workflows
       eventTypes:
         - UPDATE
-      filter:
-        fields:
-          - key: status.phase
-            operation: "!="
-            value: Pending
-          - key: status.phase
-            operation: "!="
-            value: Running
-          - key: status.phase
-            operation: "!="
-            value: Unknown
-          - key: status.finishedAt
-            operation: "!="
-            value: ""

--- a/argocd/applications/froussard/workflow-completions-sensor.yaml
+++ b/argocd/applications/froussard/workflow-completions-sensor.yaml
@@ -25,6 +25,9 @@ spec:
     serviceAccountName: workflow-completions-sensor
   triggers:
     - template:
+        name: log-workflow-completion
+        log: {}
+    - template:
         name: publish-workflow-completion
         kafka:
           url: kafka-kafka-bootstrap.kafka:9092


### PR DESCRIPTION
## Summary

- Remove EventSource status filters so workflow updates reach the event bus.
- Add a log trigger for workflow completion events to confirm sensor execution.
- Keep the Kafka publish payload unchanged.

## Related Issues

Fixes #2166

## Testing

- bun run lint:argocd

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
