### PR TITLE
fix(facteur): always use autonomous workflow

### DIFF
--- a/argocd/applications/facteur/overlays/cluster/facteur-config.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-config.yaml
@@ -15,7 +15,7 @@ data:
       enabled: true
       namespace: argo-workflows
       autonomous_namespace: jangar
-      workflow_template: github-codex-implementation
+      workflow_template: codex-autonomous
       autonomous_workflow_template: codex-autonomous
       service_account: codex-workflow
       autonomous_service_account: jangar-inspector

--- a/services/facteur/README.md
+++ b/services/facteur/README.md
@@ -106,7 +106,7 @@ Cluster deployments rely on a namespace-scoped Grafana Alloy deployment (`argocd
 
 ### Codex implementation orchestration
 
-Implementation runs through the implementation orchestrator (`codex_implementation_orchestrator.enabled=true`, or the env alias `FACTEUR_CODEX_ENABLE_IMPLEMENTATION_ORCHESTRATION`) to submit the `github-codex-implementation` workflow with the same persistence + idempotency guarantees. When a Codex task is marked autonomous, Facteur switches to the `codex-autonomous` workflow template (configurable via `codex_implementation_orchestrator.autonomous_workflow_template`).
+Implementation runs through the implementation orchestrator (`codex_implementation_orchestrator.enabled=true`, or the env alias `FACTEUR_CODEX_ENABLE_IMPLEMENTATION_ORCHESTRATION`) and submits the `codex-autonomous` workflow template (configurable via `codex_implementation_orchestrator.autonomous_workflow_template`, defaulting to `codex-autonomous` in the `jangar` namespace).
 
 ## Container image
 

--- a/services/facteur/cmd/facteur/serve.go
+++ b/services/facteur/cmd/facteur/serve.go
@@ -55,14 +55,16 @@ func NewServeCommand() *cobra.Command {
 			}
 			cfg.Postgres.DSN = dsn
 
+			implementerNamespace := firstNonEmpty(cfg.Implementer.AutonomousNamespace, cfg.Implementer.Namespace, cfg.Argo.Namespace, "jangar")
+			implementerTemplate := firstNonEmpty(cfg.Implementer.AutonomousWorkflowTemplate, "codex-autonomous")
 			cmd.Printf(
 				"config: argo ns=%s template=%s sa=%s implementer_enabled=%t implementer_ns=%s implementer_template=%s redis=%s postgres=%s listen=%s\n",
 				cfg.Argo.Namespace,
 				cfg.Argo.WorkflowTemplate,
 				cfg.Argo.ServiceAccount,
 				cfg.Implementer.Enabled,
-				firstNonEmpty(cfg.Implementer.Namespace, cfg.Argo.Namespace),
-				firstNonEmpty(cfg.Implementer.WorkflowTemplate, cfg.Argo.WorkflowTemplate),
+				implementerNamespace,
+				implementerTemplate,
 				redactURL(cfg.Redis.URL),
 				redactURL(cfg.Postgres.DSN),
 				cfg.Server.ListenAddress,
@@ -142,7 +144,6 @@ func NewServeCommand() *cobra.Command {
 				if implementerCfg.ServiceAccount == "" {
 					implementerCfg.ServiceAccount = cfg.Argo.ServiceAccount
 				}
-				implementerCfg.GenerateNamePrefix = "github-codex-implementation-"
 				if implementerCfg.AutonomousWorkflowTemplate == "" {
 					implementerCfg.AutonomousWorkflowTemplate = "codex-autonomous"
 				}
@@ -159,10 +160,12 @@ func NewServeCommand() *cobra.Command {
 					Enabled:     true,
 					Implementer: implementer,
 				}
+				effectiveNamespace := firstNonEmpty(implementerCfg.AutonomousNamespace, implementerCfg.Namespace, "jangar")
+				effectiveTemplate := firstNonEmpty(implementerCfg.AutonomousWorkflowTemplate, "codex-autonomous")
 				cmd.Printf(
 					"codex implementation orchestration enabled (namespace=%s template=%s)\n",
-					implementerCfg.Namespace,
-					implementerCfg.WorkflowTemplate,
+					effectiveNamespace,
+					effectiveTemplate,
 				)
 			}
 

--- a/services/facteur/config/example.yaml
+++ b/services/facteur/config/example.yaml
@@ -45,7 +45,7 @@ codex_implementation_orchestrator:
   enabled: false
   namespace: argo
   autonomous_namespace: jangar
-  workflow_template: github-codex-implementation
+  workflow_template: codex-autonomous
   autonomous_workflow_template: codex-autonomous
   service_account: facteur
   autonomous_service_account: jangar-inspector

--- a/services/facteur/internal/config/config_test.go
+++ b/services/facteur/internal/config/config_test.go
@@ -33,7 +33,7 @@ codex_implementation_orchestrator:
   enabled: true
   namespace: implementation
   autonomous_namespace: jangar
-  workflow_template: github-codex-implementation
+  workflow_template: codex-autonomous
   service_account: implementer
   autonomous_service_account: jangar-inspector
   parameters:
@@ -71,7 +71,7 @@ codex_listener:
 		require.True(t, cfg.Implementer.Enabled)
 		require.Equal(t, "implementation", cfg.Implementer.Namespace)
 		require.Equal(t, "jangar", cfg.Implementer.AutonomousNamespace)
-		require.Equal(t, "github-codex-implementation", cfg.Implementer.WorkflowTemplate)
+		require.Equal(t, "codex-autonomous", cfg.Implementer.WorkflowTemplate)
 		require.Equal(t, "implementer", cfg.Implementer.ServiceAccount)
 		require.Equal(t, "jangar-inspector", cfg.Implementer.AutonomousServiceAccount)
 		require.Equal(t, map[string]string{"eventbody": "{}"}, cfg.Implementer.Parameters)
@@ -106,7 +106,7 @@ argo:
 		t.Setenv("FACTEUR_ARGO_WORKFLOW_TEMPLATE", "env-template")
 		t.Setenv("FACTEUR_POSTGRES_DSN", "postgres://override")
 		t.Setenv("FACTEUR_CODEX_ENABLE_IMPLEMENTATION_ORCHESTRATION", "true")
-		t.Setenv("FACTEUR_CODEX_IMPLEMENTATION_ORCHESTRATOR_WORKFLOW_TEMPLATE", "env-implementation")
+		t.Setenv("FACTEUR_CODEX_IMPLEMENTATION_ORCHESTRATOR_WORKFLOW_TEMPLATE", "env-autonomous")
 
 		cfg, err := config.LoadWithOptions(config.Options{Path: path, EnvPrefix: "FACTEUR"})
 		require.NoError(t, err)
@@ -116,7 +116,7 @@ argo:
 		require.Equal(t, ":8080", cfg.Server.ListenAddress)
 		require.False(t, cfg.Codex.Enabled)
 		require.True(t, cfg.Implementer.Enabled)
-		require.Equal(t, "env-implementation", cfg.Implementer.WorkflowTemplate)
+		require.Equal(t, "env-autonomous", cfg.Implementer.WorkflowTemplate)
 	})
 
 	t.Run("missing required fields", func(t *testing.T) {

--- a/services/facteur/internal/orchestrator/implementation_test.go
+++ b/services/facteur/internal/orchestrator/implementation_test.go
@@ -99,16 +99,20 @@ func TestImplementer_Success(t *testing.T) {
 	store := &fakeStore{}
 	runner := &fakeRunner{
 		responses: []runnerResponse{
-			{result: argo.RunResult{Namespace: "argo-workflows", WorkflowName: "github-codex-implementation-123", SubmittedAt: time.Unix(1735601000, 0)}},
+			{result: argo.RunResult{Namespace: "jangar", WorkflowName: "codex-autonomous-123", SubmittedAt: time.Unix(1735601000, 0)}},
 		},
 	}
 
 	implementerInstance, err := NewImplementer(store, runner, Config{
-		Namespace:          "argo-workflows",
-		WorkflowTemplate:   "github-codex-implementation",
-		ServiceAccount:     "implementer-sa",
-		Parameters:         map[string]string{"environment": "staging"},
-		GenerateNamePrefix: "github-codex-implementation-",
+		Namespace:                    "argo-workflows",
+		AutonomousNamespace:          "jangar",
+		WorkflowTemplate:             "codex-autonomous",
+		AutonomousWorkflowTemplate:   "codex-autonomous",
+		ServiceAccount:               "implementer-sa",
+		AutonomousServiceAccount:     "jangar-inspector",
+		Parameters:                   map[string]string{"environment": "staging"},
+		GenerateNamePrefix:           "codex-autonomous-",
+		AutonomousGenerateNamePrefix: "codex-autonomous-",
 	})
 	require.NoError(t, err)
 
@@ -148,10 +152,10 @@ func TestImplementer_Success(t *testing.T) {
 	require.Equal(t, 1, runner.calls)
 	require.Len(t, runner.inputs, 1)
 	input := runner.inputs[0]
-	require.Equal(t, "argo-workflows", input.Namespace)
-	require.Equal(t, "github-codex-implementation", input.WorkflowTemplate)
-	require.Equal(t, "implementer-sa", input.ServiceAccount)
-	require.Equal(t, "github-codex-implementation-", input.GenerateNamePrefix)
+	require.Equal(t, "jangar", input.Namespace)
+	require.Equal(t, "codex-autonomous", input.WorkflowTemplate)
+	require.Equal(t, "jangar-inspector", input.ServiceAccount)
+	require.Equal(t, "codex-autonomous-", input.GenerateNamePrefix)
 	require.Equal(t, "staging", input.Parameters["environment"])
 	require.Equal(t, "proompteng/lab", input.Parameters["repository"])
 	require.Equal(t, "1966", input.Parameters["issue_number"])
@@ -198,7 +202,7 @@ func TestImplementer_AutonomousOverrides(t *testing.T) {
 	implementerInstance, err := NewImplementer(store, runner, Config{
 		Namespace:                  "argo-workflows",
 		AutonomousNamespace:        "jangar",
-		WorkflowTemplate:           "github-codex-implementation",
+		WorkflowTemplate:           "codex-autonomous",
 		AutonomousWorkflowTemplate: "codex-autonomous",
 		ServiceAccount:             "codex-workflow",
 		AutonomousServiceAccount:   "jangar-inspector",
@@ -230,7 +234,7 @@ func TestImplementer_DuplicateDelivery(t *testing.T) {
 	store := &fakeStore{}
 	runner := &fakeRunner{
 		responses: []runnerResponse{
-			{result: argo.RunResult{Namespace: "codex", WorkflowName: "github-codex-implementation-456", SubmittedAt: time.Unix(1735601001, 0)}},
+			{result: argo.RunResult{Namespace: "jangar", WorkflowName: "codex-autonomous-456", SubmittedAt: time.Unix(1735601001, 0)}},
 		},
 	}
 

--- a/services/facteur/internal/server/server_test.go
+++ b/services/facteur/internal/server/server_test.go
@@ -101,8 +101,8 @@ func TestEventsEndpointRejectsEmptyPayload(t *testing.T) {
 
 func TestCodexTasksImplementationDispatches(t *testing.T) {
 	implementer := &stubImplementer{result: orchestrator.Result{
-		Namespace:    "argo-workflows",
-		WorkflowName: "github-codex-implementation-abc123",
+		Namespace:    "jangar",
+		WorkflowName: "codex-autonomous-abc123",
 		SubmittedAt:  time.Unix(1735600400, 0).UTC(),
 	}}
 	srv, err := server.New(server.Options{
@@ -134,8 +134,8 @@ func TestCodexTasksImplementationDispatches(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
 	_ = resp.Body.Close()
 	require.Equal(t, "implementation", data["stage"])
-	require.Equal(t, "argo-workflows", data["namespace"])
-	require.Equal(t, "github-codex-implementation-abc123", data["workflowName"])
+	require.Equal(t, "jangar", data["namespace"])
+	require.Equal(t, "codex-autonomous-abc123", data["workflowName"])
 	require.Equal(t, implementer.result.SubmittedAt.Format(time.RFC3339), data["submittedAt"])
 	require.False(t, data["duplicate"].(bool))
 	require.Equal(t, 1, implementer.calls)


### PR DESCRIPTION
## Summary

- Route codex implementation orchestration to the autonomous workflow template by default.
- Align facteur configs/docs/tests with codex-autonomous defaults.
- Update facteur startup logging to show autonomous namespace/template selection.

## Related Issues

None

## Testing

- `cd services/facteur && go test ./...` (fails: `TestSetupAndForceFlush` in `services/facteur/internal/telemetry` due to `OTLP metrics endpoint 404`)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (with failure noted).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
