### PR TITLE
feat(agents): mount codex auth secret

### DIFF
--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -135,6 +135,14 @@ spec:
             - name: JANGAR_AGENT_RUNNER_SCHEDULER_NAME
               value: {{ .Values.controller.defaultWorkload.schedulerName | quote }}
             {{- end }}
+            {{- if .Values.controller.authSecret.name }}
+            - name: JANGAR_AGENT_RUNNER_CODEX_AUTH_SECRET_NAME
+              value: {{ .Values.controller.authSecret.name | quote }}
+            - name: JANGAR_AGENT_RUNNER_CODEX_AUTH_SECRET_KEY
+              value: {{ .Values.controller.authSecret.key | default "auth.json" | quote }}
+            - name: JANGAR_AGENT_RUNNER_CODEX_AUTH_MOUNT_PATH
+              value: {{ .Values.controller.authSecret.mountPath | default "/root/.codex/auth.json" | quote }}
+            {{- end }}
             {{- if .Values.kubernetesApi.host }}
             - name: KUBERNETES_SERVICE_HOST
               value: {{ .Values.kubernetesApi.host | quote }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -236,6 +236,15 @@
             "schedulerName": { "type": "string" }
           },
           "additionalProperties": false
+        },
+        "authSecret": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string" },
+            "mountPath": { "type": "string" }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -133,6 +133,10 @@ controller:
     imagePullSecrets: []
     priorityClassName: ""
     schedulerName: ""
+  authSecret:
+    name: ""
+    key: "auth.json"
+    mountPath: "/root/.codex/auth.json"
 
 orchestrationController:
   enabled: true

--- a/services/jangar/src/routes/agents-control-plane/agent-runs/$name.tsx
+++ b/services/jangar/src/routes/agents-control-plane/agent-runs/$name.tsx
@@ -17,19 +17,13 @@ import { buildBaseSummaryItems } from '@/components/agents-control-plane-primiti
 import { parseNamespaceSearch } from '@/components/agents-control-plane-search'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
+  type AgentRunLogPod,
   fetchAgentRunLogs,
   fetchPrimitiveDetail,
   fetchPrimitiveEvents,
-  type AgentRunLogPod,
   type PrimitiveEventItem,
 } from '@/data/agents-control-plane'
 import { cn } from '@/lib/utils'
@@ -239,14 +233,16 @@ function AgentRunDetailPage() {
     void loadLogs()
   }, [activeTab, loadLogs, resource])
 
+  const logScope = `${params.name}:${searchState.namespace ?? ''}`
   React.useEffect(() => {
+    if (!logScope) return
     setLogPods([])
     setLogPod(null)
     setLogContainer(null)
     setLogText('')
     setTailLines('200')
     setLogsError(null)
-  }, [params.name, searchState.namespace])
+  }, [logScope])
 
   const statusLabel = resource ? deriveStatusLabel(resource) : 'Unknown'
   const conditions = resource ? getStatusConditions(resource) : []
