### PR TITLE
feat(jangar): expand agents control-plane UI (#2555)

### DIFF
--- a/services/jangar/src/components/app-sidebar.tsx
+++ b/services/jangar/src/components/app-sidebar.tsx
@@ -87,26 +87,62 @@ const appNav: AppNavItem[] = [
   },
 ]
 
-const agentsControlNav = [
-  { to: '/agents-control-plane', label: 'Overview', icon: IconRobot },
-  { to: '/agents-control-plane/agents', label: 'Agents', icon: IconMessages },
-  { to: '/agents-control-plane/agent-runs', label: 'Agent runs', icon: IconList },
-  { to: '/agents-control-plane/agent-providers', label: 'Agent providers', icon: IconDatabase },
-  { to: '/agents-control-plane/implementation-specs', label: 'Implementation specs', icon: IconBrain },
-  { to: '/agents-control-plane/implementation-sources', label: 'Implementation sources', icon: IconGitPullRequest },
-  { to: '/agents-control-plane/memories', label: 'Memories', icon: IconHeart },
-  { to: '/agents-control-plane/tools', label: 'Tools', icon: IconTool },
-  { to: '/agents-control-plane/tool-runs', label: 'Tool runs', icon: IconActivity },
-  { to: '/agents-control-plane/approvals', label: 'Approvals', icon: IconChecklist },
-  { to: '/agents-control-plane/budgets', label: 'Budgets', icon: IconWallet },
-  { to: '/agents-control-plane/signals', label: 'Signals', icon: IconBroadcast },
-  { to: '/agents-control-plane/signal-deliveries', label: 'Signal deliveries', icon: IconSend },
-  { to: '/agents-control-plane/schedules', label: 'Schedules', icon: IconCalendar },
-  { to: '/agents-control-plane/artifacts', label: 'Artifacts', icon: IconPackage },
-  { to: '/agents-control-plane/workspaces', label: 'Workspaces', icon: IconBriefcase },
-  { to: '/agents-control-plane/secret-bindings', label: 'Secret bindings', icon: IconKey },
-  { to: '/agents-control-plane/orchestrations', label: 'Orchestrations', icon: IconRoute },
-  { to: '/agents-control-plane/orchestration-runs', label: 'Orchestration runs', icon: IconTimeline },
+type AgentsControlNavGroup = {
+  label: string
+  items: AppNavItem[]
+}
+
+const agentsControlOverview: AppNavItem = { to: '/agents-control-plane', label: 'Overview', icon: IconRobot }
+
+const agentsControlGroups: AgentsControlNavGroup[] = [
+  {
+    label: 'Resources',
+    items: [
+      { to: '/agents-control-plane/agents', label: 'Agents', icon: IconMessages },
+      { to: '/agents-control-plane/agent-providers', label: 'Agent providers', icon: IconDatabase },
+      { to: '/agents-control-plane/implementation-specs', label: 'Implementation specs', icon: IconBrain },
+      { to: '/agents-control-plane/implementation-sources', label: 'Implementation sources', icon: IconGitPullRequest },
+      { to: '/agents-control-plane/tools', label: 'Tools', icon: IconTool },
+    ],
+  },
+  {
+    label: 'Runs',
+    items: [
+      { to: '/agents-control-plane/agent-runs', label: 'Agent runs', icon: IconList },
+      { to: '/agents-control-plane/tool-runs', label: 'Tool runs', icon: IconActivity },
+    ],
+  },
+  {
+    label: 'Policies',
+    items: [
+      { to: '/agents-control-plane/approvals', label: 'Approvals', icon: IconChecklist },
+      { to: '/agents-control-plane/budgets', label: 'Budgets', icon: IconWallet },
+      { to: '/agents-control-plane/secret-bindings', label: 'Secret bindings', icon: IconKey },
+    ],
+  },
+  {
+    label: 'Signals',
+    items: [
+      { to: '/agents-control-plane/signals', label: 'Signals', icon: IconBroadcast },
+      { to: '/agents-control-plane/signal-deliveries', label: 'Signal deliveries', icon: IconSend },
+    ],
+  },
+  {
+    label: 'Storage',
+    items: [
+      { to: '/agents-control-plane/memories', label: 'Memories', icon: IconHeart },
+      { to: '/agents-control-plane/artifacts', label: 'Artifacts', icon: IconPackage },
+      { to: '/agents-control-plane/workspaces', label: 'Workspaces', icon: IconBriefcase },
+    ],
+  },
+  {
+    label: 'Orchestration',
+    items: [
+      { to: '/agents-control-plane/orchestrations', label: 'Orchestrations', icon: IconRoute },
+      { to: '/agents-control-plane/orchestration-runs', label: 'Orchestration runs', icon: IconTimeline },
+      { to: '/agents-control-plane/schedules', label: 'Schedules', icon: IconCalendar },
+    ],
+  },
 ] as const
 
 const apiNav = [
@@ -211,20 +247,42 @@ export function AppSidebar() {
 
         <SidebarGroup>
           <SidebarGroupLabel>Agents</SidebarGroupLabel>
-          <SidebarGroupContent>
+          <SidebarGroupContent className="space-y-2">
             <SidebarMenu>
-              {agentsControlNav.map((item) => (
-                <SidebarMenuItem key={item.to}>
-                  <SidebarNavButton
-                    icon={item.icon}
-                    isActive={pathname === item.to || pathname.startsWith(`${item.to}/`)}
-                    isCollapsed={isCollapsed}
-                    label={item.label}
-                    to={item.to}
-                  />
-                </SidebarMenuItem>
-              ))}
+              <SidebarMenuItem key={agentsControlOverview.to}>
+                <SidebarNavButton
+                  icon={agentsControlOverview.icon}
+                  isActive={
+                    pathname === agentsControlOverview.to || pathname.startsWith(`${agentsControlOverview.to}/`)
+                  }
+                  isCollapsed={isCollapsed}
+                  label={agentsControlOverview.label}
+                  to={agentsControlOverview.to}
+                />
+              </SidebarMenuItem>
             </SidebarMenu>
+            {agentsControlGroups.map((group) => (
+              <div key={group.label} className="space-y-1">
+                {isCollapsed ? null : (
+                  <div className="px-3 pt-2 text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+                    {group.label}
+                  </div>
+                )}
+                <SidebarMenu>
+                  {group.items.map((item) => (
+                    <SidebarMenuItem key={item.to}>
+                      <SidebarNavButton
+                        icon={item.icon}
+                        isActive={pathname === item.to || pathname.startsWith(`${item.to}/`)}
+                        isCollapsed={isCollapsed}
+                        label={item.label}
+                        to={item.to}
+                      />
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              </div>
+            ))}
           </SidebarGroupContent>
         </SidebarGroup>
 

--- a/services/jangar/src/routes/agents-control-plane/agent-providers/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/agent-providers/index.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import * as React from 'react'
 
-import { deriveStatusLabel, getMetadataValue, readNestedValue, StatusBadge } from '@/components/agents-control-plane'
+import {
+  deriveStatusLabel,
+  getMetadataValue,
+  readNestedArrayValue,
+  readNestedValue,
+  StatusBadge,
+} from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -12,25 +18,35 @@ export const Route = createFileRoute('/agents-control-plane/agent-providers/')({
   component: AgentProvidersListPage,
 })
 
+const formatCount = (value: unknown, label: string) => {
+  const count = Array.isArray(value) ? value.length : 0
+  if (count === 0) return '—'
+  return `${count} ${label}${count === 1 ? '' : 's'}`
+}
+
+const formatObjectCount = (value: unknown, label: string) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '—'
+  const count = Object.keys(value as Record<string, unknown>).length
+  if (count === 0) return '—'
+  return `${count} ${label}${count === 1 ? '' : 's'}`
+}
+
 const buildProviderFields = (resource: PrimitiveResource) => [
   {
-    label: 'Type',
-    value: readNestedValue(resource, ['spec', 'type']) ?? readNestedValue(resource, ['spec', 'provider']) ?? '—',
+    label: 'Binary',
+    value: readNestedValue(resource, ['spec', 'binary']) ?? '—',
   },
   {
-    label: 'Endpoint',
-    value: readNestedValue(resource, ['spec', 'endpoint']) ?? '—',
+    label: 'Args template',
+    value: readNestedArrayValue(resource, ['spec', 'argsTemplate']) ?? '—',
   },
   {
-    label: 'Secret',
-    value:
-      readNestedValue(resource, ['spec', 'connection', 'secretRef', 'name']) ??
-      readNestedValue(resource, ['spec', 'secretRef', 'name']) ??
-      '—',
+    label: 'Env template',
+    value: formatObjectCount(resource.spec.envTemplate, 'var'),
   },
   {
-    label: 'Mode',
-    value: readNestedValue(resource, ['spec', 'mode']) ?? '—',
+    label: 'Input files',
+    value: formatCount(resource.spec.inputFiles, 'file'),
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/approvals/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/approvals/$name.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { readNestedArrayValue, readNestedValue } from '@/components/agents-control-plane'
+import { readNestedValue } from '@/components/agents-control-plane'
 import { PrimitiveDetailPage } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
 
@@ -8,6 +8,29 @@ export const Route = createFileRoute('/agents-control-plane/approvals/$name')({
   validateSearch: parseNamespaceSearch,
   component: ApprovalDetailRoute,
 })
+
+const formatCount = (value: unknown, label: string) => {
+  const count = Array.isArray(value) ? value.length : 0
+  if (count === 0) return '—'
+  return `${count} ${label}${count === 1 ? '' : 's'}`
+}
+
+const readFirstSubject = (value: unknown) => {
+  if (!Array.isArray(value)) return '—'
+  const first = value[0]
+  if (!first || typeof first !== 'object' || Array.isArray(first)) return '—'
+  const record = first as Record<string, unknown>
+  const kind = typeof record.kind === 'string' ? record.kind : null
+  const name = typeof record.name === 'string' ? record.name : null
+  if (kind && name) return `${kind}/${name}`
+  return kind ?? name ?? '—'
+}
+
+const readSpecValue = (resource: Record<string, unknown>, key: string) => {
+  const spec = resource.spec
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return null
+  return (spec as Record<string, unknown>)[key] ?? null
+}
 
 function ApprovalDetailRoute() {
   const params = Route.useParams()
@@ -21,13 +44,17 @@ function ApprovalDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/approvals"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
-        { label: 'Mode', value: readNestedValue(resource, ['spec', 'mode']) ?? '—' },
-        { label: 'Required approvals', value: readNestedValue(resource, ['spec', 'requiredApprovals']) ?? '—' },
-        { label: 'Approvers', value: readNestedArrayValue(resource, ['spec', 'approvers']) ?? '—' },
-        { label: 'Timeout', value: readNestedValue(resource, ['spec', 'timeoutSeconds']) ?? '—' },
-      ]}
+      summaryItems={(resource, namespace) => {
+        const subjects = readSpecValue(resource, 'subjects') ?? []
+        return [
+          { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+          { label: 'Mode', value: readNestedValue(resource, ['spec', 'mode']) ?? '—' },
+          { label: 'Default decision', value: readNestedValue(resource, ['spec', 'defaultDecision']) ?? '—' },
+          { label: 'Subjects', value: formatCount(subjects, 'subject') },
+          { label: 'First subject', value: readFirstSubject(subjects) },
+          { label: 'Last decision', value: readNestedValue(resource, ['status', 'lastDecisionAt']) ?? '—' },
+        ]
+      }}
     />
   )
 }

--- a/services/jangar/src/routes/agents-control-plane/approvals/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/approvals/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { readNestedArrayValue, readNestedValue } from '@/components/agents-control-plane'
+import { readNestedValue } from '@/components/agents-control-plane'
 import { PrimitiveListPage } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import type { PrimitiveResource } from '@/data/agents-control-plane'
@@ -10,22 +10,28 @@ export const Route = createFileRoute('/agents-control-plane/approvals/')({
   component: ApprovalsListRoute,
 })
 
+const formatCount = (value: unknown, label: string) => {
+  const count = Array.isArray(value) ? value.length : 0
+  if (count === 0) return '—'
+  return `${count} ${label}${count === 1 ? '' : 's'}`
+}
+
 const fields = [
   {
     label: 'Mode',
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'mode']) ?? '—',
   },
   {
-    label: 'Required',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'requiredApprovals']) ?? '—',
+    label: 'Default decision',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'defaultDecision']) ?? '—',
   },
   {
-    label: 'Approvers',
-    value: (resource: PrimitiveResource) => readNestedArrayValue(resource, ['spec', 'approvers']) ?? '—',
+    label: 'Subjects',
+    value: (resource: PrimitiveResource) => formatCount(resource.spec.subjects, 'subject'),
   },
   {
-    label: 'Timeout',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'timeoutSeconds']) ?? '—',
+    label: 'Last decision',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'lastDecisionAt']) ?? '—',
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/artifacts/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/artifacts/$name.tsx
@@ -24,9 +24,9 @@ function ArtifactDetailRoute() {
       summaryItems={(resource, namespace) => [
         { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
         { label: 'Storage', value: readNestedValue(resource, ['spec', 'storageRef', 'name']) ?? '—' },
-        { label: 'Provider', value: readNestedValue(resource, ['spec', 'storageRef', 'provider']) ?? '—' },
         { label: 'TTL', value: readNestedValue(resource, ['spec', 'lifecycle', 'ttlDays']) ?? '—' },
-        { label: 'Content type', value: readNestedValue(resource, ['spec', 'metadata', 'contentType']) ?? '—' },
+        { label: 'URI', value: readNestedValue(resource, ['status', 'uri']) ?? '—' },
+        { label: 'Checksum', value: readNestedValue(resource, ['status', 'checksum']) ?? '—' },
       ]}
     />
   )

--- a/services/jangar/src/routes/agents-control-plane/artifacts/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/artifacts/index.tsx
@@ -16,16 +16,16 @@ const fields = [
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'storageRef', 'name']) ?? '—',
   },
   {
-    label: 'Provider',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'storageRef', 'provider']) ?? '—',
-  },
-  {
     label: 'TTL',
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'lifecycle', 'ttlDays']) ?? '—',
   },
   {
-    label: 'Content type',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'metadata', 'contentType']) ?? '—',
+    label: 'URI',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'uri']) ?? '—',
+  },
+  {
+    label: 'Checksum',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'checksum']) ?? '—',
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/budgets/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/budgets/$name.tsx
@@ -23,11 +23,13 @@ function BudgetDetailRoute() {
       searchState={searchState}
       summaryItems={(resource, namespace) => [
         { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
-        { label: 'Composition', value: readNestedValue(resource, ['spec', 'compositionRef', 'name']) ?? '—' },
         { label: 'CPU limit', value: readNestedValue(resource, ['spec', 'limits', 'cpu']) ?? '—' },
+        { label: 'Memory limit', value: readNestedValue(resource, ['spec', 'limits', 'memory']) ?? '—' },
+        { label: 'GPU limit', value: readNestedValue(resource, ['spec', 'limits', 'gpu']) ?? '—' },
         { label: 'Token limit', value: readNestedValue(resource, ['spec', 'limits', 'tokens']) ?? '—' },
         { label: 'Dollar limit', value: readNestedValue(resource, ['spec', 'limits', 'dollars']) ?? '—' },
-        { label: 'Window', value: readNestedValue(resource, ['spec', 'window', 'period']) ?? '—' },
+        { label: 'Tokens used', value: readNestedValue(resource, ['status', 'used', 'tokens']) ?? '—' },
+        { label: 'Dollars used', value: readNestedValue(resource, ['status', 'used', 'dollars']) ?? '—' },
       ]}
     />
   )

--- a/services/jangar/src/routes/agents-control-plane/budgets/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/budgets/index.tsx
@@ -12,12 +12,12 @@ export const Route = createFileRoute('/agents-control-plane/budgets/')({
 
 const fields = [
   {
-    label: 'Composition',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'compositionRef', 'name']) ?? '—',
-  },
-  {
     label: 'CPU',
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'limits', 'cpu']) ?? '—',
+  },
+  {
+    label: 'Memory',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'limits', 'memory']) ?? '—',
   },
   {
     label: 'Tokens',

--- a/services/jangar/src/routes/agents-control-plane/implementation-sources/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-sources/$name.tsx
@@ -23,6 +23,14 @@ export const Route = createFileRoute('/agents-control-plane/implementation-sourc
   component: ImplementationSourceDetailPage,
 })
 
