### PR TITLE
fix(local-path): label namespace for hostPath

### DIFF
--- a/argocd/applications/local-path/kustomization.yaml
+++ b/argocd/applications/local-path/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
   - github.com/rancher/local-path-provisioner/deploy?ref=v0.0.31
 patches:
   - target:
+      kind: Namespace
+      name: local-path-storage
+    path: patches/namespace-labels.patch.yaml
+  - target:
       kind: ConfigMap
       name: local-path-config
       namespace: local-path-storage

--- a/argocd/applications/local-path/patches/namespace-labels.patch.yaml
+++ b/argocd/applications/local-path/patches/namespace-labels.patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary
- Patch the local-path namespace to enforce privileged PodSecurity labels
- Prevent local-path helper pods from being blocked by PSA

## Related Issues
None

## Testing
- N/A (GitOps change not applied yet)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
