### PR TITLE
chore(agents): bump jangar image 883622da

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "e27375c0"
-  digest: sha256:95d600a8376b06e8791d4e198063af943e9f004ba33b753123dd7247b8f1dc71
+  tag: "883622da"
+  digest: sha256:19891d4f6d89ea8b24c932684e24c39f3c6ea26b06ed5c02afcb8eb9749b1781
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary
- bump agents chart to jangar image 883622da (agent-runner spec fix)

## Testing
- not run (config-only change)
