### PR TITLE
feat(argo): publish codex workflow events to NATS

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -3,6 +3,7 @@ FROM ghcr.io/openai/codex-universal:latest
 
 ARG ARGO_VERSION=v3.6.3
 ARG KUBECONFORM_VERSION=v0.6.7
+ARG NATSCLI_VERSION=v0.3.0
 ARG TARGETARCH=arm64
 ARG TEMPORAL_VERSION=v1.5.1
 ARG CODEX_AUTH_CHECKSUM=unspecified
@@ -26,7 +27,7 @@ RUN bash -lc 'source /root/.nvm/nvm.sh && nvm install ${CODEX_ENV_NODE_VERSION}'
 
 RUN set -eux; \
     apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 -o Debug::Acquire::http=true \
-    && apt-get install -y -V --no-install-recommends ca-certificates curl gnupg git gh jq python3 xz-utils protobuf-compiler libprotobuf-dev build-essential pkg-config \
+    && apt-get install -y -V --no-install-recommends ca-certificates curl gnupg git gh jq python3 xz-utils protobuf-compiler libprotobuf-dev build-essential pkg-config unzip \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
     && chmod a+r /etc/apt/keyrings/docker.gpg \
@@ -61,6 +62,23 @@ RUN set -eux; \
     tar -xzf "${KUBECONFORM_ARCHIVE}" -C /tmp kubeconform; \
     install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform; \
     rm -f "${KUBECONFORM_ARCHIVE}" /tmp/kubeconform
+
+RUN set -eux; \
+    ARCH="${TARGETARCH:-arm64}"; \
+    case "${ARCH}" in \
+      amd64|arm64) \
+        ;; \
+      *) \
+        echo "Unsupported TARGETARCH: ${ARCH}" >&2; \
+        exit 1; \
+        ;; \
+    esac; \
+    NATS_VERSION="${NATSCLI_VERSION#v}"; \
+    NATS_ARCHIVE="/tmp/nats-${NATS_VERSION}-linux-${ARCH}.zip"; \
+    curl -fsSL -o "${NATS_ARCHIVE}" "https://github.com/nats-io/natscli/releases/download/${NATSCLI_VERSION}/nats-${NATS_VERSION}-linux-${ARCH}.zip"; \
+    unzip -q "${NATS_ARCHIVE}" -d /tmp; \
+    install -m 0755 "/tmp/nats-${NATS_VERSION}-linux-${ARCH}/nats" /usr/local/bin/nats; \
+    rm -rf "${NATS_ARCHIVE}" "/tmp/nats-${NATS_VERSION}-linux-${ARCH}"
 
 RUN set -eux; \
     ARCH="${TARGETARCH:-arm64}"; \
@@ -107,6 +125,7 @@ COPY apps/froussard/src/codex/cli/codex-bootstrap.ts /usr/local/bin/codex-bootst
 COPY apps/froussard/src/codex/cli/codex-implement.ts /usr/local/bin/codex-implement
 COPY apps/froussard/src/codex/cli/codex-research.ts /usr/local/bin/codex-research
 COPY apps/froussard/src/codex/cli/codex-graf.ts /usr/local/bin/codex-graf
+COPY apps/froussard/scripts/codex-nats-publish.sh /usr/local/bin/codex-nats-publish
 COPY apps/froussard/scripts/discord-channel.ts /usr/local/bin/discord-channel.ts
 COPY apps/froussard/src/codex/cli/lib /usr/local/bin/lib
 # Provide @proompteng/codex for the CLI helpers at runtime.
@@ -118,7 +137,7 @@ RUN bash -lc 'cd /opt/proompteng/packages/discord && bun install --no-save && bu
 RUN mkdir -p /usr/local/node_modules/@proompteng \
     && cp -R /opt/proompteng/packages/codex /usr/local/node_modules/@proompteng/codex \
     && cp -R /opt/proompteng/packages/discord /usr/local/node_modules/@proompteng/discord
-RUN chmod +x /usr/local/bin/codex-bootstrap /usr/local/bin/codex-implement /usr/local/bin/codex-research /usr/local/bin/codex-graf /usr/local/bin/discord-channel.ts
+RUN chmod +x /usr/local/bin/codex-bootstrap /usr/local/bin/codex-implement /usr/local/bin/codex-research /usr/local/bin/codex-graf /usr/local/bin/codex-nats-publish /usr/local/bin/discord-channel.ts
 
 WORKDIR /workspace
 ENTRYPOINT ["/usr/local/bin/codex-bootstrap"]

