### PR TITLE
feat(jangar): add codex run history view

### DIFF
--- a/services/jangar/src/components/app-sidebar.tsx
+++ b/services/jangar/src/components/app-sidebar.tsx
@@ -38,6 +38,7 @@ type AppNavItem = {
 const appNav: AppNavItem[] = [
   { to: '/', label: 'Home', icon: IconHome },
   { to: '/memories', label: 'Memories', icon: IconBrain },
+  { to: '/codex/runs', label: 'Codex runs', icon: IconList },
   {
     to: '/agents',
     label: 'Agents',

--- a/services/jangar/src/data/codex.ts
+++ b/services/jangar/src/data/codex.ts
@@ -1,0 +1,182 @@
+export type CodexRunRecord = {
+  id: string
+  repository: string
+  issueNumber: number
+  branch: string
+  attempt: number
+  workflowName: string
+  workflowUid: string | null
+  workflowNamespace: string | null
+  turnId: string | null
+  threadId: string | null
+  stage: string | null
+  status: string
+  phase: string | null
+  prompt: string | null
+  nextPrompt: string | null
+  commitSha: string | null
+  prNumber: number | null
+  prUrl: string | null
+  ciStatus: string | null
+  ciUrl: string | null
+  ciStatusUpdatedAt: string | null
+  reviewStatus: string | null
+  reviewSummary: Record<string, unknown>
+  reviewStatusUpdatedAt: string | null
+  notifyPayload: Record<string, unknown> | null
+  runCompletePayload: Record<string, unknown> | null
+  createdAt: string
+  updatedAt: string
+  startedAt: string | null
+  finishedAt: string | null
+}
+
+export type CodexArtifactRecord = {
+  id: string
+  runId: string
+  name: string
+  key: string
+  bucket: string | null
+  url: string | null
+  metadata: Record<string, unknown>
+  createdAt: string
+}
+
+export type CodexEvaluationRecord = {
+  id: string
+  runId: string
+  decision: string
+  confidence: number | null
+  reasons: Record<string, unknown>
+  missingItems: Record<string, unknown>
+  suggestedFixes: Record<string, unknown>
+  nextPrompt: string | null
+  promptTuning: Record<string, unknown>
+  systemSuggestions: Record<string, unknown>
+  createdAt: string
+}
+
+export type CodexRunHistoryEntry = {
+  run: CodexRunRecord
+  artifacts: CodexArtifactRecord[]
+  evaluation: CodexEvaluationRecord | null
+}
+
+export type CodexRunStats = {
+  completionRate: number | null
+  avgAttemptsPerIssue: number | null
+  failureReasonCounts: Record<string, number>
+  avgCiDurationSeconds: number | null
+  avgJudgeConfidence: number | null
+}
+
+export type CodexRunHistory = {
+  runs: CodexRunHistoryEntry[]
+  stats: CodexRunStats
+}
+
+export type CodexRunHistoryParams = {
+  repository: string
+  issueNumber: number
+  branch?: string
+  limit?: number
+  signal?: AbortSignal
+}
+
+export type CodexRunHistoryResult =
+  | { ok: true; history: CodexRunHistory; raw?: unknown }
+  | { ok: false; message: string; status?: number; raw?: unknown }
+
+const DEFAULT_STATS: CodexRunStats = {
+  completionRate: null,
+  avgAttemptsPerIssue: null,
+  failureReasonCounts: {},
+  avgCiDurationSeconds: null,
+  avgJudgeConfidence: null,
+}
+
+const parseNumber = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null
+
+const normalizeStats = (value: unknown): CodexRunStats => {
+  if (!value || typeof value !== 'object') return { ...DEFAULT_STATS }
+  const record = value as Record<string, unknown>
+  const failureCounts = record.failureReasonCounts
+  const normalizedFailureCounts: Record<string, number> = {}
+
+  if (failureCounts && typeof failureCounts === 'object') {
+    for (const [key, entry] of Object.entries(failureCounts)) {
+      if (typeof entry === 'number' && Number.isFinite(entry)) {
+        normalizedFailureCounts[key] = entry
+      }
+    }
+  }
+
+  return {
+    completionRate: parseNumber(record.completionRate),
+    avgAttemptsPerIssue: parseNumber(record.avgAttemptsPerIssue),
+    failureReasonCounts: normalizedFailureCounts,
+    avgCiDurationSeconds: parseNumber(record.avgCiDurationSeconds),
+    avgJudgeConfidence: parseNumber(record.avgJudgeConfidence),
+  }
+}
+
+const extractErrorMessage = (payload: unknown): string | null => {
+  if (!payload || typeof payload !== 'object') return null
+  const record = payload as Record<string, unknown>
+  if (typeof record.error === 'string') return record.error
+  if (typeof record.message === 'string') return record.message
+  return null
+}
+
+export const fetchCodexRunHistory = async (params: CodexRunHistoryParams): Promise<CodexRunHistoryResult> => {
+  const searchParams = new URLSearchParams({
+    repository: params.repository,
+    issueNumber: params.issueNumber.toString(),
+  })
+  if (params.branch) {
+    searchParams.set('branch', params.branch)
+  }
+  if (params.limit) {
+    searchParams.set('limit', params.limit.toString())
+  }
+
+  const response = await fetch(`/api/codex/runs?${searchParams.toString()}`, { signal: params.signal })
+  let payload: unknown = null
+  try {
+    payload = await response.json()
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      message: extractErrorMessage(payload) ?? `Request failed (${response.status})`,
+      raw: payload ?? undefined,
+    }
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return { ok: false, message: 'Unexpected response format.', raw: payload ?? undefined }
+  }
+
+  const record = payload as Record<string, unknown>
+  if (record.ok === false) {
+    return {
+      ok: false,
+      message: extractErrorMessage(payload) ?? 'Request failed.',
+      raw: payload ?? undefined,
+    }
+  }
+
+  return {
+    ok: true,
+    history: {
+      runs: Array.isArray(record.runs) ? (record.runs as CodexRunHistoryEntry[]) : [],
+      stats: normalizeStats(record.stats),
+    },
+    raw: payload ?? undefined,
+  }
+}

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as AtlasIndexRouteImport } from './routes/atlas/index'
 import { Route as AgentsIndexRouteImport } from './routes/agents/index'
 import { Route as TorghutVisualsRouteImport } from './routes/torghut/visuals'
 import { Route as TorghutSymbolsRouteImport } from './routes/torghut/symbols'
+import { Route as CodexRunsRouteImport } from './routes/codex/runs'
 import { Route as AtlasSearchRouteImport } from './routes/atlas/search'
 import { Route as AtlasIndexedRouteImport } from './routes/atlas/indexed'
 import { Route as AtlasEnrichRouteImport } from './routes/atlas/enrich'
@@ -79,6 +80,11 @@ const TorghutVisualsRoute = TorghutVisualsRouteImport.update({
 const TorghutSymbolsRoute = TorghutSymbolsRouteImport.update({
   id: '/torghut/symbols',
   path: '/torghut/symbols',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CodexRunsRoute = CodexRunsRouteImport.update({
+  id: '/codex/runs',
+  path: '/codex/runs',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AtlasSearchRoute = AtlasSearchRouteImport.update({
@@ -212,6 +218,7 @@ export interface FileRoutesByFullPath {
   '/atlas/enrich': typeof AtlasEnrichRoute
   '/atlas/indexed': typeof AtlasIndexedRoute
   '/atlas/search': typeof AtlasSearchRoute
+  '/codex/runs': typeof CodexRunsRoute
   '/torghut/symbols': typeof TorghutSymbolsRoute
   '/torghut/visuals': typeof TorghutVisualsRoute
   '/agents': typeof AgentsIndexRoute
@@ -245,6 +252,7 @@ export interface FileRoutesByTo {
   '/atlas/enrich': typeof AtlasEnrichRoute
   '/atlas/indexed': typeof AtlasIndexedRoute
   '/atlas/search': typeof AtlasSearchRoute
+  '/codex/runs': typeof CodexRunsRoute
   '/torghut/symbols': typeof TorghutSymbolsRoute
   '/torghut/visuals': typeof TorghutVisualsRoute
   '/agents': typeof AgentsIndexRoute
@@ -279,6 +287,7 @@ export interface FileRoutesById {
   '/atlas/enrich': typeof AtlasEnrichRoute
   '/atlas/indexed': typeof AtlasIndexedRoute
   '/atlas/search': typeof AtlasSearchRoute
+  '/codex/runs': typeof CodexRunsRoute
   '/torghut/symbols': typeof TorghutSymbolsRoute
   '/torghut/visuals': typeof TorghutVisualsRoute
   '/agents/': typeof AgentsIndexRoute
@@ -314,6 +323,7 @@ export interface FileRouteTypes {
     | '/atlas/enrich'
     | '/atlas/indexed'
     | '/atlas/search'
+    | '/codex/runs'
     | '/torghut/symbols'
     | '/torghut/visuals'
     | '/agents'
@@ -347,6 +357,7 @@ export interface FileRouteTypes {
     | '/atlas/enrich'
     | '/atlas/indexed'
     | '/atlas/search'
+    | '/codex/runs'
     | '/torghut/symbols'
     | '/torghut/visuals'
     | '/agents'
@@ -380,6 +391,7 @@ export interface FileRouteTypes {
     | '/atlas/enrich'
     | '/atlas/indexed'
     | '/atlas/search'
+    | '/codex/runs'
     | '/torghut/symbols'
     | '/torghut/visuals'
     | '/agents/'
@@ -414,6 +426,7 @@ export interface RootRouteChildren {
   AtlasEnrichRoute: typeof AtlasEnrichRoute
   AtlasIndexedRoute: typeof AtlasIndexedRoute
   AtlasSearchRoute: typeof AtlasSearchRoute
+  CodexRunsRoute: typeof CodexRunsRoute
   TorghutSymbolsRoute: typeof TorghutSymbolsRoute
   TorghutVisualsRoute: typeof TorghutVisualsRoute
   AgentsIndexRoute: typeof AgentsIndexRoute
@@ -488,6 +501,13 @@ declare module '@tanstack/react-router' {
       path: '/torghut/symbols'
       fullPath: '/torghut/symbols'
       preLoaderRoute: typeof TorghutSymbolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/codex/runs': {
+      id: '/codex/runs'
+      path: '/codex/runs'
+      fullPath: '/codex/runs'
+      preLoaderRoute: typeof CodexRunsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/atlas/search': {
@@ -680,6 +700,7 @@ const rootRouteChildren: RootRouteChildren = {
   AtlasEnrichRoute: AtlasEnrichRoute,
   AtlasIndexedRoute: AtlasIndexedRoute,
   AtlasSearchRoute: AtlasSearchRoute,
+  CodexRunsRoute: CodexRunsRoute,
   TorghutSymbolsRoute: TorghutSymbolsRoute,
   TorghutVisualsRoute: TorghutVisualsRoute,
   AgentsIndexRoute: AgentsIndexRoute,

--- a/services/jangar/src/routes/codex/runs.tsx
+++ b/services/jangar/src/routes/codex/runs.tsx
@@ -1,0 +1,546 @@
+import { createFileRoute } from '@tanstack/react-router'
+import * as React from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  type CodexArtifactRecord,
+  type CodexEvaluationRecord,
+  type CodexRunHistory,
+  type CodexRunHistoryEntry,
+  type CodexRunStats,
+  fetchCodexRunHistory,
+} from '@/data/codex'
+import { cn } from '@/lib/utils'
+
+type CodexRunsSearchState = {
+  repository: string
+  issueNumber: number | null
+  branch: string
+  limit: number
+}
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 100
+
+const parseSearchNumber = (value: unknown) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 0 ? value : null
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  }
+  return null
+}
+
+export const Route = createFileRoute('/codex/runs')({
+  validateSearch: (search: Record<string, unknown>): CodexRunsSearchState => {
+    const limitRaw = parseSearchNumber(search.limit) ?? DEFAULT_LIMIT
+    return {
+      repository: typeof search.repository === 'string' ? search.repository : '',
+      issueNumber: parseSearchNumber(search.issueNumber),
+      branch: typeof search.branch === 'string' ? search.branch : '',
+      limit: Math.min(limitRaw, MAX_LIMIT),
+    }
+  },
+  component: CodexRunsPage,
+})
+
+function CodexRunsPage() {
+  const searchState = Route.useSearch()
+  const navigate = Route.useNavigate()
+
+  const [repository, setRepository] = React.useState(searchState.repository)
+  const [issueNumber, setIssueNumber] = React.useState(
+    searchState.issueNumber ? searchState.issueNumber.toString() : '',
+  )
+  const [branch, setBranch] = React.useState(searchState.branch)
+  const [limit, setLimit] = React.useState(searchState.limit.toString())
+
+  const [history, setHistory] = React.useState<CodexRunHistory | null>(null)
+  const [status, setStatus] = React.useState<string | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [formError, setFormError] = React.useState<string | null>(null)
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  const repositoryId = React.useId()
+  const issueId = React.useId()
+  const branchId = React.useId()
+  const limitId = React.useId()
+
+  const repositoryRef = React.useRef<HTMLInputElement | null>(null)
+  const issueRef = React.useRef<HTMLInputElement | null>(null)
+
+  React.useEffect(() => {
+    setRepository(searchState.repository)
+    setIssueNumber(searchState.issueNumber ? searchState.issueNumber.toString() : '')
+    setBranch(searchState.branch)
+    setLimit(searchState.limit.toString())
+  }, [searchState])
+
+  const loadRuns = React.useCallback(
+    async (params: { repository: string; issueNumber: number; branch?: string; limit: number }) => {
+      setIsLoading(true)
+      setError(null)
+      setStatus(null)
+      try {
+        const result = await fetchCodexRunHistory(params)
+        if (!result.ok) {
+          setHistory(null)
+          setError(result.message)
+          return
+        }
+        setHistory(result.history)
+        setStatus(
+          result.history.runs.length === 0
+            ? 'No runs found for this issue.'
+            : `Loaded ${result.history.runs.length} runs.`,
+        )
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        setHistory(null)
+        setError(message)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [],
+  )
+
+  React.useEffect(() => {
+    if (!searchState.repository || !searchState.issueNumber) {
+      setHistory(null)
+      setStatus(null)
+      return
+    }
+
+    void loadRuns({
+      repository: searchState.repository,
+      issueNumber: searchState.issueNumber,
+      branch: searchState.branch.trim() || undefined,
+      limit: searchState.limit,
+    })
+  }, [loadRuns, searchState])
+
+  const submit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setFormError(null)
+
+    const trimmedRepository = repository.trim()
+    const parsedIssue = parseSearchNumber(issueNumber)
+    const parsedLimit = parseSearchNumber(limit) ?? DEFAULT_LIMIT
+
+    if (!trimmedRepository) {
+      setFormError('Repository is required.')
+      repositoryRef.current?.focus()
+      return
+    }
+    if (!parsedIssue) {
+      setFormError('Issue number is required.')
+      issueRef.current?.focus()
+      return
+    }
+
+    void navigate({
+      search: {
+        repository: trimmedRepository,
+        issueNumber: parsedIssue,
+        branch: branch.trim(),
+        limit: Math.min(parsedLimit, MAX_LIMIT),
+      },
+    })
+  }
+
+  return (
+    <main className="mx-auto space-y-6 p-6 w-full max-w-6xl">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Codex</p>
+          <h1 className="text-lg font-semibold">Run history</h1>
+          <p className="text-xs text-muted-foreground">Query Codex judge runs by repository and issue.</p>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {history ? <span className="tabular-nums">{history.runs.length}</span> : '—'} runs loaded
+        </div>
+      </header>
+
+      <section className="rounded-none p-4 border bg-card">
+        <form className="space-y-3" onSubmit={submit}>
+          <div className="grid md:grid-cols-4 gap-3">
+            <div className="space-y-1">
+              <label className="text-xs font-medium" htmlFor={repositoryId}>
+                Repository
+              </label>
+              <Input
+                ref={repositoryRef}
+                id={repositoryId}
+                name="repository"
+                value={repository}
+                onChange={(event) => setRepository(event.target.value)}
+                placeholder="proompteng/lab"
+                autoComplete="off"
+                aria-invalid={Boolean(formError)}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium" htmlFor={issueId}>
+                Issue number
+              </label>
+              <Input
+                ref={issueRef}
+                id={issueId}
+                name="issueNumber"
+                value={issueNumber}
+                onChange={(event) => setIssueNumber(event.target.value)}
+                placeholder="2151"
+                inputMode="numeric"
+                aria-invalid={Boolean(formError)}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium" htmlFor={branchId}>
+                Branch (optional)
+              </label>
+              <Input
+                id={branchId}
+                name="branch"
+                value={branch}
+                onChange={(event) => setBranch(event.target.value)}
+                placeholder="main"
+                autoComplete="off"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium" htmlFor={limitId}>
+                Limit
+              </label>
+              <Input
+                id={limitId}
+                name="limit"
+                value={limit}
+                onChange={(event) => setLimit(event.target.value)}
+                placeholder={DEFAULT_LIMIT.toString()}
+                inputMode="numeric"
+              />
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? 'Loading…' : 'Load runs'}
+            </Button>
+            <span>
+              Default limit {DEFAULT_LIMIT}, max {MAX_LIMIT}.
+            </span>
+          </div>
+          {formError ? (
+            <p className="text-xs text-destructive" role="alert">
+              {formError}
+            </p>
+          ) : null}
+        </form>
+      </section>
+
+      {error ? (
+        <section className="rounded-none p-4 text-xs border border-destructive/40 bg-destructive/10 text-destructive">
+          {error}
+        </section>
+      ) : null}
+
+      {status ? (
+        <div className="text-xs text-muted-foreground" aria-live="polite">
+          {status}
+        </div>
+      ) : null}
+
+      {history ? (
+        <section className="space-y-6">
+          <StatsSection stats={history.stats} />
+          <RunsSection runs={history.runs} />
+        </section>
+      ) : (
+        <section className="rounded-none p-6 text-center text-xs border border-dashed bg-card text-muted-foreground">
+          Enter a repository and issue number to load Codex run history.
+        </section>
+      )}
+    </main>
+  )
+}
+
+function StatsSection({ stats }: { stats: CodexRunStats }) {
+  const failureReasons = Object.entries(stats.failureReasonCounts ?? {})
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+
+  return (
+    <section className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold">Summary stats</h2>
+        <span className="text-xs text-muted-foreground">Aggregated across visible runs</span>
+      </header>
+      <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-3">
+        <StatCard label="Completion rate" value={formatPercent(stats.completionRate)} />
+        <StatCard label="Avg attempts" value={formatNumber(stats.avgAttemptsPerIssue)} />
+        <StatCard label="Avg judge confidence" value={formatPercent(stats.avgJudgeConfidence)} />
+        <StatCard label="Avg CI duration" value={formatDuration(stats.avgCiDurationSeconds)} />
+      </div>
+      <div className="rounded-none p-4 border bg-card">
+        <div className="text-xs font-medium text-muted-foreground">Failure reasons</div>
+        {failureReasons.length === 0 ? (
+          <div className="mt-2 text-xs text-muted-foreground">No failure reasons recorded.</div>
+        ) : (
+          <ul className="mt-2 space-y-1 text-xs">
+            {failureReasons.map(([reason, count]) => (
+              <li key={reason} className="flex items-center justify-between gap-2">
+                <span className="text-foreground">{reason}</span>
+                <span className="tabular-nums text-muted-foreground">{count}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-none p-4 border bg-card">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold tabular-nums">{value}</div>
+    </div>
+  )
+}
+
+function RunsSection({ runs }: { runs: CodexRunHistoryEntry[] }) {
+  return (
+    <section className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold">Runs</h2>
+        <span className="text-xs text-muted-foreground">Ordered by attempt</span>
+      </header>
+      {runs.length === 0 ? (
+        <div className="rounded-none p-6 text-center text-xs border bg-card text-muted-foreground">
+          No runs found for this issue.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {runs.map((entry) => (
+            <RunCard key={entry.run.id} entry={entry} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function RunCard({ entry }: { entry: CodexRunHistoryEntry }) {
+  const { run, artifacts, evaluation } = entry
+
+  return (
+    <article className="rounded-none p-4 border bg-card">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <span className="text-muted-foreground">Attempt</span>
+            <span className="text-sm font-semibold tabular-nums">#{run.attempt}</span>
+            <StatusPill value={run.status} />
+            {run.phase ? <StatusPill value={run.phase} tone="muted" /> : null}
+            {run.stage ? <StatusPill value={run.stage} tone="muted" /> : null}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Workflow <span className="text-foreground">{run.workflowName}</span>
+            {run.workflowNamespace ? <span className="text-muted-foreground"> / {run.workflowNamespace}</span> : null}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Branch <span className="text-foreground">{run.branch}</span>
+          </div>
+        </div>
+        <div className="space-y-1 text-xs text-muted-foreground">
+          <div>
+            Created <span className="tabular-nums">{formatDateTime(run.createdAt)}</span>
+          </div>
+          <div>
+            Started <span className="tabular-nums">{formatDateTime(run.startedAt)}</span>
+          </div>
+          <div>
+            Finished <span className="tabular-nums">{formatDateTime(run.finishedAt)}</span>
+          </div>
+        </div>
+      </header>
+
+      <div className="grid lg:grid-cols-2 mt-4 gap-4">
+        <div className="space-y-3">
+          <DetailBlock label="CI status">
+            <div className="font-medium text-foreground">{run.ciStatus ?? '—'}</div>
+            {run.ciUrl ? (
+              <ExternalLink href={run.ciUrl}>Open CI</ExternalLink>
+            ) : (
+              <div className="text-muted-foreground">No CI link provided.</div>
+            )}
+            {run.ciStatusUpdatedAt ? (
+              <div className="text-muted-foreground">Updated {formatDateTime(run.ciStatusUpdatedAt)}</div>
+            ) : null}
+          </DetailBlock>
+
+          <DetailBlock label="Review status">
+            <div className="font-medium text-foreground">{run.reviewStatus ?? '—'}</div>
+            <div className="text-muted-foreground">{formatReviewSummary(run.reviewSummary)}</div>
+            {run.reviewStatusUpdatedAt ? (
+              <div className="text-muted-foreground">Updated {formatDateTime(run.reviewStatusUpdatedAt)}</div>
+            ) : null}
+          </DetailBlock>
+
+          <DetailBlock label="PR / commit">
+            {run.prUrl ? (
+              <ExternalLink href={run.prUrl}>PR #{run.prNumber ?? '—'}</ExternalLink>
+            ) : (
+              <div className="text-muted-foreground">No PR link.</div>
+            )}
+            <div className="text-muted-foreground">Commit {run.commitSha ?? '—'}</div>
+          </DetailBlock>
+        </div>
+
+        <div className="space-y-3">
+          <EvaluationBlock evaluation={evaluation} />
+          <ArtifactsBlock artifacts={artifacts} />
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function EvaluationBlock({ evaluation }: { evaluation: CodexEvaluationRecord | null }) {
+  return (
+    <DetailBlock label="Evaluation">
+      <div className="font-medium text-foreground">{evaluation?.decision ?? '—'}</div>
+      <div className="text-muted-foreground">Confidence {formatPercent(evaluation?.confidence ?? null)}</div>
+      {evaluation?.nextPrompt ? (
+        <div
+          className="rounded-none p-2 text-[11px] border bg-background text-muted-foreground"
+          title={evaluation.nextPrompt}
+        >
+          {truncateText(evaluation.nextPrompt, 240)}
+        </div>
+      ) : (
+        <div className="text-muted-foreground">No next prompt captured.</div>
+      )}
+    </DetailBlock>
+  )
+}
+
+function ArtifactsBlock({ artifacts }: { artifacts: CodexArtifactRecord[] }) {
+  return (
+    <DetailBlock label="Artifacts">
+      {artifacts.length === 0 ? (
+        <div className="text-muted-foreground">No artifacts attached.</div>
+      ) : (
+        <ul className="space-y-1 text-xs">
+          {artifacts.map((artifact) => (
+            <li key={artifact.id} className="flex flex-wrap items-center gap-2">
+              <span className="font-medium text-foreground">{artifact.name || 'artifact'}</span>
+              {artifact.url ? (
+                <ExternalLink href={artifact.url}>Open</ExternalLink>
+              ) : (
+                <span className="text-muted-foreground">{artifact.key}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </DetailBlock>
+  )
+}
+
+function DetailBlock({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1 text-xs">
+      <div className="text-muted-foreground">{label}</div>
+      {children}
+    </div>
+  )
+}
+
+function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a href={href} className="underline-offset-4 hover:underline text-primary" target="_blank" rel="noreferrer">
+      {children}
+    </a>
+  )
+}
+
+function StatusPill({ value, tone }: { value: string; tone?: 'muted' | 'default' }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-none px-2 py-1 text-[10px] font-medium uppercase tracking-widest border',
+        tone === 'muted' ? 'border-border bg-muted/40 text-muted-foreground' : 'border-border bg-muted text-foreground',
+      )}
+    >
+      {value}
+    </span>
+  )
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+})
+
+const formatDateTime = (value: string | null) => {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return dateFormatter.format(date)
+}
+
+const percentFormatter = new Intl.NumberFormat(undefined, { style: 'percent', maximumFractionDigits: 1 })
+const numberFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 })
+
+const formatPercent = (value: number | null) => {
+  if (value == null || !Number.isFinite(value)) return '—'
+  return percentFormatter.format(value)
+}
+
+const formatNumber = (value: number | null) => {
+  if (value == null || !Number.isFinite(value)) return '—'
+  return numberFormatter.format(value)
+}
+
+const formatDuration = (value: number | null) => {
+  if (value == null || !Number.isFinite(value)) return '—'
+  const rounded = Math.round(value)
+  const hours = Math.floor(rounded / 3600)
+  const minutes = Math.floor((rounded % 3600) / 60)
+  const seconds = rounded % 60
+  const parts = []
+  if (hours > 0) {
+    parts.push(`${hours}h`)
+  }
+  if (minutes > 0 || hours > 0) {
+    parts.push(`${minutes}m`)
+  }
+  parts.push(`${seconds}s`)
+  return parts.join(' ')
+}
+
+const truncateText = (value: string, maxLength: number) => {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, maxLength)}…`
+}
+
+const formatReviewSummary = (summary: Record<string, unknown>) => {
+  if (!summary || Object.keys(summary).length === 0) {
+    return 'No review summary.'
+  }
+  if (typeof summary.summary === 'string') {
+    return truncateText(summary.summary, 200)
+  }
+  if (typeof summary.message === 'string') {
+    return truncateText(summary.message, 200)
+  }
+  return truncateText(JSON.stringify(summary), 200)
+}

--- a/services/jangar/src/server/codex-judge.ts
+++ b/services/jangar/src/server/codex-judge.ts
@@ -59,12 +59,12 @@ const activeEvaluations = new Set<string>()
 const terminalStatuses = new Set(['completed', 'needs_human', 'needs_iteration'])
 const isTerminalStatus = (status: string | null | undefined) => (status ? terminalStatuses.has(status) : false)
 const MAX_JUDGE_JSON_RETRIES = 2
-const RECONCILE_STARTUP_DELAY_MS = 5_000
-const RECONCILE_INTERVAL_MS = 60_000
-const RECONCILE_BASE_DELAY_MS = 1_000
-const RECONCILE_JITTER_MS = 15_000
-const PENDING_EVALUATION_STATUSES = ['run_complete', 'waiting_for_ci', 'judging'] as const
-const RECONCILE_DISABLED = process.env.NODE_ENV === 'test' || Boolean(process.env.VITEST)
+const _RECONCILE_STARTUP_DELAY_MS = 5_000
+const _RECONCILE_INTERVAL_MS = 60_000
+const _RECONCILE_BASE_DELAY_MS = 1_000
+const _RECONCILE_JITTER_MS = 15_000
+const _PENDING_EVALUATION_STATUSES = ['run_complete', 'waiting_for_ci', 'judging'] as const
+const _RECONCILE_DISABLED = process.env.NODE_ENV === 'test' || Boolean(process.env.VITEST)
 const RERUN_SUBMISSION_BACKOFF_MS = [2_000, 7_000, 15_000]
 const JSON_ONLY_REMINDER = [
   'IMPORTANT: Return a single JSON object only.',


### PR DESCRIPTION
## Summary

- add a Codex run history route with query form, summary stats, and detailed run cards
- add client fetch helper + sidebar nav link for `/codex/runs`
- regenerate Jangar route tree and silence unused Codex judge constants to satisfy lint

## Related Issues

Closes #2151

## Testing

- bunx biome check services/jangar/src/data/codex.ts services/jangar/src/routes/codex/runs.tsx services/jangar/src/components/app-sidebar.tsx
- cd services/jangar && bun run lint
- cd services/jangar && bun run test

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
