### PR TITLE
chore(deploy): update froussard and jangar images

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -20,7 +20,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:1fa1a811ec77ed96bf33bb75ff1b09ddf013eb04e1044c1554103ff31c4b84ab
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:adc2215803c2b19f520a51b45bf28cc79d29591059c38f28e576798fc9f88204
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -67,9 +67,9 @@ spec:
             - name: OTEL_SERVICE_NAMESPACE
               value: froussard
             - name: FROUSSARD_VERSION
-              value: v0.390.3-4-gb81cb73b6
+              value: v0.396.1-1-g8c1fcf958
             - name: FROUSSARD_COMMIT
-              value: b81cb73b656c9d61c3c28648450d75a0101e98eb
+              value: 8c1fcf958f66f9ac72f3756c53f7161bcdd64999
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-01-04T09:41:13.639Z"
+    deploy.knative.dev/rollout: "2026-01-04T21:23:37.552Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -34,5 +34,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a7cc14f92"
-    digest: sha256:cf99f1501b0c5c954f278570d6bcb3d7fed1094db64cf48f369f8c8b90651a42
+    newTag: "8c1fcf958"
+    digest: sha256:7f9b61fc52c6ad1418011baffccce1b281a14ed6bc067b2e340cd33ccf085b8e


### PR DESCRIPTION
## Summary

- Deploy the latest Froussard image digest in the Knative service manifest.
- Bump Jangar image tag in kustomize and refresh the rollout annotation.
- No functional config changes beyond image/rollout updates.

## Related Issues

None

## Testing

- bun run packages/scripts/src/froussard/deploy-service.ts
- bun run packages/scripts/src/jangar/deploy-service.ts

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
