### PR TITLE
fix(scripts): handle sudo stdin and tilde paths

### DIFF
--- a/docs/jangar/primitives/README.md
+++ b/docs/jangar/primitives/README.md
@@ -1,0 +1,56 @@
+# Jangar Platform Primitives
+
+This directory documents the domain primitives used by the Jangar control plane to run long-horizon agent work. The
+primitives are designed to be provider-decoupled and compatible with Crossplane configuration packages, while
+integrating with the existing Argo workflow runtime in this repository.
+
+## Scope
+
+These documents describe:
+
+- Agent execution primitives (`Agent`, `AgentRun`, `AgentProvider`, and the `agent-runner` entrypoint)
+- Memory primitives (`Memory`, `MemoryStore`, and provider-backed datasets)
+- Orchestration primitives (`Orchestration`, `OrchestrationRun`, and composable steps/DAGs)
+- Supporting primitives required for long-horizon runs (artifacts, signals, approvals, schedules, budgets)
+- CI + packaging requirements for OCI-compliant Crossplane configuration packages
+- Jangar’s role as the control plane (policy, lifecycle, and unified API surface)
+
+## Repository locations
+
+- Crossplane configuration packages: `packages/crossplane/`
+- GitOps delivery (Argo CD apps): `argocd/applications/`
+- Argo workflow templates: `argocd/applications/argo-workflows/`, `argocd/applications/froussard/`
+- Facteur orchestration runtime: `services/facteur/internal/argo/`, `services/facteur/internal/orchestrator/`
+- Codex workflows: `argocd/applications/froussard/github-codex-implementation-workflow-template.yaml`
+
+## Control plane
+
+Jangar remains the control plane for every primitive documented here. All external callers must interact with
+Jangar APIs; Jangar creates and manages the underlying CRDs and reconciles status for user-facing consumers.
+
+## Current platform services (Argo CD apps)
+
+Relevant live services in the current GitOps manifests include:
+
+- `crossplane`
+- `argo-workflows`
+- `nats`
+- `kafka`
+- `temporal`
+- `jangar`
+- `facteur`
+- `froussard`
+
+## Documents
+
+- `agent.md`
+- `agent-implementation.md`
+- `memory.md`
+- `memory-implementation.md`
+- `orchestration.md`
+- `orchestration-implementation.md`
+- `supporting-primitives.md`
+- `control-plane.md`
+- `ci-and-packaging.md`
+- `jangar-implementation.md`
+- `ci-workflows.md`

