### PR TITLE
feat(agents): warn on deprecated VCS auth

### DIFF
--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -144,6 +144,18 @@ Token scopes & expiry guidance:
 - GitLab tokens must include `read_repository` for read-only workflows and `write_repository` for pushes/merges.
 - Bitbucket access tokens should include repository read/write scopes matching your intended mode.
 - Gitea API tokens need repo access; set `spec.auth.username` if your HTTPS auth requires a specific account name.
+- If `spec.auth.token.type` is omitted, the controller applies the provider default (e.g., `fine_grained` for GitHub).
+- Deprecated token types surface Warning conditions on the provider and runs; configure overrides in values.
+
+Values example (deprecated token types):
+```yaml
+controller:
+  vcsProviders:
+    enabled: true
+    deprecatedTokenTypes:
+      github:
+        - pat
+```
 
 Example token auth (GitHub fine-grained PAT):
 ```yaml
@@ -201,6 +213,11 @@ database:
 controller:
   namespaces:
     - agents
+  vcsProviders:
+    enabled: true
+    deprecatedTokenTypes:
+      github:
+        - pat
 
 rbac:
   clusterScoped: false

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -299,7 +299,10 @@
             "enabled": { "type": "boolean" },
             "deprecatedTokenTypes": {
               "type": "object",
-              "additionalProperties": { "type": "array", "items": { "type": "string" } }
+              "additionalProperties": {
+                "type": "array",
+                "items": { "type": "string", "enum": ["pat", "fine_grained", "api_token", "access_token"] }
+              }
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
## Summary
- Updated VCS auth normalization and deprecation warnings in the controller, surfaced warnings on AgentRun conditions, and documented/validated deprecated token overrides in the chart docs/schema. Changes are in `services/jangar/src/server/agents-controller.ts` and `services/jangar/src/server/__tests__/agents-controller.test.ts` with docs/schema updates in `charts/agents/README.md` and `charts/agents/values.schema.json`.

## Related Issues
- #9107

## Testing
- Not run (not provided).

## Known Gaps
- None.
