### PR TITLE
feat(agents): enforce namespaced install guardrails

### DIFF
--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -99,6 +99,14 @@ Agent memory backends are configured separately via the `Memory` CRD.
 ### Controller scope
 - Single namespace: default
 - Multi-namespace: set `controller.namespaces` and `rbac.clusterScoped=true`
+- Wildcard: set `controller.namespaces=["*"]` and `rbac.clusterScoped=true`
+
+#### Namespaced vs cluster-scoped install matrix
+| Install mode | controller.namespaces | rbac.clusterScoped | RBAC scope |
+| --- | --- | --- | --- |
+| Namespaced (single) | `[]` or `["agents"]` | `false` | Role + RoleBinding |
+| Multi-namespace (explicit) | `["team-a", "team-b"]` | `true` | ClusterRole + ClusterRoleBinding |
+| Wildcard (all namespaces) | `["*"]` | `true` | ClusterRole + ClusterRoleBinding (namespace list/watch) |
 
 ### gRPC service (optional)
 Enable gRPC for agentctl or in-cluster clients:

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -147,6 +147,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: JANGAR_RBAC_CLUSTER_SCOPED
+              value: {{ .Values.rbac.clusterScoped | default false | quote }}
             - name: JANGAR_PRIMITIVES_NAMESPACES
               value: {{ include "agents.controllerNamespaces" . | quote }}
             {{- if .Values.controller.enabled }}

--- a/charts/agents/templates/validation.yaml
+++ b/charts/agents/templates/validation.yaml
@@ -1,0 +1,30 @@
+{{- $errors := list -}}
+{{- $clusterScoped := .Values.rbac.clusterScoped | default false -}}
+{{- $controllerNamespaces := .Values.controller.namespaces | default (list) -}}
+{{- $orchestrationNamespaces := .Values.orchestrationController.namespaces | default (list) -}}
+{{- $supportingNamespaces := .Values.supportingController.namespaces | default (list) -}}
+
+{{- if and (gt (len $controllerNamespaces) 1) (not $clusterScoped) -}}
+{{- $errors = append $errors "rbac.clusterScoped must be true when controller.namespaces has multiple entries." -}}
+{{- end -}}
+{{- if and (has "*" $controllerNamespaces) (not $clusterScoped) -}}
+{{- $errors = append $errors "rbac.clusterScoped must be true when controller.namespaces includes '*' (wildcard)." -}}
+{{- end -}}
+
+{{- if and (gt (len $orchestrationNamespaces) 1) (not $clusterScoped) -}}
+{{- $errors = append $errors "rbac.clusterScoped must be true when orchestrationController.namespaces has multiple entries." -}}
+{{- end -}}
+{{- if and (has "*" $orchestrationNamespaces) (not $clusterScoped) -}}
+{{- $errors = append $errors "rbac.clusterScoped must be true when orchestrationController.namespaces includes '*' (wildcard)." -}}
+{{- end -}}
+
+{{- if and (gt (len $supportingNamespaces) 1) (not $clusterScoped) -}}
+{{- $errors = append $errors "rbac.clusterScoped must be true when supportingController.namespaces has multiple entries." -}}
+{{- end -}}
+{{- if and (has "*" $supportingNamespaces) (not $clusterScoped) -}}
+{{- $errors = append $errors "rbac.clusterScoped must be true when supportingController.namespaces includes '*' (wildcard)." -}}
+{{- end -}}
+
+{{- if gt (len $errors) 0 -}}
+{{- fail (printf "Agents chart values validation failed:\n- %s" (join "\n- " $errors)) -}}
+{{- end -}}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -430,5 +430,151 @@
       },
       "additionalProperties": false
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "controller": {
+            "properties": {
+              "namespaces": { "type": "array", "minItems": 2 }
+            },
+            "required": ["namespaces"]
+          }
+        },
+        "required": ["controller"]
+      },
+      "then": {
+        "properties": {
+          "rbac": {
+            "properties": {
+              "clusterScoped": { "const": true }
+            },
+            "required": ["clusterScoped"]
+          }
+        },
+        "required": ["rbac"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "controller": {
+            "properties": {
+              "namespaces": { "type": "array", "contains": { "const": "*" } }
+            },
+            "required": ["namespaces"]
+          }
+        },
+        "required": ["controller"]
+      },
+      "then": {
+        "properties": {
+          "rbac": {
+            "properties": {
+              "clusterScoped": { "const": true }
+            },
+            "required": ["clusterScoped"]
+          }
+        },
+        "required": ["rbac"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "orchestrationController": {
+            "properties": {
+              "namespaces": { "type": "array", "minItems": 2 }
+            },
+            "required": ["namespaces"]
+          }
+        },
+        "required": ["orchestrationController"]
+      },
+      "then": {
+        "properties": {
+          "rbac": {
+            "properties": {
+              "clusterScoped": { "const": true }
+            },
+            "required": ["clusterScoped"]
+          }
+        },
+        "required": ["rbac"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "orchestrationController": {
+            "properties": {
+              "namespaces": { "type": "array", "contains": { "const": "*" } }
+            },
+            "required": ["namespaces"]
+          }
+        },
+        "required": ["orchestrationController"]
+      },
+      "then": {
+        "properties": {
+          "rbac": {
+            "properties": {
+              "clusterScoped": { "const": true }
+            },
+            "required": ["clusterScoped"]
+          }
+        },
+        "required": ["rbac"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "supportingController": {
+            "properties": {
+              "namespaces": { "type": "array", "minItems": 2 }
+            },
+            "required": ["namespaces"]
+          }
+        },
+        "required": ["supportingController"]
+      },
+      "then": {
+        "properties": {
+          "rbac": {
+            "properties": {
+              "clusterScoped": { "const": true }
+            },
+            "required": ["clusterScoped"]
+          }
+        },
+        "required": ["rbac"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "supportingController": {
+            "properties": {
+              "namespaces": { "type": "array", "contains": { "const": "*" } }
+            },
+            "required": ["namespaces"]
+          }
+        },
+        "required": ["supportingController"]
+      },
+      "then": {
+        "properties": {
+          "rbac": {
+            "properties": {
+              "clusterScoped": { "const": true }
+            },
+            "required": ["clusterScoped"]
+          }
+        },
+        "required": ["rbac"]
+      }
+    }
+  ]
 }

