### PR TITLE
fix(agentctl): use tap token for release checkout

### DIFF
--- a/.github/workflows/agentctl-release.yml
+++ b/.github/workflows/agentctl-release.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           repository: proompteng/homebrew-tap
           path: homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN != '' && secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Update tap formula
         run: |


### PR DESCRIPTION
## Summary
- use HOMEBREW_TAP_TOKEN directly in the release workflow checkout

## Testing
- not run (workflow change)
