### PR TITLE
fix(codex): ignore codex artifacts and tolerate existing PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,6 +255,8 @@ packages/temporal-bun-sdk/releases/
 packages/temporal-bun-sdk/vendor/
 packages/temporal-bun-sdk/Users/
 **/zig-out/
+.codex/
+.codex-*
 .codex/cache
 .worktrees/
 

--- a/apps/froussard/src/codex/cli/codex-implement.ts
+++ b/apps/froussard/src/codex/cli/codex-implement.ts
@@ -867,6 +867,10 @@ const createPullRequest = async (
   const result = await runCommand('gh', args)
   if (result.exitCode !== 0) {
     const message = result.stderr.trim() || result.stdout.trim()
+    const existing = await listPullRequestByHead(repository, headBranch).catch(() => null)
+    if (existing) {
+      return existing
+    }
     throw new Error(`Failed to create PR for ${headBranch}: ${message}`)
   }
   return listPullRequestByHead(repository, headBranch)


### PR DESCRIPTION
## Summary

- ignore transient Codex artifacts in git to keep worktrees clean
- tolerate `gh pr create` returning “already exists” and reuse the existing PR
- reduce implementation workflow retries caused by dirty worktrees/duplicate PR creation

## Related Issues

None

## Testing

- bunx biome check apps/froussard/src/codex/cli/codex-implement.ts

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
