### PR TITLE
fix(graf): deploy java25 distroless runtime

### DIFF
--- a/argocd/applications/graf/knative-service.yaml
+++ b/argocd/applications/graf/knative-service.yaml
@@ -17,14 +17,14 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "60"
-        client.knative.dev/updateTimestamp: 2025-11-16T01:32:44.481Z
+        client.knative.dev/updateTimestamp: 2025-12-29T07:38:13.277Z
     spec:
       timeoutSeconds: 60
       containerConcurrency: 0
       serviceAccountName: graf
       containers:
         - name: user-container
-          image: registry.ide-newton.ts.net/proompteng/graf@sha256:e00fce9e6ad0d04741e0a35168e1e6748cdbb561433c24b3a3542277ef6621fb
+          image: registry.ide-newton.ts.net/proompteng/graf@sha256:71a3830bfcf07f0c8d7d183724e41615768ec0a996b4029f1bba4879bb5aa17f
           imagePullPolicy: Always
           ports:
             - name: http1
@@ -51,9 +51,9 @@ spec:
                   name: graf-api
                   key: bearer-tokens
             - name: GRAF_VERSION
-              value: v0.309.1-1-g94f5e999
+              value: v0.376.0-11-gbf8e763f
             - name: GRAF_COMMIT
-              value: 94f5e99956ef8c91bbe620cb17585ee88581d098
+              value: bf8e763fd6c6b70381c6b0872b0bf757f77d8a80
             - name: MINIO_ENDPOINT
               value: http://observability-minio.minio.svc.cluster.local:9000
             - name: MINIO_BUCKET

--- a/services/graf/Dockerfile
+++ b/services/graf/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /workspace
 COPY --chown=gradle:gradle . .
 RUN ./gradlew clean quarkusBuild --no-daemon
 
-FROM gcr.io/distroless/java25-debian12:nonroot
+FROM gcr.io/distroless/java25:nonroot
 WORKDIR /app
 COPY --from=builder /workspace/build/quarkus-app /app/quarkus-app
 ENV PORT=8080

--- a/services/graf/README.md
+++ b/services/graf/README.md
@@ -98,7 +98,7 @@ Run `./gradlew ktlintCheck` (the same plugin also supports `./gradlew ktlintForm
    ```bash
    bun packages/scripts/src/graf/deploy-service.ts
    ```
-The runtime image copies `build/quarkus-app` into `gcr.io/distroless/java25-debian12:nonroot` and starts `quarkus-run.jar`.
+The runtime image copies `build/quarkus-app` into `gcr.io/distroless/java25:nonroot` and starts `quarkus-run.jar`.
 
 ## Startup behavior
 


### PR DESCRIPTION
## Summary
- Switch Graf runtime base to `gcr.io/distroless/java25:nonroot` to match the available distroless tag.
- Deploy a new Graf image and update the Knative service metadata (image digest/version/commit).
- Document the updated runtime image in the Graf README.

## Related Issues
None

## Testing
- bun packages/scripts/src/graf/deploy-service.ts

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
