### PR TITLE
feat(agents): add vcs auth adapters and deprecation warnings

### DIFF
--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -125,6 +125,46 @@ Define a VersionControlProvider resource to decouple repo access from issue inta
 agent runtimes that clone, commit, push, or open pull requests. Pair it with a SecretBinding that
 allows the provider's secret.
 
+Auth options (examples):
+```yaml
+# Token auth (recommended for most providers)
+auth:
+  method: token
+  token:
+    secretRef:
+      name: vcs-token
+      key: token
+    type: fine_grained
+
+# GitHub App auth (GitHub only)
+auth:
+  method: app
+  app:
+    appId: "12345"
+    installationId: "67890"
+    privateKeySecretRef:
+      name: github-app-key
+      key: privateKey
+    tokenTtlSeconds: 3600
+
+# SSH auth
+auth:
+  method: ssh
+  ssh:
+    privateKeySecretRef:
+      name: vcs-ssh-key
+      key: privateKey
+    knownHostsConfigMapRef:
+      name: vcs-known-hosts
+      key: known_hosts
+```
+
+Token scopes and expiry guidance:
+- GitHub App installation tokens expire after 1 hour; keep `auth.app.tokenTtlSeconds` <= 3600.
+- GitLab tokens need `read_repository` for read and `write_repository` for write access.
+- Bitbucket HTTPS tokens use the username `x-token-auth` when no username is specified.
+- GitHub classic PATs (`auth.token.type=pat`) are deprecated; prefer `fine_grained`.
+
 ## Example production values
 ```yaml
 image:

--- a/charts/agents/examples/versioncontrolprovider-github.yaml
+++ b/charts/agents/examples/versioncontrolprovider-github.yaml
@@ -13,6 +13,7 @@ spec:
       secretRef:
         name: codex-github-token
         key: token
+      type: fine_grained
   repositoryPolicy:
     allow:
       - proompteng/*

--- a/docs/agents/designs/design-07-multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/design-07-multi-provider-auth-deprecations.md
@@ -1,0 +1,29 @@
+# Multi-Provider Auth Standards and Deprecations
+
+Status: Draft (2026-02-04)
+
+## Problem
+Provider auth modes differ and deprecations cause silent failures.
+
+## Goals
+- Normalize auth fields across providers.
+- Detect deprecated auth types early.
+
+## Non-Goals
+- Implementing all provider features.
+
+## Design
+- Define provider-specific auth adapters.
+- Add warnings for deprecated token types.
+
+## Chart Changes
+- Expose auth options in values examples.
+- Document token scopes and expiry guidance.
+
+## Controller Changes
+- Validate auth config by provider.
+- Surface warnings in status conditions.
+
+## Acceptance Criteria
+- Provider misconfigurations are rejected with clear errors.
+- Deprecations emit warnings before failures.


### PR DESCRIPTION
## Summary

- add provider-specific VCS auth adapters with deprecated token warnings in controller status
- document multi-provider auth guidance and add design note + example token type
- cover new auth validation paths with controller tests

## Related Issues

None

## Testing

- bun run --filter @proompteng/jangar test -- src/server/__tests__/agents-controller.test.ts -t "reconcileVersionControlProvider" (fails: @proompteng/temporal-bun-sdk entry resolution error)
- mise exec helm@3 -- helm lint charts/agents
- mise exec helm@3 kustomize@5.6.0 -- kustomize build --enable-helm argocd/applications/agents

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
