### PR TITLE
feat(agents): tighten crossplane converter validation

### DIFF
--- a/docs/agents/crossplane-migration.md
+++ b/docs/agents/crossplane-migration.md
@@ -93,7 +93,7 @@ be installed alongside native Agents CRDs.
 - Keep names/namespaces stable so references continue to resolve.
 - Convert labels/annotations that your workflows rely on.
 - Remove managedFields, ownerReferences, and status blocks before applying the native CRDs.
-- The converter will warn about dropped fields and require required native fields (`spec.providerRef`, `spec.agentRef`, `spec.runtime.type`, `spec.binary`) before writing output.
+- The converter will warn about dropped fields and require required native fields (`spec.providerRef`, `spec.agentRef`, `spec.runtime.type`, `spec.binary`, plus `spec.implementation` or `spec.implementationSpecRef` for AgentRuns) before writing output.
 
 ## Mapping: XAgent → Agent
 | Crossplane field | Native field | Notes |


### PR DESCRIPTION
## Summary

- Ensure AgentRun runtime config is omitted when empty to satisfy CRD validation.
- Require AgentRuns to include `spec.implementation` or `spec.implementationSpecRef` during conversion.
- Document the additional AgentRun requirement in the Crossplane migration guide.

## Related Issues

- Closes #2513

## Testing

- `python3 -m py_compile scripts/agents/convert-crossplane-claims.py`

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
