### PR TITLE
feat(agentctl): add control-plane status/diagnose command

### DIFF
--- a/docs/agents/agentctl-cli-design.md
+++ b/docs/agents/agentctl-cli-design.md
@@ -35,6 +35,7 @@ It talks to the Jangar controller over gRPC.
 - `agentctl version [--client]`
 - `agentctl config view|set`
 - `agentctl completion <shell>`
+- `agentctl status` / `agentctl diagnose` (control-plane health)
 
 ### Agent
 - `agentctl agent get <name>`
@@ -77,6 +78,77 @@ It talks to the Jangar controller over gRPC.
 - `agentctl run list`
 - `agentctl run logs <name> [--follow]` (via Jangar gRPC)
 - `agentctl run cancel <name>`
+
+### Status / Diagnose
+`agentctl status` and `agentctl diagnose` call the Jangar control-plane status endpoint and present a summary table
+by component and namespace. Use `--output json` for machine parsing.
+
+Example table:
+
+```
+component                  | namespace | status     | message
+---------------------------|-----------|------------|------------------------------
+namespace                  | agents    | healthy    |
+agents-controller          | agents    | healthy    |
+supporting-controller      | agents    | healthy    |
+orchestration-controller   | agents    | healthy    |
+runtime:workflow           | agents    | healthy    |
+runtime:job                | agents    | healthy    |
+runtime:temporal           | agents    | configured | temporal configuration resolved
+runtime:custom             | agents    | unknown    | custom runtime configured per AgentRun
+database                   | agents    | healthy    |
+grpc                       | agents    | healthy    | 127.0.0.1:50051
+```
+
+`--output json` includes:
+
+```json
+{
+  "service": "jangar",
+  "generated_at": "...",
+  "controllers": [
+    {
+      "name": "agents-controller",
+      "enabled": true,
+      "started": true,
+      "crds_ready": true,
+      "missing_crds": [],
+      "last_checked_at": "...",
+      "status": "healthy",
+      "message": ""
+    }
+  ],
+  "runtime_adapters": [
+    {
+      "name": "workflow",
+      "available": true,
+      "status": "healthy",
+      "message": "",
+      "endpoint": ""
+    }
+  ],
+  "database": {
+    "configured": true,
+    "connected": true,
+    "status": "healthy",
+    "message": "",
+    "latency_ms": 12
+  },
+  "grpc": {
+    "enabled": true,
+    "address": "127.0.0.1:50051",
+    "status": "healthy",
+    "message": ""
+  },
+  "namespaces": [
+    {
+      "namespace": "agents",
+      "status": "healthy",
+      "degraded_components": []
+    }
+  ]
+}
+```
 
 ## Flags & Defaults
 - `--namespace` / `-n` (default `agents`).