--- a/docs/agents/designs/design-05-namespaced-install-matrix.md
+++ b/docs/agents/designs/design-05-namespaced-install-matrix.md
@@ -1,0 +1,28 @@
+# Namespaced vs Cluster-Scoped Install Matrix
+
+Status: Draft (2026-02-04)
+
+## Problem
+Multi-tenant clusters need clear RBAC and scope guarantees.
+
+## Goals
+- Support strict namespaced installs by default.
+- Document when cluster-scoped RBAC is required.
+
+## Non-Goals
+- Global reconciliation without explicit opt-in.
+
+## Design
+- Make rbac.clusterScoped explicit and required for multi-namespace.
+- Add validation to prevent misconfiguration.
+
+## Chart Changes
+- Validate controller.namespaces and rbac.clusterScoped.
+- Document scope matrix.
+
+## Controller Changes
+- Fail fast on namespace wildcard without cluster RBAC.
+
+## Acceptance Criteria
+- Namespaced install works without cluster permissions.
+- Misconfigured installs surface clear errors.

--- a/services/jangar/src/server/__tests__/namespace-scope.test.ts
+++ b/services/jangar/src/server/__tests__/namespace-scope.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { assertClusterScopedForWildcard } from '~/server/namespace-scope'
+
+const original = process.env.JANGAR_RBAC_CLUSTER_SCOPED
+
+afterEach(() => {
+  if (original == null) {
+    delete process.env.JANGAR_RBAC_CLUSTER_SCOPED
+  } else {
+    process.env.JANGAR_RBAC_CLUSTER_SCOPED = original
+  }
+})
+
+describe('namespace scope', () => {
+  it('throws when wildcard namespaces are used without cluster RBAC', () => {
+    delete process.env.JANGAR_RBAC_CLUSTER_SCOPED
+    expect(() => assertClusterScopedForWildcard(['*'], 'agents controller')).toThrow(
+      '[jangar] agents controller namespaces \'*\' require rbac.clusterScoped=true',
+    )
+  })
+
+  it('allows wildcard namespaces when cluster RBAC is enabled', () => {
+    process.env.JANGAR_RBAC_CLUSTER_SCOPED = 'true'
+    expect(() => assertClusterScopedForWildcard(['*'], 'agents controller')).not.toThrow()
+  })
+
+  it('allows non-wildcard namespaces without cluster RBAC', () => {
+    delete process.env.JANGAR_RBAC_CLUSTER_SCOPED
+    expect(() => assertClusterScopedForWildcard(['agents'], 'agents controller')).not.toThrow()
+  })
+})

--- a/services/jangar/src/server/agents-controller.ts
+++ b/services/jangar/src/server/agents-controller.ts
@@ -4,6 +4,7 @@ import { createHash, createPrivateKey, createSign } from 'node:crypto'
 import { createTemporalClient, loadTemporalConfig, temporalCallOptions } from '@proompteng/temporal-bun-sdk'
 
 import { startResourceWatch } from '~/server/kube-watch'
+import { assertClusterScopedForWildcard } from '~/server/namespace-scope'
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
 import { shouldApplyStatus } from '~/server/status-utils'
