### PR TITLE
chore(agents): bump jangar image 7a411309

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "497de83c"
-  digest: sha256:5e9d04853e143891487803b5faed0640ae5dee1301e7262d934098ae5a70865b
+  tag: "7a411309"
+  digest: sha256:7068ed258f25ea46b7c3a24ff6645a27ff602b971b520b191416c31e2b857d1d
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary

- bump agents chart to Jangar image 7a411309
- update image digest for reproducible deploys
- keep deployment pinned to new controller + UI changes

## Related Issues

None.

## Testing

- Not run (image bump only).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
