### PR TITLE
ci(agents): validate kustomize build

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           version: v3.14.4
 
+      - name: Install kustomize
+        uses: imranismail/setup-kustomize@v2
+
       - name: Install kubeconform
         run: |
           KUBECONFORM_VERSION="v0.7.0"
@@ -54,6 +57,8 @@ jobs:
           kubeconform -v
 
       - name: Validate Agents chart and CRDs
+        env:
+          AGENTS_VALIDATE_KUSTOMIZE: "1"
         run: scripts/agents/validate-agents.sh
 
   integration:

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -154,6 +154,10 @@ kubeconform --strict --summary --ignore-missing-schemas \
   --schema-location default \
   "${ROOT_DIR}/argocd/applications/agents/application.yaml"
 
+if [[ "${AGENTS_VALIDATE_KUSTOMIZE:-0}" == "1" ]]; then
+  kustomize build --enable-helm "${ROOT_DIR}/argocd/applications/agents" >/dev/null
+fi
+
 CRD_DIR="${CHART_DIR}/crds" python3 - <<'PY'
 import json
 import os


### PR DESCRIPTION
## Summary
- Added optional kustomize build validation gated by `AGENTS_VALIDATE_KUSTOMIZE` in `scripts/agents/validate-agents.sh`, and enabled it in the agents CI validate job with kustomize installed. Updated `.github/workflows/agents-ci.yml` to set the flag only in CI, keeping local behavior unchanged.

## Related Issues
- #2729

## Testing
- Not run (not provided).

## Known Gaps
- None.
