### PR TITLE
fix(argocd): ignore kubevirt vm annotations

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -473,6 +473,8 @@ spec:
           namespace: workers
           name: workers
           jqPathExpressions:
+            - .metadata.annotations
+            - .metadata.finalizers
             - .spec.template.spec.architecture
             - .spec.template.spec.domain.firmware
             - .spec.template.spec.domain.machine


### PR DESCRIPTION
## Summary

- Ignore KubeVirt-managed VM annotations/finalizer that keep `workers-ryzen` OutOfSync.
- Keep ignore rules scoped to the `workers` VM only.

## Related Issues

None

## Testing

- N/A (Argo CD ignoreDifferences update)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
