### PR TITLE
chore(torghut): deploy v0.377.4-3-g5e393f6e

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -17,13 +17,13 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "80"
-        client.knative.dev/updateTimestamp: 2025-12-29T01:50:48.323Z
+        client.knative.dev/updateTimestamp: 2025-12-30T08:55:07.224Z
     spec:
       containerConcurrency: 0
       timeoutSeconds: 60
       containers:
         - name: user-container
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9ecb053e4bb8464925b12171e5d648700f70ee8d409e0fedff8ca50cc5975f56
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e15edebfd74f95f307ca12e7a361317b0bf2137618af2c09630cf2552ec587e5
           imagePullPolicy: Always
           ports:
             - name: http1
@@ -72,9 +72,9 @@ spec:
             - name: CLICKHOUSE_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.374.2-9-g68d870d6
+              value: v0.377.4-3-g5e393f6e
             - name: TORGHUT_COMMIT
-              value: 68d870d6b2f1b01ab951e4bfc1f7e24ba5bb023f
+              value: 5e393f6e4bf5405b84a94e1e55dfb7e287417791
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:8493b91ab4b9ca50212c36b198a1f8f98d8a5c30797343247643b5243a872349
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:0e6755ee83a55a0836cd9fafc1de4b6ef7781e81f1abdcc1ea4737b7220dae5c
   imagePullPolicy: IfNotPresent
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
@@ -153,9 +153,9 @@ spec:
                   name: observability-minio-creds
                   key: secretkey
             - name: TORGHUT_TA_VERSION
-              value: v0.374.2-9-g68d870d6
+              value: v0.377.4-3-g5e393f6e
             - name: TORGHUT_TA_COMMIT
-              value: 68d870d6b2f1b01ab951e4bfc1f7e24ba5bb023f
+              value: 5e393f6e4bf5405b84a94e1e55dfb7e287417791
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2025-12-29T01:50:48.329Z
+        kubectl.kubernetes.io/restartedAt: 2025-12-30T08:55:07.229Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:
@@ -25,7 +25,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:8bc3d3eaaf3c298290846b55a1eb6aea0c5b173dc0ac89ef917cab0e632032f8
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:5dbda5ca4d04180cfb16c0fce5b52bb2c252f7330a6f6c7666cad6f12f862cba
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -49,9 +49,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: v0.374.2-9-g68d870d6
+              value: v0.377.4-3-g5e393f6e
             - name: TORGHUT_WS_COMMIT
-              value: 68d870d6b2f1b01ab951e4bfc1f7e24ba5bb023f
+              value: 5e393f6e4bf5405b84a94e1e55dfb7e287417791
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary

- Deploy torghut v0.377.4-3-g5e393f6e
- Update torghut app/websocket/TA image digests
- Refresh torghut version/commit env vars across manifests

## Related Issues

None

## Testing

- TORGHUT_SKIP_MIGRATIONS=true bun run deploy:torghut

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed as not applicable.
- [x] Documentation, release notes, and follow-ups are not required for this change.
