### PR TITLE
feat(jangar): mount run secrets into jobs

### DIFF
--- a/docs/agents/agents-helm-chart-design.md
+++ b/docs/agents/agents-helm-chart-design.md
@@ -202,7 +202,7 @@ Workload requirements:
 Overrides:
 - `spec.runtime`: runtime-specific configuration for this run (runtime-agnostic schema; examples may include Temporal).
 - `spec.parameters`: map of string -> string parameters for the provider.
-- `spec.secrets`: named secret refs allowed for this run.
+- `spec.secrets`: named secret refs allowed for this run (mounted via `envFrom`, keys become env vars).
 
 Status fields (required):
 - `status.phase`: Pending | Running | Succeeded | Failed | Cancelled

--- a/docs/agents/jangar-controller-design.md
+++ b/docs/agents/jangar-controller-design.md
@@ -31,7 +31,7 @@ Inputs:
 - `spec.runtime`
 - `spec.workload`
 - `spec.memoryRef` (optional override)
-- `spec.parameters`, `spec.secrets`
+- `spec.parameters`, `spec.secrets` (secrets are exposed via `envFrom` in job/workflow pods)
 
 Steps:
 1. Validate required fields and access policy.

--- a/services/jangar/src/server/agents-controller.ts
+++ b/services/jangar/src/server/agents-controller.ts
@@ -1260,6 +1260,8 @@ const submitJobRun = async (
     memory,
     Array.isArray(outputArtifacts) ? outputArtifacts : [],
   )
+  const runSecrets = parseStringList(readNested(agentRun, ['spec', 'secrets']))
+  const envFrom = runSecrets.map((name) => ({ secretRef: { name } }))
 
   const inputEntries = inputFiles
     .map((file: Record<string, unknown>) => ({
@@ -1366,6 +1368,7 @@ const submitJobRun = async (
               command: [binary],
               args,
               env: [{ name: 'AGENT_RUN_SPEC', value: '/workspace/run.json' }, ...env],
+              envFrom: envFrom.length > 0 ? envFrom : undefined,
               resources: buildJobResources(workload),
               volumeMounts: [...volumeMounts, ...configVolumeMounts],
             },


### PR DESCRIPTION
## Summary

- mount AgentRun secrets into job pods via envFrom
- document AgentRun secret exposure as env vars in controller and chart design docs
- keep secret allowlist enforcement intact

## Related Issues

None.

## Testing

- Not run (controller change only).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
