### PR TITLE
chore(agents): update jangar image digest

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "c9c5c097"
-  digest: sha256:6848b2017f40e0ec7376eaad1f2fea5decfc98cc7755940dc3988f58a1e59211
+  tag: "c95fa362"
+  digest: sha256:9d3c5a0d681b7e47d78325836b28b029d4c1b5c5049e74f661f32261cc21c9a9
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary
- bump agents ArgoCD values to the newly built Jangar image
- roll forward to image tag c95fa362 and digest sha256:9d3c5a0d681b7e47d78325836b28b029d4c1b5c5049e74f661f32261cc21c9a9
- prepare agents namespace rollout for websocket-gated build

## Related Issues
None

## Testing
- Not run (values-only change; rollout verification will be done after merge/sync)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
