### PR TITLE
fix(argocd): escape image updater template

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -26,7 +26,7 @@ spec:
                   argocd-image-updater.argoproj.io/proompteng: semver
                   argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-ssh
                   argocd-image-updater.argoproj.io/git-repository: git@github.com:proompteng/lab.git
-                  argocd-image-updater.argoproj.io/git-branch: main:release/{{.SHA256}}
+                  argocd-image-updater.argoproj.io/git-branch: 'main:release/{{"{{.SHA256}}"}}'
                   argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/proompteng
                 automation: auto
                 enabled: true
@@ -40,7 +40,7 @@ spec:
                   argocd-image-updater.argoproj.io/docs: semver
                   argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-ssh
                   argocd-image-updater.argoproj.io/git-repository: git@github.com:proompteng/lab.git
-                  argocd-image-updater.argoproj.io/git-branch: main:release/{{.SHA256}}
+                  argocd-image-updater.argoproj.io/git-branch: 'main:release/{{"{{.SHA256}}"}}'
                   argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/docs
                 automation: auto
                 enabled: true
@@ -62,7 +62,7 @@ spec:
                   argocd-image-updater.argoproj.io/kitty-krew: semver
                   argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-ssh
                   argocd-image-updater.argoproj.io/git-repository: git@github.com:proompteng/lab.git
-                  argocd-image-updater.argoproj.io/git-branch: main:release/{{.SHA256}}
+                  argocd-image-updater.argoproj.io/git-branch: 'main:release/{{"{{.SHA256}}"}}'
                   argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/kitty-krew
                 automation: auto
                 enabled: false
@@ -76,7 +76,7 @@ spec:
                   argocd-image-updater.argoproj.io/reviseur: semver
                   argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-ssh
                   argocd-image-updater.argoproj.io/git-repository: git@github.com:proompteng/lab.git
-                  argocd-image-updater.argoproj.io/git-branch: main:release/{{.SHA256}}
+                  argocd-image-updater.argoproj.io/git-branch: 'main:release/{{"{{.SHA256}}"}}'
                   argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/reviseur
                 automation: auto
                 enabled: false
@@ -201,7 +201,7 @@ spec:
                   argocd-image-updater.argoproj.io/dernier: semver
                   argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-ssh
                   argocd-image-updater.argoproj.io/git-repository: git@github.com:proompteng/lab.git
-                  argocd-image-updater.argoproj.io/git-branch: main:release/{{.SHA256}}
+                  argocd-image-updater.argoproj.io/git-branch: 'main:release/{{"{{.SHA256}}"}}'
                   argocd-image-updater.argoproj.io/write-back-target: kustomization:/argocd/applications/dernier
                 automation: manual
                 enabled: true


### PR DESCRIPTION
## Summary
- escape argocd-image-updater SHA256 template in product appset annotations to avoid ApplicationSet goTemplate errors

## Related Issues
None

## Testing
- bun run lint:argocd

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
