### PR TITLE
docs(jangar): one-shot autonomous codex run design

### DIFF
--- a/docs/jangar/codex-one-shot-autonomy.md
+++ b/docs/jangar/codex-one-shot-autonomy.md
@@ -165,7 +165,14 @@ flowchart LR
 - GitOps preferred: merge triggers Argo CD sync.
 - Optionally trigger Argo deploy workflow via `argo-client.ts`.
 
-### 5.11 Step 10: Persist Evidence
+### 5.11 Step 10: Post-Deploy Verification (Required)
+After the deployment is reported ready, the system must **automatically run end-to-end and integration tests**.
+- Run service-level integration suites (API + workflow hooks).
+- Run UI E2E suites (Playwright) covering the PR review surface and judge linkage.
+- Failures must gate completion and trigger either rollback or `needs_iteration`.
+  - Record failures in artifacts and `codex_judge.evaluations` with a clear reason.
+
+### 5.12 Step 11: Persist Evidence
 - Store artifacts in `codex_judge.artifacts`.
 - Store evaluation in `codex_judge.evaluations`.
 - Store memories in `memories.entries`.
@@ -270,6 +277,7 @@ stateDiagram-v2
 - CI + review + mergeable = pass.
 - Judge decision = pass.
 - PR merged and deployment triggered.
+- Post-deploy E2E + integration tests completed successfully.
 - Artifacts and memories persisted.
 
 ## 11) Operational Notes


### PR DESCRIPTION
## Summary

- add a one-shot autonomous Codex run design doc for Jangar
- document current cluster + database grounding and observed gaps
- include detailed workflow, data model, API, and UI requirements with mermaid diagrams

## Related Issues

None

## Testing

- N/A (documentation-only change)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
