### PR TITLE
fix(jangar): drop unsupported agentrun runtime

### DIFF
--- a/argocd/applications/jangar/jangar-primitives-agentrun.yaml
+++ b/argocd/applications/jangar/jangar-primitives-agentrun.yaml
@@ -8,8 +8,6 @@ spec:
     name: agentrun-argo
   agentRef:
     name: jangar-primitives-agent
-  runtime:
-    type: argo
   parameters:
     repository: proompteng/lab
     base: main


### PR DESCRIPTION
## Summary
- remove AgentRun.runtime from jangar primitives to match current XAgentRun schema

## Related Issues
None

## Testing
- N/A (applies via Argo CD)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
