### PR TITLE
chore(coder): ensure codex via bun

### DIFF
--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -49,6 +49,7 @@ This document explains how to maintain the single `k8s-arm64` template in Coder,
 
 - Installs Bun (via the official shell script) so package scripts use the same runtime locally and in automation.
 - Installs CLI dependencies in this order: `bun`, `convex@1.27.0`, `@openai/codex`, `kubectl`, `argocd`, `gh`.
+- Symlinks `codex`, `kubectl`, `argocd`, and `gh` into `/tmp/coder-script-data/bin` so non-interactive shells can reach them.
 - Appends `BUN_INSTALL/bin` and `~/.local/bin` to the login shells (`.profile`, `.bashrc`, `.zshrc`) so future shells inherit the toolchain.
 - Dependency install runs only when a manifest exists: `bun install --frozen-lockfile` when a Bun lockfile is present, otherwise `bun install` when only `package.json` is present.
 
@@ -128,4 +129,4 @@ Following this loop keeps the template lineage clean and ensures future Codex ru
 
 - Template version `1.0.18` removes the Node.js module and relies on Bun for JavaScript tooling.
 - CLI installs now use Bun (`bun add -g`) for `convex` and `@openai/codex`.
-- `kubectl`, `argocd`, and `gh` binaries remain symlinked into `/tmp/coder-script-data/bin` for non-interactive shells.
+- `codex`, `kubectl`, `argocd`, and `gh` binaries are symlinked into `/tmp/coder-script-data/bin` for non-interactive shells.

--- a/kubernetes/coder/README.md
+++ b/kubernetes/coder/README.md
@@ -49,7 +49,7 @@ coder workspaces create sutro --template "kubernetes/coder"
 - `coder/cursor@1.3.2` to expose Cursor Desktop
 - `coder_script.bootstrap_tools` runs on start to:
   - Install Bun (via the official installer)
-  - Install Convex CLI, OpenAI Codex CLI, kubectl, Argo CD CLI, and GitHub CLI when missing
+  - Install Convex CLI, OpenAI Codex CLI, kubectl, Argo CD CLI, and GitHub CLI when missing (Codex via Bun global)
   - Expand the repository path, then run `bun install --frozen-lockfile` or `bun install` based on repo files
   - Persist Bun environment variables in `.profile` and `.zshrc`
 

--- a/kubernetes/coder/main.tf
+++ b/kubernetes/coder/main.tf
@@ -441,6 +441,9 @@ resource "coder_script" "bootstrap_tools" {
         fail "Codex CLI install failed; see $LOG_DIR/codex-install.log"
       fi
     fi
+    if command -v codex >/dev/null 2>&1; then
+      ln -sf "$(command -v codex)" /tmp/coder-script-data/bin/codex
+    fi
 
     if ! command -v kubectl >/dev/null 2>&1; then
       log "Installing kubectl"

--- a/kubernetes/coder/template.yaml
+++ b/kubernetes/coder/template.yaml
@@ -1,5 +1,5 @@
 name: k8s-arm64
-version: "1.0.18"
+version: "1.0.19"
 display_name: Kubernetes Workspace (arm64)
 description: Coder workspace on Kubernetes with arm64 agent and code-server.
 icon: https://raw.githubusercontent.com/coder/coder/main/site/static/icon/code.svg


### PR DESCRIPTION
## Summary

- Ensure Codex CLI is installed globally via Bun in the Coder template.
- Symlink `codex` into `/tmp/coder-script-data/bin` so non-interactive shells can find it.
- Bump the template version to 1.0.19 and update docs.

## Related Issues

None.

## Testing

- Not run (template/doc updates only).

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
