### PR TITLE
docs(codex): clarify auto-commit behavior

### DIFF
--- a/docs/autonomous-codex-design.md
+++ b/docs/autonomous-codex-design.md
@@ -196,8 +196,8 @@ Key components evolve from the current codebase:
 1. **Automated Tests**
    - Workflow steps must run repo-specific commands (e.g., `bun run lint:<app>`, `go test ./...`).
    - Results appended to progress comment and stored in `runs`.
-   - Implementation runs must always auto-commit changes, even on failure, so worktree diffs are authoritative. This keeps the
-     progress record aligned with the exact patch produced during the run.
+   - Implementation runs must always auto-commit changes, even on failure, so worktree diffs are authoritative. The progress
+     record must match the exact patch produced during the run.
 
 2. **Policy Checks**
    - Integration stage ensures branch protection rules (status checks, reviewer approvals).


### PR DESCRIPTION
## Summary

- clarify Quality Gates note that implementation runs auto-commit on failure
- align progress record wording with authoritative worktree diffs
- keep change scoped to autonomous codex design docs

## Related Issues

Resolves #2359

## Testing

- bun run format

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.