### PR TITLE
feat(argocd): render homepage as tiles

### DIFF
--- a/argocd/applications/homepage/configmap.yaml
+++ b/argocd/applications/homepage/configmap.yaml
@@ -119,6 +119,7 @@ data:
     cardBlur: sm
     iconStyle: theme
     fullWidth: true
+    maxGroupColumns: 6
     useEqualHeights: false
     disableCollapse: true
     statusStyle: dot
@@ -129,11 +130,10 @@ data:
       showSearchSuggestions: true
       provider: duckduckgo
     layout:
-      apps:
-        style: row
-        columns: 6
-        header: false
-        useEqualHeights: false
+      - apps:
+          style: column
+          header: false
+          useEqualHeights: false
   widgets.yaml: |
     - logo:
         icon: mdi-home-variant


### PR DESCRIPTION
## Summary

- switch Homepage layout to column-based tiles and allow up to six columns
- keep masonry-style heights by leaving equal heights disabled

## Related Issues

None

## Testing

- bun run lint:argocd

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
