### PR TITLE
fix(ryzen): keep kubelet manifests dir writable

### DIFF
--- a/devices/ryzen/docs/cluster-bootstrap.md
+++ b/devices/ryzen/docs/cluster-bootstrap.md
@@ -15,6 +15,7 @@ Node-level patches:
 - `devices/ryzen/manifests/tailscale-extension-service.yaml` (Tailscale extension service config)
 - `devices/ryzen/manifests/amdgpu-extensions.patch.yaml` (AMD GPU extensions; fill in versions)
 - `devices/ryzen/manifests/kata-firecracker.patch.yaml` (enable blockfile + kata-fc runtime)
+- `devices/ryzen/manifests/kubelet-manifests.patch.yaml` (keep /etc/kubernetes writable for kubelet bootstrap)
 
 Related docs:
 - `devices/ryzen/docs/node-level-dependencies.md`
@@ -96,6 +97,7 @@ talosctl apply-config --insecure -n 192.168.1.194 -e 192.168.1.194 \
 #   --config-patch @devices/ryzen/manifests/tailscale-extension-service.yaml
 #   --config-patch @devices/ryzen/manifests/amdgpu-extensions.patch.yaml
 #   --config-patch @devices/ryzen/manifests/kata-firecracker.patch.yaml
+#   --config-patch @devices/ryzen/manifests/kubelet-manifests.patch.yaml
 ```
 
 ## 3) Bootstrap the cluster

--- a/devices/ryzen/manifests/kubelet-manifests.patch.yaml
+++ b/devices/ryzen/manifests/kubelet-manifests.patch.yaml
@@ -1,0 +1,3 @@
+machine:
+  kubelet:
+    disableManifestsDirectory: false


### PR DESCRIPTION
## Summary
- Add a Talos patch to keep /etc/kubernetes writable for kubelet bootstrap
- Document the patch in the Ryzen bootstrap runbook

## Related Issues
None

## Testing
- N/A (Talos patch not applied yet)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
