### PR TITLE
chore(coder): avoid gh install pipefail

### DIFF
--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -130,6 +130,6 @@ Following this loop keeps the template lineage clean and ensures future Codex ru
 
 ## Latest Update (January 7, 2026)
 
-- Template version `1.0.29` installs Node.js LTS via nvm alongside Bun and adds recommended CLI tools.
+- Template version `1.0.30` installs Node.js LTS via nvm alongside Bun and adds recommended CLI tools.
 - CLI installs use Bun (`bun add -g` for `convex`, `bun install -g` for `@openai/codex`).
 - `kubectl`, `argocd`, and `gh` binaries are symlinked into `/tmp/coder-script-data/bin` for non-interactive shells.

--- a/kubernetes/coder/main.tf
+++ b/kubernetes/coder/main.tf
@@ -604,7 +604,7 @@ resource "coder_script" "bootstrap_tools" {
       GH_VERSION="2.55.0"
       GH_JSON=""
       if GH_JSON="$(curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://api.github.com/repos/cli/cli/releases/latest 2>"$LOG_DIR/gh-version.log")"; then
-        GH_VERSION="$(printf '%s' "$GH_JSON" | grep -m1 '\"tag_name\"' | sed -E 's/.*\"tag_name\": *\"v?([^\" ]+)\".*/\\1/')"
+        GH_VERSION="$(printf '%s' "$GH_JSON" | grep -m1 '\"tag_name\"' | sed -E 's/.*\"tag_name\": *\"v?([^\" ]+)\".*/\\1/' || true)"
       fi
       if [ -z "$GH_VERSION" ]; then
         GH_VERSION="2.55.0"
@@ -620,7 +620,7 @@ resource "coder_script" "bootstrap_tools" {
         rm -rf "$GH_TMP"
         fail "GitHub CLI extract failed; see $LOG_DIR/gh-install.log"
       fi
-      GH_DIR="$(find "$GH_TMP" -maxdepth 1 -type d -name 'gh_*' | head -n1)"
+      GH_DIR="$(find "$GH_TMP" -maxdepth 1 -type d -name 'gh_*' -print -quit)"
       if [ -z "$GH_DIR" ] || [ ! -x "$GH_DIR/bin/gh" ]; then
         rm -rf "$GH_TMP"
         fail "GitHub CLI archive missing expected binary; see $LOG_DIR/gh-install.log"

--- a/kubernetes/coder/template.yaml
+++ b/kubernetes/coder/template.yaml
@@ -1,5 +1,5 @@
 name: k8s-arm64
-version: "1.0.29"
+version: "1.0.30"
 display_name: Kubernetes Workspace (arm64)
 description: Coder workspace on Kubernetes with arm64 agent and code-server.
 icon: https://raw.githubusercontent.com/coder/coder/main/site/static/icon/code.svg


### PR DESCRIPTION
## Summary

- Avoid pipefail SIGPIPE during GitHub CLI install by removing the head pipeline.
- Keep GH version parsing from failing when the tag is missing.
- Bump template version to 1.0.30 and update docs.

## Related Issues

None.

## Testing

- Not run (template/doc updates only).

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
