### PR TITLE
feat(jangar): enforce codex review gate

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -88,8 +88,6 @@ spec:
                   key: token
             - name: JANGAR_CODEX_REVIEWERS
               value: codex,codex[bot],chatgpt-codex-connector,chatgpt-codex-connector[bot],gregkonush
-            - name: JANGAR_CODEX_REVIEW_POLICY
-              value: bypass
             - name: JANGAR_CI_EVENT_STREAM_ENABLED
               value: "true"
             - name: JANGAR_GITHUB_MIN_REQUEST_SPACING_MS

--- a/docs/nats-argo-agent-communications.md
+++ b/docs/nats-argo-agent-communications.md
@@ -290,12 +290,10 @@ Store creds as Kubernetes secrets in the appropriate namespaces; if needed, mirr
 
 ## Observability
 
-- Enable NATS monitoring endpoints.
-- Optionally enable `promExporter` in the NATS Helm values and add a scrape target in `argocd/applications/observability`.
-- Track:
-  - publish rate per subject
-  - JetStream storage growth
-  - consumer lag for `jangar-agent-comms`
+- Jangar emits OTLP metrics for SSE + agent comms (`services/jangar/src/server/metrics.ts`).
+- Alerts + dashboards are wired in `argocd/applications/observability/graf-mimir-rules.yaml` and
+  `argocd/applications/observability/codex-pipeline-dashboard-configmap.yaml` (Kafka lag + JetStream pending).
+- NATS monitoring endpoints / promExporter can be enabled if deeper JetStream telemetry is needed.
 
 ## Rollout plan
 

