### PR TITLE
feat(argocd): add homepage application

### DIFF
--- a/argocd/applications/homepage/clusterrole.yaml
+++ b/argocd/applications/homepage/clusterrole.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+      - gateways
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list

--- a/argocd/applications/homepage/clusterrolebinding.yaml
+++ b/argocd/applications/homepage/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: homepage
+subjects:
+  - kind: ServiceAccount
+    name: homepage
+    namespace: homepage

--- a/argocd/applications/homepage/configmap.yaml
+++ b/argocd/applications/homepage/configmap.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+data:
+  bookmarks.yaml: |
+    []
+  custom.css: |
+  custom.js: |
+  docker.yaml: |
+    {}
+  kubernetes.yaml: |
+    mode: cluster
+    ingress: true
+    traefik: true
+  services.yaml: |
+    - Public:
+        - Proompteng:
+            href: https://proompteng.ai
+        - App:
+            href: https://app.proompteng.ai
+        - CMS:
+            href: https://cms.proompteng.ai
+        - Docs:
+            href: https://docs.proompteng.ai
+        - Discourse:
+            href: https://forum.proompteng.ai
+    - Tailscale:
+        - Homepage:
+            href: https://homepage.ide-newton.ts.net
+        - Jangar:
+            href: https://jangar.ide-newton.ts.net
+        - OpenWebUI:
+            href: https://openwebui.ide-newton.ts.net
+        - Jangar VSCode:
+            href: https://jangar-vscode.ide-newton.ts.net
+        - Facteur:
+            href: https://facteur.ide-newton.ts.net
+        - GoLink:
+            href: https://go.ide-newton.ts.net
+        - Torghut:
+            href: https://torghut.ide-newton.ts.net
+    - Internal:
+        - Agents:
+            href: https://argocd.proompteng.ai/applications/agents
+        - Agents CI:
+            href: https://argocd.proompteng.ai/applications/agents-ci
+        - Bumba:
+            href: https://argocd.proompteng.ai/applications/bumba
+        - Oirat:
+            href: https://argocd.proompteng.ai/applications/oirat
+        - Dernier:
+            href: https://argocd.proompteng.ai/applications/dernier
+        - Froussard:
+            href: https://argocd.proompteng.ai/applications/froussard
+  settings.yaml: |
+    title: Homelab
+  widgets.yaml: |
+    []

--- a/argocd/applications/homepage/deployment.yaml
+++ b/argocd/applications/homepage/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: homepage
+  template:
+    metadata:
+      labels:
+        app: homepage
+        app.kubernetes.io/name: homepage
+    spec:
+      serviceAccountName: homepage
+      containers:
+        - name: homepage
+          image: ghcr.io/gethomepage/homepage
+          resources:
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+          env:
+            - name: HOMEPAGE_ALLOWED_HOSTS
+              value: homepage,homepage.ide-newton.ts.net
+          ports:
+            - name: http
+              containerPort: 3000
+          volumeMounts:
+            - name: config
+              mountPath: /app/config/bookmarks.yaml
+              subPath: bookmarks.yaml
+            - name: config
+              mountPath: /app/config/custom.css
+              subPath: custom.css
+            - name: config
+              mountPath: /app/config/custom.js
+              subPath: custom.js
+            - name: config
+              mountPath: /app/config/docker.yaml
+              subPath: docker.yaml
+            - name: config
+              mountPath: /app/config/kubernetes.yaml
+              subPath: kubernetes.yaml
+            - name: config
+              mountPath: /app/config/services.yaml
+              subPath: services.yaml
+            - name: config
+              mountPath: /app/config/settings.yaml
+              subPath: settings.yaml
+            - name: config
+              mountPath: /app/config/widgets.yaml
+              subPath: widgets.yaml
+            - name: logs
+              mountPath: /app/config/logs
+      volumes:
+        - name: config
+          configMap:
+            name: homepage
+        - name: logs
+          emptyDir: {}

--- a/argocd/applications/homepage/kustomization.yaml
+++ b/argocd/applications/homepage/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - tailscale-service.yaml
+images:
+  - name: ghcr.io/gethomepage/homepage
+    newName: ghcr.io/gethomepage/homepage
+    newTag: v1.7.0

--- a/argocd/applications/homepage/service.yaml
+++ b/argocd/applications/homepage/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  selector:
+    app: homepage
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/argocd/applications/homepage/serviceaccount.yaml
+++ b/argocd/applications/homepage/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: homepage
+  namespace: homepage
+  labels:
+    app.kubernetes.io/name: homepage

--- a/argocd/applications/homepage/tailscale-service.yaml
+++ b/argocd/applications/homepage/tailscale-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homepage-tailscale
+  namespace: homepage
+  annotations:
+    tailscale.com/hostname: homepage
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app: homepage
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -48,6 +48,14 @@ spec:
                   argocd.argoproj.io/sync-wave: "5"
                 automation: auto
                 enabled: true
+              - name: homepage
+                path: argocd/applications/homepage
+                namespace: homepage
+                renderWithLovely: false
+                annotations:
+                  argocd.argoproj.io/sync-wave: "5"
+                automation: auto
+                enabled: true
               - name: discourse
                 path: argocd/applications/discourse
                 namespace: discourse


### PR DESCRIPTION
## Summary

- add a new Homepage ArgoCD application with config/RBAC, service, and Tailscale LB
- include Homepage in the product ApplicationSet for auto sync
- seed Homepage services list with links to enabled apps

## Related Issues

None

## Testing

- bun run lint:argocd

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
