### PR TITLE
chore(kubernetes): default k3s channel to latest

### DIFF
--- a/kubernetes/install-k3s.ts
+++ b/kubernetes/install-k3s.ts
@@ -16,6 +16,8 @@ const kubeConfigPath = process.env.K3S_LOCAL_PATH ?? `${homeDir}/.kube/config`
 const kubeContext = process.env.K3S_CONTEXT ?? 'default'
 const primaryHost = process.env.K3S_PRIMARY_HOST ?? '192.168.1.150'
 const apiLoadBalancer = process.env.K3S_API_LB ?? '192.168.1.200'
+const k3sChannel = process.env.K3S_CHANNEL ?? 'latest'
+const k3sVersion = process.env.K3S_VERSION
 
 function readParallelism(value: string | undefined, fallback: number) {
   if (!value) {
@@ -189,6 +191,13 @@ async function fetchNodeToken() {
   return output
 }
 
+function k3sVersionArgs() {
+  if (k3sVersion) {
+    return ['--k3s-version', k3sVersion]
+  }
+  return ['--k3s-channel', k3sChannel]
+}
+
 async function installPrimary() {
   console.log(`Setting up primary server ${primaryHost}`)
   await exec([
@@ -205,6 +214,7 @@ async function installPrimary() {
     kubeContext,
     '--ssh-key',
     sshKeyPath,
+    ...k3sVersionArgs(),
     '--k3s-extra-args',
     serverExtraArgs,
   ])
@@ -227,6 +237,7 @@ async function joinAdditionalServers(nodeToken: string) {
       sshUser,
       '--ssh-key',
       sshKeyPath,
+      ...k3sVersionArgs(),
       '--k3s-extra-args',
       serverExtraArgs,
     ])
@@ -249,6 +260,7 @@ async function joinWorkers(nodeToken: string) {
       sshUser,
       '--ssh-key',
       sshKeyPath,
+      ...k3sVersionArgs(),
       '--k3s-extra-args',
       workerExtraArgs,
     ])


### PR DESCRIPTION
## Summary
- default K3s installs to the latest channel by default
- allow pinning via K3S_VERSION and reuse across install/join paths
- keep server/worker extra args unchanged

## Related Issues
None

## Testing
- N/A (script change only; not executed in CI)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
