### PR TITLE
fix(longhorn): apply csi toleration patch

### DIFF
--- a/argocd/applications/longhorn/kustomization.yaml
+++ b/argocd/applications/longhorn/kustomization.yaml
@@ -9,5 +9,10 @@ helmCharts:
     namespace: longhorn-system
     valuesFile: longhorn-values.yaml
     includeCRDs: true
-patchesStrategicMerge:
-  - patches/longhorn-csi-plugin-tolerations.patch.yaml
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: longhorn-csi-plugin
+    path: patches/longhorn-csi-plugin-tolerations.patch.yaml

--- a/argocd/applications/longhorn/patches/longhorn-csi-plugin-tolerations.patch.yaml
+++ b/argocd/applications/longhorn/patches/longhorn-csi-plugin-tolerations.patch.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: longhorn-csi-plugin
-  namespace: longhorn-system
 spec:
   template:
     spec:


### PR DESCRIPTION
## Summary

- Switch Longhorn CSI toleration patch to targeted `patches` entry.
- Remove namespace from the patch so kustomize can match the Helm-rendered DaemonSet.

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd`

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
