### PR TITLE
chore(graf): speed up image builds

### DIFF
--- a/services/graf/Dockerfile
+++ b/services/graf/Dockerfile
@@ -2,8 +2,13 @@
 
 FROM gradle:9.2-jdk25 as builder
 WORKDIR /workspace
+ARG GRAF_GRADLE_TASKS="quarkusBuild"
+ARG GRAF_GRADLE_ARGS="--no-daemon --build-cache"
+ENV GRADLE_USER_HOME=/home/gradle/.gradle
 COPY --chown=gradle:gradle . .
-RUN ./gradlew clean quarkusBuild --no-daemon
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+  --mount=type=cache,target=/workspace/.gradle \
+  /bin/bash -lc "./gradlew ${GRAF_GRADLE_TASKS} ${GRAF_GRADLE_ARGS}"
 
 FROM gcr.io/distroless/java25:nonroot
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Drop `clean` from the Graf Docker build and add Gradle cache mounts.
- Allow Graf image builds to use buildx cache and custom Gradle args.

## Related Issues

None.

## Testing

- N/A (build behavior change only)

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
