### PR TITLE
fix(crossplane): harden memory provider field lookup

### DIFF
--- a/packages/crossplane/functions/function-memory-connection/fn.go
+++ b/packages/crossplane/functions/function-memory-connection/fn.go
@@ -279,10 +279,16 @@ func getStringField(obj map[string]any, path string) string {
 		return ""
 	}
 	value, err := fieldpath.Pave(obj).GetValue(path)
-	if err != nil {
+	if err == nil {
+		if s, ok := value.(string); ok {
+			return s
+		}
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) == 0 {
 		return ""
 	}
-	if s, ok := value.(string); ok {
+	if s, found, err := unstructured.NestedString(obj, segments...); err == nil && found {
 		return s
 	}
 	return ""


### PR DESCRIPTION
## Summary

- Add fallback lookup for providerRef values in memory connection function.
- Make providerRef extraction resilient to fieldpath lookup failures.
- Keep behavior unchanged when the primary lookup succeeds.

## Related Issues

None

## Testing

- `go test ./packages/crossplane/functions/function-memory-connection/...`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
