### PR TITLE
feat(jangar): show codex runs PR status

### DIFF
--- a/services/jangar/src/data/codex.ts
+++ b/services/jangar/src/data/codex.ts
@@ -50,6 +50,8 @@ export type CodexRunSummaryRecord = {
   commitSha: string | null
   prNumber: number | null
   prUrl: string | null
+  prState: string | null
+  prMerged: boolean | null
   ciStatus: string | null
   reviewStatus: string | null
   createdAt: string

--- a/services/jangar/src/routes/codex/runs.tsx
+++ b/services/jangar/src/routes/codex/runs.tsx
@@ -261,42 +261,49 @@ function CodexRunsPage() {
                   <th className="px-3 py-2 text-left font-medium">Repository</th>
                   <th className="px-3 py-2 text-left font-medium">Review status</th>
                   <th className="px-3 py-2 text-left font-medium">PR</th>
+                  <th className="px-3 py-2 text-left font-medium">PR status</th>
                   <th className="px-3 py-2 text-left font-medium">Updated</th>
                 </tr>
               </thead>
               <tbody>
-                {reviewQueue.map((run) => (
-                  <tr key={`review-${run.id}`} className="border-b last:border-0">
-                    <td className="px-3 py-2 whitespace-nowrap">
-                      <Link
-                        to="/codex/search"
-                        search={{
-                          repository: run.repository,
-                          issueNumber: run.issueNumber,
-                          branch: '',
-                          limit: DEFAULT_SEARCH_LIMIT,
-                        }}
-                        className="text-primary hover:underline"
-                      >
-                        #{run.issueNumber}
-                      </Link>
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.repository}</td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
-                      {run.reviewStatus ?? 'pending'}
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap">
-                      {run.prUrl ? (
-                        <ExternalLink href={run.prUrl}>PR #{run.prNumber ?? '—'}</ExternalLink>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
-                      {formatDateTime(run.updatedAt)}
-                    </td>
-                  </tr>
-                ))}
+                {reviewQueue.map((run) => {
+                  const prStatus = getPrStatus(run)
+                  return (
+                    <tr key={`review-${run.id}`} className="border-b last:border-0">
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <Link
+                          to="/codex/search"
+                          search={{
+                            repository: run.repository,
+                            issueNumber: run.issueNumber,
+                            branch: '',
+                            limit: DEFAULT_SEARCH_LIMIT,
+                          }}
+                          className="text-primary hover:underline"
+                        >
+                          #{run.issueNumber}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.repository}</td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                        {run.reviewStatus ?? 'pending'}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        {run.prUrl ? (
+                          <ExternalLink href={run.prUrl}>PR #{run.prNumber ?? '—'}</ExternalLink>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                        {prStatus ? <StatusPill value={prStatus} tone="muted" /> : '—'}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                        {formatDateTime(run.updatedAt)}
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           </div>
@@ -337,68 +344,75 @@ function CodexRunsPage() {
                   <th className="px-3 py-2 text-left font-medium">Workflow</th>
                   <th className="px-3 py-2 text-left font-medium">Branch</th>
                   <th className="px-3 py-2 text-left font-medium">PR</th>
+                  <th className="px-3 py-2 text-left font-medium">PR status</th>
                   <th className="px-3 py-2 text-left font-medium">CI</th>
                   <th className="px-3 py-2 text-left font-medium">Review</th>
                   <th className="px-3 py-2 text-left font-medium">Created</th>
                 </tr>
               </thead>
               <tbody>
-                {runs.map((run) => (
-                  <tr key={run.id} className="border-b last:border-0">
-                    <td className="px-3 py-2 whitespace-nowrap">
-                      <Link
-                        to="/codex/search"
-                        search={{
-                          repository: run.repository,
-                          issueNumber: run.issueNumber,
-                          branch: '',
-                          limit: DEFAULT_SEARCH_LIMIT,
-                        }}
-                        className="text-primary hover:underline"
-                      >
-                        #{run.issueNumber}
-                      </Link>
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.repository}</td>
-                    <td className="px-3 py-2 whitespace-nowrap tabular-nums">#{run.attempt}</td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
-                      {run.iteration ? (
-                        <span className="tabular-nums">
-                          {run.iteration}
-                          {run.iterationCycle ? `/${run.iterationCycle}` : ''}
-                        </span>
-                      ) : (
-                        '—'
-                      )}
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap">
-                      <StatusPill value={run.status} />
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
-                      {run.stage ?? '—'} / {run.phase ?? '—'}
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.decision ?? '—'}</td>
-                    <td className="px-3 py-2 whitespace-nowrap">
-                      <div className="text-foreground">{run.workflowName}</div>
-                      {run.workflowNamespace ? (
-                        <div className="text-muted-foreground">{run.workflowNamespace}</div>
-                      ) : null}
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.branch}</td>
-                    <td className="px-3 py-2 whitespace-nowrap">
-                      {run.prUrl ? (
-                        <ExternalLink href={run.prUrl}>PR #{run.prNumber ?? '—'}</ExternalLink>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
-                    </td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.ciStatus ?? '—'}</td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.reviewStatus ?? '—'}</td>
-                    <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
-                      {formatDateTime(run.createdAt)}
-                    </td>
-                  </tr>
-                ))}
+                {runs.map((run) => {
+                  const prStatus = getPrStatus(run)
+                  return (
+                    <tr key={run.id} className="border-b last:border-0">
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <Link
+                          to="/codex/search"
+                          search={{
+                            repository: run.repository,
+                            issueNumber: run.issueNumber,
+                            branch: '',
+                            limit: DEFAULT_SEARCH_LIMIT,
+                          }}
+                          className="text-primary hover:underline"
+                        >
+                          #{run.issueNumber}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.repository}</td>
+                      <td className="px-3 py-2 whitespace-nowrap tabular-nums">#{run.attempt}</td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                        {run.iteration ? (
+                          <span className="tabular-nums">
+                            {run.iteration}
+                            {run.iterationCycle ? `/${run.iterationCycle}` : ''}
+                          </span>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <StatusPill value={run.status} />
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                        {run.stage ?? '—'} / {run.phase ?? '—'}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.decision ?? '—'}</td>
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <div className="text-foreground">{run.workflowName}</div>
+                        {run.workflowNamespace ? (
+                          <div className="text-muted-foreground">{run.workflowNamespace}</div>
+                        ) : null}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.branch}</td>
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        {run.prUrl ? (
+                          <ExternalLink href={run.prUrl}>PR #{run.prNumber ?? '—'}</ExternalLink>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                        {prStatus ? <StatusPill value={prStatus} tone="muted" /> : '—'}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.ciStatus ?? '—'}</td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">{run.reviewStatus ?? '—'}</td>
+                      <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                        {formatDateTime(run.createdAt)}
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           </div>
@@ -468,6 +482,12 @@ function StatusPill({ value, tone }: { value: string; tone?: 'muted' | 'default'
       {value}
     </span>
   )
+}
+
+const getPrStatus = (run: CodexRunSummaryRecord): string | null => {
+  if (run.prNumber == null) return null
+  if (run.prMerged) return 'merged'
+  return run.prState ?? null
 }
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {

--- a/services/jangar/src/server/__tests__/codex-judge-recent-runs.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-recent-runs.test.ts
@@ -20,6 +20,8 @@ const buildRunSummary = (overrides: Partial<CodexRunSummaryRecord> = {}): CodexR
   commitSha: null,
   prNumber: null,
   prUrl: null,
+  prState: null,
+  prMerged: null,
   ciStatus: null,
   reviewStatus: null,
   createdAt: '2025-01-01T00:00:00Z',

--- a/services/jangar/src/server/__tests__/codex-judge-runs-page.test.ts
+++ b/services/jangar/src/server/__tests__/codex-judge-runs-page.test.ts
@@ -20,6 +20,8 @@ const buildRunSummary = (overrides: Partial<CodexRunSummaryRecord> = {}): CodexR
   commitSha: null,
   prNumber: null,
   prUrl: null,
+  prState: null,
+  prMerged: null,
   ciStatus: null,
   reviewStatus: null,
   createdAt: '2025-01-01T00:00:00Z',


### PR DESCRIPTION
## Summary
- join `jangar_github.pr_state` into codex run summaries for PR state/merge status
- expose PR status in Codex run types and API responses
- render PR status badges in review queue and all runs tables
- update codex runs API tests for the new fields

## Related Issues
- Closes #2400

## Testing
- bun run --cwd services/jangar lint
- bun run --cwd services/jangar test -- codex-judge-runs-page.test.ts codex-judge-recent-runs.test.ts

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
