### PR TITLE
chore(kafka): declare torghut ta topics

### DIFF
--- a/argocd/applications/kafka/torghut-topics.yaml
+++ b/argocd/applications/kafka/torghut-topics.yaml
@@ -57,3 +57,48 @@ spec:
     compression.type: lz4
     retention.ms: 604800000
     cleanup.policy: compact,delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: torghut.ta.bars.1s.v1
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    compression.type: lz4
+    retention.ms: 1209600000
+    cleanup.policy: delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: torghut.ta.signals.v1
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    compression.type: lz4
+    retention.ms: 1209600000
+    cleanup.policy: delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: torghut.ta.status.v1
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    compression.type: lz4
+    retention.ms: 604800000
+    cleanup.policy: compact,delete


### PR DESCRIPTION
## Summary

- Declare torghut TA Kafka topics (bars, signals, status) in GitOps.

## Related Issues

None

## Testing

- Manual: `kubectl get kafkatopic -n kafka | rg 'torghut.ta'`
- Manual: verified spec config for `torghut.ta.bars.1s.v1` via `kubectl get kafkatopic -o jsonpath`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds three TA Kafka topics to GitOps.
> 
> - Adds `torghut.ta.bars.1s.v1` and `torghut.ta.signals.v1` (1 partition, 3 replicas, `lz4`, 14d retention, `delete`)
> - Adds `torghut.ta.status.v1` (1 partition, 3 replicas, `lz4`, 7d retention, `compact,delete`)
> - Declared in `argocd/applications/kafka/torghut-topics.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8706868f37f3103c1f0ee79e4d03dce5bc57f96c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->