### PR TITLE
chore(temporal-bun-sdk): bump scaffold sdk version

### DIFF
--- a/packages/temporal-bun-sdk/src/bin/temporal-bun.ts
+++ b/packages/temporal-bun-sdk/src/bin/temporal-bun.ts
@@ -393,7 +393,7 @@ export function projectTemplates(name: string): Template[] {
             'docker:build': 'bun run scripts/build-docker.ts --tag temporal-worker:latest',
           },
           dependencies: {
-            '@proompteng/temporal-bun-sdk': '^0.1.0',
+            '@proompteng/temporal-bun-sdk': '^0.5.0',
             effect: '^3.2.0',
           },
           devDependencies: {


### PR DESCRIPTION
## Summary

- Bump the `temporal-bun init` scaffold dependency to `@proompteng/temporal-bun-sdk` `^0.5.0`.

## Related Issues

None

## Testing

- N/A (template-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
