### PR TITLE
feat(argocd): add kubevirt appset

### DIFF
--- a/argocd/applications/kubevirt/kustomization.yaml
+++ b/argocd/applications/kubevirt/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubevirt
+resources:
+  - https://github.com/kubevirt/kubevirt/releases/download/v1.7.0/kubevirt-operator.yaml
+  - https://github.com/kubevirt/kubevirt/releases/download/v1.7.0/kubevirt-cr.yaml

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -51,6 +51,14 @@ spec:
                   argocd.argoproj.io/sync-wave: "-1"
                 automation: manual
                 enabled: "true"
+              - name: kubevirt
+                path: argocd/applications/kubevirt
+                namespace: kubevirt
+                annotations:
+                  argocd.argoproj.io/sync-wave: "1"
+                automation: manual
+                enabled: "true"
+                clusters: ryzen
               - name: external-dns
                 path: argocd/applications/external-dns
                 namespace: external-dns


### PR DESCRIPTION
## Summary
- add KubeVirt application (operator + CR) managed by Argo CD
- target KubeVirt only to the ryzen cluster via platform ApplicationSet

## Related Issues
None

## Testing
- bun run lint:argocd

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