+const readScopeTarget = (resource: Record<string, unknown>) =>
+  readNestedValue(resource, ['spec', 'scope', 'repository']) ??
+  readNestedValue(resource, ['spec', 'scope', 'project']) ??
+  readNestedValue(resource, ['spec', 'scope', 'organization']) ??
+  readNestedValue(resource, ['spec', 'scope', 'team']) ??
+  readNestedValue(resource, ['spec', 'scope', 'query']) ??
+  '—'
+
 function ImplementationSourceDetailPage() {
   const params = Route.useParams()
   const searchState = Route.useSearch()
@@ -84,17 +92,11 @@ function ImplementationSourceDetailPage() {
   const summaryItems = resource
     ? [
         { label: 'Namespace', value: getMetadataValue(resource, 'namespace') ?? searchState.namespace },
-        {
-          label: 'Type',
-          value: readNestedValue(resource, ['spec', 'type']) ?? readNestedValue(resource, ['spec', 'provider']) ?? '—',
-        },
-        {
-          label: 'Target',
-          value:
-            readNestedValue(resource, ['spec', 'target']) ?? readNestedValue(resource, ['spec', 'repository']) ?? '—',
-        },
-        { label: 'Cursor', value: readNestedValue(resource, ['status', 'cursor']) ?? '—' },
-        { label: 'Synced at', value: readNestedValue(resource, ['status', 'syncedAt']) ?? '—' },
+        { label: 'Provider', value: readNestedValue(resource, ['spec', 'provider']) ?? '—' },
+        { label: 'Scope', value: readScopeTarget(resource) },
+        { label: 'Auth secret', value: readNestedValue(resource, ['spec', 'auth', 'secretRef', 'name']) ?? '—' },
+        { label: 'Webhook', value: readNestedValue(resource, ['spec', 'webhook', 'enabled']) ?? '—' },
+        { label: 'Last sync', value: readNestedValue(resource, ['status', 'lastSyncedAt']) ?? '—' },
       ]
     : []
 

--- a/services/jangar/src/routes/agents-control-plane/implementation-sources/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-sources/index.tsx
@@ -12,22 +12,30 @@ export const Route = createFileRoute('/agents-control-plane/implementation-sourc
   component: ImplementationSourcesListPage,
 })
 
+const readScopeTarget = (resource: PrimitiveResource) =>
+  readNestedValue(resource, ['spec', 'scope', 'repository']) ??
+  readNestedValue(resource, ['spec', 'scope', 'project']) ??
+  readNestedValue(resource, ['spec', 'scope', 'organization']) ??
+  readNestedValue(resource, ['spec', 'scope', 'team']) ??
+  readNestedValue(resource, ['spec', 'scope', 'query']) ??
+  '—'
+
 const buildSourceFields = (resource: PrimitiveResource) => [
   {
-    label: 'Type',
-    value: readNestedValue(resource, ['spec', 'type']) ?? readNestedValue(resource, ['spec', 'provider']) ?? '—',
+    label: 'Provider',
+    value: readNestedValue(resource, ['spec', 'provider']) ?? '—',
   },
   {
-    label: 'Target',
-    value: readNestedValue(resource, ['spec', 'target']) ?? readNestedValue(resource, ['spec', 'repository']) ?? '—',
+    label: 'Scope',
+    value: readScopeTarget(resource),
   },
   {
-    label: 'Cursor',
-    value: readNestedValue(resource, ['status', 'cursor']) ?? '—',
+    label: 'Auth secret',
+    value: readNestedValue(resource, ['spec', 'auth', 'secretRef', 'name']) ?? '—',
   },
   {
-    label: 'Synced',
-    value: readNestedValue(resource, ['status', 'syncedAt']) ?? '—',
+    label: 'Last sync',
+    value: readNestedValue(resource, ['status', 'lastSyncedAt']) ?? '—',
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/implementation-specs/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-specs/$name.tsx
@@ -23,6 +23,18 @@ export const Route = createFileRoute('/agents-control-plane/implementation-specs
   component: ImplementationSpecDetailPage,
 })
 
+const formatCount = (value: unknown, label: string) => {
+  const count = Array.isArray(value) ? value.length : 0
+  if (count === 0) return '—'
+  return `${count} ${label}${count === 1 ? '' : 's'}`
+}
+
+const readSpecValue = (resource: Record<string, unknown>, key: string) => {
+  const spec = resource.spec
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return null
+  return (spec as Record<string, unknown>)[key] ?? null
+}
+
 function ImplementationSpecDetailPage() {
   const params = Route.useParams()
   const searchState = Route.useSearch()
@@ -86,13 +98,11 @@ function ImplementationSpecDetailPage() {
         { label: 'Namespace', value: getMetadataValue(resource, 'namespace') ?? searchState.namespace },
         {
           label: 'Source',
-          value:
-            readNestedValue(resource, ['spec', 'sourceRef', 'name']) ??
-            readNestedValue(resource, ['spec', 'source', 'kind']) ??
-            '—',
+          value: readNestedValue(resource, ['spec', 'source', 'provider']) ?? '—',
         },
-        { label: 'Title', value: readNestedValue(resource, ['spec', 'title']) ?? '—' },
-        { label: 'External ID', value: readNestedValue(resource, ['spec', 'externalId']) ?? '—' },
+        { label: 'Summary', value: readNestedValue(resource, ['spec', 'summary']) ?? '—' },
+        { label: 'External ID', value: readNestedValue(resource, ['spec', 'source', 'externalId']) ?? '—' },
+        { label: 'Labels', value: formatCount(readSpecValue(resource, 'labels'), 'label') },
         { label: 'Synced at', value: readNestedValue(resource, ['status', 'syncedAt']) ?? '—' },
         { label: 'Source version', value: readNestedValue(resource, ['status', 'sourceVersion']) ?? '—' },
       ]

--- a/services/jangar/src/routes/agents-control-plane/implementation-specs/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-specs/index.tsx
@@ -15,18 +15,15 @@ export const Route = createFileRoute('/agents-control-plane/implementation-specs
 const buildSpecFields = (resource: PrimitiveResource) => [
   {
     label: 'Source',
-    value:
-      readNestedValue(resource, ['spec', 'sourceRef', 'name']) ??
-      readNestedValue(resource, ['spec', 'source', 'kind']) ??
-      '—',
+    value: readNestedValue(resource, ['spec', 'source', 'provider']) ?? '—',
   },
   {
-    label: 'Title',
-    value: readNestedValue(resource, ['spec', 'title']) ?? '—',
+    label: 'Summary',
+    value: readNestedValue(resource, ['spec', 'summary']) ?? '—',
   },
   {
     label: 'External ID',
-    value: readNestedValue(resource, ['spec', 'externalId']) ?? '—',
+    value: readNestedValue(resource, ['spec', 'source', 'externalId']) ?? '—',
   },
   {
     label: 'Synced',

--- a/services/jangar/src/routes/agents-control-plane/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/index.tsx
@@ -7,48 +7,78 @@ export const Route = createFileRoute('/agents-control-plane/')({
   component: AgentsControlPlanePage,
 })
 
-const cards = [
-  { to: '/agents-control-plane/agents', title: 'Agents', description: 'Agent configurations and defaults.' },
-  { to: '/agents-control-plane/agent-runs', title: 'Agent runs', description: 'Execution history and status.' },
+const sections = [
   {
-    to: '/agents-control-plane/agent-providers',
-    title: 'Agent providers',
-    description: 'Provider runtime and integration settings.',
+    label: 'Resources',
+    items: [
+      { to: '/agents-control-plane/agents', title: 'Agents', description: 'Agent configurations and defaults.' },
+      {
+        to: '/agents-control-plane/agent-providers',
+        title: 'Agent providers',
+        description: 'Provider runtime and integration settings.',
+      },
+      {
+        to: '/agents-control-plane/implementation-specs',
+        title: 'Implementation specs',
+        description: 'Normalized implementation definitions.',
+      },
+      {
+        to: '/agents-control-plane/implementation-sources',
+        title: 'Implementation sources',
+        description: 'Upstream feeds that generate specs.',
+      },
+      { to: '/agents-control-plane/tools', title: 'Tools', description: 'Tool definitions and runtime wiring.' },
+    ],
   },
   {
-    to: '/agents-control-plane/implementation-specs',
-    title: 'Implementation specs',
-    description: 'Normalized implementation definitions.',
+    label: 'Runs',
+    items: [
+      { to: '/agents-control-plane/agent-runs', title: 'Agent runs', description: 'Execution history and status.' },
+      { to: '/agents-control-plane/tool-runs', title: 'Tool runs', description: 'Execution history for tools.' },
+    ],
   },
   {
-    to: '/agents-control-plane/implementation-sources',
-    title: 'Implementation sources',
-    description: 'Upstream feeds that generate specs.',
+    label: 'Policies',
+    items: [
+      { to: '/agents-control-plane/approvals', title: 'Approvals', description: 'Approval policies and gates.' },
+      { to: '/agents-control-plane/budgets', title: 'Budgets', description: 'Budget ceilings and enforcement.' },
+      {
+        to: '/agents-control-plane/secret-bindings',
+        title: 'Secret bindings',
+        description: 'Secret access control policies.',
+      },
+    ],
   },
-  { to: '/agents-control-plane/memories', title: 'Memories', description: 'Memory backends and health.' },
-  { to: '/agents-control-plane/tools', title: 'Tools', description: 'Tool definitions and runtime wiring.' },
-  { to: '/agents-control-plane/tool-runs', title: 'Tool runs', description: 'Execution history for tools.' },
-  { to: '/agents-control-plane/approvals', title: 'Approvals', description: 'Approval policies and gates.' },
-  { to: '/agents-control-plane/budgets', title: 'Budgets', description: 'Budget ceilings and enforcement.' },
-  { to: '/agents-control-plane/signals', title: 'Signals', description: 'Signal definitions and retention.' },
   {
-    to: '/agents-control-plane/signal-deliveries',
-    title: 'Signal deliveries',
-    description: 'Delivery records and payloads.',
+    label: 'Signals',
+    items: [
+      { to: '/agents-control-plane/signals', title: 'Signals', description: 'Signal definitions and routing.' },
+      {
+        to: '/agents-control-plane/signal-deliveries',
+        title: 'Signal deliveries',
+        description: 'Delivery records and payloads.',
+      },
+    ],
   },
-  { to: '/agents-control-plane/schedules', title: 'Schedules', description: 'Recurring schedule definitions.' },
-  { to: '/agents-control-plane/artifacts', title: 'Artifacts', description: 'Artifact storage configuration.' },
-  { to: '/agents-control-plane/workspaces', title: 'Workspaces', description: 'Workspace storage definitions.' },
   {
-    to: '/agents-control-plane/secret-bindings',
-    title: 'Secret bindings',
-    description: 'Secret access control policies.',
+    label: 'Storage',
+    items: [
+      { to: '/agents-control-plane/memories', title: 'Memories', description: 'Memory backends and health.' },
+      { to: '/agents-control-plane/artifacts', title: 'Artifacts', description: 'Artifact storage configuration.' },
+      { to: '/agents-control-plane/workspaces', title: 'Workspaces', description: 'Workspace storage definitions.' },
+    ],
   },
-  { to: '/agents-control-plane/orchestrations', title: 'Orchestrations', description: 'Orchestration templates.' },
   {
-    to: '/agents-control-plane/orchestration-runs',
-    title: 'Orchestration runs',
-    description: 'Execution records for orchestrations.',
+    label: 'Orchestration',
+    items: [
+      { to: '/agents-control-plane/orchestrations', title: 'Orchestrations', description: 'Orchestration templates.' },
+      {
+        to: '/agents-control-plane/orchestration-runs',
+        title: 'Orchestration runs',
+        description: 'Execution records for orchestrations.',
+      },
+      { to: '/agents-control-plane/schedules', title: 'Schedules', description: 'Recurring schedule definitions.' },
+    ],
   },
 ]
 
@@ -61,16 +91,23 @@ function AgentsControlPlanePage() {
         <p className="text-xs text-muted-foreground">Browse core agent primitives and review their current status.</p>
       </header>
 
-      <section className="grid gap-4 sm:grid-cols-2">
-        {cards.map((card) => (
-          <div key={card.to} className="space-y-3 rounded-none border border-border bg-card p-4">
-            <div className="space-y-1">
-              <h2 className="text-sm font-semibold text-foreground">{card.title}</h2>
-              <p className="text-xs text-muted-foreground">{card.description}</p>
+      <section className="space-y-6">
+        {sections.map((section) => (
+          <div key={section.label} className="space-y-3">
+            <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">{section.label}</div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {section.items.map((card) => (
+                <div key={card.to} className="space-y-3 rounded-none border border-border bg-card p-4">
+                  <div className="space-y-1">
+                    <h2 className="text-sm font-semibold text-foreground">{card.title}</h2>
+                    <p className="text-xs text-muted-foreground">{card.description}</p>
+                  </div>
+                  <Link to={card.to} className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}>
+                    Open
+                  </Link>
+                </div>
+              ))}
             </div>
-            <Link to={card.to} className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}>
-              Open
-            </Link>
           </div>
         ))}
       </section>

--- a/services/jangar/src/routes/agents-control-plane/memories/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/memories/$name.tsx
@@ -8,6 +8,7 @@ import {
   EventsList,
   getMetadataValue,
   getStatusConditions,
+  readNestedArrayValue,
   readNestedValue,
   StatusBadge,
   YamlCodeBlock,
@@ -85,12 +86,13 @@ function MemoryDetailPage() {
     ? [
         { label: 'Namespace', value: getMetadataValue(resource, 'namespace') ?? searchState.namespace },
         { label: 'Type', value: readNestedValue(resource, ['spec', 'type']) ?? '—' },
-        { label: 'Provider', value: readNestedValue(resource, ['spec', 'provider']) ?? '—' },
+        { label: 'Default', value: readNestedValue(resource, ['spec', 'default']) ?? '—' },
         {
           label: 'Secret',
           value: readNestedValue(resource, ['spec', 'connection', 'secretRef', 'name']) ?? '—',
         },
-        { label: 'Phase', value: readNestedValue(resource, ['status', 'phase']) ?? '—' },
+        { label: 'Capabilities', value: readNestedArrayValue(resource, ['spec', 'capabilities']) ?? '—' },
+        { label: 'Last checked', value: readNestedValue(resource, ['status', 'lastCheckedAt']) ?? '—' },
       ]
     : []
 

--- a/services/jangar/src/routes/agents-control-plane/memories/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/memories/index.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import * as React from 'react'
 
-import { deriveStatusLabel, getMetadataValue, readNestedValue, StatusBadge } from '@/components/agents-control-plane'
+import {
+  deriveStatusLabel,
+  getMetadataValue,
+  readNestedArrayValue,
+  readNestedValue,
+  StatusBadge,
+} from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -18,16 +24,16 @@ const buildMemoryFields = (resource: PrimitiveResource) => [
     value: readNestedValue(resource, ['spec', 'type']) ?? '—',
   },
   {
+    label: 'Default',
+    value: readNestedValue(resource, ['spec', 'default']) ?? '—',
+  },
+  {
     label: 'Secret',
     value: readNestedValue(resource, ['spec', 'connection', 'secretRef', 'name']) ?? '—',
   },
   {
-    label: 'Provider',
-    value: readNestedValue(resource, ['spec', 'provider']) ?? '—',
-  },
-  {
-    label: 'Phase',
-    value: readNestedValue(resource, ['status', 'phase']) ?? '—',
+    label: 'Capabilities',
+    value: readNestedArrayValue(resource, ['spec', 'capabilities']) ?? '—',
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/orchestration-runs/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/orchestration-runs/$name.tsx
@@ -24,9 +24,10 @@ function OrchestrationRunDetailRoute() {
       summaryItems={(resource, namespace) => [
         { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
         { label: 'Orchestration', value: readNestedValue(resource, ['spec', 'orchestrationRef', 'name']) ?? '—' },
-        { label: 'Composition', value: readNestedValue(resource, ['spec', 'compositionRef', 'name']) ?? '—' },
-        { label: 'Run ID', value: readNestedValue(resource, ['spec', 'parameters', 'runId']) ?? '—' },
+        { label: 'Run ID', value: readNestedValue(resource, ['status', 'runId']) ?? '—' },
         { label: 'Delivery ID', value: readNestedValue(resource, ['spec', 'deliveryId']) ?? '—' },
+        { label: 'Started', value: readNestedValue(resource, ['status', 'startedAt']) ?? '—' },
+        { label: 'Finished', value: readNestedValue(resource, ['status', 'finishedAt']) ?? '—' },
       ]}
     />
   )

--- a/services/jangar/src/routes/agents-control-plane/orchestration-runs/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/orchestration-runs/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { readNestedValue } from '@/components/agents-control-plane'
+import { formatTimestamp, readNestedValue } from '@/components/agents-control-plane'
 import { PrimitiveListPage } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import type { PrimitiveResource } from '@/data/agents-control-plane'
@@ -16,16 +16,16 @@ const fields = [
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'orchestrationRef', 'name']) ?? '—',
   },
   {
-    label: 'Composition',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'compositionRef', 'name']) ?? '—',
-  },
-  {
     label: 'Run ID',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'parameters', 'runId']) ?? '—',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'runId']) ?? '—',
   },
   {
     label: 'Delivery ID',
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'deliveryId']) ?? '—',
+  },
+  {
+    label: 'Started',
+    value: (resource: PrimitiveResource) => formatTimestamp(readNestedValue(resource, ['status', 'startedAt'])),
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/orchestrations/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/orchestrations/$name.tsx
@@ -15,6 +15,13 @@ const formatCount = (value: unknown, label: string) => {
   return `${count} ${label}${count === 1 ? '' : 's'}`
 }
 
+const formatObjectCount = (value: unknown, label: string) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '—'
+  const count = Object.keys(value as Record<string, unknown>).length
+  if (count === 0) return '—'
+  return `${count} ${label}${count === 1 ? '' : 's'}`
+}
+
 const readFirstStep = (value: unknown) => {
   if (!Array.isArray(value)) return '—'
   const first = value[0]
@@ -46,12 +53,13 @@ function OrchestrationDetailRoute() {
       searchState={searchState}
       summaryItems={(resource, namespace) => {
         const steps = readSpecValue(resource, 'steps')
+        const policies = readSpecValue(resource, 'policies')
         return [
           { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
-          { label: 'Composition', value: readNestedValue(resource, ['spec', 'compositionRef', 'name']) ?? '—' },
           { label: 'Entrypoint', value: readNestedValue(resource, ['spec', 'entrypoint']) ?? '—' },
           { label: 'Steps', value: formatCount(steps, 'step') },
           { label: 'First step', value: readFirstStep(steps) },
+          { label: 'Policies', value: formatObjectCount(policies, 'policy') },
         ]
       }}
     />

--- a/services/jangar/src/routes/agents-control-plane/orchestrations/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/orchestrations/index.tsx
@@ -16,6 +16,13 @@ const formatCount = (value: unknown, label: string) => {
   return `${count} ${label}${count === 1 ? '' : 's'}`
 }
 
+const formatObjectCount = (value: unknown, label: string) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '—'
+  const count = Object.keys(value as Record<string, unknown>).length
+  if (count === 0) return '—'
+  return `${count} ${label}${count === 1 ? '' : 's'}`
+}
+
 const readFirstStepKind = (resource: PrimitiveResource) => {
   const steps = Array.isArray(resource.spec.steps) ? resource.spec.steps : []
   const first = steps[0]
@@ -25,10 +32,6 @@ const readFirstStepKind = (resource: PrimitiveResource) => {
 }
 
 const fields = [
-  {
-    label: 'Composition',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'compositionRef', 'name']) ?? '—',
-  },
   {
     label: 'Entrypoint',
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'entrypoint']) ?? '—',
@@ -40,6 +43,10 @@ const fields = [
   {
     label: 'First step',
     value: (resource: PrimitiveResource) => readFirstStepKind(resource),
+  },
+  {
+    label: 'Policies',
+    value: (resource: PrimitiveResource) => formatObjectCount(resource.spec.policies, 'policy'),
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/secret-bindings/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/secret-bindings/$name.tsx
@@ -48,10 +48,10 @@ function SecretBindingDetailRoute() {
         const subjects = readSpecValue(resource, 'subjects')
         return [
           { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
-          { label: 'Subject namespace', value: readNestedValue(resource, ['spec', 'namespace']) ?? '—' },
           { label: 'Allowed secrets', value: readNestedArrayValue(resource, ['spec', 'allowedSecrets']) ?? '—' },
           { label: 'Subjects', value: formatCount(subjects, 'subject') },
           { label: 'First subject', value: readFirstSubject(subjects) },
+          { label: 'Phase', value: readNestedValue(resource, ['status', 'phase']) ?? '—' },
         ]
       }}
     />

--- a/services/jangar/src/routes/agents-control-plane/secret-bindings/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/secret-bindings/index.tsx
@@ -16,19 +16,20 @@ const formatCount = (value: unknown, label: string) => {
   return `${count} ${label}${count === 1 ? '' : 's'}`
 }
 
-const readFirstSubjectKind = (resource: PrimitiveResource) => {
+const readFirstSubject = (resource: PrimitiveResource) => {
   const subjects = Array.isArray(resource.spec.subjects) ? resource.spec.subjects : []
   const first = subjects[0]
   if (!first || typeof first !== 'object' || Array.isArray(first)) return '—'
   const record = first as Record<string, unknown>
-  return typeof record.kind === 'string' && record.kind.trim().length > 0 ? record.kind : '—'
+  const kind = typeof record.kind === 'string' && record.kind.trim().length > 0 ? record.kind : null
+  const name = typeof record.name === 'string' && record.name.trim().length > 0 ? record.name : null
+  const namespace = typeof record.namespace === 'string' && record.namespace.trim().length > 0 ? record.namespace : null
+  if (kind && name && namespace) return `${kind}/${name} (${namespace})`
+  if (kind && name) return `${kind}/${name}`
+  return kind ?? name ?? '—'
 }
 
 const fields = [
-  {
-    label: 'Namespace',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'namespace']) ?? '—',
-  },
   {
     label: 'Allowed secrets',
     value: (resource: PrimitiveResource) => readNestedArrayValue(resource, ['spec', 'allowedSecrets']) ?? '—',
@@ -38,8 +39,12 @@ const fields = [
     value: (resource: PrimitiveResource) => formatCount(resource.spec.subjects, 'subject'),
   },
   {
-    label: 'Subject kind',
-    value: (resource: PrimitiveResource) => readFirstSubjectKind(resource),
+    label: 'First subject',
+    value: (resource: PrimitiveResource) => readFirstSubject(resource),
+  },
+  {
+    label: 'Phase',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'phase']) ?? '—',
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/signal-deliveries/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/signal-deliveries/$name.tsx
@@ -9,6 +9,19 @@ export const Route = createFileRoute('/agents-control-plane/signal-deliveries/$n
   component: SignalDeliveryDetailRoute,
 })
 
+const formatObjectKeys = (value: unknown) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '—'
+  const count = Object.keys(value as Record<string, unknown>).length
+  if (count === 0) return '—'
+  return `${count} ${count === 1 ? 'key' : 'keys'}`
+}
+
+const readSpecValue = (resource: Record<string, unknown>, key: string) => {
+  const spec = resource.spec
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return null
+  return (spec as Record<string, unknown>)[key] ?? null
+}
+
 function SignalDeliveryDetailRoute() {
   const params = Route.useParams()
   const searchState = Route.useSearch()
@@ -24,9 +37,9 @@ function SignalDeliveryDetailRoute() {
       summaryItems={(resource, namespace) => [
         { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
         { label: 'Signal', value: readNestedValue(resource, ['spec', 'signalRef', 'name']) ?? '—' },
-        { label: 'Signal namespace', value: readNestedValue(resource, ['spec', 'signalRef', 'namespace']) ?? '—' },
         { label: 'Delivery ID', value: readNestedValue(resource, ['spec', 'deliveryId']) ?? '—' },
-        { label: 'Payload', value: readNestedValue(resource, ['spec', 'payload', 'message']) ?? '—' },
+        { label: 'Payload', value: formatObjectKeys(readSpecValue(resource, 'payload')) },
+        { label: 'Delivered', value: readNestedValue(resource, ['status', 'deliveredAt']) ?? '—' },
       ]}
     />
   )

--- a/services/jangar/src/routes/agents-control-plane/signal-deliveries/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/signal-deliveries/index.tsx
@@ -10,14 +10,17 @@ export const Route = createFileRoute('/agents-control-plane/signal-deliveries/')
   component: SignalDeliveriesListRoute,
 })
 
+const formatObjectKeys = (value: unknown) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '—'
+  const count = Object.keys(value as Record<string, unknown>).length
+  if (count === 0) return '—'
+  return `${count} ${count === 1 ? 'key' : 'keys'}`
+}
+
 const fields = [
   {
     label: 'Signal',
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'signalRef', 'name']) ?? '—',
-  },
-  {
-    label: 'Signal namespace',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'signalRef', 'namespace']) ?? '—',
   },
   {
     label: 'Delivery ID',
@@ -25,7 +28,11 @@ const fields = [
   },
   {
     label: 'Payload',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'payload', 'message']) ?? '—',
