### PR TITLE
chore(agents): deploy jangar b4fd3c580

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 9b3dca27d
-  digest: sha256:2c3b0256b9f7256580a0042fcb535cb9570306104155dab03dfa67dd29470d21
+  tag: b4fd3c580
+  digest: sha256:35fc3880c9716d0e06a25f8e5f5d707c66fdab5a54f5a9287ca025ccffd80169
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary

- Update agents chart values to deploy Jangar image `b4fd3c580` (digest `sha256:35fc3880c9716d0e06a25f8e5f5d707c66fdab5a54f5a9287ca025ccffd80169`).

## Related Issues

None

## Testing

- `bun run packages/scripts/src/agents/deploy-service.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
