### PR TITLE
feat(workers): enable tailscale bootstrap in kubevirt vm

### DIFF
--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -128,6 +128,46 @@ stringData:
                   name: "e*"
                 dhcp4: true
                 dhcp6: false
+      - path: /etc/default/tailscale-auth
+        owner: root:root
+        permissions: '0600'
+        content: |-
+          TAILSCALE_AUTHKEY=
+          TAILSCALE_EXTRA_ARGS=
+      - path: /etc/systemd/system/tailscale-up.service
+        owner: root:root
+        permissions: '0644'
+        content: |-
+          [Unit]
+          Description=Run tailscale up when auth key is available
+          After=tailscaled.service network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/tailscale-up-if-auth
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=multi-user.target
+      - path: /usr/local/bin/tailscale-up-if-auth
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          ENV_FILE="/etc/default/tailscale-auth"
+          if [ ! -f "${ENV_FILE}" ]; then
+            exit 0
+          fi
+          # shellcheck disable=SC1090
+          . "${ENV_FILE}"
+          if [ -z "${TAILSCALE_AUTHKEY:-}" ]; then
+            echo "TAILSCALE_AUTHKEY not set; skipping tailscale up" >&2
+            exit 0
+          fi
+          EXTRA_ARGS="${TAILSCALE_EXTRA_ARGS:-}"
+          tailscale up --authkey="${TAILSCALE_AUTHKEY}" ${EXTRA_ARGS}
       - path: /usr/local/bin/start-chrome-remote-debug
         owner: root:root
         permissions: '0755'
@@ -177,6 +217,7 @@ stringData:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOco184B4eZEOoLP5ehTK9cgsJgbelKWUxXuO3+S38U/
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII0/89LwFLAM6tu2gtbwVDrQwFhPiW55RciZo0RUVMrF
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH77X+Ekaz8sSLPImUYO8VYhgDDcb+DXkqU26UZ2PaAP
+          - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMqGcgm6U9z2d9kH5SNjm4wZumlbMxndFi40iNEhI2OKvfSoE4OQJQ8j5KCiu6GrcE2biJcqP1dkMCaJ8xcaYA8= sshid.io/gregkonush
     ssh_pwauth: false
     disable_root: true
     runcmd:
