### PR TITLE
fix(crossplane): skip workflow readiness checks

### DIFF
--- a/packages/crossplane/configuration-agents/compositions/agentrun-argo.yaml
+++ b/packages/crossplane/configuration-agents/compositions/agentrun-argo.yaml
@@ -49,6 +49,8 @@ spec:
                 name: workflowName
             readinessChecks:
               - type: None
+            readinessChecks:
+              - type: None
     - step: parameters-map-to-list
       functionRef:
         name: function-map-to-list

--- a/packages/crossplane/configuration-orchestration/compositions/orchestrationrun-argo.yaml
+++ b/packages/crossplane/configuration-orchestration/compositions/orchestrationrun-argo.yaml
@@ -36,6 +36,8 @@ spec:
                 toFieldPath: spec.arguments.parameters
                 policy:
                   fromFieldPath: Optional
+            readinessChecks:
+              - type: None
     - step: parameters-map-to-list
       functionRef:
         name: function-map-to-list


### PR DESCRIPTION
## Summary
- mark composed Argo Workflows as ready immediately to avoid stuck Ready=false

## Related Issues
None

## Testing
- N/A (composition change; validated via cluster reconciliation)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
