### PR TITLE
feat(jangar): terminal UX/perf follow-ups

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-01-02T22:26:09.532Z"
+    deploy.knative.dev/rollout: "2026-01-02T23:48:52.700Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -34,5 +34,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c5dc0b8b7"
-    digest: sha256:06207ebecddffd8d93a362cfcafb4f4fd1b9583a56d262840c3a66693e8b020b
+    newTag: "ae018ec0e"
+    digest: sha256:e7822487db213d4f515b90bd4c7e3a45deedabbecc4feacd12fc6b94089f5513

--- a/services/jangar/src/server/terminal-log-tailer.test.ts
+++ b/services/jangar/src/server/terminal-log-tailer.test.ts
@@ -1,0 +1,69 @@
+import { appendFile, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const decodeOutput = (payload: unknown) => {
+  if (!payload || typeof payload !== 'object') return null
+  if (!('type' in payload) || !('data' in payload)) return null
+  const record = payload as { type?: string; data?: string }
+  if (record.type !== 'output' || typeof record.data !== 'string') return null
+  return Buffer.from(record.data, 'base64').toString('utf8')
+}
+
+describe('TerminalLogTailer', () => {
+  const previousEnv = { ...process.env }
+  let logDir = ''
+
+  beforeEach(async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'jangar-terminal-log-'))
+    process.env.JANGAR_TERMINAL_LOG_DIR = logDir
+    process.env.JANGAR_TERMINAL_LOG_MAX_BYTES = '256'
+    process.env.JANGAR_TERMINAL_LOG_RETAIN_BYTES = '128'
+    vi.resetModules()
+  })
+
+  afterEach(async () => {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
+    Object.assign(process.env, previousEnv)
+    if (logDir) {
+      await rm(logDir, { recursive: true, force: true })
+    }
+  })
+
+  test('streams output after log trim', async () => {
+    const sessionId = 'jangar-terminal-log-test'
+    const { getTerminalLogPath } = await import('./terminals')
+    const { TerminalLogTailer } = await import('./terminal-log-tailer')
+
+    const logPath = await getTerminalLogPath(sessionId)
+    const outputs: string[] = []
+
+    const tailer = new TerminalLogTailer(sessionId, { watch: false, minPollIntervalMs: 5, maxPollIntervalMs: 10 })
+    await tailer.addPeer({
+      send: (payload) => {
+        const decoded = decodeOutput(payload)
+        if (decoded) outputs.push(decoded)
+      },
+    })
+
+    await appendFile(logPath, 'alpha-'.repeat(24))
+    await tailer.readNow()
+
+    await appendFile(logPath, 'beta-'.repeat(40))
+    await tailer.readNow()
+
+    await appendFile(logPath, 'gamma')
+    await tailer.readNow()
+
+    tailer.dispose()
+
+    const combined = outputs.join('')
+    expect(combined).toContain('alpha-')
+    expect(combined).toContain('beta-')
+    expect(combined).toContain('gamma')
+  })
+})

