### PR TITLE
ci(agents): validate chart CRDs

### DIFF
--- a/docs/agents/ci-validation-plan.md
+++ b/docs/agents/ci-validation-plan.md
@@ -7,6 +7,7 @@ Status: Current (2026-01-19)
   - Structural schema
   - JSON size <= 256KB
   - `subresources.status` present
+- Validate CRDs with kubeconform (`charts/agents/crds/*.yaml`).
 - Validate CRD examples against schemas.
   - Use `scripts/agents/validate-agents.sh` (also runs `helm lint` and render checks).
 


### PR DESCRIPTION
## Summary

- validate `charts/agents/crds/*.yaml` with kubeconform using the Kubernetes JSON schema definitions
- keep kubeconform CRD validation configurable via `KUBECONFORM_K8S_VERSION`
- document CRD validation in the agents CI validation plan

## Related Issues

Resolves #2623.

## Testing

- `mise exec helm@3 -- scripts/agents/validate-agents.sh`

## Breaking Changes

None.

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
