### PR TITLE
fix(agent-comms): stabilize SSE and general publishes

### DIFF
--- a/apps/froussard/scripts/codex-nats-publish.ts
+++ b/apps/froussard/scripts/codex-nats-publish.ts
@@ -293,12 +293,13 @@ const main = async () => {
   const publishLine = async (line: string) => {
     const content = line.trim()
     if (!content) return
-    const messageId = crypto.randomUUID()
+    const runMessageId = crypto.randomUUID()
     const sentAt = new Date().toISOString()
-    const payload = buildPayload(options, content, context, options.channel, messageId, sentAt)
+    const payload = buildPayload(options, content, context, options.channel, runMessageId, sentAt)
     await publishPayload(runSubject, payload, natsArgs)
     if (options.publishGeneral) {
-      const generalPayload = buildPayload(options, content, context, 'general', messageId, sentAt)
+      const generalMessageId = crypto.randomUUID()
+      const generalPayload = buildPayload(options, content, context, 'general', generalMessageId, sentAt)
       await publishPayload(generalSubject, generalPayload, natsArgs)
     }
   }

--- a/services/jangar/src/components/agent-comms.tsx
+++ b/services/jangar/src/components/agent-comms.tsx
@@ -177,12 +177,12 @@ export const useAgentEventStream = ({ runId, channel, maxMessages }: AgentStream
 
     source.onopen = () => {
       setStatus('open')
+      setError(null)
     }
 
     source.onerror = () => {
       setStatus('error')
-      setError('Stream disconnected. Refresh to retry.')
-      source.close()
+      setError('Stream disconnected. Retrying...')
     }
 
     source.onmessage = (event) => {


### PR DESCRIPTION
## Summary
- keep agent SSE connections alive with an initial comment + retry directive
- let the UI retry EventSource connections instead of hard-closing on transient errors
- use unique message ids when publishing general channel events to avoid dedupe drops

## Related Issues
None

## Testing
- Not run (not requested)

## Screenshots (if applicable)
Not applicable.

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
