### PR TITLE
fix(argocd): replace ApplicationSet CRD apply

### DIFF
--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -52,3 +52,4 @@ patches:
     target:
       kind: NetworkPolicy
       name: argocd-dex-server-network-policy
+  - path: overlays/argocd-applicationset-crd.yaml

--- a/argocd/applications/argocd/overlays/argocd-applicationset-crd.yaml
+++ b/argocd/applications/argocd/overlays/argocd-applicationset-crd.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applicationsets.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true


### PR DESCRIPTION
## Summary

- add Argo CD patch to replace the ApplicationSet CRD instead of client-side apply
- avoid oversized last-applied annotations during CRD reconciliation
- wire the patch into the Argo CD kustomization overlays

## Related Issues

None.

## Testing

- Not run (manifest-only change).

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
