### PR TITLE
docs(agents): document psa namespace labeling

### DIFF
--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -295,6 +295,12 @@ Enable reruns or system-improvement flows using:
 - Scope controllers to specific namespaces unless you need cluster-wide control.
 - Prefer image digests in production (`values-prod.yaml`).
 
+## Pod Security Admission
+Configure PSA labels via `podSecurityAdmission.labels` and enable them with `podSecurityAdmission.enabled=true`.
+Set `podSecurityAdmission.createNamespace=true` when the chart should create and label the namespace.
+For existing namespaces, keep `createNamespace=false` and apply the PSA labels out-of-band to avoid
+Helm ownership conflicts.
+
 ## Admission control
 - Configure backpressure with `controller.queue.*` and `controller.rate.*` in `values.yaml`.
 - Queue limits cap pending AgentRuns; rate limits cap submit throughput.

--- a/docs/agents/designs/design-22-pod-security-admission.md
+++ b/docs/agents/designs/design-22-pod-security-admission.md
@@ -1,0 +1,27 @@
+# Pod Security Admission Labels
+
+Status: Draft (2026-02-04)
+
+## Problem
+Namespaces need PSA labels for enforcement.
+
+## Goals
+- Allow optional PSA labels on the namespace.
+- Support opt-in enforcement.
+
+## Non-Goals
+- Managing PodSecurityPolicies.
+
+## Design
+- Add values for PSA labels and optional namespace creation.
+- Document compatibility with existing namespaces.
+
+## Chart Changes
+- Add namespace label template gated by values.
+
+## Controller Changes
+- None.
+
+## Acceptance Criteria
+- Namespace labels are applied when enabled.
+- No changes when disabled.


### PR DESCRIPTION
## Summary
- add PSA namespace labeling design doc
- document pod security admission labeling options in the agents chart README
- note compatibility guidance for existing namespaces

## Related Issues
None

## Testing
- `mise exec helm@3 -- helm lint charts/agents` (failed: helm v3 download timed out/reset)
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents` (failed: helm v3 download reset)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
