### PR TITLE
fix(argocd): move list templates under generators

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -79,6 +79,10 @@ spec:
               argocd.argoproj.io/sync-wave: "1"
             automation: manual
             enabled: true
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: enabled
@@ -86,12 +90,12 @@ spec:
             values: ["false", "False", "0"]
           - key: clusters
             operator: DoesNotExist
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *bootstrap_elements
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: enabled
@@ -100,12 +104,14 @@ spec:
           - key: clusters
             operator: In
             values: ["in-cluster", "all"]
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *bootstrap_elements
+        template:
+          metadata:
+            name: '{{ .name }}-ryzen'
+          spec:
+            destination:
+              name: ryzen
       selector:
         matchExpressions:
           - key: enabled
@@ -114,12 +120,6 @@ spec:
           - key: clusters
             operator: In
             values: ["ryzen", "all"]
-      template:
-        metadata:
-          name: '{{ .name }}-ryzen'
-        spec:
-          destination:
-            name: ryzen
   template:
     metadata:
       name: '{{ .name }}'

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -19,6 +19,10 @@ spec:
             enabled: true
             annotations:
               argocd.argoproj.io/sync-wave: "6"
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: enabled
@@ -29,12 +33,12 @@ spec:
               - "0"
           - key: clusters
             operator: DoesNotExist
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *cdk8s_elements
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: enabled
@@ -48,12 +52,14 @@ spec:
             values:
               - "in-cluster"
               - "all"
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *cdk8s_elements
+        template:
+          metadata:
+            name: "{{ .name }}-ryzen"
+          spec:
+            destination:
+              name: ryzen
       selector:
         matchExpressions:
           - key: enabled
@@ -67,12 +73,6 @@ spec:
             values:
               - "ryzen"
               - "all"
-      template:
-        metadata:
-          name: "{{ .name }}-ryzen"
-        spec:
-          destination:
-            name: ryzen
   template:
     metadata:
       name: "{{ .name }}"

--- a/argocd/applicationsets/helm-apps.yaml
+++ b/argocd/applicationsets/helm-apps.yaml
@@ -10,38 +10,38 @@ spec:
   generators:
     - list:
         elements: &helm_elements []
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: clusters
             operator: DoesNotExist
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *helm_elements
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: clusters
             operator: In
             values: ["in-cluster", "all"]
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *helm_elements
+        template:
+          metadata:
+            name: "{{.name}}-ryzen"
+          spec:
+            destination:
+              name: ryzen
       selector:
         matchExpressions:
           - key: clusters
             operator: In
             values: ["ryzen", "all"]
-      template:
-        metadata:
-          name: "{{.name}}-ryzen"
-        spec:
-          destination:
-            name: ryzen
   template:
     metadata:
       name: "{{.name}}"

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -262,6 +262,10 @@ spec:
               argocd.argoproj.io/sync-wave: "4"
             automation: auto
             enabled: "true"
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: enabled
@@ -269,12 +273,12 @@ spec:
             values: ["false", "False", "0"]
           - key: clusters
             operator: DoesNotExist
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *platform_elements
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: enabled
@@ -283,12 +287,14 @@ spec:
           - key: clusters
             operator: In
             values: ["in-cluster", "all"]
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *platform_elements
+        template:
+          metadata:
+            name: '{{ .name }}-ryzen'
+          spec:
+            destination:
+              name: ryzen
       selector:
         matchExpressions:
           - key: enabled
@@ -297,12 +303,6 @@ spec:
           - key: clusters
             operator: In
             values: ["ryzen", "all"]
-      template:
-        metadata:
-          name: '{{ .name }}-ryzen'
-        spec:
-          destination:
-            name: ryzen
   template:
     metadata:
       name: "{{ .name }}"

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -217,6 +217,10 @@ spec:
                   - /spec/template/spec/containers/0/resources
             automation: manual
             enabled: true
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: enabled
@@ -224,12 +228,12 @@ spec:
             values: ["false", "False", "0"]
           - key: clusters
             operator: DoesNotExist
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *product_elements
+        template:
+          spec:
+            destination:
+              server: https://kubernetes.default.svc
       selector:
         matchExpressions:
           - key: enabled
@@ -238,12 +242,14 @@ spec:
           - key: clusters
             operator: In
             values: ["in-cluster", "all"]
-      template:
-        spec:
-          destination:
-            server: https://kubernetes.default.svc
     - list:
         elements: *product_elements
+        template:
+          metadata:
+            name: "{{ .name }}-ryzen"
+          spec:
+            destination:
+              name: ryzen
       selector:
         matchExpressions:
           - key: enabled
@@ -252,12 +258,6 @@ spec:
           - key: clusters
             operator: In
             values: ["ryzen", "all"]
-      template:
-        metadata:
-          name: "{{ .name }}-ryzen"
-        spec:
-          destination:
-            name: ryzen
   template:
     metadata:
       name: "{{ .name }}"


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- move per-generator templates into `list.template` for ApplicationSets
- keep destination overrides for in-cluster vs ryzen within list generator schema
- avoid ApplicationSet validation errors from unsupported generator-level template blocks

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->
None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- Not run (requires Argo CD ApplicationSet controller validation)

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->
None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
