### PR TITLE
fix(argocd): drop kata crio mount

### DIFF
--- a/argocd/applications/kata-containers/kustomization.yaml
+++ b/argocd/applications/kata-containers/kustomization.yaml
@@ -8,3 +8,13 @@ helmCharts:
     releaseName: kata-deploy
     namespace: kube-system
     valuesFile: values.yaml
+patches:
+  - target:
+      kind: DaemonSet
+      name: kata-deploy
+      namespace: kube-system
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/volumes/0
+      - op: remove
+        path: /spec/template/spec/containers/0/volumeMounts/0


### PR DESCRIPTION
## Summary

- Remove the kata-deploy CRI-O hostPath mount that fails on read-only /etc
- Keep kata-deploy Helm settings otherwise unchanged

## Related Issues

None

## Testing

- bun run lint:argocd

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.