### PR TITLE
chore(agents): bump jangar image 121eac60

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "21c68324"
-  digest: sha256:3acc27bcf4b478d54b2a5a30bea25840c18bbbf7e77cd89cdfe40a56414acb71
+  tag: "121eac60"
+  digest: sha256:85a4d53149691a51d5cec7f096d56c4667b5046599e85fae4d621c777d5b6ef0
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary

- bump Jangar image tag/digest to 121eac60
- deploy controller health fix build to agents chart
- keep Argo CD deployment aligned with latest main

## Related Issues

None

## Testing

- Not run (image built/pushed in-cluster via `packages/scripts/src/jangar/build-image.ts`)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
