### PR TITLE
fix(gitops): render agents CRDs via helm

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: agents
-resources:
-  - ../../../charts/agents/crds
 helmGlobals:
   chartHome: ../../../charts
 helmCharts:
@@ -11,3 +9,4 @@ helmCharts:
     namespace: agents
     valuesFile: values.yaml
     version: 0.6.0
+    includeCRDs: true


### PR DESCRIPTION
## Summary

- remove direct CRD directory reference from agents kustomization
- render Agents CRDs via Helm includeCRDs
- fix Argo CD sync failure caused by missing crds kustomization

## Related Issues

None.

## Testing

- Not run (manifest-only change).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
