### PR TITLE
fix(arc): add listener container stub

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -39,6 +39,8 @@ spec:
             spec:
               hostNetwork: true
               dnsPolicy: ClusterFirstWithHostNet
+              containers:
+                - name: listener
           template:
             spec:
               hostNetwork: true


### PR DESCRIPTION
## Summary

- Add listener container stub so ARC listenerTemplate validates
- Keep hostNetwork + ClusterFirstWithHostNet for ARC listener
- Unblock ArgoCD sync of arc app

## Related Issues

None

## Testing

- argocd app sync arc (expected to succeed after merge)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
