### PR TITLE
feat(agentctl): publish bun binaries to homebrew tap

### DIFF
--- a/.github/workflows/agentctl-release.yml
+++ b/.github/workflows/agentctl-release.yml
@@ -3,7 +3,7 @@ name: agentctl release
 on:
   push:
     tags:
-      - 'v*'
+      - 'agentctl-v*'
 
 permissions:
   contents: write
@@ -106,6 +106,24 @@ jobs:
         with:
           files: release-artifacts/**/*
           generate_release_notes: true
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v5
+        with:
+          repository: proompteng/homebrew-tap
+          path: homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN != '' && secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Update tap formula
+        run: |
+          mkdir -p homebrew-tap/Formula
+          cp release-artifacts/agentctl.rb homebrew-tap/Formula/agentctl.rb
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/agentctl.rb
+          git commit -m "agentctl ${GITHUB_REF_NAME}" || exit 0
+          git push
 
   publish-npm:
     name: Publish npm package

--- a/services/jangar/agentctl/README.md
+++ b/services/jangar/agentctl/README.md
@@ -15,6 +15,7 @@ npx @proompteng/agentctl --help
 ### Homebrew
 
 ```bash
+brew tap proompteng/tap
 brew install proompteng/tap/agentctl
 ```
 

--- a/services/jangar/agentctl/scripts/homebrew/agentctl.rb
+++ b/services/jangar/agentctl/scripts/homebrew/agentctl.rb
@@ -3,26 +3,25 @@ class Agentctl < Formula
   homepage "https://github.com/proompteng/lab/tree/main/services/jangar/agentctl"
   version "__VERSION__"
   license "MIT"
-  depends_on "node"
 
   on_macos do
     on_arm do
-      url "https://github.com/proompteng/lab/releases/download/v#{version}/agentctl-#{version}-darwin-arm64.tar.gz"
+      url "https://github.com/proompteng/lab/releases/download/agentctl-v#{version}/agentctl-#{version}-darwin-arm64.tar.gz"
       sha256 "__SHA256_DARWIN_ARM64__"
     end
     on_intel do
-      url "https://github.com/proompteng/lab/releases/download/v#{version}/agentctl-#{version}-darwin-amd64.tar.gz"
+      url "https://github.com/proompteng/lab/releases/download/agentctl-v#{version}/agentctl-#{version}-darwin-amd64.tar.gz"
       sha256 "__SHA256_DARWIN_AMD64__"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/proompteng/lab/releases/download/v#{version}/agentctl-#{version}-linux-arm64.tar.gz"
+      url "https://github.com/proompteng/lab/releases/download/agentctl-v#{version}/agentctl-#{version}-linux-arm64.tar.gz"
       sha256 "__SHA256_LINUX_ARM64__"
     end
     on_intel do
-      url "https://github.com/proompteng/lab/releases/download/v#{version}/agentctl-#{version}-linux-amd64.tar.gz"
+      url "https://github.com/proompteng/lab/releases/download/agentctl-v#{version}/agentctl-#{version}-linux-amd64.tar.gz"
       sha256 "__SHA256_LINUX_AMD64__"
     end
   end
@@ -32,6 +31,6 @@ class Agentctl < Formula
   end
 
   test do
-    system bin/"agentctl", "--help"
+    system bin/"agentctl", "version", "--client"
   end
 end


### PR DESCRIPTION
## Summary
- build agentctl release artifacts with bun compile targets
- update release workflow to publish agentctl-v* and sync homebrew tap
- adjust homebrew formula template + README install steps

## Testing
- not run (release workflow builds artifacts and validates binaries)
