### PR TITLE
docs(jangar): add in-app PR review design

### DIFF
--- a/docs/jangar/github-pr-review-in-app.md
+++ b/docs/jangar/github-pr-review-in-app.md
@@ -123,7 +123,7 @@ flowchart LR
   FR -->|raw payloads| RAW
   FR -->|filtered PR + review + CI| CJ
   CJ --> KS[KafkaSource jangar-codex-github-events]
-  KS --> JAPI[/api/codex/github-events]
+  KS --> JAPI["/api/codex/github-events"]
   JAPI --> JDB[(Jangar DB)]
   JDB --> JUI[Jangar PR Review UI]
 ```


### PR DESCRIPTION
## Summary

- Add Jangar design doc for in-app GitHub PR review/merge.
- Ground event ingestion on Froussard Kafka topics + existing Jangar webhook consumer.
- Document no-polling requirement and CI/review signal sources.

## Related Issues

None

## Testing

- N/A (documentation only)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
