### PR TITLE
fix(kata): seed containerd config on talos

### DIFF
--- a/argocd/applications/kata-containers/kata-deploy-talos.patch.yaml
+++ b/argocd/applications/kata-containers/kata-deploy-talos.patch.yaml
@@ -6,6 +6,18 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+        - name: seed-containerd-config
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /etc/containerd
+              touch /etc/containerd/config.toml
+          volumeMounts:
+            - name: containerd-conf
+              mountPath: /etc/containerd/
       volumes:
         - name: containerd-conf
           hostPath:


### PR DESCRIPTION
## Summary

- Add an init container so kata-deploy can create `/etc/containerd/config.toml` on Talos via `/var/etc/containerd`.
- Keep kata-deploy functional without touching read-only `/etc` paths.

## Related Issues

None

## Testing

- mise exec helm@3 -- kustomize build --enable-helm argocd/applications/kata-containers

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
