### PR TITLE
agents chart: optional resource quota + limit range templates

### DIFF
--- a/charts/agents/templates/limitrange.yaml
+++ b/charts/agents/templates/limitrange.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.limitRange.enabled }}
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+    {{- with .Values.limitRange.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.limitRange.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  limits:
+    {{- toYaml .Values.limitRange.limits | nindent 4 }}
+{{- end }}

--- a/charts/agents/templates/resourcequota.yaml
+++ b/charts/agents/templates/resourcequota.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.resourceQuota.enabled }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ include "agents.fullname" . }}
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+    {{- with .Values.resourceQuota.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.resourceQuota.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.resourceQuota.hard }}
+  hard:
+    {{- toYaml .Values.resourceQuota.hard | nindent 4 }}
+  {{- end }}
+  {{- if .Values.resourceQuota.scopes }}
+  scopes:
+    {{- toYaml .Values.resourceQuota.scopes | nindent 4 }}
+  {{- end }}
+  {{- if .Values.resourceQuota.scopeSelector }}
+  scopeSelector:
+    {{- toYaml .Values.resourceQuota.scopeSelector | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -93,6 +93,28 @@
       },
       "additionalProperties": false
     },
+    "resourceQuota": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "hard": { "type": "object", "additionalProperties": { "type": "string" } },
+        "scopes": { "type": "array", "items": { "type": "string" } },
+        "scopeSelector": { "type": "object" },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "limitRange": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "limits": { "type": "array", "items": { "type": "object" } },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
     "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
     "podLabels": { "type": "object", "additionalProperties": { "type": "string" } },
     "securityContext": { "type": "object" },

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -56,6 +56,20 @@ resources:
     memory: 256Mi
   limits: {}
 
+resourceQuota:
+  enabled: false
+  hard: {}
+  scopes: []
+  scopeSelector: {}
+  annotations: {}
+  labels: {}
+
+limitRange:
+  enabled: false
+  limits: []
+  annotations: {}
+  labels: {}
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
## Summary
- Added ResourceQuota and LimitRange support to the agents chart with configurable values, schema validation, and conditional templates, matching existing label/annotation conventions.

## Related Issues
- #2741

## Testing
- Not run (not provided).

## Known Gaps
- None.