--- a/proto/proompteng/jangar/v1/agentctl.proto
+++ b/proto/proompteng/jangar/v1/agentctl.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/proompteng/lab/services/jangar/internal/agentctl
 
 service AgentctlService {
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+  rpc GetControlPlaneStatus(GetControlPlaneStatusRequest) returns (GetControlPlaneStatusResponse);
 
   rpc ListAgents(ListAgentsRequest) returns (ListAgentsResponse);
   rpc GetAgent(GetAgentRequest) returns (GetAgentResponse);
@@ -861,4 +862,58 @@ message StreamAgentRunLogsRequest {
 message StreamAgentRunLogsResponse {
   string stream = 1;
   string message = 2;
+}
+
+message GetControlPlaneStatusRequest {
+  string namespace = 1;
+}
+
+message GetControlPlaneStatusResponse {
+  string service = 1;
+  string generated_at = 2;
+  repeated ControllerHealth controllers = 3;
+  repeated RuntimeAdapterHealth runtime_adapters = 4;
+  DatabaseHealth database = 5;
+  GrpcHealth grpc = 6;
+  repeated NamespaceHealth namespaces = 7;
+}
+
+message ControllerHealth {
+  string name = 1;
+  bool enabled = 2;
+  bool started = 3;
+  bool crds_ready = 4;
+  repeated string missing_crds = 5;
+  string last_checked_at = 6;
+  string status = 7;
+  string message = 8;
+}
+
+message RuntimeAdapterHealth {
+  string name = 1;
+  bool available = 2;
+  string status = 3;
+  string message = 4;
+  string endpoint = 5;
+}
+
+message DatabaseHealth {
+  bool configured = 1;
+  bool connected = 2;
+  string status = 3;
+  string message = 4;
+  int32 latency_ms = 5;
+}
+
+message GrpcHealth {
+  bool enabled = 1;
+  string address = 2;
+  string status = 3;
+  string message = 4;
+}
+
+message NamespaceHealth {
+  string namespace = 1;
+  string status = 2;
+  repeated string degraded_components = 3;
 }

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -139,6 +139,13 @@ export JANGAR_GRPC_TOKEN=... # server-side
 export AGENTCTL_TOKEN=...    # client-side
 ```
 
+Control-plane status:
+
+```bash
+agentctl status
+agentctl status --output json
+```
+
 Environment variables:
 
 - `JANGAR_GRPC_ENABLED` (default: off)

--- a/services/jangar/agentctl/proto/proompteng/jangar/v1/agentctl.proto
+++ b/services/jangar/agentctl/proto/proompteng/jangar/v1/agentctl.proto
@@ -6,11 +6,17 @@ option go_package = "github.com/proompteng/lab/services/jangar/internal/agentctl
 
 service AgentctlService {
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+  rpc GetControlPlaneStatus(GetControlPlaneStatusRequest) returns (GetControlPlaneStatusResponse);
 
   rpc ListAgents(ListAgentsRequest) returns (ListAgentsResponse);
   rpc GetAgent(GetAgentRequest) returns (GetAgentResponse);
   rpc ApplyAgent(ApplyAgentRequest) returns (ApplyAgentResponse);
   rpc DeleteAgent(DeleteAgentRequest) returns (DeleteAgentResponse);
+
+  rpc ListAgentProviders(ListAgentProvidersRequest) returns (ListAgentProvidersResponse);
+  rpc GetAgentProvider(GetAgentProviderRequest) returns (GetAgentProviderResponse);
+  rpc ApplyAgentProvider(ApplyAgentProviderRequest) returns (ApplyAgentProviderResponse);
+  rpc DeleteAgentProvider(DeleteAgentProviderRequest) returns (DeleteAgentProviderResponse);
 
   rpc ListImplementationSpecs(ListImplementationSpecsRequest) returns (ListImplementationSpecsResponse);
   rpc GetImplementationSpec(GetImplementationSpecRequest) returns (GetImplementationSpecResponse);
@@ -27,6 +33,66 @@ service AgentctlService {
   rpc GetMemory(GetMemoryRequest) returns (GetMemoryResponse);
   rpc ApplyMemory(ApplyMemoryRequest) returns (ApplyMemoryResponse);
   rpc DeleteMemory(DeleteMemoryRequest) returns (DeleteMemoryResponse);
+
+  rpc ListTools(ListToolsRequest) returns (ListToolsResponse);
+  rpc GetTool(GetToolRequest) returns (GetToolResponse);
+  rpc ApplyTool(ApplyToolRequest) returns (ApplyToolResponse);
+  rpc DeleteTool(DeleteToolRequest) returns (DeleteToolResponse);
+
+  rpc ListToolRuns(ListToolRunsRequest) returns (ListToolRunsResponse);
+  rpc GetToolRun(GetToolRunRequest) returns (GetToolRunResponse);
+  rpc ApplyToolRun(ApplyToolRunRequest) returns (ApplyToolRunResponse);
+  rpc DeleteToolRun(DeleteToolRunRequest) returns (DeleteToolRunResponse);
+
+  rpc ListOrchestrations(ListOrchestrationsRequest) returns (ListOrchestrationsResponse);
+  rpc GetOrchestration(GetOrchestrationRequest) returns (GetOrchestrationResponse);
+  rpc ApplyOrchestration(ApplyOrchestrationRequest) returns (ApplyOrchestrationResponse);
+  rpc DeleteOrchestration(DeleteOrchestrationRequest) returns (DeleteOrchestrationResponse);
+
+  rpc ListOrchestrationRuns(ListOrchestrationRunsRequest) returns (ListOrchestrationRunsResponse);
+  rpc GetOrchestrationRun(GetOrchestrationRunRequest) returns (GetOrchestrationRunResponse);
+  rpc ApplyOrchestrationRun(ApplyOrchestrationRunRequest) returns (ApplyOrchestrationRunResponse);
+  rpc DeleteOrchestrationRun(DeleteOrchestrationRunRequest) returns (DeleteOrchestrationRunResponse);
+
+  rpc ListApprovalPolicies(ListApprovalPoliciesRequest) returns (ListApprovalPoliciesResponse);
+  rpc GetApprovalPolicy(GetApprovalPolicyRequest) returns (GetApprovalPolicyResponse);
+  rpc ApplyApprovalPolicy(ApplyApprovalPolicyRequest) returns (ApplyApprovalPolicyResponse);
+  rpc DeleteApprovalPolicy(DeleteApprovalPolicyRequest) returns (DeleteApprovalPolicyResponse);
+
+  rpc ListBudgets(ListBudgetsRequest) returns (ListBudgetsResponse);
+  rpc GetBudget(GetBudgetRequest) returns (GetBudgetResponse);
+  rpc ApplyBudget(ApplyBudgetRequest) returns (ApplyBudgetResponse);
+  rpc DeleteBudget(DeleteBudgetRequest) returns (DeleteBudgetResponse);
+
+  rpc ListSecretBindings(ListSecretBindingsRequest) returns (ListSecretBindingsResponse);
+  rpc GetSecretBinding(GetSecretBindingRequest) returns (GetSecretBindingResponse);
+  rpc ApplySecretBinding(ApplySecretBindingRequest) returns (ApplySecretBindingResponse);
+  rpc DeleteSecretBinding(DeleteSecretBindingRequest) returns (DeleteSecretBindingResponse);
+
+  rpc ListSignals(ListSignalsRequest) returns (ListSignalsResponse);
+  rpc GetSignal(GetSignalRequest) returns (GetSignalResponse);
+  rpc ApplySignal(ApplySignalRequest) returns (ApplySignalResponse);
+  rpc DeleteSignal(DeleteSignalRequest) returns (DeleteSignalResponse);
+
+  rpc ListSignalDeliveries(ListSignalDeliveriesRequest) returns (ListSignalDeliveriesResponse);
+  rpc GetSignalDelivery(GetSignalDeliveryRequest) returns (GetSignalDeliveryResponse);
+  rpc ApplySignalDelivery(ApplySignalDeliveryRequest) returns (ApplySignalDeliveryResponse);
+  rpc DeleteSignalDelivery(DeleteSignalDeliveryRequest) returns (DeleteSignalDeliveryResponse);
+
+  rpc ListSchedules(ListSchedulesRequest) returns (ListSchedulesResponse);
+  rpc GetSchedule(GetScheduleRequest) returns (GetScheduleResponse);
+  rpc ApplySchedule(ApplyScheduleRequest) returns (ApplyScheduleResponse);
+  rpc DeleteSchedule(DeleteScheduleRequest) returns (DeleteScheduleResponse);
+
+  rpc ListArtifacts(ListArtifactsRequest) returns (ListArtifactsResponse);
+  rpc GetArtifact(GetArtifactRequest) returns (GetArtifactResponse);
+  rpc ApplyArtifact(ApplyArtifactRequest) returns (ApplyArtifactResponse);
+  rpc DeleteArtifact(DeleteArtifactRequest) returns (DeleteArtifactResponse);
+
+  rpc ListWorkspaces(ListWorkspacesRequest) returns (ListWorkspacesResponse);
+  rpc GetWorkspace(GetWorkspaceRequest) returns (GetWorkspaceResponse);
+  rpc ApplyWorkspace(ApplyWorkspaceRequest) returns (ApplyWorkspaceResponse);
+  rpc DeleteWorkspace(DeleteWorkspaceRequest) returns (DeleteWorkspaceResponse);
 
   rpc ListAgentRuns(ListAgentRunsRequest) returns (ListAgentRunsResponse);
   rpc GetAgentRun(GetAgentRunRequest) returns (GetAgentRunResponse);
@@ -80,6 +146,44 @@ message DeleteAgentRequest {
 }
 
 message DeleteAgentResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListAgentProvidersRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListAgentProvidersResponse {
+  string json = 1;
+}
+
+message GetAgentProviderRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetAgentProviderResponse {
+  string json = 1;
+}
+
+message ApplyAgentProviderRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyAgentProviderResponse {
+  string json = 1;
+}
+
+message DeleteAgentProviderRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteAgentProviderResponse {
   bool ok = 1;
   string message = 2;
   string json = 3;
@@ -255,6 +359,462 @@ message DeleteMemoryResponse {
   string json = 3;
 }
 
+message ListToolsRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListToolsResponse {
+  string json = 1;
+}
+
+message GetToolRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetToolResponse {
+  string json = 1;
+}
+
+message ApplyToolRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyToolResponse {
+  string json = 1;
+}
+
+message DeleteToolRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteToolResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListToolRunsRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListToolRunsResponse {
+  string json = 1;
+}
+
+message GetToolRunRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetToolRunResponse {
+  string json = 1;
+}
+
+message ApplyToolRunRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyToolRunResponse {
+  string json = 1;
+}
+
+message DeleteToolRunRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteToolRunResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListOrchestrationsRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListOrchestrationsResponse {
+  string json = 1;
+}
+
+message GetOrchestrationRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetOrchestrationResponse {
+  string json = 1;
+}
+
+message ApplyOrchestrationRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyOrchestrationResponse {
+  string json = 1;
+}
+
+message DeleteOrchestrationRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteOrchestrationResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListOrchestrationRunsRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListOrchestrationRunsResponse {
+  string json = 1;
+}
+
+message GetOrchestrationRunRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetOrchestrationRunResponse {
+  string json = 1;
+}
+
+message ApplyOrchestrationRunRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyOrchestrationRunResponse {
+  string json = 1;
+}
+
+message DeleteOrchestrationRunRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteOrchestrationRunResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListApprovalPoliciesRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListApprovalPoliciesResponse {
+  string json = 1;
+}
+
+message GetApprovalPolicyRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetApprovalPolicyResponse {
+  string json = 1;
+}
+
+message ApplyApprovalPolicyRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyApprovalPolicyResponse {
+  string json = 1;
+}
+
+message DeleteApprovalPolicyRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteApprovalPolicyResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListBudgetsRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListBudgetsResponse {
+  string json = 1;
+}
+
+message GetBudgetRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetBudgetResponse {
+  string json = 1;
+}
+
+message ApplyBudgetRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyBudgetResponse {
+  string json = 1;
+}
+
+message DeleteBudgetRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteBudgetResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListSecretBindingsRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListSecretBindingsResponse {
+  string json = 1;
+}
+
+message GetSecretBindingRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetSecretBindingResponse {
+  string json = 1;
+}
+
+message ApplySecretBindingRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplySecretBindingResponse {
+  string json = 1;
+}
+
+message DeleteSecretBindingRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteSecretBindingResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListSignalsRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListSignalsResponse {
+  string json = 1;
+}
+
+message GetSignalRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetSignalResponse {
+  string json = 1;
+}
+
+message ApplySignalRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplySignalResponse {
+  string json = 1;
+}
+
+message DeleteSignalRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteSignalResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListSignalDeliveriesRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListSignalDeliveriesResponse {
+  string json = 1;
+}
+
+message GetSignalDeliveryRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetSignalDeliveryResponse {
+  string json = 1;
+}
+
+message ApplySignalDeliveryRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplySignalDeliveryResponse {
+  string json = 1;
+}
+
+message DeleteSignalDeliveryRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteSignalDeliveryResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListSchedulesRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListSchedulesResponse {
+  string json = 1;
+}
+
+message GetScheduleRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetScheduleResponse {
+  string json = 1;
+}
+
+message ApplyScheduleRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyScheduleResponse {
+  string json = 1;
+}
+
+message DeleteScheduleRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteScheduleResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListArtifactsRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListArtifactsResponse {
+  string json = 1;
+}
+
+message GetArtifactRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetArtifactResponse {
+  string json = 1;
+}
+
+message ApplyArtifactRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyArtifactResponse {
+  string json = 1;
+}
+
+message DeleteArtifactRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteArtifactResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
+message ListWorkspacesRequest {
+  string namespace = 1;
+  string label_selector = 2;
+}
+
+message ListWorkspacesResponse {
+  string json = 1;
+}
+
+message GetWorkspaceRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message GetWorkspaceResponse {
+  string json = 1;
+}
+
+message ApplyWorkspaceRequest {
+  string namespace = 1;
+  string manifest_yaml = 2;
+}
+
+message ApplyWorkspaceResponse {
+  string json = 1;
+}
+
+message DeleteWorkspaceRequest {
+  string namespace = 1;
+  string name = 2;
+}
+
+message DeleteWorkspaceResponse {
+  bool ok = 1;
+  string message = 2;
+  string json = 3;
+}
+
 message ListAgentRunsRequest {
   string namespace = 1;
   string label_selector = 2;
@@ -302,4 +862,58 @@ message StreamAgentRunLogsRequest {
 message StreamAgentRunLogsResponse {
   string stream = 1;
   string message = 2;
+}
+
+message GetControlPlaneStatusRequest {
+  string namespace = 1;
+}
+
+message GetControlPlaneStatusResponse {
+  string service = 1;
+  string generated_at = 2;
+  repeated ControllerHealth controllers = 3;
+  repeated RuntimeAdapterHealth runtime_adapters = 4;
+  DatabaseHealth database = 5;
+  GrpcHealth grpc = 6;
+  repeated NamespaceHealth namespaces = 7;
+}
+
+message ControllerHealth {
+  string name = 1;
+  bool enabled = 2;
+  bool started = 3;
+  bool crds_ready = 4;
+  repeated string missing_crds = 5;
+  string last_checked_at = 6;
+  string status = 7;
+  string message = 8;
+}
+
+message RuntimeAdapterHealth {
+  string name = 1;
+  bool available = 2;
+  string status = 3;
+  string message = 4;
+  string endpoint = 5;
+}
+
+message DatabaseHealth {
+  bool configured = 1;
+  bool connected = 2;
+  string status = 3;
+  string message = 4;
+  int32 latency_ms = 5;
+}
+
+message GrpcHealth {
+  bool enabled = 1;
+  string address = 2;
+  string status = 3;
+  string message = 4;
+}
+
+message NamespaceHealth {
+  string namespace = 1;
+  string status = 2;
+  repeated string degraded_components = 3;
 }

--- a/services/jangar/src/server/agentctl-grpc.ts
+++ b/services/jangar/src/server/agentctl-grpc.ts
@@ -235,9 +235,11 @@ const resolveAdapterFromController = (controllerStatus: string, controllerMessag
 const resolveTemporalAdapter = async () => {
   try {
     const config = await loadTemporalConfig({
-      host: DEFAULT_TEMPORAL_HOST,
-      port: DEFAULT_TEMPORAL_PORT,
-      address: DEFAULT_TEMPORAL_ADDRESS,
+      defaults: {
+        host: DEFAULT_TEMPORAL_HOST,
+        port: DEFAULT_TEMPORAL_PORT,
+        address: DEFAULT_TEMPORAL_ADDRESS,
+      },
     })
     return {
       name: 'temporal',

--- a/services/jangar/src/server/agentctl-grpc.ts
+++ b/services/jangar/src/server/agentctl-grpc.ts
@@ -6,13 +6,22 @@ import { fileURLToPath } from 'node:url'
 import * as grpc from '@grpc/grpc-js'
 import { status as GrpcStatus, ServerCredentials, type ServerUnaryCall, type ServerWritableStream } from '@grpc/grpc-js'
 import { loadSync } from '@grpc/proto-loader'
+import { loadTemporalConfig } from '@proompteng/temporal-bun-sdk'
+import { sql } from 'kysely'
 import { postAgentRunsHandler } from '~/routes/v1/agent-runs'
+import { getAgentsControllerHealth } from '~/server/agents-controller'
+import { getDb } from '~/server/db'
+import { getOrchestrationControllerHealth } from '~/server/orchestration-controller'
 import { asRecord, asString } from '~/server/primitives-http'
 import { createKubernetesClient, type KubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
+import { getSupportingControllerHealth } from '~/server/supporting-primitives-controller'
 
 const DEFAULT_NAMESPACE = 'agents'
 const DEFAULT_GRPC_PORT = 50051
 const SERVICE_NAME = 'jangar'
+const DEFAULT_TEMPORAL_HOST = 'temporal-frontend.temporal.svc.cluster.local'
+const DEFAULT_TEMPORAL_PORT = 7233
+const DEFAULT_TEMPORAL_ADDRESS = `${DEFAULT_TEMPORAL_HOST}:${DEFAULT_TEMPORAL_PORT}`
 
 type AgentctlServer = {
   server: grpc.Server
@@ -50,6 +59,7 @@ type SubmitRunRequest = {
   memory_ref?: string
 }
 type LogsRequest = { namespace?: string; name?: string; follow?: boolean }
+type ControlPlaneStatusRequest = { namespace?: string }
 
 const resolveProtoPath = () => {
   const envPath = process.env.JANGAR_GRPC_PROTO_PATH?.trim()
@@ -144,6 +154,140 @@ const handleUnaryError = (callback: UnaryCallback, error: unknown) => {
   }
   const message = error instanceof Error ? error.message : String(error)
   callback({ code: GrpcStatus.INTERNAL, message }, null)
+}
+
+const normalizeMessage = (value: unknown) => (value instanceof Error ? value.message : String(value))
+
+const buildControllerStatus = (name: string, health: ReturnType<typeof getAgentsControllerHealth>) => {
+  if (!health.enabled) {
+    return {
+      name,
+      enabled: false,
+      started: health.started,
+      crds_ready: false,
+      missing_crds: health.missingCrds,
+      last_checked_at: health.lastCheckedAt ?? '',
+      status: 'disabled',
+      message: 'controller disabled',
+    }
+  }
+  if (!health.started) {
+    return {
+      name,
+      enabled: true,
+      started: false,
+      crds_ready: false,
+      missing_crds: health.missingCrds,
+      last_checked_at: health.lastCheckedAt ?? '',
+      status: 'degraded',
+      message: 'controller not started',
+    }
+  }
+  if (health.crdsReady === false) {
+    return {
+      name,
+      enabled: true,
+      started: true,
+      crds_ready: false,
+      missing_crds: health.missingCrds,
+      last_checked_at: health.lastCheckedAt ?? '',
+      status: 'degraded',
+      message: `missing CRDs: ${health.missingCrds.join(', ') || 'unknown'}`,
+    }
+  }
+  if (health.crdsReady === null) {
+    return {
+      name,
+      enabled: true,
+      started: true,
+      crds_ready: false,
+      missing_crds: health.missingCrds,
+      last_checked_at: health.lastCheckedAt ?? '',
+      status: 'unknown',
+      message: 'CRD status not yet checked',
+    }
+  }
+  return {
+    name,
+    enabled: true,
+    started: true,
+    crds_ready: true,
+    missing_crds: health.missingCrds,
+    last_checked_at: health.lastCheckedAt ?? '',
+    status: 'healthy',
+    message: '',
+  }
+}
+
+const resolveAdapterFromController = (controllerStatus: string, controllerMessage: string) => {
+  if (controllerStatus === 'healthy') {
+    return { available: true, status: 'healthy', message: '' }
+  }
+  if (controllerStatus === 'unknown') {
+    return { available: false, status: 'unknown', message: controllerMessage || 'controller status unknown' }
+  }
+  if (controllerStatus === 'disabled') {
+    return { available: false, status: 'disabled', message: controllerMessage || 'controller disabled' }
+  }
+  return { available: false, status: 'degraded', message: controllerMessage || 'controller unhealthy' }
+}
+
+const resolveTemporalAdapter = async () => {
+  try {
+    const config = await loadTemporalConfig({
+      host: DEFAULT_TEMPORAL_HOST,
+      port: DEFAULT_TEMPORAL_PORT,
+      address: DEFAULT_TEMPORAL_ADDRESS,
+    })
+    return {
+      name: 'temporal',
+      available: true,
+      status: 'configured',
+      message: 'temporal configuration resolved',
+      endpoint: config.address ?? DEFAULT_TEMPORAL_ADDRESS,
+    }
+  } catch (error) {
+    return {
+      name: 'temporal',
+      available: false,
+      status: 'degraded',
+      message: normalizeMessage(error),
+      endpoint: DEFAULT_TEMPORAL_ADDRESS,
+    }
+  }
+}
+
+const checkDatabase = async () => {
+  const db = getDb()
+  if (!db) {
+    return {
+      configured: false,
+      connected: false,
+      status: 'disabled',
+      message: 'DATABASE_URL not set',
+      latency_ms: 0,
+    }
+  }
+
+  const start = Date.now()
+  try {
+    await sql`select 1`.execute(db)
+    return {
+      configured: true,
+      connected: true,
+      status: 'healthy',
+      message: '',
+      latency_ms: Math.max(0, Date.now() - start),
+    }
+  } catch (error) {
+    return {
+      configured: true,
+      connected: false,
+      status: 'degraded',
+      message: normalizeMessage(error),
+      latency_ms: Math.max(0, Date.now() - start),
+    }
+  }
 }
 
 const createListHandler =
@@ -812,6 +956,86 @@ export const startAgentctlGrpcServer = (): AgentctlServer | null => {
       call.on('close', () => {
         child.kill('SIGTERM')
       })
+    },
+
+    GetControlPlaneStatus: async (call: UnaryCall<ControlPlaneStatusRequest>, callback: UnaryCallback) => {
+      const authError = requireAuth(call)
+      if (authError) return callback(authError, null)
+      try {
+        const namespace = normalizeNamespace(call.request?.namespace)
+        const agentsController = buildControllerStatus('agents-controller', getAgentsControllerHealth())
+        const supportingController = buildControllerStatus('supporting-controller', getSupportingControllerHealth())
+        const orchestrationController = buildControllerStatus(
+          'orchestration-controller',
+          getOrchestrationControllerHealth(),
+        )
+        const controllers = [agentsController, supportingController, orchestrationController]
+
+        const workflowAdapter = resolveAdapterFromController(agentsController.status, agentsController.message)
+        const jobAdapter = resolveAdapterFromController(agentsController.status, agentsController.message)
+
+        const runtimeAdapters = [
+          {
+            name: 'workflow',
+            available: workflowAdapter.available,
+            status: workflowAdapter.status,
+            message: workflowAdapter.message,
+            endpoint: '',
+          },
+          {
+            name: 'job',
+            available: jobAdapter.available,
+            status: jobAdapter.status,
+            message: jobAdapter.message,
+            endpoint: '',
+          },
+          await resolveTemporalAdapter(),
+          {
+            name: 'custom',
+            available: true,
+            status: 'unknown',
+            message: 'custom runtime configured per AgentRun',
+            endpoint: '',
+          },
+        ]
+
+        const database = await checkDatabase()
+        const grpcStatus = {
+          enabled: true,
+          address,
+          status: 'healthy',
+          message: '',
+        }
+
+        const degradedComponents = [
+          ...controllers
+            .filter((controller) => controller.status === 'degraded' || controller.status === 'disabled')
+            .map((controller) => controller.name),
+          ...runtimeAdapters
+            .filter((adapter) => adapter.status === 'degraded')
+            .map((adapter) => `runtime:${adapter.name}`),
+          ...(database.status === 'healthy' ? [] : ['database']),
+          ...(grpcStatus.status === 'healthy' ? [] : ['grpc']),
+        ]
+
+        callback(null, {
+          service: SERVICE_NAME,
+          generated_at: new Date().toISOString(),
+          controllers,
+          runtime_adapters: runtimeAdapters,
+          database,
+          grpc: grpcStatus,
+          namespaces: [
+            {
+              namespace,
+              status: degradedComponents.length === 0 ? 'healthy' : 'degraded',
+              degraded_components: degradedComponents,
+            },
+          ],
+        })
+      } catch (error) {
+        handleUnaryError(callback, error)
+      }
     },
   })
 

--- a/services/jangar/src/server/agents-controller.ts
+++ b/services/jangar/src/server/agents-controller.ts
@@ -2236,7 +2236,7 @@ const reconcileNamespaceState = async (
   await reconcileNamespaceSnapshot(kube, namespace, snapshot, state, concurrency)
 }
 
-const reconcileAll = async (
+const _reconcileAll = async (
   kube: ReturnType<typeof createKubernetesClient>,
   state: ControllerState,
   namespaces: string[],


### PR DESCRIPTION
## Summary
- add control-plane status gRPC endpoint with controller/runtime/database health aggregation
- add agentctl status/diagnose command with table + json/yaml output
- document status command in agentctl CLI design and Jangar README

## Related Issues
- Closes #2563

## Testing
- bun run --filter @proompteng/jangar lint
- bun run --filter @proompteng/agentctl lint

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
