### PR TITLE
fix(ryzen): harden talos kata/firecracker install

### DIFF
--- a/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
+++ b/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
@@ -35,11 +35,13 @@ spec:
               apt-get update
               apt-get install -y --no-install-recommends e2fsprogs util-linux
 
-              ROOT=/host/var/mnt/blockfile-scratch/containerd-blockfile
-              SCRATCH=${ROOT}/scratch
+              ROOT_SCRATCH=/host/var/blockfile-scratch
+              SCRATCH=${ROOT_SCRATCH}/scratch
+              ROOT_BLOCKFILE=/host/var/mnt/blockfile-scratch/containerd-blockfile
               SIZE=10G
 
-              mkdir -p ${ROOT}
+              mkdir -p ${ROOT_SCRATCH}
+              mkdir -p ${ROOT_BLOCKFILE}/snapshots
 
               if [ ! -f "${SCRATCH}" ]; then
                 truncate -s ${SIZE} ${SCRATCH}
@@ -51,6 +53,8 @@ spec:
               fi
           volumeMounts:
             - name: host-blockfile-root
+              mountPath: /host/var/blockfile-scratch
+            - name: host-blockfile-volume
               mountPath: /host/var/mnt/blockfile-scratch
       containers:
         - name: hold
@@ -65,9 +69,15 @@ spec:
               memory: 64Mi
           volumeMounts:
             - name: host-blockfile-root
+              mountPath: /host/var/blockfile-scratch
+            - name: host-blockfile-volume
               mountPath: /host/var/mnt/blockfile-scratch
       volumes:
         - name: host-blockfile-root
+          hostPath:
+            path: /var/blockfile-scratch
+            type: DirectoryOrCreate
+        - name: host-blockfile-volume
           hostPath:
             path: /var/mnt/blockfile-scratch
             type: DirectoryOrCreate

--- a/devices/ryzen/manifests/blockfile.patch.yaml
+++ b/devices/ryzen/manifests/blockfile.patch.yaml
@@ -6,3 +6,4 @@ provisioning:
     match: disk.transport == 'nvme'
   minSize: 500GB
   maxSize: 500GB
+  grow: false

--- a/devices/ryzen/manifests/ephemeral-volume.patch.yaml
+++ b/devices/ryzen/manifests/ephemeral-volume.patch.yaml
@@ -2,4 +2,8 @@ apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
 provisioning:
-  maxSize: 100GiB
+  diskSelector:
+    match: disk.transport == 'nvme'
+  minSize: 100GB
+  maxSize: 100GB
+  grow: false

--- a/devices/ryzen/manifests/hostname.patch.yaml
+++ b/devices/ryzen/manifests/hostname.patch.yaml
@@ -1,3 +1,4 @@
 apiVersion: v1alpha1
 kind: HostnameConfig
 hostname: ryzen
+auto: off

--- a/devices/ryzen/manifests/installer-image.patch.yaml
+++ b/devices/ryzen/manifests/installer-image.patch.yaml
@@ -1,0 +1,3 @@
+machine:
+  install:
+    image: factory.talos.dev/metal-installer/34373fc18f4c01525d9421119e41b72fc83885c640f798c0ee723a38decd6e9b:v1.12.1

--- a/devices/ryzen/manifests/kata-firecracker.patch.yaml
+++ b/devices/ryzen/manifests/kata-firecracker.patch.yaml
@@ -17,13 +17,17 @@ machine:
         imports = [
             "/etc/cri/conf.d/cri.toml",
         ]
+
+        [debug]
+        level = "info"
+        format = "json"
     - path: /etc/cri/conf.d/20-customization.part
       op: overwrite
       permissions: 0o644
       content: |
         [plugins."io.containerd.snapshotter.v1.blockfile"]
           root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-          scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
+          scratch_file = "/var/blockfile-scratch/scratch"
           fs_type = "ext4"
           mount_options = []
           recreate_scratch = false
@@ -31,17 +35,17 @@ machine:
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc"]
           snapshotter = "blockfile"
           runtime_type = "io.containerd.kata-fc.v2"
