### PR TITLE
docs: add kubectl apply example for helm charts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@
 
 ## Kubernetes (kubectl)
 - Use explicit namespaces with kubectl (e.g., `kubectl get pods -n <ns>`).
+- Helm charts present: `mise exec helm@3 -- kustomize build --enable-helm <path> | kubectl apply -n <ns> -f -`.
 - CNPG access: `kubectl cnpg psql -n <ns> <cluster> -- <psql args>` (psql flags after `--`).
 
 ## When in Doubt


### PR DESCRIPTION
## Summary

- Add a kubectl apply example that pins Helm 3 via mise when kustomize renders Helm charts.

## Related Issues

None

## Testing

- N/A (documentation-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
