### PR TITLE
fix(codex): migrate web_search config keys

### DIFF
--- a/argocd/applications/agents/codex-agentprovider.yaml
+++ b/argocd/applications/agents/codex-agentprovider.yaml
@@ -18,11 +18,10 @@ spec:
         preferred_auth_method = "apikey"
         approval_policy = "never"
         sandbox_mode = "danger-full-access"
+        web_search = "live"
 
         [features]
         undo = true
-        web_search_request = true
-        web_search_cached = true
         enable_request_compression = true
         apply_patch_freeform = true
         unified_exec = true
@@ -46,4 +45,3 @@ spec:
       path: /workspace/.agent/runner.log
     - name: runner-status
       path: /workspace/.agent/status.json
-

--- a/argocd/applications/workers/cloud-init-secret.yaml
+++ b/argocd/applications/workers/cloud-init-secret.yaml
@@ -45,11 +45,10 @@ stringData:
           approval_policy = "never"
           sandbox_mode = "danger-full-access"
           suppress_unstable_features_warning = true
+          web_search = "live"
 
           [features]
           undo = true
-          web_search_request = true
-          web_search_cached = true
           enable_request_compression = true
           apply_patch_freeform = true
           unified_exec = true
@@ -298,9 +297,9 @@ stringData:
           approval_policy = "never"
           sandbox_mode = "danger-full-access"
           suppress_unstable_features_warning = true
+          web_search = "live"
 
           [features]
-          web_search_request = true
           unified_exec = true
           streamable_shell = true
           apply_patch_freeform = true

--- a/charts/agents/examples/agentprovider-native-workflow.yaml
+++ b/charts/agents/examples/agentprovider-native-workflow.yaml
@@ -18,11 +18,10 @@ spec:
         approval_policy = "never"
         sandbox_mode = "danger-full-access"
         suppress_unstable_features_warning = true
+        web_search = "live"
 
         [features]
         undo = true
-        web_search_request = true
-        web_search_cached = true
         enable_request_compression = true
         apply_patch_freeform = true
         unified_exec = true

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -253,8 +253,7 @@ export class CodexAppServerClient {
     this.approval = normalizeApprovalPolicy(approval)
     this.defaultModel = defaultModel
     this.defaultEffort = defaultEffort
-    this.threadConfig =
-      threadConfig === undefined ? { mcp_servers: {}, 'features.web_search_request': true } : threadConfig
+    this.threadConfig = threadConfig === undefined ? { mcp_servers: {}, web_search: 'live' } : threadConfig
     this.experimentalRawEvents = experimentalRawEvents
     this.bootstrapTimeoutMs = bootstrapTimeoutMs
 

--- a/packages/codex/src/codex-exec.ts
+++ b/packages/codex/src/codex-exec.ts
@@ -82,7 +82,8 @@ export class CodexExec {
     }
 
     if (args.webSearchEnabled !== undefined) {
-      commandArgs.push('--config', `features.web_search_request=${args.webSearchEnabled}`)
+      // `features.web_search_request` is deprecated; `web_search` controls mode.
+      commandArgs.push('--config', `web_search="${args.webSearchEnabled ? 'live' : 'disabled'}"`)
     }
 
     if (args.approvalPolicy) {

--- a/packages/codex/src/runner.ts
+++ b/packages/codex/src/runner.ts
@@ -280,7 +280,8 @@ export class CodexRunner {
       commandArgs.push('--config', `sandbox_workspace_write.network_access=${networkAccessEnabled}`)
     }
     if (webSearchEnabled !== undefined) {
-      commandArgs.push('--config', `features.web_search_request=${webSearchEnabled}`)
+      // `features.web_search_request` is deprecated; `web_search` controls mode.
+      commandArgs.push('--config', `web_search="${webSearchEnabled ? 'live' : 'disabled'}"`)
     }
     if (approvalPolicy) {
       commandArgs.push('--config', `approval_policy="${approvalPolicy}"`)

--- a/scripts/codex-config-template.toml
+++ b/scripts/codex-config-template.toml
@@ -4,11 +4,10 @@ model_reasoning_effort = "medium"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 suppress_unstable_features_warning = true
+web_search = "live"
 
 [features]
 undo = true
-web_search_request = true
-web_search_cached = true
 enable_request_compression = true
 apply_patch_freeform = true
 unified_exec = true

--- a/services/jangar/scripts/codex-config-container.toml
+++ b/services/jangar/scripts/codex-config-container.toml
@@ -7,11 +7,10 @@ model_auto_compact_token_limit = 24000
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 suppress_unstable_features_warning = true
+web_search = "live"
 
 [features]
 undo = true
-web_search_request = true
-web_search_cached = true
 enable_request_compression = true
 apply_patch_freeform = true
 unified_exec = true

--- a/services/jangar/src/server/codex-client.ts
+++ b/services/jangar/src/server/codex-client.ts
@@ -16,7 +16,7 @@ const defaultFactory: Factory = (options) =>
     defaultModel: options?.defaultModel,
     threadConfig: {
       'features.rmcp_client': true,
-      'features.web_search_request': true,
+      web_search: 'live',
       mcp_servers: {
         memories: {
           url: resolveMcpUrl(),


### PR DESCRIPTION
## Summary

- Migrated Codex config from deprecated `[features].web_search_cached` / `[features].web_search_request` to `web_search = "live"`.
- Updated embedded TOML config blocks (Argo CD, Helm examples, scripts) to set `web_search = "live"`.
- Updated TS clients/runner overrides to use `web_search` instead of deprecated feature flags.

## Related Issues

None

## Testing

- `bunx biome check packages/codex/src/app-server-client.ts packages/codex/src/codex-exec.ts packages/codex/src/runner.ts services/jangar/src/server/codex-client.ts`
- `rg -n "\\[features\\]\\.web_search_cached|\\[features\\]\\.web_search_request|features\\.web_search_cached\\s*=|features\\.web_search_request\\s*=" -S .`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