--- a/docs/jangar/primitives/agent-implementation.md
+++ b/docs/jangar/primitives/agent-implementation.md
@@ -1,0 +1,378 @@
+# Agent Primitive (Implementation-Grade Spec)
+
+This document is implementation-grade. It defines the exact CRD schema, runtime contract, and Crossplane
+composition needed to deploy the Agent primitive in production.
+
+## 1) CRDs (XRD + Claim)
+
+### 1.1 XAgent (composite)
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xagents.agents.proompteng.ai
+spec:
+  group: agents.proompteng.ai
+  names:
+    kind: XAgent
+    plural: xagents
+  claimNames:
+    kind: Agent
+    plural: agents
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - providerRef
+                - runtime
+              properties:
+                providerRef:
+                  type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                runtime:
+                  type: object
+                  required: [type]
+                  properties:
+                    type:
+                      type: string
+                      enum: [argo, temporal, job, custom]
+                    argo:
+                      type: object
+                      properties:
+                        workflowTemplate:
+                          type: string
+                        namespace:
+                          type: string
+                          default: argo-workflows
+                        serviceAccount:
+                          type: string
+                          default: codex-workflow
+                    temporal:
+                      type: object
+                      properties:
+                        workflowType:
+                          type: string
+                        taskQueue:
+                          type: string
+                    job:
+                      type: object
+                      properties:
+                        image:
+                          type: string
+                        command:
+                          type: array
+                          items: { type: string }
+                inputs:
+                  type: object
+                  properties:
+                    repository: { type: string }
+                    issueNumber: { type: integer }
+                    base: { type: string }
+                    head: { type: string }
+                    stage: { type: string }
+                payloads:
+                  type: object
+                  properties:
+                    rawEventB64: { type: string }
+                    eventBodyB64: { type: string }
+                    promptJson: { type: string }
+                resources:
+                  type: object
+                  properties:
+                    cpu: { type: string }
+                    memory: { type: string }
+                    ephemeral: { type: string }
+                env:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, value]
+                    properties:
+                      name: { type: string }
+                      value: { type: string }
+                observability:
+                  type: object
+                  properties:
+                    natsEnabled: { type: boolean, default: true }
+                    kafkaCompletions: { type: boolean, default: true }
+                    grafEnabled: { type: boolean, default: false }
+                security:
+                  type: object
+                  properties:
+                    allowPrivileged: { type: boolean, default: false }
+                    allowedServiceAccounts:
+                      type: array
+                      items: { type: string }
+                    allowedSecrets:
+                      type: array
+                      items: { type: string }
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type: { type: string }
+                      status: { type: string }
+                      reason: { type: string }
+                      message: { type: string }
+```
+
+### 1.2 AgentRun (composite)
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xagentruns.agents.proompteng.ai
+spec:
+  group: agents.proompteng.ai
+  names:
+    kind: XAgentRun
+    plural: xagentruns
+  claimNames:
+    kind: AgentRun
+    plural: agentruns
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - agentRef
+              properties:
+                agentRef:
+                  type: object
+                  required: [name]
+                  properties:
+                    name: { type: string }
+                parameters:
+                  type: object
+                  additionalProperties: { type: string }
+                deliveryId:
+                  type: string
+                runtimeOverrides:
+                  type: object
+                  properties:
+                    argo:
+                      type: object
+                      properties:
+                        namespace: { type: string }
+                        serviceAccount: { type: string }
+                retryPolicy:
+                  type: object
+                  properties:
+                    limit: { type: integer, default: 0 }
+                timeoutSeconds:
+                  type: integer
+            status:
+              type: object
+              properties:
+                phase: { type: string }
+                workflowName: { type: string }
+                workflowUID: { type: string }
+                submittedAt: { type: string }
+                finishedAt: { type: string }
+                artifactKeys:
+                  type: array
+                  items: { type: string }
+```
+
+### 1.3 AgentProvider (cluster-scoped)
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xagentproviders.agents.proompteng.ai
+spec:
+  group: agents.proompteng.ai
+  names:
+    kind: XAgentProvider
+    plural: xagentproviders
+  claimNames:
+    kind: AgentProvider
+    plural: agentproviders
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required: [binary]
+              properties:
+                binary: { type: string }
+                argsTemplate:
+                  type: array
+                  items: { type: string }
+                envTemplate:
+                  type: object
+                  additionalProperties: { type: string }
+                inputFiles:
+                  type: array
+                  items:
+                    type: object
+                    required: [path, content]
+                    properties:
+                      path: { type: string }
+                      content: { type: string }
+                outputArtifacts:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, path]
+                    properties:
+                      name: { type: string }
+                      path: { type: string }
+```
+
+## 2) Runtime contract: agent-runner
+
+### 2.1 Input JSON schema
+
+`agent-runner` accepts a single JSON spec:
+
+```json
+{
+  "provider": "codex",
+  "inputs": {
+    "repository": "proompteng/lab",
+    "base": "main",
+    "head": "codex/issue-1966-demo",
+    "stage": "implementation"
+  },
+  "payloads": {
+    "promptJson": "{...}",
+    "rawEventB64": "e30=",
+    "eventBodyB64": "e30="
+  },
+  "observability": {
+    "natsUrl": "nats://nats.nats.svc:4222",
+    "grafBaseUrl": "http://graf.graf.svc.cluster.local"
+  },
+  "artifacts": {
+    "statusPath": "/workspace/.agent/status.json",
+    "logPath": "/workspace/.agent/log.txt"
+  }
+}
+```
+
+### 2.2 Execution rules
+
+- Load `AgentProvider` by name.
+- Render `argsTemplate`, `envTemplate`, and `inputFiles`.
+- Execute `binary` + rendered args.
+- Write status JSON on completion with exit code and output artifacts.
+
+### 2.3 Exit status
+
+- Exit code `0`: success
+- Non-zero: failure (AgentRun status must map to Failed)
+
+## 3) Argo Composition (provider-kubernetes)
+
+### 3.1 AgentRun -> Workflow (minimal composition)
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: agentrun-argo
+  labels:
+    runtime: argo
+spec:
+  compositeTypeRef:
+    apiVersion: agents.proompteng.ai/v1alpha1
+    kind: XAgentRun
+  resources:
+    - name: workflow
+      base:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Workflow
+        metadata:
+          namespace: argo-workflows
+        spec:
+          workflowTemplateRef:
+            name: ""
+          arguments:
+            parameters: []
+      patches:
+        - fromFieldPath: "spec.runtimeOverrides.argo.namespace"
+          toFieldPath: "metadata.namespace"
+          policy:
+            fromFieldPath: Optional
+        - fromFieldPath: "spec.parameters"
+          toFieldPath: "spec.arguments.parameters"
+          transforms:
+            - type: map
+              map:
+                # Implementation detail: convert map to list of {name,value}
+                # Use Composition Function to do map->list conversion.
+      connectionDetails:
+        - fromConnectionSecretKey: workflowName
+```
+
+Implementation note: Use a Composition Function to convert `spec.parameters` map into
+`Workflow.spec.arguments.parameters` list.
+
+### 3.2 Status mapping
+
+- `Workflow.status.phase` -> `AgentRun.status.phase`
+- `Workflow.metadata.name` -> `AgentRun.status.workflowName`
+- `Workflow.metadata.uid` -> `AgentRun.status.workflowUID`
+
+## 4) Jangar API
+
+### 4.1 Endpoints
+
+- `POST /v1/agents`
+- `POST /v1/agent-runs`
+- `GET /v1/agent-runs/{id}`
+- `GET /v1/agent-runs?agentId=...`
+
+### 4.2 Idempotency
+
+- `Idempotency-Key` header maps to `AgentRun.spec.deliveryId`.
+
+## 5) Runtime image requirements
+
+- Codex runtime image must include:
+  - `/usr/local/bin/agent-runner`
+  - `/usr/local/bin/codex`
+- Jangar runtime image must include:
+  - `/usr/local/bin/agent-runner`
+  - provider CLIs used for local execution or tooling
+
+## 6) Required workflow template updates
+
+- Replace direct CLI invocation with `agent-runner` where feasible.
+- Preserve existing env vars (WORKFLOW_*, AGENT_*, NATS_*).

