### PR TITLE
chore(argocd): ignore flink CRD defaults

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -397,6 +397,27 @@ spec:
           name: knative-serving-operator-aggregated-stable
           jqPathExpressions:
             - .rules
+        - kind: CustomResourceDefinition
+          group: apiextensions.k8s.io
+          name: flinkdeployments.flink.apache.org
+          jqPathExpressions:
+            - .spec.conversion
+            - .spec.names.listKind
+            - .spec.versions[].additionalPrinterColumns[].priority
+        - kind: CustomResourceDefinition
+          group: apiextensions.k8s.io
+          name: flinksessionjobs.flink.apache.org
+          jqPathExpressions:
+            - .spec.conversion
+            - .spec.names.listKind
+            - .spec.versions[].additionalPrinterColumns[].priority
+        - kind: CustomResourceDefinition
+          group: apiextensions.k8s.io
+          name: flinkstatesnapshots.flink.apache.org
+          jqPathExpressions:
+            - .spec.conversion
+            - .spec.names.listKind
+            - .spec.versions[].additionalPrinterColumns[].priority
   templatePatch: |
     {{- if .annotations }}
     metadata:


### PR DESCRIPTION
## Summary
- Ignore server-defaulted CRD fields for Flink operator resources
- Prevent ArgoCD diff noise from conversion/listKind/printer column priority defaults
- Keep Flink application in sync without forcing CRD re-applies

## Related Issues
None

## Testing
- kubectl -n argocd get application flink -o jsonpath='{.status.sync.status} {.status.health.status}'

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
