### PR TITLE
feat(agents): add provider auth warnings

### DIFF
--- a/charts/agents/examples/versioncontrolprovider-github.yaml
+++ b/charts/agents/examples/versioncontrolprovider-github.yaml
@@ -13,6 +13,7 @@ spec:
       secretRef:
         name: codex-github-token
         key: token
+      type: fine_grained
   repositoryPolicy:
     allow:
       - proompteng/*

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -164,6 +164,10 @@ spec:
               value: {{ .Values.controller.agentRunRetentionSeconds | default 2592000 | quote }}
             - name: JANGAR_AGENTS_CONTROLLER_VCS_PROVIDERS_ENABLED
               value: {{ .Values.controller.vcsProviders.enabled | default true | quote }}
+            {{- if .Values.controller.vcsProviders.deprecatedTokenTypes }}
+            - name: JANGAR_AGENTS_CONTROLLER_VCS_DEPRECATED_TOKEN_TYPES
+              value: {{ .Values.controller.vcsProviders.deprecatedTokenTypes | toJson | quote }}
+            {{- end }}
             {{- if .Values.controller.authSecret.name }}
             - name: JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME
               value: {{ .Values.controller.authSecret.name | quote }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -259,7 +259,11 @@
         "vcsProviders": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" }
+            "enabled": { "type": "boolean" },
+            "deprecatedTokenTypes": {
+              "type": "object",
+              "additionalProperties": { "type": "array", "items": { "type": "string" } }
+            }
           },
           "additionalProperties": false
         },

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -146,6 +146,9 @@ controller:
     mountPath: /root/.codex
   vcsProviders:
     enabled: true
+    deprecatedTokenTypes:
+      github:
+        - pat
   defaultWorkload:
     serviceAccountName: ""
     nodeSelector: {}

--- a/docs/agents/designs/design-07-multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/design-07-multi-provider-auth-deprecations.md
@@ -1,0 +1,29 @@
+# Multi-Provider Auth Standards and Deprecations
+
+Status: Draft (2026-02-04)
+
+## Problem
+Provider auth modes differ and deprecations cause silent failures.
+
+## Goals
+- Normalize auth fields across providers.
+- Detect deprecated auth types early.
+
+## Non-Goals
+- Implementing all provider features.
+
+## Design
+- Define provider-specific auth adapters.
+- Add warnings for deprecated token types.
+
+## Chart Changes
+- Expose auth options in values examples.
+- Document token scopes and expiry guidance.
+
+## Controller Changes
+- Validate auth config by provider.
+- Surface warnings in status conditions.
+
+## Acceptance Criteria
+- Provider misconfigurations are rejected with clear errors.
+- Deprecations emit warnings before failures.


### PR DESCRIPTION
## Summary

- add provider-specific auth validation and deprecation warnings in the controller
- expose deprecated token types via chart values and deployment env
- document VCS auth options plus scope/expiry guidance in chart README and examples
- add controller tests covering deprecated/unsupported auth configurations

## Related Issues

None

## Testing

- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 kustomize@5 -- kustomize build --enable-helm argocd/applications/agents`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
