### PR TITLE
fix(agentctl): embed package version in binaries

### DIFF
--- a/services/jangar/agentctl/package.json
+++ b/services/jangar/agentctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proompteng/agentctl",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CLI for managing Agents via Kubernetes or Jangar gRPC",
   "license": "MIT",
   "type": "module",

--- a/services/jangar/agentctl/src/__tests__/version.test.ts
+++ b/services/jangar/agentctl/src/__tests__/version.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import pkg from '../../package.json'
+import { getVersion } from '../legacy'
+
+type PackageJson = {
+  version?: string
+}
+
+const packageJson = pkg as PackageJson
+
+const withEnv = (value: string | undefined, run: () => void) => {
+  const previous = process.env.AGENTCTL_VERSION
+  if (value === undefined) {
+    delete process.env.AGENTCTL_VERSION
+  } else {
+    process.env.AGENTCTL_VERSION = value
+  }
+  try {
+    run()
+  } finally {
+    if (previous === undefined) {
+      delete process.env.AGENTCTL_VERSION
+    } else {
+      process.env.AGENTCTL_VERSION = previous
+    }
+  }
+}
+
+describe('getVersion', () => {
+  it('prefers AGENTCTL_VERSION when set', () => {
+    withEnv('9.9.9', () => {
+      expect(getVersion()).toBe('9.9.9')
+    })
+  })
+
+  it('defaults to package.json version', () => {
+    withEnv(undefined, () => {
+      expect(getVersion()).toBe(packageJson.version)
+    })
+  })
+})

--- a/services/jangar/agentctl/src/legacy.ts
+++ b/services/jangar/agentctl/src/legacy.ts
@@ -20,6 +20,7 @@ import {
 import * as protobuf from 'protobufjs'
 import YAML from 'yaml'
 import { EMBEDDED_AGENTCTL_PROTO } from './embedded-proto'
+import { PACKAGE_VERSION } from './version'
 
 const EXIT_VALIDATION = 2
 const EXIT_RUNTIME = 4
@@ -377,6 +378,7 @@ const RPC_RESOURCE_MAP: Record<string, { list: string; get: string; apply: strin
 const getVersion = () => {
   const env = process.env.AGENTCTL_VERSION?.trim()
   if (env) return env
+  if (PACKAGE_VERSION && PACKAGE_VERSION !== 'dev') return PACKAGE_VERSION
   try {
     const moduleDir = resolve(fileURLToPath(import.meta.url), '..')
     const pkgCandidates = [
@@ -394,7 +396,7 @@ const getVersion = () => {
   } catch {
     // ignore
   }
-  return 'dev'
+  return PACKAGE_VERSION
 }
 
 const usage = (version: string) =>

--- a/services/jangar/agentctl/src/version.ts
+++ b/services/jangar/agentctl/src/version.ts
@@ -1,0 +1,9 @@
+import pkg from '../package.json'
+
+type PackageJson = {
+  version?: string
+}
+
+const packageJson = pkg as PackageJson
+
+export const PACKAGE_VERSION = packageJson.version ?? 'dev'


### PR DESCRIPTION
## Summary

- Embed package.json version into agentctl binaries with env override support.
- Add version unit tests to lock expected behavior.
- Bump agentctl package version to 0.1.5.

## Related Issues

None.

## Testing

- bun run --filter @proompteng/agentctl lint
- bun run --filter @proompteng/agentctl test
- bun run --filter @proompteng/agentctl build:bin
- services/jangar/agentctl/dist/agentctl version --client

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
