### PR TITLE
fix(kata): place blockfile scratch on volume

### DIFF
--- a/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
+++ b/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
@@ -35,13 +35,11 @@ spec:
               apt-get update
               apt-get install -y --no-install-recommends e2fsprogs util-linux
 
-              ROOT=/host/var/lib/containerd/blockfile-scratch
-              SCRATCH=${ROOT}/scratch.ext4
+              ROOT=/host/var/mnt/blockfile-scratch/containerd-blockfile
+              SCRATCH=${ROOT}/scratch
               SIZE=10G
-              BLOCKFILE_ROOT=/host/var/mnt/blockfile-scratch/containerd-blockfile
 
               mkdir -p ${ROOT}
-              mkdir -p ${BLOCKFILE_ROOT}
 
               if [ ! -f "${SCRATCH}" ]; then
                 truncate -s ${SIZE} ${SCRATCH}
@@ -52,8 +50,6 @@ spec:
                 fi
               fi
           volumeMounts:
-            - name: host-blockfile
-              mountPath: /host/var/lib/containerd/blockfile-scratch
             - name: host-blockfile-root
               mountPath: /host/var/mnt/blockfile-scratch
       containers:
@@ -68,15 +64,9 @@ spec:
               cpu: 50m
               memory: 64Mi
           volumeMounts:
-            - name: host-blockfile
-              mountPath: /host/var/lib/containerd/blockfile-scratch
             - name: host-blockfile-root
               mountPath: /host/var/mnt/blockfile-scratch
       volumes:
-        - name: host-blockfile
-          hostPath:
-            path: /var/lib/containerd/blockfile-scratch
-            type: DirectoryOrCreate
         - name: host-blockfile-root
           hostPath:
             path: /var/mnt/blockfile-scratch

--- a/devices/ryzen/docs/node-level-dependencies.md
+++ b/devices/ryzen/docs/node-level-dependencies.md
@@ -246,7 +246,7 @@ Expected: the `local-path` StorageClass exists and the provisioner is Running on
 Firecracker-backed Kata containers use containerd’s **blockfile** snapshotter, which
 requires a scratch file on disk. We dedicate a **500GB** user volume named
 `blockfile-scratch`, mounted at `/var/mnt/blockfile-scratch`, while the scratch
-file itself lives under `/var/lib/containerd/blockfile-scratch` so CRI can read
+file itself lives under `/var/mnt/blockfile-scratch/containerd-blockfile` so CRI can read
 it during boot.
 
 Sources:
@@ -280,7 +280,7 @@ talosctl patch machineconfig --patch @devices/ryzen/manifests/blockfile.patch.ya
 
 ### Validate
 - `talosctl get volumemountstatuses | rg blockfile-scratch`
-- `/var/lib/containerd/blockfile-scratch/scratch.ext4` exists after the blockfile DaemonSet runs.
+- `/var/mnt/blockfile-scratch/containerd-blockfile/scratch` exists after the blockfile DaemonSet runs.
 
 ## AMD GPU (ROCm) node-level install
 

--- a/devices/ryzen/manifests/kata-firecracker.patch.yaml
+++ b/devices/ryzen/manifests/kata-firecracker.patch.yaml
@@ -23,7 +23,7 @@ machine:
       content: |
         [plugins."io.containerd.snapshotter.v1.blockfile"]
           root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-          scratch_file = "/var/lib/containerd/blockfile-scratch/scratch.ext4"
+          scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
           fs_type = "ext4"
           mount_options = []
           recreate_scratch = false

--- a/docs/kata-firecracker-talos/README.md
+++ b/docs/kata-firecracker-talos/README.md
@@ -76,7 +76,7 @@ machine:
       content: |
 [plugins."io.containerd.snapshotter.v1.blockfile"]
   root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-  scratch_file = "/var/lib/containerd/blockfile-scratch/scratch.ext4"
+  scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
           fs_type = "ext4"
           mount_options = []
           recreate_scratch = false
@@ -144,8 +144,8 @@ spec:
           apt-get update
           apt-get install -y --no-install-recommends e2fsprogs util-linux
 
