### PR TITLE
fix(minio): harden object browser init clone

### DIFF
--- a/argocd/applications/minio/observability-object-browser-deployment.yaml
+++ b/argocd/applications/minio/observability-object-browser-deployment.yaml
@@ -49,6 +49,7 @@ spec:
               export GOMODCACHE=/work/modcache
               export GOPATH=/work/gopath
               mkdir -p /work/bin "$GOCACHE" "$GOMODCACHE" "$GOPATH"
+              rm -rf /work/src
               git clone --depth 1 --branch v2.0.4 https://github.com/minio/object-browser.git /work/src
               cd /work/src
               GO111MODULE=on CGO_ENABLED=0 go build -trimpath --tags=kqueue --ldflags "-s -w" -o /work/console ./cmd/console


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- Ensure object browser init container cleans stale /work/src before cloning.
- Prevent CrashLoopBackOff when the init container restarts in-place.

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- N/A (manifest change; will be validated via ArgoCD sync)

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->
None.

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
