### PR TITLE
feat(agents): allow quota/limit range name overrides

### DIFF
--- a/charts/agents/templates/limitrange.yaml
+++ b/charts/agents/templates/limitrange.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: LimitRange
 metadata:
-  name: {{ include "agents.fullname" . }}
+  name: {{ .Values.limitRange.name | default (include "agents.fullname" .) }}
   namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
   labels:
     {{- include "agents.labels" . | nindent 4 }}

--- a/charts/agents/templates/resourcequota.yaml
+++ b/charts/agents/templates/resourcequota.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: {{ include "agents.fullname" . }}
+  name: {{ .Values.resourceQuota.name | default (include "agents.fullname" .) }}
   namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
   labels:
     {{- include "agents.labels" . | nindent 4 }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -93,28 +93,6 @@
       },
       "additionalProperties": false
     },
-    "resourceQuota": {
-      "type": "object",
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "hard": { "type": "object", "additionalProperties": { "type": "string" } },
-        "scopes": { "type": "array", "items": { "type": "string" } },
-        "scopeSelector": { "type": "object" },
-        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
-        "labels": { "type": "object", "additionalProperties": { "type": "string" } }
-      },
-      "additionalProperties": false
-    },
-    "limitRange": {
-      "type": "object",
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "limits": { "type": "array", "items": { "type": "object" } },
-        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
-        "labels": { "type": "object", "additionalProperties": { "type": "string" } }
-      },
-      "additionalProperties": false
-    },
     "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
     "podLabels": { "type": "object", "additionalProperties": { "type": "string" } },
     "securityContext": { "type": "object" },
@@ -164,6 +142,30 @@
         "ingress": { "type": "array", "items": { "type": "object" } },
         "egress": { "type": "array", "items": { "type": "object" } },
         "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "resourceQuota": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "name": { "type": "string" },
+        "hard": { "type": "object", "additionalProperties": { "type": "string" } },
+        "scopes": { "type": "array", "items": { "type": "string" } },
+        "scopeSelector": { "type": "object" },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "limitRange": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "name": { "type": "string" },
+        "limits": { "type": "array", "items": { "type": "object" } },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } }
       },
       "additionalProperties": false
     },

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -58,6 +58,7 @@ resources:
 
 resourceQuota:
   enabled: false
+  name: ""
   hard: {}
   scopes: []
   scopeSelector: {}
@@ -66,6 +67,7 @@ resourceQuota:
 
 limitRange:
   enabled: false
+  name: ""
   limits: []
   annotations: {}
   labels: {}


### PR DESCRIPTION
## Summary
- allow ResourceQuota/LimitRange name overrides via chart values
- sync values.yaml and values.schema.json with the new name fields
- wire templates to respect custom names when provided

## Related Issues
- Closes #2741

## Testing
- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 -- helm template charts/agents --values charts/agents/values-local.yaml > /tmp/agents-template.yaml`

## Breaking Changes
None.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
