### PR TITLE
fix(argo): ensure judge output files exist

### DIFF
--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -190,6 +190,7 @@ spec:
 
             git -C "$WORKTREE_DIR" fetch --all --prune
 
+            mkdir -p /workspace/lab /workspace/.codex
             # Ensure judge output files exist for all stages to satisfy Argo output collection.
             : > "/workspace/lab/.codex-judge-decision.txt"
             : > "/workspace/lab/.codex-judge-next-prompt.txt"


### PR DESCRIPTION
## Summary

- ensure `/workspace/lab` and `/workspace/.codex` exist before touching judge output files
- prevent Argo artifact collection failures when the repo path is missing

## Related Issues

None

## Testing

- N/A (manifest-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
