### PR TITLE
docs(jangar): route CI/review updates via Kafka

### DIFF
--- a/docs/jangar/codex-judge-argo-design.md
+++ b/docs/jangar/codex-judge-argo-design.md
@@ -308,4 +308,5 @@ stateDiagram-v2
 ## Default Policy Decisions
 - Prompt template location: `apps/froussard/src/codex.ts` (`buildImplementationPrompt`).
 - Max attempts: 3 (configurable); backoff: exponential (5m, 15m, 45m) with max cap 60m.
-- CI integration: GitHub checks/check-runs delivered via Froussard webhooks (no polling in Jangar).
+- CI integration: Froussard filters GitHub webhook events Jangar needs (CI + PR review signals) into a dedicated Kafka
+  topic; Jangar consumes that topic and updates run state (no polling in Jangar).


### PR DESCRIPTION
## Summary
- document CI/review updates flowing through a filtered Kafka stream instead of direct webhook fan-out
- list the GitHub events Froussard should filter for Jangar
- align CI integration notes with no-polling behavior

## Related Issues
None

## Testing
- N/A (docs-only changes)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
