### PR TITLE
fix(workers): defer ubuntu profile ownership

### DIFF
--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -63,7 +63,7 @@ stringData:
           [projects."/home/ubuntu"]
           trust_level = "trusted"
       - path: /home/ubuntu/.profile
-        owner: ubuntu:ubuntu
+        owner: root:root
         permissions: '0644'
         content: |-
           export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
## Summary

- set .profile owner to root to avoid write_files user lookup failure
- rely on later chown step for ubuntu ownership
- fix cloud-init write_files error

## Related Issues

None

## Testing

- N/A (cloud-init config update)

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
