### PR TITLE
fix(agents): use uri key for CNPG secret

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -16,7 +16,7 @@ rbac:
 database:
   secretRef:
     name: jangar-db-app
-    key: url
+    key: uri
 agentComms:
   enabled: false
 grpc:


### PR DESCRIPTION
## Summary
- Point agents chart at the CNPG secret's uri key (not url).

## Testing
- Not run (values change).