### PR TITLE
feat(agents): add sample primitives for control plane

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -1,6 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: agents
+resources:
+  - sample-approvalpolicy.yaml
+  - sample-budget.yaml
+  - sample-signal.yaml
 helmGlobals:
   chartHome: ../../../charts
 helmCharts:

--- a/argocd/applications/agents/sample-approvalpolicy.yaml
+++ b/argocd/applications/agents/sample-approvalpolicy.yaml
@@ -1,0 +1,8 @@
+apiVersion: approvals.proompteng.ai/v1alpha1
+kind: ApprovalPolicy
+metadata:
+  name: sample-approval-policy
+  namespace: agents
+spec:
+  mode: manual
+  defaultDecision: deny

--- a/argocd/applications/agents/sample-budget.yaml
+++ b/argocd/applications/agents/sample-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: budgets.proompteng.ai/v1alpha1
+kind: Budget
+metadata:
+  name: sample-budget
+  namespace: agents
+spec:
+  limits:
+    tokens: "1000"
+    dollars: "5"
+    cpu: "1"
+    memory: "1Gi"

--- a/argocd/applications/agents/sample-signal.yaml
+++ b/argocd/applications/agents/sample-signal.yaml
@@ -1,0 +1,8 @@
+apiVersion: signals.proompteng.ai/v1alpha1
+kind: Signal
+metadata:
+  name: sample-signal
+  namespace: agents
+spec:
+  channel: slack
+  description: Sample signal for agentctl and control-plane UI


### PR DESCRIPTION
## Summary

- add sample ApprovalPolicy, Budget, and Signal manifests in the agents namespace
- wire the samples into the agents Argo CD kustomization for sync
- provide non-critical primitives for agentctl/control-plane UI visibility

## Related Issues

Resolves #2617

## Testing

- scripts/argo-lint.sh
- scripts/kubeconform.sh argocd

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
