### PR TITLE
feat(agents): add topology spread constraints for AgentRun pods

### DIFF
--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -111,6 +111,10 @@ spec:
             - name: JANGAR_AGENT_RUNNER_TOLERATIONS
               value: {{ .Values.controller.defaultWorkload.tolerations | toJson | quote }}
             {{- end }}
+            {{- if and .Values.controller.defaultWorkload.topologySpreadConstraints (gt (len .Values.controller.defaultWorkload.topologySpreadConstraints) 0) }}
+            - name: JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS
+              value: {{ .Values.controller.defaultWorkload.topologySpreadConstraints | toJson | quote }}
+            {{- end }}
             {{- if and .Values.controller.defaultWorkload.affinity (gt (len .Values.controller.defaultWorkload.affinity) 0) }}
             - name: JANGAR_AGENT_RUNNER_AFFINITY
               value: {{ .Values.controller.defaultWorkload.affinity | toJson | quote }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -229,6 +229,7 @@
             "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
             "tolerations": { "type": "array", "items": { "type": "object" } },
             "affinity": { "type": "object" },
+            "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
             "podSecurityContext": { "type": "object" },
             "imagePullSecrets": { "type": "array", "items": { "type": "string" } },
             "priorityClassName": { "type": "string" },

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -128,6 +128,7 @@ controller:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    topologySpreadConstraints: []
     podSecurityContext: {}
     imagePullSecrets: []
     priorityClassName: ""

--- a/services/jangar/src/server/agents-controller.ts
+++ b/services/jangar/src/server/agents-controller.ts
@@ -1451,6 +1451,9 @@ const submitJobRun = async (
   const tolerations =
     (Array.isArray(runtimeConfig.tolerations) ? runtimeConfig.tolerations : null) ??
     parseEnvArray('JANGAR_AGENT_RUNNER_TOLERATIONS')
+  const topologySpreadConstraints =
+    (Array.isArray(runtimeConfig.topologySpreadConstraints) ? runtimeConfig.topologySpreadConstraints : null) ??
+    parseEnvArray('JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS')
   const affinity = asRecord(runtimeConfig.affinity) ?? parseEnvRecord('JANGAR_AGENT_RUNNER_AFFINITY')
   const podSecurityContext =
     asRecord(runtimeConfig.podSecurityContext) ?? parseEnvRecord('JANGAR_AGENT_RUNNER_POD_SECURITY_CONTEXT')
@@ -1571,6 +1574,9 @@ const submitJobRun = async (
   }
   if (tolerations && tolerations.length > 0) {
     jobPodSpec.tolerations = tolerations
+  }
+  if (topologySpreadConstraints && topologySpreadConstraints.length > 0) {
+    jobPodSpec.topologySpreadConstraints = topologySpreadConstraints
   }
   if (affinity && Object.keys(affinity).length > 0) {
     jobPodSpec.affinity = affinity


### PR DESCRIPTION
## Summary
- Added chart/runtime support for topology spread constraints on AgentRun jobs, including values/schema wiring and controller env/runtime parsing that safely ignores invalid JSON. Updated deployment to emit the new env var only when configured, keeping behavior opt‑in and backwards‑compatible.

## Related Issues
- #2727

## Testing
- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 kustomize@5 -- kustomize build --enable-helm argocd/applications/agents`

## Known Gaps
- None.
