### PR TITLE
fix(jangar): enforce commit-SHA CI gating

### DIFF
--- a/docs/jangar/codex-judge-argo-design.md
+++ b/docs/jangar/codex-judge-argo-design.md
@@ -206,7 +206,8 @@ Artifact access:
 - CI is sourced from GitHub Actions status for the commit SHA produced by the current attempt.
 - Jangar must gate on the exact commit SHA (not branch-level status) to avoid stale green checks from prior attempts.
 - Jangar does not rely on Argo-local tests for completion.
- - Commit SHA source order: PR head SHA (preferred) -> head branch SHA -> fallback to status artifact/manifest.
+- Commit SHA source order: PR head SHA (preferred) -> implementation manifest/status artifacts -> stored commit SHA from notify payload.
+- If the commit SHA cannot be resolved, treat as infra failure and retry (no branch-head fallback).
 
 ## PR Review Gate (Codex Review)
 - Jangar must wait for the Codex review to complete on the PR (review by `codex`/`codex[bot]` or the configured reviewer identity).


### PR DESCRIPTION
## Summary

- Remove branch-head CI fallback and require attempt commit SHA for gating.
- Retry runs when commit SHA is missing; add CI gating tests for missing/known SHAs.
- Update Jangar CI design doc to document commit-SHA-only behavior.

## Related Issues

Fixes #2227

## Testing

- `bunx biome check services/jangar/src/server/codex-judge.ts services/jangar/src/server/__tests__/codex-judge-ci.test.ts services/jangar/src/server/__tests__/codex-judge.test.ts docs/jangar/codex-judge-argo-design.md`
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/codex-judge-ci.test.ts src/server/__tests__/codex-judge.test.ts`

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
