### PR TITLE
fix(ryzen): align blockfile scratch path

### DIFF
--- a/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
+++ b/argocd/applications/kata-containers/blockfile-scratch-daemonset.yaml
@@ -35,12 +35,10 @@ spec:
               apt-get update
               apt-get install -y --no-install-recommends e2fsprogs util-linux
 
-              ROOT_SCRATCH=/host/var/blockfile-scratch
-              SCRATCH=${ROOT_SCRATCH}/scratch
               ROOT_BLOCKFILE=/host/var/mnt/blockfile-scratch/containerd-blockfile
+              SCRATCH=${ROOT_BLOCKFILE}/scratch
               SIZE=10G
 
-              mkdir -p ${ROOT_SCRATCH}
               mkdir -p ${ROOT_BLOCKFILE}/snapshots
 
               if [ ! -f "${SCRATCH}" ]; then
@@ -52,8 +50,6 @@ spec:
                 fi
               fi
           volumeMounts:
-            - name: host-blockfile-root
-              mountPath: /host/var/blockfile-scratch
             - name: host-blockfile-volume
               mountPath: /host/var/mnt/blockfile-scratch
       containers:
@@ -68,15 +64,9 @@ spec:
               cpu: 50m
               memory: 64Mi
           volumeMounts:
-            - name: host-blockfile-root
-              mountPath: /host/var/blockfile-scratch
             - name: host-blockfile-volume
               mountPath: /host/var/mnt/blockfile-scratch
       volumes:
-        - name: host-blockfile-root
-          hostPath:
-            path: /var/blockfile-scratch
-            type: DirectoryOrCreate
         - name: host-blockfile-volume
           hostPath:
             path: /var/mnt/blockfile-scratch

--- a/devices/ryzen/docs/cluster-bootstrap.md
+++ b/devices/ryzen/docs/cluster-bootstrap.md
@@ -114,7 +114,7 @@ exists, or containerd will fail to load CRI and the node will never become Ready
 1) Bring up the cluster without the kata/firecracker patch and register the cluster
 in Argo CD so the `kata-containers` app can create the scratch file.
 
-2) Verify `/var/blockfile-scratch/scratch` exists on the node.
+2) Verify `/var/mnt/blockfile-scratch/containerd-blockfile/scratch` exists on the node.
 
 3) Re-apply the config with the kata/firecracker patch (reboot required):
 

--- a/devices/ryzen/docs/node-level-dependencies.md
+++ b/devices/ryzen/docs/node-level-dependencies.md
@@ -255,7 +255,8 @@ Expected: the `local-path` StorageClass exists and the provisioner is Running on
 Firecracker-backed Kata containers use containerd’s **blockfile** snapshotter, which
 requires a scratch file on disk. We dedicate a **500GB** user volume named
 `blockfile-scratch`, mounted at `/var/mnt/blockfile-scratch`, while the scratch
-file itself lives under `/var/blockfile-scratch` so CRI can read it during boot
+file itself lives under `/var/mnt/blockfile-scratch/containerd-blockfile/scratch`
+so CRI can read it during boot
 without waiting for the user volume mount.
 
 Important: **do not enable the blockfile snapshotter until the scratch file exists**.
@@ -303,7 +304,7 @@ talosctl patch machineconfig --patch @devices/ryzen/manifests/blockfile.patch.ya
 
 ### Validate
 - `talosctl get volumemountstatuses | rg blockfile-scratch`
-- `/var/blockfile-scratch/scratch` exists after the blockfile DaemonSet runs.
+- `/var/mnt/blockfile-scratch/containerd-blockfile/scratch` exists after the blockfile DaemonSet runs.
 
 ### Enable kata/firecracker after scratch exists
 

--- a/devices/ryzen/manifests/kata-firecracker.patch.yaml
+++ b/devices/ryzen/manifests/kata-firecracker.patch.yaml
@@ -27,7 +27,7 @@ machine:
       content: |
         [plugins."io.containerd.snapshotter.v1.blockfile"]
           root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-          scratch_file = "/var/blockfile-scratch/scratch"