--- a/docs/jangar/primitives/agent.md
+++ b/docs/jangar/primitives/agent.md
@@ -1,0 +1,151 @@
+# Agent Primitive
+
+## Purpose
+
+The `Agent` primitive represents a provider-agnostic intent to run an agent workload. It decouples the
+user-facing API from any specific runtime (Argo, Temporal, Kubernetes Jobs, etc.) and provides a stable
+contract for long-horizon agent execution.
+
+Jangar is the control plane for all `Agent` resources. All creation, update, and deletion flows
+must pass through Jangar.
+
+## Grounding in the current codebase
+
+- Workflow submission runtime: `services/facteur/internal/argo/workflow_runner.go`
+- Argo client + workflow build: `services/facteur/internal/argo/kube_client.go`
+- Orchestration dispatch: `services/facteur/internal/orchestrator/implementation.go`
+- Workflow templates (Argo):
+  - `argocd/applications/froussard/github-codex-implementation-workflow-template.yaml`
+  - `argocd/applications/froussard/codex-autonomous-workflow-template.yaml`
+  - `argocd/applications/argo-workflows/codex-research-workflow.yaml`
+
+## CRDs
+
+### Agent (claim)
+Namespace-scoped, app-facing. Describes intent and desired runtime.
+
+```yaml
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: Agent
+metadata:
+  name: codex-implementation
+spec:
+  providerRef:
+    name: codex
+  runtime:
+    type: argo
+    argo:
+      workflowTemplate: github-codex-implementation
+      namespace: argo-workflows
+      serviceAccount: codex-workflow
+  inputs:
+    repository: proompteng/lab
+    issueNumber: 1966
+    base: main
+    head: codex/issue-1966-demo
+  payloads:
+    rawEventB64: e30=
+    eventBodyB64: e30=
+  observability:
+    natsEnabled: true
+    kafkaCompletions: true
+  resources:
+    cpu: "2"
+    memory: "4Gi"
+```
+
+### AgentRun (execution)
+Namespace-scoped execution record. One AgentRun maps to one runtime execution.
+
+```yaml
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: codex-implementation-20260105-001
+spec:
+  agentRef:
+    name: codex-implementation
+  parameters:
+    eventBodyB64: e30=
+  deliveryId: 3f6d7b5d-acde-4aa0-9f31-8b4d2c4d3a4e
+```
+
+### AgentProvider (CLI adapter)
+Defines how to invoke a provider’s CLI without baking provider-specific logic into workflows.
+
+```yaml
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentProvider
+metadata:
+  name: codex
+spec:
+  binary: /usr/local/bin/codex
+  argsTemplate:
+    - exec
+    - --repo
+    - "{{inputs.repository}}"
+    - --base
+    - "{{inputs.base}}"
+    - --head
+    - "{{inputs.head}}"
+  envTemplate:
+    WORKFLOW_STAGE: "{{inputs.stage}}"
+  inputFiles:
+    - path: /workspace/agent/prompt.json
+      content: "{{payloads.promptJson}}"
+  outputArtifacts:
+    - name: implementation-log
+      path: /workspace/lab/.codex-implementation.log
+```
+
+## Unified entrypoint
+
+### Requirement: `agent-runner`
+All runtimes must invoke a single entrypoint binary that applies the `AgentProvider` adapter and executes the
+provider CLI. This keeps the platform provider-agnostic.
+
+- Path: `/usr/local/bin/agent-runner`
+- Inputs: JSON spec from file or env
+- Output: standard status + artifacts
+
+### Runtime image requirements
+The unified entrypoint must exist in every runtime image used for agent execution.
+
+- Codex runtime image must include:
+  - `/usr/local/bin/agent-runner`
+  - `/usr/local/bin/codex`
+- Jangar runtime image must include:
+  - `/usr/local/bin/agent-runner`
+  - provider CLI binaries for any in-cluster agent execution it coordinates
+
+## Provider decoupling rules
+
+- `Agent` and `AgentRun` expose provider-agnostic fields only.
+- Provider-specific fields live under `spec.runtime.<provider>` or `spec.provider.<provider>`.
+- Crossplane compositions bind the runtime provider at reconciliation time.
+
+## Runtime mapping (Argo)
+
+- `Agent` references an Argo `WorkflowTemplate` by name.
+- `AgentRun` composes into an Argo `Workflow` with parameters mapped from `AgentRun.spec.parameters`.
+
+## Status contract
+
+`AgentRun.status` must include:
+
+- `phase`: Pending | Running | Succeeded | Failed | Cancelled
+- `workflowName`, `workflowUID` (if provider is Argo)
+- `submittedAt`, `finishedAt`
+- `artifactKeys` and any runtime metadata
+
+## Observability
+
+- Enforce `WORKFLOW_*` and `AGENT_*` env vars for traceability.
+- Use existing NATS + Kafka patterns:
+  - NATS agent comms: `docs/nats-argo-agent-communications.md`
+  - Kafka workflow completion: `apps/froussard/scripts/codex-run-complete-kafka.ts`
+
+## Security
+
+- Default service account remains `codex-workflow` for Argo executions.
+- Privileged workloads must be gated with explicit policy (see `supporting-primitives.md`).

--- a/docs/jangar/primitives/ci-and-packaging.md
+++ b/docs/jangar/primitives/ci-and-packaging.md
@@ -1,0 +1,57 @@
+# CI and Crossplane Packaging
+
+## Repository layout
+
+All Crossplane configuration packages live in `packages/crossplane/`. Each package must be OCI-compliant and
+contain a `crossplane.yaml` at its root.
+
+Example:
+
+```
+packages/
+  crossplane/
+    configuration-agents/
+      crossplane.yaml
+      apis/
+      compositions/
+    configuration-memory/
+      crossplane.yaml
+      apis/
+      compositions/
+    configuration-orchestration/
+      crossplane.yaml
+      apis/
+      compositions/
+```
+
+## OCI compliance requirements
+
+- The configuration package is an OCI image.
+- `crossplane.yaml` is required at the package root.
+- Package contents must only include XRDs and Compositions (other files must be excluded in build).
+
+## CI requirements
+
+CI must validate all packages on PR and on main merge:
+
+1) Build each package with the Crossplane CLI.
+2) Fail if package contains invalid or non-supported files.
+
+Example validation command:
+
+```
+crossplane xpkg build \
+  --package-root=packages/crossplane/configuration-agents \
+  --ignore="**/examples/**"
+```
+
+## GitOps delivery
+
+Argo CD should install configuration packages via `Configuration` CRs and reference the OCI image produced
+by CI.
+
+## Ownership
+
+- Jangar owns the control-plane API and lifecycle.
+- Crossplane owns provider reconciliation.
+- Argo CD owns deployment and drift reconciliation.

