### PR TITLE
feat(codex): add agent-runner entrypoint

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -125,6 +125,8 @@ COPY apps/froussard/src/codex/cli/codex-bootstrap.ts /usr/local/bin/codex-bootst
 COPY apps/froussard/src/codex/cli/codex-implement.ts /usr/local/bin/codex-implement
 COPY apps/froussard/src/codex/cli/codex-research.ts /usr/local/bin/codex-research
 COPY apps/froussard/src/codex/cli/codex-graf.ts /usr/local/bin/codex-graf
+COPY services/jangar/scripts/agent-runner.ts /usr/local/bin/agent-runner
+COPY services/jangar/scripts/agent-providers /etc/agent-providers
 COPY apps/froussard/scripts/codex-nats-publish.ts /usr/local/bin/codex-nats-publish
 COPY apps/froussard/scripts/codex-nats-soak.ts /usr/local/bin/codex-nats-soak
 COPY apps/froussard/scripts/discord-channel.ts /usr/local/bin/discord-channel.ts
@@ -138,7 +140,7 @@ RUN bash -lc 'cd /opt/proompteng/packages/discord && bun install --no-save && bu
 RUN mkdir -p /usr/local/node_modules/@proompteng \
     && cp -R /opt/proompteng/packages/codex /usr/local/node_modules/@proompteng/codex \
     && cp -R /opt/proompteng/packages/discord /usr/local/node_modules/@proompteng/discord
-RUN chmod +x /usr/local/bin/codex-bootstrap /usr/local/bin/codex-implement /usr/local/bin/codex-research /usr/local/bin/codex-graf /usr/local/bin/codex-nats-publish /usr/local/bin/codex-nats-soak /usr/local/bin/discord-channel.ts
+RUN chmod +x /usr/local/bin/codex-bootstrap /usr/local/bin/codex-implement /usr/local/bin/codex-research /usr/local/bin/codex-graf /usr/local/bin/agent-runner /usr/local/bin/codex-nats-publish /usr/local/bin/codex-nats-soak /usr/local/bin/discord-channel.ts
 
 WORKDIR /workspace
 ENTRYPOINT ["/usr/local/bin/codex-bootstrap"]

--- a/argocd/applications/argo-workflows/codex-research-workflow.yaml
+++ b/argocd/applications/argo-workflows/codex-research-workflow.yaml
@@ -126,7 +126,25 @@ spec:
 
             echo "Launching Codex research run"
             set +e
-            codex-research "$PROMPT_FILE" "$METADATA_FILE"
+            AGENT_SPEC=$(mktemp)
+            cat > "$AGENT_SPEC" <<JSON
+            {
+              "provider": "codex-research",
+              "inputs": {
+                "stage": "research"
+              },
+              "payloads": {
+                "promptPath": "$PROMPT_FILE",
+                "metadataPath": "$METADATA_FILE"
+              },
+              "artifacts": {
+                "statusPath": "/workspace/lab/.agent-status.json",
+                "logPath": "/workspace/lab/.agent-runner.log"
+              }
+            }
+            JSON
+
+            /usr/local/bin/agent-runner --spec "$AGENT_SPEC"
             EXIT_CODE=$?
             set -e
 

--- a/argocd/applications/facteur/overlays/cluster/facteur-workflowtemplate.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-workflowtemplate.yaml
@@ -117,7 +117,24 @@ spec:
             export JSON_OUTPUT_PATH="${JSON_OUTPUT_PATH:-/workspace/lab/.codex-implementation-events.jsonl}"
             export AGENT_OUTPUT_PATH="${AGENT_OUTPUT_PATH:-/workspace/lab/.codex-implementation-agent.log}"
 
-            codex-implement
+            AGENT_SPEC=$(mktemp)
+            cat > "$AGENT_SPEC" <<JSON
+            {
+              "provider": "codex",
+              "inputs": {
+                "stage": "${CODEX_STAGE}"
+              },
+              "payloads": {
+                "eventBodyPath": "$PAYLOAD_FILE"
+              },
+              "artifacts": {
+                "statusPath": "/workspace/lab/.agent-status.json",
+                "logPath": "/workspace/lab/.agent-runner.log"
+              }
+            }
+            JSON
+
+            /usr/local/bin/agent-runner --spec "$AGENT_SPEC"
 
             if [[ -s "$OUTPUT_PATH" ]]; then
               echo "Codex implementation output:" >&2

--- a/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
+++ b/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: codex-autonomous
   namespace: argo-workflows
   annotations:
-    codex-universal-image-digest: sha256:9535df91f16138a85b755d350fc716e3779c9b5ae78a939013a67d08613b8fc6
+    codex-universal-image-digest: sha256:5b7d7fef0161cde502f8cc18ea18160d7c5595d4ccd1fc28de04ea09c026ab45
 spec:
   serviceAccountName: codex-workflow
   parallelism: 1
@@ -757,7 +757,26 @@ spec:
 
             echo "Executing ${WORKFLOW_STAGE} workflow" >&2
             set +e
