### PR TITLE
feat(graf): expose api via tailscale

### DIFF
--- a/argocd/applications/graf/README.md
+++ b/argocd/applications/graf/README.md
@@ -4,7 +4,8 @@
 - This directory exposes a `kustomization.yaml` that renders the latest Neo4j Helm chart (2025.10.1) via the Kustomize `helmCharts` plugin. The chart now installs its CRDs and uses the `longhorn` storage class for the data volume.
 - The Argo CD `graf` application deploys the chart into the `graf` namespace and creates the Helm release named `graf`. It also applies `knative-service.yaml`, which registers the Kotlin persistence service in the same namespace so Temporal/Knative can reach the graph API.
 - The Knative service pulls its image from the shared Tailscale registry host `registry.ide-newton.ts.net/proompteng/graf:latest`.
-- A `graf-neo4j-browser` LoadBalancer service is applied alongside the Helm release; it carries `tailscale.com/hostname=graf` so operators can reach the Neo4j Browser via that tailnet DNS name.
+- A `graf-neo4j-browser` LoadBalancer service is applied alongside the Helm release; it carries `tailscale.com/hostname=neo4j` so operators can reach the Neo4j Browser via that tailnet DNS name.
+- The Graf API Knative service is exposed through a Tailscale LoadBalancer at host `graf`.
 - Neo4j credentials live in the `graf-auth` SealedSecret checked in as `graf-auth-secret.yaml`; the Helm values reference it via `neo4j.passwordFromSecret`. Rotate them by generating a new password, updating the sealed secret, and applying it before syncing Argo CD.
 - The `/v1` graph APIs now require a bearer token. The Knative service reads `GRAF_API_BEARER_TOKENS` from the `graf-api` SealedSecret defined in `graf-api-secret.yaml` (`bearer-tokens` key, comma or newline separated). The checked-in manifest currently contains a placeholder (`REPLACE_WITH_ACTUAL_TOKENS`), so re-seal it with the real tokens before the next sync:
 - The Codex workflow template and its RBAC helpers live in `argocd/applications/argo-workflows` because they must stay in the `argo-workflows` namespace; they are no longer rendered through this `graf` kustomization.

--- a/argocd/applications/graf/kustomization.yaml
+++ b/argocd/applications/graf/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ingressroute.yaml
   - graf-metallb-service.yaml
   - neo4j-browser-service.yaml
+  - tailscale-service.yaml
   - graf-workflows-clusterrolebinding.yaml
   - graf-otel-configmap.yaml
   - graf-quarkus-configmap.yaml

--- a/argocd/applications/graf/neo4j-browser-service.yaml
+++ b/argocd/applications/graf/neo4j-browser-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: graf-neo4j-browser
   namespace: graf
   annotations:
-    tailscale.com/hostname: graf
+    tailscale.com/hostname: neo4j
 spec:
   type: LoadBalancer
   loadBalancerClass: tailscale

--- a/argocd/applications/graf/tailscale-service.yaml
+++ b/argocd/applications/graf/tailscale-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: graf-tailscale
+  namespace: graf
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: graf
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    serving.knative.dev/service: graf
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
## Summary

- Rename Graf Neo4j Browser Tailscale hostname to `neo4j`.
- Add a Tailscale LoadBalancer for the Graf API at hostname `graf`.
- Wire the new service into the Graf kustomization and update docs.

## Related Issues

None.

## Testing

- kubectl -n graf get svc graf-neo4j-browser graf-tailscale

## Breaking Changes

- Neo4j Browser Tailscale hostname changes from `graf` to `neo4j`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