--- a/docs/jangar/primitives/ci-workflows.md
+++ b/docs/jangar/primitives/ci-workflows.md
@@ -1,0 +1,47 @@
+# CI Workflows (Implementation-Grade)
+
+This document defines the exact CI checks required for Crossplane configuration packages.
+
+## 1) GitHub Actions workflow (example)
+
+```yaml
+name: crossplane-xpkg
+on:
+  pull_request:
+    paths:
+      - 'packages/crossplane/**'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/crossplane/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Crossplane CLI
+        run: |
+          curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
+          sudo mv crp /usr/local/bin/crossplane
+      - name: Build agents package
+        run: |
+          crossplane xpkg build --package-root=packages/crossplane/configuration-agents --ignore='**/examples/**'
+      - name: Build memory package
+        run: |
+          crossplane xpkg build --package-root=packages/crossplane/configuration-memory --ignore='**/examples/**'
+      - name: Build orchestration package
+        run: |
+          crossplane xpkg build --package-root=packages/crossplane/configuration-orchestration --ignore='**/examples/**'
+```
+
+## 2) Required checks
+
+- Must run on PR and main
+- Must fail if `crossplane.yaml` is missing or malformed
+- Must fail if non-XRD/Composition YAML is included
+
+## 3) Optional release step (main)
+
+- Build OCI image and push to registry
+- Update `Configuration` CRs in GitOps to point at new image tags

--- a/docs/jangar/primitives/control-plane.md
+++ b/docs/jangar/primitives/control-plane.md
@@ -1,0 +1,52 @@
+# Jangar Control Plane
+
+## Purpose
+
+Jangar is the control plane for all primitives in `*.proompteng.ai`. It is the only external API
+surface for creating and managing Agent, Memory, Orchestration, and supporting primitives.
+
+## Responsibilities
+
+- Create/update/delete primitives (CRDs) on behalf of users
+- Enforce policy and guardrails (security, budgets, approvals)
+- Normalize provider-agnostic specs into provider bindings
+- Aggregate status and expose a unified API
+- Persist audit logs and lifecycle history in `jangar-db`
+
+## API surface (example)
+
+- `POST /v1/agents`
+- `POST /v1/agent-runs`
+- `POST /v1/memories`
+- `POST /v1/orchestrations`
+- `POST /v1/orchestration-runs`
+- `GET /v1/runs/{id}`
+
+## Status aggregation
+
+Jangar must watch and aggregate:
+
+- AgentRun and OrchestrationRun status
+- Provider-specific resource status (Argo, Temporal, etc.)
+- Error conditions and retry state
+
+## Policy enforcement
+
+- Reject disallowed providers or service accounts
+- Enforce secrets allowlists
+- Gate privileged steps and deployments
+- Enforce budgets and concurrency limits
+
+## Persistence
+
+Use `jangar-db` (CNPG) as source of truth for:
+
+- run metadata
+- audit events
+- policy decisions
+- cross-run correlation
+
+## Idempotency
+
+All Jangar endpoints must accept an idempotency key (`deliveryId`), stored in the database,
+and return consistent results on retries.

--- a/docs/jangar/primitives/control-plane.md
+++ b/docs/jangar/primitives/control-plane.md
@@ -19,8 +19,14 @@ surface for creating and managing Agent, Memory, Orchestration, and supporting p
 - `POST /v1/agent-runs`
 - `POST /v1/memories`
 - `POST /v1/orchestrations`
-- `POST /v1/orchestration-runs`
+- `POST /v1/orchestration-executions`
 - `GET /v1/runs/{id}`
+
+## Standalone runs endpoint
+
+`GET /v1/runs/{id}` provides a unified read-only view across run types. It resolves an ID to the
+underlying execution (AgentRun or OrchestrationExecution), returning a normalized status payload.
+This is used by UI and event consumers that only know a run ID and do not want to branch on type.
 
 ## Status aggregation
 

