### PR TITLE
fix(workers): start ssh before desktop install

### DIFF
--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -23,7 +23,6 @@ stringData:
     mounts:
       - ["/dev/vdb", "/home/ubuntu/data", "ext4", "defaults,nofail", "0", "2"]
     packages:
-      - ubuntu-desktop
       - openssh-server
       - ca-certificates
       - curl
@@ -155,11 +154,13 @@ stringData:
     ssh_pwauth: false
     disable_root: true
     runcmd:
+      - [ bash, -lc, 'systemctl enable --now ssh' ]
       - [ bash, -lc, 'install -m 0755 -d /etc/apt/keyrings' ]
       - [ bash, -lc, 'curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg' ]
       - [ bash, -lc, 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list' ]
       - [ bash, -lc, 'apt-get update' ]
-      - [ bash, -lc, 'apt-get install -y google-chrome-stable' ]
+      - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-desktop' ]
+      - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable' ]
       - [ bash, -lc, 'apt-get clean && rm -rf /var/lib/apt/lists/*' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash''"' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''source ~/.nvm/nvm.sh && nvm install --lts && nvm alias default lts/*''"' ]
@@ -169,6 +170,5 @@ stringData:
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''[ -d ~/github.com/lab ] || git clone --depth 1 https://github.com/proompteng/lab ~/github.com/lab''"' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''rm -rf ~/.codex/skills && mkdir -p ~/.codex/skills && cp -R ~/github.com/lab/skills/. ~/.codex/skills/''"' ]
       - [ bash, -lc, 'systemctl daemon-reload' ]
-      - [ bash, -lc, 'systemctl enable --now ssh' ]
       - [ bash, -lc, 'systemctl enable --now chrome-remote-debug.service chrome-devtools-mcp.service' ]
       - [ bash, -lc, 'chown -R ubuntu:ubuntu /home/ubuntu/.codex /home/ubuntu/data || true' ]


### PR DESCRIPTION
## Summary

- move ubuntu-desktop installation into runcmd after ssh is enabled
- keep openssh-server in packages for earlier availability
- add noninteractive desktop/chrome installs to reduce blocking

## Related Issues

None

## Testing

- N/A (config change to cloud-init; will verify after Argo CD sync)

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
