### PR TITLE
fix(crossplane): allow workflow access

### DIFF
--- a/argocd/applications/crossplane/rbac/crossplane-workflowtemplate-access.yaml
+++ b/argocd/applications/crossplane/rbac/crossplane-workflowtemplate-access.yaml
@@ -7,6 +7,7 @@ rules:
       - argoproj.io
     resources:
       - workflowtemplates
+      - workflows
     verbs:
       - get
       - list


### PR DESCRIPTION
## Summary
- allow Crossplane to create/manage Argo Workflows in addition to WorkflowTemplates

## Related Issues
None

## Testing
- N/A (RBAC change only)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
