### PR TITLE
chore(coder): bump to 2.28.6 and bun-only template

### DIFF
--- a/argocd/applications/coder/Chart.yaml
+++ b/argocd/applications/coder/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 appVersion: 0.0.1
 description: Coder open source developer platform
 name: coder
-version: 2.27.0
+version: 2.28.6
 type: application
 dependencies:
   - name: coder
-    version: 2.27.0
+    version: 2.28.6
     repository: https://helm.coder.com/v2

--- a/kubernetes/coder/README.md
+++ b/kubernetes/coder/README.md
@@ -6,7 +6,7 @@ This template provisions a Coder workspace on Kubernetes with:
 - `code-server` exposed at <http://localhost:13337>
 - Persistent home volume sized via the `home_disk_size` parameter
 - Git checkout via `coder/git-clone`, followed by dependency install on first boot
-- Cursor launcher, Node.js via nvm (LTS), kubectl, Argo CD CLI, Convex CLI, and OpenAI Codex CLI
+- Cursor launcher, Bun, kubectl, Argo CD CLI, Convex CLI, OpenAI Codex CLI, and GitHub CLI
 
 ## Install
 
@@ -47,10 +47,9 @@ coder workspaces create sutro --template "kubernetes/coder"
 
 - `coder/git-clone@1.1.1` for repository checkout
 - `coder/cursor@1.3.2` to expose Cursor Desktop
-- `thezoker/nodejs@1.0.11` to install Node.js via nvm
 - `coder_script.bootstrap_tools` runs on start to:
-  - Install Node.js LTS (fallback to 22) and Bun 1.3.5
-  - Install Convex CLI, OpenAI Codex CLI, kubectl, and Argo CD CLI when missing
+  - Install Bun (via the official installer)
+  - Install Convex CLI, OpenAI Codex CLI, kubectl, Argo CD CLI, and GitHub CLI when missing
   - Expand the repository path, then run `bun install --frozen-lockfile` or `bun install` based on repo files
   - Persist Bun environment variables in `.profile` and `.zshrc`
 

--- a/kubernetes/coder/template.yaml
+++ b/kubernetes/coder/template.yaml
@@ -1,5 +1,5 @@
 name: k8s-arm64
-version: "1.0.17"
+version: "1.0.18"
 display_name: Kubernetes Workspace (arm64)
 description: Coder workspace on Kubernetes with arm64 agent and code-server.
 icon: https://raw.githubusercontent.com/coder/coder/main/site/static/icon/code.svg


### PR DESCRIPTION
## Summary

- Bump Coder Helm chart dependency to 2.28.6 for Argo CD.
- Remove the Node.js module from the Coder template; bootstrap now uses Bun for JS tooling and CLI installs.
- Update the template version to 1.0.18 and refresh Coder template docs.

## Related Issues

None.

## Testing

- Not run (configuration/docs updates only).

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
