### PR TITLE
fix(agentctl): use kubectl backend for kube mode

### DIFF
--- a/services/jangar/agentctl/README.md
+++ b/services/jangar/agentctl/README.md
@@ -20,7 +20,7 @@ brew install proompteng/tap/agentctl
 ```
 
 ## Modes
-- **Kube mode (default):** uses kubeconfig + context and talks to the Kubernetes API directly.
+- **Kube mode (default):** uses kubeconfig + context and shells out to `kubectl` (JSON output). Requires `kubectl` on PATH.
 - **gRPC mode (optional):** uses the Jangar gRPC endpoint; enable with `--grpc` or `AGENTCTL_MODE=grpc`.
 
 ## Quickstart

--- a/services/jangar/agentctl/src/__tests__/kubectl.test.ts
+++ b/services/jangar/agentctl/src/__tests__/kubectl.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { buildKubectlArgs, KubectlError, resetKubectlRunner, runKubectlJson, setKubectlRunner } from '../kube/kubectl'
+
+afterEach(() => {
+  resetKubectlRunner()
+})
+
+describe('kubectl helpers', () => {
+  it('builds kubectl args with kubeconfig, context, and namespace', () => {
+    const args = buildKubectlArgs({ kubeconfig: '/tmp/kube', context: 'dev', namespace: 'agents' })
+    expect(args).toEqual(['--kubeconfig', '/tmp/kube', '--context', 'dev', '-n', 'agents'])
+  })
+
+  it('parses JSON output', async () => {
+    setKubectlRunner(async () => ({ stdout: '{"ok":true}', stderr: '', exitCode: 0 }))
+    const result = await runKubectlJson<{ ok: boolean }>(['get', 'ns', 'agents', '-o', 'json'], {})
+    expect(result.ok).toBe(true)
+  })
+
+  it('throws a KubectlError on non-zero exit', async () => {
+    setKubectlRunner(async () => ({
+      stdout: '',
+      stderr: 'Error from server (NotFound): namespaces "agents" not found',
+      exitCode: 1,
+    }))
+    await expect(runKubectlJson(['get', 'ns', 'agents', '-o', 'json'], {})).rejects.toThrow(KubectlError)
+  })
+})

--- a/services/jangar/agentctl/src/cli/commands/resources.ts
+++ b/services/jangar/agentctl/src/cli/commands/resources.ts
@@ -90,7 +90,7 @@ const makeResourceCommand = (name: string, extras: Array<Command.Command<unknown
       const transport = yield* TransportService
       if (transport.mode === 'kube') {
         const resource = yield* Effect.promise(() =>
-          getCustomObjectOptional(transport.clients, spec, resourceName, resolved.namespace),
+          getCustomObjectOptional(transport.backend, spec, resourceName, resolved.namespace),
         )
         if (!resource) throw new Error(`${name} ${resourceName} not found`)
         outputResource(resource, resolved.output)
@@ -116,7 +116,7 @@ const makeResourceCommand = (name: string, extras: Array<Command.Command<unknown
       const describeOutput = resolveDescribeOutput(resolved.output, flags.output)
       if (transport.mode === 'kube') {
         const resource = yield* Effect.promise(() =>
-          getCustomObjectOptional(transport.clients, spec, resourceName, resolved.namespace),
+          getCustomObjectOptional(transport.backend, spec, resourceName, resolved.namespace),
         )
         if (!resource) throw new Error(`${name} ${resourceName} not found`)
         outputResource(resource, describeOutput)
@@ -142,7 +142,7 @@ const makeResourceCommand = (name: string, extras: Array<Command.Command<unknown
       const labelSelector = Option.getOrUndefined(selector)
       if (transport.mode === 'kube') {
         const resource = yield* Effect.promise(() =>
-          listCustomObjects(transport.clients, spec, resolved.namespace, labelSelector),
+          listCustomObjects(transport.backend, spec, resolved.namespace, labelSelector),
         )
         outputList(resource, resolved.output)
         return
@@ -172,7 +172,7 @@ const makeResourceCommand = (name: string, extras: Array<Command.Command<unknown
         while (true) {
           if (transport.mode === 'kube') {
             const resource = yield* Effect.promise(() =>
-              listCustomObjects(transport.clients, spec, resolved.namespace, labelSelector),
+              listCustomObjects(transport.backend, spec, resolved.namespace, labelSelector),
             )
             if (resolved.output === 'table') {
               clearScreen()
@@ -208,7 +208,7 @@ const makeResourceCommand = (name: string, extras: Array<Command.Command<unknown
       const transport = yield* TransportService
       const manifest = yield* Effect.promise(() => readFileContent(file))
       if (transport.mode === 'kube') {
-        const resources = yield* Effect.promise(() => applyManifest(transport.clients, manifest, resolved.namespace))
+        const resources = yield* Effect.promise(() => applyManifest(transport.backend, manifest, resolved.namespace))
         outputResources(resources, resolved.output)
         return
       }
@@ -231,7 +231,7 @@ const makeResourceCommand = (name: string, extras: Array<Command.Command<unknown
       const transport = yield* TransportService
       if (transport.mode === 'kube') {
         const result = yield* Effect.promise(() =>
-          deleteCustomObject(transport.clients, spec, resolved.namespace, resourceName),
+          deleteCustomObject(transport.backend, spec, resolved.namespace, resourceName),
         )
         if (!result) throw new Error(`${name} ${resourceName} not found`)
         console.log('deleted')
@@ -291,7 +291,7 @@ const makeImplCreateCommand = () => {
           },
         }
         const resource = yield* Effect.promise(() =>
-          createCustomObject(transport.clients, RESOURCE_SPECS.impl, resolved.namespace, manifest),
+          createCustomObject(transport.backend, RESOURCE_SPECS.impl, resolved.namespace, manifest),
         )
         outputResource(resource, resolved.output)
         return
@@ -393,7 +393,7 @@ const makeImplInitCommand = () => {
 
         if (transport.mode === 'kube') {
           const resources = yield* Effect.promise(() =>
-            applyManifest(transport.clients, manifestYaml, resolved.namespace),
+            applyManifest(transport.backend, manifestYaml, resolved.namespace),
           )
           outputResources(resources, resolved.output)
           return

--- a/services/jangar/agentctl/src/kube/backend.ts
+++ b/services/jangar/agentctl/src/kube/backend.ts
@@ -1,0 +1,99 @@
+import { buildKubectlArgs, KubectlError, type KubectlOptions, runKubectl, runKubectlJson } from './kubectl'
+
+export type KubeResourceSpec = {
+  kind: string
+  group: string
+  version: string
+  plural: string
+}
+
+export type KubeBackend = {
+  readNamespace: (name: string) => Promise<Record<string, unknown>>
+  listDeployments: (namespace: string, labelSelector?: string) => Promise<Record<string, unknown>>
+  listCrds: () => Promise<Record<string, unknown>>
+  listCustomObjects: (
+    spec: KubeResourceSpec,
+    namespace: string,
+    labelSelector?: string,
+  ) => Promise<Record<string, unknown>>
+  getCustomObject: (spec: KubeResourceSpec, namespace: string, name: string) => Promise<Record<string, unknown>>
+  createCustomObject: (
+    spec: KubeResourceSpec,
+    namespace: string,
+    body: Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>
+  replaceCustomObject: (
+    spec: KubeResourceSpec,
+    namespace: string,
+    name: string,
+    body: Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>
+  deleteCustomObject: (spec: KubeResourceSpec, namespace: string, name: string) => Promise<Record<string, unknown>>
+  listPods: (namespace: string, labelSelector?: string) => Promise<Record<string, unknown>>
+  deleteJob: (namespace: string, name: string) => Promise<void>
+  deleteJobsBySelector: (namespace: string, selector: string) => Promise<void>
+  streamPodLogs: (namespace: string, podName: string, container?: string, follow?: boolean) => Promise<void>
+}
+
+const resourceRef = (spec: KubeResourceSpec) => `${spec.plural}.${spec.group}`
+
+const withNamespace = (options: KubectlOptions, namespace?: string): KubectlOptions => ({
+  kubeconfig: options.kubeconfig,
+  context: options.context,
+  namespace,
+})
+
+export const createKubectlBackend = (options: KubectlOptions): KubeBackend => ({
+  readNamespace: (name) => runKubectlJson(['get', 'namespace', name, '-o', 'json'], withNamespace(options)),
+  listDeployments: (namespace, labelSelector) => {
+    const args = ['get', 'deployment', '-o', 'json']
+    if (labelSelector) args.push('-l', labelSelector)
+    return runKubectlJson(args, withNamespace(options, namespace))
+  },
+  listCrds: () => runKubectlJson(['get', 'crd', '-o', 'json'], withNamespace(options)),
+  listCustomObjects: (spec, namespace, labelSelector) => {
+    const args = ['get', resourceRef(spec), '-o', 'json']
+    if (labelSelector) args.push('-l', labelSelector)
+    return runKubectlJson(args, withNamespace(options, namespace))
+  },
+  getCustomObject: (spec, namespace, name) =>
+    runKubectlJson(['get', resourceRef(spec), name, '-o', 'json'], withNamespace(options, namespace)),
+  createCustomObject: (_spec, namespace, body) =>
+    runKubectlJson(['create', '-f', '-', '-o', 'json'], withNamespace(options, namespace), JSON.stringify(body)),
+  replaceCustomObject: (_spec, namespace, _name, body) =>
+    runKubectlJson(['replace', '-f', '-', '-o', 'json'], withNamespace(options, namespace), JSON.stringify(body)),
+  deleteCustomObject: (spec, namespace, name) =>
+    runKubectlJson(['delete', resourceRef(spec), name, '-o', 'json'], withNamespace(options, namespace)),
+  listPods: (namespace, labelSelector) => {
+    const args = ['get', 'pods', '-o', 'json']
+    if (labelSelector) args.push('-l', labelSelector)
+    return runKubectlJson(args, withNamespace(options, namespace))
+  },
+  deleteJob: async (namespace, name) => {
+    const result = await runKubectl(['delete', 'job', name], withNamespace(options, namespace))
+    if (result.exitCode !== 0) {
+      const message = result.stderr.trim() || result.stdout.trim() || `kubectl delete job ${name} failed`
+      throw new KubectlError(message, result.stderr, result.exitCode)
+    }
+  },
+  deleteJobsBySelector: async (namespace, selector) => {
+    const result = await runKubectl(['delete', 'job', '-l', selector], withNamespace(options, namespace))
+    if (result.exitCode !== 0) {
+      const message = result.stderr.trim() || result.stdout.trim() || `kubectl delete job -l ${selector} failed`
+      throw new KubectlError(message, result.stderr, result.exitCode)
+    }
+  },
+  streamPodLogs: async (namespace, podName, container, follow) => {
+    const args = ['logs', podName]
+    if (container) args.push('-c', container)
+    if (follow) args.push('-f')
+    const proc = Bun.spawn(['kubectl', ...buildKubectlArgs(withNamespace(options, namespace)), ...args], {
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
+      throw new KubectlError(`kubectl logs failed with exit code ${exitCode}`, undefined, exitCode)
+    }
+  },
+})

--- a/services/jangar/agentctl/src/kube/kubectl.ts
+++ b/services/jangar/agentctl/src/kube/kubectl.ts
@@ -1,0 +1,91 @@
+export type KubectlOptions = {
+  kubeconfig?: string
+  context?: string
+  namespace?: string
+}
+
+export type KubectlResult = {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+export class KubectlError extends Error {
+  readonly stderr?: string
+  readonly exitCode?: number
+
+  constructor(message: string, stderr?: string, exitCode?: number) {
+    super(message)
+    this.name = 'KubectlError'
+    this.stderr = stderr
+    this.exitCode = exitCode
+  }
+}
+
+export const buildKubectlArgs = (options: KubectlOptions) => {
+  const args: string[] = []
+  if (options.kubeconfig) {
+    args.push('--kubeconfig', options.kubeconfig)
+  }
+  if (options.context) {
+    args.push('--context', options.context)
+  }
+  if (options.namespace) {
+    args.push('-n', options.namespace)
+  }
+  return args
+}
+
+export type KubectlRunner = (args: string[], options: KubectlOptions, stdin?: string) => Promise<KubectlResult>
+
+const defaultRunner: KubectlRunner = async (args, options, stdin) => {
+  const proc = Bun.spawn(['kubectl', ...buildKubectlArgs(options), ...args], {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  if (stdin) {
+    proc.stdin.write(stdin)
+  }
+  proc.stdin.end()
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  return { stdout, stderr, exitCode }
+}
+
+let runner: KubectlRunner = defaultRunner
+
+export const setKubectlRunner = (next: KubectlRunner) => {
+  runner = next
+}
+
+export const resetKubectlRunner = () => {
+  runner = defaultRunner
+}
+
+export const runKubectl = (args: string[], options: KubectlOptions, stdin?: string) => runner(args, options, stdin)
+
+export const runKubectlJson = async <T>(args: string[], options: KubectlOptions, stdin?: string): Promise<T> => {
+  const result = await runKubectl(args, options, stdin)
+  const stdout = result.stdout.trim()
+  const stderr = result.stderr.trim()
+  if (result.exitCode !== 0) {
+    const message = stderr || stdout || `kubectl ${args.join(' ')} failed`
+    throw new KubectlError(message, result.stderr, result.exitCode)
+  }
+  if (!stdout) {
+    throw new KubectlError(`kubectl ${args.join(' ')} returned empty output`, result.stderr, result.exitCode)
+  }
+  try {
+    return JSON.parse(stdout) as T
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new KubectlError(`kubectl ${args.join(' ')} returned non-JSON output: ${message}`, stdout, result.exitCode)
+  }
+}


### PR DESCRIPTION
## Summary

- Switch kube mode to a kubectl-backed transport to avoid Bun TLS errors.
- Add kubectl helper + backend with JSON parsing and log streaming.
- Update kube-mode commands and add unit tests for kubectl helpers.

## Related Issues

None.

## Testing

- bun run --filter @proompteng/agentctl lint
- bun run --filter @proompteng/agentctl test
- bun src/index.ts status

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
