### PR TITLE
docs: add kubectl usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,10 @@
 - Do not edit generated directories (`dist/`, `build/`, `_generated`) or lockfiles (`bun.lock`, `bun.lockb`); regenerate via the owning tool.
 - Default to GitOps (edit `argocd/` manifests and let Argo CD sync). Only apply directly to the cluster when explicitly asked or in an emergency, and document the deviation.
 
+## Kubernetes (kubectl)
+- Use explicit namespaces with kubectl (e.g., `kubectl get pods -n <ns>`).
+- CNPG access: `kubectl cnpg psql -n <ns> <cluster> -- <psql args>` (psql flags after `--`).
+
 ## When in Doubt
 - Check the nearest README for service-specific commands.
 - Search internet with correct keyword and questions containing context using web.run.


### PR DESCRIPTION
## Summary

- Add concise kubectl usage guidance to AGENTS.md.
- Document CNPG psql access command.

## Related Issues

None.

## Testing

- N/A (documentation-only change).

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