--- a/services/jangar/src/server/terminal-log-tailer.ts
+++ b/services/jangar/src/server/terminal-log-tailer.ts
@@ -1,0 +1,199 @@
+import { watch } from 'node:fs'
+import { open as openFile } from 'node:fs/promises'
+
+import { getTerminalLogPath, trimTerminalLogIfNeeded } from './terminals'
+
+const DEFAULT_MIN_POLL_MS = 60
+const DEFAULT_MAX_POLL_MS = 1000
+const DEFAULT_READ_CHUNK_BYTES = 64 * 1024
+const LOG_TRIM_COOLDOWN_MS = 5000
+
+type TailerPeer = {
+  send: (payload: unknown) => void
+}
+
+type TerminalLogTailerOptions = {
+  minPollIntervalMs?: number
+  maxPollIntervalMs?: number
+  readChunkBytes?: number
+  watch?: boolean
+}
+
+const encodeBase64 = (value: Uint8Array) => Buffer.from(value).toString('base64')
+
+export class TerminalLogTailer {
+  private readonly sessionId: string
+  private readonly minPollMs: number
+  private readonly maxPollMs: number
+  private readonly readChunkBytes: number
+  private readonly watchEnabled: boolean
+  private peers = new Set<TailerPeer>()
+  private handle: Awaited<ReturnType<typeof openFile>> | null = null
+  private watcher: ReturnType<typeof watch> | null = null
+  private offset = 0
+  private pollTimer: ReturnType<typeof setTimeout> | null = null
+  private pollIntervalMs: number
+  private reading = false
+  private readQueued = false
+  private lastTrimAt = 0
+  private logPath: string | null = null
+
+  constructor(sessionId: string, options: TerminalLogTailerOptions = {}) {
+    this.sessionId = sessionId
+    this.minPollMs = options.minPollIntervalMs ?? DEFAULT_MIN_POLL_MS
+    this.maxPollMs = options.maxPollIntervalMs ?? DEFAULT_MAX_POLL_MS
+    this.readChunkBytes = options.readChunkBytes ?? DEFAULT_READ_CHUNK_BYTES
+    this.watchEnabled = options.watch ?? true
+    this.pollIntervalMs = this.minPollMs
+  }
+
+  async addPeer(peer: TailerPeer) {
+    this.peers.add(peer)
+    await this.ensureHandle()
+    this.pollIntervalMs = this.minPollMs
+    this.ensureWatch()
+    this.queueRead(0)
+    this.ensurePoll()
+  }
+
+  removePeer(peer: TailerPeer) {
+    this.peers.delete(peer)
+    if (this.peers.size === 0) {
+      this.stop()
+    }
+  }
+
+  async readNow() {
+    await this.readOnce()
+  }
+
+  getPeerCount() {
+    return this.peers.size
+  }
+
+  dispose() {
+    this.peers.clear()
+    this.stop()
+  }
+
+  private async ensureHandle() {
+    if (this.handle) return
+    const logPath = await getTerminalLogPath(this.sessionId)
+    this.logPath = logPath
+    this.handle = await openFile(logPath, 'r')
+    const stats = await this.handle.stat()
+    this.offset = stats.size
+  }
+
+  private ensureWatch() {
+    if (!this.watchEnabled || this.watcher || !this.logPath) return
+    try {
+      this.watcher = watch(this.logPath, { persistent: false }, () => {
+        this.queueRead(0)
+      })
+      this.watcher.on('error', () => {
+        this.watcher?.close()
+        this.watcher = null
+      })
+    } catch {
+      this.watcher = null
+    }
+  }
+
+  private ensurePoll() {
+    if (this.pollTimer || this.peers.size === 0) return
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null
+      void this.readOnce()
+    }, this.pollIntervalMs)
+  }
+
+  private stop() {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer)
+      this.pollTimer = null
+    }
+    if (this.watcher) {
+      this.watcher.close()
+      this.watcher = null
+    }
+    if (this.handle) {
+      void this.handle.close().catch(() => {})
+      this.handle = null
+    }
+    this.offset = 0
+  }
+
+  private queueRead(delayMs: number) {
+    if (this.readQueued || this.peers.size === 0) return
+    this.readQueued = true
+    setTimeout(() => {
+      this.readQueued = false
+      void this.readOnce()
+    }, delayMs)
+  }
+
+  private async readOnce() {
+    if (this.reading || this.peers.size === 0) {
+      this.ensurePoll()
+      return
+    }
+    this.reading = true
+    try {
+      await this.ensureHandle()
+      if (!this.handle) return
+
+      let stats = await this.handle.stat()
+      if (stats.size < this.offset) {
+        this.offset = stats.size
+      }
+
+      const now = Date.now()
+      if (stats.size > 0 && now - this.lastTrimAt > LOG_TRIM_COOLDOWN_MS) {
+        const result = await trimTerminalLogIfNeeded(this.sessionId)
+        if (result.trimmed) {
+          stats = await this.handle.stat()
+          this.offset = Math.min(this.offset, stats.size)
+        }
+        this.lastTrimAt = now
+      }
+
+      let bytesSent = 0
+      while (stats.size > this.offset) {
+        const remaining = stats.size - this.offset
+        const chunkSize = Math.min(remaining, this.readChunkBytes)
+        const buffer = Buffer.alloc(chunkSize)
+        const { bytesRead } = await this.handle.read(buffer, 0, chunkSize, this.offset)
+        if (!bytesRead) break
+        this.offset += bytesRead
+        bytesSent += bytesRead
+        this.broadcast({ type: 'output', data: encodeBase64(buffer.subarray(0, bytesRead)) })
+      }
+
+      if (bytesSent > 0) {
+        this.pollIntervalMs = this.minPollMs
+      } else {
+        this.pollIntervalMs = Math.min(this.maxPollMs, Math.round(this.pollIntervalMs * 1.4))
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to read terminal log.'
+      this.broadcast({ type: 'error', message, fatal: false })
+      this.pollIntervalMs = Math.min(this.maxPollMs, Math.round(this.pollIntervalMs * 1.6))
+    } finally {
+      this.reading = false
+      this.ensurePoll()
+    }
+  }
+
+  private broadcast(payload: unknown) {
+    for (const peer of this.peers) {
+      try {
+        peer.send(payload)
+      } catch {
+        // ignore peer errors
+      }
+    }
+  }
+}
+
+export type { TailerPeer, TerminalLogTailerOptions }