-            /usr/local/bin/codex-implement "$EVENT_FILE"
+            AGENT_SPEC=$(mktemp)
+            cat > "$AGENT_SPEC" <<JSON
+            {
+              "provider": "codex",
+              "inputs": {
+                "base": "${BASE_BRANCH}",
+                "head": "${HEAD_BRANCH}",
+                "stage": "${WORKFLOW_STAGE}"
+              },
+              "payloads": {
+                "eventBodyPath": "$EVENT_FILE"
+              },
+              "artifacts": {
+                "statusPath": "/workspace/lab/.agent-status.json",
+                "logPath": "/workspace/lab/.agent-runner.log"
+              }
+            }
+            JSON
+
+            /usr/local/bin/agent-runner --spec "$AGENT_SPEC"
             EXIT_CODE=$?
             set -e
 

--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -352,7 +352,26 @@ spec:
 
             echo "Executing implementation workflow" >&2
             set +e
-            /usr/local/bin/codex-implement "$EVENT_FILE"
+            AGENT_SPEC=$(mktemp)
+            cat > "$AGENT_SPEC" <<JSON
+            {
+              "provider": "codex",
+              "inputs": {
+                "base": "{{inputs.parameters.base}}",
+                "head": "{{inputs.parameters.head}}",
+                "stage": "implementation"
+              },
+              "payloads": {
+                "eventBodyPath": "$EVENT_FILE"
+              },
+              "artifacts": {
+                "statusPath": "/workspace/lab/.agent-status.json",
+                "logPath": "/workspace/lab/.agent-runner.log"
+              }
+            }
+            JSON
+
+            /usr/local/bin/agent-runner --spec "$AGENT_SPEC"
             EXIT_CODE=$?
             set -e
 
@@ -796,7 +815,26 @@ spec:
 
             echo "Executing ${WORKFLOW_STAGE} workflow" >&2
             set +e
-            /usr/local/bin/codex-implement "$EVENT_FILE"
+            AGENT_SPEC=$(mktemp)
+            cat > "$AGENT_SPEC" <<JSON
+            {
+              "provider": "codex",
+              "inputs": {
+                "base": "${BASE_BRANCH}",
+                "head": "${HEAD_BRANCH}",
+                "stage": "${WORKFLOW_STAGE}"
+              },
+              "payloads": {
+                "eventBodyPath": "$EVENT_FILE"
+              },
+              "artifacts": {
+                "statusPath": "/workspace/lab/.agent-status.json",
+                "logPath": "/workspace/lab/.agent-runner.log"
+              }
+            }
+            JSON
+
+            /usr/local/bin/agent-runner --spec "$AGENT_SPEC"
             EXIT_CODE=$?
             set -e
 

--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -484,7 +484,10 @@ RUN mkdir -p /root/.codex
 RUN --mount=type=secret,id=codexauth,target=/tmp/codex_auth.json \
   install -m 600 /tmp/codex_auth.json /root/.codex/auth.json
 COPY --from=jangar-build /app/services/jangar/scripts/codex-config-container.toml /root/.codex/config.toml
+COPY --from=jangar-build /app/services/jangar/scripts/agent-runner.ts /usr/local/bin/agent-runner
+COPY --from=jangar-build /app/services/jangar/scripts/agent-providers /etc/agent-providers
 COPY skills/ /root/.codex/skills/
+RUN chmod +x /usr/local/bin/agent-runner
 
 # Start the compiled Nitro server produced by `bun --bun vite build`
 CMD ["bun", "run", ".output/server/index.mjs"]

--- a/services/jangar/scripts/agent-providers/codex-research.json
+++ b/services/jangar/scripts/agent-providers/codex-research.json
@@ -1,0 +1,8 @@
+{
+  "name": "codex-research",
+  "binary": "/usr/local/bin/codex-research",
+  "argsTemplate": ["{{payloads.promptPath}}", "{{payloads.metadataPath}}"],
+  "envTemplate": {
+    "WORKFLOW_STAGE": "{{inputs.stage}}"
+  }
+}

--- a/services/jangar/scripts/agent-providers/codex.json
+++ b/services/jangar/scripts/agent-providers/codex.json
@@ -1,0 +1,9 @@
+{
+  "name": "codex",
+  "binary": "/usr/local/bin/codex-implement",
+  "argsTemplate": ["{{payloads.eventBodyPath}}"],
+  "envTemplate": {
+    "WORKFLOW_STAGE": "{{inputs.stage}}",
+    "CODEX_STAGE": "{{inputs.stage}}"
+  }
+}


### PR DESCRIPTION
## Summary

- add agent-runner entrypoint and provider specs for codex + codex-research
- update codex workflow templates to invoke agent-runner instead of direct CLI calls
- include agent-runner in codex/jangar images and update codex-universal digest

## Related Issues

None

## Testing

- bunx biome check services/jangar/scripts/agent-runner.ts
- bun test apps/froussard/src/__tests__/argo-manifests.test.ts

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