--- a/apps/froussard/scripts/codex-nats-publish.sh
+++ b/apps/froussard/scripts/codex-nats-publish.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: codex-nats-publish --kind <status|log> [options]
+
+Options:
+  --kind <value>        Required kind for the event.
+  --content <text>      Publish a single event with the provided content.
+  --log-file <path>     Tail a log file and publish each line as an event.
+  --channel <value>     Channel name for run-specific events (default: run).
+  --publish-general     Also publish each event to argo.workflow.general.<kind>.
+  --status <value>      Optional status value for status events.
+  --exit-code <value>   Optional exit code for status events.
+  -h, --help            Show this help text.
+
+Environment:
+  NATS_URL              NATS server URL.
+  NATS_CREDS            Optional credentials content.
+  NATS_CREDS_FILE       Optional credentials file path.
+  NATS_SUBJECT_PREFIX   Subject prefix (default: argo.workflow).
+  WORKFLOW_NAME         Argo workflow name.
+  WORKFLOW_UID          Argo workflow uid.
+  WORKFLOW_NAMESPACE    Argo workflow namespace.
+  WORKFLOW_STAGE        Optional workflow stage.
+  WORKFLOW_STEP         Optional workflow step (e.g. pod name).
+  AGENT_ID              Agent identifier.
+USAGE
+}
+
+kind=''
+content=''
+log_file=''
+channel='run'
+publish_general=false
+status=''
+exit_code=''
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kind)
+      kind=${2:-}
+      shift 2
+      ;;
+    --content)
+      content=${2:-}
+      shift 2
+      ;;
+    --log-file)
+      log_file=${2:-}
+      shift 2
+      ;;
+    --channel)
+      channel=${2:-}
+      shift 2
+      ;;
+    --publish-general)
+      publish_general=true
+      shift
+      ;;
+    --status)
+      status=${2:-}
+      shift 2
+      ;;
+    --exit-code)
+      exit_code=${2:-}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$kind" ]]; then
+  echo "Missing required --kind" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ -z "${NATS_URL:-}" ]]; then
+  exit 0
+fi
+
+if ! command -v nats >/dev/null 2>&1; then
+  echo "nats CLI not found; skipping publish" >&2
+  exit 0
+fi
+
+workflow_namespace=${WORKFLOW_NAMESPACE:-argo-workflows}
+workflow_name=${WORKFLOW_NAME:-unknown}
+workflow_uid=${WORKFLOW_UID:-unknown}
+workflow_stage=${WORKFLOW_STAGE:-}
+workflow_step=${WORKFLOW_STEP:-${STEP_ID:-}}
+agent_id=${AGENT_ID:-unknown}
+subject_prefix=${NATS_SUBJECT_PREFIX:-argo.workflow}
+
+creds_file=''
+creds_tmp=''
+if [[ -n "${NATS_CREDS_FILE:-}" ]]; then
+  creds_file=$NATS_CREDS_FILE
+elif [[ -n "${NATS_CREDS:-}" ]]; then
+  creds_tmp=$(mktemp)
+  printf '%s' "$NATS_CREDS" > "$creds_tmp"
+  creds_file=$creds_tmp
+fi
+
+cleanup_creds() {
+  if [[ -n "$creds_tmp" ]]; then
+    rm -f "$creds_tmp"
+  fi
+}
+trap cleanup_creds EXIT
+
+nats_args=(--server "$NATS_URL")
+if [[ -n "$creds_file" ]]; then
+  nats_args+=(--creds "$creds_file")
+fi
+
+run_subject="${subject_prefix}.${workflow_namespace}.${workflow_name}.${workflow_uid}.agent.${agent_id}.${kind}"
+general_subject="${subject_prefix}.general.${kind}"
+
+build_payload() {
+  local message_id=$1
+  local sent_at=$2
+  local content_value=$3
+  local channel_value=$4
+
+  jq -cn \
+    --arg message_id "$message_id" \
+    --arg sent_at "$sent_at" \
+    --arg kind "$kind" \
+    --arg workflow_uid "$workflow_uid" \
+    --arg workflow_name "$workflow_name" \
+    --arg workflow_namespace "$workflow_namespace" \
+    --arg workflow_stage "$workflow_stage" \
+    --arg workflow_step "$workflow_step" \
+    --arg agent_id "$agent_id" \
+    --arg channel "$channel_value" \
+    --arg content "$content_value" \
+    --arg status "$status" \
+    --arg exit_code "$exit_code" \
+    '{
+      message_id: $message_id,
+      sent_at: $sent_at,
+      kind: $kind,
+      workflow_uid: $workflow_uid,
+      workflow_name: $workflow_name,
+      workflow_namespace: $workflow_namespace,
+      agent_id: $agent_id,
+      channel: $channel,
+      content: $content
+    }
+    + ( ($workflow_stage | length) > 0 ? {workflow_stage: $workflow_stage} : {} )
+    + ( ($workflow_step | length) > 0 ? {workflow_step: $workflow_step} : {} )
+    + ( ($status | length) > 0 ? {status: $status} : {} )
+    + ( ($exit_code | length) > 0 ? {exit_code: ($exit_code | tonumber)} : {} )'
+}
+
+publish_payload() {
+  local subject=$1
+  local payload=$2
+
+  if ! nats pub "$subject" "${nats_args[@]}" -H 'content-type: application/json' "$payload" >/dev/null 2>&1; then
+    echo "Failed to publish to $subject" >&2
+  fi
+}
+
+publish_event() {
+  local line=$1
+  if [[ -z "$line" ]]; then
+    return
+  fi
+
+  local message_id
+  message_id=$(cat /proc/sys/kernel/random/uuid)
+  local sent_at
+  sent_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+  local run_payload
+  run_payload=$(build_payload "$message_id" "$sent_at" "$line" "$channel")
+  publish_payload "$run_subject" "$run_payload"
+
+  if [[ "$publish_general" == true ]]; then
+    local general_payload
+    general_payload=$(build_payload "$message_id" "$sent_at" "$line" 'general')
+    publish_payload "$general_subject" "$general_payload"
+  fi
+}
+
+if [[ -n "$log_file" ]]; then
+  tail -n +1 -F "$log_file" | while IFS= read -r line; do
+    publish_event "$line"
+  done
+  exit 0
+fi
+
+if [[ -n "$content" ]]; then
+  publish_event "$content"
+  exit 0
+fi
+
+while IFS= read -r line; do
+  publish_event "$line"
+done