-          ROOT=/var/lib/containerd/blockfile-scratch
-          SCRATCH=${ROOT}/scratch.ext4
+          ROOT=/var/mnt/blockfile-scratch/containerd-blockfile
+          SCRATCH=${ROOT}/scratch
           SIZE=10G
 
           mkdir -p $ROOT
@@ -160,11 +160,11 @@ spec:
           fi
       volumeMounts:
         - name: blockfile
-          mountPath: /var/lib/containerd/blockfile-scratch
+          mountPath: /var/mnt/blockfile-scratch/containerd-blockfile
   volumes:
     - name: blockfile
       hostPath:
-        path: /var/lib/containerd/blockfile-scratch
+        path: /var/mnt/blockfile-scratch/containerd-blockfile
         type: DirectoryOrCreate
 ```
 

--- a/docs/kata-firecracker-talos/investigation-2026-01-15.md
+++ b/docs/kata-firecracker-talos/investigation-2026-01-15.md
@@ -172,7 +172,7 @@ In `/etc/cri/conf.d/20-customization.part`:
 ```
 [plugins."io.containerd.snapshotter.v1.blockfile"]
   root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-  scratch_file = "/var/lib/containerd/blockfile-scratch/scratch.ext4"
+  scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
   fs_type = "ext4"
   mount_options = []
   recreate_scratch = false
@@ -198,11 +198,11 @@ In `/etc/cri/conf.d/20-customization.part`:
 
 ### 3) Create scratch file (ext4)
 
-Create `/var/lib/containerd/blockfile-scratch/scratch.ext4` and format it with ext4:
+Create `/var/mnt/blockfile-scratch/containerd-blockfile/scratch` and format it with ext4:
 
 ```
-truncate -s 10G /var/lib/containerd/blockfile-scratch/scratch.ext4
-mkfs.ext4 -F /var/lib/containerd/blockfile-scratch/scratch.ext4
+truncate -s 10G /var/mnt/blockfile-scratch/containerd-blockfile/scratch
+mkfs.ext4 -F /var/mnt/blockfile-scratch/containerd-blockfile/scratch
 ```
 
 ### 4) Reboot Talos

--- a/docs/kata-firecracker-talos/rebuild-from-scratch.md
+++ b/docs/kata-firecracker-talos/rebuild-from-scratch.md
@@ -83,7 +83,7 @@ Add this to `/etc/cri/conf.d/20-customization.part` (via `machine.files`):
 ```toml
 [plugins."io.containerd.snapshotter.v1.blockfile"]
   root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-  scratch_file = "/var/lib/containerd/blockfile-scratch/scratch.ext4"
+  scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
   fs_type = "ext4"
   mount_options = []
   recreate_scratch = false
@@ -163,8 +163,8 @@ spec:
           apt-get update
           apt-get install -y --no-install-recommends e2fsprogs util-linux
 
-          ROOT=/host/var/lib/containerd/blockfile-scratch
-          SCRATCH=${ROOT}/scratch.ext4
+          ROOT=/host/var/mnt/blockfile-scratch/containerd-blockfile
+          SCRATCH=${ROOT}/scratch
           SIZE=10G
 
           mkdir -p ${ROOT}
@@ -182,11 +182,11 @@ spec:
           dumpe2fs -h ${SCRATCH} | head -n 10
       volumeMounts:
         - name: host-blockfile
-          mountPath: /host/var/lib/containerd/blockfile-scratch
+          mountPath: /host/var/mnt/blockfile-scratch/containerd-blockfile
   volumes:
     - name: host-blockfile
       hostPath:
-        path: /var/lib/containerd/blockfile-scratch
+        path: /var/mnt/blockfile-scratch/containerd-blockfile
         type: DirectoryOrCreate
 ```
 


### PR DESCRIPTION
## Summary
- Place blockfile scratch file inside the blockfile volume root
- Update Talos config and docs to match the new scratch location

## Related Issues
None

## Testing
- N/A (GitOps change not applied yet)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
