### PR TITLE
feat(jangar-ui): rebase control-plane metrics (#2621)

### DIFF
--- a/services/jangar/src/routes/agents-control-plane/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 
+import { formatTimestamp } from '@/components/agents-control-plane'
 import {
   ControlPlaneControllersPanel,
   ControlPlaneOverviewTile,
@@ -88,7 +89,7 @@ function AgentsControlPlanePage() {
           <div>
             Namespace <span className="font-semibold text-foreground">{searchState.namespace}</span>
           </div>
-          <div>Last updated {lastUpdatedAt ? new Date(lastUpdatedAt).toLocaleString() : '—'}</div>
+          <div>Last updated {formatTimestamp(lastUpdatedAt)}</div>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary

- Restore per-controller status counts in the agents control-plane overview.
- Align controller health rollups with count aggregation for Ready/Running/Failed/Unknown.
- Standardize the overview header last-updated timestamp formatting.

## Related Issues

Closes #2621

## Testing

- bun run --cwd services/jangar lint

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
