### PR TITLE
fix(workers): correct cloud-init yaml

### DIFF
--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -83,10 +83,10 @@ stringData:
 
           [Install]
           WantedBy=multi-user.target
-  - path: /etc/systemd/system/chrome-devtools-mcp.service
-    owner: root:root
-    permissions: '0644'
-    content: |-
+      - path: /etc/systemd/system/chrome-devtools-mcp.service
+        owner: root:root
+        permissions: '0644'
+        content: |-
           [Unit]
           Description=Chrome DevTools MCP server
           After=chrome-remote-debug.service network-online.target
@@ -101,20 +101,20 @@ stringData:
           RestartSec=3
 
           [Install]
-      WantedBy=multi-user.target
-  - path: /etc/netplan/99-kubevirt.yaml
-    owner: root:root
-    permissions: '0644'
-    content: |-
-      network:
-        version: 2
-        renderer: NetworkManager
-        ethernets:
-          default:
-            match:
-              name: "e*"
-            dhcp4: true
-            dhcp6: false
+          WantedBy=multi-user.target
+      - path: /etc/netplan/99-kubevirt.yaml
+        owner: root:root
+        permissions: '0644'
+        content: |-
+          network:
+            version: 2
+            renderer: NetworkManager
+            ethernets:
+              default:
+                match:
+                  name: "e*"
+                dhcp4: true
+                dhcp6: false
       - path: /usr/local/bin/start-chrome-remote-debug
         owner: root:root
         permissions: '0755'


### PR DESCRIPTION
## Summary

- fix cloud-init yaml indentation for workers VM
- keep netplan and systemd unit entries in the write_files list
- restore valid secret rendering for Argo CD

## Related Issues

None

## Testing

- N/A (manifest formatting fix)

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
