### PR TITLE
fix(jangar): gate websocket support

### DIFF
--- a/services/jangar/nitro.config.ts
+++ b/services/jangar/nitro.config.ts
@@ -1,8 +1,12 @@
 import { defineNitroConfig } from 'nitro/config'
 
+const websocketEnabled = ['1', 'true', 'yes', 'on'].includes(
+  (process.env.JANGAR_WEBSOCKETS_ENABLED ?? '').toLowerCase(),
+)
+
 export default defineNitroConfig({
   preset: 'bun',
   experimental: {
-    websocket: true,
+    websocket: websocketEnabled,
   },
 })


### PR DESCRIPTION
## Summary
- Gate Nitro websocket support behind JANGAR_WEBSOCKETS_ENABLED to prevent startup crash.

## Testing
- Not run (config change).