### PR TITLE
feat(agents): vendor-neutral comms + push events

### DIFF
--- a/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
+++ b/argocd/applications/froussard/github-codex-implementation-workflow-template.yaml
@@ -89,9 +89,9 @@ spec:
           - name: NATS_URL
             value: nats://nats.nats.svc.cluster.local:4222
           - name: NATS_SUBJECT_PREFIX
-            value: argo.workflow
+            value: workflow
           - name: NATS_CONTEXT_SUBJECT
-            value: argo.workflow.general.>
+            value: workflow.general.>
           - name: NATS_USER
             valueFrom:
               secretKeyRef:

--- a/argocd/applications/nats/stream-agent-comms.yaml
+++ b/argocd/applications/nats/stream-agent-comms.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   name: agent-comms
   subjects:
+    - workflow.>
+    - agents.workflow.>
     - argo.workflow.>
     - workflow_comms.agent_messages.>
   retention: limits

--- a/argocd/applications/nats/values.yaml
+++ b/argocd/applications/nats/values.yaml
@@ -29,10 +29,14 @@ config:
             publish:
               - "$JS.API.>"
               - "$JS.ACK.>"
+              - "workflow.>"
+              - "agents.workflow.>"
               - "argo.workflow.>"
               - "workflow_comms.agent_messages.>"
             subscribe:
               - "_INBOX.>"
+              - "workflow.>"
+              - "agents.workflow.>"
               - "argo.workflow.>"
               - "workflow_comms.agent_messages.>"
         - user: jangar
@@ -42,6 +46,8 @@ config:
               - "$JS.API.>"
               - "$JS.ACK.>"
             subscribe:
+              - "workflow.>"
+              - "agents.workflow.>"
               - "argo.workflow.>"
               - "_INBOX.>"
               - "workflow_comms.agent_messages.>"

--- a/docs/agents/agentctl-cli-design.md
+++ b/docs/agents/agentctl-cli-design.md
@@ -2,11 +2,12 @@
 
 Status: Current (2026-01-19)
 
-Location: `services/jangar/agentctl` (ships with the Jangar service; not a separate product).
+Location: `services/jangar/agentctl` (ships with the Jangar service; **not** a separate product or service).
 
 ## Purpose
 `agentctl` is the Jangar CLI for managing Agents primitives and submitting AgentRuns without hand‑writing YAML.
-It talks to the Jangar controller over gRPC.
+It is a thin wrapper around Jangar’s gRPC endpoints (like `kubectl`/`argocd`/`virtctl` style CLIs) and **never**
+talks to Kubernetes directly.
 
 ## Goals
 - CRUD for Agent, AgentRun, ImplementationSpec, ImplementationSource, Memory.
@@ -14,6 +15,7 @@ It talks to the Jangar controller over gRPC.
 - First‑class “run” command to submit an AgentRun from flags or a spec file.
 - Works against any Kubernetes cluster where Jangar is deployed.
 - In‑cluster gRPC by default (port‑forward or in‑cluster usage).
+- Packaged via Bun into a single binary and distributed via npm and Homebrew.
 - Human‑friendly status, logs, and controller health.
 
 ## Non‑goals
@@ -24,6 +26,7 @@ It talks to the Jangar controller over gRPC.
 ## Architecture
 - Client talks to the Jangar gRPC API (no direct Kubernetes access).
 - Default namespace is `agents`, with explicit overrides via flags/config.
+- CLI is bundled and versioned with the Jangar service, even though it is published independently.
 - Jangar is the source of truth for list/get/apply/delete operations.
 
 ### gRPC connectivity (current + future)

--- a/docs/agents/agentctl-release.md
+++ b/docs/agents/agentctl-release.md
@@ -1,6 +1,6 @@
 # agentctl release process
 
-This document describes how to build and publish `agentctl` for npm and Homebrew.
+This document describes how to build and publish `agentctl` (bundled with the Jangar service) for npm and Homebrew.
 
 ## Prereqs
 

--- a/services/jangar/agentctl/README.md
+++ b/services/jangar/agentctl/README.md
@@ -1,6 +1,7 @@
 # agentctl
 
-`agentctl` is a gRPC CLI for managing Agents primitives through the Jangar controller. It never calls Kubernetes directly; all operations go through the Jangar gRPC API.
+`agentctl` is a gRPC CLI for managing Agents primitives through the Jangar controller. It ships with the Jangar service
+and never calls Kubernetes directly; all operations go through the Jangar gRPC API.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- shift agent comms subjects to vendor-neutral `workflow.*` defaults with optional overrides
- switch agent events SSE to push-based delivery via the in-process bus (no polling)
- refresh agentctl and chart implementation docs to reaffirm gRPC-only + no polling stance

## Related Issues
None

## Testing
- N/A (config + routing changes only; not run locally)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
