### PR TITLE
Agents chart: five production features (agent-run)

### DIFF
--- a/charts/agents/templates/argocd-hooks.yaml
+++ b/charts/agents/templates/argocd-hooks.yaml
@@ -1,8 +1,23 @@
 {{- if .Values.argocdHooks.enabled -}}
 {{- $namespace := .Values.namespaceOverride | default .Release.Namespace -}}
 {{- $serviceAccount := .Values.argocdHooks.serviceAccountName | default (include "agents.serviceAccountName" .) -}}
-{{- $smokeName := dig "metadata" "name" "" .Values.argocdHooks.smoke.agentRun -}}
+{{- $smokeAgentRun := deepCopy .Values.argocdHooks.smoke.agentRun -}}
+{{- $smokeName := dig "metadata" "name" "" $smokeAgentRun -}}
 {{- $labelSelector := .Values.argocdHooks.smoke.labelSelector | default (printf "agents.proompteng.ai/agent-run=%s" $smokeName) -}}
+{{- if and .Values.argocdHooks.postSync.enabled (gt (len $smokeAgentRun) 0) (not $smokeName) -}}
+{{- fail "argocdHooks.postSync.enabled requires argocdHooks.smoke.agentRun.metadata.name" -}}
+{{- end }}
+{{- if gt (len $smokeAgentRun) 0 -}}
+{{- $_ := set $smokeAgentRun "apiVersion" (default "agents.proompteng.ai/v1" (get $smokeAgentRun "apiVersion")) -}}
+{{- $_ := set $smokeAgentRun "kind" (default "AgentRun" (get $smokeAgentRun "kind")) -}}
+{{- end }}
+{{- if $smokeName -}}
+{{- $metadata := (get $smokeAgentRun "metadata") | default (dict) -}}
+{{- $labels := (get $metadata "labels") | default (dict) -}}
+{{- $_ := set $labels "agents.proompteng.ai/agent-run" $smokeName -}}
+{{- $_ := set $metadata "labels" $labels -}}
+{{- $_ := set $smokeAgentRun "metadata" $metadata -}}
+{{- end }}
 {{- if and .Values.argocdHooks.preSync.enabled (or $smokeName .Values.argocdHooks.smoke.labelSelector) -}}
 apiVersion: batch/v1
 kind: Job
@@ -38,11 +53,12 @@ spec:
               kubectl -n "{{ $namespace }}" delete agentruns.agents.proompteng.ai "{{ $smokeName }}" --ignore-not-found
               {{- end }}
               {{- if $labelSelector }}
+              kubectl -n "{{ $namespace }}" delete agentruns.agents.proompteng.ai -l "{{ $labelSelector }}" --ignore-not-found
               kubectl -n "{{ $namespace }}" delete jobs -l "{{ $labelSelector }}" --ignore-not-found
               kubectl -n "{{ $namespace }}" delete configmaps -l "{{ $labelSelector }}" --ignore-not-found
               {{- end }}
 {{- end }}
-{{- if and .Values.argocdHooks.postSync.enabled $smokeName (gt (len .Values.argocdHooks.smoke.agentRun) 0) -}}
+{{- if and .Values.argocdHooks.postSync.enabled $smokeName (gt (len $smokeAgentRun) 0) -}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -75,12 +91,13 @@ spec:
             - |
               set -euo pipefail
               cat <<'EOF' | kubectl -n "{{ $namespace }}" apply -f -
-{{- toYaml .Values.argocdHooks.smoke.agentRun | nindent 14 }}
+{{- toYaml $smokeAgentRun | nindent 14 }}
               EOF
               kubectl -n "{{ $namespace }}" wait --for=condition=Succeeded "agentruns.agents.proompteng.ai/{{ $smokeName }}" --timeout={{ .Values.argocdHooks.postSync.waitTimeout }}
               {{- if .Values.argocdHooks.postSync.cleanup }}
               kubectl -n "{{ $namespace }}" delete agentruns.agents.proompteng.ai "{{ $smokeName }}" --ignore-not-found
               {{- if $labelSelector }}
+              kubectl -n "{{ $namespace }}" delete agentruns.agents.proompteng.ai -l "{{ $labelSelector }}" --ignore-not-found
               kubectl -n "{{ $namespace }}" delete jobs -l "{{ $labelSelector }}" --ignore-not-found
               kubectl -n "{{ $namespace }}" delete configmaps -l "{{ $labelSelector }}" --ignore-not-found
               {{- end }}

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{- if or .Values.kubernetesApi.host .Values.kubernetesApi.port }}
+{{- if not (and .Values.kubernetesApi.host .Values.kubernetesApi.port) }}
+{{- fail "kubernetesApi.host and kubernetesApi.port must be set together" -}}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/agents/templates/runner-rbac.yaml
+++ b/charts/agents/templates/runner-rbac.yaml
@@ -1,13 +1,21 @@
-{{- if and .Values.runnerServiceAccount.rbac.create (include "agents.runnerServiceAccountName" .) -}}
+{{- $runnerServiceAccountName := include "agents.runnerServiceAccountName" . -}}
+{{- if and .Values.runnerServiceAccount.rbac.create (not $runnerServiceAccountName) -}}
+{{- fail "runnerServiceAccount.rbac.create requires runnerServiceAccount.name or runnerServiceAccount.create" -}}
+{{- end }}
+{{- if and .Values.runnerServiceAccount.rbac.create $runnerServiceAccountName -}}
 {{- $namespace := .Values.namespaceOverride | default .Release.Namespace -}}
