### PR TITLE
fix(jangar): set echo entrypoint

### DIFF
--- a/argocd/applications/argo-workflows/jangar-primitives-echo-workflowtemplate.yaml
+++ b/argocd/applications/argo-workflows/jangar-primitives-echo-workflowtemplate.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argo-workflows
 spec:
   serviceAccountName: codex-workflow
+  entrypoint: echo
   templates:
     - name: echo
       inputs:


### PR DESCRIPTION
## Summary
- set entrypoint on jangar-primitives echo WorkflowTemplate so Argo workflows can run

## Related Issues
None

## Testing
- N/A (manifest change; validation in cluster after sync)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
