### PR TITLE
chore(agents): bump jangar image

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "d7d6242b"
-  digest: sha256:e80784d8b94c7de7a2c688646eec1471268438a2dbe78953264b8f19434aec56
+  tag: "f06b73ba"
+  digest: sha256:e937dfbf962e2d261e517ba55a3745b660db17e1d0a806a36f4560c60d17cd1f
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary
- bump agents deployment image tag/digest to `f06b73ba`
- align GitOps values with newly built Jangar image

## Related Issues
None

## Testing
- Not run (image built and pushed in-cluster)

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
