### PR TITLE
fix(orchestration): use claim label for template

### DIFF
--- a/packages/crossplane/configuration-orchestration/compositions/orchestration-argo-template.yaml
+++ b/packages/crossplane/configuration-orchestration/compositions/orchestration-argo-template.yaml
@@ -37,7 +37,7 @@ spec:
                 toFieldPath: metadata.name
                 policy:
                   fromFieldPath: Optional
-              - fromFieldPath: spec.claimRef.name
+              - fromFieldPath: metadata.labels["crossplane.io/claim-name"]
                 toFieldPath: metadata.name
                 policy:
                   fromFieldPath: Optional


### PR DESCRIPTION
## Summary
- use claim-name label when setting WorkflowTemplate name for Orchestration

## Related Issues
None

## Testing
- N/A (composition change; validated via cluster reconciliation)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
