### PR TITLE
fix(workers): keep network online after desktop install

### DIFF
--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -83,10 +83,10 @@ stringData:
 
           [Install]
           WantedBy=multi-user.target
-      - path: /etc/systemd/system/chrome-devtools-mcp.service
-        owner: root:root
-        permissions: '0644'
-        content: |-
+  - path: /etc/systemd/system/chrome-devtools-mcp.service
+    owner: root:root
+    permissions: '0644'
+    content: |-
           [Unit]
           Description=Chrome DevTools MCP server
           After=chrome-remote-debug.service network-online.target
@@ -101,7 +101,20 @@ stringData:
           RestartSec=3
 
           [Install]
-          WantedBy=multi-user.target
+      WantedBy=multi-user.target
+  - path: /etc/netplan/99-kubevirt.yaml
+    owner: root:root
+    permissions: '0644'
+    content: |-
+      network:
+        version: 2
+        renderer: NetworkManager
+        ethernets:
+          default:
+            match:
+              name: "e*"
+            dhcp4: true
+            dhcp6: false
       - path: /usr/local/bin/start-chrome-remote-debug
         owner: root:root
         permissions: '0755'
@@ -160,6 +173,8 @@ stringData:
       - [ bash, -lc, 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list' ]
       - [ bash, -lc, 'apt-get update' ]
       - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-desktop' ]
+      - [ bash, -lc, 'systemctl enable --now NetworkManager' ]
+      - [ bash, -lc, 'netplan apply' ]
       - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable' ]
       - [ bash, -lc, 'apt-get clean && rm -rf /var/lib/apt/lists/*' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash''"' ]
@@ -170,5 +185,6 @@ stringData:
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''[ -d ~/github.com/lab ] || git clone --depth 1 https://github.com/proompteng/lab ~/github.com/lab''"' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''rm -rf ~/.codex/skills && mkdir -p ~/.codex/skills && cp -R ~/github.com/lab/skills/. ~/.codex/skills/''"' ]
       - [ bash, -lc, 'systemctl daemon-reload' ]
+      - [ bash, -lc, 'systemctl restart ssh' ]
       - [ bash, -lc, 'systemctl enable --now chrome-remote-debug.service chrome-devtools-mcp.service' ]
       - [ bash, -lc, 'chown -R ubuntu:ubuntu /home/ubuntu/.codex /home/ubuntu/data || true' ]


### PR DESCRIPTION
## Summary

- add netplan file to keep NetworkManager as renderer after ubuntu-desktop install
- enable NetworkManager and re-apply netplan during cloud-init
- restart ssh after desktop install to keep access reliable

## Related Issues

None

## Testing

- N/A (cloud-init config update; requires Argo CD sync + VM reprovision)

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
