### PR TITLE
feat(jangar): add control-plane summary endpoint

### DIFF
--- a/services/jangar/src/routes/api/agents/control-plane/summary.test.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/summary.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getControlPlaneSummary } from '~/routes/api/agents/control-plane/summary'
+import { RESOURCE_MAP } from '~/server/primitives-kube'
+
+const buildList = (items: Record<string, unknown>[] = []) => ({ items })
+
+describe('control plane summary route', () => {
+  it('aggregates totals and run phases', async () => {
+    const lists: Record<string, Record<string, unknown>> = {
+      [RESOURCE_MAP.Agent]: buildList([{}, {}]),
+      [RESOURCE_MAP.AgentRun]: buildList([
+        { status: { phase: 'Pending' } },
+        { status: { phase: 'Running' } },
+        { status: { phase: 'Running' } },
+        { status: {} },
+      ]),
+      [RESOURCE_MAP.Orchestration]: buildList([]),
+      [RESOURCE_MAP.OrchestrationRun]: buildList([
+        { status: { phase: 'Succeeded' } },
+        { status: { phase: 'Failed' } },
+        { status: { phase: 'Cancelled' } },
+      ]),
+      [RESOURCE_MAP.ImplementationSpec]: buildList([{}]),
+      [RESOURCE_MAP.ImplementationSource]: buildList([{}, {}, {}]),
+      [RESOURCE_MAP.Memory]: buildList([]),
+      [RESOURCE_MAP.Tool]: buildList([{}]),
+      [RESOURCE_MAP.Signal]: buildList([{}, {}]),
+      [RESOURCE_MAP.Schedule]: buildList([]),
+      [RESOURCE_MAP.Artifact]: buildList([{}]),
+      [RESOURCE_MAP.Workspace]: buildList([{}, {}]),
+    }
+
+    const kube = {
+      list: vi.fn(async (resource: string) => lists[resource] ?? buildList()),
+    }
+
+    const response = await getControlPlaneSummary(
+      new Request('http://localhost/api/agents/control-plane/summary?namespace=agents'),
+      { kubeClient: kube },
+    )
+
+    expect(kube.list).toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.ok).toBe(true)
+    expect(payload.namespace).toBe('agents')
+
+    const resources = payload.resources as Record<string, Record<string, unknown>>
+    expect(resources.Agent.total).toBe(2)
+    expect(resources.AgentRun.total).toBe(4)
+    expect(resources.Orchestration.total).toBe(0)
+    expect(resources.OrchestrationRun.total).toBe(3)
+
+    const agentRunPhases = resources.AgentRun.phases as Record<string, number>
+    expect(agentRunPhases.Pending).toBe(1)
+    expect(agentRunPhases.Running).toBe(2)
+    expect(agentRunPhases.Unknown).toBe(1)
+
+    const orchestrationRunPhases = resources.OrchestrationRun.phases as Record<string, number>
+    expect(orchestrationRunPhases.Succeeded).toBe(1)
+    expect(orchestrationRunPhases.Failed).toBe(1)
+    expect(orchestrationRunPhases.Cancelled).toBe(1)
+  })
+
+  it('includes per-kind errors when listing fails', async () => {
+    const kube = {
+      list: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.Memory) {
+          throw new Error('boom')
+        }
+        return buildList([])
+      }),
+    }
+
+    const response = await getControlPlaneSummary(new Request('http://localhost/api/agents/control-plane/summary'), {
+      kubeClient: kube,
+    })
+
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as Record<string, unknown>
+    const resources = payload.resources as Record<string, Record<string, unknown>>
+    expect(resources.Memory.total).toBe(0)
+    expect(resources.Memory.error).toBe('boom')
+    expect(resources.Memory.phases).toBeUndefined()
+  })
+})

--- a/services/jangar/src/routes/api/agents/control-plane/summary.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/summary.ts
@@ -1,0 +1,101 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { type AgentPrimitiveKind, resolvePrimitiveKind } from '~/server/primitives-control-plane'
+import { asRecord, asString, normalizeNamespace, okResponse } from '~/server/primitives-http'
+import { createKubernetesClient } from '~/server/primitives-kube'
+
+export const Route = createFileRoute('/api/agents/control-plane/summary')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getControlPlaneSummary(request),
+    },
+  },
+})
+
+const SUMMARY_KINDS: AgentPrimitiveKind[] = [
+  'Agent',
+  'AgentRun',
+  'Orchestration',
+  'OrchestrationRun',
+  'ImplementationSpec',
+  'ImplementationSource',
+  'Memory',
+  'Tool',
+  'Signal',
+  'Schedule',
+  'Artifact',
+  'Workspace',
+]
+
+const RUN_PHASES = ['Pending', 'Running', 'Succeeded', 'Failed', 'Cancelled'] as const
+
+type RunPhase = (typeof RUN_PHASES)[number] | 'Unknown' | string
+
+type SummaryEntry = {
+  total: number
+  error?: string
+  phases?: Record<RunPhase, number>
+}
+
+const buildPhaseCounts = (): Record<RunPhase, number> => ({
+  Pending: 0,
+  Running: 0,
+  Succeeded: 0,
+  Failed: 0,
+  Cancelled: 0,
+  Unknown: 0,
+})
+
+const countRunPhases = (items: unknown[]): Record<RunPhase, number> => {
+  const phases = buildPhaseCounts()
+
+  for (const item of items) {
+    const record = asRecord(item) ?? {}
+    const status = asRecord(record.status) ?? {}
+    const phase = asString(status.phase) ?? 'Unknown'
+    if (!(phase in phases)) {
+      phases[phase] = 0
+    }
+    phases[phase] += 1
+  }
+
+  return phases
+}
+
+export const getControlPlaneSummary = async (
+  request: Request,
+  deps: { kubeClient?: ReturnType<typeof createKubernetesClient> } = {},
+) => {
+  const url = new URL(request.url)
+  const namespace = normalizeNamespace(url.searchParams.get('namespace'), 'agents')
+  const kube = deps.kubeClient ?? createKubernetesClient()
+
+  const resources = Object.fromEntries(
+    await Promise.all(
+      SUMMARY_KINDS.map(async (kind): Promise<[AgentPrimitiveKind, SummaryEntry]> => {
+        const resolved = resolvePrimitiveKind(kind)
+        if (!resolved) {
+          return [kind, { total: 0, error: `Unknown kind: ${kind}` }]
+        }
+
+        try {
+          const list = await kube.list(resolved.resource, namespace)
+          const items = Array.isArray(list.items) ? list.items : []
+          const entry: SummaryEntry = { total: items.length }
+          if (resolved.kind === 'AgentRun' || resolved.kind === 'OrchestrationRun') {
+            entry.phases = countRunPhases(items)
+          }
+          return [resolved.kind, entry]
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          const entry: SummaryEntry = { total: 0, error: message }
+          if (resolved.kind === 'AgentRun' || resolved.kind === 'OrchestrationRun') {
+            entry.phases = buildPhaseCounts()
+          }
+          return [resolved.kind, entry]
+        }
+      }),
+    ),
+  ) as Record<AgentPrimitiveKind, SummaryEntry>
+
+  return okResponse({ ok: true, namespace, resources })
+}


### PR DESCRIPTION
## Summary
- add control-plane summary API with totals + run phase breakdowns
- include error details per kind and namespace handling
- add unit tests for summary aggregation

## Related Issues
- Resolves #2662

## Testing
- bun run --filter @proompteng/jangar lint
- bun run --filter @proompteng/jangar test

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
