### PR TITLE
fix(argocd): delay kubevirt cr

### DIFF
--- a/argocd/applications/kubevirt/kustomization.yaml
+++ b/argocd/applications/kubevirt/kustomization.yaml
@@ -4,3 +4,15 @@ namespace: kubevirt
 resources:
   - https://github.com/kubevirt/kubevirt/releases/download/v1.7.0/kubevirt-operator.yaml
   - https://github.com/kubevirt/kubevirt/releases/download/v1.7.0/kubevirt-cr.yaml
+patches:
+  - target:
+      kind: KubeVirt
+      name: kubevirt
+    patch: |-
+      apiVersion: kubevirt.io/v1
+      kind: KubeVirt
+      metadata:
+        name: kubevirt
+        annotations:
+          argocd.argoproj.io/sync-wave: "1"
+          argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
## Summary

- Add sync-wave and SkipDryRunOnMissingResource annotations to the KubeVirt CR
- Ensure CRDs are established before the KubeVirt CR applies
- Keep kubevirt appset behavior unchanged beyond ordering

## Related Issues

None

## Testing

- argocd app sync kubevirt-ryzen

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
