### PR TITLE
fix(argocd): ignore CDI CRD and workers VM defaults

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -463,6 +463,19 @@ spec:
             - .spec.conversion
             - .spec.names.listKind
             - .spec.versions[].additionalPrinterColumns[].priority
+        - kind: CustomResourceDefinition
+          group: apiextensions.k8s.io
+          name: cdis.cdi.kubevirt.io
+          jqPathExpressions:
+            - .spec.versions
+        - kind: VirtualMachine
+          group: kubevirt.io
+          namespace: workers
+          name: workers
+          jqPathExpressions:
+            - .spec.template.spec.architecture
+            - .spec.template.spec.domain.firmware
+            - .spec.template.spec.domain.machine
   templatePatch: |
     {{- if .annotations }}
     metadata:


### PR DESCRIPTION
## Summary

- Ignore CDI CRD version drift that Argo CD reports for `cdis.cdi.kubevirt.io`.
- Ignore KubeVirt defaulted VM fields for `workers` so the app reports Synced.
- Keep ignore rules scoped to the specific CRD and VM.

## Related Issues

None

## Testing

- N/A (config-only Argo CD ignoreDifferences change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
