### PR TITLE
fix: repair argocd image updater overlay

### DIFF
--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -32,7 +32,6 @@ patches:
       kind: Deployment
       name: argocd-repo-server
   - path: overlays/argocd-image-updater-config.yaml
-  - path: overlays/argocd-image-updater-namespace-delete.yaml
   - path: overlays/argocd-server-deployment.yaml
     target:
       kind: Deployment

--- a/argocd/applications/argocd/overlays/argocd-image-updater-config.yaml
+++ b/argocd/applications/argocd/overlays/argocd-image-updater-config.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-image-updater-config
-  namespace: argocd-image-updater-system
 data:
   git.email: noreply@proompteng.ai
   git.user: Proompt Eng


### PR DESCRIPTION
## Summary

- stop patching a non-existent image-updater namespace deletion
- make the image-updater config patch match the installed ConfigMap

## Related Issues

None

## Testing

- Applied to cluster: `kubectl apply -k argocd/applications/argocd`

## Screenshots (if applicable)

Not applicable

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
