### PR TITLE
feat(agents): add supporting primitives controller

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "b26b7c9f"
-  digest: sha256:57422ffab48d65e0f9b36ee6133a895e9f6d6aa3bd02b60d84c3e88ea2af9926
+  tag: "d7d6242b"
+  digest: sha256:e80784d8b94c7de7a2c688646eec1471268438a2dbe78953264b8f19434aec56
   pullPolicy: IfNotPresent
 resources:
   requests:

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -4,8 +4,8 @@ description: Minimal Agents control plane (Jangar) with CRDs
 home: https://github.com/proompteng/lab
 kubeVersion: ">=1.25.0-0"
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.8.0
+appVersion: "0.8.0"
 icon: https://avatars.githubusercontent.com/u/165504663?s=200&v=4
 keywords:
   - agents
@@ -45,6 +45,42 @@ annotations:
     - kind: Memory
       version: v1alpha1
       name: memories.agents.proompteng.ai
+    - kind: Orchestration
+      version: v1alpha1
+      name: orchestrations.orchestration.proompteng.ai
+    - kind: OrchestrationRun
+      version: v1alpha1
+      name: orchestrationruns.orchestration.proompteng.ai
+    - kind: ApprovalPolicy
+      version: v1alpha1
+      name: approvalpolicies.approvals.proompteng.ai
+    - kind: Budget
+      version: v1alpha1
+      name: budgets.budgets.proompteng.ai
+    - kind: SecretBinding
+      version: v1alpha1
+      name: secretbindings.security.proompteng.ai
+    - kind: Signal
+      version: v1alpha1
+      name: signals.signals.proompteng.ai
+    - kind: SignalDelivery
+      version: v1alpha1
+      name: signaldeliveries.signals.proompteng.ai
+    - kind: Tool
+      version: v1alpha1
+      name: tools.tools.proompteng.ai
+    - kind: ToolRun
+      version: v1alpha1
+      name: toolruns.tools.proompteng.ai
+    - kind: Schedule
+      version: v1alpha1
+      name: schedules.schedules.proompteng.ai
+    - kind: Artifact
+      version: v1alpha1
+      name: artifacts.artifacts.proompteng.ai
+    - kind: Workspace
+      version: v1alpha1
+      name: workspaces.workspaces.proompteng.ai
   artifacthub.io/crdsExamples: |
     - apiVersion: agents.proompteng.ai/v1alpha1
       kind: AgentProvider
@@ -101,11 +137,36 @@ annotations:
           name: codex-impl-sample
         runtime:
           type: workflow
+    - apiVersion: orchestration.proompteng.ai/v1alpha1
+      kind: Orchestration
+      metadata:
+        name: codex-autonomous
+      spec:
+        entrypoint: main
+        steps:
+          - name: implement
+            kind: AgentRun
+            agentRef:
+              name: codex-agent
+            implementationSpecRef:
+              name: codex-impl-sample
+    - apiVersion: orchestration.proompteng.ai/v1alpha1
+      kind: OrchestrationRun
+      metadata:
+        name: codex-autonomous-run
+      spec:
+        orchestrationRef:
+          name: codex-autonomous
+        parameters:
+          repository: proompteng/lab
+          issueNumber: "1234"
   artifacthub.io/changes: |
     - kind: added
-      description: "AgentRun printer columns now include Phase and Agent for improved UX."
+      description: "Add native CRDs for orchestration, tools, signals, schedules, artifacts, and workspaces."
+    - kind: added
+      description: "Native orchestration controller with ToolRun job execution."
+    - kind: added
+      description: "Supporting primitives controller with schedule CronJobs and workspace PVC provisioning."
     - kind: changed
-      description: "AgentRun workflow runtime labels Jobs/ConfigMaps with traceability metadata."
-    - kind: changed
-      description: "Controller readiness fails fast when Agents CRDs are missing."
+      description: "Agents chart includes orchestration controller settings and expanded RBAC."
   artifacthub.io/operator: "true"

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -3,10 +3,12 @@
 Minimal, production‑ready bundle for the Agents control plane (Jangar) plus Agents CRDs.
 
 ## Features
-- Ships v1alpha1 CRDs: Agent, AgentRun, AgentProvider, ImplementationSpec, ImplementationSource, Memory.
+- Ships v1alpha1 CRDs: Agent, AgentRun, AgentProvider, ImplementationSpec, ImplementationSource, Memory,
+  Orchestration, OrchestrationRun, ApprovalPolicy, Budget, SecretBinding, Signal, SignalDelivery, Tool, ToolRun,
+  Schedule, Artifact, Workspace.
 - Deploys the Jangar control-plane deployment + service.
 - Minimal chart footprint (no ingress, no embedded database, no backups, no migrations job).
-- Controller runs in‑cluster and reconciles AgentRun, ImplementationSpec, ImplementationSource, AgentProvider, Memory.
+- Controllers run in‑cluster and reconcile Agents, Orchestration, and supporting primitives (schedules, tools, workspaces).
 - Job runtime creates input/run spec ConfigMaps and labels Jobs for traceability.
 - Artifact Hub metadata included (Apache‑2.0 license).
 
@@ -28,6 +30,22 @@ kubectl apply -n agents -f charts/agents/examples/agent-sample.yaml
 kubectl apply -n agents -f charts/agents/examples/memory-sample.yaml
 kubectl apply -n agents -f charts/agents/examples/implementationspec-sample.yaml
 kubectl apply -n agents -f charts/agents/examples/agentrun-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/tool-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/orchestration-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/orchestrationrun-sample.yaml
