### PR TITLE
chore(agents): bump jangar image 643e7aee

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "adc7c846"
-  digest: sha256:1cd0d8784f866073eef9d0ca9d202fb12782112f7efeeb051e23b2e7eba9ed4c
+  tag: "643e7aee"
+  digest: sha256:44b9509bfc538bc18419dbe35b9b4f30049898170c722af735120faeccaeaa7c
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary

- bump agents chart image to Jangar build 643e7aee (includes latest UI + agent comms pull consumer)

## Related Issues

None

## Testing

- Not run (image built and pushed in-cluster)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
