### PR TITLE
refactor(agents): remove argo-specific defaults

### DIFF
--- a/docs/agents/agents-helm-chart-design.md
+++ b/docs/agents/agents-helm-chart-design.md
@@ -87,6 +87,7 @@ It provides:
 
 Default runtime stance:
 - The vanilla chart runs the native `job`/`workflow` runtimes with no external workflow engine required.
+- The default workflow runtime is vendor-neutral and ships without Argo-specific defaults or subjects.
 - External adapters are opt-in via explicit runtime configuration or environment settings.
 - Ingestion is webhook-only by design (no polling).
 

--- a/docs/agents/agents-helm-chart-implementation.md
+++ b/docs/agents/agents-helm-chart-implementation.md
@@ -142,7 +142,7 @@ Controller behavior requires permissions to:
 Agent comms publishes vendor-neutral NATS subjects using the following pattern:
 - `agents.workflow.<namespace>.<workflow>.<uid>.agent.<agentId>.<kind>` for workflow-scoped agent messages.
 - `agents.workflow.general.<kind>` for general agent status updates.
-Breaking change (2026-01-20): the subscriber only accepts `agents.workflow.*` subjects; legacy subjects are no longer supported.
+Breaking change (2026-01-20): the subscriber only accepts `agents.workflow.*` subjects.
 
 ### RBAC modes
 Support two modes:

--- a/services/jangar/scripts/minio-presign-check.ts
+++ b/services/jangar/scripts/minio-presign-check.ts
@@ -22,11 +22,13 @@ const parseBool = (value: string | undefined) => {
   return ['1', 'true', 'yes'].includes(value.trim().toLowerCase())
 }
 
+const DEFAULT_BUCKET = 'agents-artifacts'
+
 const main = async () => {
   const endpointRaw = requireEnv('MINIO_ENDPOINT')
   const accessKey = requireEnv('MINIO_ACCESS_KEY')
   const secretKey = requireEnv('MINIO_SECRET_KEY')
-  const bucket = (process.env.MINIO_BUCKET ?? process.env.ARTIFACT_BUCKET ?? 'agents-artifacts').trim()
+  const bucket = (process.env.MINIO_BUCKET ?? process.env.ARTIFACT_BUCKET ?? DEFAULT_BUCKET).trim()
   if (!bucket) {
     throw new Error('Missing MINIO_BUCKET')
   }

--- a/services/jangar/src/server/agent-comms-subscriber.ts
+++ b/services/jangar/src/server/agent-comms-subscriber.ts
@@ -149,6 +149,7 @@ const normalizePayload = (raw: string, subject: string): AgentMessageInput | nul
   const parsed = safeParseJson(raw)
   const record = toRecord(parsed)
   const subjectInfo = parseSubject(subject)
+  if (!subjectInfo) return null
   const candidate = record ? (toRecord(record.message) ?? toRecord(record.data) ?? record) : null
 
   const payload = candidate ?? {}


### PR DESCRIPTION
## Summary
- Enforce agents.workflow-only subject parsing for agent comms ingestion.
- Set a vendor-neutral default artifact bucket for MinIO presign checks.
- Update Agents docs to emphasize vendor-neutral runtime + webhook-only ingestion and clarify the subject breaking change.

## Related Issues
Resolves #2590

## Testing
- bun --cwd services/jangar run lint

## Breaking Changes
- Agent comms subscriber now rejects non-`agents.workflow.*` subjects (breaking change dated 2026-01-20 in docs).

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
