### PR TITLE
docs(agents): clarify worktree merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@
 
 ## Merge Guidelines
 - Use squash merges for pull requests.
+- Use `gh pr merge 2202 --squash -R proompteng/lab` (no `--delete-branch`; avoids worktree checkout conflicts).
 
 ## Generated Artifacts & Safety
 - Do not edit generated directories (`dist/`, `build/`, `_generated`) or lockfiles (`bun.lock`, `bun.lockb`); regenerate via the owning tool.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,4 +167,3 @@ kubectl --kubeconfig ~/.kube/altra.yaml apply -f ./tofu/harvester/templates
 - Use the current/default kube context by default; do not pass a kubeconfig path unless explicitly requested.
 - Scope kubectl to the target namespace with `-n`; prefer read-only queries (get/describe/logs) and short-lived actions (rollout restart). Avoid `kubectl apply` for desired state unless asked.
 - Manage apps declaratively via Git under `argocd/`; pin chart versions and avoid ad-hoc Helm installs.
-- Do not run git commands; propose file edits only. The user commits, pushes, and syncs ArgoCD.


### PR DESCRIPTION
## Summary

- Clarify the recommended `gh pr merge` command when worktrees are in use.
- Remove the git-command restriction from CLAUDE guidance.

## Related Issues

None

## Testing

- N/A (docs only)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