@@ -184,7 +185,9 @@ const parseNamespaces = () => {
     .split(',')
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
-  return list.length > 0 ? list : DEFAULT_NAMESPACES
+  const namespaces = list.length > 0 ? list : DEFAULT_NAMESPACES
+  assertClusterScopedForWildcard(namespaces, 'agents controller')
+  return namespaces
 }
 
 const resolveCrdCheckNamespace = () => {

--- a/services/jangar/src/server/implementation-source-webhooks.ts
+++ b/services/jangar/src/server/implementation-source-webhooks.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
 
+import { assertClusterScopedForWildcard } from '~/server/namespace-scope'
 import { asRecord, asString, errorResponse, okResponse, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
 import { shouldApplyStatus } from '~/server/status-utils'
@@ -49,7 +50,9 @@ const parseNamespaces = () => {
     .split(',')
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
-  return list.length > 0 ? list : DEFAULT_NAMESPACES
+  const namespaces = list.length > 0 ? list : DEFAULT_NAMESPACES
+  assertClusterScopedForWildcard(namespaces, 'implementation source webhooks')
+  return namespaces
 }
 
 const runKubectl = (args: string[]) =>

--- a/services/jangar/src/server/namespace-scope.ts
+++ b/services/jangar/src/server/namespace-scope.ts
@@ -1,0 +1,15 @@
+const parseBooleanEnv = (value: string | undefined, fallback: boolean) => {
+  if (value == null) return fallback
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'y'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'n'].includes(normalized)) return false
+  return fallback
+}
+
+const isClusterScoped = () => parseBooleanEnv(process.env.JANGAR_RBAC_CLUSTER_SCOPED, false)
+
+export const assertClusterScopedForWildcard = (namespaces: string[], label: string) => {
+  if (!namespaces.includes('*')) return
+  if (isClusterScoped()) return
+  throw new Error(`[jangar] ${label} namespaces '*' require rbac.clusterScoped=true`)
+}

--- a/services/jangar/src/server/orchestration-controller.ts
+++ b/services/jangar/src/server/orchestration-controller.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 
 import { startResourceWatch } from '~/server/kube-watch'
+import { assertClusterScopedForWildcard } from '~/server/namespace-scope'
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
 import { shouldApplyStatus } from '~/server/status-utils'
@@ -108,7 +109,9 @@ const parseNamespaces = () => {
     .split(',')
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
-  return list.length > 0 ? list : DEFAULT_NAMESPACES
+  const namespaces = list.length > 0 ? list : DEFAULT_NAMESPACES
+  assertClusterScopedForWildcard(namespaces, 'orchestration controller')
+  return namespaces
 }
 
 const resolveCrdCheckNamespace = () => {

--- a/services/jangar/src/server/primitives-reconciler.ts
+++ b/services/jangar/src/server/primitives-reconciler.ts
@@ -1,4 +1,5 @@
 import { startResourceWatch } from '~/server/kube-watch'
+import { assertClusterScopedForWildcard } from '~/server/namespace-scope'
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
 import { hydrateMemoryRecord } from '~/server/primitives-memory'
@@ -41,7 +42,9 @@ const parseNamespaces = () => {
     .split(',')
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
-  return list.length > 0 ? list : DEFAULT_NAMESPACES
+  const namespaces = list.length > 0 ? list : DEFAULT_NAMESPACES
+  assertClusterScopedForWildcard(namespaces, 'primitives reconciler')
+  return namespaces
 }
 
 const enqueueNamespaceTask = (namespace: string, task: () => Promise<void>) => {

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 
 import { startResourceWatch } from '~/server/kube-watch'
+import { assertClusterScopedForWildcard } from '~/server/namespace-scope'
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
 import { shouldApplyStatus } from '~/server/status-utils'
@@ -71,7 +72,9 @@ const parseNamespaces = () => {
     .split(',')
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
-  return list.length > 0 ? list : DEFAULT_NAMESPACES
+  const namespaces = list.length > 0 ? list : DEFAULT_NAMESPACES
+  assertClusterScopedForWildcard(namespaces, 'supporting controller')
+  return namespaces
 }
 
 const runKubectl = (args: string[]) =>


### PR DESCRIPTION
## Summary
- Added helm/chart guardrails and controller checks for wildcard namespaces, plus documentation and a new design doc for the namespaced vs cluster-scoped install matrix. Updated controller runtime behavior to fail fast when `*` is configured without cluster RBAC, and added a small Vitest covering the new guardrails. Changes are in `charts/agents/templates/validation.yaml`, `charts/agents/templates/deployment.yaml`, `charts/agents/values.schema.json`, `charts/agents/README.md`, `services/jangar/src/server/namespace-scope.ts`, `services/jangar/src/server/agents-controller.ts`, `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/supporting-primitives-controller.ts`, `services/jangar/src/server/primitives-reconciler.ts`, `services/jangar/src/server/implementation-source-webhooks.ts`, `services/jangar/src/server/__tests__/namespace-scope.test.ts`, `docs/agents/designs/design-05-namespaced-install-matrix.md`.

## Related Issues
- #9005

## Testing
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/namespace-scope.test.ts`
- `MISE_HTTP_TIMEOUT=120 mise exec helm@3 -- helm lint charts/agents` (failed: helm download timed out)
- `MISE_HTTP_TIMEOUT=180 mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents` (failed: helm download connection reset)

## Known Gaps
- None.
