### PR TITLE
feat(jangar): add YAML inspector and revision timeline

### DIFF
--- a/services/jangar/src/components/agents-control-plane-primitives.tsx
+++ b/services/jangar/src/components/agents-control-plane-primitives.tsx
@@ -15,12 +15,13 @@ import {
   getResourceReconciledAt,
   getResourceUpdatedAt,
   getStatusConditions,
+  ResourceRevisionTimeline,
   StatusBadge,
   summarizeConditions,
-  YamlCodeBlock,
+  YamlInspector,
 } from '@/components/agents-control-plane'
 import { DEFAULT_NAMESPACE, type NamespaceSearchState } from '@/components/agents-control-plane-search'
-import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
+import { useControlPlaneStream, useResourceRevisionTimeline } from '@/components/agents-control-plane-stream'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -279,7 +280,14 @@ export function PrimitiveDetailPage({
   const [error, setError] = React.useState<string | null>(null)
   const [eventsError, setEventsError] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
-  const reloadTimerRef = React.useRef<number | null>(null)
+
+  const revisionStream = useResourceRevisionTimeline({
+    kind,
+    name,
+    namespace: searchState.namespace,
+    limit: 25,
+    onResource: (nextResource) => setResource(nextResource),
+  })
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -323,24 +331,6 @@ export function PrimitiveDetailPage({
   React.useEffect(() => {
     void load()
   }, [load])
-
-  const scheduleReload = React.useCallback(() => {
-    if (reloadTimerRef.current !== null) return
-    reloadTimerRef.current = window.setTimeout(() => {
-      reloadTimerRef.current = null
-      void load()
-    }, 350)
-  }, [load])
-
-  useControlPlaneStream(searchState.namespace, {
-    onEvent: (event) => {
-      if (event.type !== 'resource') return
-      if (event.kind !== kind) return
-      if (event.name !== name) return
-      if (event.namespace !== searchState.namespace) return
-      scheduleReload()
-    },
-  })
 
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
@@ -407,11 +397,23 @@ export function PrimitiveDetailPage({
                 </pre>
               </div>
             </section>
+            <section className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-none border border-border bg-card p-4">
+                <YamlInspector value={resource} />
+              </div>
+              <div className="space-y-3 rounded-none border border-border bg-card p-4">
+                <h2 className="text-sm font-semibold text-foreground">Revision timeline</h2>
+                <ResourceRevisionTimeline
+                  entries={revisionStream.entries}
+                  status={revisionStream.status}
+                  error={revisionStream.error}
+                />
+              </div>
+            </section>
           </TabsContent>
           <TabsContent value="yaml">
             <section className="space-y-3 rounded-none border border-border bg-card p-4">
-              <h2 className="text-sm font-semibold text-foreground">Resource YAML</h2>
-              <YamlCodeBlock value={resource} />
+              <YamlInspector value={resource} />
             </section>
           </TabsContent>
           <TabsContent value="conditions">

--- a/services/jangar/src/components/agents-control-plane-stream.tsx
+++ b/services/jangar/src/components/agents-control-plane-stream.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+import type { ResourceRevisionEntry } from '@/components/agents-control-plane'
+import { getResourcePhase } from '@/components/agents-control-plane'
 import type { AgentPrimitiveKind, ControlPlaneStatus, PrimitiveResource } from '@/data/agents-control-plane'
 
 export type ControlPlaneStreamStatus = 'connecting' | 'open' | 'error' | 'closed'
@@ -31,10 +33,28 @@ type ControlPlaneStreamHandlers = {
   onEvent?: (event: ControlPlaneStreamEvent) => void
 }
 
-type ControlPlaneStreamState = {
+export type ControlPlaneStreamState = {
   status: ControlPlaneStreamStatus
   error: string | null
   lastEventAt: string | null
+}
+
+export type ResourceStreamEvent = {
+  type: string
+  kind: AgentPrimitiveKind
+  namespace: string
+  name: string | null
+  resource: PrimitiveResource
+}
+
+export type ResourceStreamErrorEvent = {
+  type: 'ERROR'
+  error: string
+}
+
+type ResourceStreamHandlers = {
+  onEvent?: (event: ResourceStreamEvent) => void
+  onError?: (message: string) => void
 }
 
 const safeParseJson = (value: string) => {
@@ -49,6 +69,22 @@ const isStreamEvent = (payload: unknown): payload is ControlPlaneStreamEvent => 
   if (!payload || typeof payload !== 'object') return false
   const record = payload as Record<string, unknown>
   return typeof record.type === 'string'
+}
+
+const isResourceStreamEvent = (payload: unknown): payload is ResourceStreamEvent => {
+  if (!payload || typeof payload !== 'object') return false
+  const record = payload as Record<string, unknown>
+  if (typeof record.type !== 'string') return false
+  if (typeof record.kind !== 'string') return false
+  if (typeof record.namespace !== 'string') return false
+  if (!record.resource || typeof record.resource !== 'object' || Array.isArray(record.resource)) return false
+  return true
+}
+
+const isResourceErrorEvent = (payload: unknown): payload is ResourceStreamErrorEvent => {
+  if (!payload || typeof payload !== 'object') return false
+  const record = payload as Record<string, unknown>
+  return record.type === 'ERROR' && typeof record.error === 'string'
 }
 
 export const useControlPlaneStream = (
@@ -118,4 +154,134 @@ export const useControlPlaneStream = (
   }, [namespace])
 
   return { status, error, lastEventAt }
+}
+
+export const useControlPlaneResourceStream = (
+  params: { kind: AgentPrimitiveKind; name: string; namespace: string },
+  handlers: ResourceStreamHandlers,
+): ControlPlaneStreamState => {
+  const [status, setStatus] = React.useState<ControlPlaneStreamStatus>('connecting')
+  const [error, setError] = React.useState<string | null>(null)
+  const [lastEventAt, setLastEventAt] = React.useState<string | null>(null)
+  const openedRef = React.useRef(false)
+  const handlersRef = React.useRef(handlers)
+
+  React.useEffect(() => {
+    handlersRef.current = handlers
+  }, [handlers])
+
+  React.useEffect(() => {
+    const trimmedNamespace = params.namespace.trim()
+    const trimmedName = params.name.trim()
+    if (!trimmedNamespace || !trimmedName) {
+      setStatus('closed')
+      setError(null)
+      setLastEventAt(null)
+      return
+    }
+
+    setStatus('connecting')
+    setError(null)
+    setLastEventAt(null)
+    openedRef.current = false
+
+    const searchParams = new URLSearchParams({
+      kind: params.kind,
+      name: trimmedName,
+      namespace: trimmedNamespace,
+      stream: '1',
+    })
+    const source = new EventSource(`/api/agents/control-plane/resource?${searchParams.toString()}`)
+
+    source.onopen = () => {
+      openedRef.current = true
+      setStatus('open')
+      setError(null)
+    }
+
+    source.onerror = () => {
+      if (source.readyState === EventSource.CLOSED) {
+        setStatus('error')
+        const message = 'Stream disconnected.'
+        setError(message)
+        handlersRef.current.onError?.(message)
+        return
+      }
+      if (!openedRef.current) {
+        setStatus('connecting')
+        setError(null)
+        return
+      }
+      setStatus('open')
+      setError(null)
+    }
+
+    source.onmessage = (event) => {
+      if (!event.data) return
+      const parsed = safeParseJson(event.data)
+      if (isResourceErrorEvent(parsed)) {
+        setStatus('error')
+        setError(parsed.error)
+        handlersRef.current.onError?.(parsed.error)
+        return
+      }
+      if (!isResourceStreamEvent(parsed)) return
+      if (parsed.kind !== params.kind) return
+      handlersRef.current.onEvent?.(parsed)
+      setLastEventAt(new Date().toISOString())
+    }
+
+    return () => {
+      source.close()
+      setStatus('closed')
+    }
+  }, [params.kind, params.name, params.namespace])
+
+  return { status, error, lastEventAt }
+}
+
+export const useResourceRevisionTimeline = (params: {
+  kind: AgentPrimitiveKind
+  name: string
+  namespace: string
+  limit?: number
+  onResource?: (resource: PrimitiveResource) => void
+}) => {
+  const limit = params.limit ?? 25
+  const [entries, setEntries] = React.useState<ResourceRevisionEntry[]>([])
+  const [streamError, setStreamError] = React.useState<string | null>(null)
+  const entryIdRef = React.useRef(0)
+
+  const stream = useControlPlaneResourceStream(
+    { kind: params.kind, name: params.name, namespace: params.namespace },
+    {
+      onEvent: (event) => {
+        entryIdRef.current += 1
+        const timestamp = new Date().toISOString()
+        const entry: ResourceRevisionEntry = {
+          id: `${timestamp}-${entryIdRef.current}`,
+          type: event.type,
+          timestamp,
+          name: event.name ?? params.name,
+          namespace: event.namespace ?? params.namespace,
+          phase: getResourcePhase(event.resource),
+        }
+        setEntries((prev) => [entry, ...prev].slice(0, limit))
+        params.onResource?.(event.resource)
+      },
+      onError: (message) => setStreamError(message),
+    },
+  )
+
+  React.useEffect(() => {
+    void params.kind
+    void params.name
+    void params.namespace
+    void limit
+    setEntries([])
+    setStreamError(null)
+    entryIdRef.current = 0
+  }, [params.kind, params.name, params.namespace, limit])
+
+  return { entries, status: stream.status, error: streamError ?? stream.error }
 }

--- a/services/jangar/src/routes/agents-control-plane/agent-providers/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/agent-providers/$name.tsx
@@ -8,14 +8,15 @@ import {
   EventsList,
   getMetadataValue,
   getStatusConditions,
+  ResourceRevisionTimeline,
   readNestedArrayValue,
   readNestedValue,
   StatusBadge,
-  YamlCodeBlock,
+  YamlInspector,
 } from '@/components/agents-control-plane'
 import { buildBaseSummaryItems } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
-import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
+import { useResourceRevisionTimeline } from '@/components/agents-control-plane-stream'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fetchPrimitiveDetail, fetchPrimitiveEvents, type PrimitiveEventItem } from '@/data/agents-control-plane'
@@ -54,7 +55,14 @@ function AgentProviderDetailPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [eventsError, setEventsError] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
-  const reloadTimerRef = React.useRef<number | null>(null)
+
+  const revisionStream = useResourceRevisionTimeline({
+    kind: 'AgentProvider',
+    name: params.name,
+    namespace: searchState.namespace,
+    limit: 25,
+    onResource: (nextResource) => setResource(nextResource),
+  })
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -98,24 +106,6 @@ function AgentProviderDetailPage() {
   React.useEffect(() => {
     void load()
   }, [load])
-
-  const scheduleReload = React.useCallback(() => {
-    if (reloadTimerRef.current !== null) return
-    reloadTimerRef.current = window.setTimeout(() => {
-      reloadTimerRef.current = null
-      void load()
-    }, 350)
-  }, [load])
-
-  useControlPlaneStream(searchState.namespace, {
-    onEvent: (event) => {
-      if (event.type !== 'resource') return
-      if (event.kind !== 'AgentProvider') return
-      if (event.name !== params.name) return
-      if (event.namespace !== searchState.namespace) return
-      scheduleReload()
-    },
-  })
 
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
@@ -189,11 +179,23 @@ function AgentProviderDetailPage() {
                 </pre>
               </div>
             </section>
+            <section className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-none border border-border bg-card p-4">
+                <YamlInspector value={resource} />
+              </div>
+              <div className="space-y-3 rounded-none border border-border bg-card p-4">
+                <h2 className="text-sm font-semibold text-foreground">Revision timeline</h2>
+                <ResourceRevisionTimeline
+                  entries={revisionStream.entries}
+                  status={revisionStream.status}
+                  error={revisionStream.error}
+                />
+              </div>
+            </section>
           </TabsContent>
           <TabsContent value="yaml">
             <section className="space-y-3 rounded-none border border-border bg-card p-4">
-              <h2 className="text-sm font-semibold text-foreground">Resource YAML</h2>
-              <YamlCodeBlock value={resource} />
+              <YamlInspector value={resource} />
             </section>
           </TabsContent>
           <TabsContent value="conditions">

--- a/services/jangar/src/routes/agents-control-plane/agents/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/agents/$name.tsx
@@ -8,13 +8,14 @@ import {
   EventsList,
   getMetadataValue,
   getStatusConditions,
+  ResourceRevisionTimeline,
   readNestedValue,
   StatusBadge,
-  YamlCodeBlock,
+  YamlInspector,
 } from '@/components/agents-control-plane'
 import { buildBaseSummaryItems } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
-import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
+import { useResourceRevisionTimeline } from '@/components/agents-control-plane-stream'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fetchPrimitiveDetail, fetchPrimitiveEvents, type PrimitiveEventItem } from '@/data/agents-control-plane'
@@ -34,7 +35,14 @@ function AgentDetailPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [eventsError, setEventsError] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
-  const reloadTimerRef = React.useRef<number | null>(null)
+
+  const revisionStream = useResourceRevisionTimeline({
+    kind: 'Agent',
+    name: params.name,
+    namespace: searchState.namespace,
+    limit: 25,
+    onResource: (nextResource) => setResource(nextResource),
+  })
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -78,24 +86,6 @@ function AgentDetailPage() {
   React.useEffect(() => {
     void load()
   }, [load])
-
-  const scheduleReload = React.useCallback(() => {
-    if (reloadTimerRef.current !== null) return
-    reloadTimerRef.current = window.setTimeout(() => {
-      reloadTimerRef.current = null
-      void load()
-    }, 350)
-  }, [load])
-
-  useControlPlaneStream(searchState.namespace, {
-    onEvent: (event) => {
-      if (event.type !== 'resource') return
-      if (event.kind !== 'Agent') return
-      if (event.name !== params.name) return
-      if (event.namespace !== searchState.namespace) return
-      scheduleReload()
-    },
-  })
 
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
@@ -168,11 +158,23 @@ function AgentDetailPage() {
                 </pre>
               </div>
             </section>
+            <section className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-none border border-border bg-card p-4">
+                <YamlInspector value={resource} />
+              </div>
+              <div className="space-y-3 rounded-none border border-border bg-card p-4">
+                <h2 className="text-sm font-semibold text-foreground">Revision timeline</h2>
+                <ResourceRevisionTimeline
+                  entries={revisionStream.entries}
+                  status={revisionStream.status}
+                  error={revisionStream.error}
+                />
+              </div>
+            </section>
           </TabsContent>
           <TabsContent value="yaml">
             <section className="space-y-3 rounded-none border border-border bg-card p-4">
-              <h2 className="text-sm font-semibold text-foreground">Resource YAML</h2>
-              <YamlCodeBlock value={resource} />
+              <YamlInspector value={resource} />
             </section>
           </TabsContent>
           <TabsContent value="conditions">

--- a/services/jangar/src/routes/agents-control-plane/implementation-sources/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-sources/$name.tsx
@@ -8,13 +8,14 @@ import {
   EventsList,
   getMetadataValue,
   getStatusConditions,
+  ResourceRevisionTimeline,
   readNestedValue,
   StatusBadge,
-  YamlCodeBlock,
+  YamlInspector,
 } from '@/components/agents-control-plane'
 import { buildBaseSummaryItems } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
-import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
+import { useResourceRevisionTimeline } from '@/components/agents-control-plane-stream'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fetchPrimitiveDetail, fetchPrimitiveEvents, type PrimitiveEventItem } from '@/data/agents-control-plane'
@@ -42,7 +43,14 @@ function ImplementationSourceDetailPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [eventsError, setEventsError] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
-  const reloadTimerRef = React.useRef<number | null>(null)
+
+  const revisionStream = useResourceRevisionTimeline({
+    kind: 'ImplementationSource',
+    name: params.name,
+    namespace: searchState.namespace,
+    limit: 25,
+    onResource: (nextResource) => setResource(nextResource),
+  })
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -86,24 +94,6 @@ function ImplementationSourceDetailPage() {
   React.useEffect(() => {
     void load()
   }, [load])
-
-  const scheduleReload = React.useCallback(() => {
-    if (reloadTimerRef.current !== null) return
-    reloadTimerRef.current = window.setTimeout(() => {
-      reloadTimerRef.current = null
-      void load()
-    }, 350)
-  }, [load])
-
-  useControlPlaneStream(searchState.namespace, {
-    onEvent: (event) => {
-      if (event.type !== 'resource') return
-      if (event.kind !== 'ImplementationSource') return
-      if (event.name !== params.name) return
-      if (event.namespace !== searchState.namespace) return
-      scheduleReload()
-    },
-  })
 
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
@@ -177,11 +167,23 @@ function ImplementationSourceDetailPage() {
                 </pre>
               </div>
             </section>
+            <section className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-none border border-border bg-card p-4">
+                <YamlInspector value={resource} />
+              </div>
+              <div className="space-y-3 rounded-none border border-border bg-card p-4">
+                <h2 className="text-sm font-semibold text-foreground">Revision timeline</h2>
+                <ResourceRevisionTimeline
+                  entries={revisionStream.entries}
+                  status={revisionStream.status}
+                  error={revisionStream.error}
+                />
+              </div>
+            </section>
           </TabsContent>
           <TabsContent value="yaml">
             <section className="space-y-3 rounded-none border border-border bg-card p-4">
-              <h2 className="text-sm font-semibold text-foreground">Resource YAML</h2>
-              <YamlCodeBlock value={resource} />
+              <YamlInspector value={resource} />
             </section>
           </TabsContent>
           <TabsContent value="conditions">

--- a/services/jangar/src/routes/agents-control-plane/implementation-specs/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/implementation-specs/$name.tsx
@@ -8,13 +8,14 @@ import {
   EventsList,
   getMetadataValue,
   getStatusConditions,
+  ResourceRevisionTimeline,
   readNestedValue,
   StatusBadge,
-  YamlCodeBlock,
+  YamlInspector,
 } from '@/components/agents-control-plane'
 import { buildBaseSummaryItems } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
-import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
+import { useResourceRevisionTimeline } from '@/components/agents-control-plane-stream'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fetchPrimitiveDetail, fetchPrimitiveEvents, type PrimitiveEventItem } from '@/data/agents-control-plane'
@@ -46,7 +47,14 @@ function ImplementationSpecDetailPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [eventsError, setEventsError] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
-  const reloadTimerRef = React.useRef<number | null>(null)
+
+  const revisionStream = useResourceRevisionTimeline({
+    kind: 'ImplementationSpec',
+    name: params.name,
+    namespace: searchState.namespace,
+    limit: 25,
+    onResource: (nextResource) => setResource(nextResource),
+  })
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -90,24 +98,6 @@ function ImplementationSpecDetailPage() {
   React.useEffect(() => {
     void load()
   }, [load])
-
-  const scheduleReload = React.useCallback(() => {
-    if (reloadTimerRef.current !== null) return
-    reloadTimerRef.current = window.setTimeout(() => {
-      reloadTimerRef.current = null
-      void load()
-    }, 350)
-  }, [load])
-
-  useControlPlaneStream(searchState.namespace, {
-    onEvent: (event) => {
-      if (event.type !== 'resource') return
-      if (event.kind !== 'ImplementationSpec') return
-      if (event.name !== params.name) return
-      if (event.namespace !== searchState.namespace) return
-      scheduleReload()
-    },
-  })
 
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
@@ -185,11 +175,23 @@ function ImplementationSpecDetailPage() {
                 </pre>
               </div>
             </section>
+            <section className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-none border border-border bg-card p-4">
+                <YamlInspector value={resource} />
+              </div>
+              <div className="space-y-3 rounded-none border border-border bg-card p-4">
+                <h2 className="text-sm font-semibold text-foreground">Revision timeline</h2>
+                <ResourceRevisionTimeline
+                  entries={revisionStream.entries}
+                  status={revisionStream.status}
+                  error={revisionStream.error}
+                />
+              </div>
+            </section>
           </TabsContent>
           <TabsContent value="yaml">
             <section className="space-y-3 rounded-none border border-border bg-card p-4">
-              <h2 className="text-sm font-semibold text-foreground">Resource YAML</h2>
-              <YamlCodeBlock value={resource} />
+              <YamlInspector value={resource} />
             </section>
           </TabsContent>
           <TabsContent value="conditions">

--- a/services/jangar/src/routes/agents-control-plane/memories/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/memories/$name.tsx
@@ -8,14 +8,15 @@ import {
   EventsList,
   getMetadataValue,
   getStatusConditions,
+  ResourceRevisionTimeline,
   readNestedArrayValue,
   readNestedValue,
   StatusBadge,
-  YamlCodeBlock,
+  YamlInspector,
 } from '@/components/agents-control-plane'
 import { buildBaseSummaryItems } from '@/components/agents-control-plane-primitives'
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
-import { useControlPlaneStream } from '@/components/agents-control-plane-stream'
+import { useResourceRevisionTimeline } from '@/components/agents-control-plane-stream'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { fetchPrimitiveDetail, fetchPrimitiveEvents, type PrimitiveEventItem } from '@/data/agents-control-plane'
@@ -35,7 +36,14 @@ function MemoryDetailPage() {
   const [error, setError] = React.useState<string | null>(null)
   const [eventsError, setEventsError] = React.useState<string | null>(null)
   const [isLoading, setIsLoading] = React.useState(false)
-  const reloadTimerRef = React.useRef<number | null>(null)
+
+  const revisionStream = useResourceRevisionTimeline({
+    kind: 'Memory',
+    name: params.name,
+    namespace: searchState.namespace,
+    limit: 25,
+    onResource: (nextResource) => setResource(nextResource),
+  })
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -79,24 +87,6 @@ function MemoryDetailPage() {
   React.useEffect(() => {
     void load()
   }, [load])
-
-  const scheduleReload = React.useCallback(() => {
-    if (reloadTimerRef.current !== null) return
-    reloadTimerRef.current = window.setTimeout(() => {
-      reloadTimerRef.current = null
-      void load()
-    }, 350)
-  }, [load])
-
-  useControlPlaneStream(searchState.namespace, {
-    onEvent: (event) => {
-      if (event.type !== 'resource') return
-      if (event.kind !== 'Memory') return
-      if (event.name !== params.name) return
-      if (event.namespace !== searchState.namespace) return
-      scheduleReload()
-    },
-  })
 
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
@@ -173,11 +163,23 @@ function MemoryDetailPage() {
                 </pre>
               </div>
             </section>
+            <section className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-none border border-border bg-card p-4">
+                <YamlInspector value={resource} />
+              </div>
+              <div className="space-y-3 rounded-none border border-border bg-card p-4">
+                <h2 className="text-sm font-semibold text-foreground">Revision timeline</h2>
+                <ResourceRevisionTimeline
+                  entries={revisionStream.entries}
+                  status={revisionStream.status}
+                  error={revisionStream.error}
+                />
+              </div>
+            </section>
           </TabsContent>
           <TabsContent value="yaml">
             <section className="space-y-3 rounded-none border border-border bg-card p-4">
-              <h2 className="text-sm font-semibold text-foreground">Resource YAML</h2>
-              <YamlCodeBlock value={resource} />
+              <YamlInspector value={resource} />
             </section>
           </TabsContent>
           <TabsContent value="conditions">


### PR DESCRIPTION
## Summary
- add YAML inspector with copy affordance to control-plane detail pages
- stream revision timeline entries from resource watch events (last 25)
- replace polling reloads on detail pages with watch stream updates

## Related Issues
- Closes #2672

## Testing
- bun run format
- bun run --filter @proompteng/jangar lint

## Screenshots (if applicable)
- N/A

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
