### PR TITLE
fix(kata): init blockfile root path

### DIFF
--- a/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
+++ b/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
@@ -38,8 +38,10 @@ spec:
               ROOT=/host/var/lib/containerd/blockfile-scratch
               SCRATCH=${ROOT}/scratch.ext4
               SIZE=10G
+              BLOCKFILE_ROOT=/host/var/mnt/blockfile-scratch/containerd-blockfile
 
               mkdir -p ${ROOT}
+              mkdir -p ${BLOCKFILE_ROOT}
 
               if [ ! -f "${SCRATCH}" ]; then
                 truncate -s ${SIZE} ${SCRATCH}
@@ -52,6 +54,8 @@ spec:
           volumeMounts:
             - name: host-blockfile
               mountPath: /host/var/lib/containerd/blockfile-scratch
+            - name: host-blockfile-root
+              mountPath: /host/var/mnt/blockfile-scratch
       containers:
         - name: hold
           image: busybox:1.36
@@ -66,8 +70,14 @@ spec:
           volumeMounts:
             - name: host-blockfile
               mountPath: /host/var/lib/containerd/blockfile-scratch
+            - name: host-blockfile-root
+              mountPath: /host/var/mnt/blockfile-scratch
       volumes:
         - name: host-blockfile
           hostPath:
             path: /var/lib/containerd/blockfile-scratch
+            type: DirectoryOrCreate
+        - name: host-blockfile-root
+          hostPath:
+            path: /var/mnt/blockfile-scratch
             type: DirectoryOrCreate


### PR DESCRIPTION
## Summary
- Ensure blockfile scratch init creates the blockfile root directory
- Mount /var/mnt/blockfile-scratch into the init container

## Related Issues
None

## Testing
- N/A (GitOps change not applied yet)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
