### PR TITLE
feat(ryzen): talos bootstrap + workers namespace labels

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -68,6 +68,11 @@ spec:
                 automation: manual
                 enabled: "true"
                 clusters: ryzen
+                managedNamespaceMetadata:
+                  labels:
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
               - name: kata-containers
                 path: argocd/applications/kata-containers
                 namespace: kube-system
@@ -470,7 +475,8 @@ spec:
     {{- $hasDestName := hasKey . "destinationName" -}}
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
     {{- $auto := eq .automation "auto" -}}
-    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto -}}
+    {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS -}}
     {{- if $needsSpec }}
     spec:
       {{- if or $hasDestServer $hasDestName }}
@@ -487,10 +493,27 @@ spec:
         plugin:
           name: lovely
       {{- end }}
-      {{- if $auto }}
+      {{- if or $auto $hasManagedNS }}
       syncPolicy:
+        {{- if $auto }}
         automated:
           prune: true
           selfHeal: true
+        {{- end }}
+        {{- if $hasManagedNS }}
+        managedNamespaceMetadata:
+          {{- if hasKey .managedNamespaceMetadata "labels" }}
+          labels:
+            {{- range $key, $value := .managedNamespaceMetadata.labels }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if hasKey .managedNamespaceMetadata "annotations" }}
+          annotations:
+            {{- range $key, $value := .managedNamespaceMetadata.annotations }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
       {{- end }}
     {{- end }}

--- a/devices/ryzen/docs/cluster-bootstrap.md
+++ b/devices/ryzen/docs/cluster-bootstrap.md
@@ -1,0 +1,136 @@
+# Ryzen Talos bootstrap (USB install)
+
+This runbook is for the Ryzen Talos node booted from USB at `192.168.1.194`.
+It keeps the setup reproducible by using the patches in `devices/ryzen/manifests`
+plus the existing Talos/KubeVirt docs in this repo.
+
+## Manifest inventory (ryzen)
+
+Node-level patches:
+- `devices/ryzen/manifests/ephemeral-volume.patch.yaml` (limit system disk to 100GiB)
+- `devices/ryzen/manifests/local-path.patch.yaml` (user volume for local-path, grows to free space)
+- `devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml` (allow workloads on single-node controlplane)
+- `devices/ryzen/manifests/hostname.patch.yaml` (set Talos hostname to `ryzen`)
+- `devices/ryzen/manifests/tailscale-extension-service.yaml` (Tailscale extension service config)
+- `devices/ryzen/manifests/amdgpu-extensions.patch.yaml` (AMD GPU extensions; fill in versions)
+- `devices/ryzen/manifests/kata-firecracker.patch.yaml` (enable blockfile + kata-fc runtime)
+
+Related docs:
+- `devices/ryzen/docs/node-level-dependencies.md`
+- `docs/kata-firecracker-talos/README.md`
+- `docs/kata-firecracker-talos/rebuild-from-scratch.md`
+- `docs/kubevirt/workers-ryzen.md`
+
+## 1) Generate Talos config (store in `devices/ryzen/`)
+
+These files are gitignored on purpose:
+- `devices/ryzen/controlplane.yaml`
+- `devices/ryzen/worker.yaml`
+- `devices/ryzen/talosconfig`
+
+Generate configs with the node endpoint. Confirm the install disk (likely
+`/dev/nvme0n1` on the 2TB NVMe) before running.
+
+```bash
+# Example for a single-node controlplane endpoint
+# (adjust the endpoint if you use a load balancer)
+
+export TALOSCONFIG=$PWD/devices/ryzen/talosconfig
+
+talosctl gen config ryzen https://192.168.1.194:6443 \
+  --output-dir devices/ryzen \
+  --install-disk /dev/nvme0n1
+```
+
+## 2) Apply disk layout + node patches
+
+Talos only applies volume sizing at install time. Make sure these patches are
+in place before the first `apply-config` / install.
+
+### 2.1 System disk size (100GiB)
+
+The EPHEMERAL volume is capped at 100GiB with this patch:
+
+- `devices/ryzen/manifests/ephemeral-volume.patch.yaml`
+
+### 2.2 User volume for local-path
+
+The local-path provisioner uses a 1.5TB minimum user volume on the same NVMe
+disk and grows to consume remaining free space:
+
+- `devices/ryzen/manifests/local-path.patch.yaml`
+
+### 2.3 Optional patches
+
+- `devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml` (single-node)
+- `devices/ryzen/manifests/hostname.patch.yaml`
+- `devices/ryzen/manifests/tailscale-extension-service.yaml`
+- `devices/ryzen/manifests/amdgpu-extensions.patch.yaml`
+- `devices/ryzen/manifests/kata-firecracker.patch.yaml` (reboot required)
+
+### 2.4 Apply config with patches
+
+Use config patches so the generated files stay clean and reproducible:
+
+```bash
+export TALOSCONFIG=$PWD/devices/ryzen/talosconfig
+
+# Controlplane (single-node example)
+talosctl apply-config -n 192.168.1.194 \
+  -f devices/ryzen/controlplane.yaml \
+  --config-patch @devices/ryzen/manifests/ephemeral-volume.patch.yaml \
+  --config-patch @devices/ryzen/manifests/local-path.patch.yaml
+
+# Optional patches you can add at install time:
+#   --config-patch @devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml
+#   --config-patch @devices/ryzen/manifests/hostname.patch.yaml
+#   --config-patch @devices/ryzen/manifests/tailscale-extension-service.yaml
+#   --config-patch @devices/ryzen/manifests/amdgpu-extensions.patch.yaml
+#   --config-patch @devices/ryzen/manifests/kata-firecracker.patch.yaml
+```
+
+## 3) Bootstrap the cluster
+
+For a brand new controlplane, run the bootstrap step once:
+
+```bash
+talosctl bootstrap -n 192.168.1.194
+```
+
+Wait for Kubernetes API to become available and set kubeconfig as needed.
+
+## 4) KubeVirt + Firecracker
+
+KubeVirt is installed via Argo CD and Firecracker is enabled through
+Talos + Kata configuration. Use these runbooks for the full procedure:
+
+- `docs/kata-firecracker-talos/README.md`
+- `docs/kata-firecracker-talos/rebuild-from-scratch.md`
+
+The KubeVirt workers VM setup is documented here:
+
+- `docs/kubevirt/workers-ryzen.md`
+
+## 5) Argo CD cluster re-registration (ryzen)
+
+Once the new cluster is ready, remove the old Argo CD cluster entry and
+re-add the new one so ApplicationSets target `destinationName: ryzen`.
+
+```bash
+argocd cluster list
+argocd cluster rm ryzen
+
+# Use the kubeconfig context for the new cluster
+argocd cluster add <kube-context> --name ryzen
+```
+
+## 6) Argo CD applications that target ryzen
+
+Argo CD uses ApplicationSets with `clusters: ryzen` entries. The current
+ryzen-scoped apps include:
+
+- `argocd/applicationsets/bootstrap.yaml`: `local-path`
+- `argocd/applicationsets/platform.yaml`: `kubevirt`, `cdi`, `workers`, `kata-containers`
+
+When the cluster is registered, these ApplicationSets should render the
+`*-ryzen` Applications automatically.

--- a/devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml
+++ b/devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml
@@ -1,0 +1,2 @@
+cluster:
+  allowSchedulingOnControlPlanes: true

--- a/devices/ryzen/manifests/ephemeral-volume.patch.yaml
+++ b/devices/ryzen/manifests/ephemeral-volume.patch.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+provisioning:
+  maxSize: 100GiB

--- a/devices/ryzen/manifests/hostname.patch.yaml
+++ b/devices/ryzen/manifests/hostname.patch.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: ryzen

--- a/devices/ryzen/manifests/kata-firecracker.patch.yaml
+++ b/devices/ryzen/manifests/kata-firecracker.patch.yaml
@@ -1,0 +1,47 @@
+machine:
+  files:
+    - path: /etc/cri/containerd.toml
+      op: overwrite
+      permissions: 0o644
+      content: |
+        version = 3
+
+        disabled_plugins = [
+            "io.containerd.differ.v1.erofs",
+            "io.containerd.internal.v1.tracing",
+            "io.containerd.snapshotter.v1.erofs",
+            "io.containerd.ttrpc.v1.otelttrpc",
+            "io.containerd.tracing.processor.v1.otlp",
+        ]
+
+        imports = [
+            "/etc/cri/conf.d/cri.toml",
+        ]
+    - path: /etc/cri/conf.d/20-customization.part
+      op: overwrite
+      permissions: 0o644
+      content: |
+        [plugins."io.containerd.snapshotter.v1.blockfile"]
+          root_path = "/var/lib/containerd/io.containerd.snapshotter.v1.blockfile"
+          scratch_file = "/var/lib/containerd/blockfile/scratch.ext4"
+          fs_type = "ext4"
+          mount_options = []
+          recreate_scratch = false
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc"]
+          snapshotter = "blockfile"
+          runtime_type = "io.containerd.kata-fc.v2"
+          runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+          privileged_without_host_devices = true
+          pod_annotations = ["io.katacontainers.*"]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc".options]
+            ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+
+        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc"]
+          snapshotter = "blockfile"
+          runtime_type = "io.containerd.kata-fc.v2"
+          runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+          privileged_without_host_devices = true
+          pod_annotations = ["io.katacontainers.*"]
+          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc".options]
+            ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"

--- a/devices/ryzen/manifests/local-path.patch.yaml
+++ b/devices/ryzen/manifests/local-path.patch.yaml
@@ -5,4 +5,4 @@ provisioning:
   diskSelector:
     match: disk.transport == 'nvme' || disk.transport == 'sata'
   minSize: 1500GB
-  maxSize: 1500GB
+  grow: true


### PR DESCRIPTION
## Summary
- document Talos USB bootstrap and new ryzen patch inventory
- add Talos patches for EPHEMERAL sizing, local-path growth, control-plane scheduling, hostname, and kata/firecracker config
- enable managed namespace labels for workers via ApplicationSet template

## Related Issues
None

## Testing
- N/A (config/docs updates only; runtime validation performed via talosctl/kubectl/argocd during cluster bootstrap)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
