### PR TITLE
docs(agents): add leader election design

### DIFF
--- a/docs/agents/leader-election-design.md
+++ b/docs/agents/leader-election-design.md
@@ -1,0 +1,82 @@
+# Leader Election Design (Jangar Controllers)
+
+Status: Current (2026-01-29)
+
+## Purpose
+Define how Jangar controllers use Kubernetes leader election to support safe horizontal scaling, prevent double
+reconciliation, and provide predictable failover behavior.
+
+## Goals
+- Ensure exactly one active reconciler per controller group at any time.
+- Provide fast, deterministic failover on leader loss.
+- Keep webhook and gRPC mutation paths leader-gated to avoid duplicate writes.
+- Surface clear status and metrics around leadership changes.
+
+## Non-Goals
+- Sharding reconciliation across multiple active leaders.
+- Cross-cluster coordination or multi-region leader election.
+- Replacing Kubernetes coordination primitives.
+
+## Design Overview
+Jangar runs with multiple replicas but only one replica actively reconciles resources. Leader election uses the
+Kubernetes Lease API (`coordination.k8s.io/v1`) with a single shared lock per controller group.
+
+### Lease Details
+- **Resource**: `Lease` in the controller namespace.
+- **Default lease name**: `jangar-controller-leader`.
+- **Namespace**: release namespace (same as the deployment), configurable.
+- **Owner identity**: `<pod-name>_<uid>`.
+
+### Controller Grouping
+- **Default**: one lease for the whole Jangar controller process (agents, supporting, orchestration).
+- **Future**: allow split leases per controller group if we separate processes.
+
+### Timing Defaults
+- `leaseDurationSeconds`: 30
+- `renewDeadlineSeconds`: 20
+- `retryPeriodSeconds`: 5
+
+These values are conservative and align with Kubernetes controller-runtime defaults. They may be tuned for
+higher-latency clusters but must keep `retryPeriod < renewDeadline < leaseDuration`.
+
+## Traffic & Readiness
+- **Readiness**: only the leader reports ready. Non-leaders stay alive but not ready to receive traffic.
+- **Webhook ingestion**: leader-only. Non-leaders return `503` with a `Retry-After` header.
+- **gRPC** (optional): leader-only. This ensures `agentctl` and automation always hit the active reconciler.
+
+## Failure Modes & Recovery
+- **Leader crash**: a standby replica acquires the lease within ~1 lease duration.
+- **Network partition**: if the leader cannot renew before `renewDeadline`, it stops reconciling and reports
+  not-ready; a new leader takes over.
+- **Split brain prevention**: Lease API guarantees single-holder semantics; controllers must halt reconcile
+  loops when leadership is lost.
+
+## Observability
+- Events: log leadership acquisition and loss with lease name and namespace.
+- Metrics:
+  - `jangar_leader_elected` (gauge, 1 for leader, 0 for follower)
+  - `jangar_leader_changes_total` (counter)
+- Status endpoint: expose `leader: true|false`, `lease_name`, and `lease_namespace`.
+
+## RBAC Requirements
+Jangar service account must be able to manage Leases in its namespace:
+- `get`, `list`, `watch`, `create`, `update`, `patch` on `leases.coordination.k8s.io`.
+
+## Configuration (Helm Values)
+Expose the following values under `controller.leaderElection`:
+- `enabled` (default `true`)
+- `leaseName` (default `jangar-controller-leader`)
+- `leaseNamespace` (default release namespace)
+- `leaseDurationSeconds` (default `30`)
+- `renewDeadlineSeconds` (default `20`)
+- `retryPeriodSeconds` (default `5`)
+
+## Validation
+- Deploy with `replicaCount=2` and confirm only one pod is ready.
+- Kill the leader pod and verify another pod becomes leader within 30s.
+- Confirm webhooks and gRPC calls are rejected by non-leaders.
+
+## Related Docs
+- `docs/agents/agents-helm-chart-implementation.md`
+- `docs/agents/jangar-controller-design.md`
+- `docs/agents/production-readiness-design.md`

--- a/docs/agents/production-readiness-design.md
+++ b/docs/agents/production-readiness-design.md
@@ -4,7 +4,9 @@ Status: Current (2026-01-19)
 
 ## API & Contracts
 - Full CRD schemas for all resources (spec + status) with defaults and validation rules.
-- Explicit size limits for large fields (e.g., ImplementationSpec text).
+- Explicit size limits for large fields (ImplementationSpec text/description, summaries, acceptance criteria).
+- ImplementationSpec contract: required `spec.text`, optional `spec.source` metadata, summary/description limits,
+  and acceptance-criteria caps aligned to the CRD schema.
 - Conversion strategy when moving beyond v1alpha1 (webhook design + deprecation policy).
 - Runtime adapter contract: submit/status/cancel inputs and error codes.
 - Agent-runner spec contract: required fields, workspace layout, artifact paths.
@@ -16,7 +18,7 @@ Status: Current (2026-01-19)
 - Concurrency controls per AgentRun and per namespace.
 - Backoff/retry policy for each reconciler (AgentRun, ImplementationSource, Memory).
 - Idempotency keys for run submission to avoid duplicates.
-- Controller leader election and horizontal scaling strategy.
+- Controller leader election and horizontal scaling strategy (see `docs/agents/leader-election-design.md`).
 
 ## Security & Compliance
 - Threat model and trust boundaries (cluster, integrations, runtime, secrets).
@@ -63,6 +65,7 @@ Status: Current (2026-01-19)
 - Concurrency defaults: 10 in-flight AgentRuns per namespace, 5 per Agent, 100 cluster-wide.
 - Retry/backoff: exponential with base 5s, max 5m, jitter 20%.
 - Retention: AgentRun records 30 days; logs/artifacts 7 days (runtime configurable).
-- Size limits: ImplementationSpec text 128KB; parameters max 100 entries, 2KB per value.
+- Size limits: ImplementationSpec text 128KB, description 128KB, summary 256 chars, acceptanceCriteria 50 items;
+  parameters max 100 entries, 2KB per value.
 - Supply chain: images signed (cosign), SBOMs (SPDX) published per release.
 - Release cadence: monthly minor, patch releases as needed for security fixes.


### PR DESCRIPTION
## Summary
- Add leader election design doc for Jangar controllers (Lease strategy, readiness gating, RBAC, values defaults)
- Align production readiness requirements with leader election and ImplementationSpec limits
- Update agents helm chart implementation plan to reference the leader election doc

## Related Issues
None

## Testing
- N/A (docs-only)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
