### PR TITLE
chore(argocd): ignore torghut knative defaults

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -155,6 +155,19 @@ spec:
             namespace: torghut
             annotations:
               argocd.argoproj.io/sync-wave: "6"
+            ignoreDifferences:
+              - group: serving.knative.dev
+                kind: Service
+                jsonPointers:
+                  - /metadata/annotations
+                  - /metadata/labels
+                  - /spec/traffic
+                  - /spec/template/metadata/annotations
+                  - /spec/template/metadata/creationTimestamp
+                  - /spec/template/metadata/labels
+                  - /spec/template/spec/containers/0/ports/0/protocol
+                  - /spec/template/spec/containers/0/readinessProbe
+                  - /spec/template/spec/enableServiceLinks
             automation: manual
             enabled: true
           - name: miel


### PR DESCRIPTION
## Summary
- Ignore Knative server-defaulted fields for the torghut Service
- Prevent ArgoCD diff noise from traffic/readiness/protocol defaults
- Keep torghut application synced without forcing redeploys

## Related Issues
None

## Testing
- kubectl -n argocd get application torghut -o jsonpath='{.status.sync.status} {.status.health.status}'

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
