### PR TITLE
feat(jangar): reconcile implementation sources

### DIFF
--- a/docs/agents/jangar-controller-design.md
+++ b/docs/agents/jangar-controller-design.md
@@ -68,14 +68,14 @@ Inputs:
 - Provider config for GitHub or Linear.
 
 Steps:
-1. Authenticate and connect (webhook-only).
+1. Validate provider + auth secret + webhook enabled (webhook-only, no polling).
 2. Normalize external issue payload into ImplementationSpec.
 3. Create or update ImplementationSpec objects.
 4. Record last webhook sync and errors in status.
 
 Status:
 - `status.lastSyncedAt`
-- `status.conditions`: Ready, Error
+- `status.conditions`: Ready, InvalidSpec, Unreachable, WebhookDisabled
 
 ### Memory
 Inputs:


### PR DESCRIPTION
## Summary

- add ImplementationSource reconciliation in agents controller (webhook-only validation)
- validate provider, secret ref, and webhook enabled; surface Ready/InvalidSpec/Unreachable status
- document ImplementationSource status conditions in controller design doc

## Related Issues

None.

## Testing

- Not run (controller change only).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
