### PR TITLE
fix(codex): run in worktree and skip repo check

### DIFF
--- a/apps/froussard/src/codex/cli/lib/codex-runner.ts
+++ b/apps/froussard/src/codex/cli/lib/codex-runner.ts
@@ -567,6 +567,12 @@ export const runCodexSession = async ({
     model: process.env.CODEX_MODEL?.trim() || undefined,
     jsonMode: 'json',
     dangerouslyBypassApprovalsAndSandbox: true,
+    workingDirectory: process.env.WORKTREE?.trim() || undefined,
+    sandboxMode: (process.env.CODEX_SANDBOX_MODE?.trim() || 'workspace-write') as
+      | 'workspace-write'
+      | 'workspace-readonly'
+      | 'unrestricted',
+    skipGitRepoCheck: (process.env.CODEX_SKIP_GIT_REPO_CHECK ?? '1').trim() !== '0',
     lastMessagePath: outputPath,
     eventsPath: jsonOutputPath,
     agentLogPath: agentOutputPath,


### PR DESCRIPTION
## Summary
- run codex sessions from the worktree and bypass repo checks in codex runner

## Testing
- not run (runner option wiring)
