### PR TITLE
chore(agents): bump jangar image acd00ea5

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "7a411309"
-  digest: sha256:7068ed258f25ea46b7c3a24ff6645a27ff602b971b520b191416c31e2b857d1d
+  tag: "acd00ea5"
+  digest: sha256:a4c5f39be7fa20102c5b12e55db44c213e240ed4d37f534c7487d0367f79e0a8
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary

- bump agents chart to Jangar image acd00ea5
- update image digest for reproducible deploys
- include envFrom secret mounting support in runtime image

## Related Issues

None.

## Testing

- Not run (image bump only).

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
