### PR TITLE
fix(jangar): enable stateful OpenWebUI chat mode

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -164,6 +164,8 @@ spec:
               value: "1"
             - name: CODEX_INTERNAL_ORIGINATOR_OVERRIDE
               value: codex
+            - name: JANGAR_STATEFUL_CHAT_MODE
+              value: "1"
             - name: JANGAR_REDIS_URL
               value: redis://jangar-openwebui-redis:6379/1
             - name: NATS_URL


### PR DESCRIPTION
## Summary

- Enables `JANGAR_STATEFUL_CHAT_MODE=1` in the `jangar` Deployment.
- Prevents OpenWebUI chats from repeatedly re-sending the full transcript into an already-stateful Codex thread (a common cause of frequent context compactions).

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