--- a/docs/jangar/primitives/jangar-implementation.md
+++ b/docs/jangar/primitives/jangar-implementation.md
@@ -1,0 +1,109 @@
+# Jangar Implementation Requirements
+
+This document defines the concrete API, database schema, and controller responsibilities
+required to implement the primitives in production.
+
+## 1) API surface
+
+### Agents
+
+- `POST /v1/agents`
+- `GET /v1/agents/{id}`
+- `POST /v1/agent-runs`
+- `GET /v1/agent-runs/{id}`
+- `GET /v1/agent-runs?agentId=...`
+
+### Memory
+
+- `POST /v1/memories`
+- `GET /v1/memories/{id}`
+- `POST /v1/memory-queries`
+
+### Orchestration
+
+- `POST /v1/orchestrations`
+- `GET /v1/orchestrations/{id}`
+- `POST /v1/orchestration-runs`
+- `GET /v1/orchestration-runs/{id}`
+
+### Common
+
+- `GET /v1/runs/{id}` (aggregate AgentRun + OrchestrationRun)
+
+### Idempotency
+
+All POST endpoints require `Idempotency-Key` and map to `deliveryId` in spec.
+
+## 2) Database schema (jangar-db)
+
+### 2.1 Tables
+
+```sql
+CREATE TABLE IF NOT EXISTS agent_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_name text NOT NULL,
+  delivery_id text NOT NULL,
+  provider text NOT NULL,
+  status text NOT NULL,
+  external_run_id text,
+  payload jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS agent_runs_delivery_id_idx ON agent_runs(delivery_id);
+
+CREATE TABLE IF NOT EXISTS memory_resources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  memory_name text NOT NULL,
+  provider text NOT NULL,
+  status text NOT NULL,
+  connection_secret jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS orchestration_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  orchestration_name text NOT NULL,
+  delivery_id text NOT NULL,
+  provider text NOT NULL,
+  status text NOT NULL,
+  external_run_id text,
+  payload jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS orchestration_runs_delivery_id_idx ON orchestration_runs(delivery_id);
+
+CREATE TABLE IF NOT EXISTS audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_type text NOT NULL,
+  entity_id uuid NOT NULL,
+  event_type text NOT NULL,
+  payload jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+## 3) Controller responsibilities
+
+Jangar must implement:
+
+- CRD creation + updates (Agent, AgentRun, Memory, Orchestration)
+- Status reconciliation (poll or watch provider resources)
+- Policy enforcement (budgets, approvals, secrets)
+- Retry + idempotency
+- Audit log emission
+
+## 4) Provider watchers
+
+- Argo: watch `Workflow` and `WorkflowTemplate`
+- CNPG: read secrets and cluster status
+- NATS/Kafka: ingest runtime events
+
+## 5) Security
+
+- Enforce allowlist of service accounts and secrets
+- Persist every policy decision in `audit_events`

--- a/docs/jangar/primitives/memory-implementation.md
+++ b/docs/jangar/primitives/memory-implementation.md
@@ -1,0 +1,229 @@
+# Memory Primitive (Implementation-Grade Spec)
+
+This document defines the full CRD schema and Postgres-backed implementation for the Memory primitive,
+while preserving provider portability.
+
+## 1) CRDs
+
+### 1.1 XMemory (composite)
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xmemories.memory.proompteng.ai
+spec:
+  group: memory.proompteng.ai
+  names:
+    kind: XMemory
+    plural: xmemories
+  claimNames:
+    kind: Memory
+    plural: memories
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - providerRef
+                - dataset
+              properties:
+                providerRef:
+                  type: object
+                  required: [name]
+                  properties:
+                    name: { type: string }
+                dataset:
+                  type: object
+                  required: [name, schema]
+                  properties:
+                    name: { type: string }
+                    schema: { type: string }
+                retention:
+                  type: object
+                  properties:
+                    ttlDays: { type: integer, default: 90 }
+                embeddings:
+                  type: object
+                  properties:
+                    enabled: { type: boolean, default: true }
+                    dimension: { type: integer, default: 1536 }
+                access:
+                  type: object
+                  properties:
+                    readerRole: { type: string }
+                    writerRole: { type: string }
+            status:
+              type: object
+              properties:
+                providerType: { type: string }
+                endpoint: { type: string }
+                database: { type: string }
+                schema: { type: string }
+                connectionSecretRef:
+                  type: object
+                  properties:
+                    name: { type: string }
+                    namespace: { type: string }
+```
+
+### 1.2 MemoryProvider
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xmemoryproviders.memory.proompteng.ai
+spec:
+  group: memory.proompteng.ai
+  names:
+    kind: XMemoryProvider
+    plural: xmemoryproviders
+  claimNames:
+    kind: MemoryProvider
+    plural: memoryproviders
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [type]
+              properties:
+                type:
+                  type: string
+                  enum: [postgres, redis, s3, custom]
+                postgres:
+                  type: object
+                  properties:
+                    clusterRef:
+                      type: object
+                      required: [name, namespace]
+                      properties:
+                        name: { type: string }
+                        namespace: { type: string }
+                    database: { type: string }
+                    schema: { type: string }
+                    enablePgVector: { type: boolean, default: true }
+                    connectionSecret:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        namespace: { type: string }
+```
+
+## 2) Postgres provider implementation (first provider)
+
+### 2.1 CNPG baseline
+
+The live cluster already includes CNPG clusters suitable for memory storage:
+
+- `facteur/facteur-vector-cluster`
+- `jangar/jangar-db`
+
+### 2.2 SQL schema (baseline)
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS memory_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  dataset text NOT NULL,
+  event_type text NOT NULL,
+  payload jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS memory_embeddings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  dataset text NOT NULL,
+  key text NOT NULL,
+  embedding vector(1536),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS memory_embeddings_dataset_key_idx ON memory_embeddings(dataset, key);
+CREATE INDEX IF NOT EXISTS memory_embeddings_vector_idx ON memory_embeddings USING ivfflat (embedding vector_cosine_ops);
+
+CREATE TABLE IF NOT EXISTS memory_kv (
+  dataset text NOT NULL,
+  key text NOT NULL,
+  value jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (dataset, key)
+);
+```
+
+### 2.3 Provisioning flow (provider-kubernetes + SQL init job)
+
+1) `MemoryProvider` references a CNPG cluster.
+2) Composition creates a Kubernetes Job in the target namespace to run SQL migrations.
+3) Connection secret is written to `Memory.status.connectionSecretRef`.
+
+### 2.4 Connection secret
+
+Required keys:
+
+- `endpoint`
+- `database`
+- `schema`
+- `username`
+- `password`
+
+## 3) Crossplane Composition (Postgres)
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: memory-postgres
+  labels:
+    provider: postgres
+spec:
+  compositeTypeRef:
+    apiVersion: memory.proompteng.ai/v1alpha1
+    kind: XMemory
+  resources:
+    - name: init-sql-job
+      base:
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          namespace: facteur
+        spec:
+          template:
+            spec:
+              restartPolicy: OnFailure
+              containers:
+                - name: init
+                  image: postgres:16
+                  command: ["/bin/bash", "-lc"]
+                  args:
+                    - |
+                      psql "$POSTGRES_DSN" -f /migrations/memory.sql
+      patches:
+        - fromFieldPath: spec.dataset.schema
+          toFieldPath: spec.template.spec.containers[0].env[?(@.name=="PGSCHEMA")].value
+```
+
+Implementation note: use Composition Function for dynamic SQL injection and secrets binding.
+
+## 4) Provider decoupling
+
+- Only `MemoryProvider` specifies backend details.
+- Memory consumers never see provider-specific fields.
+- Switching providers requires only updating `Memory.spec.providerRef` or composition selector.

--- a/docs/jangar/primitives/memory.md
+++ b/docs/jangar/primitives/memory.md
@@ -1,0 +1,106 @@
+# Memory Primitive
+
+## Purpose
+
+The `Memory` primitive provides a provider-agnostic contract for durable, queryable, and retrievable memory
+associated with agents and workflows. It supports vector embeddings, retention policies, and access control
+without coupling to a specific backend implementation.
+
+Jangar is the control plane for all `Memory` resources.
+
+## Grounding in the current platform
+
+- Existing CNPG clusters (live): `facteur/facteur-vector-cluster`, `jangar/jangar-db`
+- Current agent event storage direction: `docs/nats-argo-agent-communications.md`
+
+## CRDs
+
+### Memory (claim)
+Namespace-scoped, app-facing memory dataset.
+
+```yaml
+apiVersion: memory.proompteng.ai/v1alpha1
+kind: Memory
+metadata:
+  name: codex-agent-memory
+spec:
+  providerRef:
+    name: postgres-default
+  dataset:
+    name: codex_agent
+    schema: agent_memory
+  retention:
+    ttlDays: 90
+  embeddings:
+    enabled: true
+    dimension: 1536
+  access:
+    readerRole: memory_reader
+    writerRole: memory_writer
+```
+
+### MemoryStore (internal)
+Composite resource that binds the logical memory dataset to a concrete provider.
+
+## Provider decoupling rules
+
+- `Memory.spec` includes only intent and schema-level requirements.
+- Provider details live under `spec.provider.<type>` or are supplied by a referenced provider resource.
+- Switching providers is achieved by updating the `providerRef` or composition selector, without changing
+  application-level contracts.
+
+## Postgres provider (first implementation)
+
+### Requirements
+
+- Backed by CloudNativePG (CNPG) clusters
+- `pgvector` extension enabled for embeddings
+- Stable connection secret with role-based access
+
+### Provider configuration
+
+```yaml
+apiVersion: memory.proompteng.ai/v1alpha1
+kind: MemoryProvider
+metadata:
+  name: postgres-default
+spec:
+  type: postgres
+  postgres:
+    clusterRef:
+      name: facteur-vector-cluster
+      namespace: facteur
+    database: memory_codex_agent
+    schema: agent_memory
+    enablePgVector: true
+```
+
+### Connection contract
+
+`Memory.status.connectionSecretRef` must include:
+
+- `endpoint`
+- `database`
+- `schema`
+- `username`
+- `password`
+
+## Schema baseline
+
+- `memory_events` (append-only)
+- `memory_embeddings` (vector + metadata)
+- `memory_kv` (simple key/value)
+
+## Retention
+
+Retention is enforced by provider-specific jobs (SQL or background worker). The retention contract
+is stored on the Memory resource; the backend implementation must honor it.
+
+## Access model
+
+- Readers are granted `SELECT` and `EXECUTE` on schema functions
+- Writers are granted `INSERT/UPDATE` on tables, plus vector upsert
+
+## Observability
+
+Jangar should emit memory lifecycle events and link them to agent/orchestration runs via run IDs.

--- a/docs/jangar/primitives/orchestration-implementation.md
+++ b/docs/jangar/primitives/orchestration-implementation.md
@@ -1,0 +1,192 @@
+# Orchestration Primitive (Implementation-Grade Spec)
+
+This document specifies Orchestration primitives with a composable DAG model and provider mappings.
+The design is runtime-agnostic, with Argo as the first implementation.
+
+## 1) CRDs
+
+### 1.1 XOrchestration
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xorchestrations.orchestration.proompteng.ai
+spec:
+  group: orchestration.proompteng.ai
+  names:
+    kind: XOrchestration
+    plural: xorchestrations
+  claimNames:
+    kind: Orchestration
+    plural: orchestrations
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [entrypoint, steps]
+              properties:
+                entrypoint: { type: string }
+                steps:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, kind]
+                    properties:
+                      name: { type: string }
+                      kind:
+                        type: string
+                        enum: [AgentRun, ToolRun, MemoryOp, ApprovalGate, SignalWait, SubOrchestration, Checkpoint]
+                      dependsOn:
+                        type: array
+                        items: { type: string }
+                      agentRef:
+                        type: string
+                      toolRef:
+                        type: string
+                      memoryRef:
+                        type: string
+                      policyRef:
+                        type: string
+                      with:
+                        type: object
+                        additionalProperties: { type: string }
+                policies:
+                  type: object
+                  properties:
+                    retries:
+                      type: object
+                      properties:
+                        limit: { type: integer, default: 0 }
+                    timeouts:
+                      type: object
+                      properties:
+                        totalSeconds: { type: integer }
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type: { type: string }
+                      status: { type: string }
+                      reason: { type: string }
+                      message: { type: string }
+```
+
+### 1.2 OrchestrationRun
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xorchestrationruns.orchestration.proompteng.ai
+spec:
+  group: orchestration.proompteng.ai
+  names:
+    kind: XOrchestrationRun
+    plural: xorchestrationruns
+  claimNames:
+    kind: OrchestrationRun
+    plural: orchestrationruns
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [orchestrationRef]
+              properties:
+                orchestrationRef:
+                  type: object
+                  required: [name]
+                  properties:
+                    name: { type: string }
+                parameters:
+                  type: object
+                  additionalProperties: { type: string }
+                deliveryId: { type: string }
+            status:
+              type: object
+              properties:
+                phase: { type: string }
+                runId: { type: string }
+                startedAt: { type: string }
+                finishedAt: { type: string }
+                stepStatuses:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name: { type: string }
+                      phase: { type: string }
+                      startedAt: { type: string }
+                      finishedAt: { type: string }
+```
+
+## 2) Argo runtime mapping
+
+### 2.1 Orchestration -> WorkflowTemplate
+
+- `spec.steps` maps to Argo DAG tasks
+- `dependsOn` maps to `dependencies`
+- `AgentRun` steps map to a template that calls `agent-runner`
+
+### 2.2 OrchestrationRun -> Workflow
+
+- `spec.orchestrationRef` -> `workflowTemplateRef`
+- `spec.parameters` -> `arguments.parameters`
+
+## 3) Example Argo DAG task mapping
+
+```yaml
+- name: implement
+  templateRef:
+    name: github-codex-implementation
+    template: implement
+- name: judge
+  dependencies: [implement]
+  templateRef:
+    name: codex-judge
+    template: judge
+```
+
+## 4) Step kinds (behavior)
+
+- `AgentRun`: submit agent execution, wait for completion
+- `ToolRun`: execute a platform tool (git merge, deploy, etc.)
+- `MemoryOp`: read/write memory entries
+- `ApprovalGate`: block until manual or policy approval
+- `SignalWait`: block until an external signal arrives
+- `SubOrchestration`: run another Orchestration
+- `Checkpoint`: persist state snapshot to Memory
+
+## 5) Idempotency
+
+`OrchestrationRun.spec.deliveryId` is required for idempotent behavior and
+is persisted by Jangar to avoid duplicate dispatch.
+
+## 6) Status mapping
+
+- Argo `Workflow.status.phase` -> `OrchestrationRun.status.phase`
+- Argo `Workflow.metadata.name` -> `OrchestrationRun.status.runId`
+
+## 7) Observability
+
+- Ensure each step writes `WORKFLOW_*` and `AGENT_*` env vars
+- Publish NATS agent events on every step

--- a/docs/jangar/primitives/orchestration.md
+++ b/docs/jangar/primitives/orchestration.md
@@ -1,0 +1,123 @@
+# Orchestration Primitive
+
+## Purpose
+
+The Orchestration primitive represents a composable workflow definition and execution that coordinates
+multiple steps (agent runs, tool invocations, memory operations) over long horizons. It is provider-agnostic
+and can be implemented by Argo, Temporal, or other workflow engines.
+
+Jangar is the control plane for orchestration resources.
+
+## Grounding in the current platform
+
+- Existing Argo templates: `codex-autonomous`, `github-codex-implementation`, `codex-research-workflow`
+- Facteur orchestration entrypoint: `services/facteur/internal/orchestrator/implementation.go`
+- Argo runtime namespace: `argo-workflows`
+
+## CRDs
+
+### Orchestration (definition)
+Defines the DAG, steps, and policies.
+
+```yaml
+apiVersion: orchestration.proompteng.ai/v1alpha1
+kind: Orchestration
+metadata:
+  name: codex-autonomous
+spec:
+  entrypoint: implement
+  steps:
+    - name: implement
+      kind: AgentRun
+      agentRef: codex-implementation
+      with:
+        inputs:
+          repository: proompteng/lab
+          issueNumber: 1966
+    - name: judge
+      kind: AgentRun
+      dependsOn: [implement]
+      agentRef: codex-judge
+    - name: gate
+      kind: ApprovalGate
+      dependsOn: [judge]
+      policyRef: codex-merge-policy
+    - name: merge
+      kind: Tool
+      dependsOn: [gate]
+      toolRef: git-merge
+    - name: deploy
+      kind: Tool
+      dependsOn: [merge]
+      toolRef: argocd-deploy
+  policies:
+    retries:
+      limit: 2
+    timeouts:
+      totalSeconds: 7200
+```
+
+### OrchestrationRun (execution)
+Executes a definition with concrete parameters and records status.
+
+```yaml
+apiVersion: orchestration.proompteng.ai/v1alpha1
+kind: OrchestrationRun
+metadata:
+  name: codex-autonomous-20260105-001
+spec:
+  orchestrationRef:
+    name: codex-autonomous
+  parameters:
+    repository: proompteng/lab
+    issueNumber: 1966
+```
+
+## Step model
+
+Each step is an atomic unit with:
+
+- `kind`: AgentRun | Tool | MemoryOp | ApprovalGate | SignalWait | SubOrchestration
+- `dependsOn`: array of step names
+- `with`: parameter overrides
+- `outputs`: named outputs for downstream steps
+
+## Provider decoupling rules
+
+- `Orchestration` is runtime-agnostic.
+- Provider binding happens at reconciliation via Crossplane composition or Jangar runtime routing.
+- Provider-specific fields live under `spec.runtime.<provider>`.
+
+## Mapping to Argo (current runtime)
+
+- `Orchestration` → `WorkflowTemplate` (or DAG template)
+- `OrchestrationRun` → `Workflow`
+- `dependsOn` maps to DAG dependencies
+- `AgentRun` steps map to `templateRef` to existing agent workflow templates
+
+## Mapping to Temporal (future runtime)
+
+- `Orchestration` → Workflow Type and Task Queue
+- `steps` map to Activities or Child Workflows
+- `OrchestrationRun` stores Temporal Workflow ID + Run ID
+
+## State + status
+
+`OrchestrationRun.status` must include:
+
+- `phase`: Pending | Running | Succeeded | Failed | Cancelled
+- `runId`: provider-specific run identifier
+- `startedAt`, `finishedAt`
+- `stepStatuses`: array of step states + timestamps
+
+## Long-horizon features
+
+- `SignalWait` step to block until external events arrive
+- `Checkpoint` step to persist intermediate state to Memory
+- `ResumeFrom` policy for partial replay
+- `Budget` integration to halt if cost exceeds threshold
+
+## Idempotency
+
+- OrchestrationRun must be idempotent via `deliveryId` (if present)
+- Jangar owns retries and de-duplication for orchestration creation

--- a/docs/jangar/primitives/supporting-primitives.md
+++ b/docs/jangar/primitives/supporting-primitives.md
@@ -1,0 +1,80 @@
+# Supporting Primitives for Long-Horizon Agents
+
+This document enumerates the additional primitives required to run long-horizon agent workflows safely
+and portably. These are platform-level contracts managed by Jangar.
+
+## 1) Artifact
+
+**Purpose:** durable storage for logs, patches, datasets, model outputs.
+
+- Claim: `Artifact`
+- Execution: `ArtifactRef` embedded in AgentRun/OrchestrationRun status
+- Provider-agnostic (S3, GCS, MinIO, local)
+
+Key fields:
+
+- `spec.storageRef`
+- `spec.lifecycle.ttlDays`
+- `status.uri`, `status.checksum`
+
+## 2) Signal
+
+**Purpose:** external event + coordination signal.
+
+- Claim: `Signal` (definitions)
+- `SignalDelivery` (events)
+
+Used for:
+
+- external approvals
+- human-in-the-loop checkpoints
+- system callbacks from webhooks
+
+## 3) ApprovalPolicy
+
+**Purpose:** gate and enforce compliance rules.
+
+- Supports manual approvals, automated checks, and policy exceptions
+- Used by Orchestration steps (ApprovalGate)
+
+## 4) Schedule
+
+**Purpose:** time-based triggers for AgentRuns and OrchestrationRuns.
+
+- `Schedule` defines cron, timezone, and target resource
+- Provider-agnostic; can map to K8s CronJob or Temporal schedules
+
+## 5) Budget
+
+**Purpose:** cost and resource ceilings for long-horizon workloads.
+
+- `Budget` defines CPU, GPU, token, and dollar limits
+- Jangar enforces policy and halts runs when exceeded
+
+## 6) Tool
+
+**Purpose:** standardized interface for non-agent commands or platform actions.
+
+- `Tool` declares interface and required inputs/outputs
+- `ToolRun` is the execution record
+- Used for `git merge`, `deploy`, `validate`, `scan`, etc.
+
+## 7) SecretBinding
+
+**Purpose:** centralized access control for secrets and external credentials.
+
+- Bindings explicitly list allowed secret names for each Agent/Orchestration
+- Prevents direct access by runtimes without Jangar approval
+
+## 8) Workspace
+
+**Purpose:** persistent or ephemeral workspaces for multi-step runs.
+
+- `Workspace` defines storage class, size, and lifecycle
+- Orchestration steps can mount a shared workspace
+
+## Common design rules
+
+- Each primitive is provider-agnostic and resolved by Jangar via provider refs.
+- Status fields must be consistent across providers.
+- Every primitive emits audit events for traceability.

--- a/scripts/trust-ca-macos.ts
+++ b/scripts/trust-ca-macos.ts
@@ -90,6 +90,7 @@ async function main() {
 
   console.log(`> ${preview}`)
   const processResult = Bun.spawn(command, {
+    stdin: 'inherit',
     stdout: 'inherit',
     stderr: 'inherit',
   })

--- a/scripts/trust-ca-macos.ts
+++ b/scripts/trust-ca-macos.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { resolve } from 'node:path'
 
 interface Options {
@@ -66,14 +67,24 @@ function parseArgs(argv: string[]): Options {
   return options
 }
 
+function expandHome(value: string): string {
+  if (value === '~') {
+    return homedir()
+  }
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return `${homedir()}/${value.slice(2)}`
+  }
+  return value
+}
+
 async function main() {
   if (process.platform !== 'darwin') {
     throw new Error('This script only supports macOS (darwin).')
   }
 
   const options = parseArgs(process.argv.slice(2))
-  const certPath = resolve(options.certPath)
-  const keychain = resolve(options.keychain)
+  const certPath = resolve(expandHome(options.certPath))
+  const keychain = resolve(expandHome(options.keychain))
 
   if (!existsSync(certPath)) {
     throw new Error(`Certificate not found: ${certPath}`)


### PR DESCRIPTION
## Summary

- inherit stdin when invoking sudo so macOS password prompts can be read
- expand `~` paths before resolving cert/keychain locations

## Related Issues

None.

## Testing

- Not run (script change only).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