--- a/apps/froussard/scripts/codex-nats-publish.sh
+++ b/apps/froussard/scripts/codex-nats-publish.sh
@@ -122,6 +122,11 @@ trap cleanup_creds EXIT
 nats_args=(--server "$NATS_URL")
 if [[ -n "$creds_file" ]]; then
   nats_args+=(--creds "$creds_file")
+elif [[ -n "${NATS_USER:-}" ]]; then
+  nats_args+=(--user "$NATS_USER")
+  if [[ -n "${NATS_PASSWORD:-}" ]]; then
+    nats_args+=(--password "$NATS_PASSWORD")
+  fi
 fi
 
 run_subject="${subject_prefix}.${workflow_namespace}.${workflow_name}.${workflow_uid}.agent.${agent_id}.${kind}"
@@ -168,7 +173,7 @@ publish_payload() {
   local subject=$1
   local payload=$2
 
-  if ! nats pub "$subject" "${nats_args[@]}" -H 'content-type: application/json' "$payload" >/dev/null 2>&1; then
+  if ! nats pub "${nats_args[@]}" -H 'content-type: application/json' "$subject" "$payload" >/dev/null 2>&1; then
     echo "Failed to publish to $subject" >&2
   fi
 }

--- a/argocd/applications/argo-workflows/codex-research-workflow.yaml
+++ b/argocd/applications/argo-workflows/codex-research-workflow.yaml
@@ -42,18 +42,6 @@ spec:
                 name: graf-api
                 key: bearer-tokens
                 optional: true
-          - name: NATS_URL
-            value: nats://nats.nats.svc.cluster.local:4222
-          - name: NATS_USER
-            valueFrom:
-              secretKeyRef:
-                name: nats-agents-credentials
-                key: username
-          - name: NATS_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: nats-agents-credentials
-                key: password
           - name: CODEX_GRAF_BASE_URL
             value: "http://graf.graf.svc.cluster.local"
           - name: NATS_URL

--- a/argocd/applications/argo-workflows/codex-research-workflow.yaml
+++ b/argocd/applications/argo-workflows/codex-research-workflow.yaml
@@ -56,6 +56,36 @@ spec:
                 key: password
           - name: CODEX_GRAF_BASE_URL
             value: "http://graf.graf.svc.cluster.local"
+          - name: NATS_URL
+            value: nats://nats.nats.svc.cluster.local:4222
+          - name: NATS_USER
+            valueFrom:
+              secretKeyRef:
+                name: nats-agents-credentials
+                key: username
+          - name: NATS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: nats-agents-credentials
+                key: password
+          - name: NATS_CREDS
+            valueFrom:
+              secretKeyRef:
+                name: nats-agent-creds
+                key: creds
+                optional: true
+          - name: WORKFLOW_NAME
+            value: '{{workflow.name}}'
+          - name: WORKFLOW_UID
+            value: '{{workflow.uid}}'
+          - name: WORKFLOW_NAMESPACE
+            value: '{{workflow.namespace}}'
+          - name: WORKFLOW_STAGE
+            value: research
+          - name: WORKFLOW_STEP
+            value: '{{pod.name}}'
+          - name: AGENT_ID
+            value: research
         command: ["/usr/local/bin/codex-bootstrap"]
         args:
           - "/bin/bash"
