### PR TITLE
fix(agents): force-push split repo history

### DIFF
--- a/.github/workflows/agents-sync.yml
+++ b/.github/workflows/agents-sync.yml
@@ -45,7 +45,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git remote add origin "https://x-access-token:${AGENTS_SPLIT_TOKEN}@github.com/proompteng/agents.git"
-          git push -u origin HEAD:main
+          git push --force-with-lease -u origin HEAD:main
 
           helm package . --destination "${tmpdir}/chart-packages"
           echo "${AGENTS_SPLIT_TOKEN}" | helm registry login ghcr.io -u proompteng --password-stdin


### PR DESCRIPTION
## Summary

- force-push the split repo history after git filter-repo

## Related Issues

None

## Testing

- N/A (workflow change only)

## Screenshots (if applicable)

Not applicable

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
