### PR TITLE
docs(torghut): add automated trading one-shot plan

### DIFF
--- a/docs/torghut/automated-trading.md
+++ b/docs/torghut/automated-trading.md
@@ -21,6 +21,18 @@ SignalIngestor -> DecisionEngine -> RiskEngine -> OrderExecutor -> Reconciler
                                    ↘ Persistence (trade_decisions, executions)
 ```
 
+```mermaid
+flowchart LR
+  CH[(ClickHouse ta_signals)] --> ING[SignalIngestor]
+  ING --> DEC[DecisionEngine]
+  DEC --> RISK[RiskEngine]
+  RISK --> EXEC[OrderExecutor]
+  EXEC --> ALPACA[Alpaca API]
+  EXEC --> DB[(Postgres: trade_decisions, executions)]
+  ALPACA --> REC[Reconciler]
+  REC --> DB
+```
+
 ## One‑Shot Execution Steps (implementation within a single Codex run)
 
 ### 1) Create trading modules (code)


### PR DESCRIPTION
## Summary

- Add a one-shot automated trading execution doc for torghut.

## Related Issues

None

## Testing

- N/A (documentation only)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section not applicable.
- [x] Documentation, release notes, and follow-ups are updated or tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a focused, end-to-end plan for implementing torghut’s automated trading pipeline.
> 
> - Defines components: `SignalIngestor -> DecisionEngine -> RiskEngine -> OrderExecutor -> Reconciler` with ClickHouse signals and Alpaca execution
> - Specifies new module layout under `services/torghut/app/trading/*` and service wiring via `TRADING_ENABLED`
> - Details config flags (`TRADING_MODE`, signal/universe sources, poll interval) and DB migrations (decision hash, timestamps, cursor)
> - Outlines idempotency via `decision_hash` and risk gates (position/notional limits, allowlist, paper/live gating)
> - Lists observability metrics/logs, deployment options (Knative vs worker), and unit/integration test scope
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fdec3e7dde789bcc19672383d9ea95752522b8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->