### PR TITLE
feat(jangar): add agents control-plane UI + SSE updates

### DIFF
--- a/services/jangar/src/components/agents-control-plane-overview.tsx
+++ b/services/jangar/src/components/agents-control-plane-overview.tsx
@@ -8,6 +8,7 @@ import {
   getMetadataValue,
   StatusBadge,
 } from '@/components/agents-control-plane'
+import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
 import { buttonVariants } from '@/components/ui/button'
 import type { AgentPrimitiveKind, PrimitiveEventItem, PrimitiveResource } from '@/data/agents-control-plane'
 import { fetchPrimitiveEvents, fetchPrimitiveList } from '@/data/agents-control-plane'
@@ -299,6 +300,7 @@ export const useControlPlaneOverview = (namespace: string): OverviewState => {
   const [error, setError] = React.useState<string | null>(null)
   const [lastUpdatedAt, setLastUpdatedAt] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
+  const reloadTimerRef = React.useRef<number | null>(null)
 
   const load = React.useCallback(
     async (signal?: AbortSignal) => {
@@ -417,6 +419,23 @@ export const useControlPlaneOverview = (namespace: string): OverviewState => {
     void load(controller.signal)
     return () => controller.abort()
   }, [load])
+
+  const scheduleReload = React.useCallback(() => {
+    if (reloadTimerRef.current !== null) return
+    reloadTimerRef.current = window.setTimeout(() => {
+      reloadTimerRef.current = null
+      const controller = new AbortController()
+      void load(controller.signal)
+    }, 500)
+  }, [load])
+
+  useControlPlaneStream(namespace, {
+    onEvent: (event) => {
+      if (event.type !== 'resource') return
+      if (event.namespace !== namespace) return
+      scheduleReload()
+    },
+  })
 
   const refresh = React.useCallback(() => {
     const controller = new AbortController()

--- a/services/jangar/src/components/agents-control-plane-status.tsx
+++ b/services/jangar/src/components/agents-control-plane-status.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react'
+
+import { formatTimestamp, StatusBadge } from '@/components/agents-control-plane'
+import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
+import type { ControlPlaneStatus } from '@/data/agents-control-plane'
+import { fetchControlPlaneStatus } from '@/data/agents-control-plane'
+
+export type ControlPlaneStatusState = {
+  status: ControlPlaneStatus | null
+  error: string | null
+  isLoading: boolean
+  lastUpdatedAt: string | null
+}
+
+export const useControlPlaneStatus = (namespace: string): ControlPlaneStatusState => {
+  const [status, setStatus] = React.useState<ControlPlaneStatus | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [lastUpdatedAt, setLastUpdatedAt] = React.useState<string | null>(null)
+
+  const load = React.useCallback(
+    async (signal?: AbortSignal) => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const result = await fetchControlPlaneStatus({ namespace, signal })
+        if (!result.ok) {
+          setError(result.message)
+          setStatus(null)
+          return
+        }
+        setStatus(result.status)
+        setLastUpdatedAt(result.status.generated_at)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(err instanceof Error ? err.message : 'Failed to load control plane status')
+        setStatus(null)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [namespace],
+  )
+
+  React.useEffect(() => {
+    const controller = new AbortController()
+    void load(controller.signal)
+    return () => controller.abort()
+  }, [load])
+
+  useControlPlaneStream(namespace, {
+    onEvent: (event) => {
+      if (event.type !== 'status') return
+      if (event.namespace !== namespace) return
+      setStatus(event.status)
+      setLastUpdatedAt(event.status.generated_at)
+    },
+  })
+
+  return { status, error, isLoading, lastUpdatedAt }
+}
+
+const renderSummaryValue = (value: string | number | boolean | null) => {
+  if (value == null || value === '') return '—'
+  return String(value)
+}
+
+export const ControlPlaneStatusPanel = ({
+  status,
+  error,
+  isLoading,
+}: {
+  status: ControlPlaneStatus | null
+  error: string | null
+  isLoading: boolean
+}) => (
+  <section className="rounded-none border p-4 space-y-4 border-border bg-card">
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-foreground">Control plane status</h2>
+        <span className="text-xs text-muted-foreground">{formatTimestamp(status?.generated_at ?? null)}</span>
+      </div>
+      <p className="text-xs text-muted-foreground">Health and reconciliation status from the control plane.</p>
+    </div>
+
+    {error ? <div className="text-xs text-destructive">{error}</div> : null}
+    {isLoading && !status ? <div className="text-xs text-muted-foreground">Loading status…</div> : null}
+
+    {status ? (
+      <div className="space-y-4 text-xs">
+        <div className="space-y-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Controllers</div>
+          <ul className="space-y-2">
+            {status.controllers.map((controller) => (
+              <li key={controller.name} className="rounded-none border p-2 border-border/60 bg-muted/30">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-medium text-foreground">{controller.name}</span>
+                  <StatusBadge label={controller.status} />
+                </div>
+                <div className="mt-1 text-muted-foreground">{controller.message || 'OK'}</div>
+                <div className="mt-1 text-muted-foreground">
+                  CRDs ready: {controller.crds_ready ? 'yes' : 'no'} · Last checked{' '}
+                  {formatTimestamp(controller.last_checked_at)}
+                </div>
+                {controller.missing_crds.length > 0 ? (
+                  <div className="mt-1 text-muted-foreground">Missing: {controller.missing_crds.join(', ')}</div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Runtime adapters
+          </div>
+          <ul className="space-y-2">
+            {status.runtime_adapters.map((adapter) => (
+              <li key={adapter.name} className="rounded-none border p-2 border-border/60 bg-muted/30">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-medium text-foreground">{adapter.name}</span>
+                  <StatusBadge label={adapter.status} />
+                </div>
+                <div className="mt-1 text-muted-foreground">{adapter.message || 'OK'}</div>
+                {adapter.endpoint ? (
+                  <div className="mt-1 text-muted-foreground">Endpoint: {adapter.endpoint}</div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Dependencies</div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <div className="rounded-none border p-2 border-border/60 bg-muted/30 space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium text-foreground">Database</span>
+                <StatusBadge label={status.database.status} />
+              </div>
+              <div className="text-muted-foreground">{status.database.message || 'OK'}</div>
+              <div className="text-muted-foreground">Latency: {renderSummaryValue(status.database.latency_ms)} ms</div>
+            </div>
+            <div className="rounded-none border p-2 border-border/60 bg-muted/30 space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium text-foreground">gRPC</span>
+                <StatusBadge label={status.grpc.status} />
+              </div>
+              <div className="text-muted-foreground">{status.grpc.message || 'OK'}</div>
+              <div className="text-muted-foreground">Address: {status.grpc.address || '—'}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Namespaces</div>
+          <ul className="space-y-2">
+            {status.namespaces.map((entry) => (
+              <li key={entry.namespace} className="rounded-none border p-2 border-border/60 bg-muted/30">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-medium text-foreground">{entry.namespace}</span>
+                  <StatusBadge label={entry.status} />
+                </div>
+                <div className="mt-1 text-muted-foreground">
+                  Degraded: {entry.degraded_components.length > 0 ? entry.degraded_components.join(', ') : 'None'}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    ) : null}
+  </section>
+)

--- a/services/jangar/src/components/agents-control-plane-stream.tsx
+++ b/services/jangar/src/components/agents-control-plane-stream.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react'
+
+import type { AgentPrimitiveKind, ControlPlaneStatus, PrimitiveResource } from '@/data/agents-control-plane'
+
+export type ControlPlaneStreamStatus = 'connecting' | 'open' | 'error' | 'closed'
+
+export type ControlPlaneResourceEvent = {
+  type: 'resource'
+  kind: AgentPrimitiveKind
+  namespace: string
+  action: string | null
+  name: string | null
+  resource: PrimitiveResource
+}
+
+export type ControlPlaneStatusEvent = {
+  type: 'status'
+  namespace: string
+  status: ControlPlaneStatus
+}
+
+export type ControlPlaneErrorEvent = {
+  type: 'error'
+  namespace: string
+  message: string
+}
+
+export type ControlPlaneStreamEvent = ControlPlaneResourceEvent | ControlPlaneStatusEvent | ControlPlaneErrorEvent
+
+type ControlPlaneStreamHandlers = {
+  onEvent?: (event: ControlPlaneStreamEvent) => void
+}
+
+type ControlPlaneStreamState = {
+  status: ControlPlaneStreamStatus
+  error: string | null
+  lastEventAt: string | null
+}
+
+const safeParseJson = (value: string) => {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return null
+  }
+}
+
+const isStreamEvent = (payload: unknown): payload is ControlPlaneStreamEvent => {
+  if (!payload || typeof payload !== 'object') return false
+  const record = payload as Record<string, unknown>
+  return typeof record.type === 'string'
+}
+
+export const useControlPlaneStream = (
+  namespace: string,
+  handlers: ControlPlaneStreamHandlers,
+): ControlPlaneStreamState => {
+  const [status, setStatus] = React.useState<ControlPlaneStreamStatus>('connecting')
+  const [error, setError] = React.useState<string | null>(null)
+  const [lastEventAt, setLastEventAt] = React.useState<string | null>(null)
+  const openedRef = React.useRef(false)
+  const handlersRef = React.useRef(handlers)
+
+  React.useEffect(() => {
+    handlersRef.current = handlers
+  }, [handlers])
+
+  React.useEffect(() => {
+    const trimmedNamespace = namespace.trim()
+    if (!trimmedNamespace) {
+      setStatus('closed')
+      setError(null)
+      setLastEventAt(null)
+      return
+    }
+
+    setStatus('connecting')
+    setError(null)
+    setLastEventAt(null)
+    openedRef.current = false
+
+    const params = new URLSearchParams({ namespace: trimmedNamespace })
+    const source = new EventSource(`/api/agents/control-plane/stream?${params.toString()}`)
+
+    source.onopen = () => {
+      openedRef.current = true
+      setStatus('open')
+      setError(null)
+    }
+
+    source.onerror = () => {
+      if (source.readyState === EventSource.CLOSED) {
+        setStatus('error')
+        setError('Stream disconnected.')
+        return
+      }
+      if (!openedRef.current) {
+        setStatus('connecting')
+        setError(null)
+        return
+      }
+      setStatus('open')
+      setError(null)
+    }
+
+    source.onmessage = (event) => {
+      if (!event.data) return
+      const parsed = safeParseJson(event.data)
+      if (!isStreamEvent(parsed)) return
+      handlersRef.current.onEvent?.(parsed)
+      setLastEventAt(new Date().toISOString())
+    }
+
+    return () => {
+      source.close()
+      setStatus('closed')
+    }
+  }, [namespace])
+
+  return { status, error, lastEventAt }
+}

--- a/services/jangar/src/components/agents-control-plane.tsx
+++ b/services/jangar/src/components/agents-control-plane.tsx
@@ -143,6 +143,38 @@ export const getResourceUpdatedAt = (resource: Record<string, unknown>) =>
   getLatestManagedFieldTime(resource) ??
   getMetadataValue(resource, 'creationTimestamp')
 
+export const getResourceReconciledAt = (resource: Record<string, unknown>) =>
+  readNestedValue(resource, ['status', 'reconciledAt']) ??
+  readNestedValue(resource, ['status', 'lastReconciledAt']) ??
+  readNestedValue(resource, ['status', 'lastReconciled']) ??
+  readNestedValue(resource, ['status', 'lastAppliedAt']) ??
+  readNestedValue(resource, ['status', 'lastSyncedAt']) ??
+  readNestedValue(resource, ['status', 'observedAt']) ??
+  null
+
+export const getResourceObservedGeneration = (resource: Record<string, unknown>) =>
+  readNestedValue(resource, ['status', 'observedGeneration']) ??
+  readNestedValue(resource, ['status', 'observedRevision']) ??
+  null
+
+export const getResourceGeneration = (resource: Record<string, unknown>) =>
+  readNestedValue(resource, ['metadata', 'generation']) ??
+  readNestedValue(resource, ['metadata', 'resourceVersion']) ??
+  null
+
+export const formatGenerationSummary = (resource: Record<string, unknown>) => {
+  const observed = getResourceObservedGeneration(resource)
+  const generation = getResourceGeneration(resource)
+  if (!observed && !generation) return '—'
+  if (observed && generation && observed !== generation) {
+    return `${observed} / ${generation}`
+  }
+  if (observed && generation) {
+    return `${observed} / ${generation}`
+  }
+  return observed ?? generation ?? '—'
+}
+
 export const getSpecValue = (resource: Record<string, unknown>, key: string) => {
   const spec = readRecord(resource.spec) ?? {}
   return readString(spec[key])

--- a/services/jangar/src/components/app-sidebar.tsx
+++ b/services/jangar/src/components/app-sidebar.tsx
@@ -92,7 +92,7 @@ type AgentsControlNavGroup = {
   items: AppNavItem[]
 }
 
-const agentsControlOverview: AppNavItem = { to: '/agents-control-plane', label: 'Overview', icon: IconRobot }
+const agentsControlOverview: AppNavItem = { to: '/agents-control-plane', label: 'Control plane', icon: IconRobot }
 
 const agentsControlGroups: AgentsControlNavGroup[] = [
   {

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -113,10 +113,11 @@ import { Route as ApiTerminalsSessionIdInputRouteImport } from './routes/api/ter
 import { Route as ApiTerminalsSessionIdDeleteRouteImport } from './routes/api/terminals/$sessionId/delete'
 import { Route as ApiCodexRunsRecentRouteImport } from './routes/api/codex/runs/recent'
 import { Route as ApiCodexRunsListRouteImport } from './routes/api/codex/runs/list'
+import { Route as ApiAgentsControlPlaneStreamRouteImport } from './routes/api/agents/control-plane/stream'
+import { Route as ApiAgentsControlPlaneStatusRouteImport } from './routes/api/agents/control-plane/status'
 import { Route as ApiAgentsControlPlaneResourcesRouteImport } from './routes/api/agents/control-plane/resources'
 import { Route as ApiAgentsControlPlaneResourceRouteImport } from './routes/api/agents/control-plane/resource'
 import { Route as ApiAgentsControlPlaneEventsRouteImport } from './routes/api/agents/control-plane/events'
-import { Route as ApiAgentsControlPlaneStatusRouteImport } from './routes/api/agents/control-plane/status'
 import { Route as GithubPullsOwnerRepoNumberRouteImport } from './routes/github/pulls/$owner/$repo/$number'
 import { Route as ApiAgentsImplementationSourcesWebhooksProviderRouteImport } from './routes/api/agents/implementation-sources/webhooks/$provider'
 import { Route as ApiGithubPullsOwnerRepoNumberRouteImport } from './routes/api/github/pulls/$owner/$repo/$number'
@@ -691,6 +692,18 @@ const ApiCodexRunsListRoute = ApiCodexRunsListRouteImport.update({
   path: '/list',
   getParentRoute: () => ApiCodexRunsRoute,
 } as any)
+const ApiAgentsControlPlaneStreamRoute =
+  ApiAgentsControlPlaneStreamRouteImport.update({
+    id: '/api/agents/control-plane/stream',
+    path: '/api/agents/control-plane/stream',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiAgentsControlPlaneStatusRoute =
+  ApiAgentsControlPlaneStatusRouteImport.update({
+    id: '/api/agents/control-plane/status',
+    path: '/api/agents/control-plane/status',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiAgentsControlPlaneResourcesRoute =
   ApiAgentsControlPlaneResourcesRouteImport.update({
     id: '/api/agents/control-plane/resources',
@@ -707,12 +720,6 @@ const ApiAgentsControlPlaneEventsRoute =
   ApiAgentsControlPlaneEventsRouteImport.update({
     id: '/api/agents/control-plane/events',
     path: '/api/agents/control-plane/events',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const ApiAgentsControlPlaneStatusRoute =
-  ApiAgentsControlPlaneStatusRouteImport.update({
-    id: '/api/agents/control-plane/status',
-    path: '/api/agents/control-plane/status',
     getParentRoute: () => rootRouteImport,
   } as any)
 const GithubPullsOwnerRepoNumberRoute =
@@ -875,9 +882,10 @@ export interface FileRoutesByFullPath {
   '/github/pulls/': typeof GithubPullsIndexRoute
   '/terminals/$sessionId/': typeof TerminalsSessionIdIndexRoute
   '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
-  '/api/agents/control-plane/status': typeof ApiAgentsControlPlaneStatusRoute
   '/api/agents/control-plane/resource': typeof ApiAgentsControlPlaneResourceRoute
   '/api/agents/control-plane/resources': typeof ApiAgentsControlPlaneResourcesRoute
+  '/api/agents/control-plane/status': typeof ApiAgentsControlPlaneStatusRoute
+  '/api/agents/control-plane/stream': typeof ApiAgentsControlPlaneStreamRoute
   '/api/codex/runs/list': typeof ApiCodexRunsListRoute
   '/api/codex/runs/recent': typeof ApiCodexRunsRecentRoute
   '/api/terminals/$sessionId/delete': typeof ApiTerminalsSessionIdDeleteRoute
@@ -994,9 +1002,10 @@ export interface FileRoutesByTo {
   '/github/pulls': typeof GithubPullsIndexRoute
   '/terminals/$sessionId': typeof TerminalsSessionIdIndexRoute
   '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
-  '/api/agents/control-plane/status': typeof ApiAgentsControlPlaneStatusRoute
   '/api/agents/control-plane/resource': typeof ApiAgentsControlPlaneResourceRoute
   '/api/agents/control-plane/resources': typeof ApiAgentsControlPlaneResourcesRoute
+  '/api/agents/control-plane/status': typeof ApiAgentsControlPlaneStatusRoute
+  '/api/agents/control-plane/stream': typeof ApiAgentsControlPlaneStreamRoute
   '/api/codex/runs/list': typeof ApiCodexRunsListRoute
   '/api/codex/runs/recent': typeof ApiCodexRunsRecentRoute
   '/api/terminals/$sessionId/delete': typeof ApiTerminalsSessionIdDeleteRoute
@@ -1116,9 +1125,10 @@ export interface FileRoutesById {
   '/github/pulls/': typeof GithubPullsIndexRoute
   '/terminals/$sessionId/': typeof TerminalsSessionIdIndexRoute
   '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
-  '/api/agents/control-plane/status': typeof ApiAgentsControlPlaneStatusRoute
   '/api/agents/control-plane/resource': typeof ApiAgentsControlPlaneResourceRoute
   '/api/agents/control-plane/resources': typeof ApiAgentsControlPlaneResourcesRoute
+  '/api/agents/control-plane/status': typeof ApiAgentsControlPlaneStatusRoute
+  '/api/agents/control-plane/stream': typeof ApiAgentsControlPlaneStreamRoute
   '/api/codex/runs/list': typeof ApiCodexRunsListRoute
   '/api/codex/runs/recent': typeof ApiCodexRunsRecentRoute
   '/api/terminals/$sessionId/delete': typeof ApiTerminalsSessionIdDeleteRoute
@@ -1239,9 +1249,10 @@ export interface FileRouteTypes {
     | '/github/pulls/'
     | '/terminals/$sessionId/'
     | '/api/agents/control-plane/events'
-    | '/api/agents/control-plane/status'
     | '/api/agents/control-plane/resource'
     | '/api/agents/control-plane/resources'
+    | '/api/agents/control-plane/status'
+    | '/api/agents/control-plane/stream'
     | '/api/codex/runs/list'
     | '/api/codex/runs/recent'
     | '/api/terminals/$sessionId/delete'
@@ -1358,9 +1369,10 @@ export interface FileRouteTypes {
     | '/github/pulls'
     | '/terminals/$sessionId'
     | '/api/agents/control-plane/events'
-    | '/api/agents/control-plane/status'
     | '/api/agents/control-plane/resource'
     | '/api/agents/control-plane/resources'
+    | '/api/agents/control-plane/status'
+    | '/api/agents/control-plane/stream'
     | '/api/codex/runs/list'
     | '/api/codex/runs/recent'
     | '/api/terminals/$sessionId/delete'
@@ -1479,9 +1491,10 @@ export interface FileRouteTypes {
     | '/github/pulls/'
     | '/terminals/$sessionId/'
     | '/api/agents/control-plane/events'
-    | '/api/agents/control-plane/status'
     | '/api/agents/control-plane/resource'
     | '/api/agents/control-plane/resources'
+    | '/api/agents/control-plane/status'
+    | '/api/agents/control-plane/stream'
     | '/api/codex/runs/list'
     | '/api/codex/runs/recent'
     | '/api/terminals/$sessionId/delete'
@@ -1592,9 +1605,10 @@ export interface RootRouteChildren {
   AgentsControlPlaneToolsIndexRoute: typeof AgentsControlPlaneToolsIndexRoute
   AgentsControlPlaneWorkspacesIndexRoute: typeof AgentsControlPlaneWorkspacesIndexRoute
   ApiAgentsControlPlaneEventsRoute: typeof ApiAgentsControlPlaneEventsRoute
-  ApiAgentsControlPlaneStatusRoute: typeof ApiAgentsControlPlaneStatusRoute
   ApiAgentsControlPlaneResourceRoute: typeof ApiAgentsControlPlaneResourceRoute
   ApiAgentsControlPlaneResourcesRoute: typeof ApiAgentsControlPlaneResourcesRoute
+  ApiAgentsControlPlaneStatusRoute: typeof ApiAgentsControlPlaneStatusRoute
+  ApiAgentsControlPlaneStreamRoute: typeof ApiAgentsControlPlaneStreamRoute
   ApiTorghutTaBarsRoute: typeof ApiTorghutTaBarsRoute
   ApiTorghutTaLatestRoute: typeof ApiTorghutTaLatestRoute
   ApiTorghutTaSignalsRoute: typeof ApiTorghutTaSignalsRoute
@@ -2332,6 +2346,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiCodexRunsListRouteImport
       parentRoute: typeof ApiCodexRunsRoute
     }
+    '/api/agents/control-plane/stream': {
+      id: '/api/agents/control-plane/stream'
+      path: '/api/agents/control-plane/stream'
+      fullPath: '/api/agents/control-plane/stream'
+      preLoaderRoute: typeof ApiAgentsControlPlaneStreamRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agents/control-plane/status': {
+      id: '/api/agents/control-plane/status'
+      path: '/api/agents/control-plane/status'
+      fullPath: '/api/agents/control-plane/status'
+      preLoaderRoute: typeof ApiAgentsControlPlaneStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/agents/control-plane/resources': {
       id: '/api/agents/control-plane/resources'
       path: '/api/agents/control-plane/resources'
@@ -2351,13 +2379,6 @@ declare module '@tanstack/react-router' {
       path: '/api/agents/control-plane/events'
       fullPath: '/api/agents/control-plane/events'
       preLoaderRoute: typeof ApiAgentsControlPlaneEventsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/agents/control-plane/status': {
-      id: '/api/agents/control-plane/status'
-      path: '/api/agents/control-plane/status'
-      fullPath: '/api/agents/control-plane/status'
-      preLoaderRoute: typeof ApiAgentsControlPlaneStatusRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/github/pulls/$owner/$repo/$number': {
@@ -2745,9 +2766,10 @@ const rootRouteChildren: RootRouteChildren = {
   AgentsControlPlaneWorkspacesIndexRoute:
     AgentsControlPlaneWorkspacesIndexRoute,
   ApiAgentsControlPlaneEventsRoute: ApiAgentsControlPlaneEventsRoute,
-  ApiAgentsControlPlaneStatusRoute: ApiAgentsControlPlaneStatusRoute,
   ApiAgentsControlPlaneResourceRoute: ApiAgentsControlPlaneResourceRoute,
   ApiAgentsControlPlaneResourcesRoute: ApiAgentsControlPlaneResourcesRoute,
+  ApiAgentsControlPlaneStatusRoute: ApiAgentsControlPlaneStatusRoute,
+  ApiAgentsControlPlaneStreamRoute: ApiAgentsControlPlaneStreamRoute,
   ApiTorghutTaBarsRoute: ApiTorghutTaBarsRoute,
   ApiTorghutTaLatestRoute: ApiTorghutTaLatestRoute,
   ApiTorghutTaSignalsRoute: ApiTorghutTaSignalsRoute,

--- a/services/jangar/src/routes/agents-control-plane/agents/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/agents/index.tsx
@@ -3,15 +3,18 @@ import * as React from 'react'
 
 import {
   deriveStatusCategory,
+  formatGenerationSummary,
   formatTimestamp,
   getMetadataValue,
   getResourceCreatedAt,
+  getResourceReconciledAt,
   getResourceUpdatedAt,
   readNestedValue,
   StatusBadge,
   summarizeConditions,
 } from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
+import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { fetchPrimitiveList, type PrimitiveResource } from '@/data/agents-control-plane'
@@ -50,6 +53,7 @@ function AgentsListPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [status, setStatus] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
+  const reloadTimerRef = React.useRef<number | null>(null)
 
   const namespaceId = React.useId()
 
@@ -84,6 +88,23 @@ function AgentsListPage() {
   React.useEffect(() => {
     void load(searchState.namespace)
   }, [load, searchState.namespace])
+
+  const scheduleReload = React.useCallback(() => {
+    if (reloadTimerRef.current !== null) return
+    reloadTimerRef.current = window.setTimeout(() => {
+      reloadTimerRef.current = null
+      void load(searchState.namespace)
+    }, 350)
+  }, [load, searchState.namespace])
+
+  useControlPlaneStream(searchState.namespace, {
+    onEvent: (event) => {
+      if (event.type !== 'resource') return
+      if (event.kind !== 'Agent') return
+      if (event.namespace !== searchState.namespace) return
+      scheduleReload()
+    },
+  })
 
   const submit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -145,6 +166,8 @@ function AgentsListPage() {
             const conditionSummary = summarizeConditions(resource)
             const createdAt = getResourceCreatedAt(resource)
             const updatedAt = getResourceUpdatedAt(resource)
+            const reconciledAt = getResourceReconciledAt(resource)
+            const generationSummary = formatGenerationSummary(resource)
             const fields = buildAgentFields(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
@@ -177,6 +200,14 @@ function AgentsListPage() {
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="text-[10px] uppercase tracking-wide">Updated</span>
                       <span className="text-foreground">{formatTimestamp(updatedAt)}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Reconciled</span>
+                      <span className="text-foreground">{formatTimestamp(reconciledAt)}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Observed gen</span>
+                      <span className="text-foreground">{generationSummary}</span>
                     </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">

--- a/services/jangar/src/routes/agents-control-plane/approvals/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/approvals/$name.tsx
@@ -44,10 +44,9 @@ function ApprovalDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/approvals"
       searchState={searchState}
-      summaryItems={(resource, namespace) => {
+      summaryItems={(resource, _namespace) => {
         const subjects = readSpecValue(resource, 'subjects') ?? []
         return [
-          { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
           { label: 'Mode', value: readNestedValue(resource, ['spec', 'mode']) ?? '—' },
           { label: 'Default decision', value: readNestedValue(resource, ['spec', 'defaultDecision']) ?? '—' },
           { label: 'Subjects', value: formatCount(subjects, 'subject') },

--- a/services/jangar/src/routes/agents-control-plane/artifacts/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/artifacts/$name.tsx
@@ -21,8 +21,7 @@ function ArtifactDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/artifacts"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'Storage', value: readNestedValue(resource, ['spec', 'storageRef', 'name']) ?? '—' },
         { label: 'TTL', value: readNestedValue(resource, ['spec', 'lifecycle', 'ttlDays']) ?? '—' },
         { label: 'URI', value: readNestedValue(resource, ['status', 'uri']) ?? '—' },

--- a/services/jangar/src/routes/agents-control-plane/budgets/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/budgets/$name.tsx
@@ -21,8 +21,7 @@ function BudgetDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/budgets"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'CPU limit', value: readNestedValue(resource, ['spec', 'limits', 'cpu']) ?? '—' },
         { label: 'Memory limit', value: readNestedValue(resource, ['spec', 'limits', 'memory']) ?? '—' },
         { label: 'GPU limit', value: readNestedValue(resource, ['spec', 'limits', 'gpu']) ?? '—' },

--- a/services/jangar/src/routes/agents-control-plane/implementation-sources/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-sources/index.tsx
@@ -3,15 +3,18 @@ import * as React from 'react'
 
 import {
   deriveStatusCategory,
+  formatGenerationSummary,
   formatTimestamp,
   getMetadataValue,
   getResourceCreatedAt,
+  getResourceReconciledAt,
   getResourceUpdatedAt,
   readNestedValue,
   StatusBadge,
   summarizeConditions,
 } from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
+import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { fetchPrimitiveList, type PrimitiveResource } from '@/data/agents-control-plane'
@@ -58,6 +61,7 @@ function ImplementationSourcesListPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [status, setStatus] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
+  const reloadTimerRef = React.useRef<number | null>(null)
 
   const namespaceId = React.useId()
 
@@ -94,6 +98,23 @@ function ImplementationSourcesListPage() {
   React.useEffect(() => {
     void load(searchState.namespace)
   }, [load, searchState.namespace])
+
+  const scheduleReload = React.useCallback(() => {
+    if (reloadTimerRef.current !== null) return
+    reloadTimerRef.current = window.setTimeout(() => {
+      reloadTimerRef.current = null
+      void load(searchState.namespace)
+    }, 350)
+  }, [load, searchState.namespace])
+
+  useControlPlaneStream(searchState.namespace, {
+    onEvent: (event) => {
+      if (event.type !== 'resource') return
+      if (event.kind !== 'ImplementationSource') return
+      if (event.namespace !== searchState.namespace) return
+      scheduleReload()
+    },
+  })
 
   const submit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -155,6 +176,8 @@ function ImplementationSourcesListPage() {
             const conditionSummary = summarizeConditions(resource)
             const createdAt = getResourceCreatedAt(resource)
             const updatedAt = getResourceUpdatedAt(resource)
+            const reconciledAt = getResourceReconciledAt(resource)
+            const generationSummary = formatGenerationSummary(resource)
             const fields = buildSourceFields(resource)
             return (
               <li key={`${resourceNamespace}/${name}`} className="border-b border-border last:border-b-0">
@@ -187,6 +210,14 @@ function ImplementationSourcesListPage() {
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="text-[10px] uppercase tracking-wide">Updated</span>
                       <span className="text-foreground">{formatTimestamp(updatedAt)}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Reconciled</span>
+                      <span className="text-foreground">{formatTimestamp(reconciledAt)}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] uppercase tracking-wide">Observed gen</span>
+                      <span className="text-foreground">{generationSummary}</span>
                     </div>
                   </div>
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">

--- a/services/jangar/src/routes/agents-control-plane/implementation-specs/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-specs/$name.tsx
@@ -12,7 +12,9 @@ import {
   StatusBadge,
   YamlCodeBlock,
 } from '@/components/agents-control-plane'
+import { buildBaseSummaryItems } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
+import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fetchPrimitiveDetail, fetchPrimitiveEvents, type PrimitiveEventItem } from '@/data/agents-control-plane'
@@ -44,6 +46,7 @@ function ImplementationSpecDetailPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [eventsError, setEventsError] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
+  const reloadTimerRef = React.useRef<number | null>(null)
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -88,6 +91,24 @@ function ImplementationSpecDetailPage() {
     void load()
   }, [load])
 
+  const scheduleReload = React.useCallback(() => {
+    if (reloadTimerRef.current !== null) return
+    reloadTimerRef.current = window.setTimeout(() => {
+      reloadTimerRef.current = null
+      void load()
+    }, 350)
+  }, [load])
+
+  useControlPlaneStream(searchState.namespace, {
+    onEvent: (event) => {
+      if (event.type !== 'resource') return
+      if (event.kind !== 'ImplementationSpec') return
+      if (event.name !== params.name) return
+      if (event.namespace !== searchState.namespace) return
+      scheduleReload()
+    },
+  })
+
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
   const spec = resource && typeof resource.spec === 'object' ? resource.spec : {}
@@ -95,7 +116,7 @@ function ImplementationSpecDetailPage() {
 
   const summaryItems = resource
     ? [
-        { label: 'Namespace', value: getMetadataValue(resource, 'namespace') ?? searchState.namespace },
+        ...buildBaseSummaryItems(resource, searchState.namespace),
         {
           label: 'Source',
           value: readNestedValue(resource, ['spec', 'source', 'provider']) ?? '—',

--- a/services/jangar/src/routes/agents-control-plane/index.tsx
+++ b/services/jangar/src/routes/agents-control-plane/index.tsx
@@ -10,6 +10,7 @@ import {
   useControlPlaneOverview,
 } from '@/components/agents-control-plane-overview'
 import { DEFAULT_NAMESPACE, parseNamespaceSearch } from '@/components/agents-control-plane-search'
+import { ControlPlaneStatusPanel, useControlPlaneStatus } from '@/components/agents-control-plane-status'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
@@ -32,6 +33,7 @@ function AgentsControlPlanePage() {
   const searchId = React.useId()
 
   const { tiles, problems, isLoading, error, lastUpdatedAt, refresh } = useControlPlaneOverview(searchState.namespace)
+  const controlPlaneStatus = useControlPlaneStatus(searchState.namespace)
 
   React.useEffect(() => {
     setNamespace(searchState.namespace)
@@ -177,6 +179,11 @@ function AgentsControlPlanePage() {
         </div>
 
         <div className="space-y-6">
+          <ControlPlaneStatusPanel
+            status={controlPlaneStatus.status}
+            error={controlPlaneStatus.error}
+            isLoading={controlPlaneStatus.isLoading}
+          />
           <ControlPlaneControllersPanel tiles={tiles} />
           <ControlPlaneProblems
             problems={problems}

--- a/services/jangar/src/routes/agents-control-plane/memories/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/memories/$name.tsx
@@ -13,7 +13,9 @@ import {
   StatusBadge,
   YamlCodeBlock,
 } from '@/components/agents-control-plane'
+import { buildBaseSummaryItems } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
+import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fetchPrimitiveDetail, fetchPrimitiveEvents, type PrimitiveEventItem } from '@/data/agents-control-plane'
@@ -33,6 +35,7 @@ function MemoryDetailPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [eventsError, setEventsError] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
+  const reloadTimerRef = React.useRef<number | null>(null)
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -77,6 +80,24 @@ function MemoryDetailPage() {
     void load()
   }, [load])
 
+  const scheduleReload = React.useCallback(() => {
+    if (reloadTimerRef.current !== null) return
+    reloadTimerRef.current = window.setTimeout(() => {
+      reloadTimerRef.current = null
+      void load()
+    }, 350)
+  }, [load])
+
+  useControlPlaneStream(searchState.namespace, {
+    onEvent: (event) => {
+      if (event.type !== 'resource') return
+      if (event.kind !== 'Memory') return
+      if (event.name !== params.name) return
+      if (event.namespace !== searchState.namespace) return
+      scheduleReload()
+    },
+  })
+
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
   const spec = resource && typeof resource.spec === 'object' ? resource.spec : {}
@@ -84,7 +105,7 @@ function MemoryDetailPage() {
 
   const summaryItems = resource
     ? [
-        { label: 'Namespace', value: getMetadataValue(resource, 'namespace') ?? searchState.namespace },
+        ...buildBaseSummaryItems(resource, searchState.namespace),
         { label: 'Type', value: readNestedValue(resource, ['spec', 'type']) ?? '—' },
         { label: 'Default', value: readNestedValue(resource, ['spec', 'default']) ?? '—' },
         {

--- a/services/jangar/src/routes/agents-control-plane/orchestration-runs/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/orchestration-runs/$name.tsx
@@ -21,8 +21,7 @@ function OrchestrationRunDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/orchestration-runs"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'Orchestration', value: readNestedValue(resource, ['spec', 'orchestrationRef', 'name']) ?? '—' },
         { label: 'Run ID', value: readNestedValue(resource, ['status', 'runId']) ?? '—' },
         { label: 'Delivery ID', value: readNestedValue(resource, ['spec', 'deliveryId']) ?? '—' },

--- a/services/jangar/src/routes/agents-control-plane/orchestrations/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/orchestrations/$name.tsx
@@ -51,11 +51,10 @@ function OrchestrationDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/orchestrations"
       searchState={searchState}
-      summaryItems={(resource, namespace) => {
+      summaryItems={(resource, _namespace) => {
         const steps = readSpecValue(resource, 'steps')
         const policies = readSpecValue(resource, 'policies')
         return [
-          { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
           { label: 'Entrypoint', value: readNestedValue(resource, ['spec', 'entrypoint']) ?? '—' },
           { label: 'Steps', value: formatCount(steps, 'step') },
           { label: 'First step', value: readFirstStep(steps) },

--- a/services/jangar/src/routes/agents-control-plane/schedules/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/schedules/$name.tsx
@@ -21,8 +21,7 @@ function ScheduleDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/schedules"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'Cron', value: readNestedValue(resource, ['spec', 'cron']) ?? '—' },
         { label: 'Timezone', value: readNestedValue(resource, ['spec', 'timezone']) ?? '—' },
         { label: 'Target kind', value: readNestedValue(resource, ['spec', 'targetRef', 'kind']) ?? '—' },

--- a/services/jangar/src/routes/agents-control-plane/secret-bindings/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/secret-bindings/$name.tsx
@@ -44,10 +44,9 @@ function SecretBindingDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/secret-bindings"
       searchState={searchState}
-      summaryItems={(resource, namespace) => {
+      summaryItems={(resource, _namespace) => {
         const subjects = readSpecValue(resource, 'subjects')
         return [
-          { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
           { label: 'Allowed secrets', value: readNestedArrayValue(resource, ['spec', 'allowedSecrets']) ?? '—' },
           { label: 'Subjects', value: formatCount(subjects, 'subject') },
           { label: 'First subject', value: readFirstSubject(subjects) },

--- a/services/jangar/src/routes/agents-control-plane/signal-deliveries/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/signal-deliveries/$name.tsx
@@ -34,8 +34,7 @@ function SignalDeliveryDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/signal-deliveries"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'Signal', value: readNestedValue(resource, ['spec', 'signalRef', 'name']) ?? '—' },
         { label: 'Delivery ID', value: readNestedValue(resource, ['spec', 'deliveryId']) ?? '—' },
         { label: 'Payload', value: formatObjectKeys(readSpecValue(resource, 'payload')) },

--- a/services/jangar/src/routes/agents-control-plane/signals/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/signals/$name.tsx
@@ -34,8 +34,7 @@ function SignalDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/signals"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'Channel', value: readNestedValue(resource, ['spec', 'channel']) ?? '—' },
         { label: 'Description', value: readNestedValue(resource, ['spec', 'description']) ?? '—' },
         { label: 'Payload', value: formatObjectKeys(readSpecValue(resource, 'payload')) },

--- a/services/jangar/src/routes/agents-control-plane/tool-runs/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/tool-runs/$name.tsx
@@ -21,8 +21,7 @@ function ToolRunDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/tool-runs"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'Tool', value: readNestedValue(resource, ['spec', 'toolRef', 'name']) ?? '—' },
         { label: 'Delivery ID', value: readNestedValue(resource, ['spec', 'deliveryId']) ?? '—' },
         { label: 'Run ID', value: readNestedValue(resource, ['status', 'runId']) ?? '—' },

--- a/services/jangar/src/routes/agents-control-plane/tools/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/tools/$name.tsx
@@ -21,8 +21,7 @@ function ToolDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/tools"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'Image', value: readNestedValue(resource, ['spec', 'image']) ?? '—' },
         { label: 'Command', value: readNestedArrayValue(resource, ['spec', 'command']) ?? '—' },
         { label: 'Args', value: readNestedArrayValue(resource, ['spec', 'args']) ?? '—' },

--- a/services/jangar/src/routes/agents-control-plane/workspaces/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/workspaces/$name.tsx
@@ -21,8 +21,7 @@ function WorkspaceDetailRoute() {
       name={params.name}
       backPath="/agents-control-plane/workspaces"
       searchState={searchState}
-      summaryItems={(resource, namespace) => [
-        { label: 'Namespace', value: readNestedValue(resource, ['metadata', 'namespace']) ?? namespace },
+      summaryItems={(resource, _namespace) => [
         { label: 'Size', value: readNestedValue(resource, ['spec', 'size']) ?? '—' },
         { label: 'Access modes', value: readNestedArrayValue(resource, ['spec', 'accessModes']) ?? '—' },
         { label: 'Storage class', value: readNestedValue(resource, ['spec', 'storageClassName']) ?? '—' },

--- a/services/jangar/src/routes/api/agents/control-plane/status.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/status.ts
@@ -1,32 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
-
-import { buildControlPlaneStatus, type GrpcStatus } from '~/server/control-plane-status'
+import { resolveGrpcStatus } from '~/server/control-plane-grpc'
+import { buildControlPlaneStatus } from '~/server/control-plane-status'
 import { errorResponse, normalizeNamespace, okResponse } from '~/server/primitives-http'
-
-const DEFAULT_GRPC_PORT = 50051
-
-const resolveGrpcStatus = (): GrpcStatus => {
-  const enabled = (process.env.JANGAR_GRPC_ENABLED ?? '').trim().toLowerCase()
-  if (!['1', 'true', 'yes', 'on'].includes(enabled)) {
-    return {
-      enabled: false,
-      address: '',
-      status: 'disabled',
-      message: 'gRPC disabled',
-    }
-  }
-
-  const host = (process.env.JANGAR_GRPC_HOST ?? '').trim() || '127.0.0.1'
-  const port = Number.parseInt(process.env.JANGAR_GRPC_PORT ?? '', 10) || DEFAULT_GRPC_PORT
-  const address = process.env.JANGAR_GRPC_ADDRESS?.trim() || `${host}:${port}`
-
-  return {
-    enabled: true,
-    address,
-    status: 'healthy',
-    message: '',
-  }
-}
 
 export const Route = createFileRoute('/api/agents/control-plane/status')({
   server: {
@@ -36,14 +11,14 @@ export const Route = createFileRoute('/api/agents/control-plane/status')({
   },
 })
 
-export const getControlPlaneStatus = async (request: Request, deps: { grpc?: GrpcStatus } = {}) => {
+export const getControlPlaneStatus = async (request: Request) => {
   const url = new URL(request.url)
   const namespace = normalizeNamespace(url.searchParams.get('namespace'), 'agents')
 
   try {
     const status = await buildControlPlaneStatus({
       namespace,
-      grpc: deps.grpc ?? resolveGrpcStatus(),
+      grpc: resolveGrpcStatus(),
     })
     return okResponse(status)
   } catch (error) {

--- a/services/jangar/src/routes/api/agents/control-plane/stream.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/stream.ts
@@ -1,0 +1,248 @@
+import { EventEmitter } from 'node:events'
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { safeJsonStringify } from '~/server/chat-text'
+import { resolveGrpcStatus } from '~/server/control-plane-grpc'
+import { buildControlPlaneStatus, type ControlPlaneStatus } from '~/server/control-plane-status'
+import { startResourceWatch } from '~/server/kube-watch'
+import { recordSseConnection, recordSseError } from '~/server/metrics'
+import { type AgentPrimitiveKind, listPrimitiveKinds, resolvePrimitiveKind } from '~/server/primitives-control-plane'
+import { asRecord, asString, normalizeNamespace } from '~/server/primitives-http'
+
+export const Route = createFileRoute('/api/agents/control-plane/stream')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => streamControlPlaneEvents(request),
+    },
+  },
+})
+
+type ControlPlaneResourceEvent = {
+  type: 'resource'
+  kind: AgentPrimitiveKind
+  namespace: string
+  action: string | null
+  name: string | null
+  resource: Record<string, unknown>
+}
+
+type ControlPlaneStatusEvent = {
+  type: 'status'
+  namespace: string
+  status: ControlPlaneStatus
+}
+
+type ControlPlaneErrorEvent = {
+  type: 'error'
+  namespace: string
+  message: string
+}
+
+type ControlPlaneStreamEvent = ControlPlaneResourceEvent | ControlPlaneStatusEvent | ControlPlaneErrorEvent
+
+type NamespaceStream = {
+  emitter: EventEmitter
+  refCount: number
+  watchers: Array<{ stop: () => void }>
+  statusTimeout: NodeJS.Timeout | null
+  lastStatus: ControlPlaneStatus | null
+}
+
+const HEARTBEAT_INTERVAL_MS = 15_000
+const STATUS_DEBOUNCE_MS = 500
+
+const namespaceStreams = new Map<string, NamespaceStream>()
+
+const toSummary = (resource: Record<string, unknown>) => ({
+  apiVersion: asString(resource.apiVersion) ?? null,
+  kind: asString(resource.kind) ?? null,
+  metadata: asRecord(resource.metadata) ?? {},
+  spec: asRecord(resource.spec) ?? {},
+  status: asRecord(resource.status) ?? {},
+})
+
+const buildStatus = async (namespace: string) =>
+  buildControlPlaneStatus({
+    namespace,
+    grpc: resolveGrpcStatus(),
+  })
+
+const emitStatus = async (stream: NamespaceStream, namespace: string) => {
+  if (stream.statusTimeout) {
+    clearTimeout(stream.statusTimeout)
+    stream.statusTimeout = null
+  }
+  try {
+    const status = await buildStatus(namespace)
+    stream.lastStatus = status
+    stream.emitter.emit('event', { type: 'status', namespace, status } satisfies ControlPlaneStatusEvent)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    recordSseError('control-plane', 'status')
+    stream.emitter.emit('event', { type: 'error', namespace, message } satisfies ControlPlaneErrorEvent)
+  }
+}
+
+const scheduleStatusRefresh = (stream: NamespaceStream, namespace: string) => {
+  if (stream.statusTimeout) return
+  stream.statusTimeout = setTimeout(() => {
+    void emitStatus(stream, namespace)
+  }, STATUS_DEBOUNCE_MS)
+}
+
+const ensureNamespaceStream = (namespace: string): NamespaceStream => {
+  const existing = namespaceStreams.get(namespace)
+  if (existing) {
+    existing.refCount += 1
+    return existing
+  }
+
+  const emitter = new EventEmitter()
+  emitter.setMaxListeners(0)
+
+  const stream: NamespaceStream = {
+    emitter,
+    refCount: 1,
+    watchers: [],
+    statusTimeout: null,
+    lastStatus: null,
+  }
+
+  const kinds = listPrimitiveKinds()
+  for (const kind of kinds) {
+    const resolved = resolvePrimitiveKind(kind)
+    if (!resolved) continue
+
+    stream.watchers.push(
+      startResourceWatch({
+        resource: resolved.resource,
+        namespace,
+        logPrefix: '[jangar][control-plane-stream]',
+        onEvent: (event) => {
+          const payload = asRecord(event.object) ?? {}
+          const summary = toSummary(payload)
+          const metadata = asRecord(summary.metadata) ?? {}
+          const resourceNamespace = asString(metadata.namespace) ?? namespace
+          const name = asString(metadata.name) ?? null
+          stream.emitter.emit('event', {
+            type: 'resource',
+            kind: resolved.kind,
+            namespace: resourceNamespace,
+            action: event.type ?? null,
+            name,
+            resource: summary,
+          } satisfies ControlPlaneResourceEvent)
+          scheduleStatusRefresh(stream, namespace)
+        },
+        onError: (error) => {
+          const message = error instanceof Error ? error.message : String(error)
+          recordSseError('control-plane', 'watch')
+          stream.emitter.emit('event', { type: 'error', namespace, message } satisfies ControlPlaneErrorEvent)
+        },
+      }),
+    )
+  }
+
+  namespaceStreams.set(namespace, stream)
+  void emitStatus(stream, namespace)
+  return stream
+}
+
+const releaseNamespaceStream = (namespace: string) => {
+  const stream = namespaceStreams.get(namespace)
+  if (!stream) return
+  stream.refCount -= 1
+  if (stream.refCount > 0) return
+
+  for (const watcher of stream.watchers) {
+    watcher.stop()
+  }
+  stream.watchers = []
+  if (stream.statusTimeout) {
+    clearTimeout(stream.statusTimeout)
+    stream.statusTimeout = null
+  }
+
+  namespaceStreams.delete(namespace)
+}
+
+const subscribeNamespaceEvents = (namespace: string, onEvent: (event: ControlPlaneStreamEvent) => void) => {
+  const stream = ensureNamespaceStream(namespace)
+  const listener = (event: ControlPlaneStreamEvent) => onEvent(event)
+  stream.emitter.on('event', listener)
+  return () => {
+    stream.emitter.off('event', listener)
+    releaseNamespaceStream(namespace)
+  }
+}
+
+export const streamControlPlaneEvents = async (request: Request) => {
+  const url = new URL(request.url)
+  const namespace = normalizeNamespace(url.searchParams.get('namespace'), 'agents')
+  const encoder = new TextEncoder()
+
+  let heartbeat: ReturnType<typeof setInterval> | null = null
+  let unsubscribe: (() => void) | null = null
+  let closed = false
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      recordSseConnection('control-plane', 'opened')
+
+      const safeEnqueue = (value: string) => {
+        if (closed) return
+        try {
+          controller.enqueue(encoder.encode(value))
+        } catch (_error) {
+          recordSseError('control-plane', 'enqueue')
+          if (!closed) {
+            closed = true
+            try {
+              controller.close()
+            } catch {
+              // ignore
+            }
+          }
+        }
+      }
+
+      const push = (payload: unknown) => {
+        safeEnqueue(`data: ${safeJsonStringify(payload)}\n\n`)
+      }
+
+      safeEnqueue('retry: 1000\n\n')
+      safeEnqueue(': connected\n\n')
+
+      unsubscribe = subscribeNamespaceEvents(namespace, (event) => {
+        push(event)
+      })
+
+      const streamState = namespaceStreams.get(namespace)
+      if (streamState?.lastStatus) {
+        push({ type: 'status', namespace, status: streamState.lastStatus })
+      }
+
+      heartbeat = setInterval(() => {
+        safeEnqueue(': keep-alive\n\n')
+      }, HEARTBEAT_INTERVAL_MS)
+    },
+    cancel() {
+      closed = true
+      recordSseConnection('control-plane', 'closed')
+      if (heartbeat) clearInterval(heartbeat)
+      heartbeat = null
+      if (unsubscribe) unsubscribe()
+      unsubscribe = null
+    },
+  })
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+    },
+  })
+}

--- a/services/jangar/src/server/__tests__/agent-comms-subscriber.test.ts
+++ b/services/jangar/src/server/__tests__/agent-comms-subscriber.test.ts
@@ -1,9 +1,9 @@
-import { StringCodec, type JsMsg } from 'nats'
+import { type JsMsg, StringCodec } from 'nats'
 import { describe, expect, it, vi } from 'vitest'
 
 import { __test__ } from '~/server/agent-comms-subscriber'
-import type { AgentMessageRecord } from '~/server/agent-messages-store'
 import { publishAgentMessages } from '~/server/agent-messages-bus'
+import type { AgentMessageRecord } from '~/server/agent-messages-store'
 import { recordAgentCommsBatch, recordAgentCommsError } from '~/server/metrics'
 
 vi.mock('~/server/agent-messages-bus', () => ({
@@ -52,6 +52,7 @@ const createStream = (messages: JsMsg[]) =>
     },
     stop: vi.fn(),
     close: vi.fn(async () => {}),
+    // biome-ignore lint/suspicious/noConfusingVoidType: align with MessageStream close signature.
   }) as AsyncIterable<JsMsg> & { stop: () => void; close: () => Promise<void | Error> }
 
 describe('agent comms subscriber consume', () => {

--- a/services/jangar/src/server/__tests__/agent-comms-subscriber.test.ts
+++ b/services/jangar/src/server/__tests__/agent-comms-subscriber.test.ts
@@ -1,7 +1,8 @@
-import type { JsMsg } from 'nats'
+import { StringCodec, type JsMsg } from 'nats'
 import { describe, expect, it, vi } from 'vitest'
 
 import { __test__ } from '~/server/agent-comms-subscriber'
+import type { AgentMessageRecord } from '~/server/agent-messages-store'
 import { publishAgentMessages } from '~/server/agent-messages-bus'
 import { recordAgentCommsBatch, recordAgentCommsError } from '~/server/metrics'
 
@@ -14,9 +15,26 @@ vi.mock('~/server/metrics', () => ({
   recordAgentCommsError: vi.fn(),
 }))
 
-type StringCodecValue = { decode: (data: Uint8Array) => string }
-
 const toBytes = (value: string) => new TextEncoder().encode(value)
+
+const buildRecord = (input: Record<string, unknown>, index: number): AgentMessageRecord => ({
+  id: `msg-${index}`,
+  workflowUid: null,
+  workflowName: null,
+  workflowNamespace: null,
+  runId: null,
+  stepId: null,
+  agentId: null,
+  role: String(input.role ?? 'assistant'),
+  kind: String(input.kind ?? 'message'),
+  timestamp: new Date().toISOString(),
+  channel: null,
+  stage: null,
+  content: String(input.content ?? ''),
+  attrs: {},
+  dedupeKey: null,
+  createdAt: new Date().toISOString(),
+})
 
 const createMessage = (payload: Record<string, unknown>, subject: string) =>
   ({
@@ -34,16 +52,21 @@ const createStream = (messages: JsMsg[]) =>
     },
     stop: vi.fn(),
     close: vi.fn(async () => {}),
-  }) as AsyncIterable<JsMsg> & { stop: () => void; close: () => Promise<undefined | Error> }
+  }) as AsyncIterable<JsMsg> & { stop: () => void; close: () => Promise<void | Error> }
 
 describe('agent comms subscriber consume', () => {
   it('acks messages after insert and records batch metrics', async () => {
     const recordBatch = vi.mocked(recordAgentCommsBatch)
-    const sc = { decode: (data: Uint8Array) => new TextDecoder().decode(data) } as StringCodecValue
+    const sc = StringCodec()
     const insertMessages = vi.fn(async (inputs: unknown[]) =>
-      inputs.map((input, index) => ({ ...(input as Record<string, unknown>), id: `msg-${index}`, createdAt: null })),
+      inputs.map((input, index) => buildRecord(input as Record<string, unknown>, index)),
     )
-    const store = { insertMessages, close: vi.fn(async () => {}) }
+    const store = {
+      insertMessages,
+      hasMessages: vi.fn(async () => false),
+      listMessages: vi.fn(async () => []),
+      close: vi.fn(async () => {}),
+    }
     const abortController = new AbortController()
     const config = { pullBatchSize: 2, pullExpiresMs: 0 } as Parameters<typeof __test__.consumeStream>[3]
 
@@ -62,11 +85,16 @@ describe('agent comms subscriber consume', () => {
 
   it('acks decode failures immediately and records decode errors', async () => {
     const recordError = vi.mocked(recordAgentCommsError)
-    const sc = { decode: (data: Uint8Array) => new TextDecoder().decode(data) } as StringCodecValue
+    const sc = StringCodec()
     const insertMessages = vi.fn(async (inputs: unknown[]) =>
-      inputs.map((input, index) => ({ ...(input as Record<string, unknown>), id: `msg-${index}`, createdAt: null })),
+      inputs.map((input, index) => buildRecord(input as Record<string, unknown>, index)),
     )
-    const store = { insertMessages, close: vi.fn(async () => {}) }
+    const store = {
+      insertMessages,
+      hasMessages: vi.fn(async () => false),
+      listMessages: vi.fn(async () => []),
+      close: vi.fn(async () => {}),
+    }
     const abortController = new AbortController()
     const config = { pullBatchSize: 1, pullExpiresMs: 0 } as Parameters<typeof __test__.consumeStream>[3]
 

--- a/services/jangar/src/server/agent-comms-subscriber.ts
+++ b/services/jangar/src/server/agent-comms-subscriber.ts
@@ -336,6 +336,7 @@ const ensureConsumer = async (manager: JetStreamManager, config: SubscriberConfi
 
 type MessageStream = AsyncIterable<JsMsg> & {
   stop?: (error?: Error) => void
+  // biome-ignore lint/suspicious/noConfusingVoidType: NATS close uses Promise<void | Error>.
   close?: () => Promise<void | Error>
 }
 

--- a/services/jangar/src/server/agent-comms-subscriber.ts
+++ b/services/jangar/src/server/agent-comms-subscriber.ts
@@ -107,6 +107,11 @@ const createDeferredPromise = (): DeferredPromise => {
   return { promise, resolve, reject }
 }
 
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
 const coerceString = (value: unknown): string | null => {
   if (typeof value === 'string') return value
   if (typeof value === 'number' && Number.isFinite(value)) return String(value)
@@ -331,7 +336,7 @@ const ensureConsumer = async (manager: JetStreamManager, config: SubscriberConfi
 
 type MessageStream = AsyncIterable<JsMsg> & {
   stop?: (error?: Error) => void
-  close?: () => Promise<undefined | Error>
+  close?: () => Promise<void | Error>
 }
 
 const consumeStream = async (

--- a/services/jangar/src/server/control-plane-grpc.ts
+++ b/services/jangar/src/server/control-plane-grpc.ts
@@ -1,0 +1,26 @@
+import type { GrpcStatus } from '~/server/control-plane-status'
+
+const DEFAULT_GRPC_PORT = 50051
+
+export const resolveGrpcStatus = (): GrpcStatus => {
+  const enabled = (process.env.JANGAR_GRPC_ENABLED ?? '').trim().toLowerCase()
+  if (!['1', 'true', 'yes', 'on'].includes(enabled)) {
+    return {
+      enabled: false,
+      address: '',
+      status: 'disabled',
+      message: 'gRPC disabled',
+    }
+  }
+
+  const host = (process.env.JANGAR_GRPC_HOST ?? '').trim() || '127.0.0.1'
+  const port = Number.parseInt(process.env.JANGAR_GRPC_PORT ?? '', 10) || DEFAULT_GRPC_PORT
+  const address = process.env.JANGAR_GRPC_ADDRESS?.trim() || `${host}:${port}`
+
+  return {
+    enabled: true,
+    address,
+    status: 'healthy',
+    message: '',
+  }
+}

--- a/services/jangar/src/server/metrics.ts
+++ b/services/jangar/src/server/metrics.ts
@@ -33,7 +33,7 @@ type MetricsState = {
   shutdown?: () => void
 }
 
-type SseStream = 'chat' | 'agent-events'
+type SseStream = 'chat' | 'agent-events' | 'control-plane'
 
 type AgentCommsErrorStage = 'fetch' | 'insert' | 'decode' | 'unknown'
 

--- a/services/jangar/tsconfig.json
+++ b/services/jangar/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "strict": true,
     "strictNullChecks": true,
+    "baseUrl": "./src",
     "paths": {
       "@/*": ["./*"],
       "~/*": ["./*"],


### PR DESCRIPTION
## Summary

- Add Agents control-plane sidebar section with dedicated list/detail routes across primitives.
- Introduce agents control-plane SSE stream + status surfaces for realtime updates.
- Tighten agent comms subscriber typing/tests to keep lint/tsc green.

## Related Issues

Closes #2653

## Testing

- bun run --filter @proompteng/jangar lint
- bun run --filter @proompteng/jangar tsc

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
