### PR TITLE
feat(agents): add minimal agents helm chart

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -9,3 +9,4 @@ helmCharts:
     namespace: agents
     includeCRDs: true
     valuesFile: values.yaml
+    version: 0.1.0

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agents
+helmGlobals:
+  chartHome: ../../charts
+helmCharts:
+  - name: agents
+    releaseName: agents
+    namespace: agents
+    includeCRDs: true
+    valuesFile: values.yaml

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: agents
 helmGlobals:
-  chartHome: ../../charts
+  chartHome: ../../../charts
 helmCharts:
   - name: agents
     releaseName: agents

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -23,3 +23,11 @@ networkPolicy:
   enabled: false
 backups:
   enabled: false
+primitives:
+  namespaces:
+    - agents
+  reconciler:
+    enabled: true
+    intervalSeconds: 30
+agentComms:
+  enabled: false

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,0 +1,25 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/proompteng/jangar
+  tag: latest
+  pullPolicy: IfNotPresent
+postgres:
+  enabled: true
+  storage:
+    size: 5Gi
+  credentials:
+    username: agents
+    database: agents
+    password: ""
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+migrations:
+  enabled: true
+ingress:
+  enabled: false
+networkPolicy:
+  enabled: false
+backups:
+  enabled: false

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -102,6 +102,13 @@ spec:
               argocd.argoproj.io/sync-wave: "6"
             automation: manual
             enabled: true
+          - name: agents
+            path: argocd/applications/agents
+            namespace: agents
+            annotations:
+              argocd.argoproj.io/sync-wave: "6"
+            automation: manual
+            enabled: true
           - name: bumba
             path: argocd/applications/bumba
             namespace: jangar

--- a/charts/agents/.helmignore
+++ b/charts/agents/.helmignore
@@ -1,0 +1,20 @@
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.hg/
+.svn/
+
+# Helm itself
+*.tgz
+Chart.lock
+
+# IDEs
+*.swp
+*.bak
+*.tmp
+.idea/
+.vscode/
+
+node_modules/
+.DS_Store

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: agents
+description: Minimal agent control-plane stack (Jangar) with CRDs and pgvector-backed storage
+home: https://github.com/proompteng/lab
+kubeVersion: ">=1.26.0-0"
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+icon: https://avatars.githubusercontent.com/u/165504663?s=200&v=4
+keywords:
+  - agents
+  - jangar
+  - codex
+  - pgvector
+  - postgres
+maintainers:
+  - name: ProomptEng
+    email: eng@proompt.com
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Source
+      url: https://github.com/proompteng/lab
+    - name: Documentation
+      url: https://github.com/proompteng/lab/tree/main/docs/jangar
+  artifacthub.io/keywords: agents,jangar,codex,pgvector,postgres
+  artifacthub.io/images: |
+    - name: jangar
+      image: ghcr.io/proompteng/jangar:latest
+    - name: postgres
+      image: docker.io/pgvector/pgvector:pg16

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -7,6 +7,7 @@ Minimal, production-ready bundle for the agent control plane (Jangar) plus Agent
 - Deploys the Jangar control-plane deployment + service.
 - Default single-replica Postgres with pgvector and idempotent migrations job.
 - Optional ingress, HPA, PDB, NetworkPolicy, and pg_dump backup CronJob.
+- Optional NATS-driven agent communications subscriber and primitives reconciler namespace scoping.
 - Dev and production example values.
 - Artifact Hub metadata included (Apache-2.0 license).
 
@@ -55,5 +56,8 @@ helm push agents-0.1.0.tgz oci://ghcr.io/proompteng/charts
 | `podDisruptionBudget.enabled` | Enable PDB | `false` |
 | `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 | `backups.enabled` | Enable pg_dump CronJob (embedded DB only) | `false` |
+| `primitives.reconciler.enabled` | Run primitives reconciler loop | `true` |
+| `primitives.namespaces` | Namespaces to watch for Agent/AgentRun | `['<release-namespace>']` |
+| `agentComms.enabled` | Enable NATS agent-comms subscriber | `false` |
 
 See `values.yaml`, `values-dev.yaml`, and `values-prod.yaml` for full options.

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -56,6 +56,7 @@ helm push agents-0.1.0.tgz oci://ghcr.io/proompteng/charts
 | `podDisruptionBudget.enabled` | Enable PDB | `false` |
 | `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 | `backups.enabled` | Enable pg_dump CronJob (embedded DB only) | `false` |
