### PR TITLE
feat(kata): gitops blockfile scratch and docs

### DIFF
--- a/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
+++ b/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kata-blockfile-scratch
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kata-blockfile-scratch
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kata-blockfile-scratch
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kata-blockfile-scratch
+    spec:
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        katacontainers.io/kata-runtime: "true"
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: create-scratch
+          image: debian:bookworm
+          securityContext:
+            privileged: true
+          command:
+            - bash
+            - -euxo
+            - pipefail
+            - -c
+            - |
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y --no-install-recommends e2fsprogs util-linux
+
+              ROOT=/host/var/lib/containerd/blockfile
+              SCRATCH=${ROOT}/scratch.ext4
+              SIZE=10G
+
+              mkdir -p ${ROOT}
+
+              if [ ! -f "${SCRATCH}" ]; then
+                truncate -s ${SIZE} ${SCRATCH}
+                mkfs.ext4 -F ${SCRATCH}
+              else
+                if ! dumpe2fs -h ${SCRATCH} >/dev/null 2>&1; then
+                  mkfs.ext4 -F ${SCRATCH}
+                fi
+              fi
+          volumeMounts:
+            - name: host-containerd
+              mountPath: /host/var/lib/containerd
+      containers:
+        - name: hold
+          image: busybox:1.36
+          command: ["sh", "-c", "sleep infinity"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+          volumeMounts:
+            - name: host-containerd
+              mountPath: /host/var/lib/containerd
+      volumes:
+        - name: host-containerd
+          hostPath:
+            path: /var/lib/containerd
+            type: DirectoryOrCreate

--- a/argocd/applications/kata-containers/kustomization.yaml
+++ b/argocd/applications/kata-containers/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
+resources:
+  - blockfile-scratch-daemonset.yaml
 helmCharts:
   - name: kata-deploy
     repo: oci://ghcr.io/kata-containers/kata-deploy-charts

--- a/argocd/applications/kata-containers/values.yaml
+++ b/argocd/applications/kata-containers/values.yaml
@@ -1,5 +1,8 @@
 k8sDistribution: "k8s"
 
+nodeSelector:
+  kata-deploy: "enabled"
+
 shims:
   clh:
     enabled: false

--- a/docs/kata-firecracker-talos/README.md
+++ b/docs/kata-firecracker-talos/README.md
@@ -198,6 +198,67 @@ spec:
           type: RuntimeDefault
 ```
 
+## 7) Example manifests (Firecracker workloads)
+
+### Minimal Pod (Firecracker / kata-fc)
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kata-fc-demo
+  namespace: default
+spec:
+  runtimeClassName: kata-fc
+  restartPolicy: Never
+  containers:
+    - name: busybox
+      image: busybox:1.36
+      command: ["sh", "-c", "echo kata-fc-demo-ok && sleep 3600"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+```
+
+### Deployment (Firecracker / kata-fc)
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kata-fc-web
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kata-fc-web
+  template:
+    metadata:
+      labels:
+        app: kata-fc-web
+    spec:
+      runtimeClassName: kata-fc
+      containers:
+        - name: web
+          image: nginx:1.27
+          ports:
+            - containerPort: 80
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 101
+            seccompProfile:
+              type: RuntimeDefault
+```
+
 ## Troubleshooting
 
 ### blockfile snapshotter missing

--- a/docs/kata-firecracker-talos/investigation-2026-01-15.md
+++ b/docs/kata-firecracker-talos/investigation-2026-01-15.md
@@ -1,0 +1,283 @@
+# Investigation: Kata + Firecracker on Talos (ryzen)
+
+Date: 2026-01-15
+Cluster: ryzen (Talos v1.12.1, Kubernetes v1.35.0)
+Node: 192.168.1.194
+
+## Goal
+Run Kata Containers with Firecracker (runtimeClass `kata-fc`) on the ryzen Talos cluster and verify with a test pod. Provide reliable proof that Firecracker-backed Kata pods start.
+
+## Environment
+- OS: Talos v1.12.1
+- Kubernetes: v1.35.0
+- containerd: v2.1.6
+- Kata system extension present (paths under `/opt/kata/...`)
+- RuntimeClass: `kata-fc`
+
+Key binaries found:
+- `/opt/kata/bin/firecracker`
+- `/opt/kata/bin/containerd-shim-kata-v2`
+- `/opt/kata/share/defaults/kata-containers/configuration-fc.toml`
+
+## Summary of Findings
+1) **Firecracker requires a block-backed rootfs**, which in containerd is typically provided via the **devmapper snapshotter**.
+2) **Talos’s containerd build on this node does not expose the devmapper snapshotter**, even after adding a devmapper config stanza. As a result, Kata+Firecracker cannot create a sandbox.
+3) Attempts to run a `kata-fc` pod fail with:
+   - `CreateContainerRequest timed out` (initially)
+   - or `failed to mount /run/kata-containers/shared/containers/...: ENOENT`
+   - and after configuring devmapper: `snapshotter devmapper was not found: not found`
+4) Firecracker never creates its API socket under `/run/vc/firecracker/.../root/run/firecracker.socket`, indicating the VMM never fully starts.
+
+This is a hard blocker unless containerd is rebuilt with devmapper support or the OS/containerd runtime is changed.
+
+## Detailed Timeline & Evidence
+
+### 1) Confirm runtime and node
+Commands:
+```
+kubectl --context=ryzen get nodes -o wide
+kubectl --context=ryzen get runtimeclass
+```
+Result:
+- Node `ryzen` Ready on Talos v1.12.1, containerd v2.1.6.
+- RuntimeClass `kata-fc` exists.
+
+### 2) Initial failure: CreateContainerRequest timed out
+Test pod:
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kata-fc-test
+  namespace: default
+spec:
+  runtimeClassName: kata-fc
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+  containers:
+    - name: busybox
+      image: busybox:1.36
+      command: ["sh", "-c", "echo kata-fc-ok && sleep 3600"]
+```
+Symptoms:
+- Pod stuck `ContainerCreating`.
+- `FailedCreatePodSandBox` with timeout.
+
+Containerd/cri log evidence (tail):
+- `getting vm status failed ... /run/vc/firecracker/.../firecracker.socket: no such file or directory`
+- `CreateContainerRequest timed out`
+
+Interpretation:
+- Kata shim attempts to talk to Firecracker API socket that never appears.
+
+### 3) ConfigPath adjustment
+Initially used a custom config under `/var/lib/kata-containers/configuration-fc.toml`, but Talos only allows `machine.files` under `/var`. To remove variables, switched to the **stock config**:
+
+Talos file (`/etc/cri/conf.d/20-customization.part`):
+```
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc"]
+  runtime_type = "io.containerd.kata-fc.v2"
+  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.*"]
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc".options]
+    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc"]
+  runtime_type = "io.containerd.kata-fc.v2"
+  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.*"]
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc".options]
+    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+```
+
+Result: timeout errors replaced by rootfs mount ENOENT errors. Firecracker still never starts.
+
+### 4) ENOENT rootfs mount failures
+Pod describe showed:
+```
+failed to mount /run/kata-containers/shared/containers/<id>/rootfs to /run/kata-containers/<id>/rootfs, with error: ENOENT
+```
+
+Interpretation:
+- Kata expects a block-based rootfs for Firecracker. Without a block snapshotter, rootfs mount path doesn’t materialize.
+
+### 5) Attempted devmapper snapshotter
+Added devmapper snapshotter config and runtime snapshotter in CRI config:
+```
+[plugins."io.containerd.snapshotter.v1.devmapper"]
+  pool_name = "containerd-pool"
+  root_path = "/var/lib/containerd/io.containerd.snapshotter.v1.devmapper"
+  base_image_size = "10GB"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc"]
+  snapshotter = "devmapper"
+  ...
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc"]
+  snapshotter = "devmapper"
+  ...
+```
+
+Created a loopback-backed thinpool (test-only) via a privileged pod:
+- Creates `/var/lib/containerd/io.containerd.snapshotter.v1.devmapper/{data,meta}`
+- `dmsetup create containerd-pool ...`
+
+Result:
+- `kata-fc-test` failed with:
+  `snapshotter devmapper was not found: not found`
+
+### 6) Confirm containerd does not load devmapper
+Containerd logs show only `native` and `overlayfs` snapshotters loaded:
+```
+io.containerd.snapshotter.v1.native
+io.containerd.snapshotter.v1.overlayfs
+```
+No devmapper plugin is present. This indicates the containerd build shipped with Talos here does not include devmapper snapshotter support.
+
+## Root Cause
+Firecracker requires block-backed rootfs. On this Talos node, containerd lacks the devmapper snapshotter, so Firecracker cannot mount the root filesystem. This prevents Firecracker from starting and causes Kata shim failures.
+
+## Resolution (Working on 2026-01-15)
+
+Talos ships the **blockfile** snapshotter but disables it in `/etc/cri/containerd.toml`.
+Re-enabling blockfile and configuring `kata-fc` to use it makes Firecracker work.
+
+### 1) Re-enable blockfile snapshotter
+
+Overwrite `/etc/cri/containerd.toml` to remove the blockfile entry from
+`disabled_plugins`:
+
+```
+version = 3
+
+disabled_plugins = [
+    "io.containerd.differ.v1.erofs",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.erofs",
+    "io.containerd.ttrpc.v1.otelttrpc",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = [
+    "/etc/cri/conf.d/cri.toml",
+]
+```
+
+### 2) Configure blockfile + kata-fc runtime
+
+In `/etc/cri/conf.d/20-customization.part`:
+
+```
+[plugins."io.containerd.snapshotter.v1.blockfile"]
+  root_path = "/var/lib/containerd/io.containerd.snapshotter.v1.blockfile"
+  scratch_file = "/var/lib/containerd/blockfile/scratch.ext4"
+  fs_type = "ext4"
+  mount_options = []
+  recreate_scratch = false
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc"]
+  snapshotter = "blockfile"
+  runtime_type = "io.containerd.kata-fc.v2"
+  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.*"]
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc".options]
+    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc"]
+  snapshotter = "blockfile"
+  runtime_type = "io.containerd.kata-fc.v2"
+  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.*"]
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc".options]
+    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+```
+
+### 3) Create scratch file (ext4)
+
+Create `/var/lib/containerd/blockfile/scratch.ext4` and format it with ext4:
+
+```
+truncate -s 10G /var/lib/containerd/blockfile/scratch.ext4
+mkfs.ext4 -F /var/lib/containerd/blockfile/scratch.ext4
+```
+
+### 4) Reboot Talos
+
+Reboot is required to reload containerd with the new base config.
+
+### Proof
+
+Blockfile snapshotter loaded:
+
+```
+io.containerd.snapshotter.v1              blockfile                linux/amd64    ok
+```
+
+Firecracker process running:
+
+```
+/firecracker --id ... --config-file /fcConfig.json
+```
+
+Guest kernel from inside pod:
+
+```
+Linux kata-fc-test 6.12.47 #1 SMP Fri Dec  5 12:15:04 UTC 2025 x86_64 GNU/Linux
+```
+
+## Internet Research (Primary Sources)
+
+### Firecracker storage model
+- Firecracker’s device model includes `virtio-block` as the storage device. This implies storage (including rootfs) is exposed to the guest as a block device, not a host file share.
+  - https://firecracker-microvm.github.io/
+
+### Containerd devmapper snapshotter
+- Devmapper snapshotter is a containerd plugin that stores snapshots in filesystem images inside a device-mapper thin pool. It requires creating a thin-pool in advance and configuring containerd to use it.
+  - https://fossies.org/linux/containerd/docs/snapshotters/devmapper.md
+
+### Talos containerd configuration merge point
+- Talos merges containerd configuration from `/etc/cri/conf.d/20-customization.part` (Talos docs).
+  - https://www.talos.dev/v1.11/talos-guides/configuration/containerd/
+
+### Talos custom image build path
+- Talos supports building custom images from source (needed if containerd must be rebuilt with devmapper support).
+  - https://www.talos.dev/v1.10/advanced/building-images/
+
+### Firecracker + devmapper in the ecosystem
+- Flintlock docs explicitly state it relies on containerd’s devmapper snapshotter to provide filesystem devices for Firecracker microVMs, reinforcing the block-backed storage requirement.
+  - https://flintlock.liquidmetal.dev/docs/getting-started/containerd/
+
+## What Works
+- Kata binaries are present (`/opt/kata/bin/firecracker`, `containerd-shim-kata-v2`).
+- RuntimeClass `kata-fc` exists.
+- KVM/vsock device nodes exist (`/dev/kvm`, `/dev/vhost-vsock`).
+- Blockfile snapshotter is enabled and loaded.
+- `kata-fc-test` pod runs successfully.
+
+## What Does Not Work
+- Devmapper snapshotter is not available in the Talos containerd build.
+
+## Required Fix Options
+1) **Keep blockfile snapshotter** (current working solution).
+2) **Custom Talos build/containerd** with devmapper snapshotter enabled (optional).
+3) **Use a different VMM** (QEMU or Cloud Hypervisor) if blockfile is not viable.
+
+## Artifacts & References
+- Talos config changes live in:
+  - `/Users/gregkonush/github.com/devices/ryzen/controlplane.yaml`
+  - `/Users/gregkonush/github.com/devices/ryzen/worker.yaml`
+- Doc: `docs/kata-firecracker-talos/README.md`
+
+## Cleanup Performed
+- Removed helper pods:
+  - `blockfile-scratch-init`
+  - `ctr-plugins-check`
+  - `ctr-fix-pause`
+
+## Next Actions
+- Optional: codify the blockfile scratch creation as a GitOps manifest.
+- Optional: evaluate a custom Talos/containerd build if devmapper is required.