--- a/services/jangar/tests/deployed.e2e.ts
+++ b/services/jangar/tests/deployed.e2e.ts
@@ -80,6 +80,9 @@ const readTerminalSize = async (page: import('@playwright/test').Page) =>
     return { cols, rows }
   })
 
+const readActiveTestId = async (page: import('@playwright/test').Page) =>
+  page.evaluate(() => document.activeElement?.getAttribute('data-testid') ?? '')
+
 const assertWebSocketStaysOpen = async (
   page: import('@playwright/test').Page,
   status: { wasClosed: () => boolean },
@@ -440,6 +443,34 @@ test.describe('deployed jangar e2e', () => {
     await expect(page.locator('.xterm-rows')).toContainText('LINE-1:', { timeout: 5_000 })
 
     await page.keyboard.press('Enter')
+
+    await request.post(`/api/terminals/${encodeURIComponent(sessionId)}/terminate`)
+    await expect.poll(() => fetchSessionStatus(sessionId), { timeout: 30_000 }).toBe('closed')
+  })
+
+  test('terminal focus UX is keyboard focusable without auto-focus', async ({ page, request }) => {
+    test.setTimeout(120_000)
+
+    const createResponse = await request.get('/api/terminals?create=1')
+    expect(createResponse.ok()).toBe(true)
+    const createPayload = (await createResponse.json()) as { ok?: boolean; session?: { id?: string } }
+    expect(createPayload.ok).toBe(true)
+    const sessionId = createPayload.session?.id ?? ''
+    expect(sessionId).toMatch(/^jangar-terminal-/)
+    await expect.poll(() => fetchSessionStatus(sessionId), { timeout: 90_000 }).toBe('ready')
+
+    await page.goto(`/terminals/${sessionId}`)
+    await waitForHydration(page)
+    await expect(page.getByText('Status: connected', { exact: false })).toBeVisible({ timeout: 20_000 })
+
+    const activeTestId = await readActiveTestId(page)
+    expect(activeTestId).not.toBe('terminal-canvas')
+    await expect(page.getByText('Focus: inactive')).toBeVisible()
+
+    const terminal = page.getByTestId('terminal-canvas')
+    await terminal.focus()
+    await expect(terminal).toBeFocused()
+    await expect(page.getByText('Focus: active')).toBeVisible()
 
     await request.post(`/api/terminals/${encodeURIComponent(sessionId)}/terminate`)
     await expect.poll(() => fetchSessionStatus(sessionId), { timeout: 30_000 }).toBe('closed')


### PR DESCRIPTION
## Summary
- add shared terminal log tailer with backoff polling + log trimming limits
- throttle snapshot capture per session and coalesce snapshot requests
- refine terminal focus UX and add coverage for focus behavior and log trimming

## Related Issues
- Closes #2292

## Testing
- cd services/jangar && bun run tsc
- cd services/jangar && bun run lint
- cd services/jangar && bun run test -- src/server/terminal-log-tailer.test.ts

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
