### PR TITLE
fix(harvester): grow kube disks and set manual routing

### DIFF
--- a/tofu/harvester/main.tf
+++ b/tofu/harvester/main.tf
@@ -21,7 +21,7 @@ locals {
   kube_master_memory    = "32Gi"
   kube_worker_memory    = "30Gi"
   docker_vm_memory      = "32Gi"
-  kube_node_disk_size   = "200Gi"
+  kube_node_disk_size   = "300Gi"
   docker_node_disk_size = "100Gi"
 
   master_mac_addresses = {
@@ -127,6 +127,17 @@ resource "harvester_network" "cluster_network" {
   cluster_network_name = data.harvester_clusternetwork.mgmt.name
   name                 = "cluster-network"
   vlan_id              = 1
+
+  labels = {
+    "network.harvesterhci.io/clusternetwork" = "mgmt"
+    "network.harvesterhci.io/ready"          = "true"
+    "network.harvesterhci.io/type"           = "L2VlanNetwork"
+    "network.harvesterhci.io/vlan-id"        = "1"
+  }
+
+  route_mode    = "manual"
+  route_cidr    = "192.168.1.0/24"
+  route_gateway = "192.168.1.254"
 }
 
 resource "harvester_virtualmachine" "kube-cluster" {


### PR DESCRIPTION
## Summary

- increase kube VM root disk size to 300Gi
- set Harvester cluster network routing to manual with explicit CIDR/gateway
- align network labels with current Harvester NAD metadata

## Related Issues

None

## Testing

- tofu plan
- kubectl --kubeconfig ~/.kube/altra.yaml -n default get pvc | rg 'kube-(master|worker)'

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts VM storage and network configuration for the Harvester-based K8s cluster.
> 
> - Bumps `local.kube_node_disk_size` from `200Gi` to `300Gi` in `tofu/harvester/main.tf`
> - Updates `harvester_network` `cluster_network` with explicit labels and sets `route_mode` to `manual` with `route_cidr` `192.168.1.0/24` and `route_gateway` `192.168.1.254`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2c61468af8c5245d3cb802608e8d819162da78b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->