### PR TITLE
chore(agentctl): bump version to 0.1.4

### DIFF
--- a/services/jangar/agentctl/package.json
+++ b/services/jangar/agentctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proompteng/agentctl",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "description": "CLI for managing Agents via Kubernetes or Jangar gRPC",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `@proompteng/agentctl` version to 0.1.4 for release.

## Related Issues

None

## Testing

- N/A (version bump only)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (N/A for version-only).
- [x] Screenshots section removed (not applicable).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