+          scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
           fs_type = "ext4"
           mount_options = []
           recreate_scratch = false

--- a/docs/kata-firecracker-talos/README.md
+++ b/docs/kata-firecracker-talos/README.md
@@ -93,7 +93,7 @@ spec:
           apt-get update
           apt-get install -y --no-install-recommends e2fsprogs util-linux
 
-          ROOT=/var/blockfile-scratch
+          ROOT=/var/mnt/blockfile-scratch/containerd-blockfile
           SCRATCH=${ROOT}/scratch
           SIZE=10G
 
@@ -141,7 +141,7 @@ machine:
       content: |
         [plugins."io.containerd.snapshotter.v1.blockfile"]
           root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-          scratch_file = "/var/blockfile-scratch/scratch"
+          scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
           fs_type = "ext4"
           mount_options = []
           recreate_scratch = false

--- a/docs/kata-firecracker-talos/investigation-2026-01-15.md
+++ b/docs/kata-firecracker-talos/investigation-2026-01-15.md
@@ -172,7 +172,7 @@ In `/etc/cri/conf.d/20-customization.part`:
 ```
 [plugins."io.containerd.snapshotter.v1.blockfile"]
   root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-  scratch_file = "/var/blockfile-scratch/scratch"
+  scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
   fs_type = "ext4"
   mount_options = []
   recreate_scratch = false
@@ -198,11 +198,11 @@ In `/etc/cri/conf.d/20-customization.part`:
 
 ### 3) Create scratch file (ext4)
 
-Create `/var/blockfile-scratch/scratch` and format it with ext4:
+Create `/var/mnt/blockfile-scratch/containerd-blockfile/scratch` and format it with ext4:
 
 ```
-truncate -s 10G /var/blockfile-scratch/scratch
-mkfs.ext4 -F /var/blockfile-scratch/scratch
+truncate -s 10G /var/mnt/blockfile-scratch/containerd-blockfile/scratch
+mkfs.ext4 -F /var/mnt/blockfile-scratch/containerd-blockfile/scratch
 ```
 
 ### 4) Reboot Talos

--- a/docs/kata-firecracker-talos/rebuild-from-scratch.md
+++ b/docs/kata-firecracker-talos/rebuild-from-scratch.md
@@ -93,7 +93,7 @@ spec:
           apt-get update
           apt-get install -y --no-install-recommends e2fsprogs util-linux
 
-          ROOT=/host/var/blockfile-scratch
+          ROOT=/host/var/mnt/blockfile-scratch/containerd-blockfile
           SCRATCH=${ROOT}/scratch
           SIZE=10G
 
@@ -112,11 +112,11 @@ spec:
           dumpe2fs -h ${SCRATCH} | head -n 10
       volumeMounts:
         - name: host-blockfile
-              mountPath: /host/var/blockfile-scratch
+              mountPath: /host/var/mnt/blockfile-scratch
   volumes:
     - name: host-blockfile
       hostPath:
-        path: /var/blockfile-scratch
+        path: /var/mnt/blockfile-scratch
         type: DirectoryOrCreate
 ```
 
@@ -164,7 +164,7 @@ Add this to `/etc/cri/conf.d/20-customization.part` (via `machine.files`):
 ```toml
 [plugins."io.containerd.snapshotter.v1.blockfile"]
   root_path = "/var/mnt/blockfile-scratch/containerd-blockfile"
-  scratch_file = "/var/blockfile-scratch/scratch"
+  scratch_file = "/var/mnt/blockfile-scratch/containerd-blockfile/scratch"
   fs_type = "ext4"
   mount_options = []
   recreate_scratch = false


### PR DESCRIPTION
## Summary
- align blockfile scratch file location with blockfile root path
- update kata/firecracker Talos patch and docs to match scratch path
- adjust scratch DaemonSet to create scratch under blockfile volume

## Related Issues
None

## Testing
- kubectl describe pod workers-fc (verified blockfile scratch missing path)
- talosctl read /etc/cri/conf.d/20-customization.part
- talosctl list /var/mnt/blockfile-scratch/containerd-blockfile

## Screenshots (if applicable)
None

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
