### PR TITLE
fix(ci): install build tools for proompteng

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,6 +94,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
## Summary

- Install build-essential in the proompteng PR job on arc-arm64
- Fix node-gyp failures caused by missing `make`
- Keep existing build/test steps unchanged

## Related Issues

None

## Testing

- not run (CI change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.