### PR TITLE
feat(froussard): add webhook idempotency guard

### DIFF
--- a/apps/froussard/src/config.test.ts
+++ b/apps/froussard/src/config.test.ts
@@ -59,6 +59,18 @@ describe('loadConfig', () => {
     expect(config.discord.defaultResponse.ephemeral).toBe(false)
   })
 
+  it('supports idempotency TTL seconds env', () => {
+    const env = {
+      ...baseEnv,
+      FROUSSARD_WEBHOOK_IDEMPOTENCY_TTL_SECONDS: '45',
+      FROUSSARD_WEBHOOK_IDEMPOTENCY_MAX_ENTRIES: '123',
+    }
+
+    const config = loadConfig(env)
+    expect(config.idempotency.ttlMs).toBe(45_000)
+    expect(config.idempotency.maxEntries).toBe(123)
+  })
+
   it('falls back to CODEX_TRIGGER_LOGIN when list env is absent', () => {
     const env = {
       ...baseEnv,

--- a/apps/froussard/src/webhooks/discord.ts
+++ b/apps/froussard/src/webhooks/discord.ts
@@ -56,11 +56,11 @@ export const createDiscordWebhookHandler =
 
     const interactionId = typeof typedInteraction.id === 'string' ? typedInteraction.id : undefined
     if (interactionId && idempotencyStore.isDuplicate(`discord:${interactionId}`)) {
-      logger.info({ interactionId }, 'duplicate discord interaction ignored')
+      logger.warn({ interactionId }, 'duplicate discord interaction ignored')
       return jsonResponse({
         type: 4,
         data: {
-          content: 'Interaction already received.',
+          content: 'Duplicate interaction ignored.',
           ...(config.discord.response.ephemeral ? { flags: EPHEMERAL_FLAG } : {}),
         },
       })

--- a/apps/froussard/src/webhooks/github.ts
+++ b/apps/froussard/src/webhooks/github.ts
@@ -389,7 +389,7 @@ export const createGithubWebhookHandler = ({
     }
 
     if (idempotencyStore.isDuplicate(`github:${deliveryId}`)) {
-      logger.info({ deliveryId, eventName, action: actionHeader ?? null }, 'duplicate github delivery ignored')
+      logger.warn({ deliveryId, eventName, action: actionHeader ?? null }, 'duplicate github webhook delivery ignored')
       return new Response(
         JSON.stringify({
           status: 'duplicate',
@@ -397,10 +397,7 @@ export const createGithubWebhookHandler = ({
           event: eventName,
           action: actionHeader ?? null,
         }),
-        {
-          status: 202,
-          headers: { 'Content-Type': 'application/json' },
-        },
+        { status: 202, headers: { 'Content-Type': 'application/json' } },
       )
     }
 

--- a/apps/froussard/src/webhooks/types.ts
+++ b/apps/froussard/src/webhooks/types.ts
@@ -1,10 +1,6 @@
 import type { DiscordResponseConfig } from '@/discord-commands'
 
 export interface WebhookConfig {
-  idempotency: {
-    ttlMs: number
-    maxEntries: number
-  }
   atlas: {
     baseUrl: string
     apiKey: string | null
@@ -31,5 +27,9 @@ export interface WebhookConfig {
   discord: {
     publicKey: string
     response: DiscordResponseConfig
+  }
+  idempotency: {
+    ttlMs: number
+    maxEntries: number
   }
 }


### PR DESCRIPTION
## Summary

- Use the shared idempotency store to short-circuit duplicate GitHub/Discord webhook deliveries with warnings
- Support TTL seconds env override alongside existing TTL ms/max entry configuration
- Add/adjust webhook and config tests for duplicate handling and idempotency config

## Related Issues

Fixes #2735

## Testing

- bunx biome check apps/froussard/src
- bun run --filter froussard test (fails: codex-bootstrap tests time out in this environment)
- bun run --filter froussard test -- src/codex/cli/__tests__/codex-bootstrap.test.ts (fails: timeouts/command assertion)
- bun run --filter froussard test -- src/config.test.ts
- bun run --filter froussard test -- src/routes/webhooks.test.ts

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
