### PR TITLE
chore(facteur): deploy 8c63f780a

### DIFF
--- a/argocd/applications/facteur/overlays/cluster/facteur-service.yaml
+++ b/argocd/applications/facteur/overlays/cluster/facteur-service.yaml
@@ -11,7 +11,7 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/target: "100"
-        deploy.knative.dev/rollout: "2026-01-06T05:58:20.867Z"
+        deploy.knative.dev/rollout: "2026-01-07T08:01:03.815Z"
     spec:
       serviceAccountName: facteur
       containers:

--- a/argocd/applications/facteur/overlays/cluster/kustomization.yaml
+++ b/argocd/applications/facteur/overlays/cluster/kustomization.yaml
@@ -21,4 +21,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/facteur
-    newTag: a1e36865e
+    newTag: 8c63f780a


### PR DESCRIPTION
## Summary

- Bump facteur image tag to 8c63f780a.
- Refresh facteur rollout annotation for deploy.

## Related Issues

None

## Testing

- N/A (manifest-only rollout change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
