### PR TITLE
fix(agents): avoid stale force-push in sync

### DIFF
--- a/.github/workflows/agents-sync.yml
+++ b/.github/workflows/agents-sync.yml
@@ -9,6 +9,10 @@ on:
       - '.github/workflows/agents-sync.yml'
   workflow_dispatch: {}
 
+concurrency:
+  group: agents-sync
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -45,7 +49,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git remote add origin "https://x-access-token:${AGENTS_SPLIT_TOKEN}@github.com/proompteng/agents.git"
-          git push --force-with-lease -u origin HEAD:main
+          git fetch origin main
+          git push --force-with-lease=main -u origin HEAD:main
 
           helm package . --destination "${tmpdir}/chart-packages"
           echo "${AGENTS_SPLIT_TOKEN}" | helm registry login ghcr.io -u proompteng --password-stdin


### PR DESCRIPTION
## Summary

- add concurrency guard for agents sync workflow
- fetch remote before force-with-lease to avoid stale info errors

## Related Issues

None

## Testing

- N/A (workflow change only)

## Screenshots (if applicable)

Not applicable

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
