### PR TITLE
fix(workers): add ubuntu profile env

### DIFF
--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -62,6 +62,14 @@ stringData:
 
           [projects."/home/ubuntu"]
           trust_level = "trusted"
+      - path: /home/ubuntu/.profile
+        owner: ubuntu:ubuntu
+        permissions: '0644'
+        content: |-
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+          export BUN_INSTALL="$HOME/.bun"
+          export PATH="$BUN_INSTALL/bin:$PATH"
       - path: /etc/systemd/system/chrome-remote-debug.service
         owner: root:root
         permissions: '0644'
@@ -104,7 +112,7 @@ stringData:
           WantedBy=multi-user.target
       - path: /etc/netplan/99-kubevirt.yaml
         owner: root:root
-        permissions: '0644'
+        permissions: '0600'
         content: |-
           network:
             version: 2


### PR DESCRIPTION
## Summary

- add /home/ubuntu/.profile with nvm/bun PATH exports
- fix netplan file permissions to satisfy netplan warnings
- ensure nvm/bun binaries land on PATH for login shells

## Related Issues

None

## Testing

- N/A (cloud-init config update)

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
