### PR TITLE
ci(agents): run integration on kind

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: scripts/agents/validate-agents.sh
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     needs: validate
     steps:
       - name: Check out repository
@@ -129,7 +129,7 @@ jobs:
         env:
           AGENTS_NAMESPACE: agents-ci
           AGENTS_RELEASE_NAME: agents-ci
-          AGENTS_VALUES_FILE: charts/agents/values-kind.yaml
+          AGENTS_VALUES_FILE: charts/agents/values-ci.yaml
           AGENTS_CREATE_NAMESPACE: "true"
           AGENTS_DB_BOOTSTRAP: "true"
           AGENTCTL_BIN: services/jangar/agentctl/dist/agentctl


### PR DESCRIPTION
## Summary
- run agents integration on a per-job kind cluster (arc-arm64)
- drop in-cluster kubeconfig setup and keep kind-based cleanup
- use values-ci.yaml so the runner can pull internal registry images

## Related Issues
None

## Testing
- Not run (workflow change only).

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.