-          runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+          runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
           privileged_without_host_devices = true
           pod_annotations = ["io.katacontainers.*"]
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc".options]
-            ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+            ConfigPath = "/usr/local/share/kata-containers/configuration.toml"
 
         [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc"]
           snapshotter = "blockfile"
           runtime_type = "io.containerd.kata-fc.v2"
-          runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+          runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
           privileged_without_host_devices = true
           pod_annotations = ["io.katacontainers.*"]
           [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc".options]
-            ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+            ConfigPath = "/usr/local/share/kata-containers/configuration.toml"

--- a/devices/ryzen/manifests/local-path.patch.yaml
+++ b/devices/ryzen/manifests/local-path.patch.yaml
@@ -4,6 +4,6 @@ name: local-path-provisioner
 provisioning:
   diskSelector:
     match: disk.transport == 'nvme'
-  minSize: 1400GB
-  maxSize: 1400GB
+  minSize: 1435GB
+  maxSize: 1435GB
   grow: false

--- a/devices/ryzen/manifests/node-labels.patch.yaml
+++ b/devices/ryzen/manifests/node-labels.patch.yaml
@@ -1,0 +1,4 @@
+machine:
+  nodeLabels:
+    kata-deploy: "enabled"
+    kubevirt.io/schedulable: "true"

--- a/docs/kata-firecracker-talos/investigation-2026-01-15.md
+++ b/docs/kata-firecracker-talos/investigation-2026-01-15.md
@@ -11,13 +11,13 @@ Run Kata Containers with Firecracker (runtimeClass `kata-fc`) on the ryzen Talos
 - OS: Talos v1.12.1
 - Kubernetes: v1.35.0
 - containerd: v2.1.6
-- Kata system extension present (paths under `/opt/kata/...`)
+- Kata system extension present (paths under `/usr/local/...`)
 - RuntimeClass: `kata-fc`
 
 Key binaries found:
-- `/opt/kata/bin/firecracker`
-- `/opt/kata/bin/containerd-shim-kata-v2`
-- `/opt/kata/share/defaults/kata-containers/configuration-fc.toml`
+- `/usr/local/bin/firecracker`
+- `/usr/local/bin/containerd-shim-kata-v2`
+- `/usr/local/share/kata-containers/configuration.toml`
 
 ## Summary of Findings
 1) **Firecracker requires a block-backed rootfs**, which in containerd is typically provided via the **devmapper snapshotter**.
@@ -77,19 +77,19 @@ Talos file (`/etc/cri/conf.d/20-customization.part`):
 ```
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc"]
   runtime_type = "io.containerd.kata-fc.v2"
-  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
   privileged_without_host_devices = true
   pod_annotations = ["io.katacontainers.*"]
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc".options]
-    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+    ConfigPath = "/usr/local/share/kata-containers/configuration.toml"
 
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc"]
   runtime_type = "io.containerd.kata-fc.v2"
-  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
   privileged_without_host_devices = true
   pod_annotations = ["io.katacontainers.*"]
   [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc".options]
-    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+    ConfigPath = "/usr/local/share/kata-containers/configuration.toml"
 ```
 
 Result: timeout errors replaced by rootfs mount ENOENT errors. Firecracker still never starts.
@@ -172,7 +172,7 @@ In `/etc/cri/conf.d/20-customization.part`:
 ```
 [plugins."io.containerd.snapshotter.v1.blockfile"]
   root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-  scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
+  scratch_file = "/var/blockfile-scratch/scratch"
   fs_type = "ext4"
   mount_options = []
   recreate_scratch = false
@@ -180,29 +180,29 @@ In `/etc/cri/conf.d/20-customization.part`:
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc"]
   snapshotter = "blockfile"
   runtime_type = "io.containerd.kata-fc.v2"
-  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
   privileged_without_host_devices = true
   pod_annotations = ["io.katacontainers.*"]
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."kata-fc".options]
-    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+    ConfigPath = "/usr/local/share/kata-containers/configuration.toml"
 
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc"]
   snapshotter = "blockfile"
   runtime_type = "io.containerd.kata-fc.v2"
-  runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+  runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
   privileged_without_host_devices = true
   pod_annotations = ["io.katacontainers.*"]
   [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."kata-fc".options]
-    ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-fc.toml"
+    ConfigPath = "/usr/local/share/kata-containers/configuration.toml"
 ```
 
 ### 3) Create scratch file (ext4)
 
-Create `/var/mnt/blockfile-scratch/containerd-blockfile/scratch` and format it with ext4:
+Create `/var/blockfile-scratch/scratch` and format it with ext4:
 
 ```
-truncate -s 10G /var/mnt/blockfile-scratch/containerd-blockfile/scratch
-mkfs.ext4 -F /var/mnt/blockfile-scratch/containerd-blockfile/scratch
+truncate -s 10G /var/blockfile-scratch/scratch
+mkfs.ext4 -F /var/blockfile-scratch/scratch
 ```
 
 ### 4) Reboot Talos
@@ -252,7 +252,7 @@ Linux kata-fc-test 6.12.47 #1 SMP Fri Dec  5 12:15:04 UTC 2025 x86_64 GNU/Linux
   - https://flintlock.liquidmetal.dev/docs/getting-started/containerd/
 
 ## What Works
-- Kata binaries are present (`/opt/kata/bin/firecracker`, `containerd-shim-kata-v2`).
+- Kata binaries are present (`/usr/local/bin/firecracker`, `containerd-shim-kata-v2`).
 - RuntimeClass `kata-fc` exists.
 - KVM/vsock device nodes exist (`/dev/kvm`, `/dev/vhost-vsock`).
 - Blockfile snapshotter is enabled and loaded.


### PR DESCRIPTION
## Summary
- document Ryzen Talos install sequence, kubeconfig naming, and kata/firecracker dependencies
- adjust Talos volume sizing (EPHEMERAL 100GiB, blockfile 500GB, local-path 1435GB)
- update kata blockfile scratch DaemonSet + runtime config patches for Talos

## Related Issues
None

## Testing
- talosctl apply-config (maintenance install with sizing + hostname/labels + installer image)
- talosctl bootstrap
- talosctl kubeconfig --context ryzen ~/.kube/config
- argocd cluster add ryzen --name ryzen

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
