### PR TITLE
fix(workers): ensure ubuntu home ownership

### DIFF
--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -177,6 +177,7 @@ stringData:
       - [ bash, -lc, 'netplan apply' ]
       - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable' ]
       - [ bash, -lc, 'apt-get clean && rm -rf /var/lib/apt/lists/*' ]
+      - [ bash, -lc, 'chown -R ubuntu:ubuntu /home/ubuntu' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash''"' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''source ~/.nvm/nvm.sh && nvm install --lts && nvm alias default lts/*''"' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''curl -fsSL https://bun.sh/install | bash''"' ]
@@ -187,4 +188,4 @@ stringData:
       - [ bash, -lc, 'systemctl daemon-reload' ]
       - [ bash, -lc, 'systemctl restart ssh' ]
       - [ bash, -lc, 'systemctl enable --now chrome-remote-debug.service chrome-devtools-mcp.service' ]
-      - [ bash, -lc, 'chown -R ubuntu:ubuntu /home/ubuntu/.codex /home/ubuntu/data || true' ]
+      - [ bash, -lc, 'chown -R ubuntu:ubuntu /home/ubuntu || true' ]


### PR DESCRIPTION
## Summary

- chown /home/ubuntu before user-space installs
- keep final ownership fix for ubuntu home
- prevent nvm/bun installs from failing on root-owned home

## Related Issues

None

## Testing

- N/A (cloud-init config update)

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
