### PR TITLE
fix(argocd): ignore kubevirt vm creation timestamps

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -475,6 +475,8 @@ spec:
           jqPathExpressions:
             - .metadata.annotations
             - .metadata.finalizers
+            - .spec.dataVolumeTemplates[].metadata.creationTimestamp
+            - .spec.template.metadata.creationTimestamp
             - .spec.template.spec.architecture
             - .spec.template.spec.domain.firmware
             - .spec.template.spec.domain.machine


### PR DESCRIPTION
## Summary

- Ignore KubeVirt VM creationTimestamp drift for workers VM dataVolumeTemplates and template metadata.
- Keep ignore rules scoped to the `workers` VM only.

## Related Issues

None

## Testing

- N/A (Argo CD ignoreDifferences update)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
