### PR TITLE
chore(agents): bump jangar image to ff47356

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "6277c4f"
-  digest: sha256:2f5112bbb45058b4541853ed22c15a791c4e401f29d445d43723aba1efedb2fd
+  tag: "ff47356"
+  digest: sha256:668d56c671bc4d96c3c75b7f4e6855717e0e189bf2e7199ff155f1a8cdd053ea
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
Updates agents chart values to use jangar image ff47356 (grpc addService fix).