### PR TITLE
fix(ci): use arc-arm64 runner for crossplane build

### DIFF
--- a/.github/workflows/crossplane-xpkg.yml
+++ b/.github/workflows/crossplane-xpkg.yml
@@ -88,7 +88,7 @@ jobs:
         run: go test ./...
   build-main:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: self-hosted
+    runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v4
       - name: Install Crossplane CLI


### PR DESCRIPTION
## Summary

- Switch crossplane build workflow to the arm64 ARC runner label.
- Aligns the build job with available self-hosted runner capacity.
- Keeps the rest of the workflow unchanged.

## Related Issues

None.

## Testing

- N/A (workflow change only; rely on CI).

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
