### PR TITLE
chore(jangar): bump openwebui to v0.7.2

### DIFF
--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -18,7 +18,7 @@ websocket:
     enabled: false
 
 image:
-  tag: v0.6.43
+  tag: v0.7.2
 
 openaiApiKey: ""
 

--- a/docs/jangar/openwebui.md
+++ b/docs/jangar/openwebui.md
@@ -1,6 +1,6 @@
 # OpenWebUI deployment (separate host)
 
-OpenWebUI is installed via the upstream Helm chart (`open-webui` v8.18.0, app v0.6.43) in the `jangar` namespace. The chart creates a StatefulSet and `open-webui` ClusterIP Service; a dedicated Tailscale LoadBalancer `openwebui-tailscale` (hostname `openwebui`) fronts it. Websocket support is enabled and backed by a Redis instance `jangar-openwebui-redis` managed by the OTCK Redis operator. Postgres comes from the existing CNPG cluster `jangar-db` (`jangar-db-app` + `jangar-db-ca`). Jangar no longer proxies or iframes OpenWebUI; users open the Tailscale host directly.
+OpenWebUI is installed via the upstream Helm chart (`open-webui` v8.19.0, app v0.7.2) in the `jangar` namespace. The chart creates a StatefulSet and `open-webui` ClusterIP Service; a dedicated Tailscale LoadBalancer `openwebui-tailscale` (hostname `openwebui`) fronts it. Websocket support is enabled and backed by a Redis instance `jangar-openwebui-redis` managed by the OTCK Redis operator. Postgres comes from the existing CNPG cluster `jangar-db` (`jangar-db-app` + `jangar-db-ca`). Jangar no longer proxies or iframes OpenWebUI; users open the Tailscale host directly.
 
 OpenWebUI forwards the chat identifier in the `x-openwebui-chat-id` header (enabled via the chart values). Jangar consumes this header to map conversations to Codex thread ids and to increment turn numbers, persisting the mapping in Redis (`redis://jangar-openwebui-redis:6379/1`) with a 7-day TTL so subsequent turns stay on the same thread.
 
@@ -23,7 +23,7 @@ OpenWebUI forwards the chat identifier in the `x-openwebui-chat-id` header (enab
 - Current code returns a single model from `/v1/models` (`gpt-5.2-codex`); set `JANGAR_MODELS`/`JANGAR_DEFAULT_MODEL` or update `services/jangar/src/server/config.ts` if this needs to change.
 
 ## Image pin
-- `ghcr.io/open-webui/open-webui:v0.6.43` (managed by the Helm chart)
+- `ghcr.io/open-webui/open-webui:v0.7.2` (managed by the Helm chart)
 
 ## Dev notes
 - Jangar UI no longer embeds OpenWebUI; if you want a quick link, point to `VITE_OPENWEBUI_EXTERNAL_URL` when running locally.

--- a/services/jangar/docker-compose.yml
+++ b/services/jangar/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped
 
   openwebui:
-    image: ghcr.io/open-webui/open-webui:v0.6.43
+    image: ghcr.io/open-webui/open-webui:v0.7.2
     container_name: jangar-openwebui
     ports:
       - "${OPENWEBUI_PORT:-8080}:8080"


### PR DESCRIPTION
## Summary

- bump OpenWebUI image tag to v0.7.2 in Argo CD values
- align local docker-compose OpenWebUI image version
- refresh OpenWebUI runbook to reflect current chart/app versions

## Related Issues

None

## Testing

- N/A (config/doc updates only)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
