### PR TITLE
chore(agents): bump jangar image 72d4cca

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "0508cf9"
-  digest: sha256:994f9f93647e1e408991b84e42cb5f0408e572b7f0739fdf68bf1065f35fae16
+  tag: "72d4cca"
+  digest: sha256:e76b5d0b9cbdc2087c1506431a1f814dfad2ad6e187ce23a5f44f47ac56895af
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary
- bump agents chart to jangar image 72d4cca
- roll out codex-implement runner image update

## Related Issues
None

## Testing
- Not run (image bump only)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
