### PR TITLE
fix(agentctl): use agents split token for tap

### DIFF
--- a/.github/workflows/agentctl-release.yml
+++ b/.github/workflows/agentctl-release.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           repository: proompteng/homebrew-tap
           path: homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN }}
 
       - name: Update tap formula
         run: |


### PR DESCRIPTION
## Summary
- use AGENTS_SPLIT_TOKEN for Homebrew tap checkout in release workflow

## Testing
- not run (workflow change)
