### PR TITLE
feat(agents): add grpc service port

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "8e480ce4"
-  digest: sha256:103cdef8c8d92e3ac6274c67d18312a683c3e71a7270c2d748ed7bfe3108fbba
+  tag: "c9c5c097"
+  digest: sha256:6848b2017f40e0ec7376eaad1f2fea5decfc98cc7755940dc3988f58a1e59211
   pullPolicy: IfNotPresent
 resources:
   requests:
@@ -19,3 +19,12 @@ database:
     key: url
 agentComms:
   enabled: false
+grpc:
+  enabled: true
+  port: 50051
+  servicePort: 50051
+env:
+  vars:
+    JANGAR_GRPC_ENABLED: "true"
+    JANGAR_GRPC_HOST: "0.0.0.0"
+    JANGAR_GRPC_PORT: "50051"

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -39,6 +39,10 @@ Optional: submit runs with `agentctl`:
 ```bash
 agentctl run submit --agent codex-agent --impl codex-impl-sample --runtime workflow --workload-image ghcr.io/proompteng/codex-agent:latest
 ```
+If you enable the gRPC port (`grpc.enabled=true`), you can port-forward it:
+```bash
+kubectl -n agents port-forward svc/agents 50051:50051 &
+```
 
 Optional: configure GitHub/Linear ingestion with `ImplementationSource` manifests:
 - `charts/agents/examples/implementationsource-github.yaml`
@@ -87,6 +91,9 @@ helm push agents-0.6.0.tgz oci://ghcr.io/proompteng/charts
 | `service.port` | Service port | `80` |
 | `service.annotations` | Service annotations | `{}` |
 | `service.labels` | Extra Service labels | `{}` |
+| `grpc.enabled` | Expose gRPC port for agentctl | `false` |
+| `grpc.port` | Container gRPC port | `50051` |
+| `grpc.servicePort` | Service gRPC port | `50051` |
 | `serviceAccount.create` | Create service account | `true` |
 | `serviceAccount.name` | Service account name override | `""` |
 | `rbac.create` | Create RBAC | `true` |

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -152,6 +152,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.grpc.enabled }}
+            - name: grpc
+              containerPort: {{ .Values.grpc.port }}
+              protocol: TCP
+            {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/agents/templates/service.yaml
+++ b/charts/agents/templates/service.yaml
@@ -19,5 +19,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.grpc.enabled }}
+    - port: {{ .Values.grpc.servicePort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    {{- end }}
   selector:
     {{- include "agents.selectorLabels" . | nindent 4 }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -46,6 +46,15 @@
       },
       "additionalProperties": false
     },
+    "grpc": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "port": { "type": "integer" },
+        "servicePort": { "type": "integer" }
+      },
+      "additionalProperties": false
+    },
     "resources": {
       "type": "object",
       "properties": {

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -28,6 +28,11 @@ service:
   annotations: {}
   labels: {}
 
+grpc:
+  enabled: false
+  port: 50051
+  servicePort: 50051
+
 resources:
   requests:
     cpu: 100m

--- a/docs/agents/agentctl-cli-design.md
+++ b/docs/agents/agentctl-cli-design.md
@@ -67,6 +67,7 @@ It talks to the Jangar controller over gRPC.
 ## Flags & Defaults
 - `--namespace` (default `agents`).
 - `--address` (gRPC address; default `127.0.0.1:50051` for port‑forward).
+- In‑cluster usage targets the `agents` service `grpc` port (requires `grpc.enabled` and `JANGAR_GRPC_*` envs in Helm values).
 - `--token` (optional shared secret).
 - `--tls` to enable TLS when configured (future-proofed).
 - `--output` (`yaml|json|table`).

--- a/docs/agents/agents-helm-chart-implementation.md
+++ b/docs/agents/agents-helm-chart-implementation.md
@@ -36,6 +36,7 @@ This document is implementation‑grade: it describes *what* needs to exist in t
 A fully functional chart must provide:
 - **CRDs** for all primitives, installed via `charts/agents/crds/`.
 - **Jangar deployment + service** with documented env configuration.
+- **Optional gRPC service port** (ClusterIP only) for `agentctl` access within the cluster.
 - **RBAC** that matches what Jangar actually does (jobs/secrets/configmaps/CRDs).
 - **Controller configuration** (namespaces, concurrency, resync interval) exposed via values.
 - **Examples** for each CRD and implementation source.
@@ -104,6 +105,7 @@ Controller behavior requires permissions to:
 - Database configuration (URL, secret ref, CA secret).
 - Controller settings (`enabled`, `namespaces`, `intervalSeconds`, `concurrency`).
 - Agent comms configuration (NATS, optional).
+- gRPC service configuration (`grpc.enabled`, `grpc.port`, `grpc.servicePort`).
 - RBAC and service account options.
 - Resource requests/limits, probes, node selectors, tolerations, security context.
 


### PR DESCRIPTION
## Summary
- Expose optional gRPC port in the agents chart and wire values/env for in-cluster agentctl.
- Update chart docs and implementation notes to reflect gRPC.
- Pin Jangar digest + gRPC env in ArgoCD values.

## Testing
- Not run (chart/docs/values change).