### PR TITLE
docs(ryzen): add node-level dependency runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ node_modules/
 .DS_Store
 kubernetes/kubeconfig
 kubeconfig
+
+devices/ryzen/controlplane.yaml
+devices/ryzen/worker.yaml
+devices/ryzen/talosconfig
 **/charts/*.tgz
 **/generated/*
 **/_generated/


### PR DESCRIPTION
## Summary
- ignore Talos machine configs for ryzen to avoid committing secrets
- add detailed runbook for Talos node-level dependencies (Tailscale + AMD GPU)
- capture authoritative references for extensions, Image Factory, and ROCm/device plugins

## Related Issues
None

## Testing
- N/A (documentation + .gitignore only)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