@@ -85,8 +115,38 @@ spec:
             export AUTO_RESEARCH_AGENT_LOG="${AUTO_RESEARCH_AGENT_LOG:-/workspace/lab/.codex-research-agent.log}"
             export AUTO_RESEARCH_RUNTIME_LOG="${AUTO_RESEARCH_RUNTIME_LOG:-/workspace/lab/.codex-research-runtime.log}"
 
+            AGENT_LOG_PATH="$AUTO_RESEARCH_AGENT_LOG"
+            NATS_PUBLISHER="/usr/local/bin/codex-nats-publish"
+            NATS_TAIL_PID=""
+
+            if [[ -x "$NATS_PUBLISHER" ]]; then
+              touch "$AGENT_LOG_PATH"
+              "$NATS_PUBLISHER" --kind status --status started --content "research started" --publish-general || true
+              "$NATS_PUBLISHER" --kind log --log-file "$AGENT_LOG_PATH" &
+              NATS_TAIL_PID=$!
+            fi
+
+            cleanup_nats() {
+              if [[ -n "${NATS_TAIL_PID:-}" ]]; then
+                kill "$NATS_TAIL_PID" 2>/dev/null || true
+                wait "$NATS_TAIL_PID" 2>/dev/null || true
+              fi
+            }
+            trap cleanup_nats EXIT
+
             echo "Launching Codex research run"
+            set +e
             codex-research "$PROMPT_FILE" "$METADATA_FILE"
+            EXIT_CODE=$?
+            set -e
+
+            cleanup_nats
+
+            if [[ -x "$NATS_PUBLISHER" ]]; then
+              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "research completed" --publish-general || true
+            fi
+
+            exit "$EXIT_CODE"
       retryStrategy:
         limit: 3
         retryPolicy: OnFailure

--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -87,6 +87,26 @@ spec:
               secretKeyRef:
                 name: nats-agents-credentials
                 key: password
+          - name: NATS_CREDS
+            valueFrom:
+              secretKeyRef:
+                name: nats-agent-creds
+                key: creds
+                optional: true
+          - name: WORKFLOW_NAME
+            value: '{{workflow.name}}'
+          - name: WORKFLOW_UID
+            value: '{{workflow.uid}}'
+          - name: WORKFLOW_NAMESPACE
+            value: '{{workflow.namespace}}'
+          - name: WORKFLOW_STAGE
+            value: implementation
+          - name: WORKFLOW_STEP
+            value: '{{pod.name}}'
+          - name: AGENT_ID
+            value: implementation
+          - name: AGENT_OUTPUT_PATH
+            value: /workspace/lab/.codex-implementation-agent.log
           - name: CODEX_GRAF_BEARER_TOKEN
             valueFrom:
               secretKeyRef:
@@ -129,8 +149,38 @@ spec:
             export OUTPUT_PATH="${IMPLEMENTATION_OUTPUT_PATH:-/workspace/lab/.codex-implementation.log}"
             export POST_TO_GITHUB=true
 
+            AGENT_LOG_PATH="${AGENT_OUTPUT_PATH:-/workspace/lab/.codex-implementation-agent.log}"
+            NATS_PUBLISHER="/usr/local/bin/codex-nats-publish"
+            NATS_TAIL_PID=""
+
+            if [[ -x "$NATS_PUBLISHER" ]]; then
+              touch "$AGENT_LOG_PATH"
+              "$NATS_PUBLISHER" --kind status --status started --content "implementation started" --publish-general || true
+              "$NATS_PUBLISHER" --kind log --log-file "$AGENT_LOG_PATH" &
+              NATS_TAIL_PID=$!
+            fi
+
+            cleanup_nats() {
+              if [[ -n "${NATS_TAIL_PID:-}" ]]; then
+                kill "$NATS_TAIL_PID" 2>/dev/null || true
+                wait "$NATS_TAIL_PID" 2>/dev/null || true
+              fi
+            }
+            trap cleanup_nats EXIT
+
             echo "Executing implementation workflow" >&2
+            set +e
             /usr/local/bin/codex-implement "$EVENT_FILE"
+            EXIT_CODE=$?
+            set -e
+
+            cleanup_nats
+
+            if [[ -x "$NATS_PUBLISHER" ]]; then
+              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "implementation completed" --publish-general || true
+            fi
+
+            exit "$EXIT_CODE"
         volumeMounts:
           - name: workdir
             mountPath: /workspace


### PR DESCRIPTION
## Summary

- Add a Codex NATS publish helper and install the NATS CLI in the codex-universal image.
- Inject NATS/workflow metadata env vars into implementation + research workflow templates.
- Publish status + log events to run-specific and general NATS subjects during workflow execution.

## Related Issues

Closes #2186

## Testing

- Not run (no JS/TS/Go changes; YAML/shell/Dockerfile updates only).

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
