### PR TITLE
fix(agents): align argocd image and chart version

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -12,5 +12,5 @@ helmCharts:
     releaseName: agents
     namespace: agents
     valuesFile: values.yaml
-    version: 0.9.0
+    version: 0.9.1
     includeCRDs: true

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: b4fd3c580
-  digest: sha256:35fc3880c9716d0e06a25f8e5f5d707c66fdab5a54f5a9287ca025ccffd80169
+  tag: 9b3dca27d
+  digest: sha256:2c3b0256b9f7256580a0042fcb535cb9570306104155dab03dfa67dd29470d21
   pullPolicy: IfNotPresent
 resources:
   requests:


### PR DESCRIPTION
## Summary

- Align agents ArgoCD values to the currently running Jangar image/digest to remove drift.
- Bump the agents chart version in the ArgoCD kustomization to 0.9.1.
- Keep the agents Deployment render consistent with cluster state.

## Related Issues

None

## Testing

- N/A (config-only change; no local tests run)

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
