### PR TITLE
fix(agents): allow tailscale ingress

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - sample-budget.yaml
   - sample-signal.yaml
   - tailscale-service.yaml
+  - tailscale-networkpolicy.yaml
 helmGlobals:
   chartHome: ../../../charts
 helmCharts:

--- a/argocd/applications/agents/tailscale-networkpolicy.yaml
+++ b/argocd/applications/agents/tailscale-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agents-tailscale-ingress
+  namespace: agents
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: agents
+      app.kubernetes.io/name: agents
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale
+      ports:
+        - protocol: TCP
+          port: http
+        - protocol: TCP
+          port: grpc


### PR DESCRIPTION
## Summary

- Allow tailscale namespace ingress to the agents controller pods.
- Keep the policy scoped to HTTP and gRPC ports only.
- Wire the policy into the agents ArgoCD kustomization.

## Related Issues

None

## Testing

- N/A (manifest-only change)

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
