### PR TITLE
docs(jangar): align primitives specs

### DIFF
--- a/docs/jangar/primitives/agent-implementation.md
+++ b/docs/jangar/primitives/agent-implementation.md
@@ -209,6 +209,7 @@ kind: CompositeResourceDefinition
 metadata:
   name: xagentproviders.agents.proompteng.ai
 spec:
+  scope: Cluster
   group: agents.proompteng.ai
   names:
     kind: XAgentProvider
@@ -349,6 +350,7 @@ Implementation note: Use a Composition Function to convert `spec.parameters` map
 - `Workflow.status.phase` -> `AgentRun.status.phase`
 - `Workflow.metadata.name` -> `AgentRun.status.workflowName`
 - `Workflow.metadata.uid` -> `AgentRun.status.workflowUID`
+- `Workflow.status.startedAt` -> `AgentRun.status.submittedAt`
 
 ## 4) Jangar API
 

--- a/docs/jangar/primitives/agent.md
+++ b/docs/jangar/primitives/agent.md
@@ -29,6 +29,7 @@ apiVersion: agents.proompteng.ai/v1alpha1
 kind: Agent
 metadata:
   name: codex-implementation
+  namespace: jangar
 spec:
   providerRef:
     name: codex
@@ -62,6 +63,7 @@ apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
   name: codex-implementation-20260105-001
+  namespace: jangar
 spec:
   agentRef:
     name: codex-implementation
@@ -73,11 +75,15 @@ spec:
 ### AgentProvider (CLI adapter)
 Defines how to invoke a provider’s CLI without baking provider-specific logic into workflows.
 
+AgentProvider is cluster-scoped at the composite level. The claim (`AgentProvider`) is namespaced
+and should be created in a control-plane namespace (e.g. `jangar`) and treated as global.
+
 ```yaml
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentProvider
 metadata:
   name: codex
+  namespace: jangar
 spec:
   binary: /usr/local/bin/codex
   argsTemplate:

--- a/docs/jangar/primitives/memory-implementation.md
+++ b/docs/jangar/primitives/memory-implementation.md
@@ -184,6 +184,14 @@ Required keys:
 - `username`
 - `password`
 
+`Memory.status.connectionSecretRef` stores only the secret name/namespace. Connection metadata
+is exposed separately on `Memory.status` (`endpoint`, `database`, `schema`).
+
+## 2.5 Schema precedence
+
+`Memory.spec.dataset.schema` is the source of truth. `MemoryProvider.spec.postgres.schema` may
+be used as a default; if both are set and differ, reconciliation should fail.
+
 ## 3) Crossplane Composition (Postgres)
 
 ```yaml

--- a/docs/jangar/primitives/memory.md
+++ b/docs/jangar/primitives/memory.md
@@ -23,6 +23,7 @@ apiVersion: memory.proompteng.ai/v1alpha1
 kind: Memory
 metadata:
   name: codex-agent-memory
+  namespace: jangar
 spec:
   providerRef:
     name: postgres-default
@@ -64,6 +65,7 @@ apiVersion: memory.proompteng.ai/v1alpha1
 kind: MemoryProvider
 metadata:
   name: postgres-default
+  namespace: jangar
 spec:
   type: postgres
   postgres:
@@ -77,11 +79,15 @@ spec:
 
 ### Connection contract
 
-`Memory.status.connectionSecretRef` must include:
+`Memory.status.connectionSecretRef` must include the `name` and `namespace` of the connection secret.
+Additional connection metadata is exposed on `Memory.status`:
 
 - `endpoint`
 - `database`
 - `schema`
+
+The referenced secret must contain:
+
 - `username`
 - `password`
 
@@ -104,3 +110,8 @@ is stored on the Memory resource; the backend implementation must honor it.
 ## Observability
 
 Jangar should emit memory lifecycle events and link them to agent/orchestration runs via run IDs.
+
+## Schema precedence
+
+`Memory.spec.dataset.schema` is the source of truth. `MemoryProvider.spec.postgres.schema` may
+provide a default; if both are set and differ, reconciliation should fail.

--- a/docs/jangar/primitives/orchestration-implementation.md
+++ b/docs/jangar/primitives/orchestration-implementation.md
@@ -176,10 +176,13 @@ spec:
 - `SubOrchestration`: run another Orchestration
 - `Checkpoint`: persist state snapshot to Memory
 
+Implementation note: `spec.steps[*].with` is a string map. If structured input is required,
+encode it as JSON strings and decode in the runtime template.
+
 ## 5) Idempotency
 
-`OrchestrationRun.spec.deliveryId` is required for idempotent behavior and
-is persisted by Jangar to avoid duplicate dispatch.
+`OrchestrationRun.spec.deliveryId` enables idempotent behavior and should be
+persisted by Jangar to avoid duplicate dispatch.
 
 ## 6) Status mapping
 


### PR DESCRIPTION
## Summary

- Align orchestration examples and step kinds with ToolRun + main entrypoint and string `with` params.
- Clarify provider binding, idempotency language, and submittedAt mapping across Agent/Orchestration docs.
- Fix memory connection contract and schema precedence; add missing namespaces to examples.

## Related Issues

None

## Testing

- N/A (docs-only changes)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
