### PR TITLE
feat(argocd): add multi-cluster appsets

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -96,10 +96,24 @@ spec:
     - matrix:
         generators:
           - list:
-              elements: &bootstrap_clusters
+              elements: &bootstrap_clusters_in
                 - cluster: in-cluster
                   suffix: ""
                   destinationServer: https://kubernetes.default.svc
+          - list:
+              elements: *bootstrap_elements
+            selector:
+              matchExpressions:
+                - key: enabled
+                  operator: NotIn
+                  values: ["false", "False", "0"]
+                - key: clusters
+                  operator: In
+                  values: ["in-cluster", "all"]
+    - matrix:
+        generators:
+          - list:
+              elements: &bootstrap_clusters_ryzen
                 - cluster: ryzen
                   suffix: "-ryzen"
                   destinationName: ryzen
@@ -112,7 +126,7 @@ spec:
                   values: ["false", "False", "0"]
                 - key: clusters
                   operator: In
-                  values: ["{{ .cluster }}", "all"]
+                  values: ["ryzen", "all"]
   template:
     metadata:
       name: '{{ .name }}{{ .suffix }}'

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -36,10 +36,24 @@ spec:
     - matrix:
         generators:
           - list:
-              elements: &clusters
+              elements: &clusters_in
                 - cluster: in-cluster
                   suffix: ""
                   destinationServer: https://kubernetes.default.svc
+          - list:
+              elements: *cdk8s_elements
+            selector:
+              matchExpressions:
+                - key: enabled
+                  operator: NotIn
+                  values: ["false", "False", "0"]
+                - key: clusters
+                  operator: In
+                  values: ["in-cluster", "all"]
+    - matrix:
+        generators:
+          - list:
+              elements: &clusters_ryzen
                 - cluster: ryzen
                   suffix: "-ryzen"
                   destinationName: ryzen
@@ -52,7 +66,7 @@ spec:
                   values: ["false", "False", "0"]
                 - key: clusters
                   operator: In
-                  values: ["{{ .cluster }}", "all"]
+                  values: ["ryzen", "all"]
   template:
     metadata:
       name: "{{ .name }}{{ .suffix }}"

--- a/argocd/applicationsets/helm-apps.yaml
+++ b/argocd/applicationsets/helm-apps.yaml
@@ -27,10 +27,24 @@ spec:
     - matrix:
         generators:
           - list:
-              elements: &clusters
+              elements: &clusters_in
                 - cluster: in-cluster
                   suffix: ""
                   destinationServer: https://kubernetes.default.svc
+          - list:
+              elements: *helm_elements
+            selector:
+              matchExpressions:
+                - key: enabled
+                  operator: NotIn
+                  values: ["false", "False", "0"]
+                - key: clusters
+                  operator: In
+                  values: ["in-cluster", "all"]
+    - matrix:
+        generators:
+          - list:
+              elements: &clusters_ryzen
                 - cluster: ryzen
                   suffix: "-ryzen"
                   destinationName: ryzen
@@ -43,7 +57,7 @@ spec:
                   values: ["false", "False", "0"]
                 - key: clusters
                   operator: In
-                  values: ["{{ .cluster }}", "all"]
+                  values: ["ryzen", "all"]
   template:
     metadata:
       name: "{{ .name }}{{ .suffix }}"

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -279,10 +279,24 @@ spec:
     - matrix:
         generators:
           - list:
-              elements: &clusters
+              elements: &clusters_in
                 - cluster: in-cluster
                   suffix: ""
                   destinationServer: https://kubernetes.default.svc
+          - list:
+              elements: *platform_elements
+            selector:
+              matchExpressions:
+                - key: enabled
+                  operator: NotIn
+                  values: ["false", "False", "0"]
+                - key: clusters
+                  operator: In
+                  values: ["in-cluster", "all"]
+    - matrix:
+        generators:
+          - list:
+              elements: &clusters_ryzen
                 - cluster: ryzen
                   suffix: "-ryzen"
                   destinationName: ryzen
@@ -295,7 +309,7 @@ spec:
                   values: ["false", "False", "0"]
                 - key: clusters
                   operator: In
-                  values: ["{{ .cluster }}", "all"]
+                  values: ["ryzen", "all"]
   template:
     metadata:
       name: "{{ .name }}{{ .suffix }}"

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -234,10 +234,24 @@ spec:
     - matrix:
         generators:
           - list:
-              elements: &clusters
+              elements: &clusters_in
                 - cluster: in-cluster
                   suffix: ""
                   destinationServer: https://kubernetes.default.svc
+          - list:
+              elements: *product_elements
+            selector:
+              matchExpressions:
+                - key: enabled
+                  operator: NotIn
+                  values: ["false", "False", "0"]
+                - key: clusters
+                  operator: In
+                  values: ["in-cluster", "all"]
+    - matrix:
+        generators:
+          - list:
+              elements: &clusters_ryzen
                 - cluster: ryzen
                   suffix: "-ryzen"
                   destinationName: ryzen
@@ -250,7 +264,7 @@ spec:
                   values: ["false", "False", "0"]
                 - key: clusters
                   operator: In
-                  values: ["{{ .cluster }}", "all"]
+                  values: ["ryzen", "all"]
   template:
     metadata:
       name: "{{ .name }}{{ .suffix }}"


### PR DESCRIPTION
## Summary
- switch ApplicationSets to matrix generators for in-cluster/ryzen/all targeting
- add destination server/name via templatePatch and suffix naming
- fix list generator nesting to satisfy ApplicationSet schema validation

## Related Issues
None

## Testing
- bun run lint:argocd

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