+{{- $rules := .Values.runnerServiceAccount.rbac.rules -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "agents.runnerServiceAccountName" . }}
+  name: {{ $runnerServiceAccountName }}
   namespace: {{ $namespace }}
   labels:
     {{- include "agents.labels" . | nindent 4 }}
 rules:
+  {{- if and $rules (gt (len $rules) 0) }}
+  {{- toYaml $rules | nindent 2 }}
+  {{- else }}
   - apiGroups: [""]
     resources:
       - pods
@@ -18,6 +26,7 @@ rules:
       - get
       - list
       - watch
+  {{- end }}
 {{- with .Values.runnerServiceAccount.rbac.extraRules }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
@@ -25,16 +34,16 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "agents.runnerServiceAccountName" . }}
+  name: {{ $runnerServiceAccountName }}
   namespace: {{ $namespace }}
   labels:
     {{- include "agents.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "agents.runnerServiceAccountName" . }}
+  name: {{ $runnerServiceAccountName }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "agents.runnerServiceAccountName" . }}
+    name: {{ $runnerServiceAccountName }}
     namespace: {{ $namespace }}
 {{- end }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -49,6 +49,7 @@
           "type": "object",
           "properties": {
             "create": { "type": "boolean" },
+            "rules": { "type": "array", "items": { "type": "object" } },
             "extraRules": { "type": "array", "items": { "type": "object" } }
           },
           "additionalProperties": false
@@ -388,5 +389,135 @@
       },
       "additionalProperties": false
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["runnerServiceAccount"],
+        "properties": {
+          "runnerServiceAccount": {
+            "required": ["rbac"],
+            "properties": {
+              "rbac": {
+                "required": ["create"],
+                "properties": {
+                  "create": { "const": true }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "runnerServiceAccount": {
+            "anyOf": [
+              {
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 }
+                }
+              },
+              {
+                "required": ["create"],
+                "properties": {
+                  "create": { "const": true }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["kubernetesApi"],
+        "properties": {
+          "kubernetesApi": {
+            "required": ["host"],
+            "properties": {
+              "host": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "kubernetesApi": {
+            "required": ["port"],
+            "properties": {
+              "port": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["kubernetesApi"],
+        "properties": {
+          "kubernetesApi": {
+            "required": ["port"],
+            "properties": {
+              "port": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "kubernetesApi": {
+            "required": ["host"],
+            "properties": {
+              "host": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["argocdHooks"],
+        "properties": {
+          "argocdHooks": {
+            "required": ["enabled", "postSync"],
+            "properties": {
+              "enabled": { "const": true },
+              "postSync": {
+                "required": ["enabled"],
+                "properties": {
+                  "enabled": { "const": true }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "argocdHooks": {
+            "required": ["smoke"],
+            "properties": {
+              "smoke": {
+                "required": ["agentRun"],
+                "properties": {
+                  "agentRun": {
+                    "required": ["metadata"],
+                    "properties": {
+                      "metadata": {
+                        "required": ["name"],
+                        "properties": {
+                          "name": { "type": "string", "minLength": 1 }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -31,6 +31,7 @@ runnerServiceAccount:
   setAsDefault: true
   rbac:
     create: false
+    rules: []
     extraRules: []
 
 rbac:


### PR DESCRIPTION
## Summary
- Updated the agents chart to add configurable runner RBAC rules with guardrails, hardened ArgoCD smoke hook jobs with default labels/cleanup and required metadata, and tightened schema/template validation for Kubernetes API overrides. Changes are in `charts/agents/templates/argocd-hooks.yaml`, `charts/agents/templates/deployment.yaml`, `charts/agents/templates/runner-rbac.yaml`, `charts/agents/values.yaml`, and `charts/agents/values.schema.json`.

## Related Issues
- #2723

## Testing
- `mise exec helm@3 -- helm lint /workspace/lab/charts/agents`
- `mise exec helm@3 kustomize@5 -- kustomize build --enable-helm /workspace/lab/argocd/applications/agents`

## Known Gaps
- None.
