### PR TITLE
chore(local-path): use writable host path

### DIFF
--- a/argocd/applications/local-path/patches/local-path-config.patch.yaml
+++ b/argocd/applications/local-path/patches/local-path-config.patch.yaml
@@ -9,7 +9,7 @@ data:
       "nodePathMap":[
         {
           "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
-          "paths":["/var/mnt/local-path-provisioner"]
+          "paths":["/var/lib/local-path-provisioner"]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- switch local-path storage root to /var/lib/local-path-provisioner to avoid read-only /var/mnt on Talos

## Testing
- not run (manifest-only change)

## Checklist
- [ ] documentation updated (if needed)
- [ ] tests added/updated (if needed)

