### PR TITLE
fix(crossplane): harden map-to-list

### DIFF
--- a/packages/crossplane/configuration-agents/compositions/agentrun-argo.yaml
+++ b/packages/crossplane/configuration-agents/compositions/agentrun-argo.yaml
@@ -44,7 +44,8 @@ spec:
                 policy:
                   fromFieldPath: Optional
             connectionDetails:
-              - fromFieldPath: metadata.name
+              - type: FromFieldPath
+                fromFieldPath: metadata.name
                 name: workflowName
             readinessChecks:
               - type: None


### PR DESCRIPTION
## Summary
- allow map-to-list to fall back to observed composite data and treat missing maps as empty
- add coverage for observed fallback and missing field behavior
- fix agentrun composition connectionDetails with explicit type

## Related Issues
None

## Testing
- go test ./packages/crossplane/functions/function-map-to-list/...

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
