### PR TITLE
chore(coder): install node lts via nvm

### DIFF
--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -48,6 +48,7 @@ This document explains how to maintain the single `k8s-arm64` template in Coder,
 ## Bootstrap Script Overview
 
 - Installs Bun (via the official shell script) so package scripts use the same runtime locally and in automation.
+- Installs Node.js LTS via nvm.
 - Installs CLI dependencies in this order: `bun`, `convex@1.27.0`, `@openai/codex` (via `bun install -g`), `kubectl`, `argocd`, `gh`.
 - Symlinks `kubectl`, `argocd`, and `gh` into `/tmp/coder-script-data/bin` so non-interactive shells can reach them.
 - Workspace pods run with a service account bound to `cluster-admin` via a RoleBinding (namespace-scoped) so in-cluster `kubectl` has admin access.
@@ -128,6 +129,6 @@ Following this loop keeps the template lineage clean and ensures future Codex ru
 
 ## Latest Update (January 7, 2026)
 
-- Template version `1.0.18` removes the Node.js module and relies on Bun for JavaScript tooling.
-- CLI installs now use Bun (`bun add -g`) for `convex` and `@openai/codex`.
-- `codex`, `kubectl`, `argocd`, and `gh` binaries are symlinked into `/tmp/coder-script-data/bin` for non-interactive shells.
+- Template version `1.0.27` installs Node.js LTS via nvm alongside Bun.
+- CLI installs use Bun (`bun add -g` for `convex`, `bun install -g` for `@openai/codex`).
+- `kubectl`, `argocd`, and `gh` binaries are symlinked into `/tmp/coder-script-data/bin` for non-interactive shells.

--- a/kubernetes/coder/README.md
+++ b/kubernetes/coder/README.md
@@ -49,6 +49,7 @@ coder workspaces create sutro --template "kubernetes/coder"
 - `coder/cursor@1.3.2` to expose Cursor Desktop
 - `coder_script.bootstrap_tools` runs on start to:
   - Install Bun (via the official installer)
+  - Install Node.js LTS via nvm
   - Install Convex CLI, OpenAI Codex CLI, kubectl, Argo CD CLI, and GitHub CLI when missing (Codex via Bun global)
   - Expand the repository path, then run `bun install --frozen-lockfile` or `bun install` based on repo files
   - Persist Bun environment variables in `.profile` and `.zshrc`

--- a/kubernetes/coder/template.yaml
+++ b/kubernetes/coder/template.yaml
@@ -1,5 +1,5 @@
 name: k8s-arm64
-version: "1.0.26"
+version: "1.0.27"
 display_name: Kubernetes Workspace (arm64)
 description: Coder workspace on Kubernetes with arm64 agent and code-server.
 icon: https://raw.githubusercontent.com/coder/coder/main/site/static/icon/code.svg


### PR DESCRIPTION
## Summary

- Install Node.js LTS via nvm in the Coder workspace bootstrap.
- Persist nvm initialization in shell profiles.
- Bump template version to 1.0.27 and update docs.

## Related Issues

None.

## Testing

- Not run (template/doc updates only).

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
