### PR TITLE
fix(argo): add docker-lib volume for codex

### DIFF
--- a/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
+++ b/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
@@ -51,6 +51,9 @@ spec:
         resources:
           requests:
             storage: 10Gi
+  volumes:
+    - name: docker-lib
+      emptyDir: {}
   templates:
     - name: codex-dag
       dag:


### PR DESCRIPTION
## Summary
- add missing `docker-lib` emptyDir volume to `codex-autonomous` workflow
- unblocks codex-autonomous runs that mount the Docker sidecar volume
- ensures Argo workflow spec validates at runtime

## Related Issues
None.

## Testing
- Not run (requires Argo CD sync and rerun of codex-autonomous workflow).

## Screenshots (if applicable)
N/A

## Breaking Changes
None.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
