### PR TITLE
fix(graf): accept codex ingest payloads

### DIFF
--- a/services/graf/src/main/kotlin/ai/proompteng/graf/model/Requests.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/model/Requests.kt
@@ -7,7 +7,10 @@ import kotlinx.serialization.json.JsonElement
 @Serializable
 data class EntityRequest(
   val id: String? = null,
-  val label: String,
+  val label: String? = null,
+  @SerialName("type")
+  val type: String? = null,
+  val name: String? = null,
   val properties: Map<String, JsonElement> = emptyMap(),
   val artifactId: String? = null,
   val researchSource: String? = null,

--- a/services/graf/src/main/kotlin/ai/proompteng/graf/model/Responses.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/model/Responses.kt
@@ -1,0 +1,22 @@
+package ai.proompteng.graf.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ErrorResponse(
+  val error: String,
+)
+
+@Serializable
+data class ServiceStatusResponse(
+  val service: String,
+  val status: String,
+  val version: String? = null,
+  val commit: String? = null,
+)
+
+@Serializable
+data class HealthzResponse(
+  val status: String,
+  val port: String? = null,
+)

--- a/services/graf/src/main/kotlin/ai/proompteng/graf/resources/ServiceResource.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/resources/ServiceResource.kt
@@ -1,5 +1,7 @@
 package ai.proompteng.graf.resources
 
+import ai.proompteng.graf.model.HealthzResponse
+import ai.proompteng.graf.model.ServiceStatusResponse
 import ai.proompteng.graf.telemetry.GrafRouteTemplate
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
@@ -14,22 +16,22 @@ class ServiceResource {
   @GET
   @GrafRouteTemplate("GET /")
   @Produces(MediaType.APPLICATION_JSON)
-  fun root(): Map<String, String?> =
-    mapOf(
-      "service" to "graf",
-      "status" to "ok",
-      "version" to buildVersion,
-      "commit" to buildCommit,
+  fun root(): ServiceStatusResponse =
+    ServiceStatusResponse(
+      service = "graf",
+      status = "ok",
+      version = buildVersion,
+      commit = buildCommit,
     )
 
   @GET
   @Path("healthz")
   @GrafRouteTemplate("GET /healthz")
   @Produces(MediaType.APPLICATION_JSON)
-  fun healthz(): Map<String, String?> =
-    mapOf(
-      "status" to "ok",
-      "port" to ServiceEnvironment.get("PORT"),
+  fun healthz(): HealthzResponse =
+    HealthzResponse(
+      status = "ok",
+      port = ServiceEnvironment.get("PORT"),
     )
 }
 

--- a/services/graf/src/main/kotlin/ai/proompteng/graf/security/SecurityProviders.kt
+++ b/services/graf/src/main/kotlin/ai/proompteng/graf/security/SecurityProviders.kt
@@ -1,5 +1,6 @@
 package ai.proompteng.graf.security
 
+import ai.proompteng.graf.model.ErrorResponse
 import ai.proompteng.graf.security.requireBearerToken
 import ai.proompteng.graf.telemetry.GrafTelemetry
 import jakarta.annotation.Priority
@@ -49,7 +50,7 @@ class IllegalArgumentExceptionMapper : ExceptionMapper<IllegalArgumentException>
     logger.warn(exception) { exception.message ?: "bad request" }
     return Response
       .status(Response.Status.BAD_REQUEST)
-      .entity(mapOf("error" to (exception.message ?: "bad request")))
+      .entity(ErrorResponse(exception.message ?: "bad request"))
       .type(MediaType.APPLICATION_JSON)
       .build()
   }
@@ -62,7 +63,7 @@ class GenericExceptionMapper : ExceptionMapper<Throwable> {
     logger.info { "spanId=${GrafTelemetry.currentSpanId()} traceId=${GrafTelemetry.currentTraceId()}" }
     return Response
       .status(Response.Status.INTERNAL_SERVER_ERROR)
-      .entity(mapOf("error" to "internal server error"))
+      .entity(ErrorResponse("internal server error"))
       .type(MediaType.APPLICATION_JSON)
       .build()
   }

--- a/services/graf/src/test/kotlin/ai/proompteng/graf/resources/ServiceResourceTest.kt
+++ b/services/graf/src/test/kotlin/ai/proompteng/graf/resources/ServiceResourceTest.kt
@@ -20,10 +20,10 @@ class ServiceResourceTest {
 
       val response = resource.root()
 
-      assertEquals("graf", response["service"])
-      assertEquals("ok", response["status"])
-      assertEquals("2025.11.11", response["version"])
-      assertEquals("abc123", response["commit"])
+      assertEquals("graf", response.service)
+      assertEquals("ok", response.status)
+      assertEquals("2025.11.11", response.version)
+      assertEquals("abc123", response.commit)
     }
 
   @Test
@@ -37,8 +37,8 @@ class ServiceResourceTest {
 
       val response = resource.healthz()
 
-      assertEquals("ok", response["status"])
-      assertEquals("8080", response["port"])
+      assertEquals("ok", response.status)
+      assertEquals("8080", response.port)
     }
 
   private fun withEnv(

--- a/services/graf/src/test/kotlin/ai/proompteng/graf/security/GrafSecurityTest.kt
+++ b/services/graf/src/test/kotlin/ai/proompteng/graf/security/GrafSecurityTest.kt
@@ -1,5 +1,6 @@
 package ai.proompteng.graf.security
 
+import ai.proompteng.graf.model.ErrorResponse
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -77,8 +78,8 @@ class GrafSecurityTest {
     val response = mapper.toResponse(java.lang.IllegalArgumentException("bad input"))
 
     assertEquals(400, response.status)
-    val payload = response.entity as Map<*, *>
-    assertEquals("bad input", payload["error"])
+    val payload = response.entity as ErrorResponse
+    assertEquals("bad input", payload.error)
   }
 
   @Test
@@ -87,8 +88,8 @@ class GrafSecurityTest {
     val response = mapper.toResponse(RuntimeException("boom"))
 
     assertEquals(500, response.status)
-    val payload = response.entity as Map<*, *>
-    assertEquals("internal server error", payload["error"])
+    val payload = response.entity as ErrorResponse
+    assertEquals("internal server error", payload.error)
     assertTrue(response.mediaType.toString().contains("application/json"))
   }
 }


### PR DESCRIPTION
## Summary

- Accept Codex entity payloads that use `type` and top-level `name` fields.
- Replace map-based JSON error responses with serializable DTOs.
- Update Graf service/health responses and tests for the new DTOs.

## Related Issues

None.

## Testing

- ./gradlew test (services/graf)

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
