### PR TITLE
fix(argocd): gate kata deploy daemonset

### DIFF
--- a/argocd/applications/kata-containers/values.yaml
+++ b/argocd/applications/kata-containers/values.yaml
@@ -1,5 +1,8 @@
 k8sDistribution: "k8s"
 
+nodeSelector:
+  kata-deploy: "enabled"
+
 shims:
   clh:
     enabled: false


### PR DESCRIPTION
## Summary

- Gate kata-deploy DaemonSet scheduling behind a dedicated node label
- Prevent kata-deploy from crashlooping on Talos hosts

## Related Issues

None

## Testing

- not run (values change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.