+| `rbac.create` | Create namespaced RBAC (Role/RoleBinding) for the control plane | `true` |
 | `primitives.reconciler.enabled` | Run primitives reconciler loop | `true` |
 | `primitives.namespaces` | Namespaces to watch for Agent/AgentRun | `['<release-namespace>']` |
 | `agentComms.enabled` | Enable NATS agent-comms subscriber | `false` |

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -1,0 +1,59 @@
+# Agents Helm Chart
+
+Minimal, production-ready bundle for the agent control plane (Jangar) plus Agent/AgentRun/AgentProvider CRDs and an optional embedded Postgres/pgvector.
+
+## Features
+- Ships Agent, AgentRun, and AgentProvider CRDs.
+- Deploys the Jangar control-plane deployment + service.
+- Default single-replica Postgres with pgvector and idempotent migrations job.
+- Optional ingress, HPA, PDB, NetworkPolicy, and pg_dump backup CronJob.
+- Dev and production example values.
+- Artifact Hub metadata included (Apache-2.0 license).
+
+## Quickstart (kind/minikube)
+```bash
+# From repo root
+helm lint charts/agents
+helm template charts/agents --values charts/agents/values-dev.yaml
+helm install agents charts/agents --namespace agents --create-namespace \
+  --values charts/agents/values-dev.yaml
+kubectl -n agents port-forward svc/agents 8080:80 &
+curl -sf http://127.0.0.1:8080/health
+```
+
+Apply the sample CRDs:
+```bash
+kubectl apply -n agents -f charts/agents/examples/agentprovider-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/agent-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/agentrun-sample.yaml
+```
+
+## Production notes
+- Prefer external Postgres with TLS: see `charts/agents/values-prod.yaml`.
+- Use digest-pinned images for both Jangar and Postgres (already set in `values-prod`).
+- Enable NetworkPolicy and PodDisruptionBudget for HA clusters.
+- Migrations job creates `pgcrypto` + `vector` extensions and tables idempotently.
+- Optional backup CronJob runs `pg_dump --format=custom` into a PVC with retention trimming.
+
+## Publishing (OCI)
+```bash
+helm package charts/agents
+helm push agents-0.1.0.tgz oci://ghcr.io/proompteng/charts
+```
+
+## Values
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `replicaCount` | Control-plane replicas | `1` |
+| `image.repository` | Jangar image repo | `ghcr.io/proompteng/jangar` |
+| `image.tag` | Jangar image tag | `latest` |
+| `postgres.enabled` | Deploy embedded Postgres/pgvector | `true` |
+| `externalDatabase.enabled` | Use external Postgres instead of embedded | `false` |
+| `migrations.enabled` | Run pre-install/upgrade migrations job | `true` |
+| `ingress.enabled` | Create Ingress | `false` |
+| `autoscaling.enabled` | Enable HPA | `false` |
+| `podDisruptionBudget.enabled` | Enable PDB | `false` |
+| `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
+| `backups.enabled` | Enable pg_dump CronJob (embedded DB only) | `false` |
+
+See `values.yaml`, `values-dev.yaml`, and `values-prod.yaml` for full options.

--- a/charts/agents/crds/agent.yaml
+++ b/charts/agents/crds/agent.yaml
@@ -1,0 +1,159 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: agents.agents.proompteng.ai
+spec:
+  group: agents.proompteng.ai
+  names:
+    kind: Agent
+    plural: agents
+    singular: agent
+    shortNames:
+      - agt
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [providerRef, runtime]
+              properties:
+                providerRef:
+                  type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                runtime:
+                  type: object
+                  required: [type]
+                  properties:
+                    type:
+                      type: string
+                      enum: [argo, temporal, job, custom]
+                    argo:
+                      type: object
+                      properties:
+                        workflowTemplate:
+                          type: string
+                        namespace:
+                          type: string
+                          default: argo-workflows
+                        serviceAccount:
+                          type: string
+                          default: codex-workflow
+                    temporal:
+                      type: object
+                      properties:
+                        workflowType:
+                          type: string
+                        taskQueue:
+                          type: string
+                    job:
+                      type: object
+                      properties:
+                        image:
+                          type: string
+                        command:
+                          type: array
+                          items:
+                            type: string
+                    custom:
+                      type: object
+                      additionalProperties: true
+                inputs:
+                  type: object
+                  properties:
+                    repository:
+                      type: string
+                    issueNumber:
+                      type: integer
+                    base:
+                      type: string
+                    head:
+                      type: string
+                    stage:
+                      type: string
+                payloads:
+                  type: object
+                  properties:
+                    rawEventB64:
+                      type: string
+                    eventBodyB64:
+                      type: string
+                    promptJson:
+                      type: string
+                resources:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                    memory:
+                      type: string
+                    ephemeral:
+                      type: string
+                env:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, value]
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                observability:
+                  type: object
+                  properties:
+                    natsEnabled:
+                      type: boolean
+                      default: true
+                    kafkaCompletions:
+                      type: boolean
+                      default: true
+                    grafEnabled:
+                      type: boolean
+                      default: false
+                security:
+                  type: object
+                  properties:
+                    allowPrivileged:
+                      type: boolean
+                      default: false
+                    allowedServiceAccounts:
+                      type: array
+                      items:
+                        type: string
+                    allowedSecrets:
+                      type: array
+                      items:
+                        type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                phase:
+                  type: string
+                observedGeneration:
+                  type: integer

--- a/charts/agents/crds/agentprovider.yaml
+++ b/charts/agents/crds/agentprovider.yaml
@@ -1,0 +1,79 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: agentproviders.agents.proompteng.ai
+spec:
+  group: agents.proompteng.ai
+  names:
+    kind: AgentProvider
+    plural: agentproviders
+    singular: agentprovider
+    shortNames:
+      - agprov
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [binary]
+              properties:
+                binary:
+                  type: string
+                argsTemplate:
+                  type: array
+                  items:
+                    type: string
+                envTemplate:
+                  type: object
+                  additionalProperties:
+                    type: string
+                inputFiles:
+                  type: array
+                  items:
+                    type: object
+                    required: [path, content]
+                    properties:
+                      path:
+                        type: string
+                      content:
+                        type: string
+                outputArtifacts:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, path]
+                    properties:
+                      name:
+                        type: string
+                      path:
+                        type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/charts/agents/crds/agentrun.yaml
+++ b/charts/agents/crds/agentrun.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: agentruns.agents.proompteng.ai
+spec:
+  group: agents.proompteng.ai
+  names:
+    kind: AgentRun
+    plural: agentruns
+    singular: agentrun
+    shortNames:
+      - agrun
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [agentRef]
+              properties:
+                agentRef:
+                  type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                parameters:
+                  type: object
+                  additionalProperties:
+                    type: string
+                deliveryId:
+                  type: string
+                runtimeOverrides:
+                  type: object
+                  properties:
+                    argo:
+                      type: object
+                      properties:
+                        namespace:
+                          type: string
+                        serviceAccount:
+                          type: string
+                retryPolicy:
+                  type: object
+                  properties:
+                    limit:
+                      type: integer
+                      default: 0
+                timeoutSeconds:
+                  type: integer
+                secrets:
+                  type: array
+                  items:
+                    type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Running, Succeeded, Failed, Cancelled]
+                workflowName:
+                  type: string
+                workflowUID:
+                  type: string
+                submittedAt:
+                  type: string
+                  format: date-time
+                finishedAt:
+                  type: string
+                  format: date-time
+                artifactKeys:
+                  type: array
+                  items:
+                    type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/charts/agents/examples/agent-sample.yaml
+++ b/charts/agents/examples/agent-sample.yaml
@@ -1,0 +1,25 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: Agent
+metadata:
+  name: sample-agent
+  namespace: agents
+spec:
+  providerRef:
+    name: sample-provider
+  runtime:
+    type: argo
+    argo:
+      workflowTemplate: sample-agent-template
+      namespace: argo-workflows
+      serviceAccount: codex-workflow
+  inputs:
+    repository: proompteng/lab
+    issueNumber: 1234
+    base: main
+    head: feature/example
+    stage: implementation
+  payloads:
+    promptJson: '{"summary":"hello agents"}'
+  observability:
+    natsEnabled: true
+    kafkaCompletions: false

--- a/charts/agents/examples/agentprovider-sample.yaml
+++ b/charts/agents/examples/agentprovider-sample.yaml
@@ -1,0 +1,17 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentProvider
+metadata:
+  name: sample-provider
+  namespace: agents
+spec:
+  binary: /usr/local/bin/agent-runner
+  argsTemplate:
+    - "{{payloads.promptJson}}"
+  envTemplate:
+    SAMPLE_ENV: "{{inputs.repository}}"
+  inputFiles:
+    - path: /workspace/prompt.json
+      content: "{{payloads.promptJson}}"
+  outputArtifacts:
+    - name: agent-log
+      path: /workspace/agent.log

--- a/charts/agents/examples/agentrun-sample.yaml
+++ b/charts/agents/examples/agentrun-sample.yaml
@@ -1,0 +1,13 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  generateName: sample-agent-run-
+  namespace: agents
+spec:
+  agentRef:
+    name: sample-agent
+  parameters:
+    payload: e30=
+  deliveryId: "demo-1234"
+  retryPolicy:
+    limit: 1

--- a/charts/agents/files/sql/migrations.sql
+++ b/charts/agents/files/sql/migrations.sql
@@ -1,0 +1,56 @@
+-- Agents schema bootstrap
+-- Idempotent migration used by the Helm pre-install/upgrade job.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS agent_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_name TEXT NOT NULL,
+  delivery_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  status TEXT NOT NULL,
+  external_run_id TEXT,
+  payload JSONB NOT NULL DEFAULT '{}'::JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS agent_runs_delivery_id_idx ON agent_runs(delivery_id);
+CREATE INDEX IF NOT EXISTS agent_runs_external_run_id_idx ON agent_runs(external_run_id);
+
+CREATE TABLE IF NOT EXISTS memory_resources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  memory_name TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  status TEXT NOT NULL,
+  connection_secret JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS memory_resources_name_idx ON memory_resources(memory_name);
+
+CREATE TABLE IF NOT EXISTS orchestration_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  orchestration_name TEXT NOT NULL,
+  delivery_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  status TEXT NOT NULL,
+  external_run_id TEXT,
+  payload JSONB NOT NULL DEFAULT '{}'::JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS orchestration_runs_delivery_id_idx ON orchestration_runs(delivery_id);
+CREATE INDEX IF NOT EXISTS orchestration_runs_external_run_id_idx ON orchestration_runs(external_run_id);
+
+CREATE TABLE IF NOT EXISTS audit_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_type TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  event_type TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/charts/agents/templates/NOTES.txt
+++ b/charts/agents/templates/NOTES.txt
@@ -1,0 +1,5 @@
+1. Control plane: {{ include "agents.fullname" . }}
+2. Service: kubectl -n {{ .Values.namespaceOverride | default .Release.Namespace }} get svc {{ include "agents.fullname" . }}
+3. Health: kubectl -n {{ .Values.namespaceOverride | default .Release.Namespace }} port-forward svc/{{ include "agents.fullname" . }} 8080:80 &
+   curl -sf http://127.0.0.1:8080/health
+4. CRDs: Agent, AgentRun, AgentProvider (group agents.proompteng.ai)

--- a/charts/agents/templates/_helpers.tpl
+++ b/charts/agents/templates/_helpers.tpl
@@ -115,8 +115,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $host := include "agents.databaseHost" . -}}
 {{- $db := include "agents.databaseName" . -}}
 {{- $port := include "agents.databasePort" . -}}
-{{- $ssl := ternary .Values.externalDatabase.sslMode "disable" .Values.externalDatabase.enabled -}}
+{{- $ssl := "disable" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- $ssl = default "require" .Values.externalDatabase.sslMode -}}
+{{- end -}}
 {{- printf "postgresql://%s:%s@%s:%s/%s?sslmode=%s" $user $pass $host $port $db $ssl -}}
+{{- end -}}
+
+{{- define "agents.primitivesNamespaces" -}}
+{{- $namespaces := .Values.primitives.namespaces | default (list) -}}
+{{- if or (not $namespaces) (eq (len $namespaces) 0) -}}
+{{- $namespaces = list (.Values.namespaceOverride | default .Release.Namespace) -}}
+{{- end -}}
+{{- join "," $namespaces -}}
 {{- end -}}
 
 {{- define "agents.postgresPassword" -}}

--- a/charts/agents/templates/_helpers.tpl
+++ b/charts/agents/templates/_helpers.tpl
@@ -1,0 +1,133 @@
+{{- define "agents.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "agents.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "agents.labels" -}}
+app.kubernetes.io/name: {{ include "agents.name" . }}
+helm.sh/chart: {{ include "agents.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "agents.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agents.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "agents.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- printf "%s-sa" (include "agents.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.postgres.fullname" -}}
+{{- printf "%s-postgres" (include "agents.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "agents.databaseSecretName" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- "" -}}
+{{- else if .Values.postgres.credentials.existingSecret -}}
+{{- .Values.postgres.credentials.existingSecret -}}
+{{- else -}}
+{{- printf "%s-db" (include "agents.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.databaseUser" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.user | default "agents" -}}
+{{- else -}}
+{{- .Values.postgres.credentials.username | default "agents" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.databaseName" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.database | default "agents" -}}
+{{- else -}}
+{{- .Values.postgres.credentials.database | default "agents" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.databaseHost" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- required "externalDatabase.host is required when externalDatabase.enabled" .Values.externalDatabase.host -}}
+{{- else -}}
+{{- printf "%s.%s.svc.cluster.local" (include "agents.postgres.fullname" .) (.Values.namespaceOverride | default .Release.Namespace) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.databasePort" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.port | default 5432 -}}
+{{- else -}}
+{{- .Values.postgres.service.port | default 5432 -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.databasePassword" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- if .Values.externalDatabase.passwordSecret.name -}}
+{{- "" -}}
+{{- else -}}
+{{- .Values.externalDatabase.password | default "" -}}
+{{- end -}}
+{{- else if .Values.postgres.credentials.password -}}
+{{- .Values.postgres.credentials.password -}}
+{{- else -}}
+{{- $secret := lookup "v1" "Secret" (.Values.namespaceOverride | default .Release.Namespace) (include "agents.databaseSecretName" .) -}}
+{{- if $secret -}}
+{{- index $secret.data "password" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 20 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.databaseUrl" -}}
+{{- $user := include "agents.databaseUser" . -}}
+{{- $pass := include "agents.databasePassword" . -}}
+{{- $host := include "agents.databaseHost" . -}}
+{{- $db := include "agents.databaseName" . -}}
+{{- $port := include "agents.databasePort" . -}}
+{{- $ssl := ternary .Values.externalDatabase.sslMode "disable" .Values.externalDatabase.enabled -}}
+{{- printf "postgresql://%s:%s@%s:%s/%s?sslmode=%s" $user $pass $host $port $db $ssl -}}
+{{- end -}}
+
+{{- define "agents.postgresPassword" -}}
+{{- if .Values.postgres.credentials.password -}}
+{{- .Values.postgres.credentials.password -}}
+{{- else -}}
+{{- $secret := lookup "v1" "Secret" (.Values.namespaceOverride | default .Release.Namespace) (include "agents.databaseSecretName" .) -}}
+{{- if $secret -}}
+{{- index $secret.data "password" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 20 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/agents/templates/backup-cronjob.yaml
+++ b/charts/agents/templates/backup-cronjob.yaml
@@ -1,0 +1,54 @@
+{{- if and .Values.backups.enabled .Values.postgres.enabled (not .Values.externalDatabase.enabled) -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "agents.fullname" . }}-backup
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backups.schedule | quote }}
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            {{- include "agents.labels" . | nindent 12 }}
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ include "agents.serviceAccountName" . }}
+          containers:
+            - name: pgdump
+              image: "{{ .Values.backups.image.repository }}:{{ .Values.backups.image.tag }}{{- if .Values.backups.image.digest }}@{{ .Values.backups.image.digest }}{{ end }}"
+              imagePullPolicy: {{ .Values.backups.image.pullPolicy }}
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "agents.databaseSecretName" . }}
+                      key: uri
+                - name: RETENTION_DAYS
+                  value: {{ .Values.backups.retentionDays | quote }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  ts=$(date +%F-%H%M%S)
+                  target=/backup/agents-$ts.dump
+                  echo "Writing backup to ${target}"
+                  pg_dump --format=custom --file="${target}" "$DATABASE_URL"
+                  if [ -n "$RETENTION_DAYS" ]; then
+                    find /backup -type f -mtime +${RETENTION_DAYS} -print -delete
+                  fi
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+              resources:
+                {{- toYaml .Values.backups.resources | nindent 16 }}
+          volumes:
+            - name: backup
+              persistentVolumeClaim:
+                claimName: {{ default (printf "%s-backup" (include "agents.fullname" .)) .Values.backups.storage.existingClaim }}
+{{- end -}}

--- a/charts/agents/templates/backup-pvc.yaml
+++ b/charts/agents/templates/backup-pvc.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.backups.enabled .Values.postgres.enabled (not .Values.externalDatabase.enabled) -}}
+{{- if not .Values.backups.storage.existingClaim -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agents.fullname" . }}-backup
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.backups.storage.size }}
+  {{- if .Values.backups.storage.storageClass }}
+  storageClassName: {{ .Values.backups.storage.storageClass }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/agents/templates/database-secret.yaml
+++ b/charts/agents/templates/database-secret.yaml
@@ -1,0 +1,21 @@
+{{- if and (not .Values.externalDatabase.enabled) (not .Values.postgres.credentials.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agents.databaseSecretName" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+  {{- with .Values.authSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  username: {{ include "agents.databaseUser" . | b64enc | quote }}
+  password: {{ include "agents.postgresPassword" . | b64enc | quote }}
+  database: {{ include "agents.databaseName" . | b64enc | quote }}
+  host: {{ include "agents.databaseHost" . | b64enc | quote }}
+  port: {{ include "agents.databasePort" . | toString | b64enc | quote }}
+  uri: {{ include "agents.databaseUrl" . | b64enc | quote }}
+{{- end -}}

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -90,6 +90,47 @@ spec:
             - name: {{ $name }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- if .Values.primitives.reconciler.enabled }}
+            - name: JANGAR_PRIMITIVES_RECONCILER
+              value: "1"
+            - name: JANGAR_PRIMITIVES_NAMESPACES
+              value: {{ include "agents.primitivesNamespaces" . | quote }}
+            - name: JANGAR_PRIMITIVES_RECONCILER_INTERVAL_SECONDS
+              value: {{ .Values.primitives.reconciler.intervalSeconds | default 30 | quote }}
+            {{- else }}
+            - name: JANGAR_PRIMITIVES_RECONCILER
+              value: "0"
+            {{- end }}
+            {{- if .Values.agentComms.enabled }}
+            - name: JANGAR_AGENT_COMMS_SUBSCRIBER_DISABLED
+              value: "false"
+            - name: NATS_URL
+              value: {{ .Values.agentComms.nats.url | default "nats://nats.nats.svc.cluster.local:4222" | quote }}
+            {{- if .Values.agentComms.nats.userSecret.name }}
+            - name: NATS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.agentComms.nats.userSecret.name }}
+                  key: {{ .Values.agentComms.nats.userSecret.usernameKey | default "username" }}
+            - name: NATS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.agentComms.nats.userSecret.name }}
+                  key: {{ .Values.agentComms.nats.userSecret.passwordKey | default "password" }}
+            {{- else }}
+            {{- if .Values.agentComms.nats.user }}
+            - name: NATS_USER
+              value: {{ .Values.agentComms.nats.user | quote }}
+            {{- end }}
+            {{- if .Values.agentComms.nats.password }}
+            - name: NATS_PASSWORD
+              value: {{ .Values.agentComms.nats.password | quote }}
+            {{- end }}
+            {{- end }}
+            {{- else }}
+            - name: JANGAR_AGENT_COMMS_SUBSCRIBER_DISABLED
+              value: "true"
+            {{- end }}
             {{- range .Values.env.secrets }}
             - name: {{ .name }}
               valueFrom:

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -1,0 +1,149 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "agents.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "agents.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "agents.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "agents.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{ end }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- if .Values.externalDatabase.enabled }}
+            - name: DATABASE_HOST
+              value: {{ required "externalDatabase.host is required when externalDatabase.enabled" .Values.externalDatabase.host | quote }}
+            - name: DATABASE_PORT
+              value: {{ default 5432 .Values.externalDatabase.port | quote }}
+            - name: DATABASE_NAME
+              value: {{ include "agents.databaseName" . | quote }}
+            - name: DATABASE_USER
+              value: {{ include "agents.databaseUser" . | quote }}
+            - name: DATABASE_PASSWORD
+              {{- if .Values.externalDatabase.passwordSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalDatabase.passwordSecret.name }}
+                  key: {{ .Values.externalDatabase.passwordSecret.key | default "password" }}
+              {{- else }}
+              value: {{ required "externalDatabase.password or passwordSecret.name must be set" (.Values.externalDatabase.password | default "") | quote }}
+              {{- end }}
+            - name: PGSSLMODE
+              value: {{ default "require" .Values.externalDatabase.sslMode | quote }}
+            - name: DATABASE_URL
+              value: >-
+                postgresql://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE_NAME)?sslmode=$(PGSSLMODE)
+            {{- else }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agents.databaseSecretName" . }}
+                  key: uri
+            - name: PGSSLMODE
+              value: disable
+            {{- end }}
+            {{- range $name, $value := .Values.env.vars }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range .Values.env.secrets }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .key | default "value" }}
+            {{- end }}
+            {{- range .Values.env.config }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .configMapName }}
+                  key: {{ .key | default .name }}
+            {{- end }}
+            {{- range .Values.env.extra }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- range .Values.extraVolumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              {{- with .subPath }}
+              subPath: {{ . }}
+              {{- end }}
+            {{- end }}
+      volumes:
+        {{- range .Values.extraVolumes }}
+        - name: {{ .name }}
+          {{- toYaml .volume | nindent 10 }}
+        {{- end }}

--- a/charts/agents/templates/hpa.yaml
+++ b/charts/agents/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agents.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/agents/templates/ingress.yaml
+++ b/charts/agents/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "agents.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agents/templates/migrations-configmap.yaml
+++ b/charts/agents/templates/migrations-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.migrations.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agents.fullname" . }}-migrations
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+data:
+  bootstrap.sql: |
+{{ (.Files.Get "sql/migrations.sql") | indent 4 }}
+{{- end -}}

--- a/charts/agents/templates/migrations-configmap.yaml
+++ b/charts/agents/templates/migrations-configmap.yaml
@@ -8,5 +8,5 @@ metadata:
     {{- include "agents.labels" . | nindent 4 }}
 data:
   bootstrap.sql: |
-{{ (.Files.Get "sql/migrations.sql") | indent 4 }}
+{{ (.Files.Get "files/sql/migrations.sql") | indent 4 }}
 {{- end -}}

--- a/charts/agents/templates/migrations-job.yaml
+++ b/charts/agents/templates/migrations-job.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.migrations.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agents.fullname" . }}-migrations
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": {{ .Values.migrations.hookWeight | default "-5" | quote }}
+    {{- with .Values.migrations.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "agents.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "agents.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: "{{ .Values.migrations.image.repository }}:{{ .Values.migrations.image.tag }}{{- if .Values.migrations.image.digest }}@{{ .Values.migrations.image.digest }}{{ end }}"
+          imagePullPolicy: {{ .Values.migrations.image.pullPolicy }}
+          env:
+            {{- if .Values.externalDatabase.enabled }}
+            - name: DATABASE_HOST
+              value: {{ required "externalDatabase.host is required when externalDatabase.enabled" .Values.externalDatabase.host | quote }}
+            - name: DATABASE_PORT
+              value: {{ default 5432 .Values.externalDatabase.port | quote }}
+            - name: DATABASE_NAME
+              value: {{ include "agents.databaseName" . | quote }}
+            - name: DATABASE_USER
+              value: {{ include "agents.databaseUser" . | quote }}
+            - name: DATABASE_PASSWORD
+              {{- if .Values.externalDatabase.passwordSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalDatabase.passwordSecret.name }}
+                  key: {{ .Values.externalDatabase.passwordSecret.key | default "password" }}
+              {{- else }}
+              value: {{ required "externalDatabase.password or passwordSecret.name must be set" (.Values.externalDatabase.password | default "") | quote }}
+              {{- end }}
+            - name: PGSSLMODE
+              value: {{ default "require" .Values.externalDatabase.sslMode | quote }}
+            - name: DATABASE_URL
+              value: >-
+                postgresql://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE_NAME)?sslmode=$(PGSSLMODE)
+            {{- else }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agents.databaseSecretName" . }}
+                  key: uri
+            - name: PGSSLMODE
+              value: disable
+            {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              echo "Running migrations against ${DATABASE_URL}"
+              psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /migrations/bootstrap.sql
+          volumeMounts:
+            - name: migrations
+              mountPath: /migrations
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+      volumes:
+        - name: migrations
+          configMap:
+            name: {{ include "agents.fullname" . }}-migrations
+            items:
+              - key: bootstrap.sql
+                path: bootstrap.sql
+{{- end -}}

--- a/charts/agents/templates/migrations-job.yaml
+++ b/charts/agents/templates/migrations-job.yaml
@@ -7,7 +7,15 @@ metadata:
   labels:
     {{- include "agents.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    {{- $hooks := list "pre-upgrade" }}
+    {{- if .Values.externalDatabase.enabled }}
+    {{- $hooks = append $hooks "pre-install" }}
+    {{- else }}
+    {{- /* when we manage Postgres ourselves, wait for it to come up */ -}}
+    {{- $hooks = append $hooks "post-install" }}
+    {{- $hooks = append $hooks "post-upgrade" }}
+    {{- end }}
+    "helm.sh/hook": {{ join "," $hooks }}
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": {{ .Values.migrations.hookWeight | default "-5" | quote }}
     {{- with .Values.migrations.annotations }}
@@ -60,10 +68,20 @@ spec:
               value: disable
             {{- end }}
           command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
               set -euo pipefail
+              : "${DB_CONNECT_RETRIES:=30}"
+              echo "Waiting for database to become ready..."
+              for i in $(seq 1 "${DB_CONNECT_RETRIES}"); do
+                if pg_isready -d "${DATABASE_URL}" >/dev/null 2>&1; then
+                  break
+                fi
+                echo "Database not ready (attempt ${i}/${DB_CONNECT_RETRIES}), sleeping 2s..."
+                sleep 2
+              done
+              pg_isready -d "${DATABASE_URL}"
               echo "Running migrations against ${DATABASE_URL}"
               psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /migrations/bootstrap.sql
           volumeMounts:

--- a/charts/agents/templates/networkpolicy.yaml
+++ b/charts/agents/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+    {{- with .Values.networkPolicy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "agents.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agents/templates/pdb.yaml
+++ b/charts/agents/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "agents.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/agents/templates/postgres-service.yaml
+++ b/charts/agents/templates/postgres-service.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.postgres.enabled (not .Values.externalDatabase.enabled) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agents.postgres.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "agents.postgres.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgres
+    helm.sh/chart: {{ include "agents.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.postgres.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.service.port }}
+      targetPort: postgres
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "agents.postgres.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/agents/templates/postgres-statefulset.yaml
+++ b/charts/agents/templates/postgres-statefulset.yaml
@@ -1,0 +1,85 @@
+{{- if and .Values.postgres.enabled (not .Values.externalDatabase.enabled) -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "agents.postgres.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "agents.postgres.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgres
+    helm.sh/chart: {{ include "agents.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  serviceName: {{ include "agents.postgres.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agents.postgres.fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "agents.postgres.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: postgres
+        helm.sh/chart: {{ include "agents.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+    spec:
+      {{- with .Values.postgres.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        fsGroup: {{ .Values.postgres.securityContext.fsGroup | default 999 }}
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}{{- if .Values.postgres.image.digest }}@{{ .Values.postgres.image.digest }}{{ end }}"
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ include "agents.databaseName" . }}
+            - name: POSTGRES_USER
+              value: {{ include "agents.databaseUser" . }}
+            - name: POSTGRES_PASSWORD
+              value: {{ include "agents.postgresPassword" . }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgres.service.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: {{ include "agents.postgres.fullname" . }}
+          app.kubernetes.io/instance: {{ .Release.Name }}
+          app.kubernetes.io/component: postgres
+          helm.sh/chart: {{ include "agents.chart" . }}
+          app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgres.storage.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage.size }}
+        {{- if .Values.postgres.storage.storageClass }}
+        storageClassName: {{ .Values.postgres.storage.storageClass }}
+        {{- end }}
+{{- end -}}

--- a/charts/agents/templates/rbac.yaml
+++ b/charts/agents/templates/rbac.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - agents.proompteng.ai
+    resources:
+      - agents
+      - agentruns
+      - agentproviders
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - agents.proompteng.ai
+    resources:
+      - agents/status
+      - agentruns/status
+      - agentproviders/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - configmaps
+      - secrets
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+{{- with .Values.rbac.extraRules }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "agents.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agents.serviceAccountName" . }}
+    namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+{{- end }}

--- a/charts/agents/templates/service.yaml
+++ b/charts/agents/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agents.selectorLabels" . | nindent 4 }}

--- a/charts/agents/templates/serviceaccount.yaml
+++ b/charts/agents/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agents.serviceAccountName" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agents/values-dev.yaml
+++ b/charts/agents/values-dev.yaml
@@ -42,3 +42,13 @@ networkPolicy:
 
 autoscaling:
   enabled: false
+
+primitives:
+  namespaces:
+    - agents
+  reconciler:
+    enabled: true
+    intervalSeconds: 15
+
+agentComms:
+  enabled: false

--- a/charts/agents/values-dev.yaml
+++ b/charts/agents/values-dev.yaml
@@ -1,0 +1,44 @@
+# Kind/minikube friendly defaults
+replicaCount: 1
+
+image:
+  repository: ghcr.io/proompteng/jangar
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+postgres:
+  enabled: true
+  storage:
+    size: 2Gi
+  credentials:
+    username: agents
+    database: agents
+    password: devpassword
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+
+migrations:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+
+resources:
+  requests:
+    cpu: 150m
+    memory: 512Mi
+
+ingress:
+  enabled: false
+
+networkPolicy:
+  enabled: false
+
+autoscaling:
+  enabled: false

--- a/charts/agents/values-prod.yaml
+++ b/charts/agents/values-prod.yaml
@@ -92,3 +92,19 @@ resources:
 
 backups:
   enabled: false
+
+primitives:
+  namespaces:
+    - agents
+  reconciler:
+    enabled: true
+    intervalSeconds: 30
+
+agentComms:
+  enabled: true
+  nats:
+    url: nats://nats.nats.svc.cluster.local:4222
+    userSecret:
+      name: nats-agents-credentials
+      usernameKey: username
+      passwordKey: password

--- a/charts/agents/values-prod.yaml
+++ b/charts/agents/values-prod.yaml
@@ -1,0 +1,94 @@
+replicaCount: 2
+
+image:
+  repository: registry.ide-newton.ts.net/lab/jangar
+  tag: "8e480ce4"
+  digest: sha256:103cdef8c8d92e3ac6274c67d18312a683c3e71a7270c2d748ed7bfe3108fbba
+  pullPolicy: IfNotPresent
+  pullSecrets:
+    - registry-cred
+
+service:
+  type: ClusterIP
+  port: 80
+
+externalDatabase:
+  enabled: true
+  host: agents-db.example.com
+  port: 5432
+  database: agents
+  user: agents
+  passwordSecret:
+    name: agents-db-app
+    key: password
+  sslMode: require
+  caSecret:
+    name: agents-db-ca
+    key: ca.crt
+
+postgres:
+  enabled: false
+
+migrations:
+  image:
+    repository: docker.io/pgvector/pgvector
+    tag: pg16
+    digest: sha256:0a07c4114ba6d1d04effcce3385e9f5ce305eb02e56a3d35948a415a52f193ec
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  backoffLimit: 5
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: agents.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: agents-tls
+      hosts:
+        - agents.example.com
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 60
+  targetMemoryUtilizationPercentage: 70
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 80
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 5432
+
+resources:
+  requests:
+    cpu: 300m
+    memory: 1Gi
+  limits:
+    cpu: 1
+    memory: 2Gi
+
+backups:
+  enabled: false

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -1,0 +1,194 @@
+nameOverride: ""
+fullnameOverride: ""
+
+namespaceOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/proompteng/jangar
+  tag: latest
+  digest: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+authSecret:
+  create: true
+  name: ""
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 80
+  annotations: {}
+  labels: {}
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits: {}
+
+podAnnotations: {}
+podLabels: {}
+
+securityContext: {}
+containerSecurityContext: {}
+
+nodeSelector: {}
+affinity: {}
+tolerations: []
+
+livenessProbe:
+  enabled: true
+  path: /health
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 6
+
+readinessProbe:
+  enabled: true
+  path: /health
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 6
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: agents.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 75
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+networkPolicy:
+  enabled: false
+  egress: []
+  ingress: []
+  labels: {}
+
+env:
+  extra: []
+  secrets: []
+  config: []
+  vars:
+    NODE_ENV: production
+    PORT: "8080"
+    JANGAR_SKIP_MIGRATIONS: "0"
+
+postgres:
+  enabled: true
+  image:
+    repository: docker.io/pgvector/pgvector
+    tag: pg16
+    digest: ""
+    pullPolicy: IfNotPresent
+  storage:
+    size: 10Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+  service:
+    port: 5432
+    annotations: {}
+  credentials:
+    username: agents
+    password: ""
+    database: agents
+    existingSecret: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  securityContext:
+    fsGroup: 999
+    runAsUser: 999
+    runAsGroup: 999
+  annotations: {}
+
+externalDatabase:
+  enabled: false
+  host: ""
+  port: 5432
+  database: ""
+  user: ""
+  password: ""
+  passwordSecret:
+    name: ""
+    key: password
+  sslMode: disable
+  caSecret:
+    name: ""
+    key: ca.crt
+
+migrations:
+  enabled: true
+  image:
+    repository: docker.io/pgvector/pgvector
+    tag: pg16
+    digest: ""
+    pullPolicy: IfNotPresent
+  annotations: {}
+  backoffLimit: 3
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits: {}
+
+backups:
+  enabled: false
+  schedule: "0 3 * * *"
+  retentionDays: 7
+  image:
+    repository: docker.io/pgvector/pgvector
+    tag: pg16
+    digest: ""
+    pullPolicy: IfNotPresent
+  storage:
+    existingClaim: ""
+    size: 5Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits: {}
+
+persistence:
+  annotations: {}
+  labels: {}
+
+extraVolumes: []
+extraVolumeMounts: []
+
+logging:
+  level: info
+
+dashboard:
+  enabled: false

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -17,6 +17,10 @@ serviceAccount:
   name: ""
   annotations: {}
 
+rbac:
+  create: true
+  extraRules: []
+
 authSecret:
   create: true
   name: ""

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -97,6 +97,23 @@ env:
     PORT: "8080"
     JANGAR_SKIP_MIGRATIONS: "0"
 
+primitives:
+  namespaces: []
+  reconciler:
+    enabled: true
+    intervalSeconds: 30
+
+agentComms:
+  enabled: false
+  nats:
+    url: ""
+    user: ""
+    password: ""
+    userSecret:
+      name: ""
+      usernameKey: username
+      passwordKey: password
+
 postgres:
   enabled: true
   image:


### PR DESCRIPTION
## Summary

- Add agents Helm chart packaging Agent/AgentRun/AgentProvider CRDs, control-plane deployment, migrations, optional ingress/HPA/PDB/NetworkPolicy, backups, and example values.
- Include embedded Postgres/pgvector defaults with switchable external DB support and idempotent migration job plus sample CRDs and docs for quickstart.
- Add Argo CD application under argocd/applications/agents to deploy the chart from this repo.

## Related Issues

- Closes #2446

## Testing

- mise exec helm@3 -- helm lint charts/agents
- mise exec helm@3 -- helm template charts/agents --values charts/agents/values-dev.yaml
- kind (agents): helm install charts/agents --values charts/agents/values-dev.yaml --namespace agents; built+loaded mock image ghcr.io/proompteng/jangar:localtest (upstream image private); port-forward svc/agents 8080:80 and curl http://127.0.0.1:8080/health
- kubectl -n agents exec agents-postgres-0 -- psql -U agents -d agents -c "\\dt"
- kubectl -n agents exec agents-postgres-0 -- psql -U agents -d agents -tAc "SELECT extname FROM pg_extension WHERE extname IN ('vector','pgcrypto');"
- kubectl -n agents apply sample Agent/AgentProvider and create AgentRun; patched AgentRun status to Succeeded for smoke validation

## Screenshots (if applicable)

- N/A

## Breaking Changes

- None