--- a/docs/kata-firecracker-talos/rebuild-from-scratch.md
+++ b/docs/kata-firecracker-talos/rebuild-from-scratch.md
@@ -1,0 +1,375 @@
+# Rebuild From Scratch: Kata + Firecracker on Talos (ryzen)
+
+This is a complete, reproducible runbook to stand up Kata Containers with the
+Firecracker VMM on Talos and prove it is working.
+
+It assumes a single-node Talos cluster (ryzen) but works the same for multi-node
+clusters (apply machine config to all nodes that should run Kata/Firecracker).
+
+## High-level idea
+
+Firecracker needs a **block-backed rootfs**. On Talos, the fastest working path
+is the **containerd blockfile snapshotter** (not devmapper). Talos ships
+`blockfile`, but disables it by default, so we must:
+
+1. Remove `io.containerd.snapshotter.v1.blockfile` from `disabled_plugins` in
+   `/etc/cri/containerd.toml`.
+2. Configure blockfile snapshotter + `kata-fc` runtime in
+   `/etc/cri/conf.d/20-customization.part`.
+3. Create the scratch ext4 image under `/var`.
+4. Reboot the node so containerd reloads config.
+5. Run a test pod and verify Firecracker processes exist.
+
+## Prereqs
+
+- Talos v1.12.x node(s)
+- KVM + vhost-vsock available: `/dev/kvm`, `/dev/vhost-vsock`
+- Talos system extensions:
+  - `siderolabs/kata-containers`
+  - `siderolabs/glibc`
+- `kubectl` configured with the `ryzen` context
+- Talos config files in:
+  - `/Users/gregkonush/github.com/devices/ryzen/controlplane.yaml`
+  - `/Users/gregkonush/github.com/devices/ryzen/worker.yaml`
+
+## Step 1: Build/Upgrade Talos with system extensions
+
+Ensure Talos Image Factory schematic includes:
+
+```yaml
+customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/kata-containers
+      - siderolabs/glibc
+```
+
+Upgrade node with the resulting installer image (extensions only load at
+install/upgrade time).
+
+## Step 2: Update Talos machine config
+
+### 2.1 Overwrite `/etc/cri/containerd.toml`
+
+Talos disables blockfile in `disabled_plugins`. Remove it by overwriting the
+base CRI containerd config.
+
+Add this to `machine.files` in your Talos config (both controlplane + worker):
+
+```yaml
+- path: /etc/cri/containerd.toml
+  op: overwrite
+  permissions: 0o644
+  content: |
+    version = 3
+
+    disabled_plugins = [
+        "io.containerd.differ.v1.erofs",
+        "io.containerd.internal.v1.tracing",
+        "io.containerd.snapshotter.v1.erofs",
+        "io.containerd.ttrpc.v1.otelttrpc",
+        "io.containerd.tracing.processor.v1.otlp",
+    ]
+
+    imports = [
+        "/etc/cri/conf.d/cri.toml",
+    ]
+```
+
+### 2.2 Configure blockfile + kata-fc runtime
+
+Add this to `/etc/cri/conf.d/20-customization.part` (via `machine.files`):
+
+```toml
+[plugins."io.containerd.snapshotter.v1.blockfile"]
+  root_path = "/var/lib/containerd/io.containerd.snapshotter.v1.blockfile"
+  scratch_file = "/var/lib/containerd/blockfile/scratch.ext4"
+  fs_type = "ext4"
+  mount_options = []
+  recreate_scratch = false
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc"]
+  snapshotter = "blockfile"
+  runtime_type = "io.containerd.kata-fc.v2"
+  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.*"]
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc".options]
+    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc"]
+  snapshotter = "blockfile"
+  runtime_type = "io.containerd.kata-fc.v2"
+  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.*"]
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc".options]
+    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+```
+
+### 2.3 Apply Talos config and reboot
+
+```bash
+talosctl --talosconfig /Users/gregkonush/github.com/devices/ryzen/talosconfig \
+  apply-config -n 192.168.1.194 -f /Users/gregkonush/github.com/devices/ryzen/controlplane.yaml
+
+talosctl --talosconfig /Users/gregkonush/github.com/devices/ryzen/talosconfig \
+  reboot -n 192.168.1.194
+```
+
+Wait for the node to return Ready:
+
+```bash
+kubectl --context=ryzen get nodes -o wide
+```
+
+## Step 3: Create the blockfile scratch image
+
+The blockfile snapshotter requires a pre-created ext4/xfs scratch image.
+Create it under `/var` so it survives reboots.
+
+GitOps manifest (DaemonSet) lives at:
+
+- `argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml`
+
+Apply via Argo CD (recommended) or manually apply the same manifest.
+
+If applying manually, use the manifest below:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: blockfile-scratch-init
+  namespace: kube-system
+spec:
+  restartPolicy: Never
+  hostNetwork: true
+  hostPID: true
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: init
+      image: debian:bookworm
+      securityContext:
+        privileged: true
+      command:
+        - bash
+        - -euxo
+        - pipefail
+        - -c
+        - |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends e2fsprogs util-linux
+
+          ROOT=/host/var/lib/containerd/blockfile
+          SCRATCH=${ROOT}/scratch.ext4
+          SIZE=10G
+
+          mkdir -p ${ROOT}
+
+          if [ ! -f "${SCRATCH}" ]; then
+            truncate -s ${SIZE} ${SCRATCH}
+            mkfs.ext4 -F ${SCRATCH}
+          else
+            if ! dumpe2fs -h ${SCRATCH} >/dev/null 2>&1; then
+              mkfs.ext4 -F ${SCRATCH}
+            fi
+          fi
+
+          ls -lh ${SCRATCH}
+          dumpe2fs -h ${SCRATCH} | head -n 10
+      volumeMounts:
+        - name: host-containerd
+          mountPath: /host/var/lib/containerd
+  volumes:
+    - name: host-containerd
+      hostPath:
+        path: /var/lib/containerd
+        type: DirectoryOrCreate
+```
+
+Apply and verify:
+
+```bash
+kubectl --context=ryzen apply -f blockfile-scratch-init.yaml
+kubectl --context=ryzen -n kube-system get pod blockfile-scratch-init -o wide
+kubectl --context=ryzen -n kube-system logs blockfile-scratch-init
+```
+
+## Step 4: Verify blockfile snapshotter is loaded
+
+Containerd must show blockfile as a loaded snapshotter.
+
+Use a temporary pod to run `ctr` against the host socket:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ctr-plugins-check
+  namespace: kube-system
+spec:
+  restartPolicy: Never
+  hostNetwork: true
+  hostPID: true
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: check
+      image: debian:bookworm
+      securityContext:
+        privileged: true
+      command:
+        - bash
+        - -euxo
+        - pipefail
+        - -c
+        - |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends containerd
+          ctr -a /host/run/containerd/containerd.sock plugins ls | grep -E -i 'snapshotter|blockfile|devmapper'
+      volumeMounts:
+        - name: host-run
+          mountPath: /host/run
+  volumes:
+    - name: host-run
+      hostPath:
+        path: /run
+        type: Directory
+```
+
+Expected output includes:
+
+```
+io.containerd.snapshotter.v1              blockfile                linux/amd64    ok
+```
+
+## Step 5: Fix pause image if needed
+
+If you hit `content digest ... not found` for `registry.k8s.io/pause:3.10`,
+re-pull it using host certs:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ctr-fix-pause
+  namespace: kube-system
+spec:
+  restartPolicy: Never
+  hostNetwork: true
+  hostPID: true
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: fix
+      image: debian:bookworm
+      securityContext:
+        privileged: true
+      command:
+        - bash
+        - -euxo
+        - pipefail
+        - -c
+        - |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends containerd
+          ctr -a /host/run/containerd/containerd.sock -n k8s.io images rm registry.k8s.io/pause:3.10 || true
+          ctr -a /host/run/containerd/containerd.sock -n k8s.io images pull registry.k8s.io/pause:3.10
+      volumeMounts:
+        - name: host-run
+          mountPath: /host/run
+        - name: host-certs
+          mountPath: /etc/ssl/certs
+          readOnly: true
+  volumes:
+    - name: host-run
+      hostPath:
+        path: /run
+        type: Directory
+    - name: host-certs
+      hostPath:
+        path: /etc/ssl/certs
+        type: Directory
+```
+
+## Step 6: Run the test pod
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kata-fc-test
+  namespace: default
+spec:
+  runtimeClassName: kata-fc
+  restartPolicy: Never
+  containers:
+    - name: busybox
+      image: busybox:1.36
+      command: ["sh", "-c", "echo kata-fc-ok && sleep 3600"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+```
+
+Verify:
+
+```bash
+kubectl --context=ryzen get pod kata-fc-test -n default -o wide
+kubectl --context=ryzen exec -n default kata-fc-test -- uname -a
+```
+
+Expected: pod Running and guest kernel from inside the VM.
+
+## Step 7: Host-side proof
+
+Confirm Firecracker process exists on the host:
+
+```bash
+talosctl --talosconfig /Users/gregkonush/github.com/devices/ryzen/talosconfig \
+  processes -n 192.168.1.194 | rg -i 'firecracker|kata'
+```
+
+You should see `/firecracker --id ... --config-file /fcConfig.json`.
+
+## Troubleshooting
+
+### blockfile not loaded
+- Ensure `/etc/cri/containerd.toml` no longer lists
+  `io.containerd.snapshotter.v1.blockfile` under `disabled_plugins`.
+- Reboot after config changes.
+
+### pause image digest not found
+- Re-pull `registry.k8s.io/pause:3.10` using host certs (Step 5).
+
+### Pod stuck in `ContainerCreating`
+- Check `kubectl describe pod` for `FailedCreatePodSandBox`.
+- Check containerd logs:
+  ```bash
+  talosctl --talosconfig /Users/gregkonush/github.com/devices/ryzen/talosconfig \
+    logs -n 192.168.1.194 containerd | rg -i 'kata|firecracker|blockfile'
+  ```
+
+## Cleanup (optional)
+
+```bash
+kubectl --context=ryzen -n kube-system delete pod \
+  blockfile-scratch-init ctr-plugins-check ctr-fix-pause --ignore-not-found=true
+```
+
+## Notes
+
+- Overwriting `/etc/cri/containerd.toml` means you now own that file; keep it
+  minimal and only remove `blockfile` from `disabled_plugins`.
+- For production, consider sizing the scratch image appropriately and storing
+  it on fast local storage.


### PR DESCRIPTION
## Summary

- Added GitOps DaemonSet to create blockfile scratch image for Kata Firecracker
- Documented Talos containerd override + blockfile runtime configuration
- Added rebuild-from-scratch and investigation notes


## Related Issues

None

## Testing

- kubectl --context=ryzen get pod kata-fc-test -n default
- kubectl --context=ryzen exec -n default kata-fc-test -- uname -a
- talosctl --talosconfig /Users/gregkonush/github.com/devices/ryzen/talosconfig processes -n 192.168.1.194 | rg -i "firecracker|kata"


## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
