### PR TITLE
feat(agents): add autoscaling support

### DIFF
--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -114,6 +114,11 @@ helm push agents-0.6.0.tgz oci://ghcr.io/proompteng/charts
 | Key | Description | Default |
 | --- | ----------- | ------- |
 | `replicaCount` | Control-plane replicas | `1` |
+| `autoscaling.enabled` | Enable HorizontalPodAutoscaler | `false` |
+| `autoscaling.minReplicas` | Minimum replicas for autoscaling | `1` |
+| `autoscaling.maxReplicas` | Maximum replicas for autoscaling | `3` |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage | `80` |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization percentage | `null` |
 | `image.repository` | Jangar image repo | `ghcr.io/proompteng/jangar` |
 | `image.tag` | Jangar image tag | `latest` |
 | `image.digest` | Optional image digest pin | `""` |

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "agents.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "agents.selectorLabels" . | nindent 6 }}

--- a/charts/agents/templates/hpa.yaml
+++ b/charts/agents/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agents.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -7,6 +7,17 @@
     "fullnameOverride": { "type": "string" },
     "namespaceOverride": { "type": "string" },
     "replicaCount": { "type": "integer", "minimum": 1 },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "null"], "minimum": 1, "maximum": 100 }
+      },
+      "additionalProperties": false
+    },
     "image": {
       "type": "object",
       "properties": {

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -5,6 +5,13 @@ namespaceOverride: ""
 
 replicaCount: 1
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: null
+
 image:
   repository: ghcr.io/proompteng/jangar
   tag: latest

--- a/docs/agents/agents-helm-chart-design.md
+++ b/docs/agents/agents-helm-chart-design.md
@@ -50,7 +50,7 @@ Resources to remove from the base chart:
 - Embedded Postgres StatefulSet + Service + PVC.
 - Migrations Job + SQL ConfigMap + `files/sql`.
 - Backup CronJob + backup PVC.
-- Optional HPA/PDB/NetworkPolicy (move to an optional "extras" overlay or separate chart if still desired).
+- Optional PDB/NetworkPolicy (keep as an optional "extras" overlay or separate chart if still desired).
 
 Mermaid: chart scope overview
 ```mermaid
@@ -392,7 +392,7 @@ See:
 
 ## Decisions
 - Minimum supported Kubernetes version: 1.25+ (CRD v1, no PSP, aligns with modern clusters).
-- Optional extras: keep out of the core chart; manage via a separate `agents-extras` chart or external policy tooling.
+- Optional extras (PDB/NetworkPolicy): keep out of the core chart; manage via a separate `agents-extras` chart or external policy tooling.
 - ImplementationSpec is namespaced for multi-tenant safety.
 
 ## Appendix: Example CRD Usage (Conceptual)

--- a/docs/agents/agents-helm-chart-implementation.md
+++ b/docs/agents/agents-helm-chart-implementation.md
@@ -197,7 +197,7 @@ A release is considered “fully functional” when:
 
 ## Open Questions
 - Should the chart support an optional CRD install guard (e.g., pre‑install job) for clusters that skip `crds/`? Current best practice says no, but some GitOps tools may need explicit handling.
-- Do we need to package optional “extras” (PDB/HPA/NetworkPolicy) as a separate chart or overlay?
+- Do we need to package optional “extras” (PDB/NetworkPolicy) as a separate chart or overlay? Autoscaling is now part of the base chart.
 
 ## References
 - `docs/agents/agents-helm-chart-design.md`


### PR DESCRIPTION
## Summary

- Add an HPA template gated by `autoscaling.enabled` for the Agents chart.
- Skip Deployment `replicas` when autoscaling is enabled.
- Document autoscaling values in `values.yaml`, `values.schema.json`, `README`, and design/implementation docs.

## Related Issues

Closes #2713

## Testing

- `helm lint charts/agents`

## Screenshots (if applicable)

None

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
