### PR TITLE
fix(jangar): start controllers in nitro

### DIFF
--- a/services/jangar/nitro.config.ts
+++ b/services/jangar/nitro.config.ts
@@ -6,6 +6,7 @@ const websocketEnabled = ['1', 'true', 'yes', 'on'].includes(
   (process.env.JANGAR_WEBSOCKETS_ENABLED ?? '').toLowerCase(),
 )
 const rootDir = dirname(fileURLToPath(import.meta.url))
+const agentsRuntimePlugin = resolve(rootDir, 'server/plugins/agents-runtime')
 const agentctlPlugin = resolve(rootDir, 'server/plugins/agentctl-grpc')
 
 export default defineNitroConfig({
@@ -13,5 +14,5 @@ export default defineNitroConfig({
   experimental: {
     websocket: websocketEnabled,
   },
-  plugins: [agentctlPlugin],
+  plugins: [agentsRuntimePlugin, agentctlPlugin],
 })

--- a/services/jangar/server/plugins/agents-runtime.ts
+++ b/services/jangar/server/plugins/agents-runtime.ts
@@ -1,0 +1,6 @@
+import { defineNitroPlugin } from 'nitro/runtime'
+import { ensureAgentCommsRuntime } from '../../src/server/agent-comms-runtime'
+
+export default defineNitroPlugin(() => {
+  ensureAgentCommsRuntime()
+})

--- a/services/jangar/src/server/agent-comms-runtime.ts
+++ b/services/jangar/src/server/agent-comms-runtime.ts
@@ -13,5 +13,3 @@ export const ensureAgentCommsRuntime = () => {
   void startSupportingPrimitivesController()
   startPrimitivesReconciler()
 }
-
-ensureAgentCommsRuntime()


### PR DESCRIPTION
Ensure agents/orchestration/supporting controllers start by wiring a Nitro plugin.