### PR TITLE
fix(coder): make gh install best-effort

### DIFF
--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -130,6 +130,6 @@ Following this loop keeps the template lineage clean and ensures future Codex ru
 
 ## Latest Update (January 7, 2026)
 
-- Template version `1.0.30` installs Node.js LTS via nvm alongside Bun and adds recommended CLI tools.
+- Template version `1.0.31` installs Node.js LTS via nvm alongside Bun and adds recommended CLI tools.
 - CLI installs use Bun (`bun add -g` for `convex`, `bun install -g` for `@openai/codex`).
 - `kubectl`, `argocd`, and `gh` binaries are symlinked into `/tmp/coder-script-data/bin` for non-interactive shells.

--- a/kubernetes/coder/template.yaml
+++ b/kubernetes/coder/template.yaml
@@ -1,5 +1,5 @@
 name: k8s-arm64
-version: "1.0.30"
+version: "1.0.31"
 display_name: Kubernetes Workspace (arm64)
 description: Coder workspace on Kubernetes with arm64 agent and code-server.
 icon: https://raw.githubusercontent.com/coder/coder/main/site/static/icon/code.svg


### PR DESCRIPTION
## Summary
- Make GitHub CLI install best-effort (apt first, fallback to release download) without failing bootstrap
- Link gh into the workspace PATH only when available
- Bump Coder template version to 1.0.31 and update bootstrap docs

## Related Issues
None

## Testing
- N/A (template change; validation requires workspace rebuild)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