@@ -184,8 +225,12 @@ stringData:
       - [ bash, -lc, 'install -m 0755 -d /etc/apt/keyrings' ]
       - [ bash, -lc, 'curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg' ]
       - [ bash, -lc, 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list' ]
+      - [ bash, -lc, 'curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null' ]
+      - [ bash, -lc, 'curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list' ]
       - [ bash, -lc, 'apt-get update' ]
+      - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y tailscale' ]
       - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-desktop' ]
+      - [ bash, -lc, 'systemctl enable --now tailscaled' ]
       - [ bash, -lc, 'systemctl enable --now NetworkManager' ]
       - [ bash, -lc, 'netplan apply' ]
       - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable' ]
@@ -201,6 +246,7 @@ stringData:
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''[ -d ~/github.com/lab ] || git clone --depth 1 https://github.com/proompteng/lab ~/github.com/lab''"' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''rm -rf ~/.codex/skills && mkdir -p ~/.codex/skills && cp -R ~/github.com/lab/skills/. ~/.codex/skills/''"' ]
       - [ bash, -lc, 'systemctl daemon-reload' ]
+      - [ bash, -lc, 'systemctl enable --now tailscale-up.service' ]
       - [ bash, -lc, 'systemctl restart ssh' ]
       - [ bash, -lc, 'systemctl enable --now chrome-remote-debug.service chrome-devtools-mcp.service' ]
 ---
@@ -329,6 +375,46 @@ stringData:
                   name: "e*"
                 dhcp4: true
                 dhcp6: false
+      - path: /etc/default/tailscale-auth
+        owner: root:root
+        permissions: '0600'
+        content: |-
+          TAILSCALE_AUTHKEY=
+          TAILSCALE_EXTRA_ARGS=
+      - path: /etc/systemd/system/tailscale-up.service
+        owner: root:root
+        permissions: '0644'
+        content: |-
+          [Unit]
+          Description=Run tailscale up when auth key is available
+          After=tailscaled.service network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/tailscale-up-if-auth
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=multi-user.target
+      - path: /usr/local/bin/tailscale-up-if-auth
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          ENV_FILE="/etc/default/tailscale-auth"
+          if [ ! -f "${ENV_FILE}" ]; then
+            exit 0
+          fi
+          # shellcheck disable=SC1090
+          . "${ENV_FILE}"
+          if [ -z "${TAILSCALE_AUTHKEY:-}" ]; then
+            echo "TAILSCALE_AUTHKEY not set; skipping tailscale up" >&2
+            exit 0
+          fi
+          EXTRA_ARGS="${TAILSCALE_EXTRA_ARGS:-}"
+          tailscale up --authkey="${TAILSCALE_AUTHKEY}" ${EXTRA_ARGS}
       - path: /usr/local/bin/start-chrome-remote-debug
         owner: root:root
         permissions: '0755'
@@ -378,6 +464,7 @@ stringData:
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOco184B4eZEOoLP5ehTK9cgsJgbelKWUxXuO3+S38U/
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII0/89LwFLAM6tu2gtbwVDrQwFhPiW55RciZo0RUVMrF
           - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH77X+Ekaz8sSLPImUYO8VYhgDDcb+DXkqU26UZ2PaAP
+          - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMqGcgm6U9z2d9kH5SNjm4wZumlbMxndFi40iNEhI2OKvfSoE4OQJQ8j5KCiu6GrcE2biJcqP1dkMCaJ8xcaYA8= sshid.io/gregkonush
     ssh_pwauth: false
     disable_root: true
     runcmd:
@@ -385,8 +472,12 @@ stringData:
       - [ bash, -lc, 'install -m 0755 -d /etc/apt/keyrings' ]
       - [ bash, -lc, 'curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg' ]
       - [ bash, -lc, 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list' ]
+      - [ bash, -lc, 'curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null' ]
+      - [ bash, -lc, 'curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list' ]
       - [ bash, -lc, 'apt-get update' ]
+      - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y tailscale' ]
       - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-desktop' ]
+      - [ bash, -lc, 'systemctl enable --now tailscaled' ]
       - [ bash, -lc, 'systemctl enable --now NetworkManager' ]
       - [ bash, -lc, 'netplan apply' ]
       - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y google-chrome-stable' ]
@@ -402,6 +493,7 @@ stringData:
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''[ -d ~/github.com/lab ] || git clone --depth 1 https://github.com/proompteng/lab ~/github.com/lab''"' ]
       - [ bash, -lc, 'su - ubuntu -c "bash -lc ''rm -rf ~/.codex/skills && mkdir -p ~/.codex/skills && cp -R ~/github.com/lab/skills/. ~/.codex/skills/''"' ]
       - [ bash, -lc, 'systemctl daemon-reload' ]
+      - [ bash, -lc, 'systemctl enable --now tailscale-up.service' ]
       - [ bash, -lc, 'systemctl restart ssh' ]
       - [ bash, -lc, 'systemctl enable --now chrome-remote-debug.service chrome-devtools-mcp.service' ]
       - [ bash, -lc, 'chown -R ubuntu:ubuntu /home/ubuntu || true' ]

--- a/packages/scripts/src/workers/seed-tailscale-auth.ts
+++ b/packages/scripts/src/workers/seed-tailscale-auth.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env bun
+
+import { stat } from 'node:fs/promises'
+import os from 'node:os'
+import process from 'node:process'
+
+import { ensureCli, fatal } from '../shared/cli'
+
+type Options = {
+  namespace: string
+  vmi: string
+  user: string
+  sshKey: string
+  opPath?: string
+  authKey?: string
+  extraArgs?: string
+  kubeconfig?: string
+}
+
+const DEFAULT_OP_TAILSCALE_AUTH_PATH = 'op://infra/tailscale auth key/authkey'
+
+const parseArgs = (): Options => {
+  const args = process.argv.slice(2)
+  const options: Partial<Options> = {
+    namespace: 'workers',
+    vmi: 'workers',
+    user: 'ubuntu',
+    sshKey: `${os.homedir()}/.ssh/id_ed25519`,
+    opPath: process.env.TAILSCALE_AUTHKEY_OP_PATH ?? DEFAULT_OP_TAILSCALE_AUTH_PATH,
+    extraArgs: process.env.TAILSCALE_EXTRA_ARGS,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    switch (arg) {
+      case '--namespace':
+      case '-n': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal(`${arg} requires a value`)
+        options.namespace = value
+        break
+      }
+      case '--vmi': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--vmi requires a value')
+        options.vmi = value
+        break
+      }
+      case '--user': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--user requires a value')
+        options.user = value
+        break
+      }
+      case '--ssh-key': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--ssh-key requires a value')
+        options.sshKey = value
+        break
+      }
+      case '--op-path': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--op-path requires a value')
+        options.opPath = value
+        break
+      }
+      case '--authkey': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--authkey requires a value')
+        options.authKey = value
+        break
+      }
+      case '--extra-args': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--extra-args requires a value')
+        options.extraArgs = value
+        break
+      }
+      case '--kubeconfig': {
+        index += 1
+        const value = args[index]
+        if (!value) fatal('--kubeconfig requires a value')
+        options.kubeconfig = value
+        break
+      }
+      case '--help':
+      case '-h': {
+        printHelp()
+        process.exit(0)
+        break
+      }
+      default:
+        fatal(`Unknown option: ${arg}`)
+    }
+  }
+
+  return {
+    namespace: options.namespace ?? 'workers',
+    vmi: options.vmi ?? 'workers',
+    user: options.user ?? 'ubuntu',
+    sshKey: options.sshKey ?? `${os.homedir()}/.ssh/id_ed25519`,
+    opPath: options.opPath ?? DEFAULT_OP_TAILSCALE_AUTH_PATH,
+    authKey: options.authKey,
+    extraArgs: options.extraArgs,
+    kubeconfig: options.kubeconfig,
+  }
+}
+
+const printHelp = () => {
+  console.log(`Usage: bun run packages/scripts/src/workers/seed-tailscale-auth.ts [options]
+
+Options:
+  -n, --namespace   KubeVirt namespace (default: workers)
+  --vmi             VMI name (default: workers)
+  --user            SSH user (default: ubuntu)
+  --ssh-key         SSH private key path (default: ~/.ssh/id_ed25519)
+  --op-path         1Password path for auth key (default: op://infra/tailscale auth key/authkey)
+  --authkey         Use this auth key instead of 1Password
+  --extra-args      Extra args for tailscale up (or set TAILSCALE_EXTRA_ARGS env)
+  --kubeconfig      Path to kubeconfig for virtctl (optional)
+  -h, --help        Show this help message
+`)
+}
+
+const ensureFile = async (path: string, description: string) => {
+  try {
+    const info = await stat(path)
+    if (!info.isFile()) {
+      fatal(`${description} is not a file: ${path}`)
+    }
+  } catch (error) {
+    fatal(`${description} not found: ${path}`, error)
+  }
+}
+
+const readAuthKey = async (options: Options) => {
+  if (options.authKey) {
+    return options.authKey.trim()
+  }
+
+  ensureCli('op')
+  const path = options.opPath ?? DEFAULT_OP_TAILSCALE_AUTH_PATH
+  const subprocess = Bun.spawn(['op', 'read', path], {
+    stdout: 'pipe',
+    stderr: 'inherit',
+  })
+  const output = await new Response(subprocess.stdout).text()
+  const exitCode = await subprocess.exited
+  if (exitCode !== 0) {
+    fatal(`Failed to read Tailscale auth key from 1Password: ${path}`)
+  }
+  return output.trim()
+}
+
+const escapeSingleQuotes = (value: string) => value.replaceAll("'", "'\"'\"'")
+
+const main = async () => {
+  ensureCli('ssh')
+  ensureCli('virtctl')
+
+  const options = parseArgs()
+  await ensureFile(options.sshKey, 'SSH key')
+
+  const authKey = await readAuthKey(options)
+  if (!authKey) {
+    fatal('Tailscale auth key is empty')
+  }
+
+  const extraArgs = options.extraArgs?.trim() ?? ''
+  const content = [
+    `TAILSCALE_AUTHKEY='${escapeSingleQuotes(authKey)}'`,
+    `TAILSCALE_EXTRA_ARGS='${escapeSingleQuotes(extraArgs)}'`,
+    '',
+  ].join('\n')
+
+  const kubeconfigArgs = options.kubeconfig ? ['--kubeconfig', options.kubeconfig] : []
+  const proxyCommand = [
+    'virtctl',
+    ...kubeconfigArgs,
+    '-n',
+    options.namespace,
+    'port-forward',
+    '--stdio=true',
+    `vmi/${options.vmi}`,
+    '22',
+  ].join(' ')
+
+  const sshArgs = [
+    '-o',
+    `ProxyCommand=${proxyCommand}`,
+    '-o',
+    'StrictHostKeyChecking=no',
+    '-o',
+    'UserKnownHostsFile=/dev/null',
+    '-i',
+    options.sshKey,
+    `${options.user}@vmi/${options.vmi}`,
+    "sudo bash -lc 'umask 077; cat > /etc/default/tailscale-auth; systemctl restart tailscale-up.service'",
+  ]
+
+  console.log(`Seeding Tailscale auth key on ${options.user}@${options.vmi} (namespace ${options.namespace})`)
+  const subprocess = Bun.spawn(['ssh', ...sshArgs], {
+    stdin: 'pipe',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  void subprocess.stdin?.write(content)
+  void subprocess.stdin?.end()
+
+  const exitCode = await subprocess.exited
+  if (exitCode !== 0) {
+    fatal(`SSH copy failed (${exitCode})`)
+  }
+}
+
+if (import.meta.main) {
+  await main()
+}


### PR DESCRIPTION
## Summary

- Install and bootstrap Tailscale on the workers KubeVirt VMs via cloud-init
- Add sshid.io/gregkonush key to VM authorized_keys
- Add a script to seed the Tailscale auth key into the workers VM

## Related Issues

None

## Testing

- `kubectl apply -n workers -k argocd/applications/workers`
- Recreated `workers` VM
- `bun run packages/scripts/src/workers/seed-tailscale-auth.ts`
- `ssh ubuntu@vmi/workers 'tailscale status --json | jq -r ...'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
