### PR TITLE
fix(jangar): resolve agentctl plugin path

### DIFF
--- a/services/jangar/nitro.config.ts
+++ b/services/jangar/nitro.config.ts
@@ -1,13 +1,17 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineNitroConfig } from 'nitro/config'
 
 const websocketEnabled = ['1', 'true', 'yes', 'on'].includes(
   (process.env.JANGAR_WEBSOCKETS_ENABLED ?? '').toLowerCase(),
 )
+const rootDir = dirname(fileURLToPath(import.meta.url))
+const agentctlPlugin = resolve(rootDir, 'server/plugins/agentctl-grpc')
 
 export default defineNitroConfig({
   preset: 'bun',
   experimental: {
     websocket: websocketEnabled,
   },
-  plugins: ['~/server/plugins/agentctl-grpc'],
+  plugins: [agentctlPlugin],
 })


### PR DESCRIPTION
## Summary
- fix Nitro plugin path resolution for agentctl gRPC plugin

## Related Issues
None

## Testing
- Not run (config-only change)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
