### PR TITLE
fix(agents): expose grpc on tailscale service

### DIFF
--- a/argocd/applications/agents/tailscale-service.yaml
+++ b/argocd/applications/agents/tailscale-service.yaml
@@ -15,3 +15,6 @@ spec:
     - name: http
       port: 80
       targetPort: http
+    - name: grpc
+      port: 50051
+      targetPort: grpc


### PR DESCRIPTION
## Summary
- add gRPC port to agents tailscale service to expose agentctl traffic
- no chart logic changes; manifest-only update in Argo CD app
- keeps existing service behavior while adding an additional port

## Related Issues

None.

## Testing
- N/A (infra manifest change; no automated test coverage)

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
