### PR TITLE
chore(argocd): move crossplane to crossplane namespace

### DIFF
--- a/argocd/applications/crossplane/kustomization.yaml
+++ b/argocd/applications/crossplane/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: crossplane-system
+namespace: crossplane
 helmCharts:
   - name: crossplane
     repo: https://charts.crossplane.io/stable
     version: 2.1.3
     releaseName: crossplane
-    namespace: crossplane-system
+    namespace: crossplane
     includeCRDs: true

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -32,7 +32,7 @@ spec:
             enabled: "true"
           - name: crossplane
             path: argocd/applications/crossplane
-            namespace: crossplane-system
+            namespace: crossplane
             annotations:
               argocd.argoproj.io/sync-wave: "-1"
             automation: manual


### PR DESCRIPTION
## Summary

- move crossplane app namespace to `crossplane` in platform ApplicationSet
- align crossplane kustomization helm release namespace with `crossplane`

## Related Issues

None

## Testing

- N/A (manifest-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
