### PR TITLE
chore(local-path): use Talos user volume mount

### DIFF
--- a/argocd/applications/local-path/patches/local-path-config.patch.yaml
+++ b/argocd/applications/local-path/patches/local-path-config.patch.yaml
@@ -9,7 +9,7 @@ data:
       "nodePathMap":[
         {
           "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
-          "paths":["/var/lib/local-path-provisioner"]
+          "paths":["/var/mnt/local-path-provisioner"]
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Point local-path-provisioner at the Talos user volume mount (/var/mnt/local-path-provisioner).
- Document the Ryzen local-path user volume workflow and validation steps.

## Related Issues

None

## Testing

- `kubectl --kubeconfig ~/.kube/ryzen.yaml get storageclass` (fails: no route to host)
- `talosctl --talosconfig ~/.talos/config -n 192.168.1.194 get machinestatus` (fails: no route to host)

## Screenshots (if applicable)

N/A

## Breaking Changes

None (new PVs will land under /var/mnt/local-path-provisioner; ensure the user volume is provisioned).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
