### PR TITLE
feat(agents): add tailscale service hostname

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - sample-approvalpolicy.yaml
   - sample-budget.yaml
   - sample-signal.yaml
+  - tailscale-service.yaml
 helmGlobals:
   chartHome: ../../../charts
 helmCharts:

--- a/argocd/applications/agents/tailscale-service.yaml
+++ b/argocd/applications/agents/tailscale-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agents-tailscale
+  namespace: agents
+  annotations:
+    tailscale.com/hostname: agents
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: agents
+    app.kubernetes.io/instance: agents
+  ports:
+    - name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
## Summary

- Add a Tailscale LoadBalancer Service for the agents controller with hostname `agents`.
- Wire the new service into the ArgoCD agents kustomization.
- Keep selector aligned to the agents Helm release labels.

## Related Issues

None

## Testing

- N/A (manifest-only change)

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