+    value: (resource: PrimitiveResource) => formatObjectKeys(resource.spec.payload),
+  },
+  {
+    label: 'Delivered',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'deliveredAt']) ?? '—',
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/signals/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/signals/$name.tsx
@@ -9,6 +9,19 @@ export const Route = createFileRoute('/agents-control-plane/signals/$name')({
   component: SignalDetailRoute,
 })
 
+const formatObjectKeys = (value: unknown) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '—'
+  const count = Object.keys(value as Record<string, unknown>).length
+  if (count === 0) return '—'
+  return `${count} ${count === 1 ? 'key' : 'keys'}`
+}
+
+const readSpecValue = (resource: Record<string, unknown>, key: string) => {
+  const spec = resource.spec
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return null
+  return (spec as Record<string, unknown>)[key] ?? null
+}
+
 function SignalDetailRoute() {
   const params = Route.useParams()
   const searchState = Route.useSearch()
@@ -23,10 +36,10 @@ function SignalDetailRoute() {
       searchState={searchState}
       summaryItems={(resource, namespace) => [
         { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+        { label: 'Channel', value: readNestedValue(resource, ['spec', 'channel']) ?? '—' },
         { label: 'Description', value: readNestedValue(resource, ['spec', 'description']) ?? '—' },
-        { label: 'Retention', value: readNestedValue(resource, ['spec', 'retentionSeconds']) ?? '—' },
-        { label: 'Schema', value: readNestedValue(resource, ['spec', 'payloadSchema']) ?? '—' },
-        { label: 'Phase', value: readNestedValue(resource, ['status', 'phase']) ?? '—' },
+        { label: 'Payload', value: formatObjectKeys(readSpecValue(resource, 'payload')) },
+        { label: 'Last delivery', value: readNestedValue(resource, ['status', 'lastDeliveryAt']) ?? '—' },
       ]}
     />
   )

--- a/services/jangar/src/routes/agents-control-plane/signals/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/signals/index.tsx
@@ -10,22 +10,29 @@ export const Route = createFileRoute('/agents-control-plane/signals/')({
   component: SignalsListRoute,
 })
 
+const formatObjectKeys = (value: unknown) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '—'
+  const count = Object.keys(value as Record<string, unknown>).length
+  if (count === 0) return '—'
+  return `${count} ${count === 1 ? 'key' : 'keys'}`
+}
+
 const fields = [
+  {
+    label: 'Channel',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'channel']) ?? '—',
+  },
   {
     label: 'Description',
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'description']) ?? '—',
   },
   {
-    label: 'Retention',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'retentionSeconds']) ?? '—',
+    label: 'Payload',
+    value: (resource: PrimitiveResource) => formatObjectKeys(resource.spec.payload),
   },
   {
-    label: 'Schema',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'payloadSchema']) ?? '—',
-  },
-  {
-    label: 'Phase',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'phase']) ?? '—',
+    label: 'Last delivery',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'lastDeliveryAt']) ?? '—',
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/tool-runs/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/tool-runs/$name.tsx
@@ -24,9 +24,10 @@ function ToolRunDetailRoute() {
       summaryItems={(resource, namespace) => [
         { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
         { label: 'Tool', value: readNestedValue(resource, ['spec', 'toolRef', 'name']) ?? '—' },
-        { label: 'Action', value: readNestedValue(resource, ['spec', 'parameters', 'action']) ?? '—' },
-        { label: 'Timeout', value: readNestedValue(resource, ['spec', 'timeoutSeconds']) ?? '—' },
-        { label: 'Retry limit', value: readNestedValue(resource, ['spec', 'retryPolicy', 'limit']) ?? '—' },
+        { label: 'Delivery ID', value: readNestedValue(resource, ['spec', 'deliveryId']) ?? '—' },
+        { label: 'Run ID', value: readNestedValue(resource, ['status', 'runId']) ?? '—' },
+        { label: 'Started', value: readNestedValue(resource, ['status', 'startedAt']) ?? '—' },
+        { label: 'Finished', value: readNestedValue(resource, ['status', 'finishedAt']) ?? '—' },
       ]}
     />
   )

--- a/services/jangar/src/routes/agents-control-plane/tool-runs/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/tool-runs/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { readNestedValue } from '@/components/agents-control-plane'
+import { formatTimestamp, readNestedValue } from '@/components/agents-control-plane'
 import { PrimitiveListPage } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import type { PrimitiveResource } from '@/data/agents-control-plane'
@@ -16,16 +16,16 @@ const fields = [
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'toolRef', 'name']) ?? '—',
   },
   {
-    label: 'Action',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'parameters', 'action']) ?? '—',
+    label: 'Delivery ID',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'deliveryId']) ?? '—',
   },
   {
-    label: 'Timeout',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'timeoutSeconds']) ?? '—',
+    label: 'Run ID',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['status', 'runId']) ?? '—',
   },
   {
-    label: 'Retry limit',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'retryPolicy', 'limit']) ?? '—',
+    label: 'Started',
+    value: (resource: PrimitiveResource) => formatTimestamp(readNestedValue(resource, ['status', 'startedAt'])),
   },
 ]
 

