### PR TITLE
chore: fix skill yaml and deploy jangar

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-01-02T09:09:29.973Z"
+    deploy.knative.dev/rollout: "2026-01-02T21:30:17.770Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -34,5 +34,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c4543b1d"
-    digest: sha256:7f07668bd13275c6afba43807ea5882258284139b66f7c93a30fbff4017f318f
+    newTag: "ba2692d5d"
+    digest: sha256:f78e66221db06cfc38a5cb17c9832d83a7c053630900d4b73d3464b6088d341d

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-description: Work with GitHub in this repo: PR creation, CI checks, and gh CLI operations.
+description: "Work with GitHub in this repo: PR creation, CI checks, and gh CLI operations."
 ---
 
 # GitHub

--- a/skills/temporal/SKILL.md
+++ b/skills/temporal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: temporal
-description: Operate Temporal workflows in this repo: start/list/inspect workflows, fetch history, debug nondeterminism, reset/cancel/terminate, and check task queues via Temporal CLI.
+description: "Operate Temporal workflows in this repo: start/list/inspect workflows, fetch history, debug nondeterminism, reset/cancel/terminate, and check task queues via Temporal CLI."
 ---
 
 # Temporal


### PR DESCRIPTION
## Summary

- Quote YAML descriptions in `skills/github` and `skills/temporal` so the skill loader parses them.
- Deploy Jangar image `ba2692d5d` and update the digest in Argo CD kustomization.
- Refresh the Jangar rollout annotation to trigger the deployment.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/jangar/deploy-service.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
