### PR TITLE
fix(jangar): remove conflict markers in controllers

### DIFF
--- a/services/jangar/src/server/agents-controller.ts
+++ b/services/jangar/src/server/agents-controller.ts
@@ -231,10 +231,7 @@ const checkCrds = async (): Promise<CrdCheckState> => {
     missing: [...missing, ...forbidden],
     checkedAt: nowIso(),
   }
-<<<<<<< HEAD
   _crdCheckState = state
-=======
->>>>>>> 5247c5e7 (chore(jangar): fix lint warnings (#2660))
   controllerState.crdCheckState = state
   if (!state.ok) {
     if (missing.length > 0) {

--- a/services/jangar/src/server/orchestration-controller.ts
+++ b/services/jangar/src/server/orchestration-controller.ts
@@ -63,10 +63,7 @@ type StepStatus = {
 
 let started = controllerState.started
 let reconciling = false
-<<<<<<< HEAD
 let _crdCheckState: CrdCheckState | null = controllerState.crdCheckState
-=======
->>>>>>> 5247c5e7 (chore(jangar): fix lint warnings (#2660))
 let watchHandles: Array<{ stop: () => void }> = []
 const namespaceQueues = new Map<string, Promise<void>>()
 const retrySchedules = new Map<string, { timeout: NodeJS.Timeout; retryAt: number }>()
@@ -168,10 +165,7 @@ const checkCrds = async (): Promise<CrdCheckState> => {
     missing: [...missing, ...forbidden],
     checkedAt: nowIso(),
   }
-<<<<<<< HEAD
   _crdCheckState = state
-=======
->>>>>>> 5247c5e7 (chore(jangar): fix lint warnings (#2660))
   controllerState.crdCheckState = state
   if (!state.ok) {
     if (missing.length > 0) {

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -152,10 +152,7 @@ const checkCrds = async (): Promise<CrdCheckState> => {
     missing: [...missing, ...forbidden],
     checkedAt: nowIso(),
   }
-<<<<<<< HEAD
   _crdCheckState = state
-=======
->>>>>>> 5247c5e7 (chore(jangar): fix lint warnings (#2660))
   controllerState.crdCheckState = state
   if (!state.ok) {
     if (missing.length > 0) {


### PR DESCRIPTION
## Summary
- remove leftover merge markers in Jangar controllers
- restore CRD check state updates for health reporting
- unblock Jangar image builds

## Related Issues
None

## Testing
- Not run (conflict marker cleanup only)

## Screenshots (if applicable)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
