### PR TITLE
chore(agents): bump jangar image 21c68324

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "4917b140"
-  digest: sha256:781d1a5d1373a16c337e1d1c8023e24f513fa58b1d9d96e640561d12054a6ed8
+  tag: "21c68324"
+  digest: sha256:3acc27bcf4b478d54b2a5a30bea25840c18bbbf7e77cd89cdfe40a56414acb71
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary
- Bump agents chart to Jangar image 21c68324
- Update pinned image digest for reproducible deploys

## Related Issues
None

## Testing
- N/A (image bump only)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
