### PR TITLE
fix(codex): seed bun cache and share dir

### DIFF
--- a/apps/froussard/Dockerfile.codex
+++ b/apps/froussard/Dockerfile.codex
@@ -15,6 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     GIT_TERMINAL_PROMPT=0 \
     BUN_INSTALL=/usr/local \
     BUN_INSTALL_CACHE_DIR=/opt/bun/install/cache \
+    BUN_INSTALL_CACHE_SEED_DIR=/opt/bun/install/cache \
     DOCKER_HOST=tcp://localhost:2375 \
     DOCKER_ENABLED=0
 

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -93,6 +93,8 @@ spec:
               value: none
             - name: BUMBA_WORKSPACE_ROOT
               value: /workspace/lab
+            - name: BUN_INSTALL_CACHE_DIR
+              value: /workspace/.bun-install-cache
             - name: BUMBA_HEALTH_PORT
               value: "3001"
             - name: REPOSITORY

--- a/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
+++ b/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
@@ -101,6 +101,8 @@ spec:
             value: /workspace/lab/.worktrees/{{inputs.parameters.head}}
           - name: BUN_INSTALL_CACHE_DIR
             value: /workspace/.bun-install-cache
+          - name: BUN_INSTALL_CACHE_SEED_DIR
+            value: /opt/bun/install/cache
           - name: CODEX_ITERATION
             value: '{{inputs.parameters.iteration}}'
           - name: CODEX_ITERATION_CYCLE

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: /usr/local/bin/codex
             - name: CODEX_CWD
               value: /workspace/lab
+            - name: BUN_INSTALL_CACHE_DIR
+              value: /workspace/.bun-install-cache
             - name: CODEX_REPO_SLUG
               value: proompteng/lab
             - name: CODEX_REPO_URL


### PR DESCRIPTION
## Summary

- seed the Bun cache into the shared PVC when empty
- wire `BUN_INSTALL_CACHE_DIR` for jangar + bumba
- expose `BUN_INSTALL_CACHE_SEED_DIR` in codex image + workflow

## Related Issues

- None

## Testing

- N/A (workflow + Argo sync validate)

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
