### PR TITLE
fix(jangar): externalize node-pty for SSR

### DIFF
--- a/services/jangar/vite.config.ts
+++ b/services/jangar/vite.config.ts
@@ -7,7 +7,7 @@ import { nitro } from 'nitro/vite'
 import { defineConfig } from 'vite'
 import viteTsConfigPaths from 'vite-tsconfig-paths'
 
-const ssrExternals = ['kysely', 'nats', 'pg']
+const ssrExternals = ['kysely', 'nats', 'pg', 'node-pty']
 const bunShimEnabled = process.env.JANGAR_BUN_SHIM === '1'
 const bunShimPath = fileURLToPath(new URL('./src/server/bun-node-shim.ts', import.meta.url))
 


### PR DESCRIPTION
## Summary
- mark node-pty as an SSR external so the native module is loaded from node_modules
- prevent Nitro from bundling node-pty and breaking dynamic native require
- unblock /health readiness in agents deployment

## Related Issues
None

## Testing
- Not run (build expected in image pipeline)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
