### PR TITLE
fix(crossplane): add format type to memory transforms

### DIFF
--- a/packages/crossplane/configuration-memory/compositions/memory-postgres.yaml
+++ b/packages/crossplane/configuration-memory/compositions/memory-postgres.yaml
@@ -62,6 +62,7 @@ spec:
                 transforms:
                   - type: string
                     string:
+                      type: Format
                       fmt: '%s-memory-sql'
           - name: init-sql-job
             base:
@@ -98,12 +99,14 @@ spec:
                 transforms:
                   - type: string
                     string:
+                      type: Format
                       fmt: '%s-memory-init'
               - fromFieldPath: metadata.name
                 toFieldPath: spec.template.spec.volumes[0].configMap.name
                 transforms:
                   - type: string
                     string:
+                      type: Format
                       fmt: '%s-memory-sql'
               - fromFieldPath: spec.dataset.schema
                 toFieldPath: spec.template.spec.containers[0].env[1].value


### PR DESCRIPTION
## Summary

- Add explicit `string.type: Format` to memory composition string transforms.
- Fix Crossplane function validation errors when composing memory resources.
- Unblock Memory pipeline in the jangar primitives flow.

## Related Issues

None

## Testing

- N/A (configuration change only)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
