### PR TITLE
fix(codex): bound nats context soak

### DIFF
--- a/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
+++ b/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: codex-autonomous
   namespace: argo-workflows
   annotations:
-    codex-universal-image-digest: sha256:7c78969e7526279cfab447336cc80aab5c5bd09b9f91c82e104a8739b47984d1
+    codex-universal-image-digest: sha256:3bc9c14d91c0f1613515ce0e3e33179c9a35c2c40721f1e1e44f4139ed5197cb
 spec:
   serviceAccountName: codex-workflow
   parallelism: 1


### PR DESCRIPTION
## Summary

- bound NATS context soak to avoid hanging interactive `nats stream view`
- normalize/strip noisy stream output so JSON messages still parse when the CLI echoes prompts
- record the new multi-arch codex-universal image digest for the Argo template

## Related Issues

None.

## Testing

- `bunx biome check apps/froussard`
- `bun run lint:argocd`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_NOSYSTEM=1 bun run --filter froussard test -- --coverage`

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
