### PR TITLE
fix(agents): drop invalid crd field

### DIFF
--- a/charts/agents/crds/agents.proompteng.ai_agentproviders.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_agentproviders.yaml
@@ -21,7 +21,6 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        x-kubernetes-preserve-unknown-fields: false
         properties:
           apiVersion:
             description: |-

--- a/charts/agents/crds/agents.proompteng.ai_agentruns.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_agentruns.yaml
@@ -33,7 +33,6 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        x-kubernetes-preserve-unknown-fields: false
         properties:
           apiVersion:
             description: |-

--- a/charts/agents/crds/agents.proompteng.ai_agents.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_agents.yaml
@@ -24,7 +24,6 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        x-kubernetes-preserve-unknown-fields: false
         properties:
           apiVersion:
             description: |-

--- a/charts/agents/crds/agents.proompteng.ai_implementationsources.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_implementationsources.yaml
@@ -27,7 +27,6 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        x-kubernetes-preserve-unknown-fields: false
         properties:
           apiVersion:
             description: |-

--- a/charts/agents/crds/agents.proompteng.ai_implementationspecs.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_implementationspecs.yaml
@@ -27,7 +27,6 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        x-kubernetes-preserve-unknown-fields: false
         properties:
           apiVersion:
             description: |-

--- a/charts/agents/crds/agents.proompteng.ai_memories.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_memories.yaml
@@ -27,7 +27,6 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        x-kubernetes-preserve-unknown-fields: false
         properties:
           apiVersion:
             description: |-


### PR DESCRIPTION
## Summary
- remove invalid x-kubernetes-preserve-unknown-fields=false from agents CRDs so Argo can apply them

## Related Issues
None

## Testing
- N/A (validated by Argo CD sync)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
