### PR TITLE
fix(argo): make judge resume artifact optional

### DIFF
--- a/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
+++ b/argocd/applications/froussard/codex-autonomous-workflow-template.yaml
@@ -78,7 +78,7 @@ spec:
                 - name: iteration_cycle
                   value: '{{workflow.parameters.iteration_cycle}}'
         - - name: judge
-            template: codex-run
+            template: codex-run-judge
             arguments:
               parameters:
                 - name: repository
@@ -640,5 +640,419 @@ spec:
             path: /workspace/lab/.codex-implementation-runtime.log
           - name: implementation-resume
             path: /workspace/lab/.codex/implementation-resume.json
+          - name: implementation-notify
+            path: /workspace/lab/.codex-implementation-notify.json
+    - name: codex-run-judge
+      inputs:
+        parameters:
+          - name: repository
+          - name: issue_number
+          - name: base
+          - name: head
+          - name: prompt
+          - name: stage
+          - name: iteration
+          - name: iteration_cycle
+          - name: rawEvent
+          - name: eventBody
+      container:
+        image: registry.ide-newton.ts.net/lab/codex-universal:latest
+        imagePullPolicy: Always
+        env:
+          - name: CODEX_CWD
+            value: /workspace/lab
+          - name: CODEX_REPO_URL
+            value: 'https://github.com/{{inputs.parameters.repository}}'
+          - name: CODEX_REPO_SLUG
+            value: '{{inputs.parameters.repository}}'
+          - name: HEAD_BRANCH
+            value: '{{inputs.parameters.head}}'
+          - name: BASE_BRANCH
+            value: '{{inputs.parameters.base}}'
+          - name: DISCORD_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: discord-codex-bot
+                key: bot-token
+                optional: true
+          - name: DISCORD_GUILD_ID
+            valueFrom:
+              secretKeyRef:
+                name: discord-codex-bot
+                key: guild-id
+                optional: true
+          - name: DISCORD_CATEGORY_ID
+            valueFrom:
+              secretKeyRef:
+                name: discord-codex-bot
+                key: category-id
+                optional: true
+          - name: JANGAR_BASE_URL
+            value: http://jangar.jangar.svc.cluster.local
+          - name: NATS_URL
+            value: nats://nats.nats.svc.cluster.local:4222
+          - name: NATS_USER
+            valueFrom:
+              secretKeyRef:
+                name: nats-agents-credentials
+                key: username
+          - name: NATS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: nats-agents-credentials
+                key: password
+          - name: NATS_CREDS
+            valueFrom:
+              secretKeyRef:
+                name: nats-agent-creds
+                key: creds
+                optional: true
+          - name: MINIO_ENDPOINT
+            value: observability-minio.minio.svc.cluster.local:9000
+          - name: MINIO_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: observability-minio-creds
+                key: accesskey
+          - name: MINIO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: observability-minio-creds
+                key: secretkey
+          - name: MINIO_SECURE
+            value: 'false'
+          - name: WORKFLOW_NAME
+            value: '{{workflow.name}}'
+          - name: ARGO_WORKFLOW_NAME
+            value: '{{workflow.name}}'
+          - name: WORKFLOW_UID
+            value: '{{workflow.uid}}'
+          - name: ARGO_WORKFLOW_UID
+            value: '{{workflow.uid}}'
+          - name: WORKFLOW_NAMESPACE
+            value: '{{workflow.namespace}}'
+          - name: ARGO_WORKFLOW_NAMESPACE
+            value: '{{workflow.namespace}}'
+          - name: WORKFLOW_STAGE
+            value: '{{inputs.parameters.stage}}'
+          - name: WORKFLOW_STEP
+            value: '{{pod.name}}'
+          - name: AGENT_ID
+            value: '{{inputs.parameters.stage}}'
+          - name: AGENT_ROLE
+            value: assistant
+          - name: AGENT_OUTPUT_PATH
+            value: /workspace/lab/.codex-implementation-agent.log
+          - name: RUN_ID
+            value: '{{workflow.uid}}'
+          - name: CODEX_ITERATION
+            value: '{{inputs.parameters.iteration}}'
+          - name: CODEX_ITERATION_CYCLE
+            value: '{{inputs.parameters.iteration_cycle}}'
+          - name: CODEX_GRAF_BEARER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: graf-api
+                key: bearer-tokens
+                optional: true
+          - name: LGTM_LOKI_ENDPOINT
+            value: http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push
+          - name: DOCKER_HOST
+            value: tcp://localhost:2375
+          - name: DOCKER_TLS_VERIFY
+            value: ""
+          - name: DOCKER_ENABLED
+            value: "1"
+          - name: DOCKER_WAIT_ATTEMPTS
+            value: "12"
+        command: ["/usr/local/bin/codex-bootstrap"]
+        args:
+          - "/bin/bash"
+          - "-lc"
+          - |
+            set -euo pipefail
+
+            preflight_fail() {
+              echo "Preflight failed: $1" >&2
+              exit 1
+            }
+
+            if [[ -z "${CODEX_CWD:-}" || ! -d "$CODEX_CWD" ]]; then
+              preflight_fail "CODEX_CWD is missing or not a directory"
+            fi
+            if ! git -C "$CODEX_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+              preflight_fail "CODEX_CWD is not a git worktree"
+            fi
+            if ! gh auth status -h github.com >/dev/null 2>&1 && [[ -z "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
+              preflight_fail "Missing GitHub auth"
+            fi
+            REPO="{{inputs.parameters.repository}}"
+            if [[ -n "$REPO" ]]; then
+              gh_perm_file=$(mktemp)
+              if ! gh api "repos/${REPO}" > "$gh_perm_file"; then
+                preflight_fail "GitHub token cannot access ${REPO}"
+              fi
+              if command -v jq >/dev/null 2>&1; then
+                pr_pull=$(jq -r '.permissions.pull // false' "$gh_perm_file")
+                pr_push=$(jq -r '.permissions.push // false' "$gh_perm_file")
+                if [[ "$pr_pull" != "true" || "$pr_push" != "true" ]]; then
+                  preflight_fail "GitHub token lacks pull/push permissions for ${REPO}"
+                fi
+              fi
+              rm -f "$gh_perm_file"
+            fi
+            if [[ -z "${MINIO_ENDPOINT:-}" ]]; then
+              preflight_fail "Missing MINIO_ENDPOINT"
+            fi
+            minio_host="${MINIO_ENDPOINT%%:*}"
+            minio_port="${MINIO_ENDPOINT##*:}"
+            if [[ "$minio_port" == "$minio_host" ]]; then
+              minio_port="9000"
+            fi
+            if ! timeout 3 bash -c "</dev/tcp/${minio_host}/${minio_port}" >/dev/null 2>&1; then
+              preflight_fail "MinIO endpoint unreachable"
+            fi
+            if [[ -z "${MINIO_ACCESS_KEY:-}" || -z "${MINIO_SECRET_KEY:-}" ]]; then
+              preflight_fail "Missing MinIO credentials"
+            fi
+            export MINIO_BUCKET="${ARTIFACT_BUCKET:-argo-workflows}"
+            if ! bun /workspace/lab/services/jangar/scripts/minio-presign-check.ts >/dev/null 2>&1; then
+              preflight_fail "MinIO signed URL check failed"
+            fi
+            if [[ "${CODEX_NATS_SOAK_REQUIRED:-true}" != "false" && "${CODEX_NATS_SOAK_REQUIRED:-true}" != "0" ]]; then
+              if [[ -z "${NATS_URL:-}" ]]; then
+                preflight_fail "NATS_URL required for context soak"
+              fi
+            fi
+
+            # Ensure output paths exist before any early exits so Argo output collection never fails.
+            mkdir -p /workspace/lab /workspace/.codex
+            : > "/workspace/lab/.codex-judge-decision.txt"
+            : > "/workspace/lab/.codex-judge-next-prompt.txt"
+            : > "/workspace/lab/.codex-judge-output.json"
+
+            EVENT_FILE=$(mktemp)
+            EVENT_BODY_B64='{{inputs.parameters.eventBody}}'
+            if [[ -n "$EVENT_BODY_B64" && "$EVENT_BODY_B64" != "{}" ]]; then
+              printf '%s' "$EVENT_BODY_B64" | base64 --decode > "$EVENT_FILE"
+            else
+              cat > "$EVENT_FILE" <<'JSON'
+            {
+              "repository": "{{inputs.parameters.repository}}",
+              "issueNumber": "{{inputs.parameters.issue_number}}",
+              "base": "{{inputs.parameters.base}}",
+              "head": "{{inputs.parameters.head}}",
+              "prompt": "{{inputs.parameters.prompt}}",
+              "stage": "{{inputs.parameters.stage}}",
+              "iteration": "{{inputs.parameters.iteration}}",
+              "iteration_cycle": "{{inputs.parameters.iteration_cycle}}"
+            }
+            JSON
+            fi
+
+            if command -v jq >/dev/null 2>&1; then
+              TMP_EVENT=$(mktemp)
+              jq \
+                --arg stage "{{inputs.parameters.stage}}" \
+                --arg repo "{{inputs.parameters.repository}}" \
+                --arg issue "{{inputs.parameters.issue_number}}" \
+                --arg base "{{inputs.parameters.base}}" \
+                --arg head "{{inputs.parameters.head}}" \
+                --arg iteration "{{inputs.parameters.iteration}}" \
+                --arg iterationCycle "{{inputs.parameters.iteration_cycle}}" \
+                '.stage = ($stage // .stage) | .repository = ($repo // .repository) | .issueNumber = ($issue // .issueNumber) | .base = ($base // .base) | .head = ($head // .head) | .iteration = (if ($iteration | length) > 0 then ($iteration | tonumber?) else .iteration end) | .iteration_cycle = (if ($iterationCycle | length) > 0 then ($iterationCycle | tonumber?) else .iteration_cycle end)' \
+                "$EVENT_FILE" > "$TMP_EVENT" && mv "$TMP_EVENT" "$EVENT_FILE"
+            fi
+
+            WORKTREE_DIR="${WORKTREE:-/workspace/lab}"
+
+            if ! command -v git >/dev/null 2>&1; then
+              echo "Missing git binary in runtime image" >&2
+              exit 1
+            fi
+
+            if [[ ! -d "$WORKTREE_DIR" ]]; then
+              echo "CODEX_CWD directory missing: $WORKTREE_DIR" >&2
+              exit 1
+            fi
+
+            if [[ ! -e "$WORKTREE_DIR/.git" ]]; then
+              echo "Repository checkout missing at $WORKTREE_DIR" >&2
+              exit 1
+            fi
+
+            if [[ -z "${HEAD_BRANCH:-}" ]]; then
+              echo "Missing head branch parameter" >&2
+              exit 1
+            fi
+
+            if [[ -z "${BASE_BRANCH:-}" ]]; then
+              echo "Missing base branch parameter" >&2
+              exit 1
+            fi
+
+            if ! gh auth status -h github.com >/dev/null 2>&1 && [[ -z "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
+              echo "Missing GitHub auth" >&2
+              exit 1
+            fi
+
+            if [[ -z "${JANGAR_BASE_URL:-}" ]]; then
+              echo "Missing JANGAR_BASE_URL" >&2
+              exit 1
+            fi
+
+            git -C "$WORKTREE_DIR" fetch --all --prune
+
+            if ! git -C "$WORKTREE_DIR" rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1 \
+              && ! git -C "$WORKTREE_DIR" rev-parse --verify "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+              echo "Base ref '$BASE_BRANCH' not found in repository" >&2
+              exit 1
+            fi
+
+            if ! git -C "$WORKTREE_DIR" rev-parse --verify "$HEAD_BRANCH" >/dev/null 2>&1 \
+              && ! git -C "$WORKTREE_DIR" rev-parse --verify "origin/$HEAD_BRANCH" >/dev/null 2>&1; then
+              echo "Head ref '$HEAD_BRANCH' not found in repository" >&2
+              exit 1
+            fi
+
+            JANGAR_NOTIFY_URL="${JANGAR_BASE_URL%/}/api/codex/notify"
+            JANGAR_COMPLETE_URL="${JANGAR_BASE_URL%/}/api/codex/run-complete"
+            for endpoint in "$JANGAR_NOTIFY_URL" "$JANGAR_COMPLETE_URL"; do
+              status=$(curl -s -o /dev/null -w '%{http_code}' -X OPTIONS "$endpoint" || true)
+              if [[ "$status" == "000" ]]; then
+                echo "Jangar endpoint unreachable: $endpoint" >&2
+                exit 1
+              fi
+            done
+
+            export OUTPUT_PATH="${IMPLEMENTATION_OUTPUT_PATH:-/workspace/lab/.codex-implementation.log}"
+            export JSON_OUTPUT_PATH="${JSON_OUTPUT_PATH:-/workspace/.codex/implementation-events.jsonl}"
+            export POST_TO_GITHUB=true
+
+            AGENT_LOG_PATH="${AGENT_OUTPUT_PATH:-/workspace/lab/.codex-implementation-agent.log}"
+            NATS_PUBLISHER="/usr/local/bin/codex-nats-publish"
+            NATS_TAIL_PID=""
+
+            if [[ -x "$NATS_PUBLISHER" ]]; then
+              touch "$AGENT_LOG_PATH"
+              export CODEX_SKIP_RUN_STARTED=1
+              "$NATS_PUBLISHER" --kind run-started --content "${WORKFLOW_STAGE} started" --channel general --publish-general
+              "$NATS_PUBLISHER" --kind status --status started --content "${WORKFLOW_STAGE} started" --publish-general
+              "$NATS_PUBLISHER" --kind log --log-file "$AGENT_LOG_PATH" &
+              NATS_TAIL_PID=$!
+            fi
+
+            cleanup_nats() {
+              if [[ -n "${NATS_TAIL_PID:-}" ]]; then
+                kill "$NATS_TAIL_PID" 2>/dev/null || true
+                wait "$NATS_TAIL_PID" 2>/dev/null || true
+              fi
+            }
+            trap cleanup_nats EXIT
+
+            echo "Executing ${WORKFLOW_STAGE} workflow" >&2
+            set +e
+            AGENT_SPEC=$(mktemp)
+            cat > "$AGENT_SPEC" <<JSON
+            {
+              "provider": "codex",
+              "inputs": {
+                "base": "${BASE_BRANCH}",
+                "head": "${HEAD_BRANCH}",
+                "stage": "${WORKFLOW_STAGE}"
+              },
+              "payloads": {
+                "eventBodyPath": "$EVENT_FILE"
+              },
+              "artifacts": {
+                "statusPath": "/workspace/lab/.agent-status.json",
+                "logPath": "/workspace/lab/.agent-runner.log"
+              }
+            }
+            JSON
+
+            /usr/local/bin/agent-runner --spec "$AGENT_SPEC"
+            EXIT_CODE=$?
+            set -e
+
+            cleanup_nats
+
+            if [[ -x "$NATS_PUBLISHER" ]]; then
+              "$NATS_PUBLISHER" --kind status --status completed --exit-code "$EXIT_CODE" --content "${WORKFLOW_STAGE} completed" --publish-general
+            fi
+
+            exit "$EXIT_CODE"
+        volumeMounts:
+          - name: workdir
+            mountPath: /workspace
+          - name: docker-lib
+            mountPath: /var/lib/docker
+            readOnly: true
+        resources:
+          requests:
+            cpu: "1"
+            memory: 3Gi
+          limits:
+            cpu: "4"
+            memory: 6Gi
+      retryStrategy:
+        limit: 3
+        retryPolicy: OnFailure
+      sidecars:
+        - name: docker
+          image: docker:25.0-dind
+          command: ["dockerd-entrypoint.sh"]
+          args:
+            - "--host=tcp://0.0.0.0:2375"
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+            - name: XDG_RUNTIME_DIR
+              value: /tmp/docker-runtime
+            - name: DOCKER_HOST
+              value: tcp://0.0.0.0:2375
+          ports:
+            - containerPort: 2375
+              name: docker
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: docker-lib
+              mountPath: /var/lib/docker
+          resources:
+            requests:
+              cpu: "1"
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+      outputs:
+        parameters:
+          - name: decision
+            valueFrom:
+              path: /workspace/lab/.codex-judge-decision.txt
+          - name: next_prompt
+            valueFrom:
+              path: /workspace/lab/.codex-judge-next-prompt.txt
+        artifacts:
+          - name: judge-output
+            path: /workspace/lab/.codex-judge-output.json
+          - name: implementation-changes
+            path: /workspace/lab/.codex-implementation-changes.tar.gz
+          - name: implementation-patch
+            path: /workspace/lab/.codex-implementation.patch
+          - name: implementation-status
+            path: /workspace/lab/.codex-implementation-status.txt
+          - name: implementation-log
+            path: /workspace/lab/.codex-implementation.log
+          - name: implementation-events
+            path: /workspace/.codex/implementation-events.jsonl
+          - name: implementation-agent-log
+            path: /workspace/lab/.codex-implementation-agent.log
+          - name: implementation-runtime-log
+            path: /workspace/lab/.codex-implementation-runtime.log
+          - name: implementation-resume
+            path: /workspace/lab/.codex/implementation-resume.json
+            optional: true
           - name: implementation-notify
             path: /workspace/lab/.codex-implementation-notify.json


### PR DESCRIPTION
## Summary

- Add a judge-only `codex-run-judge` template and route the judge step to it.
- Mark `implementation-resume` as optional only for judge output collection.
- Applied the updated WorkflowTemplate to `jangar` via `kubectl` (per request).

## Related Issues

None

## Testing

- N/A (manifest-only change; no automated tests run)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
