### PR TITLE
feat(jangar-ui): agents control-plane overview dashboard

### DIFF
--- a/services/jangar/src/components/agents-control-plane-primitives.tsx
+++ b/services/jangar/src/components/agents-control-plane-primitives.tsx
@@ -5,11 +5,14 @@ import * as React from 'react'
 import {
   ConditionsList,
   DescriptionList,
+  deriveStatusCategory,
   deriveStatusLabel,
   EventsList,
+  formatTimestamp,
   getMetadataValue,
   getStatusConditions,
   StatusBadge,
+  summarizeConditions,
   YamlCodeBlock,
 } from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, type NamespaceSearchState } from '@/components/agents-control-plane-search'
@@ -164,7 +167,8 @@ export function PrimitiveListPage({
           {items.map((resource) => {
             const name = getMetadataValue(resource, 'name') ?? 'unknown'
             const resourceNamespace = getMetadataValue(resource, 'namespace') ?? searchState.namespace
-            const statusLabel = deriveStatusLabel(resource)
+            const statusLabel = deriveStatusCategory(resource)
+            const conditionSummary = summarizeConditions(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
                 <Link
@@ -179,6 +183,16 @@ export function PrimitiveListPage({
                       <div className="text-xs text-muted-foreground">{resourceNamespace}</div>
                     </div>
                     <StatusBadge label={statusLabel} />
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Conditions</span>
+                      <span className="text-foreground">{conditionSummary.summary}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Last transition</span>
+                      <span className="text-foreground">{formatTimestamp(conditionSummary.lastTransitionTime)}</span>
+                    </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
                     {fields.map((field) => (

--- a/services/jangar/src/routes/agents-control-plane/agent-providers/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/agent-providers/index.tsx
@@ -2,11 +2,13 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import * as React from 'react'
 
 import {
-  deriveStatusLabel,
+  deriveStatusCategory,
+  formatTimestamp,
   getMetadataValue,
   readNestedArrayValue,
   readNestedValue,
   StatusBadge,
+  summarizeConditions,
 } from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button } from '@/components/ui/button'
@@ -151,7 +153,8 @@ function AgentProvidersListPage() {
           {items.map((resource) => {
             const name = getMetadataValue(resource, 'name') ?? 'unknown'
             const resourceNamespace = getMetadataValue(resource, 'namespace') ?? searchState.namespace
-            const statusLabel = deriveStatusLabel(resource)
+            const statusLabel = deriveStatusCategory(resource)
+            const conditionSummary = summarizeConditions(resource)
             const fields = buildProviderFields(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
@@ -167,6 +170,16 @@ function AgentProvidersListPage() {
                       <div className="text-xs text-muted-foreground">{resourceNamespace}</div>
                     </div>
                     <StatusBadge label={statusLabel} />
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Conditions</span>
+                      <span className="text-foreground">{conditionSummary.summary}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Last transition</span>
+                      <span className="text-foreground">{formatTimestamp(conditionSummary.lastTransitionTime)}</span>
+                    </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
                     {fields.map((field) => (

--- a/services/jangar/src/routes/agents-control-plane/agent-runs/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/agent-runs/index.tsx
@@ -1,7 +1,14 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import * as React from 'react'
 
-import { deriveStatusLabel, getMetadataValue, readNestedValue, StatusBadge } from '@/components/agents-control-plane'
+import {
+  deriveStatusCategory,
+  formatTimestamp,
+  getMetadataValue,
+  readNestedValue,
+  StatusBadge,
+  summarizeConditions,
+} from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -136,7 +143,8 @@ function AgentRunsListPage() {
           {items.map((resource) => {
             const name = getMetadataValue(resource, 'name') ?? 'unknown'
             const resourceNamespace = getMetadataValue(resource, 'namespace') ?? searchState.namespace
-            const statusLabel = deriveStatusLabel(resource)
+            const statusLabel = deriveStatusCategory(resource)
+            const conditionSummary = summarizeConditions(resource)
             const fields = buildAgentRunFields(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
@@ -152,6 +160,16 @@ function AgentRunsListPage() {
                       <div className="text-xs text-muted-foreground">{resourceNamespace}</div>
                     </div>
                     <StatusBadge label={statusLabel} />
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Conditions</span>
+                      <span className="text-foreground">{conditionSummary.summary}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Last transition</span>
+                      <span className="text-foreground">{formatTimestamp(conditionSummary.lastTransitionTime)}</span>
+                    </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
                     {fields.map((field) => (

--- a/services/jangar/src/routes/agents-control-plane/agents/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/agents/index.tsx
@@ -1,7 +1,14 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import * as React from 'react'
 
-import { deriveStatusLabel, getMetadataValue, readNestedValue, StatusBadge } from '@/components/agents-control-plane'
+import {
+  deriveStatusCategory,
+  formatTimestamp,
+  getMetadataValue,
+  readNestedValue,
+  StatusBadge,
+  summarizeConditions,
+} from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -132,7 +139,8 @@ function AgentsListPage() {
           {items.map((resource) => {
             const name = getMetadataValue(resource, 'name') ?? 'unknown'
             const resourceNamespace = getMetadataValue(resource, 'namespace') ?? searchState.namespace
-            const statusLabel = deriveStatusLabel(resource)
+            const statusLabel = deriveStatusCategory(resource)
+            const conditionSummary = summarizeConditions(resource)
             const fields = buildAgentFields(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
@@ -148,6 +156,16 @@ function AgentsListPage() {
                       <div className="text-xs text-muted-foreground">{resourceNamespace}</div>
                     </div>
                     <StatusBadge label={statusLabel} />
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Conditions</span>
+                      <span className="text-foreground">{conditionSummary.summary}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Last transition</span>
+                      <span className="text-foreground">{formatTimestamp(conditionSummary.lastTransitionTime)}</span>
+                    </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
                     {fields.map((field) => (

--- a/services/jangar/src/routes/agents-control-plane/implementation-sources/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-sources/index.tsx
@@ -1,7 +1,14 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import * as React from 'react'
 
-import { deriveStatusLabel, getMetadataValue, readNestedValue, StatusBadge } from '@/components/agents-control-plane'
+import {
+  deriveStatusCategory,
+  formatTimestamp,
+  getMetadataValue,
+  readNestedValue,
+  StatusBadge,
+  summarizeConditions,
+} from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -142,7 +149,8 @@ function ImplementationSourcesListPage() {
           {items.map((resource) => {
             const name = getMetadataValue(resource, 'name') ?? 'unknown'
             const resourceNamespace = getMetadataValue(resource, 'namespace') ?? searchState.namespace
-            const statusLabel = deriveStatusLabel(resource)
+            const statusLabel = deriveStatusCategory(resource)
+            const conditionSummary = summarizeConditions(resource)
             const fields = buildSourceFields(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
@@ -158,6 +166,16 @@ function ImplementationSourcesListPage() {
                       <div className="text-xs text-muted-foreground">{resourceNamespace}</div>
                     </div>
                     <StatusBadge label={statusLabel} />
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Conditions</span>
+                      <span className="text-foreground">{conditionSummary.summary}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Last transition</span>
+                      <span className="text-foreground">{formatTimestamp(conditionSummary.lastTransitionTime)}</span>
+                    </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
                     {fields.map((field) => (

--- a/services/jangar/src/routes/agents-control-plane/implementation-specs/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-specs/index.tsx
@@ -1,7 +1,14 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import * as React from 'react'
 
-import { deriveStatusLabel, getMetadataValue, readNestedValue, StatusBadge } from '@/components/agents-control-plane'
+import {
+  deriveStatusCategory,
+  formatTimestamp,
+  getMetadataValue,
+  readNestedValue,
+  StatusBadge,
+  summarizeConditions,
+} from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -132,7 +139,8 @@ function ImplementationSpecsListPage() {
           {items.map((resource) => {
             const name = getMetadataValue(resource, 'name') ?? 'unknown'
             const resourceNamespace = getMetadataValue(resource, 'namespace') ?? searchState.namespace
-            const statusLabel = deriveStatusLabel(resource)
+            const statusLabel = deriveStatusCategory(resource)
+            const conditionSummary = summarizeConditions(resource)
             const fields = buildSpecFields(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
@@ -148,6 +156,16 @@ function ImplementationSpecsListPage() {
                       <div className="text-xs text-muted-foreground">{resourceNamespace}</div>
                     </div>
                     <StatusBadge label={statusLabel} />
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Conditions</span>
+                      <span className="text-foreground">{conditionSummary.summary}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Last transition</span>
+                      <span className="text-foreground">{formatTimestamp(conditionSummary.lastTransitionTime)}</span>
+                    </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
                     {fields.map((field) => (

--- a/services/jangar/src/routes/agents-control-plane/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 
 import {
+  ControlPlaneControllersPanel,
   ControlPlaneOverviewTile,
   ControlPlaneProblems,
   controlPlaneSections,
@@ -29,7 +30,7 @@ function AgentsControlPlanePage() {
   const namespaceId = React.useId()
   const searchId = React.useId()
 
-  const { tiles, problems, isLoading, error, refresh } = useControlPlaneOverview(searchState.namespace)
+  const { tiles, problems, isLoading, error, lastUpdatedAt, refresh } = useControlPlaneOverview(searchState.namespace)
 
   React.useEffect(() => {
     setNamespace(searchState.namespace)
@@ -59,11 +60,12 @@ function AgentsControlPlanePage() {
       (acc, tile) => {
         acc.total += tile.total
         acc.ready += tile.readyCount
-        acc.degraded += tile.degradedCount
+        acc.running += tile.runningCount
+        acc.failed += tile.failedCount
         acc.unknown += tile.unknownCount
         return acc
       },
-      { total: 0, ready: 0, degraded: 0, unknown: 0 },
+      { total: 0, ready: 0, running: 0, failed: 0, unknown: 0 },
     )
   }, [tiles])
 
@@ -82,8 +84,11 @@ function AgentsControlPlanePage() {
             ArgoCD-style overview for agent primitives, health, and recent control-plane failures.
           </p>
         </div>
-        <div className="text-xs text-muted-foreground">
-          Namespace <span className="font-semibold text-foreground">{searchState.namespace}</span>
+        <div className="text-xs text-muted-foreground space-y-1">
+          <div>
+            Namespace <span className="font-semibold text-foreground">{searchState.namespace}</span>
+          </div>
+          <div>Last updated {lastUpdatedAt ? new Date(lastUpdatedAt).toLocaleString() : '—'}</div>
         </div>
       </header>
 
@@ -128,11 +133,12 @@ function AgentsControlPlanePage() {
         </div>
       ) : null}
 
-      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
         {[
           { label: 'Total resources', value: totals.total },
           { label: 'Ready', value: totals.ready },
-          { label: 'Degraded', value: totals.degraded },
+          { label: 'Running', value: totals.running },
+          { label: 'Failed', value: totals.failed },
           { label: 'Unknown', value: totals.unknown },
         ].map((summary) => (
           <div key={summary.label} className="rounded-none border p-3 border-border bg-card">
@@ -170,6 +176,7 @@ function AgentsControlPlanePage() {
         </div>
 
         <div className="space-y-6">
+          <ControlPlaneControllersPanel tiles={tiles} />
           <ControlPlaneProblems
             problems={problems}
             namespace={searchState.namespace}

--- a/services/jangar/src/routes/agents-control-plane/memories/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/memories/index.tsx
@@ -2,11 +2,13 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import * as React from 'react'
 
 import {
-  deriveStatusLabel,
+  deriveStatusCategory,
+  formatTimestamp,
   getMetadataValue,
   readNestedArrayValue,
   readNestedValue,
   StatusBadge,
+  summarizeConditions,
 } from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button } from '@/components/ui/button'
@@ -138,7 +140,8 @@ function MemoriesListPage() {
           {items.map((resource) => {
             const name = getMetadataValue(resource, 'name') ?? 'unknown'
             const resourceNamespace = getMetadataValue(resource, 'namespace') ?? searchState.namespace
-            const statusLabel = deriveStatusLabel(resource)
+            const statusLabel = deriveStatusCategory(resource)
+            const conditionSummary = summarizeConditions(resource)
             const fields = buildMemoryFields(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
@@ -154,6 +157,16 @@ function MemoriesListPage() {
                       <div className="text-xs text-muted-foreground">{resourceNamespace}</div>
                     </div>
                     <StatusBadge label={statusLabel} />
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Conditions</span>
+                      <span className="text-foreground">{conditionSummary.summary}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Last transition</span>
+                      <span className="text-foreground">{formatTimestamp(conditionSummary.lastTransitionTime)}</span>
+                    </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
                     {fields.map((field) => (


### PR DESCRIPTION
## Summary

- Rebuilt the agents control-plane overview with per-primitive Ready/Running/Failed/Unknown counts and controller health rollups.
- Added namespace-level last-updated timestamping and refined status aggregation helpers.
- Standardized list pages to show consistent status badges, condition summaries, and last transition timestamps.

## Related Issues

- Fixes #2589

## Testing

- bun run --cwd services/jangar lint

## Screenshots (if applicable)

- Not captured (local UI not run).

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
