### PR TITLE
refactor(codex): remove judge stage from cli

### DIFF
--- a/apps/froussard/src/codex/cli/lib/codex-runner.ts
+++ b/apps/froussard/src/codex/cli/lib/codex-runner.ts
@@ -10,7 +10,7 @@ export interface DiscordChannelOptions {
 }
 
 export interface RunCodexSessionOptions {
-  stage: 'planning' | 'implementation' | 'review' | 'research' | 'judge' | 'verify'
+  stage: 'planning' | 'implementation' | 'review' | 'research' | 'verify'
   prompt: string
   outputPath: string
   jsonOutputPath: string


### PR DESCRIPTION
## Summary
- remove judge-stage handling and artifacts from codex CLI implementation flow
- drop `judge` from the Codex CLI run-stage type
- delete unused judge-specific helpers now that the stage is gone

## Related Issues
None

## Testing
- Not run (not requested)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
