### PR TITLE
fix(harvester): rebind ga102 on node boot

### DIFF
--- a/tofu/harvester/templates/ga102-vfio-bind-daemonset.yaml
+++ b/tofu/harvester/templates/ga102-vfio-bind-daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ga102-vfio-bind
+  namespace: harvester-system
+  labels:
+    app.kubernetes.io/name: ga102-vfio-bind
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ga102-vfio-bind
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ga102-vfio-bind
+    spec:
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/hostname: altra
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: binder
+          image: busybox:1.36
+          securityContext:
+            privileged: true
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              set -e
+              chroot /host /sbin/modprobe vfio-pci || true
+              if [ -e /sys/bus/pci/devices/000c:01:00.0/driver_override ]; then
+                echo vfio-pci > /sys/bus/pci/devices/000c:01:00.0/driver_override
+                echo 000c:01:00.0 > /sys/bus/pci/drivers_probe
+              fi
+              sleep infinity
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+              readOnly: true
+            - name: host-sys
+              mountPath: /sys
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /
+        - name: host-sys
+          hostPath:
+            path: /sys


### PR DESCRIPTION
## Summary
- add Harvester DaemonSet to rebind GA102 GPU to vfio-pci on node boot
- document the new guardrail in the GPU passthrough runbook
- keep docker-host GPU passthrough stable after Harvester reboots

## Related Issues
None

## Testing
- `kubectl --kubeconfig ~/.kube/altra.yaml apply -f tofu/harvester/templates/ga102-vfio-bind-daemonset.yaml`
- `kubectl --kubeconfig ~/.kube/altra.yaml -n harvester-system get ds ga102-vfio-bind -o wide`

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures stable GPU passthrough after Harvester reboots by rebinding the GA102 GPU to `vfio-pci` on node boot.
> 
> - New `tofu/harvester/templates/ga102-vfio-bind-daemonset.yaml`: privileged BusyBox-based `DaemonSet` (node `altra`) that `modprobe`s `vfio-pci` and re-binds `000c:01:00.0`, then sleeps
> - Updates `docs/harvester-gpu-pci-passthrough.md`: adds a "Prevent drift" section with apply/remove commands and notes about node/GPU scoping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc6740d388d9f0c77fa0faf0f8839ed08f4df5f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->