--- a/services/jangar/src/server/__tests__/codex-judge-artifact-fallback.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-artifact-fallback.test.ts
@@ -48,7 +48,6 @@ const globalState = globalThis as typeof globalThis & {
     githubToken: string | null
     githubApiBaseUrl: string
     codexReviewers: string[]
-    reviewBypassMode: 'strict' | 'timeout' | 'always'
     ciEventStreamEnabled: boolean
     ciMaxWaitMs: number
     reviewMaxWaitMs: number
@@ -117,7 +116,6 @@ if (!globalState.__codexJudgeConfigMock) {
     githubToken: null,
     githubApiBaseUrl: 'https://api.github.com',
     codexReviewers: [],
-    reviewBypassMode: 'strict',
     ciEventStreamEnabled: false,
     ciMaxWaitMs: 10_000,
     reviewMaxWaitMs: 10_000,

--- a/services/jangar/src/server/__tests__/codex-judge-ci.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-ci.test.ts
@@ -23,7 +23,6 @@ const globalState = globalThis as typeof globalThis & {
     githubToken: string | null
     githubApiBaseUrl: string
     codexReviewers: string[]
-    reviewBypassMode: 'strict' | 'timeout' | 'always'
     ciEventStreamEnabled: boolean
     ciMaxWaitMs: number
     reviewMaxWaitMs: number
@@ -99,7 +98,6 @@ if (!globalState.__codexJudgeConfigMock) {
     githubToken: null,
     githubApiBaseUrl: 'https://api.github.com',
     codexReviewers: [],
-    reviewBypassMode: 'strict',
     ciEventStreamEnabled: false,
     ciMaxWaitMs: 10_000,
     reviewMaxWaitMs: 10_000,
@@ -153,7 +151,6 @@ const config = {
   githubToken: null,
   githubApiBaseUrl: 'https://api.github.com',
   codexReviewers: [],
-  reviewBypassMode: 'strict',
   ciEventStreamEnabled: false,
   ciMaxWaitMs: 10_000,
   reviewMaxWaitMs: 10_000,

--- a/services/jangar/src/server/__tests__/codex-judge-github-events.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-github-events.test.ts
@@ -20,7 +20,6 @@ const globalState = globalThis as typeof globalThis & {
     githubToken: string | null
     githubApiBaseUrl: string
     codexReviewers: string[]
-    reviewBypassMode: 'strict' | 'timeout' | 'always'
     ciEventStreamEnabled: boolean
     ciMaxWaitMs: number
     reviewMaxWaitMs: number
@@ -64,7 +63,6 @@ const configMock = {
   githubToken: null,
   githubApiBaseUrl: 'https://api.github.com',
   codexReviewers: [],
-  reviewBypassMode: 'strict' as const,
   ciEventStreamEnabled: true,
   ciMaxWaitMs: 10_000,
   reviewMaxWaitMs: 10_000,

--- a/services/jangar/src/server/__tests__/codex-judge-memories.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-memories.test.ts
@@ -30,7 +30,6 @@ const globalState = globalThis as typeof globalThis & {
     githubToken: string | null
     githubApiBaseUrl: string
     codexReviewers: string[]
-    reviewBypassMode: 'strict' | 'timeout' | 'always'
     ciEventStreamEnabled: boolean
     ciMaxWaitMs: number
     reviewMaxWaitMs: number
@@ -112,7 +111,6 @@ if (!globalState.__codexJudgeConfigMock) {
     githubToken: null,
     githubApiBaseUrl: 'https://api.github.com',
     codexReviewers: [],
-    reviewBypassMode: 'strict',
     ciEventStreamEnabled: false,
     ciMaxWaitMs: 10_000,
     reviewMaxWaitMs: 10_000,
@@ -204,7 +202,6 @@ const config = {
   githubToken: null,
   githubApiBaseUrl: 'https://api.github.com',
   codexReviewers: [],
-  reviewBypassMode: 'strict',
   ciEventStreamEnabled: false,
   ciMaxWaitMs: 10_000,
   reviewMaxWaitMs: 10_000,

--- a/services/jangar/src/server/__tests__/codex-judge-supersede.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-supersede.test.ts
@@ -30,7 +30,6 @@ const globalState = globalThis as typeof globalThis & {
     githubToken: string | null
     githubApiBaseUrl: string
     codexReviewers: string[]
-    reviewBypassMode: 'strict' | 'timeout' | 'always'
     ciEventStreamEnabled: boolean
     ciMaxWaitMs: number
     reviewMaxWaitMs: number
@@ -99,7 +98,6 @@ if (!globalState.__codexJudgeConfigMock) {
     githubToken: null,
     githubApiBaseUrl: 'https://api.github.com',
     codexReviewers: [],
-    reviewBypassMode: 'strict',
     ciEventStreamEnabled: false,
     ciMaxWaitMs: 10_000,
     reviewMaxWaitMs: 10_000,
@@ -178,7 +176,6 @@ const config = {
   githubToken: null,
   githubApiBaseUrl: 'https://api.github.com',
   codexReviewers: [],
-  reviewBypassMode: 'strict',
   ciEventStreamEnabled: false,
   ciMaxWaitMs: 10_000,
   reviewMaxWaitMs: 10_000,

--- a/services/jangar/src/server/codex-judge-config.ts
+++ b/services/jangar/src/server/codex-judge-config.ts
@@ -2,7 +2,6 @@ export type CodexJudgeConfig = {
   githubToken: string | null
   githubApiBaseUrl: string
   codexReviewers: string[]
-  reviewBypassMode: 'strict' | 'timeout' | 'always'
   ciEventStreamEnabled: boolean
   ciMaxWaitMs: number
   reviewMaxWaitMs: number
@@ -37,18 +36,10 @@ const parseNumber = (raw: string | undefined, fallback: number) => {
   return parsed
 }
 
-const parseReviewBypassMode = (raw: string | undefined) => {
-  const normalized = (raw ?? '').trim().toLowerCase()
-  if (normalized === 'always' || normalized === 'bypass' || normalized === 'true') return 'always'
-  if (normalized === 'timeout' || normalized === 'bypass_on_timeout') return 'timeout'
-  return 'strict'
-}
-
 export const loadCodexJudgeConfig = (): CodexJudgeConfig => {
   const githubToken = (process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? '').trim() || null
   const githubApiBaseUrl = (process.env.GITHUB_API_BASE_URL ?? DEFAULT_GITHUB_API_BASE).trim()
   const codexReviewers = parseList(process.env.JANGAR_CODEX_REVIEWERS ?? process.env.CODEX_REVIEWERS)
-  const reviewBypassMode = parseReviewBypassMode(process.env.JANGAR_CODEX_REVIEW_POLICY)
   const ciEventStreamEnabled =
     (process.env.JANGAR_CI_EVENT_STREAM_ENABLED ?? process.env.JANGAR_GITHUB_EVENT_STREAM_ENABLED ?? 'false')
       .trim()
@@ -78,7 +69,6 @@ export const loadCodexJudgeConfig = (): CodexJudgeConfig => {
     githubToken,
     githubApiBaseUrl,
     codexReviewers,
-    reviewBypassMode,
     ciEventStreamEnabled,
     ciMaxWaitMs,
     reviewMaxWaitMs,


### PR DESCRIPTION
## Summary
- remove Codex review bypass config and logic so the review gate is always enforced
- update judge tests and Argo CD deployment env to match the stricter review policy
- refresh judge + agent comms docs to reflect current implementation state

## Related Issues
None

## Testing
- bun run lint (services/jangar)
- bun run tsc (services/jangar)
- bun run test (services/jangar)

## Breaking Changes
- `JANGAR_CODEX_REVIEW_POLICY` is no longer supported; review bypass has been removed.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the Codex PR review gate mandatory and removes all bypass behavior across config, code, and tests.
> 
> - Removes `JANGAR_CODEX_REVIEW_POLICY` support and all bypass logic; judge now waits for review completion in `codex-judge.ts`
> - Updates tests to drop `reviewBypassMode` from config mocks and assert waiting on pending reviews
> - Cleans `argocd/applications/jangar/deployment.yaml` by removing the review policy env var
> - Refreshes docs: progress inventory/date, marks run history UI and observability as done, clarifies review gate (no bypass), and details metrics/alerts and Discord link enrichment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf70777f71dc2bdcdc5944fd95bcf7bb55fd9480. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->