### PR TITLE
chore(codex): set bun cache outside repo

### DIFF
--- a/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
+++ b/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
@@ -89,12 +89,18 @@ spec:
             value: '{{inputs.parameters.base}}'
           - name: HEAD_BRANCH
             value: '{{inputs.parameters.head}}'
+          - name: WORKSPACE
+            value: /workspace/lab
+          - name: REPO_ROOT
+            value: /workspace/lab
           - name: WORKTREE
             value: /workspace/lab/.worktrees/{{inputs.parameters.head}}
           - name: TARGET_DIR
             value: /workspace/lab/.worktrees/{{inputs.parameters.head}}
           - name: CODEX_CWD
             value: /workspace/lab/.worktrees/{{inputs.parameters.head}}
+          - name: BUN_INSTALL_CACHE_DIR
+            value: /workspace/.bun-install-cache
           - name: CODEX_ITERATION
             value: '{{inputs.parameters.iteration}}'
           - name: CODEX_ITERATION_CYCLE


### PR DESCRIPTION
## Summary

- Move Bun install cache to `/workspace/.bun-install-cache` for the codex-autonomous workflow.
- Keep repo root/worktree envs aligned while avoiding repo-local cache writes.

## Related Issues

None

## Testing

- N/A (manifest-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
