### PR TITLE
fix(torghut): handle yaml parse errors in catalog

### DIFF
--- a/services/torghut/app/strategies/catalog.py
+++ b/services/torghut/app/strategies/catalog.py
@@ -91,7 +91,7 @@ class StrategyCatalog:
             if digest == self._last_digest:
                 return False
             catalog = _parse_catalog_payload(payload)
-        except (OSError, json.JSONDecodeError, ValidationError, ValueError) as exc:
+        except (OSError, json.JSONDecodeError, ValidationError, ValueError, yaml.YAMLError) as exc:
             logger.warning("Strategy catalog load failed path=%s error=%s", self.path, exc)
             return False
 


### PR DESCRIPTION
## Summary
- catch YAML parse errors in strategy catalog reload to avoid crashing trading loop

## Related Issues
None

## Testing
- Not run (not requested)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
