### PR TITLE
chore(agents): update jangar image digest

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "c95fa362"
-  digest: sha256:9d3c5a0d681b7e47d78325836b28b029d4c1b5c5049e74f661f32261cc21c9a9
+  tag: "b26b7c9f"
+  digest: sha256:57422ffab48d65e0f9b36ee6133a895e9f6d6aa3bd02b60d84c3e88ea2af9926
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary
- update agents ArgoCD values to Jangar image b26b7c9f
- roll forward to digest sha256:57422ffab48d65e0f9b36ee6133a895e9f6d6aa3bd02b60d84c3e88ea2af9926
- pick up node-pty SSR externalization fix in the agents deployment

## Related Issues
None

## Testing
- Not run (values-only change; rollout verification will be done after merge/sync)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