--- a/services/jangar/src/routes/agents-control-plane/tools/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/tools/$name.tsx
@@ -24,11 +24,12 @@ function ToolDetailRoute() {
       summaryItems={(resource, namespace) => [
         { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
         { label: 'Image', value: readNestedValue(resource, ['spec', 'image']) ?? '—' },
-        {
-          label: 'Command',
-          value: readNestedArrayValue(resource, ['spec', 'command']) ?? '—',
-        },
+        { label: 'Command', value: readNestedArrayValue(resource, ['spec', 'command']) ?? '—' },
         { label: 'Args', value: readNestedArrayValue(resource, ['spec', 'args']) ?? '—' },
+        { label: 'Service account', value: readNestedValue(resource, ['spec', 'serviceAccount']) ?? '—' },
+        { label: 'Working dir', value: readNestedValue(resource, ['spec', 'workingDir']) ?? '—' },
+        { label: 'Timeout', value: readNestedValue(resource, ['spec', 'timeoutSeconds']) ?? '—' },
+        { label: 'TTL after finish', value: readNestedValue(resource, ['spec', 'ttlSecondsAfterFinished']) ?? '—' },
       ]}
     />
   )

--- a/services/jangar/src/routes/agents-control-plane/tools/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/tools/index.tsx
@@ -23,6 +23,10 @@ const fields = [
     label: 'Args',
     value: (resource: PrimitiveResource) => readNestedArrayValue(resource, ['spec', 'args']) ?? '—',
   },
+  {
+    label: 'Timeout',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'timeoutSeconds']) ?? '—',
+  },
 ]
 
 function ToolsListRoute() {

--- a/services/jangar/src/routes/agents-control-plane/workspaces/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/workspaces/$name.tsx
@@ -26,7 +26,8 @@ function WorkspaceDetailRoute() {
         { label: 'Size', value: readNestedValue(resource, ['spec', 'size']) ?? '—' },
         { label: 'Access modes', value: readNestedArrayValue(resource, ['spec', 'accessModes']) ?? '—' },
         { label: 'Storage class', value: readNestedValue(resource, ['spec', 'storageClassName']) ?? '—' },
-        { label: 'Volume mode', value: readNestedValue(resource, ['spec', 'volumeMode']) ?? '—' },
+        { label: 'TTL', value: readNestedValue(resource, ['spec', 'ttlSeconds']) ?? '—' },
+        { label: 'Volume', value: readNestedValue(resource, ['status', 'volumeName']) ?? '—' },
       ]}
     />
   )

--- a/services/jangar/src/routes/agents-control-plane/workspaces/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/workspaces/index.tsx
@@ -24,8 +24,8 @@ const fields = [
     value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'storageClassName']) ?? '—',
   },
   {
-    label: 'Volume mode',
-    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'volumeMode']) ?? '—',
+    label: 'TTL',
+    value: (resource: PrimitiveResource) => readNestedValue(resource, ['spec', 'ttlSeconds']) ?? '—',
   },
 ]
 


### PR DESCRIPTION
## Summary

- Grouped the Agents control-plane navigation and overview into resource/run/policy/signal/storage/orchestration sections.
- Aligned list/detail views for all agents primitives with CRD spec/status fields and removed stale fields.
- Updated tool views to use native image/command/args fields with expanded summaries.

## Related Issues

Resolves #2555

## Testing

- bun run --filter @proompteng/jangar lint
- bun run --filter @proompteng/jangar test

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
