### PR TITLE
fix(longhorn): tolerate arc runner taint

### DIFF
--- a/argocd/applications/longhorn/longhorn-values.yaml
+++ b/argocd/applications/longhorn/longhorn-values.yaml
@@ -6,8 +6,33 @@ ingress:
   host: longhorn.lan
 persistence:
   defaultClassReplicaCount: 1
+global:
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: arc-runner
+      effect: NoSchedule
+longhornManager:
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: arc-runner
+      effect: NoSchedule
+longhornDriver:
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: arc-runner
+      effect: NoSchedule
+longhornUI:
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: arc-runner
+      effect: NoSchedule
 defaultSettings:
-  createDefaultDiskLabeledNodes: true
+  createDefaultDiskLabeledNodes: false
+  taintToleration: "dedicated=arc-runner:NoSchedule"
   storageReservedPercentageForDefaultDisk: 30
   storageMinimalAvailablePercentage: 20
   defaultReplicaCount: 1


### PR DESCRIPTION
## Summary
- allow Longhorn components and system-managed pods to tolerate arc-runner taint
- ensure Longhorn disks can be created on all nodes
- keep Longhorn settings aligned with dedicated runner nodes

## Related Issues
None

## Testing
- N/A (config change only)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
