### PR TITLE
chore(agents): bump jangar image 4917b140

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "643e7aee"
-  digest: sha256:44b9509bfc538bc18419dbe35b9b4f30049898170c722af735120faeccaeaa7c
+  tag: "4917b140"
+  digest: sha256:781d1a5d1373a16c337e1d1c8023e24f513fa58b1d9d96e640561d12054a6ed8
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary

- bump agents chart image to Jangar build 4917b140 (git auth fix for agent runs)

## Related Issues

None

## Testing

- Not run (image built and pushed in-cluster)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
