### PR TITLE
feat(argocd): add kata firecracker

### DIFF
--- a/argocd/applications/kata-containers/kustomization.yaml
+++ b/argocd/applications/kata-containers/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+helmCharts:
+  - name: kata-deploy
+    repo: oci://ghcr.io/kata-containers/kata-deploy-charts
+    version: 3.24.0
+    releaseName: kata-deploy
+    namespace: kube-system
+    valuesFile: values.yaml

--- a/argocd/applications/kata-containers/values.yaml
+++ b/argocd/applications/kata-containers/values.yaml
@@ -1,0 +1,47 @@
+k8sDistribution: "k8s"
+
+shims:
+  clh:
+    enabled: false
+  cloud-hypervisor:
+    enabled: false
+  dragonball:
+    enabled: false
+  fc:
+    enabled: true
+    supportedArches:
+      - amd64
+      - arm64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: "devmapper"
+  qemu:
+    enabled: false
+  qemu-runtime-rs:
+    enabled: false
+  qemu-nvidia-gpu:
+    enabled: false
+  qemu-nvidia-gpu-snp:
+    enabled: false
+  qemu-nvidia-gpu-tdx:
+    enabled: false
+  qemu-snp:
+    enabled: false
+  qemu-tdx:
+    enabled: false
+  qemu-se:
+    enabled: false
+  qemu-se-runtime-rs:
+    enabled: false
+  qemu-cca:
+    enabled: false
+  qemu-coco-dev:
+    enabled: false
+  qemu-coco-dev-runtime-rs:
+    enabled: false
+  remote:
+    enabled: false
+
+defaultShim:
+  amd64: fc
+  arm64: fc

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -59,6 +59,14 @@ spec:
                 automation: manual
                 enabled: "true"
                 clusters: ryzen
+              - name: kata-containers
+                path: argocd/applications/kata-containers
+                namespace: kube-system
+                annotations:
+                  argocd.argoproj.io/sync-wave: "1"
+                automation: manual
+                enabled: "true"
+                clusters: ryzen
               - name: external-dns
                 path: argocd/applications/external-dns
                 namespace: external-dns


### PR DESCRIPTION
## Summary

- Add kata-deploy Helm app to ArgoCD for the ryzen cluster
- Configure kata-deploy to enable only the Firecracker (fc) shim
- Set default shim to fc for amd64/arm64

## Related Issues

None

## Testing

- bun run lint:argocd

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.