### PR TITLE
chore(torghut): curb clickhouse profiler logs

### DIFF
--- a/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
@@ -10,6 +10,24 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 spec:
   configuration:
+    files:
+      config.d/99-logging-overrides.xml: |-
+        <yandex>
+          <logger>
+            <level>information</level>
+          </logger>
+        </yandex>
+      users.d/99-profile-overrides.xml: |-
+        <yandex>
+          <profiles>
+            <default>
+              <!-- Disable sampling profiler logs to keep system tables small. -->
+              <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
+              <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
+              <log_profile_events>0</log_profile_events>
+            </default>
+          </profiles>
+        </yandex>
     zookeeper:
       nodes:
         - host: keeper-torghut-keeper

--- a/docs/torghut/main-service-consumer.md
+++ b/docs/torghut/main-service-consumer.md
@@ -1,4 +1,6 @@
-# torghut Main Service Consumer Guide
+# torghut Main Service Consumer Guide (Deprecated)
+
+> **Status (2026-01-01):** The main torghut service no longer consumes TA topics. This doc is retained for reference only if a future consumer is added.
 
 ## Purpose
 How the main torghut service should consume TA outputs and switch sources safely.


### PR DESCRIPTION
## Summary

- Disable ClickHouse sampling profiler logs and lower server logger level via CHI config overrides.
- Update torghut architecture notes to reflect TA consumption changes and current Kafka security mode.
- Mark the main service TA consumer guide as deprecated.

## Related Issues

None

## Testing

- Manual: queried ClickHouse `system.settings` to confirm `query_profiler_*` and `log_profile_events` are 0.
- Manual: checked `system.parts` sizes for trace/text/metric logs after restart.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - ClickHouse: add `configuration.files` overrides in `clickhouse-cluster.yaml` to set `config.d/99-logging-overrides.xml` (`logger.level=information`) and `users.d/99-profile-overrides.xml` (`query_profiler_*_period_ns=0`, `log_profile_events=0`).
> - Architecture docs: update flow to write TA outputs to ClickHouse, clarify main service no longer consumes TA topics, and note current Kafka client mode `SASL_PLAINTEXT`; adjust feature-flag and rollout notes accordingly.
> - Docs: mark `docs/torghut/main-service-consumer.md` as deprecated with a status note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcaf64480e5735d880ded248ec2bbfd7146a6721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->