### PR TITLE
chore(jangar): deploy 7232c551

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2025-12-29T23:39:37.941Z"
+    deploy.knative.dev/rollout: "2025-12-30T00:48:42.099Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -33,5 +33,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "070f9ab9"
-    digest: sha256:35b4064c97d70b23f67df770081a016903d92753004c3d6851a95755bc3e7b1f
+    newTag: "7232c551"
+    digest: sha256:b6ef2ecfec3f25765ee61c5ada5c4e1f0166bcc0f45679b5ff250dadb22e0f10


### PR DESCRIPTION
## Summary

- Deploy Jangar image `7232c551` and update manifest rollout annotation.
- Update Argo CD kustomization with the new image tag/digest.

## Related Issues

None.

## Testing

- N/A (deployment manifest update).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
