### PR TITLE
fix(argo): use rootful dind for codex implementation

### DIFF
--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -129,7 +129,7 @@ spec:
             memory: 12Gi
       sidecars:
         - name: docker
-          image: docker:25.0-dind-rootless
+          image: docker:25.0-dind
           command: ["dockerd-entrypoint.sh"]
           args:
             - "--host=tcp://0.0.0.0:2375"


### PR DESCRIPTION
## Summary
- switch codex implementation workflow sidecar to rootful dind to restore Docker connectivity

## Testing
- N/A (manifest change)
