### PR TITLE
fix(kata): reset broken pause/ubuntu images

### DIFF
--- a/argocd/applications/kata-containers/kustomization.yaml
+++ b/argocd/applications/kata-containers/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 namespace: kube-system
 resources:
   - blockfile-scratch-daemonset.yaml
+  - pause-image-reset-job.yaml
   - runtimeclass-kata-fc.yaml

--- a/argocd/applications/kata-containers/pause-image-reset-job.yaml
+++ b/argocd/applications/kata-containers/pause-image-reset-job.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pause-image-reset
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: OnFailure
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/hostname: ryzen
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: ctr
+          image: debian:bookworm
+          securityContext:
+            privileged: true
+          command:
+            - bash
+            - -euxo
+            - pipefail
+            - -c
+            - |
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y --no-install-recommends ca-certificates containerd
+
+              CTR="ctr -a /host/run/containerd/containerd.sock -n k8s.io"
+
+              $CTR images rm registry.k8s.io/pause:3.10 || true
+              $CTR images rm registry.k8s.io/pause@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a || true
+              $CTR content rm sha256:61d9e957431bdf7a34f31cbcb23fe7966ab9da5c1df35138b1e752af15b69669 || true
+
+              $CTR images rm docker.io/library/ubuntu:24.04 || true
+              $CTR content rm sha256:a3629ac5b9f4680dc2032439ff2354e73b06aecc2e68f0035a2d7c001c8b4114 || true
+
+              $CTR images pull registry.k8s.io/pause:3.10
+              $CTR images pull docker.io/library/ubuntu:24.04
+              $CTR images ls | grep pause || true
+              $CTR images ls | grep ubuntu || true
+          volumeMounts:
+            - name: host-run
+              mountPath: /host/run
+      volumes:
+        - name: host-run
+          hostPath:
+            path: /run
+            type: Directory

--- a/devices/ryzen/docs/cluster-bootstrap.md
+++ b/devices/ryzen/docs/cluster-bootstrap.md
@@ -148,6 +148,20 @@ talosctl image pull -n 192.168.1.194 -e 192.168.1.194 --namespace cri \
 kubectl --context ryzen -n workers delete pod workers-fc --ignore-not-found=true
 ```
 
+### 2.6.2 Reset the pause image cache (content digest not found)
+
+If pod sandbox creation still fails with `content digest ... not found`, use the
+one-shot Job in the kata-containers app to delete the broken content digests and
+re-pull the pause + ubuntu images with `ctr`.
+
+Manifest: `argocd/applications/kata-containers/pause-image-reset-job.yaml`
+
+Apply with Argo CD (manual sync):
+
+```bash
+argocd app sync argocd/kata-containers-ryzen
+```
+
 ## 2.7 Install kata + glibc extensions (Image Factory)
 
 Kata requires Talos system extensions. The current Ryzen image is pinned in:

--- a/devices/ryzen/manifests/kata-firecracker.patch.yaml
+++ b/devices/ryzen/manifests/kata-firecracker.patch.yaml
@@ -32,6 +32,10 @@ machine:
           mount_options = []
           recreate_scratch = false
 
+        [plugins."io.containerd.cri.v1.images"]
+          discard_unpacked_layers = false
+          use_local_image_pull = false
+
         [plugins."io.containerd.cri.v1.images".pinned_images]
           sandbox = "registry.k8s.io/pause@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
 


### PR DESCRIPTION
## Summary

- Add a GitOps hook job that clears broken containerd content digests and re-pulls pause + ubuntu images.
- Document the reset workflow in the Talos/Kata runbooks and cluster bootstrap steps.
- Apply Talos containerd overrides for kata-fc to avoid the discard-unpacked-layer content gaps.

## Related Issues

None.

## Testing

- `kubectl -n kube-system apply -f argocd/applications/kata-containers/pause-image-reset-job.yaml`
- `kubectl -n kube-system wait --for=condition=complete job/pause-image-reset --timeout=300s`
- `kubectl -n workers apply -f argocd/applications/workers/firecracker-pod.yaml`
- `kubectl -n workers wait --for=condition=Ready pod/workers-fc --timeout=300s`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