@@ -459,7 +455,9 @@ function AgentRunDetailPage() {
             <section className="space-y-4 rounded-none border border-border bg-card p-4">
               <div className="flex flex-wrap items-end gap-3">
                 <div className="flex flex-col gap-1 flex-1 min-w-0">
-                  <label className="text-xs font-medium text-foreground">Pod</label>
+                  <label className="text-xs font-medium text-foreground" htmlFor="logPodSelect">
+                    Pod
+                  </label>
                   <Select
                     value={logPod ?? ''}
                     onValueChange={(value) => {
@@ -470,7 +468,7 @@ function AgentRunDetailPage() {
                     }}
                     disabled={!hasPods}
                   >
-                    <SelectTrigger className="w-full" aria-label="Pod">
+                    <SelectTrigger className="w-full" id="logPodSelect" aria-label="Pod">
                       <SelectValue placeholder={hasPods ? 'Select pod' : 'No pods found'} />
                     </SelectTrigger>
                     <SelectContent>
@@ -484,13 +482,15 @@ function AgentRunDetailPage() {
                   </Select>
                 </div>
                 <div className="flex flex-col gap-1 flex-1 min-w-0">
-                  <label className="text-xs font-medium text-foreground">Container</label>
+                  <label className="text-xs font-medium text-foreground" htmlFor="logContainerSelect">
+                    Container
+                  </label>
                   <Select
                     value={logContainer ?? ''}
                     onValueChange={(value) => setLogContainer(value || null)}
                     disabled={containers.length === 0}
                   >
-                    <SelectTrigger className="w-full" aria-label="Container">
+                    <SelectTrigger className="w-full" id="logContainerSelect" aria-label="Container">
                       <SelectValue placeholder={containers.length > 0 ? 'Select container' : 'No containers'} />
                     </SelectTrigger>
                     <SelectContent>

--- a/services/jangar/src/routes/api/agents/control-plane/logs.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/logs.ts
@@ -23,9 +23,7 @@ const parseTailLines = (value: string | null) => {
 
 const readContainerNames = (spec: Record<string, unknown>, key: 'containers' | 'initContainers') => {
   const entries = Array.isArray(spec[key]) ? spec[key] : []
-  return entries
-    .map((entry) => asString(asRecord(entry)?.name))
-    .filter((name): name is string => Boolean(name))
+  return entries.map((entry) => asString(asRecord(entry)?.name)).filter((name): name is string => Boolean(name))
 }
 
 const readPod = (item: Record<string, unknown>): AgentRunPod | null => {
@@ -78,9 +76,7 @@ export const getAgentRunLogs = async (
   try {
     const list = await kube.list('pods', namespace, `agents.proompteng.ai/agent-run=${name}`)
     const items = Array.isArray(list.items) ? list.items : []
-    const pods = items
-      .map((item) => readPod(asRecord(item) ?? {}))
-      .filter((pod): pod is AgentRunPod => Boolean(pod))
+    const pods = items.map((item) => readPod(asRecord(item) ?? {})).filter((pod): pod is AgentRunPod => Boolean(pod))
 
     if (pods.length === 0) {
       return okResponse({
@@ -108,7 +104,7 @@ export const getAgentRunLogs = async (
     const containerName =
       containerParam && containers.some((entry) => entry.name === containerParam)
         ? containerParam
-        : containers.find((entry) => entry.type === 'main')?.name ?? containers[0]?.name ?? null
+        : (containers.find((entry) => entry.type === 'main')?.name ?? containers[0]?.name ?? null)
 
     if (!containerName) {
       return errorResponse('container not found', 404, { name, namespace, pod: selectedPod.name })

--- a/services/jangar/src/server/__tests__/agents-control-plane-logs.test.ts
+++ b/services/jangar/src/server/__tests__/agents-control-plane-logs.test.ts
@@ -63,10 +63,9 @@ describe('control plane logs route', () => {
   })
 
   it('requires name and namespace', async () => {
-    const response = await getAgentRunLogs(
-      new Request('http://localhost/api/agents/control-plane/logs?name=run-1'),
-      { kubeClient: { list: vi.fn(), logs: vi.fn() } },
-    )
+    const response = await getAgentRunLogs(new Request('http://localhost/api/agents/control-plane/logs?name=run-1'), {
+      kubeClient: { list: vi.fn(), logs: vi.fn() },
+    })
 
     expect(response.status).toBe(400)
     const payload = (await response.json()) as Record<string, unknown>


### PR DESCRIPTION
## Summary

- Add controller-level Codex auth secret config to mount into AgentRun job pods and set `CODEX_AUTH`.
- Enforce auth secret allowlist checks for job/workflow runs.
- Expose Helm values/schema/env wiring for the auth secret configuration.
- Add controller tests for auth secret mount + disallowed secret; fix lint issues in logs UI/API/tests.

## Related Issues

Closes #2737.

## Testing

- bun run --filter @proompteng/jangar lint
- bun run --filter @proompteng/jangar test -- src/server/__tests__/agents-controller.test.ts

## Screenshots (if applicable)

None.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
