### PR TITLE
ci(agents): validate kustomize build

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -33,7 +33,25 @@ jobs:
           version: v3.14.4
 
       - name: Install kustomize
-        uses: imranismail/setup-kustomize@v2
+        run: |
+          KUSTOMIZE_VERSION="5.8.0"
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m)"
+          case "${ARCH}" in
+            x86_64|amd64) ARCH="amd64" ;;
+            aarch64|arm64) ARCH="arm64" ;;
+            *)
+              echo "Unsupported architecture: ${ARCH}" >&2
+              exit 1
+              ;;
+          esac
+          TARBALL="kustomize_v${KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz"
+          URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/${TARBALL}"
+          curl -fsSL -o kustomize.tar.gz "${URL}"
+          tar -xzf kustomize.tar.gz kustomize
+          chmod +x kustomize
+          sudo mv kustomize /usr/local/bin/
+          kustomize version
 
       - name: Install kubeconform
         run: |
@@ -57,8 +75,6 @@ jobs:
           kubeconform -v
 
       - name: Validate Agents chart and CRDs
-        env:
-          AGENTS_VALIDATE_KUSTOMIZE: "1"
         run: scripts/agents/validate-agents.sh
 
   integration:


### PR DESCRIPTION
## Summary

- install kustomize in agents-ci validation job
- render `argocd/applications/agents` via kustomize during validation to catch ArgoCD render breaks

## Related Issues

Resolves #2729

## Testing

- scripts/agents/validate-agents.sh

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
