### PR TITLE
docs(jangar): add autonomous codex design v2

### DIFF
--- a/docs/jangar/autonomous-codex-end-to-end-design-v2.md
+++ b/docs/jangar/autonomous-codex-end-to-end-design-v2.md
@@ -120,7 +120,7 @@ Before implementation or judge begins, the workflow must:
 
 ### 5.2 Two modes
 - **Implementation mode**: runs Codex, writes implementation artifacts and notify payload.
-- **Judge mode**: runs judge prompt (Codex or specialized judge binary), produces evaluation payload and required system-improvement output.
+- **Judge mode**: runs the **same Codex runtime** with a different prompt; no separate judge binary or model is allowed unless explicitly configured later.
 
 The only difference between the two modes must be the prompt and the step label. All infrastructure and capture logic is shared.
 


### PR DESCRIPTION
## Summary

- add Argo-first autonomous design v2 doc with one-turn completion contract and success guarantees
- define Argo DAG node wiring + mermaid diagram and fail-fast invariants
- add reliability/acceptance criteria and preflight requirements for production readiness

## Related Issues

None

## Testing

- N/A (documentation only)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
