### PR TITLE
fix(argo): require nats publish

### DIFF
--- a/argocd/applications/argo-workflows/codex-research-workflow.yaml
+++ b/argocd/applications/argo-workflows/codex-research-workflow.yaml
@@ -111,7 +111,7 @@ spec:
 
             if [[ -x "$NATS_PUBLISHER" ]]; then
               touch "$AGENT_LOG_PATH"
-              "$NATS_PUBLISHER" --kind status --status started --content "research started" --publish-general || true
+              "$NATS_PUBLISHER" --kind status --status started --content "research started" --publish-general
               "$NATS_PUBLISHER" --kind log --log-file "$AGENT_LOG_PATH" &
               NATS_TAIL_PID=$!
             fi
@@ -133,7 +133,7 @@ spec:
             cleanup_nats
 
             if [[ -x "$NATS_PUBLISHER" ]]; then
-              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "research completed" --publish-general || true
+              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "research completed" --publish-general
             fi
 
             exit "$EXIT_CODE"

--- a/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
+++ b/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
@@ -427,6 +427,7 @@ spec:
             # Ensure judge output files exist for all stages to satisfy Argo output collection.
             : > "/workspace/lab/.codex-judge-decision.txt"
             : > "/workspace/lab/.codex-judge-next-prompt.txt"
+            : > "/workspace/lab/.codex-nats-context.json"
 
             if ! git -C "$WORKTREE_DIR" rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1 \
               && ! git -C "$WORKTREE_DIR" rev-parse --verify "origin/$BASE_BRANCH" >/dev/null 2>&1; then
@@ -457,7 +458,7 @@ spec:
 
             if [[ -x "$NATS_PUBLISHER" ]]; then
               touch "$AGENT_LOG_PATH"
-              "$NATS_PUBLISHER" --kind status --status started --content "${WORKFLOW_STAGE} started" --publish-general || true
+              "$NATS_PUBLISHER" --kind status --status started --content "${WORKFLOW_STAGE} started" --publish-general
               "$NATS_PUBLISHER" --kind log --log-file "$AGENT_LOG_PATH" &
               NATS_TAIL_PID=$!
             fi
@@ -479,7 +480,7 @@ spec:
             cleanup_nats
 
             if [[ -x "$NATS_PUBLISHER" ]]; then
-              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "${WORKFLOW_STAGE} completed" --publish-general || true
+              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "${WORKFLOW_STAGE} completed" --publish-general
             fi
 
             exit "$EXIT_CODE"

--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -193,6 +193,7 @@ spec:
             # Ensure judge output files exist for all stages to satisfy Argo output collection.
             : > "/workspace/lab/.codex-judge-decision.txt"
             : > "/workspace/lab/.codex-judge-next-prompt.txt"
+            : > "/workspace/lab/.codex-nats-context.json"
 
             if ! git -C "$WORKTREE_DIR" rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1 \
               && ! git -C "$WORKTREE_DIR" rev-parse --verify "origin/$BASE_BRANCH" >/dev/null 2>&1; then
@@ -218,7 +219,7 @@ spec:
 
             if [[ -x "$NATS_PUBLISHER" ]]; then
               touch "$AGENT_LOG_PATH"
-              "$NATS_PUBLISHER" --kind status --status started --content "implementation started" --publish-general || true
+              "$NATS_PUBLISHER" --kind status --status started --content "implementation started" --publish-general
               "$NATS_PUBLISHER" --kind log --log-file "$AGENT_LOG_PATH" &
               NATS_TAIL_PID=$!
             fi
@@ -240,7 +241,7 @@ spec:
             cleanup_nats
 
             if [[ -x "$NATS_PUBLISHER" ]]; then
-              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "implementation completed" --publish-general || true
+              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "implementation completed" --publish-general
             fi
 
             exit "$EXIT_CODE"
@@ -593,7 +594,7 @@ spec:
 
             if [[ -x "$NATS_PUBLISHER" ]]; then
               touch "$AGENT_LOG_PATH"
-              "$NATS_PUBLISHER" --kind status --status started --content "${WORKFLOW_STAGE} started" --publish-general || true
+              "$NATS_PUBLISHER" --kind status --status started --content "${WORKFLOW_STAGE} started" --publish-general
               "$NATS_PUBLISHER" --kind log --log-file "$AGENT_LOG_PATH" &
               NATS_TAIL_PID=$!
             fi
@@ -615,7 +616,7 @@ spec:
             cleanup_nats
 
             if [[ -x "$NATS_PUBLISHER" ]]; then
-              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "${WORKFLOW_STAGE} completed" --publish-general || true
+              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "${WORKFLOW_STAGE} completed" --publish-general
             fi
 
             exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary

- remove `|| true` around `codex-nats-publish` so failures surface in Argo steps
- pre-create `.codex-nats-context.json` in codex workflows to avoid missing artifact errors
- apply the same behavior across implementation/autonomous/research templates

## Related Issues

None

## Testing

- N/A (manifest-only change)

## Screenshots (if applicable)

N/A

## Breaking Changes

Workflows now fail if `codex-nats-publish` exits non-zero.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
