### PR TITLE
chore(agents): move chart repo to proompteng/charts

### DIFF
--- a/.github/workflows/agents-sync.yml
+++ b/.github/workflows/agents-sync.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           version: v3.14.4
 
-      - name: Split charts/agents into dedicated repo and publish chart
+      - name: Split charts/agents into charts repo and publish chart
         env:
           AGENTS_SPLIT_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
         run: |
@@ -43,15 +43,15 @@ jobs:
           git clone --no-local . "${tmpdir}/agents-split"
           cd "${tmpdir}/agents-split"
 
-          git filter-repo --path charts/agents --path-rename charts/agents/:
+          git filter-repo --path charts/agents
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git remote add origin "https://x-access-token:${AGENTS_SPLIT_TOKEN}@github.com/proompteng/agents.git"
+          git remote add origin "https://x-access-token:${AGENTS_SPLIT_TOKEN}@github.com/proompteng/charts.git"
           git fetch origin main
           git push --force-with-lease=main -u origin HEAD:main
 
-          helm package . --destination "${tmpdir}/chart-packages"
+          helm package charts/agents --destination "${tmpdir}/chart-packages"
           echo "${AGENTS_SPLIT_TOKEN}" | helm registry login ghcr.io -u proompteng --password-stdin
-          helm push "${tmpdir}/chart-packages/"*.tgz oci://ghcr.io/proompteng/agents
+          helm push "${tmpdir}/chart-packages/"*.tgz oci://ghcr.io/proompteng/charts

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: agents
 description: Minimal Agents control plane (Jangar) with CRDs
-home: https://github.com/proompteng/agents
+home: https://github.com/proompteng/charts/tree/main/charts/agents
 sources:
-  - https://github.com/proompteng/agents
+  - https://github.com/proompteng/charts/tree/main/charts/agents
 kubeVersion: ">=1.25.0-0"
 type: application
 version: 0.9.1
@@ -21,9 +21,9 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Source
-      url: https://github.com/proompteng/agents
+      url: https://github.com/proompteng/charts/tree/main/charts/agents
     - name: Documentation
-      url: https://github.com/proompteng/agents/blob/main/README.md
+      url: https://github.com/proompteng/charts/blob/main/charts/agents/README.md
   artifacthub.io/keywords: agents,jangar,codex,control-plane
   artifacthub.io/images: |
     - name: jangar

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -126,7 +126,6 @@ Native orchestration runs in-cluster and supports:
 - `AgentRun`
 - `ToolRun`
 - `SubOrchestration`
-- `ApprovalGate`
 
 Enable reruns or system-improvement flows using:
 - `workflowRuntime.native.rerunOrchestration`
@@ -137,9 +136,6 @@ Enable reruns or system-improvement flows using:
 - Use `database.secretRef` and dedicated DB credentials per environment.
 - Scope controllers to specific namespaces unless you need cluster-wide control.
 - Prefer image digests in production (`values-prod.yaml`).
-
-## Crossplane
-Crossplane is not supported by Agents. Uninstall it before installing this chart so the CRDs do not conflict.
 
 ## Publishing (OCI)
 ```bash

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -3,10 +3,10 @@ name: agents
 displayName: Agents Control Plane (Jangar)
 description: Minimal Agents control plane with CRDs and native workflow runtime.
 license: Apache-2.0
-homeURL: https://github.com/proompteng/agents
+homeURL: https://github.com/proompteng/charts/tree/main/charts/agents
 repository:
-  name: proompteng/agents
-  url: https://github.com/proompteng/agents
+  name: proompteng/charts
+  url: https://github.com/proompteng/charts
 keywords:
   - agents
   - jangar

--- a/packages/scripts/src/agents/publish-chart.ts
+++ b/packages/scripts/src/agents/publish-chart.ts
@@ -6,12 +6,13 @@ import { join, resolve } from 'node:path'
 
 const rootDir = resolve(import.meta.dir, '..', '..', '..', '..')
 const outputDir = resolve(rootDir, '.chart-packages')
-const chartRepoUrl = 'https://github.com/proompteng/agents.git'
+const chartRepoUrl = 'https://github.com/proompteng/charts.git'
 
 const chartWorkDir = await Bun.makeTempDir({ dir: tmpdir() })
-const chartDir = join(chartWorkDir, 'agents')
+const chartRepoDir = join(chartWorkDir, 'charts')
+const chartDir = join(chartRepoDir, 'charts', 'agents')
 
-const cloneResult = Bun.spawnSync(['git', 'clone', '--depth', '1', chartRepoUrl, chartDir])
+const cloneResult = Bun.spawnSync(['git', 'clone', '--depth', '1', chartRepoUrl, chartRepoDir])
 if (cloneResult.exitCode !== 0) {
   const stderr = new TextDecoder().decode(cloneResult.stderr)
   throw new Error(`git clone failed: ${stderr || 'unknown error'}`)
@@ -54,11 +55,11 @@ if (!packagePath.endsWith(`-${chartVersion}.tgz`)) {
   throw new Error(`Packaged chart version does not match Chart.yaml (${chartVersion}).`)
 }
 
-const pushResult = Bun.spawnSync(['helm', 'push', packagePath, 'oci://ghcr.io/proompteng/agents'])
+const pushResult = Bun.spawnSync(['helm', 'push', packagePath, 'oci://ghcr.io/proompteng/charts'])
 
 if (pushResult.exitCode !== 0) {
   const stderr = new TextDecoder().decode(pushResult.stderr)
   throw new Error(`helm push failed: ${stderr || 'unknown error'}`)
 }
 
-console.log(`Published ${packagePath} to ghcr.io/proompteng/agents`)
+console.log(`Published ${packagePath} to ghcr.io/proompteng/charts`)


### PR DESCRIPTION
## Summary

- switch agents chart sync and publish to proompteng/charts repo + OCI namespace
- update chart metadata links to the new charts repo
- remove Crossplane/ApprovalGate mentions in chart README

## Related Issues

None

## Testing

- N/A (workflow/docs/script changes only)

## Screenshots (if applicable)

Not applicable

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
