### PR TITLE
feat(workers): use CDI root disk for desktop

### DIFF
--- a/argocd/applications/cdi/kustomization.yaml
+++ b/argocd/applications/cdi/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cdi
+resources:
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.64.0/cdi-operator.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.64.0/cdi-cr.yaml

--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -23,7 +23,7 @@ stringData:
     mounts:
       - ["/dev/vdb", "/home/ubuntu/data", "ext4", "defaults,nofail", "0", "2"]
     packages:
-      - ubuntu-desktop-minimal
+      - ubuntu-desktop
       - ca-certificates
       - curl
       - gnupg
@@ -35,7 +35,7 @@ stringData:
       - xz-utils
     write_files:
       - path: /home/ubuntu/.codex/config.toml
-        owner: ubuntu:ubuntu
+        owner: root:root
         permissions: '0600'
         content: |-
           model = "gpt-5.2-codex"

--- a/argocd/applications/workers/virtualmachine.yaml
+++ b/argocd/applications/workers/virtualmachine.yaml
@@ -14,6 +14,20 @@ spec:
         kubevirt.io/domain: workers
         app.kubernetes.io/name: workers
     spec:
+      dataVolumeTemplates:
+        - metadata:
+            name: workers-rootdisk
+          spec:
+            source:
+              http:
+                url: https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img
+            pvc:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 50Gi
+              storageClassName: local-path
       domain:
         cpu:
           cores: 2
@@ -25,6 +39,7 @@ spec:
             - name: rootdisk
               disk:
                 bus: virtio
+              bootOrder: 1
             - name: datadisk
               disk:
                 bus: virtio
@@ -39,8 +54,8 @@ spec:
           pod: {}
       volumes:
         - name: rootdisk
-          containerDisk:
-            image: quay.io/containerdisks/ubuntu:24.04
+          dataVolume:
+            name: workers-rootdisk
         - name: datadisk
           persistentVolumeClaim:
             claimName: workers-data

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -59,6 +59,14 @@ spec:
                 automation: manual
                 enabled: "true"
                 clusters: ryzen
+              - name: cdi
+                path: argocd/applications/cdi
+                namespace: cdi
+                annotations:
+                  argocd.argoproj.io/sync-wave: "1"
+                automation: manual
+                enabled: "true"
+                clusters: ryzen
               - name: workers
                 path: argocd/applications/workers
                 namespace: workers


### PR DESCRIPTION
## Summary
- add CDI app for ryzen to enable data volumes
- switch workers to a 50Gi root DataVolume (Ubuntu 24.04 cloud image) and keep 10Gi data disk
- fix cloud-init to install full ubuntu desktop and avoid user lookup errors

## Testing
- not run (manifest-only change)

## Checklist
- [ ] documentation updated (if needed)
- [ ] tests added/updated (if needed)

