### PR TITLE
fix(argocd): ignore knative service defaults

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -175,6 +175,13 @@ spec:
                 kind: Service
                 jsonPointers:
                   - /metadata/annotations
+                  - /metadata/labels
+                  - /spec/traffic
+                  - /spec/template/metadata/annotations
+                  - /spec/template/metadata/creationTimestamp
+                  - /spec/template/metadata/labels
+                  - /spec/template/spec/containers/0/ports/0/protocol
+                  - /spec/template/spec/containers/0/resources
             automation: manual
             enabled: true
       selector:


### PR DESCRIPTION
## Summary
- ignore Knative defaulted fields on froussard Service for Argo diff
- keep ApplicationSet sync status clean for froussard
- document explicit ignore pointers for traffic/ports/resources

## Related Issues
None

## Testing
- argocd app get froussard --hard-refresh

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
