### PR TITLE
fix(argocd): set codex env for implementation workflow

### DIFF
--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -47,6 +47,8 @@ spec:
         image: registry.ide-newton.ts.net/lab/codex-universal:latest
         imagePullPolicy: Always
         env:
+          - name: CODEX_CWD
+            value: /workspace/lab
           - name: HEAD_BRANCH
             value: '{{inputs.parameters.head}}'
           - name: BASE_BRANCH
@@ -103,6 +105,20 @@ spec:
                 name: nats-agent-creds
                 key: creds
                 optional: true
+          - name: MINIO_ENDPOINT
+            value: observability-minio.minio.svc.cluster.local:9000
+          - name: MINIO_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: observability-minio-creds
+                key: accesskey
+          - name: MINIO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: observability-minio-creds
+                key: secretkey
+          - name: MINIO_SECURE
+            value: 'false'
           - name: CODEX_NATS_SOAK_REQUIRED
             value: "true"
           - name: NATS_CONTEXT_PATH


### PR DESCRIPTION
## Summary

- add CODEX_CWD and MinIO envs to the implementation workflow template to satisfy preflight checks
- align implementation workflow env with codex-run requirements for artifact presign validation
- unblock github-codex-implementation runs that were failing before implementation

## Related Issues

None

## Testing

- bun run lint:argocd

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
