### PR TITLE
fix(argocd): drop unsupported agents values

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -3,31 +3,9 @@ image:
   repository: ghcr.io/proompteng/jangar
   tag: latest
   pullPolicy: IfNotPresent
-postgres:
-  enabled: true
-  storage:
-    size: 5Gi
-  credentials:
-    username: agents
-    database: agents
-    password: ""
 resources:
   requests:
     cpu: 200m
     memory: 512Mi
-migrations:
-  enabled: true
-ingress:
-  enabled: false
-networkPolicy:
-  enabled: false
-backups:
-  enabled: false
-primitives:
-  namespaces:
-    - agents
-  reconciler:
-    enabled: true
-    intervalSeconds: 30
 agentComms:
   enabled: false


### PR DESCRIPTION
## Summary
- remove unsupported values from agents application values.yaml to satisfy chart schema

## Related Issues
None

## Testing
- N/A (values schema validation happens in Argo CD)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
