### PR TITLE
fix(nats): align agent comms subjects with stream

### DIFF
--- a/apps/froussard/scripts/codex-nats-publish.ts
+++ b/apps/froussard/scripts/codex-nats-publish.ts
@@ -24,7 +24,7 @@ Options:
   --content <text>      Publish a single event with the provided content.
   --log-file <path>     Tail a log file and publish each line as an event.
   --channel <value>     Channel name for run-specific events (default: run).
-  --publish-general     Also publish each event to argo.workflow.general.<kind>.
+  --publish-general     Also publish each event to <subject-prefix>.general.<kind> (default: argo.workflow.general.<kind>).
   --status <value>      Optional status value for status events.
   --exit-code <value>   Optional exit code for status events.
   --attrs-json <value>  Optional JSON payload merged into attrs.
@@ -274,7 +274,7 @@ const main = async () => {
   const issueNumberRaw = coerceNonEmpty(process.env.CODEX_ISSUE_NUMBER) ?? coerceNonEmpty(process.env.ISSUE_NUMBER)
   const issueNumber = issueNumberRaw ? Number.parseInt(issueNumberRaw, 10) : null
   const branch = coerceNonEmpty(process.env.CODEX_BRANCH) ?? coerceNonEmpty(process.env.HEAD_BRANCH)
-  const subjectPrefix = process.env.NATS_SUBJECT_PREFIX?.trim() || 'workflow_comms.agent_messages'
+  const subjectPrefix = process.env.NATS_SUBJECT_PREFIX?.trim() || 'argo.workflow'
 
   const creds = resolveCredsFile()
   const natsArgs = buildNatsArgs(creds.path)

--- a/apps/froussard/scripts/codex-nats-soak.ts
+++ b/apps/froussard/scripts/codex-nats-soak.ts
@@ -133,12 +133,16 @@ const filterMessages = (
   filters: { repository?: string; issueNumber?: number | null; branch?: string },
 ) => {
   return messages.filter((message) => {
-    if (filters.repository && message.repository && message.repository !== filters.repository) return false
+    if (filters.repository) {
+      if (!message.repository || message.repository !== filters.repository) return false
+    }
     if (filters.issueNumber != null) {
       const normalized = normalizeIssueNumber(message.issueNumber ?? null)
-      if (normalized != null && normalized !== filters.issueNumber) return false
+      if (normalized == null || normalized !== filters.issueNumber) return false
     }
-    if (filters.branch && message.branch && message.branch !== filters.branch) return false
+    if (filters.branch) {
+      if (!message.branch || message.branch !== filters.branch) return false
+    }
     if (message.channel && message.channel !== 'general') return false
     return true
   })
@@ -147,7 +151,7 @@ const filterMessages = (
 const run = () => {
   const options: Options = {
     stream: coerceNonEmpty(process.env.NATS_STREAM) ?? 'agent-comms',
-    subject: coerceNonEmpty(process.env.NATS_CONTEXT_SUBJECT) ?? 'workflow_comms.agent_messages.general.>',
+    subject: coerceNonEmpty(process.env.NATS_CONTEXT_SUBJECT) ?? 'argo.workflow.general.>',
     count: parseNumber(process.env.NATS_CONTEXT_COUNT, 50),
     outputPath: coerceNonEmpty(process.env.NATS_CONTEXT_PATH) ?? undefined,
   }

--- a/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
+++ b/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
@@ -459,9 +459,9 @@ spec:
           - name: NATS_URL
             value: nats://nats.nats.svc.cluster.local:4222
           - name: NATS_SUBJECT_PREFIX
-            value: workflow_comms.agent_messages
+            value: argo.workflow
           - name: NATS_CONTEXT_SUBJECT
-            value: workflow_comms.agent_messages.general.>
+            value: argo.workflow.general.>
           - name: NATS_USER
             valueFrom:
               secretKeyRef:

--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -84,9 +84,9 @@ spec:
           - name: NATS_URL
             value: nats://nats.nats.svc.cluster.local:4222
           - name: NATS_SUBJECT_PREFIX
-            value: workflow_comms.agent_messages
+            value: argo.workflow
           - name: NATS_CONTEXT_SUBJECT
-            value: workflow_comms.agent_messages.general.>
+            value: argo.workflow.general.>
           - name: NATS_USER
             valueFrom:
               secretKeyRef:

--- a/argocd/applications/nats/stream-agent-comms.yaml
+++ b/argocd/applications/nats/stream-agent-comms.yaml
@@ -6,6 +6,7 @@ spec:
   name: agent-comms
   subjects:
     - argo.workflow.>
+    - workflow_comms.agent_messages.>
   retention: limits
   storage: file
   maxAge: 168h

--- a/argocd/applications/nats/values.yaml
+++ b/argocd/applications/nats/values.yaml
@@ -33,6 +33,7 @@ config:
               - "workflow_comms.agent_messages.>"
             subscribe:
               - "_INBOX.>"
+              - "argo.workflow.>"
               - "workflow_comms.agent_messages.>"
         - user: jangar
           password: << $NATS_JANGAR_PASSWORD >>

--- a/services/jangar/src/server/codex-judge-config.ts
+++ b/services/jangar/src/server/codex-judge-config.ts
@@ -53,9 +53,12 @@ const parseNumber = (raw: string | undefined, fallback: number) => {
   return parsed
 }
 
+const isTestEnv = process.env.NODE_ENV === 'test' || Boolean(process.env.VITEST)
+
 const parseJudgeMode = (raw: string | undefined) => {
   const normalized = (raw ?? 'argo').trim().toLowerCase()
-  return normalized === 'local' ? 'local' : 'argo'
+  if (normalized === 'local' && isTestEnv) return 'local'
+  return 'argo'
 }
 
 export const loadCodexJudgeConfig = (): CodexJudgeConfig => {

--- a/services/jangar/src/server/codex-judge.ts
+++ b/services/jangar/src/server/codex-judge.ts
@@ -52,7 +52,8 @@ storeReady.catch((error) => {
 const config = globalOverrides.__codexJudgeConfigMock ?? loadCodexJudgeConfig()
 const isTestEnv = process.env.NODE_ENV === 'test' || Boolean(process.env.VITEST)
 const effectiveJudgeMode = config.judgeMode === 'local' && isTestEnv ? 'local' : 'argo'
-if (config.judgeMode !== 'argo' && !isTestEnv) {
+const requestedJudgeMode = (process.env.JANGAR_CODEX_JUDGE_MODE ?? 'argo').trim().toLowerCase()
+if (!isTestEnv && requestedJudgeMode !== 'argo') {
   console.warn(
     'Jangar local judge mode is deprecated and disabled in production; forcing JANGAR_CODEX_JUDGE_MODE=argo.',
   )


### PR DESCRIPTION
## Summary
- align NATS agent-communications subjects with the `agent-comms` stream defaults
- update Argo workflow templates + NATS stream permissions for the new subject prefix
- clarify autonomous design doc NATS subject taxonomy + Jangar judge deprecation

## Related Issues
None.

## Testing
- bunx biome check apps/froussard/scripts/codex-nats-publish.ts apps/froussard/scripts/codex-nats-soak.ts services/jangar/src/server/codex-judge-config.ts services/jangar/src/server/codex-judge.ts
- bun run lint:argocd

## Screenshots (if applicable)
N/A

## Breaking Changes
None.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
