### PR TITLE
fix(agents): use internal registry image

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 1
 image:
-  repository: ghcr.io/proompteng/jangar
+  repository: registry.ide-newton.ts.net/lab/jangar
   tag: latest
   pullPolicy: IfNotPresent
 resources:


### PR DESCRIPTION
## Summary
- switch agents image to internal registry to avoid GHCR pull failures

## Related Issues
None

## Testing
- N/A (validated by Argo CD sync / rollout)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
