### PR TITLE
fix(codex): install node-gyp in codex image

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -96,7 +96,7 @@ RUN set -eux; \
     install -m 0755 "${TEMPORAL_TMPDIR}/temporal" /usr/local/bin/temporal; \
     rm -rf "${TEMPORAL_TMPDIR}"
 
-RUN bash -lc 'source /root/.nvm/nvm.sh && npm install -g @openai/codex@latest && ln -sf "$(command -v codex)" /usr/local/bin/codex && ln -sf "$(command -v node)" /usr/local/bin/node && ln -sf "$(command -v npm)" /usr/local/bin/npm'
+RUN bash -lc 'source /root/.nvm/nvm.sh && npm install -g @openai/codex@latest node-gyp && ln -sf "$(command -v codex)" /usr/local/bin/codex && ln -sf "$(command -v node)" /usr/local/bin/node && ln -sf "$(command -v npm)" /usr/local/bin/npm && ln -sf "$(command -v node-gyp)" /usr/local/bin/node-gyp'
 
 RUN mkdir -p "$WORKSPACE" /root/.codex "$BUN_INSTALL_CACHE_DIR"
 


### PR DESCRIPTION
## Summary

- install `node-gyp` in the codex-universal image
- symlink `node-gyp` into `/usr/local/bin` for runtime access
- unblock Bun install scripts that invoke `node-gyp`

## Related Issues

- None

## Testing

- N/A (image build + workflow run will validate after merge)

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
