### PR TITLE
fix(agents): stop managing chart crds

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -7,6 +7,5 @@ helmCharts:
   - name: agents
     releaseName: agents
     namespace: agents
-    includeCRDs: true
     valuesFile: values.yaml
     version: 0.1.0


### PR DESCRIPTION
## Summary
- stop Helm chart from managing agents CRDs (cluster already has Crossplane-managed CRDs)

## Related Issues
None

## Testing
- N/A (validated by Argo CD sync)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