+```
+
+Optional supporting primitives:
+```bash
+kubectl apply -n agents -f charts/agents/examples/approvalpolicy-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/budget-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/secretbinding-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/signal-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/signaldelivery-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/toolrun-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/schedule-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/artifact-sample.yaml
+kubectl apply -n agents -f charts/agents/examples/workspace-sample.yaml
 ```
 
 The memory sample includes a placeholder Secret. Update the connection string before using it in production.
@@ -105,10 +123,16 @@ helm push agents-0.6.0.tgz oci://ghcr.io/proompteng/charts
 | `envFromConfigMapRefs` | ConfigMap names to load as envFrom | `[]` |
 | `controller.enabled` | Enable Agents controller loop | `true` |
 | `controller.namespaces` | Namespaces to watch | `['<release-namespace>']` |
-| `controller.intervalSeconds` | Controller reconcile interval | `15` |
+| `controller.intervalSeconds` | Controller resync interval (0 disables periodic resync) | `0` |
 | `controller.concurrency.perNamespace` | Max running AgentRuns per namespace | `10` |
 | `controller.concurrency.perAgent` | Max running AgentRuns per Agent | `5` |
 | `controller.concurrency.cluster` | Max running AgentRuns cluster-wide | `100` |
+| `orchestrationController.enabled` | Enable Orchestration controller loop | `true` |
+| `orchestrationController.namespaces` | Namespaces to watch for OrchestrationRuns | `['<release-namespace>']` |
+| `orchestrationController.intervalSeconds` | Orchestration resync interval (0 disables periodic resync) | `0` |
+| `supportingController.enabled` | Enable supporting primitives controller | `true` |
+| `supportingController.namespaces` | Namespaces to watch for schedules/artifacts/workspaces | `['<release-namespace>']` |
+| `supportingController.intervalSeconds` | Supporting controller resync interval (0 disables periodic resync) | `0` |
 | `agentComms.enabled` | Enable NATS agent-comms subscriber | `false` |
 | `agentComms.nats.url` | NATS URL | `""` |
 | `livenessProbe.enabled` | Enable liveness probe | `true` |

--- a/charts/agents/crds/agents.proompteng.ai_implementationsources.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_implementationsources.yaml
@@ -90,17 +90,13 @@ spec:
               webhook:
                 properties:
                   enabled:
-                    default: true
+                    default: false
                     type: boolean
                 type: object
             required:
             - auth
             - provider
-            - webhook
             type: object
-            x-kubernetes-validations:
-            - message: spec.webhook.enabled must be true
-              rule: self.webhook.enabled == true
           status:
             properties:
               conditions:
@@ -159,8 +155,6 @@ spec:
                   - type
                   type: object
                 type: array
-              cursor:
-                type: string
               lastSyncedAt:
                 format: date-time
                 type: string

--- a/charts/agents/crds/approvals.proompteng.ai_approvalpolicies.yaml
+++ b/charts/agents/crds/approvals.proompteng.ai_approvalpolicies.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: approvalpolicies.approvals.proompteng.ai
+spec:
+  group: approvals.proompteng.ai
+  names:
+    kind: ApprovalPolicy
+    listKind: ApprovalPolicyList
+    plural: approvalpolicies
+    singular: approvalpolicy
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .spec.mode
+          name: Mode
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                mode:
+                  type: string
+                defaultDecision:
+                  type: string
+                subjects:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                      - kind
+                      - name
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                lastDecisionAt:
+                  format: date-time
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/artifacts.proompteng.ai_artifacts.yaml
+++ b/charts/agents/crds/artifacts.proompteng.ai_artifacts.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: artifacts.artifacts.proompteng.ai
+spec:
+  group: artifacts.proompteng.ai
+  names:
+    kind: Artifact
+    listKind: ArtifactList
+    plural: artifacts
+    singular: artifact
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .status.uri
+          name: URI
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                storageRef:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                lifecycle:
+                  type: object
+                  properties:
+                    ttlDays:
+                      format: int32
+                      type: integer
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                uri:
+                  type: string
+                checksum:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/budgets.proompteng.ai_budgets.yaml
+++ b/charts/agents/crds/budgets.proompteng.ai_budgets.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: budgets.budgets.proompteng.ai
+spec:
+  group: budgets.proompteng.ai
+  names:
+    kind: Budget
+    listKind: BudgetList
+    plural: budgets
+    singular: budget
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    tokens:
+                      type: string
+                    dollars:
+                      type: string
+                    cpu:
+                      type: string
+                    memory:
+                      type: string
+                    gpu:
+                      type: string
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                used:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    tokens:
+                      type: string
+                    dollars:
+                      type: string
+                    cpu:
+                      type: string
+                    memory:
+                      type: string
+                    gpu:
+                      type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/orchestration.proompteng.ai_orchestrationruns.yaml
+++ b/charts/agents/crds/orchestration.proompteng.ai_orchestrationruns.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: orchestrationruns.orchestration.proompteng.ai
+spec:
+  group: orchestration.proompteng.ai
+  names:
+    kind: OrchestrationRun
+    listKind: OrchestrationRunList
+    plural: orchestrationruns
+    singular: orchestrationrun
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .spec.orchestrationRef.name
+          name: Orchestration
+          type: string
+        - jsonPath: .status.runId
+          name: RunId
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                orchestrationRef:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                parameters:
+                  type: object
+                  additionalProperties:
+                    type: string
+                deliveryId:
+                  type: string
+              required:
+                - orchestrationRef
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                runId:
+                  type: string
+                startedAt:
+                  format: date-time
+                  type: string
+                finishedAt:
+                  format: date-time
+                  type: string
+                stepStatuses:
+                  type: array
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      name:
+                        type: string
+                      kind:
+                        type: string
+                      phase:
+                        type: string
+                      message:
+                        type: string
+                      startedAt:
+                        format: date-time
+                        type: string
+                      finishedAt:
+                        format: date-time
+                        type: string
+                      resourceRef:
+                        type: object
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          uid:
+                            type: string
+                      outputs:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - name
+                      - kind
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/orchestration.proompteng.ai_orchestrations.yaml
+++ b/charts/agents/crds/orchestration.proompteng.ai_orchestrations.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: orchestrations.orchestration.proompteng.ai
+spec:
+  group: orchestration.proompteng.ai
+  names:
+    kind: Orchestration
+    listKind: OrchestrationList
+    plural: orchestrations
+    singular: orchestration
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .spec.entrypoint
+          name: Entrypoint
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                entrypoint:
+                  type: string
+                steps:
+                  type: array
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      name:
+                        type: string
+                      kind:
+                        type: string
+                      dependsOn:
+                        type: array
+                        items:
+                          type: string
+                      agentRef:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      toolRef:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      orchestrationRef:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      policyRef:
+                        type: string
+                      with:
+                        type: object
+                        additionalProperties:
+                          type: string
+                    required:
+                      - name
+                      - kind
+                policies:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - steps
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/schedules.proompteng.ai_schedules.yaml
+++ b/charts/agents/crds/schedules.proompteng.ai_schedules.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: schedules.schedules.proompteng.ai
+spec:
+  group: schedules.proompteng.ai
+  names:
+    kind: Schedule
+    listKind: ScheduleList
+    plural: schedules
+    singular: schedule
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .spec.cron
+          name: Cron
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                cron:
+                  type: string
+                timezone:
+                  type: string
+                targetRef:
+                  type: object
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - kind
+                    - name
+              required:
+                - cron
+                - targetRef
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                lastRunTime:
+                  format: date-time
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/security.proompteng.ai_secretbindings.yaml
+++ b/charts/agents/crds/security.proompteng.ai_secretbindings.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: secretbindings.security.proompteng.ai
+spec:
+  group: security.proompteng.ai
+  names:
+    kind: SecretBinding
+    listKind: SecretBindingList
+    plural: secretbindings
+    singular: secretbinding
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                subjects:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                      - kind
+                      - name
+                allowedSecrets:
+                  type: array
+                  items:
+                    type: string
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/signals.proompteng.ai_signaldeliveries.yaml
+++ b/charts/agents/crds/signals.proompteng.ai_signaldeliveries.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: signaldeliveries.signals.proompteng.ai
+spec:
+  group: signals.proompteng.ai
+  names:
+    kind: SignalDelivery
+    listKind: SignalDeliveryList
+    plural: signaldeliveries
+    singular: signaldelivery
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .spec.signalRef.name
+          name: Signal
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                signalRef:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                deliveryId:
+                  type: string
+                payload:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - signalRef
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                deliveredAt:
+                  format: date-time
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/signals.proompteng.ai_signals.yaml
+++ b/charts/agents/crds/signals.proompteng.ai_signals.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: signals.signals.proompteng.ai
+spec:
+  group: signals.proompteng.ai
+  names:
+    kind: Signal
+    listKind: SignalList
+    plural: signals
+    singular: signal
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                channel:
+                  type: string
+                description:
+                  type: string
+                payload:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                lastDeliveryAt:
+                  format: date-time
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/tools.proompteng.ai_toolruns.yaml
+++ b/charts/agents/crds/tools.proompteng.ai_toolruns.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: toolruns.tools.proompteng.ai
+spec:
+  group: tools.proompteng.ai
+  names:
+    kind: ToolRun
+    listKind: ToolRunList
+    plural: toolruns
+    singular: toolrun
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .spec.toolRef.name
+          name: Tool
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                toolRef:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                parameters:
+                  type: object
+                  additionalProperties:
+                    type: string
+                deliveryId:
+                  type: string
+                runtime:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - toolRef
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                runId:
+                  type: string
+                runtimeRef:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                startedAt:
+                  format: date-time
+                  type: string
+                finishedAt:
+                  format: date-time
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/tools.proompteng.ai_tools.yaml
+++ b/charts/agents/crds/tools.proompteng.ai_tools.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: tools.tools.proompteng.ai
+spec:
+  group: tools.proompteng.ai
+  names:
+    kind: Tool
+    listKind: ToolList
+    plural: tools
+    singular: tool
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .spec.image
+          name: Image
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                command:
+                  type: array
+                  items:
+                    type: string
+                args:
+                  type: array
+                  items:
+                    type: string
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                      - name
+                      - value
+                serviceAccount:
+                  type: string
+                workingDir:
+                  type: string
+                timeoutSeconds:
+                  format: int32
+                  type: integer
+                ttlSecondsAfterFinished:
+                  format: int32
+                  type: integer
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/crds/workspaces.proompteng.ai_workspaces.yaml
+++ b/charts/agents/crds/workspaces.proompteng.ai_workspaces.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: workspaces.workspaces.proompteng.ai
+spec:
+  group: workspaces.proompteng.ai
+  names:
+    kind: Workspace
+    listKind: WorkspaceList
+    plural: workspaces
+    singular: workspace
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .status.volumeName
+          name: Volume
+          type: string
+      name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                storageClassName:
+                  type: string
+                size:
+                  type: string
+                accessModes:
+                  type: array
+                  items:
+                    type: string
+                ttlSeconds:
+                  format: int32
+                  type: integer
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                volumeName:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    required:
+                      - type
+                      - status
+      subresources:
+        status: {}

--- a/charts/agents/examples/approvalpolicy-sample.yaml
+++ b/charts/agents/examples/approvalpolicy-sample.yaml
@@ -1,0 +1,11 @@
+apiVersion: approvals.proompteng.ai/v1alpha1
+kind: ApprovalPolicy
+metadata:
+  name: default-approval
+spec:
+  mode: manual
+  defaultDecision: deny
+  subjects:
+    - kind: Orchestration
+      name: codex-autonomous
+

--- a/charts/agents/examples/artifact-sample.yaml
+++ b/charts/agents/examples/artifact-sample.yaml
@@ -1,0 +1,10 @@
+apiVersion: artifacts.proompteng.ai/v1alpha1
+kind: Artifact
+metadata:
+  name: run-logs
+spec:
+  storageRef:
+    name: default-storage
+  lifecycle:
+    ttlDays: 7
+

--- a/charts/agents/examples/budget-sample.yaml
+++ b/charts/agents/examples/budget-sample.yaml
@@ -1,0 +1,11 @@
+apiVersion: budgets.proompteng.ai/v1alpha1
+kind: Budget
+metadata:
+  name: default-budget
+spec:
+  limits:
+    tokens: "100000"
+    dollars: "50"
+    cpu: "8"
+    memory: "16Gi"
+

--- a/charts/agents/examples/orchestration-sample.yaml
+++ b/charts/agents/examples/orchestration-sample.yaml
@@ -1,0 +1,24 @@
+apiVersion: orchestration.proompteng.ai/v1alpha1
+kind: Orchestration
+metadata:
+  name: sample-orchestration
+spec:
+  entrypoint: main
+  steps:
+    - name: implement
+      kind: AgentRun
+      agentRef:
+        name: codex-agent
+      implementationSpecRef:
+        name: codex-impl-sample
+      with:
+        repository: proompteng/lab
+        issueNumber: "1234"
+    - name: notify
+      kind: ToolRun
+      dependsOn:
+        - implement
+      toolRef:
+        name: echo-tool
+      with:
+        message: "orchestration complete"

--- a/charts/agents/examples/orchestrationrun-sample.yaml
+++ b/charts/agents/examples/orchestrationrun-sample.yaml
@@ -1,0 +1,9 @@
+apiVersion: orchestration.proompteng.ai/v1alpha1
+kind: OrchestrationRun
+metadata:
+  name: sample-orchestration-run
+spec:
+  orchestrationRef:
+    name: sample-orchestration
+  parameters:
+    message: "hello from orchestration"

--- a/charts/agents/examples/schedule-sample.yaml
+++ b/charts/agents/examples/schedule-sample.yaml
@@ -1,0 +1,10 @@
+apiVersion: schedules.proompteng.ai/v1alpha1
+kind: Schedule
+metadata:
+  name: nightly-impl
+spec:
+  cron: "0 2 * * *"
+  timezone: "UTC"
+  targetRef:
+    kind: AgentRun
+    name: codex-run-sample

--- a/charts/agents/examples/secretbinding-sample.yaml
+++ b/charts/agents/examples/secretbinding-sample.yaml
@@ -1,0 +1,11 @@
+apiVersion: security.proompteng.ai/v1alpha1
+kind: SecretBinding
+metadata:
+  name: codex-secrets
+spec:
+  subjects:
+    - kind: Agent
+      name: codex-agent
+  allowedSecrets:
+    - github-token
+

--- a/charts/agents/examples/signal-sample.yaml
+++ b/charts/agents/examples/signal-sample.yaml
@@ -1,0 +1,8 @@
+apiVersion: signals.proompteng.ai/v1alpha1
+kind: Signal
+metadata:
+  name: human-approval
+spec:
+  channel: slack
+  description: Manual approval signal
+

--- a/charts/agents/examples/signaldelivery-sample.yaml
+++ b/charts/agents/examples/signaldelivery-sample.yaml
@@ -1,0 +1,11 @@
+apiVersion: signals.proompteng.ai/v1alpha1
+kind: SignalDelivery
+metadata:
+  name: approval-1
+spec:
+  signalRef:
+    name: human-approval
+  deliveryId: "delivery-001"
+  payload:
+    approved: true
+

--- a/charts/agents/examples/tool-sample.yaml
+++ b/charts/agents/examples/tool-sample.yaml
@@ -1,0 +1,11 @@
+apiVersion: tools.proompteng.ai/v1alpha1
+kind: Tool
+metadata:
+  name: echo-tool
+spec:
+  image: alpine:3.20
+  command:
+    - /bin/sh
+    - -c
+  args:
+    - "echo {{parameters.message}}"

--- a/charts/agents/examples/toolrun-sample.yaml
+++ b/charts/agents/examples/toolrun-sample.yaml
@@ -1,0 +1,9 @@
+apiVersion: tools.proompteng.ai/v1alpha1
+kind: ToolRun
+metadata:
+  name: lint-run
+spec:
+  toolRef:
+    name: echo-tool
+  parameters:
+    path: services/jangar

--- a/charts/agents/examples/workspace-sample.yaml
+++ b/charts/agents/examples/workspace-sample.yaml
@@ -1,0 +1,11 @@
+apiVersion: workspaces.proompteng.ai/v1alpha1
+kind: Workspace
+metadata:
+  name: shared-workspace
+spec:
+  storageClassName: standard
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  ttlSeconds: 86400
+

--- a/charts/agents/templates/_helpers.tpl
+++ b/charts/agents/templates/_helpers.tpl
@@ -71,3 +71,19 @@ url
 {{- end -}}
 {{- join "," $namespaces -}}
 {{- end -}}
+
+{{- define "agents.orchestrationNamespaces" -}}
+{{- $namespaces := .Values.orchestrationController.namespaces | default (list) -}}
+{{- if or (not $namespaces) (eq (len $namespaces) 0) -}}
+{{- $namespaces = list (.Values.namespaceOverride | default .Release.Namespace) -}}
+{{- end -}}
+{{- join "," $namespaces -}}
+{{- end -}}
+
+{{- define "agents.supportingNamespaces" -}}
+{{- $namespaces := .Values.supportingController.namespaces | default (list) -}}
+{{- if or (not $namespaces) (eq (len $namespaces) 0) -}}
+{{- $namespaces = list (.Values.namespaceOverride | default .Release.Namespace) -}}
+{{- end -}}
+{{- join "," $namespaces -}}
+{{- end -}}

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -72,13 +72,21 @@ spec:
             - name: {{ $name }}
               value: {{ $value | quote }}
             {{- end }}
+            - name: JANGAR_IMAGE
+              value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{ end }}"
+            - name: JANGAR_SERVICE_ACCOUNT_NAME
+              value: {{ include "agents.serviceAccountName" . | quote }}
+            - name: JANGAR_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- if .Values.controller.enabled }}
             - name: JANGAR_AGENTS_CONTROLLER_ENABLED
               value: "1"
             - name: JANGAR_AGENTS_CONTROLLER_NAMESPACES
               value: {{ include "agents.controllerNamespaces" . | quote }}
             - name: JANGAR_AGENTS_CONTROLLER_INTERVAL_SECONDS
-              value: {{ .Values.controller.intervalSeconds | default 15 | quote }}
+              value: {{ .Values.controller.intervalSeconds | quote }}
             - name: JANGAR_AGENTS_CONTROLLER_CONCURRENCY_NAMESPACE
               value: {{ .Values.controller.concurrency.perNamespace | default 10 | quote }}
             - name: JANGAR_AGENTS_CONTROLLER_CONCURRENCY_AGENT
@@ -87,6 +95,28 @@ spec:
               value: {{ .Values.controller.concurrency.cluster | default 100 | quote }}
             {{- else }}
             - name: JANGAR_AGENTS_CONTROLLER_ENABLED
+              value: "0"
+            {{- end }}
+            {{- if .Values.orchestrationController.enabled }}
+            - name: JANGAR_ORCHESTRATION_CONTROLLER_ENABLED
+              value: "1"
+            - name: JANGAR_ORCHESTRATION_CONTROLLER_NAMESPACES
+              value: {{ include "agents.orchestrationNamespaces" . | quote }}
+            - name: JANGAR_ORCHESTRATION_CONTROLLER_INTERVAL_SECONDS
+              value: {{ .Values.orchestrationController.intervalSeconds | quote }}
+            {{- else }}
+            - name: JANGAR_ORCHESTRATION_CONTROLLER_ENABLED
+              value: "0"
+            {{- end }}
+            {{- if .Values.supportingController.enabled }}
+            - name: JANGAR_SUPPORTING_CONTROLLER_ENABLED
+              value: "1"
+            - name: JANGAR_SUPPORTING_CONTROLLER_NAMESPACES
+              value: {{ include "agents.supportingNamespaces" . | quote }}
+            - name: JANGAR_SUPPORTING_CONTROLLER_INTERVAL_SECONDS
+              value: {{ .Values.supportingController.intervalSeconds | quote }}
+            {{- else }}
+            - name: JANGAR_SUPPORTING_CONTROLLER_ENABLED
               value: "0"
             {{- end }}
             {{- if .Values.agentComms.enabled }}

--- a/charts/agents/templates/rbac.yaml
+++ b/charts/agents/templates/rbac.yaml
@@ -45,9 +45,209 @@ rules:
       - update
       - patch
   - apiGroups:
+      - orchestration.proompteng.ai
+    resources:
+      - orchestrations
+      - orchestrationruns
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - orchestration.proompteng.ai
+    resources:
+      - orchestrations/status
+      - orchestrationruns/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - approvals.proompteng.ai
+    resources:
+      - approvalpolicies
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - approvals.proompteng.ai
+    resources:
+      - approvalpolicies/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - budgets.proompteng.ai
+    resources:
+      - budgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - budgets.proompteng.ai
+    resources:
+      - budgets/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - security.proompteng.ai
+    resources:
+      - secretbindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - security.proompteng.ai
+    resources:
+      - secretbindings/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - signals.proompteng.ai
+    resources:
+      - signals
+      - signaldeliveries
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - signals.proompteng.ai
+    resources:
+      - signals/status
+      - signaldeliveries/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - tools.proompteng.ai
+    resources:
+      - tools
+      - toolruns
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - tools.proompteng.ai
+    resources:
+      - tools/status
+      - toolruns/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - schedules.proompteng.ai
+    resources:
+      - schedules
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - schedules.proompteng.ai
+    resources:
+      - schedules/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - artifacts.proompteng.ai
+    resources:
+      - artifacts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - artifacts.proompteng.ai
+    resources:
+      - artifacts/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - workspaces.proompteng.ai
+    resources:
+      - workspaces
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - workspaces.proompteng.ai
+    resources:
+      - workspaces/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
       - batch
     resources:
       - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: [""]
+    resources:
+      - persistentvolumeclaims
     verbs:
       - get
       - list

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -146,7 +146,7 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "namespaces": { "type": "array", "items": { "type": "string" } },
-        "intervalSeconds": { "type": "integer", "minimum": 5 },
+        "intervalSeconds": { "type": "integer", "minimum": 0 },
         "concurrency": {
           "type": "object",
           "properties": {
@@ -156,6 +156,24 @@
           },
           "additionalProperties": false
         }
+      },
+      "additionalProperties": false
+    },
+    "orchestrationController": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "namespaces": { "type": "array", "items": { "type": "string" } },
+        "intervalSeconds": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "supportingController": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "namespaces": { "type": "array", "items": { "type": "string" } },
+        "intervalSeconds": { "type": "integer", "minimum": 0 }
       },
       "additionalProperties": false
     },

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -80,11 +80,21 @@ envFromConfigMapRefs: []
 controller:
   enabled: true
   namespaces: []
-  intervalSeconds: 15
+  intervalSeconds: 0
   concurrency:
     perNamespace: 10
     perAgent: 5
     cluster: 100
+
+orchestrationController:
+  enabled: true
+  namespaces: []
+  intervalSeconds: 0
+
+supportingController:
+  enabled: true
+  namespaces: []
+  intervalSeconds: 0
 
 agentComms:
   enabled: false

--- a/docs/agents/agentctl-cli-design.md
+++ b/docs/agents/agentctl-cli-design.md
@@ -2,7 +2,7 @@
 
 Status: Current (2026-01-19)
 
-Location: `services/jangar/agentctl`
+Location: `services/jangar/agentctl` (ships with the Jangar service; not a separate product).
 
 ## Purpose
 `agentctl` is the Jangar CLI for managing Agents primitives and submitting AgentRuns without hand‑writing YAML.
@@ -10,6 +10,7 @@ It talks to the Jangar controller over gRPC.
 
 ## Goals
 - CRUD for Agent, AgentRun, ImplementationSpec, ImplementationSource, Memory.
+- CRUD for supporting primitives (Tool, Schedule, Workspace, Signal, ApprovalPolicy, Budget, SecretBinding).
 - First‑class “run” command to submit an AgentRun from flags or a spec file.
 - Works against any Kubernetes cluster where Jangar is deployed.
 - In‑cluster gRPC by default (port‑forward or in‑cluster usage).
@@ -24,6 +25,10 @@ It talks to the Jangar controller over gRPC.
 - Client talks to the Jangar gRPC API (no direct Kubernetes access).
 - Default namespace is `agents`, with explicit overrides via flags/config.
 - Jangar is the source of truth for list/get/apply/delete operations.
+
+### gRPC connectivity (current + future)
+- **Current:** in-cluster gRPC only; external access via `kubectl port-forward` or an in-cluster client.
+- **Future-proofing:** TLS/mTLS support, optional auth tokens, and a dedicated Ingress/gateway can be layered without changing CLI commands.
 
 ## Command Surface (proposed)
 ### Core
@@ -55,6 +60,15 @@ It talks to the Jangar controller over gRPC.
 - `agentctl memory get <name>`
 - `agentctl memory apply -f <file>`
 - `agentctl memory delete <name>`
+
+### Supporting primitives
+- `agentctl tool list|get|apply|delete`
+- `agentctl schedule list|get|apply|delete`
+- `agentctl workspace list|get|apply|delete`
+- `agentctl signal list|get|apply|delete`
+- `agentctl approval list|get|apply|delete`
+- `agentctl budget list|get|apply|delete`
+- `agentctl secretbinding list|get|apply|delete`
 
 ### AgentRun
 - `agentctl run submit --agent <name> --impl <name> --runtime <type> [--workload-image ...] [--cpu ...] [--memory ...] [--idempotency-key ...]`

--- a/docs/jangar/primitives/jangar-implementation.md
+++ b/docs/jangar/primitives/jangar-implementation.md
@@ -92,14 +92,17 @@ CREATE TABLE IF NOT EXISTS audit_events (
 Jangar must implement:
 
 - CRD creation + updates (Agent, AgentRun, Memory, Orchestration)
-- Status reconciliation (poll or watch provider resources)
+- Status reconciliation (watch provider resources; optional resync interval)
 - Policy enforcement (budgets, approvals, secrets)
 - Retry + idempotency
 - Audit log emission
+- Supporting primitives reconciliation (Tool, ApprovalPolicy, Budget, SecretBinding, Signal, SignalDelivery, Schedule, Artifact, Workspace)
+- Schedule execution via native Kubernetes CronJobs (no vendor workflows)
+- Workspace provisioning via PVCs (status reflects PVC phase)
 
 ## 4) Provider watchers
 
-- Argo: watch `Workflow` and `WorkflowTemplate`
+- Native workflow runtime: watch `Job` status for AgentRun/ToolRun execution
 - CNPG: read secrets and cluster status
 - NATS/Kafka: ingest runtime events
 

--- a/docs/jangar/primitives/orchestration.md
+++ b/docs/jangar/primitives/orchestration.md
@@ -4,15 +4,15 @@
 
 The Orchestration primitive represents a composable workflow definition and execution that coordinates
 multiple steps (agent runs, tool invocations, memory operations) over long horizons. It is provider-agnostic
-and can be implemented by Argo, Temporal, or other workflow engines.
+and implemented by the Jangar native workflow runtime by default, with optional adapters for external
+workflow engines.
 
 Jangar is the control plane for orchestration resources.
 
 ## Grounding in the current platform
 
-- Existing Argo templates: `codex-autonomous`, `github-codex-implementation`, `codex-research-workflow`
-- Facteur orchestration entrypoint: `services/facteur/internal/orchestrator/implementation.go`
-- Argo runtime namespace: `argo-workflows`
+- Native runtime: `services/jangar/src/server/orchestration-controller.ts`
+- Agent execution runtime: `services/jangar/src/server/agents-controller.ts`
 
 ## CRDs
 
@@ -89,14 +89,13 @@ Each step is an atomic unit with:
 - Provider binding happens at reconciliation via the Jangar runtime router.
 - Provider-specific overrides may be introduced later.
 
-## Mapping to Argo (current runtime)
+## Native runtime (default)
 
-- `Orchestration` → `WorkflowTemplate` (or DAG template)
-- `OrchestrationRun` → `Workflow`
-- `dependsOn` maps to DAG dependencies
-- `AgentRun` steps map to `templateRef` to existing agent workflow templates
+- `Orchestration` defines the DAG and step contracts.
+- `OrchestrationRun` coordinates step execution through Jangar.
+- Steps create `AgentRun` and `ToolRun` resources and track their status.
 
-## Mapping to Temporal (future runtime)
+## Optional adapters (future)
 
 - `Orchestration` → Workflow Type and Task Queue
 - `steps` map to Activities or Child Workflows

--- a/docs/jangar/primitives/supporting-primitives.md
+++ b/docs/jangar/primitives/supporting-primitives.md
@@ -42,7 +42,8 @@ Used for:
 **Purpose:** time-based triggers for AgentRuns and OrchestrationRuns.
 
 - `Schedule` defines cron, timezone, and target resource
-- Provider-agnostic; can map to K8s CronJob or Temporal schedules
+- Native implementation uses Kubernetes `CronJob` to create AgentRun/OrchestrationRun instances (no vendor workflows)
+- `targetRef.kind` must reference an existing `AgentRun` or `OrchestrationRun` template in the cluster
 
 ## 5) Budget
 
@@ -72,6 +73,7 @@ Used for:
 
 - `Workspace` defines storage class, size, and lifecycle
 - Orchestration steps can mount a shared workspace
+- Native implementation provisions PVCs and reflects PVC status in Workspace status
 
 ## Common design rules
 

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -56,6 +56,9 @@ kubeconform --strict --summary \
   --schema-location "${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
   --schema-location "${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   --schema-location "${schema_dir}/{{.Group}}/{{.ResourceAPIVersion}}/{{.ResourceKind}}.json" \
+  --schema-location "${schema_dir}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
+  --schema-location "${schema_dir}/{{.ResourceKind}}_{{.Group}}_{{.ResourceAPIVersion}}.json" \
+  --schema-location "${schema_dir}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
   --schema-location default \
   "${CHART_DIR}/examples"/*.yaml
 
@@ -63,6 +66,9 @@ kubeconform --strict --summary \
   --schema-location "${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
   --schema-location "${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   --schema-location "${schema_dir}/{{.Group}}/{{.ResourceAPIVersion}}/{{.ResourceKind}}.json" \
+  --schema-location "${schema_dir}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
+  --schema-location "${schema_dir}/{{.ResourceKind}}_{{.Group}}_{{.ResourceAPIVersion}}.json" \
+  --schema-location "${schema_dir}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
   --schema-location default \
   "${ROOT_DIR}/argocd/applications/agents/application.yaml"
 

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -55,12 +55,14 @@ fi
 kubeconform --strict --summary \
   --schema-location "${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
   --schema-location "${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
+  --schema-location "${schema_dir}/{{.Group}}/{{.ResourceAPIVersion}}/{{.ResourceKind}}.json" \
   --schema-location default \
   "${CHART_DIR}/examples"/*.yaml
 
 kubeconform --strict --summary \
   --schema-location "${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
   --schema-location "${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
+  --schema-location "${schema_dir}/{{.Group}}/{{.ResourceAPIVersion}}/{{.ResourceKind}}.json" \
   --schema-location default \
   "${ROOT_DIR}/argocd/applications/agents/application.yaml"
 

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -33,6 +33,18 @@ python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.p
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_implementationspecs.yaml" agents.proompteng.ai v1alpha1 ImplementationSpec
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_implementationsources.yaml" agents.proompteng.ai v1alpha1 ImplementationSource
 python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/agents.proompteng.ai_memories.yaml" agents.proompteng.ai v1alpha1 Memory
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/orchestration.proompteng.ai_orchestrations.yaml" orchestration.proompteng.ai v1alpha1 Orchestration
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/orchestration.proompteng.ai_orchestrationruns.yaml" orchestration.proompteng.ai v1alpha1 OrchestrationRun
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/approvals.proompteng.ai_approvalpolicies.yaml" approvals.proompteng.ai v1alpha1 ApprovalPolicy
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/budgets.proompteng.ai_budgets.yaml" budgets.proompteng.ai v1alpha1 Budget
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/security.proompteng.ai_secretbindings.yaml" security.proompteng.ai v1alpha1 SecretBinding
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/signals.proompteng.ai_signals.yaml" signals.proompteng.ai v1alpha1 Signal
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/signals.proompteng.ai_signaldeliveries.yaml" signals.proompteng.ai v1alpha1 SignalDelivery
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/tools.proompteng.ai_tools.yaml" tools.proompteng.ai v1alpha1 Tool
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/tools.proompteng.ai_toolruns.yaml" tools.proompteng.ai v1alpha1 ToolRun
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/schedules.proompteng.ai_schedules.yaml" schedules.proompteng.ai v1alpha1 Schedule
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/artifacts.proompteng.ai_artifacts.yaml" artifacts.proompteng.ai v1alpha1 Artifact
+python3 "${ROOT_DIR}/scripts/download_crd_schema.py" "${CHART_DIR}/crds/workspaces.proompteng.ai_workspaces.yaml" workspaces.proompteng.ai v1alpha1 Workspace
 
 schema_dir="${ROOT_DIR}/schemas/custom"
 if ! command -v kubeconform >/dev/null 2>&1; then

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -53,12 +53,14 @@ if ! command -v kubeconform >/dev/null 2>&1; then
 fi
 
 kubeconform --strict --summary \
+  --schema-location "file://${schema_dir}" \
   --schema-location "file://${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
   --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   --schema-location default \
   "${CHART_DIR}/examples"/*.yaml
 
 kubeconform --strict --summary \
+  --schema-location "file://${schema_dir}" \
   --schema-location "file://${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
   --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   --schema-location default \

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -53,11 +53,13 @@ if ! command -v kubeconform >/dev/null 2>&1; then
 fi
 
 kubeconform --strict --summary \
+  --schema-location "file://${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
   --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   --schema-location default \
   "${CHART_DIR}/examples"/*.yaml
 
 kubeconform --strict --summary \
+  --schema-location "file://${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
   --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   --schema-location default \
   "${ROOT_DIR}/argocd/applications/agents/application.yaml"

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -53,16 +53,14 @@ if ! command -v kubeconform >/dev/null 2>&1; then
 fi
 
 kubeconform --strict --summary \
-  --schema-location "file://${schema_dir}" \
-  --schema-location "file://${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
-  --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
+  --schema-location "${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
+  --schema-location "${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   --schema-location default \
   "${CHART_DIR}/examples"/*.yaml
 
 kubeconform --strict --summary \
-  --schema-location "file://${schema_dir}" \
-  --schema-location "file://${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
-  --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
+  --schema-location "${schema_dir}/{{.ResourceKind}}{{.KindSuffix}}.json" \
+  --schema-location "${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   --schema-location default \
   "${ROOT_DIR}/argocd/applications/agents/application.yaml"
 

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -54,12 +54,12 @@ fi
 
 kubeconform --strict --summary \
   --schema-location default \
-  --schema-location "${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
+  --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   "${CHART_DIR}/examples"/*.yaml
 
 kubeconform --strict --summary \
   --schema-location default \
-  --schema-location "${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
+  --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
   "${ROOT_DIR}/argocd/applications/agents/application.yaml"
 
 CRD_DIR="${CHART_DIR}/crds" python3 - <<'PY'

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -53,13 +53,13 @@ if ! command -v kubeconform >/dev/null 2>&1; then
 fi
 
 kubeconform --strict --summary \
-  --schema-location default \
   --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
+  --schema-location default \
   "${CHART_DIR}/examples"/*.yaml
 
 kubeconform --strict --summary \
-  --schema-location default \
   --schema-location "file://${schema_dir}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json" \
+  --schema-location default \
   "${ROOT_DIR}/argocd/applications/agents/application.yaml"
 
 CRD_DIR="${CHART_DIR}/crds" python3 - <<'PY'

--- a/scripts/download_crd_schema.py
+++ b/scripts/download_crd_schema.py
@@ -14,6 +14,7 @@ group = sys.argv[2]
 version = sys.argv[3]
 kind = sys.argv[4]
 kind_slug = kind.lower()
+kind_suffix = f"-{group}-{version}" if group else f"-{version}"
 
 import yaml
 
@@ -33,10 +34,12 @@ for version_entry in crd.get("spec", {}).get("versions", []):
             "definitions": schema.get("definitions", {}),
             "additionalProperties": schema.get("additionalProperties", True),
         }
-        # kubeconform resolution differs across kinds; emit both lowercase and original kind.
+        # kubeconform resolution differs across kinds; emit multiple naming styles.
         out_paths = [
             Path(f"schemas/custom/{group}_{version}_{kind_slug}.json"),
             Path(f"schemas/custom/{group}_{version}_{kind}.json"),
+            Path(f"schemas/custom/{kind}{kind_suffix}.json"),
+            Path(f"schemas/custom/{kind_slug}{kind_suffix}.json"),
         ]
         for out_path in out_paths:
             out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/download_crd_schema.py
+++ b/scripts/download_crd_schema.py
@@ -40,6 +40,8 @@ for version_entry in crd.get("spec", {}).get("versions", []):
             Path(f"schemas/custom/{group}_{version}_{kind}.json"),
             Path(f"schemas/custom/{kind}{kind_suffix}.json"),
             Path(f"schemas/custom/{kind_slug}{kind_suffix}.json"),
+            Path(f"schemas/custom/{kind}.json"),
+            Path(f"schemas/custom/{kind_slug}.json"),
         ]
         for out_path in out_paths:
             out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/download_crd_schema.py
+++ b/scripts/download_crd_schema.py
@@ -42,10 +42,16 @@ for version_entry in crd.get("spec", {}).get("versions", []):
             Path(f"schemas/custom/{kind_slug}{kind_suffix}.json"),
             Path(f"schemas/custom/{kind}-{version}.json"),
             Path(f"schemas/custom/{kind_slug}-{version}.json"),
+            Path(f"schemas/custom/{kind}_{version}.json"),
+            Path(f"schemas/custom/{kind_slug}_{version}.json"),
+            Path(f"schemas/custom/{kind}_{group}_{version}.json"),
+            Path(f"schemas/custom/{kind_slug}_{group}_{version}.json"),
             Path(f"schemas/custom/{kind}.json"),
             Path(f"schemas/custom/{kind_slug}.json"),
             Path(f"schemas/custom/{group}/{version}/{kind}.json"),
             Path(f"schemas/custom/{group}/{version}/{kind_slug}.json"),
+            Path(f"schemas/custom/{group}/{kind}_{version}.json"),
+            Path(f"schemas/custom/{group}/{kind_slug}_{version}.json"),
         ]
         for out_path in out_paths:
             out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/download_crd_schema.py
+++ b/scripts/download_crd_schema.py
@@ -33,11 +33,15 @@ for version_entry in crd.get("spec", {}).get("versions", []):
             "definitions": schema.get("definitions", {}),
             "additionalProperties": schema.get("additionalProperties", True),
         }
-        # kubeconform lowercases kind when resolving schema paths.
-        out_path = Path(f"schemas/custom/{group}_{version}_{kind_slug}.json")
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(json.dumps(output))
-        print(f"wrote {out_path}")
+        # kubeconform resolution differs across kinds; emit both lowercase and original kind.
+        out_paths = [
+            Path(f"schemas/custom/{group}_{version}_{kind_slug}.json"),
+            Path(f"schemas/custom/{group}_{version}_{kind}.json"),
+        ]
+        for out_path in out_paths:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(json.dumps(output))
+            print(f"wrote {out_path}")
         sys.exit(0)
 
 print("schema not found", file=sys.stderr)

--- a/scripts/download_crd_schema.py
+++ b/scripts/download_crd_schema.py
@@ -44,6 +44,8 @@ for version_entry in crd.get("spec", {}).get("versions", []):
             Path(f"schemas/custom/{kind_slug}-{version}.json"),
             Path(f"schemas/custom/{kind}.json"),
             Path(f"schemas/custom/{kind_slug}.json"),
+            Path(f"schemas/custom/{group}/{version}/{kind}.json"),
+            Path(f"schemas/custom/{group}/{version}/{kind_slug}.json"),
         ]
         for out_path in out_paths:
             out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/download_crd_schema.py
+++ b/scripts/download_crd_schema.py
@@ -40,6 +40,8 @@ for version_entry in crd.get("spec", {}).get("versions", []):
             Path(f"schemas/custom/{group}_{version}_{kind}.json"),
             Path(f"schemas/custom/{kind}{kind_suffix}.json"),
             Path(f"schemas/custom/{kind_slug}{kind_suffix}.json"),
+            Path(f"schemas/custom/{kind}-{version}.json"),
+            Path(f"schemas/custom/{kind_slug}-{version}.json"),
             Path(f"schemas/custom/{kind}.json"),
             Path(f"schemas/custom/{kind_slug}.json"),
         ]

--- a/scripts/kubeconform.sh
+++ b/scripts/kubeconform.sh
@@ -30,6 +30,9 @@ if [[ -d "$SCHEMA_DIR" ]]; then
     "--schema-location" "${SCHEMA_DIR}/{{.ResourceKind}}{{.KindSuffix}}.json"
     "--schema-location" "${SCHEMA_DIR}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json"
     "--schema-location" "${SCHEMA_DIR}/{{.Group}}/{{.ResourceAPIVersion}}/{{.ResourceKind}}.json"
+    "--schema-location" "${SCHEMA_DIR}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+    "--schema-location" "${SCHEMA_DIR}/{{.ResourceKind}}_{{.Group}}_{{.ResourceAPIVersion}}.json"
+    "--schema-location" "${SCHEMA_DIR}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
   )
 fi
 

--- a/scripts/kubeconform.sh
+++ b/scripts/kubeconform.sh
@@ -29,6 +29,7 @@ if [[ -d "$SCHEMA_DIR" ]]; then
   SCHEMA_ARGS+=(
     "--schema-location" "${SCHEMA_DIR}/{{.ResourceKind}}{{.KindSuffix}}.json"
     "--schema-location" "${SCHEMA_DIR}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json"
+    "--schema-location" "${SCHEMA_DIR}/{{.Group}}/{{.ResourceAPIVersion}}/{{.ResourceKind}}.json"
   )
 fi
 

--- a/scripts/kubeconform.sh
+++ b/scripts/kubeconform.sh
@@ -27,9 +27,8 @@ fi
 SCHEMA_ARGS=("--schema-location" "default")
 if [[ -d "$SCHEMA_DIR" ]]; then
   SCHEMA_ARGS+=(
-    "--schema-location" "file://${SCHEMA_DIR}"
-    "--schema-location" "file://${SCHEMA_DIR}/{{.ResourceKind}}{{.KindSuffix}}.json"
-    "--schema-location" "file://${SCHEMA_DIR}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json"
+    "--schema-location" "${SCHEMA_DIR}/{{.ResourceKind}}{{.KindSuffix}}.json"
+    "--schema-location" "${SCHEMA_DIR}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json"
   )
 fi
 

--- a/scripts/kubeconform.sh
+++ b/scripts/kubeconform.sh
@@ -27,6 +27,7 @@ fi
 SCHEMA_ARGS=("--schema-location" "default")
 if [[ -d "$SCHEMA_DIR" ]]; then
   SCHEMA_ARGS+=(
+    "--schema-location" "file://${SCHEMA_DIR}"
     "--schema-location" "file://${SCHEMA_DIR}/{{.ResourceKind}}{{.KindSuffix}}.json"
     "--schema-location" "file://${SCHEMA_DIR}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json"
   )

--- a/scripts/kubeconform.sh
+++ b/scripts/kubeconform.sh
@@ -26,7 +26,10 @@ fi
 
 SCHEMA_ARGS=("--schema-location" "default")
 if [[ -d "$SCHEMA_DIR" ]]; then
-  SCHEMA_ARGS+=("--schema-location" "file://${SCHEMA_DIR}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json")
+  SCHEMA_ARGS+=(
+    "--schema-location" "file://${SCHEMA_DIR}/{{.ResourceKind}}{{.KindSuffix}}.json"
+    "--schema-location" "file://${SCHEMA_DIR}/{{.Group}}_{{.ResourceAPIVersion}}_{{.ResourceKind}}.json"
+  )
 fi
 
 kubeconform --strict --summary --ignore-missing-schemas \

--- a/services/jangar/api/agents/v1alpha1/types.go
+++ b/services/jangar/api/agents/v1alpha1/types.go
@@ -81,6 +81,7 @@ type AgentRunSpec struct {
 	ImplementationSpecRef *LocalRef             `json:"implementationSpecRef,omitempty"`
 	Implementation        *InlineImplementation `json:"implementation,omitempty"`
 	Runtime               RuntimeSpec           `json:"runtime"`
+	Workflow              *WorkflowSpec         `json:"workflow,omitempty"`
 	Workload              *WorkloadSpec         `json:"workload,omitempty"`
 	// +kubebuilder:validation:MaxProperties=100
 	Parameters     map[string]string `json:"parameters,omitempty"`
@@ -94,10 +95,25 @@ type InlineImplementation struct {
 }
 
 type RuntimeSpec struct {
-	// +kubebuilder:validation:Enum=argo;temporal;job;custom
+	// +kubebuilder:validation:Enum=workflow;job;temporal;custom
 	Type string `json:"type"`
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Config map[string]apiextensionsv1.JSON `json:"config,omitempty"`
+}
+
+type WorkflowSpec struct {
+	Steps []WorkflowStep `json:"steps"`
+}
+
+type WorkflowStep struct {
+	Name                  string                `json:"name"`
+	ImplementationSpecRef *LocalRef             `json:"implementationSpecRef,omitempty"`
+	Implementation        *InlineImplementation `json:"implementation,omitempty"`
+	// +kubebuilder:validation:MaxProperties=100
+	Parameters          map[string]string `json:"parameters,omitempty"`
+	Workload            *WorkloadSpec     `json:"workload,omitempty"`
+	Retries             int32             `json:"retries,omitempty"`
+	RetryBackoffSeconds int32             `json:"retryBackoffSeconds,omitempty"`
 }
 
 type WorkloadSpec struct {
@@ -127,11 +143,36 @@ type AgentRunStatus struct {
 	Phase string `json:"phase,omitempty"`
 	// +kubebuilder:pruning:PreserveUnknownFields
 	RuntimeRef         map[string]apiextensionsv1.JSON `json:"runtimeRef,omitempty"`
+	Workflow           *WorkflowStatus                 `json:"workflow,omitempty"`
 	StartedAt          *metav1.Time                    `json:"startedAt,omitempty"`
 	FinishedAt         *metav1.Time                    `json:"finishedAt,omitempty"`
 	Artifacts          []Artifact                      `json:"artifacts,omitempty"`
 	Conditions         []metav1.Condition              `json:"conditions,omitempty"`
 	ObservedGeneration int64                           `json:"observedGeneration,omitempty"`
+}
+
+type WorkflowStatus struct {
+	Phase              string               `json:"phase,omitempty"`
+	LastTransitionTime *metav1.Time         `json:"lastTransitionTime,omitempty"`
+	Steps              []WorkflowStepStatus `json:"steps,omitempty"`
+}
+
+type WorkflowStepStatus struct {
+	Name               string       `json:"name,omitempty"`
+	Phase              string       `json:"phase,omitempty"`
+	Attempt            int32        `json:"attempt,omitempty"`
+	StartedAt          *metav1.Time `json:"startedAt,omitempty"`
+	FinishedAt         *metav1.Time `json:"finishedAt,omitempty"`
+	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
+	Message            string       `json:"message,omitempty"`
+	NextRetryAt        *metav1.Time `json:"nextRetryAt,omitempty"`
+	JobRef             *JobRef      `json:"jobRef,omitempty"`
+}
+
+type JobRef struct {
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Uid       string `json:"uid,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/services/jangar/api/agents/v1alpha1/zz_generated.deepcopy.go
+++ b/services/jangar/api/agents/v1alpha1/zz_generated.deepcopy.go
@@ -596,7 +596,11 @@ func (in *ImplementationSourceRef) DeepCopy() *ImplementationSourceRef {
 func (in *ImplementationSourceSpec) DeepCopyInto(out *ImplementationSourceSpec) {
 	*out = *in
 	out.Auth = in.Auth
-	out.Webhook = in.Webhook
+	if in.Webhook != nil {
+		in, out := &in.Webhook, &out.Webhook
+		*out = new(ImplementationSourceWebhook)
+		**out = **in
+	}
 	if in.Scope != nil {
 		in, out := &in.Scope, &out.Scope
 		*out = new(ImplementationScope)

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as TerminalsIndexRouteImport } from './routes/terminals/index'
 import { Route as AtlasIndexRouteImport } from './routes/atlas/index'
 import { Route as AgentsIndexRouteImport } from './routes/agents/index'
+import { Route as AgentsControlPlaneIndexRouteImport } from './routes/agents-control-plane/index'
 import { Route as V1OrchestrationsRouteImport } from './routes/v1/orchestrations'
 import { Route as V1OrchestrationRunsRouteImport } from './routes/v1/orchestration-runs'
 import { Route as V1MemoryQueriesRouteImport } from './routes/v1/memory-queries'
@@ -41,6 +42,12 @@ import { Route as AgentsGeneralRouteImport } from './routes/agents/general'
 import { Route as AgentsRunIdRouteImport } from './routes/agents/$runId'
 import { Route as TerminalsSessionIdIndexRouteImport } from './routes/terminals/$sessionId/index'
 import { Route as GithubPullsIndexRouteImport } from './routes/github/pulls/index'
+import { Route as AgentsControlPlaneMemoriesIndexRouteImport } from './routes/agents-control-plane/memories/index'
+import { Route as AgentsControlPlaneImplementationSpecsIndexRouteImport } from './routes/agents-control-plane/implementation-specs/index'
+import { Route as AgentsControlPlaneImplementationSourcesIndexRouteImport } from './routes/agents-control-plane/implementation-sources/index'
+import { Route as AgentsControlPlaneAgentsIndexRouteImport } from './routes/agents-control-plane/agents/index'
+import { Route as AgentsControlPlaneAgentRunsIndexRouteImport } from './routes/agents-control-plane/agent-runs/index'
+import { Route as AgentsControlPlaneAgentProvidersIndexRouteImport } from './routes/agents-control-plane/agent-providers/index'
 import { Route as V1RunsIdRouteImport } from './routes/v1/runs/$id'
 import { Route as V1OrchestrationsIdRouteImport } from './routes/v1/orchestrations/$id'
 import { Route as V1OrchestrationRunsIdRouteImport } from './routes/v1/orchestration-runs/$id'
@@ -63,7 +70,12 @@ import { Route as ApiAtlasIndexedRouteImport } from './routes/api/atlas/indexed'
 import { Route as ApiAtlasFileRouteImport } from './routes/api/atlas/file'
 import { Route as ApiAtlasAstRouteImport } from './routes/api/atlas/ast'
 import { Route as ApiAgentsEventsRouteImport } from './routes/api/agents/events'
-import { Route as ApiAgentsImplementationSourcesWebhooksProviderRouteImport } from './routes/api/agents/implementation-sources/webhooks/$provider'
+import { Route as AgentsControlPlaneMemoriesNameRouteImport } from './routes/agents-control-plane/memories/$name'
+import { Route as AgentsControlPlaneImplementationSpecsNameRouteImport } from './routes/agents-control-plane/implementation-specs/$name'
+import { Route as AgentsControlPlaneImplementationSourcesNameRouteImport } from './routes/agents-control-plane/implementation-sources/$name'
+import { Route as AgentsControlPlaneAgentsNameRouteImport } from './routes/agents-control-plane/agents/$name'
+import { Route as AgentsControlPlaneAgentRunsNameRouteImport } from './routes/agents-control-plane/agent-runs/$name'
+import { Route as AgentsControlPlaneAgentProvidersNameRouteImport } from './routes/agents-control-plane/agent-providers/$name'
 import { Route as OpenaiV1ChatCompletionsRouteImport } from './routes/openai/v1/chat/completions'
 import { Route as ApiTorghutTaSignalsRouteImport } from './routes/api/torghut/ta/signals'
 import { Route as ApiTorghutTaLatestRouteImport } from './routes/api/torghut/ta/latest'
@@ -77,7 +89,11 @@ import { Route as ApiTerminalsSessionIdInputRouteImport } from './routes/api/ter
 import { Route as ApiTerminalsSessionIdDeleteRouteImport } from './routes/api/terminals/$sessionId/delete'
 import { Route as ApiCodexRunsRecentRouteImport } from './routes/api/codex/runs/recent'
 import { Route as ApiCodexRunsListRouteImport } from './routes/api/codex/runs/list'
+import { Route as ApiAgentsControlPlaneResourcesRouteImport } from './routes/api/agents/control-plane/resources'
+import { Route as ApiAgentsControlPlaneResourceRouteImport } from './routes/api/agents/control-plane/resource'
+import { Route as ApiAgentsControlPlaneEventsRouteImport } from './routes/api/agents/control-plane/events'
 import { Route as GithubPullsOwnerRepoNumberRouteImport } from './routes/github/pulls/$owner/$repo/$number'
+import { Route as ApiAgentsImplementationSourcesWebhooksProviderRouteImport } from './routes/api/agents/implementation-sources/webhooks/$provider'
 import { Route as ApiGithubPullsOwnerRepoNumberRouteImport } from './routes/api/github/pulls/$owner/$repo/$number'
 import { Route as ApiGithubPullsOwnerRepoNumberThreadsRouteImport } from './routes/api/github/pulls/$owner/$repo/$number/threads'
 import { Route as ApiGithubPullsOwnerRepoNumberReviewRouteImport } from './routes/api/github/pulls/$owner/$repo/$number/review'
@@ -121,6 +137,11 @@ const AtlasIndexRoute = AtlasIndexRouteImport.update({
 const AgentsIndexRoute = AgentsIndexRouteImport.update({
   id: '/agents/',
   path: '/agents/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AgentsControlPlaneIndexRoute = AgentsControlPlaneIndexRouteImport.update({
+  id: '/agents-control-plane/',
+  path: '/agents-control-plane/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const V1OrchestrationsRoute = V1OrchestrationsRouteImport.update({
@@ -248,6 +269,42 @@ const GithubPullsIndexRoute = GithubPullsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => GithubPullsRoute,
 } as any)
+const AgentsControlPlaneMemoriesIndexRoute =
+  AgentsControlPlaneMemoriesIndexRouteImport.update({
+    id: '/agents-control-plane/memories/',
+    path: '/agents-control-plane/memories/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneImplementationSpecsIndexRoute =
+  AgentsControlPlaneImplementationSpecsIndexRouteImport.update({
+    id: '/agents-control-plane/implementation-specs/',
+    path: '/agents-control-plane/implementation-specs/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneImplementationSourcesIndexRoute =
+  AgentsControlPlaneImplementationSourcesIndexRouteImport.update({
+    id: '/agents-control-plane/implementation-sources/',
+    path: '/agents-control-plane/implementation-sources/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneAgentsIndexRoute =
+  AgentsControlPlaneAgentsIndexRouteImport.update({
+    id: '/agents-control-plane/agents/',
+    path: '/agents-control-plane/agents/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneAgentRunsIndexRoute =
+  AgentsControlPlaneAgentRunsIndexRouteImport.update({
+    id: '/agents-control-plane/agent-runs/',
+    path: '/agents-control-plane/agent-runs/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneAgentProvidersIndexRoute =
+  AgentsControlPlaneAgentProvidersIndexRouteImport.update({
+    id: '/agents-control-plane/agent-providers/',
+    path: '/agents-control-plane/agent-providers/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const V1RunsIdRoute = V1RunsIdRouteImport.update({
   id: '/v1/runs/$id',
   path: '/v1/runs/$id',
@@ -359,10 +416,40 @@ const ApiAgentsEventsRoute = ApiAgentsEventsRouteImport.update({
   path: '/api/agents/events',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiAgentsImplementationSourcesWebhooksProviderRoute =
-  ApiAgentsImplementationSourcesWebhooksProviderRouteImport.update({
-    id: '/api/agents/implementation-sources/webhooks/$provider',
-    path: '/api/agents/implementation-sources/webhooks/$provider',
+const AgentsControlPlaneMemoriesNameRoute =
+  AgentsControlPlaneMemoriesNameRouteImport.update({
+    id: '/agents-control-plane/memories/$name',
+    path: '/agents-control-plane/memories/$name',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneImplementationSpecsNameRoute =
+  AgentsControlPlaneImplementationSpecsNameRouteImport.update({
+    id: '/agents-control-plane/implementation-specs/$name',
+    path: '/agents-control-plane/implementation-specs/$name',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneImplementationSourcesNameRoute =
+  AgentsControlPlaneImplementationSourcesNameRouteImport.update({
+    id: '/agents-control-plane/implementation-sources/$name',
+    path: '/agents-control-plane/implementation-sources/$name',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneAgentsNameRoute =
+  AgentsControlPlaneAgentsNameRouteImport.update({
+    id: '/agents-control-plane/agents/$name',
+    path: '/agents-control-plane/agents/$name',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneAgentRunsNameRoute =
+  AgentsControlPlaneAgentRunsNameRouteImport.update({
+    id: '/agents-control-plane/agent-runs/$name',
+    path: '/agents-control-plane/agent-runs/$name',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AgentsControlPlaneAgentProvidersNameRoute =
+  AgentsControlPlaneAgentProvidersNameRouteImport.update({
+    id: '/agents-control-plane/agent-providers/$name',
+    path: '/agents-control-plane/agent-providers/$name',
     getParentRoute: () => rootRouteImport,
   } as any)
 const OpenaiV1ChatCompletionsRoute = OpenaiV1ChatCompletionsRouteImport.update({
@@ -435,11 +522,35 @@ const ApiCodexRunsListRoute = ApiCodexRunsListRouteImport.update({
   path: '/list',
   getParentRoute: () => ApiCodexRunsRoute,
 } as any)
+const ApiAgentsControlPlaneResourcesRoute =
+  ApiAgentsControlPlaneResourcesRouteImport.update({
+    id: '/api/agents/control-plane/resources',
+    path: '/api/agents/control-plane/resources',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiAgentsControlPlaneResourceRoute =
+  ApiAgentsControlPlaneResourceRouteImport.update({
+    id: '/api/agents/control-plane/resource',
+    path: '/api/agents/control-plane/resource',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiAgentsControlPlaneEventsRoute =
+  ApiAgentsControlPlaneEventsRouteImport.update({
+    id: '/api/agents/control-plane/events',
+    path: '/api/agents/control-plane/events',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const GithubPullsOwnerRepoNumberRoute =
   GithubPullsOwnerRepoNumberRouteImport.update({
     id: '/$owner/$repo/$number',
     path: '/$owner/$repo/$number',
     getParentRoute: () => GithubPullsRoute,
+  } as any)
+const ApiAgentsImplementationSourcesWebhooksProviderRoute =
+  ApiAgentsImplementationSourcesWebhooksProviderRouteImport.update({
+    id: '/api/agents/implementation-sources/webhooks/$provider',
+    path: '/api/agents/implementation-sources/webhooks/$provider',
+    getParentRoute: () => rootRouteImport,
   } as any)
 const ApiGithubPullsOwnerRepoNumberRoute =
   ApiGithubPullsOwnerRepoNumberRouteImport.update({
@@ -524,11 +635,17 @@ export interface FileRoutesByFullPath {
   '/v1/memory-queries': typeof V1MemoryQueriesRoute
   '/v1/orchestration-runs': typeof V1OrchestrationRunsRouteWithChildren
   '/v1/orchestrations': typeof V1OrchestrationsRouteWithChildren
+  '/agents-control-plane': typeof AgentsControlPlaneIndexRoute
   '/agents': typeof AgentsIndexRoute
   '/atlas': typeof AtlasIndexRoute
   '/terminals': typeof TerminalsIndexRoute
+  '/agents-control-plane/agent-providers/$name': typeof AgentsControlPlaneAgentProvidersNameRoute
+  '/agents-control-plane/agent-runs/$name': typeof AgentsControlPlaneAgentRunsNameRoute
+  '/agents-control-plane/agents/$name': typeof AgentsControlPlaneAgentsNameRoute
+  '/agents-control-plane/implementation-sources/$name': typeof AgentsControlPlaneImplementationSourcesNameRoute
+  '/agents-control-plane/implementation-specs/$name': typeof AgentsControlPlaneImplementationSpecsNameRoute
+  '/agents-control-plane/memories/$name': typeof AgentsControlPlaneMemoriesNameRoute
   '/api/agents/events': typeof ApiAgentsEventsRoute
-  '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/atlas/ast': typeof ApiAtlasAstRoute
   '/api/atlas/file': typeof ApiAtlasFileRoute
   '/api/atlas/indexed': typeof ApiAtlasIndexedRoute
@@ -550,8 +667,17 @@ export interface FileRoutesByFullPath {
   '/v1/orchestration-runs/$id': typeof V1OrchestrationRunsIdRoute
   '/v1/orchestrations/$id': typeof V1OrchestrationsIdRoute
   '/v1/runs/$id': typeof V1RunsIdRoute
+  '/agents-control-plane/agent-providers': typeof AgentsControlPlaneAgentProvidersIndexRoute
+  '/agents-control-plane/agent-runs': typeof AgentsControlPlaneAgentRunsIndexRoute
+  '/agents-control-plane/agents': typeof AgentsControlPlaneAgentsIndexRoute
+  '/agents-control-plane/implementation-sources': typeof AgentsControlPlaneImplementationSourcesIndexRoute
+  '/agents-control-plane/implementation-specs': typeof AgentsControlPlaneImplementationSpecsIndexRoute
+  '/agents-control-plane/memories': typeof AgentsControlPlaneMemoriesIndexRoute
   '/github/pulls/': typeof GithubPullsIndexRoute
   '/terminals/$sessionId/': typeof TerminalsSessionIdIndexRoute
+  '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
+  '/api/agents/control-plane/resource': typeof ApiAgentsControlPlaneResourceRoute
+  '/api/agents/control-plane/resources': typeof ApiAgentsControlPlaneResourcesRoute
   '/api/codex/runs/list': typeof ApiCodexRunsListRoute
   '/api/codex/runs/recent': typeof ApiCodexRunsRecentRoute
   '/api/terminals/$sessionId/delete': typeof ApiTerminalsSessionIdDeleteRoute
@@ -565,6 +691,7 @@ export interface FileRoutesByFullPath {
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
   '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
+  '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/github/pulls/$owner/$repo/$number/checks': typeof ApiGithubPullsOwnerRepoNumberChecksRoute
@@ -602,11 +729,17 @@ export interface FileRoutesByTo {
   '/v1/memory-queries': typeof V1MemoryQueriesRoute
   '/v1/orchestration-runs': typeof V1OrchestrationRunsRouteWithChildren
   '/v1/orchestrations': typeof V1OrchestrationsRouteWithChildren
+  '/agents-control-plane': typeof AgentsControlPlaneIndexRoute
   '/agents': typeof AgentsIndexRoute
   '/atlas': typeof AtlasIndexRoute
   '/terminals': typeof TerminalsIndexRoute
+  '/agents-control-plane/agent-providers/$name': typeof AgentsControlPlaneAgentProvidersNameRoute
+  '/agents-control-plane/agent-runs/$name': typeof AgentsControlPlaneAgentRunsNameRoute
+  '/agents-control-plane/agents/$name': typeof AgentsControlPlaneAgentsNameRoute
+  '/agents-control-plane/implementation-sources/$name': typeof AgentsControlPlaneImplementationSourcesNameRoute
+  '/agents-control-plane/implementation-specs/$name': typeof AgentsControlPlaneImplementationSpecsNameRoute
+  '/agents-control-plane/memories/$name': typeof AgentsControlPlaneMemoriesNameRoute
   '/api/agents/events': typeof ApiAgentsEventsRoute
-  '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/atlas/ast': typeof ApiAtlasAstRoute
   '/api/atlas/file': typeof ApiAtlasFileRoute
   '/api/atlas/indexed': typeof ApiAtlasIndexedRoute
@@ -628,8 +761,17 @@ export interface FileRoutesByTo {
   '/v1/orchestration-runs/$id': typeof V1OrchestrationRunsIdRoute
   '/v1/orchestrations/$id': typeof V1OrchestrationsIdRoute
   '/v1/runs/$id': typeof V1RunsIdRoute
+  '/agents-control-plane/agent-providers': typeof AgentsControlPlaneAgentProvidersIndexRoute
+  '/agents-control-plane/agent-runs': typeof AgentsControlPlaneAgentRunsIndexRoute
+  '/agents-control-plane/agents': typeof AgentsControlPlaneAgentsIndexRoute
+  '/agents-control-plane/implementation-sources': typeof AgentsControlPlaneImplementationSourcesIndexRoute
+  '/agents-control-plane/implementation-specs': typeof AgentsControlPlaneImplementationSpecsIndexRoute
+  '/agents-control-plane/memories': typeof AgentsControlPlaneMemoriesIndexRoute
   '/github/pulls': typeof GithubPullsIndexRoute
   '/terminals/$sessionId': typeof TerminalsSessionIdIndexRoute
+  '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
+  '/api/agents/control-plane/resource': typeof ApiAgentsControlPlaneResourceRoute
+  '/api/agents/control-plane/resources': typeof ApiAgentsControlPlaneResourcesRoute
   '/api/codex/runs/list': typeof ApiCodexRunsListRoute
   '/api/codex/runs/recent': typeof ApiCodexRunsRecentRoute
   '/api/terminals/$sessionId/delete': typeof ApiTerminalsSessionIdDeleteRoute
@@ -643,6 +785,7 @@ export interface FileRoutesByTo {
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
   '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
+  '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/github/pulls/$owner/$repo/$number/checks': typeof ApiGithubPullsOwnerRepoNumberChecksRoute
@@ -683,11 +826,17 @@ export interface FileRoutesById {
   '/v1/memory-queries': typeof V1MemoryQueriesRoute
   '/v1/orchestration-runs': typeof V1OrchestrationRunsRouteWithChildren
   '/v1/orchestrations': typeof V1OrchestrationsRouteWithChildren
+  '/agents-control-plane/': typeof AgentsControlPlaneIndexRoute
   '/agents/': typeof AgentsIndexRoute
   '/atlas/': typeof AtlasIndexRoute
   '/terminals/': typeof TerminalsIndexRoute
+  '/agents-control-plane/agent-providers/$name': typeof AgentsControlPlaneAgentProvidersNameRoute
+  '/agents-control-plane/agent-runs/$name': typeof AgentsControlPlaneAgentRunsNameRoute
+  '/agents-control-plane/agents/$name': typeof AgentsControlPlaneAgentsNameRoute
+  '/agents-control-plane/implementation-sources/$name': typeof AgentsControlPlaneImplementationSourcesNameRoute
+  '/agents-control-plane/implementation-specs/$name': typeof AgentsControlPlaneImplementationSpecsNameRoute
+  '/agents-control-plane/memories/$name': typeof AgentsControlPlaneMemoriesNameRoute
   '/api/agents/events': typeof ApiAgentsEventsRoute
-  '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/atlas/ast': typeof ApiAtlasAstRoute
   '/api/atlas/file': typeof ApiAtlasFileRoute
   '/api/atlas/indexed': typeof ApiAtlasIndexedRoute
@@ -709,8 +858,17 @@ export interface FileRoutesById {
   '/v1/orchestration-runs/$id': typeof V1OrchestrationRunsIdRoute
   '/v1/orchestrations/$id': typeof V1OrchestrationsIdRoute
   '/v1/runs/$id': typeof V1RunsIdRoute
+  '/agents-control-plane/agent-providers/': typeof AgentsControlPlaneAgentProvidersIndexRoute
+  '/agents-control-plane/agent-runs/': typeof AgentsControlPlaneAgentRunsIndexRoute
+  '/agents-control-plane/agents/': typeof AgentsControlPlaneAgentsIndexRoute
+  '/agents-control-plane/implementation-sources/': typeof AgentsControlPlaneImplementationSourcesIndexRoute
+  '/agents-control-plane/implementation-specs/': typeof AgentsControlPlaneImplementationSpecsIndexRoute
+  '/agents-control-plane/memories/': typeof AgentsControlPlaneMemoriesIndexRoute
   '/github/pulls/': typeof GithubPullsIndexRoute
   '/terminals/$sessionId/': typeof TerminalsSessionIdIndexRoute
+  '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
+  '/api/agents/control-plane/resource': typeof ApiAgentsControlPlaneResourceRoute
+  '/api/agents/control-plane/resources': typeof ApiAgentsControlPlaneResourcesRoute
   '/api/codex/runs/list': typeof ApiCodexRunsListRoute
   '/api/codex/runs/recent': typeof ApiCodexRunsRecentRoute
   '/api/terminals/$sessionId/delete': typeof ApiTerminalsSessionIdDeleteRoute
@@ -724,6 +882,7 @@ export interface FileRoutesById {
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
   '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
+  '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/github/pulls/$owner/$repo/$number/checks': typeof ApiGithubPullsOwnerRepoNumberChecksRoute
@@ -765,11 +924,17 @@ export interface FileRouteTypes {
     | '/v1/memory-queries'
     | '/v1/orchestration-runs'
     | '/v1/orchestrations'
+    | '/agents-control-plane'
     | '/agents'
     | '/atlas'
     | '/terminals'
+    | '/agents-control-plane/agent-providers/$name'
+    | '/agents-control-plane/agent-runs/$name'
+    | '/agents-control-plane/agents/$name'
+    | '/agents-control-plane/implementation-sources/$name'
+    | '/agents-control-plane/implementation-specs/$name'
+    | '/agents-control-plane/memories/$name'
     | '/api/agents/events'
-    | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/atlas/ast'
     | '/api/atlas/file'
     | '/api/atlas/indexed'
@@ -791,8 +956,17 @@ export interface FileRouteTypes {
     | '/v1/orchestration-runs/$id'
     | '/v1/orchestrations/$id'
     | '/v1/runs/$id'
+    | '/agents-control-plane/agent-providers'
+    | '/agents-control-plane/agent-runs'
+    | '/agents-control-plane/agents'
+    | '/agents-control-plane/implementation-sources'
+    | '/agents-control-plane/implementation-specs'
+    | '/agents-control-plane/memories'
     | '/github/pulls/'
     | '/terminals/$sessionId/'
+    | '/api/agents/control-plane/events'
+    | '/api/agents/control-plane/resource'
+    | '/api/agents/control-plane/resources'
     | '/api/codex/runs/list'
     | '/api/codex/runs/recent'
     | '/api/terminals/$sessionId/delete'
@@ -806,6 +980,7 @@ export interface FileRouteTypes {
     | '/api/torghut/ta/latest'
     | '/api/torghut/ta/signals'
     | '/openai/v1/chat/completions'
+    | '/api/agents/implementation-sources/webhooks/$provider'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number/checks'
@@ -843,11 +1018,17 @@ export interface FileRouteTypes {
     | '/v1/memory-queries'
     | '/v1/orchestration-runs'
     | '/v1/orchestrations'
+    | '/agents-control-plane'
     | '/agents'
     | '/atlas'
     | '/terminals'
+    | '/agents-control-plane/agent-providers/$name'
+    | '/agents-control-plane/agent-runs/$name'
+    | '/agents-control-plane/agents/$name'
+    | '/agents-control-plane/implementation-sources/$name'
+    | '/agents-control-plane/implementation-specs/$name'
+    | '/agents-control-plane/memories/$name'
     | '/api/agents/events'
-    | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/atlas/ast'
     | '/api/atlas/file'
     | '/api/atlas/indexed'
@@ -869,8 +1050,17 @@ export interface FileRouteTypes {
     | '/v1/orchestration-runs/$id'
     | '/v1/orchestrations/$id'
     | '/v1/runs/$id'
+    | '/agents-control-plane/agent-providers'
+    | '/agents-control-plane/agent-runs'
+    | '/agents-control-plane/agents'
+    | '/agents-control-plane/implementation-sources'
+    | '/agents-control-plane/implementation-specs'
+    | '/agents-control-plane/memories'
     | '/github/pulls'
     | '/terminals/$sessionId'
+    | '/api/agents/control-plane/events'
+    | '/api/agents/control-plane/resource'
+    | '/api/agents/control-plane/resources'
     | '/api/codex/runs/list'
     | '/api/codex/runs/recent'
     | '/api/terminals/$sessionId/delete'
@@ -884,6 +1074,7 @@ export interface FileRouteTypes {
     | '/api/torghut/ta/latest'
     | '/api/torghut/ta/signals'
     | '/openai/v1/chat/completions'
+    | '/api/agents/implementation-sources/webhooks/$provider'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number/checks'
@@ -923,11 +1114,17 @@ export interface FileRouteTypes {
     | '/v1/memory-queries'
     | '/v1/orchestration-runs'
     | '/v1/orchestrations'
+    | '/agents-control-plane/'
     | '/agents/'
     | '/atlas/'
     | '/terminals/'
+    | '/agents-control-plane/agent-providers/$name'
+    | '/agents-control-plane/agent-runs/$name'
+    | '/agents-control-plane/agents/$name'
+    | '/agents-control-plane/implementation-sources/$name'
+    | '/agents-control-plane/implementation-specs/$name'
+    | '/agents-control-plane/memories/$name'
     | '/api/agents/events'
-    | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/atlas/ast'
     | '/api/atlas/file'
     | '/api/atlas/indexed'
@@ -949,8 +1146,17 @@ export interface FileRouteTypes {
     | '/v1/orchestration-runs/$id'
     | '/v1/orchestrations/$id'
     | '/v1/runs/$id'
+    | '/agents-control-plane/agent-providers/'
+    | '/agents-control-plane/agent-runs/'
+    | '/agents-control-plane/agents/'
+    | '/agents-control-plane/implementation-sources/'
+    | '/agents-control-plane/implementation-specs/'
+    | '/agents-control-plane/memories/'
     | '/github/pulls/'
     | '/terminals/$sessionId/'
+    | '/api/agents/control-plane/events'
+    | '/api/agents/control-plane/resource'
+    | '/api/agents/control-plane/resources'
     | '/api/codex/runs/list'
     | '/api/codex/runs/recent'
     | '/api/terminals/$sessionId/delete'
@@ -964,6 +1170,7 @@ export interface FileRouteTypes {
     | '/api/torghut/ta/latest'
     | '/api/torghut/ta/signals'
     | '/openai/v1/chat/completions'
+    | '/api/agents/implementation-sources/webhooks/$provider'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number/checks'
@@ -1004,11 +1211,17 @@ export interface RootRouteChildren {
   V1MemoryQueriesRoute: typeof V1MemoryQueriesRoute
   V1OrchestrationRunsRoute: typeof V1OrchestrationRunsRouteWithChildren
   V1OrchestrationsRoute: typeof V1OrchestrationsRouteWithChildren
+  AgentsControlPlaneIndexRoute: typeof AgentsControlPlaneIndexRoute
   AgentsIndexRoute: typeof AgentsIndexRoute
   AtlasIndexRoute: typeof AtlasIndexRoute
   TerminalsIndexRoute: typeof TerminalsIndexRoute
+  AgentsControlPlaneAgentProvidersNameRoute: typeof AgentsControlPlaneAgentProvidersNameRoute
+  AgentsControlPlaneAgentRunsNameRoute: typeof AgentsControlPlaneAgentRunsNameRoute
+  AgentsControlPlaneAgentsNameRoute: typeof AgentsControlPlaneAgentsNameRoute
+  AgentsControlPlaneImplementationSourcesNameRoute: typeof AgentsControlPlaneImplementationSourcesNameRoute
+  AgentsControlPlaneImplementationSpecsNameRoute: typeof AgentsControlPlaneImplementationSpecsNameRoute
+  AgentsControlPlaneMemoriesNameRoute: typeof AgentsControlPlaneMemoriesNameRoute
   ApiAgentsEventsRoute: typeof ApiAgentsEventsRoute
-  ApiAgentsImplementationSourcesWebhooksProviderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   ApiAtlasAstRoute: typeof ApiAtlasAstRoute
   ApiAtlasFileRoute: typeof ApiAtlasFileRoute
   ApiAtlasIndexedRoute: typeof ApiAtlasIndexedRoute
@@ -1023,10 +1236,20 @@ export interface RootRouteChildren {
   ApiTorghutSymbolsRoute: typeof ApiTorghutSymbolsRouteWithChildren
   OpenaiV1ModelsRoute: typeof OpenaiV1ModelsRoute
   V1RunsIdRoute: typeof V1RunsIdRoute
+  AgentsControlPlaneAgentProvidersIndexRoute: typeof AgentsControlPlaneAgentProvidersIndexRoute
+  AgentsControlPlaneAgentRunsIndexRoute: typeof AgentsControlPlaneAgentRunsIndexRoute
+  AgentsControlPlaneAgentsIndexRoute: typeof AgentsControlPlaneAgentsIndexRoute
+  AgentsControlPlaneImplementationSourcesIndexRoute: typeof AgentsControlPlaneImplementationSourcesIndexRoute
+  AgentsControlPlaneImplementationSpecsIndexRoute: typeof AgentsControlPlaneImplementationSpecsIndexRoute
+  AgentsControlPlaneMemoriesIndexRoute: typeof AgentsControlPlaneMemoriesIndexRoute
+  ApiAgentsControlPlaneEventsRoute: typeof ApiAgentsControlPlaneEventsRoute
+  ApiAgentsControlPlaneResourceRoute: typeof ApiAgentsControlPlaneResourceRoute
+  ApiAgentsControlPlaneResourcesRoute: typeof ApiAgentsControlPlaneResourcesRoute
   ApiTorghutTaBarsRoute: typeof ApiTorghutTaBarsRoute
   ApiTorghutTaLatestRoute: typeof ApiTorghutTaLatestRoute
   ApiTorghutTaSignalsRoute: typeof ApiTorghutTaSignalsRoute
   OpenaiV1ChatCompletionsRoute: typeof OpenaiV1ChatCompletionsRoute
+  ApiAgentsImplementationSourcesWebhooksProviderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1078,6 +1301,13 @@ declare module '@tanstack/react-router' {
       path: '/agents'
       fullPath: '/agents'
       preLoaderRoute: typeof AgentsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/': {
+      id: '/agents-control-plane/'
+      path: '/agents-control-plane'
+      fullPath: '/agents-control-plane'
+      preLoaderRoute: typeof AgentsControlPlaneIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/v1/orchestrations': {
@@ -1255,6 +1485,48 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GithubPullsIndexRouteImport
       parentRoute: typeof GithubPullsRoute
     }
+    '/agents-control-plane/memories/': {
+      id: '/agents-control-plane/memories/'
+      path: '/agents-control-plane/memories'
+      fullPath: '/agents-control-plane/memories'
+      preLoaderRoute: typeof AgentsControlPlaneMemoriesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/implementation-specs/': {
+      id: '/agents-control-plane/implementation-specs/'
+      path: '/agents-control-plane/implementation-specs'
+      fullPath: '/agents-control-plane/implementation-specs'
+      preLoaderRoute: typeof AgentsControlPlaneImplementationSpecsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/implementation-sources/': {
+      id: '/agents-control-plane/implementation-sources/'
+      path: '/agents-control-plane/implementation-sources'
+      fullPath: '/agents-control-plane/implementation-sources'
+      preLoaderRoute: typeof AgentsControlPlaneImplementationSourcesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/agents/': {
+      id: '/agents-control-plane/agents/'
+      path: '/agents-control-plane/agents'
+      fullPath: '/agents-control-plane/agents'
+      preLoaderRoute: typeof AgentsControlPlaneAgentsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/agent-runs/': {
+      id: '/agents-control-plane/agent-runs/'
+      path: '/agents-control-plane/agent-runs'
+      fullPath: '/agents-control-plane/agent-runs'
+      preLoaderRoute: typeof AgentsControlPlaneAgentRunsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/agent-providers/': {
+      id: '/agents-control-plane/agent-providers/'
+      path: '/agents-control-plane/agent-providers'
+      fullPath: '/agents-control-plane/agent-providers'
+      preLoaderRoute: typeof AgentsControlPlaneAgentProvidersIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/v1/runs/$id': {
       id: '/v1/runs/$id'
       path: '/v1/runs/$id'
@@ -1409,11 +1681,46 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAgentsEventsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/agents/implementation-sources/webhooks/$provider': {
-      id: '/api/agents/implementation-sources/webhooks/$provider'
-      path: '/api/agents/implementation-sources/webhooks/$provider'
-      fullPath: '/api/agents/implementation-sources/webhooks/$provider'
-      preLoaderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRouteImport
+    '/agents-control-plane/memories/$name': {
+      id: '/agents-control-plane/memories/$name'
+      path: '/agents-control-plane/memories/$name'
+      fullPath: '/agents-control-plane/memories/$name'
+      preLoaderRoute: typeof AgentsControlPlaneMemoriesNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/implementation-specs/$name': {
+      id: '/agents-control-plane/implementation-specs/$name'
+      path: '/agents-control-plane/implementation-specs/$name'
+      fullPath: '/agents-control-plane/implementation-specs/$name'
+      preLoaderRoute: typeof AgentsControlPlaneImplementationSpecsNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/implementation-sources/$name': {
+      id: '/agents-control-plane/implementation-sources/$name'
+      path: '/agents-control-plane/implementation-sources/$name'
+      fullPath: '/agents-control-plane/implementation-sources/$name'
+      preLoaderRoute: typeof AgentsControlPlaneImplementationSourcesNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/agents/$name': {
+      id: '/agents-control-plane/agents/$name'
+      path: '/agents-control-plane/agents/$name'
+      fullPath: '/agents-control-plane/agents/$name'
+      preLoaderRoute: typeof AgentsControlPlaneAgentsNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/agent-runs/$name': {
+      id: '/agents-control-plane/agent-runs/$name'
+      path: '/agents-control-plane/agent-runs/$name'
+      fullPath: '/agents-control-plane/agent-runs/$name'
+      preLoaderRoute: typeof AgentsControlPlaneAgentRunsNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents-control-plane/agent-providers/$name': {
+      id: '/agents-control-plane/agent-providers/$name'
+      path: '/agents-control-plane/agent-providers/$name'
+      fullPath: '/agents-control-plane/agent-providers/$name'
+      preLoaderRoute: typeof AgentsControlPlaneAgentProvidersNameRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/openai/v1/chat/completions': {
@@ -1507,12 +1814,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiCodexRunsListRouteImport
       parentRoute: typeof ApiCodexRunsRoute
     }
+    '/api/agents/control-plane/resources': {
+      id: '/api/agents/control-plane/resources'
+      path: '/api/agents/control-plane/resources'
+      fullPath: '/api/agents/control-plane/resources'
+      preLoaderRoute: typeof ApiAgentsControlPlaneResourcesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agents/control-plane/resource': {
+      id: '/api/agents/control-plane/resource'
+      path: '/api/agents/control-plane/resource'
+      fullPath: '/api/agents/control-plane/resource'
+      preLoaderRoute: typeof ApiAgentsControlPlaneResourceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agents/control-plane/events': {
+      id: '/api/agents/control-plane/events'
+      path: '/api/agents/control-plane/events'
+      fullPath: '/api/agents/control-plane/events'
+      preLoaderRoute: typeof ApiAgentsControlPlaneEventsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/github/pulls/$owner/$repo/$number': {
       id: '/github/pulls/$owner/$repo/$number'
       path: '/$owner/$repo/$number'
       fullPath: '/github/pulls/$owner/$repo/$number'
       preLoaderRoute: typeof GithubPullsOwnerRepoNumberRouteImport
       parentRoute: typeof GithubPullsRoute
+    }
+    '/api/agents/implementation-sources/webhooks/$provider': {
+      id: '/api/agents/implementation-sources/webhooks/$provider'
+      path: '/api/agents/implementation-sources/webhooks/$provider'
+      fullPath: '/api/agents/implementation-sources/webhooks/$provider'
+      preLoaderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/github/pulls/$owner/$repo/$number': {
       id: '/api/github/pulls/$owner/$repo/$number'
@@ -1814,11 +2149,20 @@ const rootRouteChildren: RootRouteChildren = {
   V1MemoryQueriesRoute: V1MemoryQueriesRoute,
   V1OrchestrationRunsRoute: V1OrchestrationRunsRouteWithChildren,
   V1OrchestrationsRoute: V1OrchestrationsRouteWithChildren,
+  AgentsControlPlaneIndexRoute: AgentsControlPlaneIndexRoute,
   AgentsIndexRoute: AgentsIndexRoute,
   AtlasIndexRoute: AtlasIndexRoute,
   TerminalsIndexRoute: TerminalsIndexRoute,
+  AgentsControlPlaneAgentProvidersNameRoute:
+    AgentsControlPlaneAgentProvidersNameRoute,
+  AgentsControlPlaneAgentRunsNameRoute: AgentsControlPlaneAgentRunsNameRoute,
+  AgentsControlPlaneAgentsNameRoute: AgentsControlPlaneAgentsNameRoute,
+  AgentsControlPlaneImplementationSourcesNameRoute:
+    AgentsControlPlaneImplementationSourcesNameRoute,
+  AgentsControlPlaneImplementationSpecsNameRoute:
+    AgentsControlPlaneImplementationSpecsNameRoute,
+  AgentsControlPlaneMemoriesNameRoute: AgentsControlPlaneMemoriesNameRoute,
   ApiAgentsEventsRoute: ApiAgentsEventsRoute,
-  ApiAgentsImplementationSourcesWebhooksProviderRoute: ApiAgentsImplementationSourcesWebhooksProviderRoute,
   ApiAtlasAstRoute: ApiAtlasAstRoute,
   ApiAtlasFileRoute: ApiAtlasFileRoute,
   ApiAtlasIndexedRoute: ApiAtlasIndexedRoute,
@@ -1833,10 +2177,24 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTorghutSymbolsRoute: ApiTorghutSymbolsRouteWithChildren,
   OpenaiV1ModelsRoute: OpenaiV1ModelsRoute,
   V1RunsIdRoute: V1RunsIdRoute,
+  AgentsControlPlaneAgentProvidersIndexRoute:
+    AgentsControlPlaneAgentProvidersIndexRoute,
+  AgentsControlPlaneAgentRunsIndexRoute: AgentsControlPlaneAgentRunsIndexRoute,
+  AgentsControlPlaneAgentsIndexRoute: AgentsControlPlaneAgentsIndexRoute,
+  AgentsControlPlaneImplementationSourcesIndexRoute:
+    AgentsControlPlaneImplementationSourcesIndexRoute,
+  AgentsControlPlaneImplementationSpecsIndexRoute:
+    AgentsControlPlaneImplementationSpecsIndexRoute,
+  AgentsControlPlaneMemoriesIndexRoute: AgentsControlPlaneMemoriesIndexRoute,
+  ApiAgentsControlPlaneEventsRoute: ApiAgentsControlPlaneEventsRoute,
+  ApiAgentsControlPlaneResourceRoute: ApiAgentsControlPlaneResourceRoute,
+  ApiAgentsControlPlaneResourcesRoute: ApiAgentsControlPlaneResourcesRoute,
   ApiTorghutTaBarsRoute: ApiTorghutTaBarsRoute,
   ApiTorghutTaLatestRoute: ApiTorghutTaLatestRoute,
   ApiTorghutTaSignalsRoute: ApiTorghutTaSignalsRoute,
   OpenaiV1ChatCompletionsRoute: OpenaiV1ChatCompletionsRoute,
+  ApiAgentsImplementationSourcesWebhooksProviderRoute:
+    ApiAgentsImplementationSourcesWebhooksProviderRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/services/jangar/src/routes/v1/orchestration-runs.ts
+++ b/services/jangar/src/routes/v1/orchestration-runs.ts
@@ -166,7 +166,7 @@ export const postOrchestrationRunsHandler = async (
     const record = await store.createOrchestrationRun({
       orchestrationName: parsed.orchestrationRef.name,
       deliveryId,
-      provider: 'argo',
+      provider: 'workflow',
       status: statusPhase,
       externalRunId,
       payload: { request: payload, resource: applied, status: asRecord(applied.status) ?? {} },

--- a/services/jangar/src/server/__tests__/github-review-ingest.test.ts
+++ b/services/jangar/src/server/__tests__/github-review-ingest.test.ts
@@ -1,22 +1,24 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { GithubWebhookEvent } from '../github-review-ingest'
 import type { GithubReviewStore } from '../github-review-store'
 
-vi.mock('../github-worktree-snapshot', () => ({
-  refreshWorktreeSnapshot: vi.fn(async () => ({
-    repository: 'proompteng/lab',
-    prNumber: 0,
-    commitSha: 'mock',
-    baseSha: 'base',
-    worktreeName: 'mock',
-    worktreePath: '/tmp/mock',
-    fileCount: 0,
-  })),
-}))
-
 const globalState = globalThis as typeof globalThis & {
   __githubReviewStoreMock?: GithubReviewStore
+  __githubWorktreeSnapshotMock?: (input: {
+    repository: string
+    prNumber: number
+    headRef: string
+    baseRef: string
+  }) => Promise<{
+    repository: string
+    prNumber: number
+    commitSha: string
+    baseSha: string
+    worktreeName: string
+    worktreePath: string
+    fileCount: number
+  }>
 }
 
 const buildStore = (): GithubReviewStore => ({
@@ -63,6 +65,19 @@ const requireHandler = async () => {
 beforeEach(() => {
   vi.clearAllMocks()
   globalState.__githubReviewStoreMock = buildStore()
+  globalState.__githubWorktreeSnapshotMock = vi.fn(async () => ({
+    repository: 'proompteng/lab',
+    prNumber: 0,
+    commitSha: 'mock',
+    baseSha: 'base',
+    worktreeName: 'mock',
+    worktreePath: '/tmp/mock',
+    fileCount: 0,
+  }))
+})
+
+afterEach(() => {
+  delete globalState.__githubWorktreeSnapshotMock
 })
 
 describe('github review ingest', () => {

--- a/services/jangar/src/server/agent-comms-runtime.ts
+++ b/services/jangar/src/server/agent-comms-runtime.ts
@@ -1,12 +1,16 @@
 import { startAgentCommsSubscriber } from '~/server/agent-comms-subscriber'
 import { startAgentsController } from '~/server/agents-controller'
+import { startOrchestrationController } from '~/server/orchestration-controller'
 import { startPrimitivesReconciler } from '~/server/primitives-reconciler'
+import { startSupportingPrimitivesController } from '~/server/supporting-primitives-controller'
 
 export const ensureAgentCommsRuntime = () => {
   void startAgentCommsSubscriber().catch((error) => {
     console.warn('Agent comms subscriber failed to start', error)
   })
   void startAgentsController()
+  void startOrchestrationController()
+  void startSupportingPrimitivesController()
   startPrimitivesReconciler()
 }
 

--- a/services/jangar/src/server/agents-controller.ts
+++ b/services/jangar/src/server/agents-controller.ts
@@ -3,9 +3,10 @@ import { createHash } from 'node:crypto'
 import { createTemporalClient, loadTemporalConfig, temporalCallOptions } from '@proompteng/temporal-bun-sdk'
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
+import { startResourceWatch } from '~/server/kube-watch'
 
 const DEFAULT_NAMESPACES = ['agents']
-const DEFAULT_INTERVAL_SECONDS = 15
+const DEFAULT_INTERVAL_SECONDS = 0
 const DEFAULT_CONCURRENCY = {
   perNamespace: 10,
   perAgent: 5,
@@ -72,10 +73,26 @@ type WorkflowStatus = {
   lastTransitionTime: string
   steps: WorkflowStepStatus[]
 }
+
+type NamespaceState = {
+  agents: Map<string, Record<string, unknown>>
+  providers: Map<string, Record<string, unknown>>
+  specs: Map<string, Record<string, unknown>>
+  memories: Map<string, Record<string, unknown>>
+  runs: Map<string, Record<string, unknown>>
+}
+
+type ControllerState = {
+  namespaces: Map<string, NamespaceState>
+}
+
 let started = false
 let intervalRef: NodeJS.Timeout | null = null
 let reconciling = false
 let temporalClientPromise: ReturnType<typeof createTemporalClient> | null = null
+let watchHandles: Array<{ stop: () => void }> = []
+let controllerState: ControllerState | null = null
+const namespaceQueues = new Map<string, Promise<void>>()
 
 const nowIso = () => new Date().toISOString()
 
@@ -128,7 +145,7 @@ const resolveNamespaces = async () => {
 const parseIntervalSeconds = () => {
   const raw = process.env.JANGAR_AGENTS_CONTROLLER_INTERVAL_SECONDS
   const parsed = raw ? Number.parseInt(raw, 10) : NaN
-  if (Number.isFinite(parsed) && parsed > 0) return parsed
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed
   return DEFAULT_INTERVAL_SECONDS
 }
 
@@ -585,6 +602,73 @@ const resolveMemory = (
     return memories.find((memory) => asString(readNested(memory, ['metadata', 'name'])) === agentRef) ?? null
   }
   return selectDefaultMemory(memories)
+}
+
+const createNamespaceState = (): NamespaceState => ({
+  agents: new Map(),
+  providers: new Map(),
+  specs: new Map(),
+  memories: new Map(),
+  runs: new Map(),
+})
+
+const ensureNamespaceState = (state: ControllerState, namespace: string) => {
+  const existing = state.namespaces.get(namespace)
+  if (existing) return existing
+  const created = createNamespaceState()
+  state.namespaces.set(namespace, created)
+  return created
+}
+
+const updateStateMap = (
+  map: Map<string, Record<string, unknown>>,
+  eventType: string | undefined,
+  resource: Record<string, unknown>,
+) => {
+  const name = asString(readNested(resource, ['metadata', 'name']))
+  if (!name) return
+  if (eventType === 'DELETED') {
+    map.delete(name)
+    return
+  }
+  map.set(name, resource)
+}
+
+const snapshotNamespace = (state: NamespaceState) => ({
+  agents: Array.from(state.agents.values()),
+  providers: Array.from(state.providers.values()),
+  specs: Array.from(state.specs.values()),
+  memories: Array.from(state.memories.values()),
+  runs: Array.from(state.runs.values()),
+})
+
+const buildInFlightCounts = (state: ControllerState, namespace: string) => {
+  const perAgent = new Map<string, number>()
+  let total = 0
+  let cluster = 0
+  for (const [ns, nsState] of state.namespaces.entries()) {
+    for (const run of nsState.runs.values()) {
+      const phase = asString(readNested(run, ['status', 'phase'])) ?? 'Pending'
+      if (phase !== 'Running') continue
+      cluster += 1
+      if (ns !== namespace) continue
+      total += 1
+      const agentName = asString(readNested(run, ['spec', 'agentRef', 'name'])) ?? 'unknown'
+      perAgent.set(agentName, (perAgent.get(agentName) ?? 0) + 1)
+    }
+  }
+  return { total, perAgent, cluster }
+}
+
+const enqueueNamespaceTask = (namespace: string, task: () => Promise<void>) => {
+  const current = namespaceQueues.get(namespace) ?? Promise.resolve()
+  const next = current
+    .catch(() => undefined)
+    .then(task)
+    .catch((error) => {
+      console.warn('[jangar] agents controller task failed', error)
+    })
+  namespaceQueues.set(namespace, next)
 }
 
 const buildRuntimeRef = (
@@ -2099,17 +2183,14 @@ const reconcileAgentRun = async (
   }
 }
 
-const reconcileNamespace = async (
+const reconcileNamespaceSnapshot = async (
   kube: ReturnType<typeof createKubernetesClient>,
   namespace: string,
-  runs: Record<string, unknown>[],
-  globalInFlight: number,
+  snapshot: ReturnType<typeof snapshotNamespace>,
+  state: ControllerState,
   concurrency: ReturnType<typeof parseConcurrency>,
 ) => {
-  const memories = listItems(await kube.list(RESOURCE_MAP.Memory, namespace))
-  const agents = listItems(await kube.list(RESOURCE_MAP.Agent, namespace))
-  const specs = listItems(await kube.list(RESOURCE_MAP.ImplementationSpec, namespace))
-  const providers = listItems(await kube.list(RESOURCE_MAP.AgentProvider, namespace))
+  const { agents, providers, specs, memories, runs } = snapshot
 
   for (const memory of memories) {
     await reconcileMemory(kube, memory, namespace)
@@ -2127,51 +2208,192 @@ const reconcileNamespace = async (
     await reconcileImplementationSpec(kube, spec)
   }
 
+  const counts = buildInFlightCounts(state, namespace)
   const inFlight = {
-    total: 0,
-    perAgent: new Map<string, number>(),
-  }
-  for (const run of runs) {
-    const phase = asString(readNested(run, ['status', 'phase'])) ?? 'Pending'
-    if (phase === 'Running') {
-      inFlight.total += 1
-      const agent = asString(readNested(run, ['spec', 'agentRef', 'name'])) ?? 'unknown'
-      inFlight.perAgent.set(agent, (inFlight.perAgent.get(agent) ?? 0) + 1)
-    }
+    total: counts.total,
+    perAgent: counts.perAgent,
   }
 
   for (const run of runs) {
-    await reconcileAgentRun(kube, run, namespace, memories, concurrency, inFlight, globalInFlight)
+    await reconcileAgentRun(kube, run, namespace, memories, concurrency, inFlight, counts.cluster)
   }
 }
 
-const reconcileOnce = async () => {
+const reconcileRunWithState = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  run: Record<string, unknown>,
+  state: ControllerState,
+  concurrency: ReturnType<typeof parseConcurrency>,
+) => {
+  const snapshot = snapshotNamespace(ensureNamespaceState(state, namespace))
+  const counts = buildInFlightCounts(state, namespace)
+  const inFlight = {
+    total: counts.total,
+    perAgent: counts.perAgent,
+  }
+  await reconcileAgentRun(kube, run, namespace, snapshot.memories, concurrency, inFlight, counts.cluster)
+}
+
+const reconcileNamespaceState = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  state: ControllerState,
+  concurrency: ReturnType<typeof parseConcurrency>,
+) => {
+  const snapshot = snapshotNamespace(ensureNamespaceState(state, namespace))
+  await reconcileNamespaceSnapshot(kube, namespace, snapshot, state, concurrency)
+}
+
+const reconcileAll = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  state: ControllerState,
+  namespaces: string[],
+  concurrency: ReturnType<typeof parseConcurrency>,
+) => {
   if (reconciling) return
   reconciling = true
   try {
-    const namespaces = await resolveNamespaces()
-    const kube = createKubernetesClient()
-    const concurrency = parseConcurrency()
-    const runsByNamespace = new Map<string, Record<string, unknown>[]>()
-    let globalInFlight = 0
     for (const namespace of namespaces) {
-      const runs = listItems(await kube.list(RESOURCE_MAP.AgentRun, namespace))
-      runsByNamespace.set(namespace, runs)
-      for (const run of runs) {
-        const phase = asString(readNested(run, ['status', 'phase'])) ?? 'Pending'
-        if (phase === 'Running') {
-          globalInFlight += 1
-        }
-      }
-    }
-    for (const namespace of namespaces) {
-      await reconcileNamespace(kube, namespace, runsByNamespace.get(namespace) ?? [], globalInFlight, concurrency)
+      await reconcileNamespaceState(kube, namespace, state, concurrency)
     }
   } catch (error) {
     console.warn('[jangar] agents controller failed', error)
   } finally {
     reconciling = false
   }
+}
+
+const seedNamespaceState = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  state: ControllerState,
+  concurrency: ReturnType<typeof parseConcurrency>,
+) => {
+  const nsState = ensureNamespaceState(state, namespace)
+  const memories = listItems(await kube.list(RESOURCE_MAP.Memory, namespace))
+  const agents = listItems(await kube.list(RESOURCE_MAP.Agent, namespace))
+  const specs = listItems(await kube.list(RESOURCE_MAP.ImplementationSpec, namespace))
+  const providers = listItems(await kube.list(RESOURCE_MAP.AgentProvider, namespace))
+  const runs = listItems(await kube.list(RESOURCE_MAP.AgentRun, namespace))
+
+  for (const resource of memories) updateStateMap(nsState.memories, 'ADDED', resource)
+  for (const resource of agents) updateStateMap(nsState.agents, 'ADDED', resource)
+  for (const resource of specs) updateStateMap(nsState.specs, 'ADDED', resource)
+  for (const resource of providers) updateStateMap(nsState.providers, 'ADDED', resource)
+  for (const resource of runs) updateStateMap(nsState.runs, 'ADDED', resource)
+
+  await reconcileNamespaceSnapshot(kube, namespace, snapshotNamespace(nsState), state, concurrency)
+}
+
+const startNamespaceWatches = (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  state: ControllerState,
+  concurrency: ReturnType<typeof parseConcurrency>,
+) => {
+  const nsState = ensureNamespaceState(state, namespace)
+  const enqueueFull = () => enqueueNamespaceTask(namespace, () => reconcileNamespaceState(kube, namespace, state, concurrency))
+
+  const handleAgentRunEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
+    const resource = asRecord(event.object)
+    if (!resource) return
+    updateStateMap(nsState.runs, event.type, resource)
+    if (event.type === 'DELETED') return
+    enqueueNamespaceTask(namespace, () => reconcileRunWithState(kube, namespace, resource, state, concurrency))
+  }
+
+  const handleAgentEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
+    const resource = asRecord(event.object)
+    if (!resource) return
+    updateStateMap(nsState.agents, event.type, resource)
+    enqueueFull()
+  }
+
+  const handleProviderEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
+    const resource = asRecord(event.object)
+    if (!resource) return
+    updateStateMap(nsState.providers, event.type, resource)
+    enqueueFull()
+  }
+
+  const handleSpecEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
+    const resource = asRecord(event.object)
+    if (!resource) return
+    updateStateMap(nsState.specs, event.type, resource)
+    enqueueFull()
+  }
+
+  const handleMemoryEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
+    const resource = asRecord(event.object)
+    if (!resource) return
+    updateStateMap(nsState.memories, event.type, resource)
+    enqueueFull()
+  }
+
+  const handleJobEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
+    const resource = asRecord(event.object)
+    if (!resource) return
+    const runName = asString(readNested(resource, ['metadata', 'labels', 'agents.proompteng.ai/agent-run']))
+    if (!runName) return
+    enqueueNamespaceTask(namespace, async () => {
+      const existing = nsState.runs.get(runName)
+      const run = existing ?? (await kube.get(RESOURCE_MAP.AgentRun, runName, namespace))
+      if (!run) return
+      nsState.runs.set(runName, run)
+      await reconcileRunWithState(kube, namespace, run, state, concurrency)
+    })
+  }
+
+  watchHandles.push(
+    startResourceWatch({
+      resource: RESOURCE_MAP.AgentRun,
+      namespace,
+      onEvent: handleAgentRunEvent,
+      onError: (error) => console.warn('[jangar] agent run watch failed', error),
+    }),
+  )
+  watchHandles.push(
+    startResourceWatch({
+      resource: RESOURCE_MAP.Agent,
+      namespace,
+      onEvent: handleAgentEvent,
+      onError: (error) => console.warn('[jangar] agent watch failed', error),
+    }),
+  )
+  watchHandles.push(
+    startResourceWatch({
+      resource: RESOURCE_MAP.AgentProvider,
+      namespace,
+      onEvent: handleProviderEvent,
+      onError: (error) => console.warn('[jangar] provider watch failed', error),
+    }),
+  )
+  watchHandles.push(
+    startResourceWatch({
+      resource: RESOURCE_MAP.ImplementationSpec,
+      namespace,
+      onEvent: handleSpecEvent,
+      onError: (error) => console.warn('[jangar] implementation spec watch failed', error),
+    }),
+  )
+  watchHandles.push(
+    startResourceWatch({
+      resource: RESOURCE_MAP.Memory,
+      namespace,
+      onEvent: handleMemoryEvent,
+      onError: (error) => console.warn('[jangar] memory watch failed', error),
+    }),
+  )
+  watchHandles.push(
+    startResourceWatch({
+      resource: 'job',
+      namespace,
+      labelSelector: 'agents.proompteng.ai/agent-run',
+      onEvent: handleJobEvent,
+      onError: (error) => console.warn('[jangar] agent job watch failed', error),
+    }),
+  )
 }
 
 export const startAgentsController = async () => {
@@ -2181,15 +2403,35 @@ export const startAgentsController = async () => {
     console.error('[jangar] agents controller will not start without CRDs')
     return
   }
-  started = true
-  void reconcileOnce()
-  const intervalMs = parseIntervalSeconds() * 1000
-  intervalRef = setInterval(() => {
-    void reconcileOnce()
-  }, intervalMs)
+  try {
+    const namespaces = await resolveNamespaces()
+    const kube = createKubernetesClient()
+    const concurrency = parseConcurrency()
+    const state: ControllerState = { namespaces: new Map() }
+    controllerState = state
+    for (const namespace of namespaces) {
+      await seedNamespaceState(kube, namespace, state, concurrency)
+    }
+    for (const namespace of namespaces) {
+      startNamespaceWatches(kube, namespace, state, concurrency)
+    }
+    const intervalSeconds = parseIntervalSeconds()
+    if (intervalSeconds > 0) {
+      intervalRef = setInterval(() => {
+        void reconcileAll(kube, state, namespaces, concurrency)
+      }, intervalSeconds * 1000)
+    }
+    started = true
+  } catch (error) {
+    console.error('[jangar] agents controller failed to start', error)
+  }
 }
 
 export const stopAgentsController = () => {
+  watchHandles.forEach((handle) => handle.stop())
+  watchHandles = []
+  controllerState = null
+  namespaceQueues.clear()
   if (intervalRef) {
     clearInterval(intervalRef)
     intervalRef = null

--- a/services/jangar/src/server/github-review-ingest.ts
+++ b/services/jangar/src/server/github-review-ingest.ts
@@ -30,6 +30,7 @@ type GithubReviewIngestResult = {
 
 const globalOverrides = globalThis as typeof globalThis & {
   __githubReviewStoreMock?: GithubReviewStore
+  __githubWorktreeSnapshotMock?: typeof refreshWorktreeSnapshot
 }
 
 let cachedStore: GithubReviewStore | null = null
@@ -41,6 +42,8 @@ const getStore = () => {
   }
   return cachedStore
 }
+
+const getWorktreeSnapshot = () => globalOverrides.__githubWorktreeSnapshotMock ?? refreshWorktreeSnapshot
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -309,7 +312,7 @@ const maybeRefreshWorktreeSnapshot = async (
   const existing = await store.getPrWorktree({ repository: input.repository, prNumber: input.prNumber })
   if (existing?.headSha && input.headSha && existing.headSha === input.headSha) return
   try {
-    await refreshWorktreeSnapshot({
+    await getWorktreeSnapshot()({
       repository: input.repository,
       prNumber: input.prNumber,
       headRef: input.headRef,

--- a/services/jangar/src/server/kube-watch.ts
+++ b/services/jangar/src/server/kube-watch.ts
@@ -27,19 +27,19 @@ const parseJsonStream = (onJson: (jsonText: string) => void) => {
   let depth = 0
   let startIndex = -1
   let inString = false
-  let escape = false
+  let escaped = false
 
   return (chunk: string) => {
     buffer += chunk
     for (let i = 0; i < buffer.length; i += 1) {
       const char = buffer[i]
       if (inString) {
-        if (escape) {
-          escape = false
+        if (escaped) {
+          escaped = false
           continue
         }
         if (char === '\\\\') {
-          escape = true
+          escaped = true
           continue
         }
         if (char === '"') {

--- a/services/jangar/src/server/kube-watch.ts
+++ b/services/jangar/src/server/kube-watch.ts
@@ -1,0 +1,171 @@
+import { spawn } from 'node:child_process'
+
+type WatchEvent = {
+  type?: string
+  object?: Record<string, unknown>
+}
+
+type WatchOptions = {
+  resource: string
+  namespace: string
+  labelSelector?: string
+  fieldSelector?: string
+  restartDelayMs?: number
+  onEvent: (event: WatchEvent) => void | Promise<void>
+  onError?: (error: Error) => void
+  logPrefix?: string
+}
+
+type WatchHandle = {
+  stop: () => void
+}
+
+const DEFAULT_RESTART_DELAY_MS = 2_000
+
+const parseJsonStream = (onJson: (jsonText: string) => void) => {
+  let buffer = ''
+  let depth = 0
+  let startIndex = -1
+  let inString = false
+  let escape = false
+
+  return (chunk: string) => {
+    buffer += chunk
+    for (let i = 0; i < buffer.length; i += 1) {
+      const char = buffer[i]
+      if (inString) {
+        if (escape) {
+          escape = false
+          continue
+        }
+        if (char === '\\\\') {
+          escape = true
+          continue
+        }
+        if (char === '"') {
+          inString = false
+        }
+        continue
+      }
+
+      if (char === '"') {
+        inString = true
+        continue
+      }
+
+      if (char === '{' || char === '[') {
+        if (depth === 0) {
+          startIndex = i
+        }
+        depth += 1
+        continue
+      }
+
+      if (char === '}' || char === ']') {
+        if (depth > 0) {
+          depth -= 1
+        }
+        if (depth === 0 && startIndex >= 0) {
+          const jsonText = buffer.slice(startIndex, i + 1)
+          onJson(jsonText)
+          buffer = buffer.slice(i + 1)
+          i = -1
+          startIndex = -1
+        }
+      }
+    }
+  }
+}
+
+export const startResourceWatch = (options: WatchOptions): WatchHandle => {
+  const {
+    resource,
+    namespace,
+    labelSelector,
+    fieldSelector,
+    restartDelayMs = DEFAULT_RESTART_DELAY_MS,
+    onEvent,
+    onError,
+    logPrefix = '[jangar][watch]',
+  } = options
+
+  let stopped = false
+  let child: ReturnType<typeof spawn> | null = null
+  let restartTimer: NodeJS.Timeout | null = null
+
+  const scheduleRestart = () => {
+    if (stopped) return
+    if (restartTimer) clearTimeout(restartTimer)
+    restartTimer = setTimeout(() => {
+      restartTimer = null
+      start()
+    }, restartDelayMs)
+  }
+
+  const start = () => {
+    if (stopped) return
+    const args = [
+      'get',
+      resource,
+      '-n',
+      namespace,
+      '--watch',
+      '--output-watch-events',
+      '-o',
+      'json',
+      '--request-timeout=0',
+    ]
+    if (labelSelector) {
+      args.push('-l', labelSelector)
+    }
+    if (fieldSelector) {
+      args.push('--field-selector', fieldSelector)
+    }
+
+    child = spawn('kubectl', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const parse = parseJsonStream((jsonText) => {
+      try {
+        const payload = JSON.parse(jsonText) as WatchEvent
+        if (!payload || typeof payload !== 'object') return
+        if (payload.type === 'BOOKMARK') return
+        void onEvent(payload)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        onError?.(new Error(`${logPrefix} failed to parse watch event: ${message}`))
+      }
+    })
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => parse(String(chunk)))
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      const message = String(chunk).trim()
+      if (message) {
+        onError?.(new Error(`${logPrefix} ${resource} (${namespace}) stderr: ${message}`))
+      }
+    })
+    child.on('error', (error) => {
+      onError?.(error instanceof Error ? error : new Error(String(error)))
+      scheduleRestart()
+    })
+    child.on('close', (code) => {
+      if (stopped) return
+      onError?.(new Error(`${logPrefix} ${resource} (${namespace}) closed with code ${code ?? 'unknown'}`))
+      scheduleRestart()
+    })
+  }
+
+  start()
+
+  return {
+    stop: () => {
+      stopped = true
+      if (restartTimer) clearTimeout(restartTimer)
+      restartTimer = null
+      if (child) {
+        child.kill()
+        child = null
+      }
+    },
+  }
+}

--- a/services/jangar/src/server/primitives-kube.ts
+++ b/services/jangar/src/server/primitives-kube.ts
@@ -159,5 +159,11 @@ export const RESOURCE_MAP = {
   ApprovalPolicy: 'approvalpolicies.approvals.proompteng.ai',
   Budget: 'budgets.budgets.proompteng.ai',
   SecretBinding: 'secretbindings.security.proompteng.ai',
+  Signal: 'signals.signals.proompteng.ai',
   SignalDelivery: 'signaldeliveries.signals.proompteng.ai',
+  Tool: 'tools.tools.proompteng.ai',
+  ToolRun: 'toolruns.tools.proompteng.ai',
+  Schedule: 'schedules.schedules.proompteng.ai',
+  Artifact: 'artifacts.artifacts.proompteng.ai',
+  Workspace: 'workspaces.workspaces.proompteng.ai',
 } as const

--- a/services/jangar/src/server/primitives-reconciler.ts
+++ b/services/jangar/src/server/primitives-reconciler.ts
@@ -1,6 +1,6 @@
+import { startResourceWatch } from '~/server/kube-watch'
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
-import { startResourceWatch } from '~/server/kube-watch'
 import { hydrateMemoryRecord } from '~/server/primitives-memory'
 import { createPrimitivesStore } from '~/server/primitives-store'
 
@@ -107,9 +107,9 @@ const resolveDeliveryId = (resource: Record<string, unknown>) => {
 
 const reconcileAgentRunItem = async (
   item: Record<string, unknown>,
-  namespace: string,
+  _namespace: string,
   store: ReturnType<typeof createPrimitivesStore>,
-  kube: ReturnType<typeof createKubernetesClient>,
+  _kube: ReturnType<typeof createKubernetesClient>,
 ) => {
   try {
     const metadata = asRecord(item.metadata) ?? {}
@@ -171,9 +171,9 @@ const reconcileAgentRuns = async (
 
 const reconcileOrchestrationRunItem = async (
   item: Record<string, unknown>,
-  namespace: string,
+  _namespace: string,
   store: ReturnType<typeof createPrimitivesStore>,
-  kube: ReturnType<typeof createKubernetesClient>,
+  _kube: ReturnType<typeof createKubernetesClient>,
 ) => {
   try {
     const metadata = asRecord(item.metadata) ?? {}
@@ -327,7 +327,9 @@ export const startPrimitivesReconciler = () => {
 }
 
 export const stopPrimitivesReconciler = () => {
-  watchHandles.forEach((handle) => handle.stop())
+  for (const handle of watchHandles) {
+    handle.stop()
+  }
   watchHandles = []
   namespaceQueues.clear()
   if (intervalRef) {

--- a/services/jangar/src/server/primitives-reconciler.ts
+++ b/services/jangar/src/server/primitives-reconciler.ts
@@ -1,5 +1,6 @@
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
+import { startResourceWatch } from '~/server/kube-watch'
 import { hydrateMemoryRecord } from '~/server/primitives-memory'
 import { createPrimitivesStore } from '~/server/primitives-store'
 
@@ -20,11 +21,14 @@ type OrchestrationRunStatus = {
 }
 
 const DEFAULT_NAMESPACES = ['jangar']
-const DEFAULT_INTERVAL_SECONDS = 30
+const DEFAULT_INTERVAL_SECONDS = 0
 
 let started = false
 let intervalRef: NodeJS.Timeout | null = null
 let reconciling = false
+let watchHandles: Array<{ stop: () => void }> = []
+const namespaceQueues = new Map<string, Promise<void>>()
+let storeRef: ReturnType<typeof createPrimitivesStore> | null = null
 
 const shouldStart = () => {
   if (process.env.NODE_ENV === 'test') return false
@@ -45,8 +49,19 @@ const parseNamespaces = () => {
 const parseIntervalSeconds = () => {
   const raw = process.env.JANGAR_PRIMITIVES_RECONCILER_INTERVAL_SECONDS
   const parsed = raw ? Number.parseInt(raw, 10) : NaN
-  if (Number.isFinite(parsed) && parsed > 0) return parsed
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed
   return DEFAULT_INTERVAL_SECONDS
+}
+
+const enqueueNamespaceTask = (namespace: string, task: () => Promise<void>) => {
+  const current = namespaceQueues.get(namespace) ?? Promise.resolve()
+  const next = current
+    .catch(() => undefined)
+    .then(task)
+    .catch((error) => {
+      console.warn('[jangar] primitives reconciler task failed', error)
+    })
+  namespaceQueues.set(namespace, next)
 }
 
 const normalizePayload = (payload: Record<string, unknown> | null | undefined) =>
@@ -84,9 +99,62 @@ const resolveDeliveryId = (resource: Record<string, unknown>) => {
   const labels = asRecord(readNested(resource, ['metadata', 'labels']))
   return (
     asString(labels?.['jangar.proompteng.ai/delivery-id']) ??
+    asString(readNested(resource, ['spec', 'deliveryId'])) ??
     asString(readNested(resource, ['spec', 'idempotencyKey'])) ??
     null
   )
+}
+
+const reconcileAgentRunItem = async (
+  item: Record<string, unknown>,
+  namespace: string,
+  store: ReturnType<typeof createPrimitivesStore>,
+  kube: ReturnType<typeof createKubernetesClient>,
+) => {
+  try {
+    const metadata = asRecord(item.metadata) ?? {}
+    const externalRunId = asString(metadata.name)
+    const deliveryId = resolveDeliveryId(item)
+    const agentName = asString(readNested(item, ['spec', 'agentRef', 'name']))
+    const status = extractAgentRunStatus(item)
+    const runtimeType =
+      asString(readNested(status.runtimeRef ?? {}, ['type'])) ?? asString(readNested(item, ['spec', 'runtime', 'type']))
+    const provider =
+      runtimeType === 'temporal' || runtimeType === 'custom' ? runtimeType : runtimeType ? 'workflow' : 'workflow'
+
+    let record = deliveryId ? await store.getAgentRunByDeliveryId(deliveryId) : null
+    if (!record && externalRunId) {
+      record = await store.getAgentRunByExternalRunId(externalRunId)
+    }
+
+    if (!record && deliveryId && agentName) {
+      record = await store.createAgentRun({
+        agentName,
+        deliveryId,
+        provider,
+        status: status.phase,
+        externalRunId: externalRunId ?? null,
+        payload: { resource: item, status },
+      })
+    }
+
+    if (!record) return
+
+    const payload = {
+      ...normalizePayload(record.payload),
+      resource: item,
+      status,
+    }
+
+    await store.updateAgentRunDetails({
+      id: record.id,
+      status: status.phase,
+      externalRunId: externalRunId ?? record.externalRunId ?? null,
+      payload,
+    })
+  } catch (error) {
+    console.warn('[jangar] failed to reconcile agent run', error)
+  }
 }
 
 const reconcileAgentRuns = async (
@@ -96,48 +164,57 @@ const reconcileAgentRuns = async (
 ) => {
   const response = await kube.list(RESOURCE_MAP.AgentRun, namespace)
   const items = Array.isArray(response.items) ? (response.items as Record<string, unknown>[]) : []
-
   for (const item of items) {
-    try {
-      const metadata = asRecord(item.metadata) ?? {}
-      const externalRunId = asString(metadata.name)
-      const deliveryId = resolveDeliveryId(item)
-      const agentName = asString(readNested(item, ['spec', 'agentRef', 'name']))
-      const status = extractAgentRunStatus(item)
+    await reconcileAgentRunItem(item, namespace, store, kube)
+  }
+}
 
-      let record = deliveryId ? await store.getAgentRunByDeliveryId(deliveryId) : null
-      if (!record && externalRunId) {
-        record = await store.getAgentRunByExternalRunId(externalRunId)
-      }
+const reconcileOrchestrationRunItem = async (
+  item: Record<string, unknown>,
+  namespace: string,
+  store: ReturnType<typeof createPrimitivesStore>,
+  kube: ReturnType<typeof createKubernetesClient>,
+) => {
+  try {
+    const metadata = asRecord(item.metadata) ?? {}
+    const externalRunId = asString(metadata.name)
+    const deliveryId = resolveDeliveryId(item)
+    const orchestrationName = asString(readNested(item, ['spec', 'orchestrationRef', 'name']))
+    const status = extractOrchestrationRunStatus(item)
+    const provider = 'workflow'
 
-      if (!record && deliveryId && agentName) {
-        record = await store.createAgentRun({
-          agentName,
-          deliveryId,
-          provider: 'argo',
-          status: status.phase,
-          externalRunId: externalRunId ?? null,
-          payload: { resource: item, status },
-        })
-      }
-
-      if (!record) continue
-
-      const payload = {
-        ...normalizePayload(record.payload),
-        resource: item,
-        status,
-      }
-
-      await store.updateAgentRunDetails({
-        id: record.id,
-        status: status.phase,
-        externalRunId: externalRunId ?? record.externalRunId ?? null,
-        payload,
-      })
-    } catch (error) {
-      console.warn('[jangar] failed to reconcile agent run', error)
+    let record = deliveryId ? await store.getOrchestrationRunByDeliveryId(deliveryId) : null
+    if (!record && externalRunId) {
+      record = await store.getOrchestrationRunByExternalRunId(externalRunId)
     }
+
+    if (!record && deliveryId && orchestrationName) {
+      record = await store.createOrchestrationRun({
+        orchestrationName,
+        deliveryId,
+        provider,
+        status: status.phase,
+        externalRunId: externalRunId ?? null,
+        payload: { resource: item, status },
+      })
+    }
+
+    if (!record) return
+
+    const payload = {
+      ...normalizePayload(record.payload),
+      resource: item,
+      status,
+    }
+
+    await store.updateOrchestrationRunDetails({
+      id: record.id,
+      status: status.phase,
+      externalRunId: externalRunId ?? record.externalRunId ?? null,
+      payload,
+    })
+  } catch (error) {
+    console.warn('[jangar] failed to reconcile orchestration run', error)
   }
 }
 
@@ -148,48 +225,8 @@ const reconcileOrchestrationRuns = async (
 ) => {
   const response = await kube.list(RESOURCE_MAP.OrchestrationRun, namespace)
   const items = Array.isArray(response.items) ? (response.items as Record<string, unknown>[]) : []
-
   for (const item of items) {
-    try {
-      const metadata = asRecord(item.metadata) ?? {}
-      const externalRunId = asString(metadata.name)
-      const deliveryId = resolveDeliveryId(item)
-      const orchestrationName = asString(readNested(item, ['spec', 'orchestrationRef', 'name']))
-      const status = extractOrchestrationRunStatus(item)
-
-      let record = deliveryId ? await store.getOrchestrationRunByDeliveryId(deliveryId) : null
-      if (!record && externalRunId) {
-        record = await store.getOrchestrationRunByExternalRunId(externalRunId)
-      }
-
-      if (!record && deliveryId && orchestrationName) {
-        record = await store.createOrchestrationRun({
-          orchestrationName,
-          deliveryId,
-          provider: 'argo',
-          status: status.phase,
-          externalRunId: externalRunId ?? null,
-          payload: { resource: item, status },
-        })
-      }
-
-      if (!record) continue
-
-      const payload = {
-        ...normalizePayload(record.payload),
-        resource: item,
-        status,
-      }
-
-      await store.updateOrchestrationRunDetails({
-        id: record.id,
-        status: status.phase,
-        externalRunId: externalRunId ?? record.externalRunId ?? null,
-        payload,
-      })
-    } catch (error) {
-      console.warn('[jangar] failed to reconcile orchestration run', error)
-    }
+    await reconcileOrchestrationRunItem(item, namespace, store, kube)
   }
 }
 
@@ -209,14 +246,15 @@ const reconcileMemories = async (
   }
 }
 
-const reconcileOnce = async () => {
+const reconcileOnce = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  store: ReturnType<typeof createPrimitivesStore>,
+  namespaces: string[],
+) => {
   if (reconciling) return
   reconciling = true
-  const store = createPrimitivesStore()
-  const kube = createKubernetesClient()
   try {
     await store.ready
-    const namespaces = parseNamespaces()
     for (const namespace of namespaces) {
       await reconcileAgentRuns(namespace, store, kube)
       await reconcileOrchestrationRuns(namespace, store, kube)
@@ -226,24 +264,79 @@ const reconcileOnce = async () => {
     console.warn('[jangar] primitives reconciler failed', error)
   } finally {
     reconciling = false
-    await store.close()
   }
 }
 
 export const startPrimitivesReconciler = () => {
   if (started || !shouldStart()) return
   started = true
-  void reconcileOnce()
-  const intervalMs = parseIntervalSeconds() * 1000
-  intervalRef = setInterval(() => {
-    void reconcileOnce()
-  }, intervalMs)
+  const store = createPrimitivesStore()
+  storeRef = store
+  const kube = createKubernetesClient()
+  const namespaces = parseNamespaces()
+
+  void reconcileOnce(kube, store, namespaces)
+
+  for (const namespace of namespaces) {
+    watchHandles.push(
+      startResourceWatch({
+        resource: RESOURCE_MAP.AgentRun,
+        namespace,
+        onEvent: (event) => {
+          const resource = asRecord(event.object)
+          if (!resource || event.type === 'DELETED') return
+          enqueueNamespaceTask(namespace, () => reconcileAgentRunItem(resource, namespace, store, kube))
+        },
+        onError: (error) => console.warn('[jangar] primitives agent run watch failed', error),
+      }),
+    )
+    watchHandles.push(
+      startResourceWatch({
+        resource: RESOURCE_MAP.OrchestrationRun,
+        namespace,
+        onEvent: (event) => {
+          const resource = asRecord(event.object)
+          if (!resource || event.type === 'DELETED') return
+          enqueueNamespaceTask(namespace, () => reconcileOrchestrationRunItem(resource, namespace, store, kube))
+        },
+        onError: (error) => console.warn('[jangar] primitives orchestration run watch failed', error),
+      }),
+    )
+    watchHandles.push(
+      startResourceWatch({
+        resource: RESOURCE_MAP.Memory,
+        namespace,
+        onEvent: (event) => {
+          const resource = asRecord(event.object)
+          if (!resource || event.type === 'DELETED') return
+          enqueueNamespaceTask(namespace, async () => {
+            await reconcileMemories(namespace, store, kube)
+          })
+        },
+        onError: (error) => console.warn('[jangar] primitives memory watch failed', error),
+      }),
+    )
+  }
+
+  const intervalSeconds = parseIntervalSeconds()
+  if (intervalSeconds > 0) {
+    intervalRef = setInterval(() => {
+      void reconcileOnce(kube, store, namespaces)
+    }, intervalSeconds * 1000)
+  }
 }
 
 export const stopPrimitivesReconciler = () => {
+  watchHandles.forEach((handle) => handle.stop())
+  watchHandles = []
+  namespaceQueues.clear()
   if (intervalRef) {
     clearInterval(intervalRef)
     intervalRef = null
+  }
+  if (storeRef) {
+    void storeRef.close()
+    storeRef = null
   }
   started = false
 }

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -1,0 +1,973 @@
+import { spawn } from 'node:child_process'
+
+import { asRecord, asString, readNested } from '~/server/primitives-http'
+import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
+import { startResourceWatch } from '~/server/kube-watch'
+
+const DEFAULT_NAMESPACES = ['agents']
+const DEFAULT_INTERVAL_SECONDS = 0
+
+const REQUIRED_CRDS = [
+  RESOURCE_MAP.Tool,
+  RESOURCE_MAP.ToolRun,
+  RESOURCE_MAP.ApprovalPolicy,
+  RESOURCE_MAP.Budget,
+  RESOURCE_MAP.SecretBinding,
+  RESOURCE_MAP.Signal,
+  RESOURCE_MAP.SignalDelivery,
+  RESOURCE_MAP.Schedule,
+  RESOURCE_MAP.Artifact,
+  RESOURCE_MAP.Workspace,
+]
+
+type Condition = {
+  type: string
+  status: 'True' | 'False' | 'Unknown'
+  reason?: string
+  message?: string
+  lastTransitionTime: string
+}
+
+type CrdCheckState = {
+  ok: boolean
+  missing: string[]
+  checkedAt: string
+}
+
+let started = false
+let intervalRef: NodeJS.Timeout | null = null
+let reconciling = false
+let crdCheckState: CrdCheckState | null = null
+let watchHandles: Array<{ stop: () => void }> = []
+const namespaceQueues = new Map<string, Promise<void>>()
+
+const nowIso = () => new Date().toISOString()
+
+const shouldStart = () => {
+  if (process.env.NODE_ENV === 'test') return false
+  const flag = (process.env.JANGAR_SUPPORTING_CONTROLLER_ENABLED ?? '1').trim().toLowerCase()
+  return flag !== '0' && flag !== 'false'
+}
+
+const parseNamespaces = () => {
+  const raw = process.env.JANGAR_SUPPORTING_CONTROLLER_NAMESPACES
+  if (!raw) return DEFAULT_NAMESPACES
+  const list = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+  return list.length > 0 ? list : DEFAULT_NAMESPACES
+}
+
+const parseIntervalSeconds = () => {
+  const raw = process.env.JANGAR_SUPPORTING_CONTROLLER_INTERVAL_SECONDS
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed
+  return DEFAULT_INTERVAL_SECONDS
+}
+
+const runKubectl = (args: string[]) =>
+  new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve) => {
+    const child = spawn('kubectl', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+    const finish = (payload: { stdout: string; stderr: string; code: number | null }) => {
+      if (settled) return
+      settled = true
+      resolve(payload)
+    }
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', (error) => {
+      finish({
+        stdout,
+        stderr: stderr || (error instanceof Error ? error.message : String(error)),
+        code: 1,
+      })
+    })
+    child.on('close', (code) => finish({ stdout, stderr, code }))
+  })
+
+const resolveCrdCheckNamespace = () => {
+  const namespaces = parseNamespaces()
+  if (namespaces.includes('*')) return 'default'
+  return namespaces[0] ?? 'default'
+}
+
+const resolveNamespaces = async () => {
+  const namespaces = parseNamespaces()
+  if (!namespaces.includes('*')) {
+    return namespaces
+  }
+  const result = await runKubectl(['get', 'namespace', '-o', 'json'])
+  if (result.code !== 0) {
+    throw new Error(result.stderr || result.stdout || 'failed to list namespaces')
+  }
+  const payload = JSON.parse(result.stdout) as Record<string, unknown>
+  const items = Array.isArray(payload.items) ? payload.items : []
+  const resolved = items
+    .map((item) => {
+      const metadata = item && typeof item === 'object' ? (item as Record<string, unknown>).metadata : null
+      const name = metadata && typeof metadata === 'object' ? (metadata as Record<string, unknown>).name : null
+      return typeof name === 'string' ? name : null
+    })
+    .filter((value): value is string => Boolean(value))
+  if (resolved.length === 0) {
+    throw new Error('no namespaces returned by kubectl')
+  }
+  return resolved
+}
+
+const checkCrds = async (): Promise<CrdCheckState> => {
+  const namespace = resolveCrdCheckNamespace()
+  const missing: string[] = []
+  const forbidden: string[] = []
+  for (const name of REQUIRED_CRDS) {
+    const resource = name.split('.')[0] ?? name
+    const result = await runKubectl(['get', resource, '-n', namespace, '-o', 'json'])
+    if (result.code !== 0) {
+      const details = (result.stderr || result.stdout || '').toLowerCase()
+      if (details.includes('forbidden') || details.includes('unauthorized')) {
+        forbidden.push(name)
+      } else {
+        missing.push(name)
+      }
+    }
+  }
+  const state = {
+    ok: missing.length === 0 && forbidden.length === 0,
+    missing: [...missing, ...forbidden],
+    checkedAt: nowIso(),
+  }
+  crdCheckState = state
+  if (!state.ok) {
+    if (missing.length > 0) {
+      console.error('[jangar] missing supporting primitives CRDs:', missing.join(', '))
+    }
+    if (forbidden.length > 0) {
+      console.error(
+        `[jangar] insufficient RBAC to read supporting primitives CRDs in namespace ${namespace}: ${forbidden.join(
+          ', ',
+        )}`,
+      )
+    }
+  }
+  return state
+}
+
+export const getSupportingControllerHealth = () => ({
+  enabled: shouldStart(),
+  started,
+  crdsReady: crdCheckState?.ok ?? null,
+  missingCrds: crdCheckState?.missing ?? [],
+  lastCheckedAt: crdCheckState?.checkedAt ?? null,
+})
+
+const enqueueNamespaceTask = (namespace: string, task: () => Promise<void>) => {
+  const current = namespaceQueues.get(namespace) ?? Promise.resolve()
+  const next = current
+    .catch(() => undefined)
+    .then(task)
+    .catch((error) => {
+      console.warn('[jangar] supporting controller task failed', error)
+    })
+  namespaceQueues.set(namespace, next)
+}
+
+const normalizeConditions = (raw: unknown): Condition[] => {
+  if (!Array.isArray(raw)) return []
+  const output: Condition[] = []
+  for (const item of raw) {
+    const record = asRecord(item)
+    if (!record) continue
+    const type = asString(record.type)
+    const status = asString(record.status)
+    if (!type || !status) continue
+    output.push({
+      type,
+      status: status === 'True' ? 'True' : status === 'False' ? 'False' : 'Unknown',
+      reason: asString(record.reason) ?? undefined,
+      message: asString(record.message) ?? undefined,
+      lastTransitionTime: asString(record.lastTransitionTime) ?? nowIso(),
+    })
+  }
+  return output
+}
+
+const upsertCondition = (conditions: Condition[], update: Omit<Condition, 'lastTransitionTime'>): Condition[] => {
+  const next = [...conditions]
+  const index = next.findIndex((cond) => cond.type === update.type)
+  if (index === -1) {
+    next.push({ ...update, lastTransitionTime: nowIso() })
+    return next
+  }
+  const existing = next[index]
+  if (existing.status !== update.status || existing.reason !== update.reason || existing.message !== update.message) {
+    next[index] = { ...existing, ...update, lastTransitionTime: nowIso() }
+  }
+  return next
+}
+
+const buildReadyCondition = (ready: boolean, reason: string, message?: string) =>
+  ({
+    type: 'Ready',
+    status: ready ? 'True' : 'False',
+    reason,
+    message,
+  }) satisfies Omit<Condition, 'lastTransitionTime'>
+
+const setStatus = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  resource: Record<string, unknown>,
+  status: Record<string, unknown>,
+) => {
+  const metadata = asRecord(resource.metadata) ?? {}
+  const name = asString(metadata.name)
+  const namespace = asString(metadata.namespace)
+  if (!name || !namespace) return
+  const apiVersion = asString(resource.apiVersion)
+  const kind = asString(resource.kind)
+  if (!apiVersion || !kind) return
+  await kube.applyStatus({ apiVersion, kind, metadata: { name, namespace }, status })
+}
+
+const listItems = (payload: Record<string, unknown>) => {
+  const items = Array.isArray(payload.items) ? payload.items : []
+  return items.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object')
+}
+
+const makeName = (base: string, suffix: string) => {
+  const max = 45
+  const sanitized = base.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-')
+  const trimmed = sanitized.length > max ? sanitized.slice(0, max) : sanitized
+  return `${trimmed}-${suffix}`
+}
+
+const buildOwnerRefs = (resource: Record<string, unknown>) => {
+  const metadata = asRecord(resource.metadata) ?? {}
+  const uid = asString(metadata.uid)
+  const name = asString(metadata.name)
+  if (!uid || !name) return undefined
+  return [
+    {
+      apiVersion: asString(resource.apiVersion) ?? '',
+      kind: asString(resource.kind) ?? '',
+      name,
+      uid,
+      controller: true,
+      blockOwnerDeletion: true,
+    },
+  ]
+}
+
+const resolveNamespace = (resource: Record<string, unknown>) =>
+  asString(readNested(resource, ['metadata', 'namespace'])) ?? 'default'
+
+const reconcileTool = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  tool: Record<string, unknown>,
+) => {
+  const spec = asRecord(tool.spec) ?? {}
+  const image = asString(spec.image)
+  const command = Array.isArray(spec.command) ? spec.command : []
+  const args = Array.isArray(spec.args) ? spec.args : []
+  const isValid = Boolean(image) && (command.length > 0 || args.length > 0)
+  const conditions = upsertCondition(
+    normalizeConditions(asRecord(tool.status)?.conditions),
+    buildReadyCondition(
+      isValid,
+      isValid ? 'Valid' : 'InvalidSpec',
+      isValid ? 'tool is ready' : 'spec.image and command or args are required',
+    ),
+  )
+  await setStatus(kube, tool, {
+    observedGeneration: asRecord(tool.metadata)?.generation ?? 0,
+    phase: isValid ? 'Ready' : 'Invalid',
+    conditions,
+  })
+}
+
+const reconcileApprovalPolicy = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  policy: Record<string, unknown>,
+) => {
+  const conditions = upsertCondition(
+    normalizeConditions(asRecord(policy.status)?.conditions),
+    buildReadyCondition(true, 'Active', 'approval policy active'),
+  )
+  await setStatus(kube, policy, {
+    observedGeneration: asRecord(policy.metadata)?.generation ?? 0,
+    phase: 'Active',
+    conditions,
+  })
+}
+
+const reconcileBudget = async (kube: ReturnType<typeof createKubernetesClient>, budget: Record<string, unknown>) => {
+  const status = asRecord(budget.status) ?? {}
+  const used = asRecord(status.used) ?? { tokens: '0', dollars: '0', cpu: '0', memory: '0', gpu: '0' }
+  const conditions = upsertCondition(
+    normalizeConditions(status.conditions),
+    buildReadyCondition(true, 'Active', 'budget active'),
+  )
+  await setStatus(kube, budget, {
+    observedGeneration: asRecord(budget.metadata)?.generation ?? 0,
+    phase: asString(status.phase) ?? 'Active',
+    used,
+    conditions,
+  })
+}
+
+const reconcileSecretBinding = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  binding: Record<string, unknown>,
+) => {
+  const spec = asRecord(binding.spec) ?? {}
+  const subjects = Array.isArray(spec.subjects) ? spec.subjects : []
+  const allowed = Array.isArray(spec.allowedSecrets) ? spec.allowedSecrets : []
+  const isValid = subjects.length > 0 && allowed.length > 0
+  const conditions = upsertCondition(
+    normalizeConditions(asRecord(binding.status)?.conditions),
+    buildReadyCondition(
+      isValid,
+      isValid ? 'Valid' : 'InvalidSpec',
+      isValid ? 'secret binding ready' : 'subjects and allowedSecrets are required',
+    ),
+  )
+  await setStatus(kube, binding, {
+    observedGeneration: asRecord(binding.metadata)?.generation ?? 0,
+    phase: isValid ? 'Ready' : 'Invalid',
+    conditions,
+  })
+}
+
+const reconcileSignal = async (kube: ReturnType<typeof createKubernetesClient>, signal: Record<string, unknown>) => {
+  const status = asRecord(signal.status) ?? {}
+  const conditions = upsertCondition(
+    normalizeConditions(status.conditions),
+    buildReadyCondition(true, 'Active', 'signal active'),
+  )
+  await setStatus(kube, signal, {
+    observedGeneration: asRecord(signal.metadata)?.generation ?? 0,
+    phase: asString(status.phase) ?? 'Active',
+    lastDeliveryAt: asString(status.lastDeliveryAt) ?? undefined,
+    conditions,
+  })
+}
+
+const reconcileSignalDelivery = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  delivery: Record<string, unknown>,
+) => {
+  const namespace = resolveNamespace(delivery)
+  const spec = asRecord(delivery.spec) ?? {}
+  const signalName = asString(readNested(spec, ['signalRef', 'name']))
+  const status = asRecord(delivery.status) ?? {}
+  if (!signalName) {
+    const conditions = upsertCondition(
+      normalizeConditions(status.conditions),
+      buildReadyCondition(false, 'InvalidSpec', 'spec.signalRef.name is required'),
+    )
+    await setStatus(kube, delivery, {
+      observedGeneration: asRecord(delivery.metadata)?.generation ?? 0,
+      phase: 'Invalid',
+      conditions,
+    })
+    return
+  }
+  const signal = await kube.get(RESOURCE_MAP.Signal, signalName, namespace)
+  if (!signal) {
+    const conditions = upsertCondition(
+      normalizeConditions(status.conditions),
+      buildReadyCondition(false, 'SignalMissing', `signal ${signalName} not found`),
+    )
+    await setStatus(kube, delivery, {
+      observedGeneration: asRecord(delivery.metadata)?.generation ?? 0,
+      phase: 'Pending',
+      conditions,
+    })
+    return
+  }
+
+  const conditions = upsertCondition(
+    normalizeConditions(status.conditions),
+    buildReadyCondition(true, 'Delivered', 'signal delivered'),
+  )
+  await setStatus(kube, delivery, {
+    observedGeneration: asRecord(delivery.metadata)?.generation ?? 0,
+    phase: 'Delivered',
+    deliveredAt: asString(status.deliveredAt) ?? nowIso(),
+    conditions,
+  })
+}
+
+const buildScheduleRunTemplate = (
+  schedule: Record<string, unknown>,
+  target: Record<string, unknown>,
+  deliveryPlaceholder: string,
+) => {
+  const targetKind = asString(target.kind) ?? ''
+  const targetNamespace = asString(readNested(target, ['metadata', 'namespace'])) ?? resolveNamespace(schedule)
+  const scheduleName = asString(readNested(schedule, ['metadata', 'name'])) ?? 'schedule'
+  const labels = {
+    'schedules.proompteng.ai/schedule': scheduleName,
+    'jangar.proompteng.ai/delivery-id': deliveryPlaceholder,
+  }
+
+  if (targetKind === 'AgentRun') {
+    const spec = asRecord(target.spec) ?? {}
+    return {
+      apiVersion: 'agents.proompteng.ai/v1alpha1',
+      kind: 'AgentRun',
+      metadata: {
+        generateName: `${scheduleName}-`,
+        namespace: targetNamespace,
+        labels,
+      },
+      spec: {
+        ...spec,
+        idempotencyKey: deliveryPlaceholder,
+      },
+    }
+  }
+
+  if (targetKind === 'OrchestrationRun') {
+    const spec = asRecord(target.spec) ?? {}
+    return {
+      apiVersion: 'orchestration.proompteng.ai/v1alpha1',
+      kind: 'OrchestrationRun',
+      metadata: {
+        generateName: `${scheduleName}-`,
+        namespace: targetNamespace,
+        labels,
+      },
+      spec: {
+        ...spec,
+        deliveryId: deliveryPlaceholder,
+      },
+    }
+  }
+
+  throw new Error(`unsupported schedule target kind: ${targetKind || 'unknown'}`)
+}
+
+const resolveScheduleTarget = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  schedule: Record<string, unknown>,
+) => {
+  const spec = asRecord(schedule.spec) ?? {}
+  const targetRef = asRecord(spec.targetRef) ?? {}
+  const targetKind = asString(targetRef.kind)
+  const targetName = asString(targetRef.name)
+  const targetNamespace = asString(targetRef.namespace) ?? resolveNamespace(schedule)
+  if (!targetKind || !targetName) {
+    throw new Error('spec.targetRef.kind and spec.targetRef.name are required')
+  }
+  if (targetKind === 'AgentRun') {
+    const target = await kube.get(RESOURCE_MAP.AgentRun, targetName, targetNamespace)
+    if (!target) throw new Error(`agent run ${targetName} not found`)
+    return target
+  }
+  if (targetKind === 'OrchestrationRun') {
+    const target = await kube.get(RESOURCE_MAP.OrchestrationRun, targetName, targetNamespace)
+    if (!target) throw new Error(`orchestration run ${targetName} not found`)
+    return target
+  }
+  throw new Error(`unsupported schedule target kind: ${targetKind}`)
+}
+
+const reconcileSchedule = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  schedule: Record<string, unknown>,
+  namespace: string,
+) => {
+  const spec = asRecord(schedule.spec) ?? {}
+  const cron = asString(spec.cron)
+  const timezone = asString(spec.timezone)
+  const status = asRecord(schedule.status) ?? {}
+  const scheduleName = asString(readNested(schedule, ['metadata', 'name'])) ?? 'schedule'
+  if (!cron) {
+    const conditions = upsertCondition(
+      normalizeConditions(status.conditions),
+      buildReadyCondition(false, 'InvalidSpec', 'spec.cron is required'),
+    )
+    await setStatus(kube, schedule, {
+      observedGeneration: asRecord(schedule.metadata)?.generation ?? 0,
+      phase: 'Invalid',
+      conditions,
+    })
+    return
+  }
+
+  try {
+    const target = await resolveScheduleTarget(kube, schedule)
+    const deliveryPlaceholder = '__JANGAR_DELIVERY_ID__'
+    const template = buildScheduleRunTemplate(schedule, target, deliveryPlaceholder)
+    const configName = makeName(scheduleName, 'template')
+    const ownerReferences = buildOwnerRefs(schedule)
+    const labels = { 'schedules.proompteng.ai/schedule': scheduleName }
+    const configMap = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: configName,
+        namespace,
+        labels,
+        ...(ownerReferences ? { ownerReferences } : {}),
+      },
+      data: {
+        'run.json': JSON.stringify(template, null, 2),
+      },
+    }
+    await kube.apply(configMap)
+
+    const image =
+      process.env.JANGAR_SCHEDULE_RUNNER_IMAGE ||
+      process.env.JANGAR_IMAGE ||
+      'ghcr.io/proompteng/jangar:latest'
+    const podNamespace = process.env.JANGAR_POD_NAMESPACE
+    const scheduleServiceAccount =
+      process.env.JANGAR_SCHEDULE_SERVICE_ACCOUNT || process.env.JANGAR_SERVICE_ACCOUNT_NAME
+    const serviceAccountName =
+      scheduleServiceAccount && podNamespace === namespace
+        ? scheduleServiceAccount
+        : process.env.JANGAR_SCHEDULE_SERVICE_ACCOUNT || undefined
+    const cronJobName = makeName(scheduleName, 'cron')
+    const cronJob = {
+      apiVersion: 'batch/v1',
+      kind: 'CronJob',
+      metadata: {
+        name: cronJobName,
+        namespace,
+        labels,
+        ...(ownerReferences ? { ownerReferences } : {}),
+      },
+      spec: {
+        schedule: cron,
+        timeZone: timezone ?? undefined,
+        concurrencyPolicy: 'Forbid',
+        successfulJobsHistoryLimit: 3,
+        failedJobsHistoryLimit: 1,
+        jobTemplate: {
+          spec: {
+            template: {
+              metadata: { labels },
+              spec: {
+                serviceAccountName,
+                restartPolicy: 'Never',
+                containers: [
+                  {
+                    name: 'schedule-runner',
+                    image,
+                    command: [
+                      '/bin/sh',
+                      '-ec',
+                      [
+                        'DELIVERY_ID=$(cat /proc/sys/kernel/random/uuid);',
+                        'sed "s/__JANGAR_DELIVERY_ID__/${DELIVERY_ID}/g" /config/run.json | kubectl create -f -',
+                      ].join(' '),
+                    ],
+                    volumeMounts: [{ name: 'schedule-template', mountPath: '/config' }],
+                  },
+                ],
+                volumes: [
+                  {
+                    name: 'schedule-template',
+                    configMap: {
+                      name: configName,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    }
+    await kube.apply(cronJob)
+    const cronResource = await kube.get('cronjob', cronJobName, namespace)
+    const lastRunTime = asString(readNested(cronResource ?? {}, ['status', 'lastScheduleTime'])) ?? undefined
+    const conditions = upsertCondition(
+      normalizeConditions(status.conditions),
+      buildReadyCondition(true, 'Active', 'schedule active'),
+    )
+    await setStatus(kube, schedule, {
+      observedGeneration: asRecord(schedule.metadata)?.generation ?? 0,
+      phase: 'Active',
+      lastRunTime,
+      conditions,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    const conditions = upsertCondition(
+      normalizeConditions(status.conditions),
+      buildReadyCondition(false, 'InvalidSpec', message),
+    )
+    await setStatus(kube, schedule, {
+      observedGeneration: asRecord(schedule.metadata)?.generation ?? 0,
+      phase: 'Invalid',
+      conditions,
+    })
+  }
+}
+
+const reconcileWorkspace = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  workspace: Record<string, unknown>,
+  namespace: string,
+) => {
+  const spec = asRecord(workspace.spec) ?? {}
+  const size = asString(spec.size)
+  const accessModes = Array.isArray(spec.accessModes) ? spec.accessModes : ['ReadWriteOnce']
+  const storageClassName = asString(spec.storageClassName)
+  const ttlSeconds = typeof spec.ttlSeconds === 'number' ? spec.ttlSeconds : null
+  const status = asRecord(workspace.status) ?? {}
+  if (!size) {
+    const conditions = upsertCondition(
+      normalizeConditions(status.conditions),
+      buildReadyCondition(false, 'InvalidSpec', 'spec.size is required'),
+    )
+    await setStatus(kube, workspace, {
+      observedGeneration: asRecord(workspace.metadata)?.generation ?? 0,
+      phase: 'Invalid',
+      conditions,
+    })
+    return
+  }
+
+  const workspaceName = asString(readNested(workspace, ['metadata', 'name'])) ?? 'workspace'
+  const ownerReferences = buildOwnerRefs(workspace)
+  const labels = { 'workspaces.proompteng.ai/workspace': workspaceName }
+  const pvc = {
+    apiVersion: 'v1',
+    kind: 'PersistentVolumeClaim',
+    metadata: {
+      name: workspaceName,
+      namespace,
+      labels,
+      ...(ownerReferences ? { ownerReferences } : {}),
+    },
+    spec: {
+      accessModes,
+      resources: { requests: { storage: size } },
+      ...(storageClassName ? { storageClassName } : {}),
+    },
+  }
+  await kube.apply(pvc)
+
+  const pvcResource = await kube.get('persistentvolumeclaim', workspaceName, namespace)
+  const pvcPhase = asString(readNested(pvcResource ?? {}, ['status', 'phase'])) ?? 'Pending'
+  const pvcVolumeName = asString(readNested(pvcResource ?? {}, ['spec', 'volumeName'])) ?? undefined
+
+  if (ttlSeconds && ttlSeconds > 0) {
+    const createdAt = asString(readNested(workspace, ['metadata', 'creationTimestamp']))
+    if (createdAt) {
+      const expiresAt = new Date(createdAt).getTime() + ttlSeconds * 1000
+      if (Number.isFinite(expiresAt) && Date.now() > expiresAt) {
+        await kube.delete('persistentvolumeclaim', workspaceName, namespace)
+        const conditions = upsertCondition(
+          normalizeConditions(status.conditions),
+          buildReadyCondition(false, 'Expired', 'workspace TTL expired'),
+        )
+        await setStatus(kube, workspace, {
+          observedGeneration: asRecord(workspace.metadata)?.generation ?? 0,
+          phase: 'Expired',
+          volumeName: pvcVolumeName,
+          conditions,
+        })
+        return
+      }
+    }
+  }
+
+  const phase = pvcPhase === 'Bound' ? 'Ready' : pvcPhase === 'Lost' ? 'Failed' : 'Pending'
+  const conditions = upsertCondition(
+    normalizeConditions(status.conditions),
+    buildReadyCondition(
+      phase === 'Ready',
+      phase === 'Ready' ? 'Bound' : 'Pending',
+      `workspace ${phase.toLowerCase()}`,
+    ),
+  )
+  await setStatus(kube, workspace, {
+    observedGeneration: asRecord(workspace.metadata)?.generation ?? 0,
+    phase,
+    volumeName: pvcVolumeName,
+    conditions,
+  })
+}
+
+const reconcileArtifact = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  artifact: Record<string, unknown>,
+) => {
+  const status = asRecord(artifact.status) ?? {}
+  const name = asString(readNested(artifact, ['metadata', 'name'])) ?? 'artifact'
+  const namespace = resolveNamespace(artifact)
+  const storageRef = asString(readNested(artifact, ['spec', 'storageRef', 'name']))
+  const uri = storageRef ? `storage://${storageRef}` : `artifact://${namespace}/${name}`
+  const conditions = upsertCondition(
+    normalizeConditions(status.conditions),
+    buildReadyCondition(true, 'Ready', 'artifact ready'),
+  )
+  await setStatus(kube, artifact, {
+    observedGeneration: asRecord(artifact.metadata)?.generation ?? 0,
+    phase: 'Ready',
+    uri,
+    checksum: asString(status.checksum) ?? undefined,
+    conditions,
+  })
+}
+
+const reconcileResource = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  resource: Record<string, unknown>,
+  namespace: string,
+) => {
+  const kind = asString(resource.kind)
+  if (!kind) return
+  if (kind === 'Tool') {
+    await reconcileTool(kube, resource)
+    return
+  }
+  if (kind === 'ApprovalPolicy') {
+    await reconcileApprovalPolicy(kube, resource)
+    return
+  }
+  if (kind === 'Budget') {
+    await reconcileBudget(kube, resource)
+    return
+  }
+  if (kind === 'SecretBinding') {
+    await reconcileSecretBinding(kube, resource)
+    return
+  }
+  if (kind === 'Signal') {
+    await reconcileSignal(kube, resource)
+    return
+  }
+  if (kind === 'SignalDelivery') {
+    await reconcileSignalDelivery(kube, resource)
+    return
+  }
+  if (kind === 'Schedule') {
+    await reconcileSchedule(kube, resource, namespace)
+    return
+  }
+  if (kind === 'Workspace') {
+    await reconcileWorkspace(kube, resource, namespace)
+    return
+  }
+  if (kind === 'Artifact') {
+    await reconcileArtifact(kube, resource)
+  }
+}
+
+const reconcileNamespace = async (kube: ReturnType<typeof createKubernetesClient>, namespace: string) => {
+  const payloads = await Promise.all([
+    kube.list(RESOURCE_MAP.Tool, namespace),
+    kube.list(RESOURCE_MAP.ApprovalPolicy, namespace),
+    kube.list(RESOURCE_MAP.Budget, namespace),
+    kube.list(RESOURCE_MAP.SecretBinding, namespace),
+    kube.list(RESOURCE_MAP.Signal, namespace),
+    kube.list(RESOURCE_MAP.SignalDelivery, namespace),
+    kube.list(RESOURCE_MAP.Schedule, namespace),
+    kube.list(RESOURCE_MAP.Artifact, namespace),
+    kube.list(RESOURCE_MAP.Workspace, namespace),
+  ])
+  const items = payloads.flatMap(listItems)
+  for (const item of items) {
+    await reconcileResource(kube, item, namespace)
+  }
+}
+
+const reconcileAll = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespaces: string[],
+) => {
+  if (reconciling) return
+  reconciling = true
+  try {
+    for (const namespace of namespaces) {
+      await reconcileNamespace(kube, namespace)
+    }
+  } catch (error) {
+    console.warn('[jangar] supporting controller reconcile failed', error)
+  } finally {
+    reconciling = false
+  }
+}
+
+const handleResourceEvent = (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  event: { type?: string; object?: Record<string, unknown> },
+) => {
+  if (event.type === 'DELETED') return
+  const resource = asRecord(event.object)
+  if (!resource) return
+  enqueueNamespaceTask(namespace, () => reconcileResource(kube, resource, namespace))
+}
+
+const handleScheduleRunnerEvent = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  event: { type?: string; object?: Record<string, unknown> },
+) => {
+  const resource = asRecord(event.object)
+  if (!resource) return
+  const scheduleName = asString(readNested(resource, ['metadata', 'labels', 'schedules.proompteng.ai/schedule']))
+  if (!scheduleName) return
+  const schedule = await kube.get(RESOURCE_MAP.Schedule, scheduleName, namespace)
+  if (!schedule) return
+  await reconcileSchedule(kube, schedule, namespace)
+}
+
+const handleWorkspaceVolumeEvent = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  event: { type?: string; object?: Record<string, unknown> },
+) => {
+  const resource = asRecord(event.object)
+  if (!resource) return
+  const workspaceName = asString(readNested(resource, ['metadata', 'labels', 'workspaces.proompteng.ai/workspace']))
+  if (!workspaceName) return
+  const workspace = await kube.get(RESOURCE_MAP.Workspace, workspaceName, namespace)
+  if (!workspace) return
+  await reconcileWorkspace(kube, workspace, namespace)
+}
+
+export const startSupportingPrimitivesController = async () => {
+  if (started || !shouldStart()) return
+  const crdsReady = await checkCrds()
+  if (!crdsReady.ok) {
+    console.error('[jangar] supporting controller will not start without CRDs')
+    return
+  }
+  try {
+    const kube = createKubernetesClient()
+    const namespaces = await resolveNamespaces()
+    void reconcileAll(kube, namespaces)
+
+    for (const namespace of namespaces) {
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.Tool,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] tool watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.ApprovalPolicy,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] approval policy watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.Budget,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] budget watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.SecretBinding,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] secret binding watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.Signal,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] signal watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.SignalDelivery,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] signal delivery watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.Schedule,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] schedule watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.Artifact,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] artifact watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: RESOURCE_MAP.Workspace,
+          namespace,
+          onEvent: (event) => handleResourceEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] workspace watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: 'cronjob',
+          namespace,
+          labelSelector: 'schedules.proompteng.ai/schedule',
+          onEvent: (event) => void handleScheduleRunnerEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] schedule cronjob watch failed', error),
+        }),
+      )
+      watchHandles.push(
+        startResourceWatch({
+          resource: 'persistentvolumeclaim',
+          namespace,
+          labelSelector: 'workspaces.proompteng.ai/workspace',
+          onEvent: (event) => void handleWorkspaceVolumeEvent(kube, namespace, event),
+          onError: (error) => console.warn('[jangar] workspace pvc watch failed', error),
+        }),
+      )
+    }
+
+    const intervalSeconds = parseIntervalSeconds()
+    if (intervalSeconds > 0) {
+      intervalRef = setInterval(() => {
+        void reconcileAll(kube, namespaces)
+      }, intervalSeconds * 1000)
+    }
+
+    started = true
+  } catch (error) {
+    console.error('[jangar] supporting controller failed to start', error)
+  }
+}
+
+export const stopSupportingPrimitivesController = () => {
+  watchHandles.forEach((handle) => handle.stop())
+  watchHandles = []
+  namespaceQueues.clear()
+  if (intervalRef) {
+    clearInterval(intervalRef)
+    intervalRef = null
+  }
+  started = false
+}

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -567,7 +567,7 @@ const reconcileSchedule = async (
                       '-ec',
                       [
                         'DELIVERY_ID=$(cat /proc/sys/kernel/random/uuid);',
-                        `sed "s/__JANGAR_DELIVERY_ID__/\\${DELIVERY_ID}/g" /config/run.json | kubectl create -f -`,
+                        `sed "s/__JANGAR_DELIVERY_ID__/\\$${'{DELIVERY_ID}'}/g" /config/run.json | kubectl create -f -`,
                       ].join(' '),
                     ],
                     volumeMounts: [{ name: 'schedule-template', mountPath: '/config' }],


### PR DESCRIPTION
## Summary

- add supporting primitives controller (schedules, workspaces, artifacts, policies, signals) with watch-based reconciliation
- add CRDs + examples for orchestration/tools/signals/schedules/artifacts/workspaces; bump chart version and RBAC for CronJobs/PVCs
- extend agents validation to include new CRD schemas; update docs/README

## Related Issues

Closes #2543

## Testing

- Not run (environment not set up for go generate/helm/kubeconform locally)

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
