### PR TITLE
chore(argo): avoid replace on minio bootstrap job

### DIFF
--- a/argocd/applications/argo-workflows/minio-bucket-job.yaml
+++ b/argocd/applications/argo-workflows/minio-bucket-job.yaml
@@ -7,8 +7,7 @@ metadata:
     app.kubernetes.io/name: argo-workflows-minio-bootstrap
   annotations:
     argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 2
   template:


### PR DESCRIPTION
## Summary

- Remove Replace sync option from the argo-workflows MinIO bootstrap hook.
- Add BeforeHookCreation to avoid Job replace errors on sync.

## Related Issues

None

## Testing

- N/A (manifest change only)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
