### PR TITLE
docs(agents): refresh design docs for current chart+gitops

### DIFF
--- a/docs/agents/designs/admission-control-policy.md
+++ b/docs/agents/designs/admission-control-policy.md
@@ -89,7 +89,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/admission-control-policy.md
+++ b/docs/agents/designs/admission-control-policy.md
@@ -1,6 +1,6 @@
 # Admission Control Policy for AgentRuns
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Reject unsafe or invalid AgentRuns before runtime submission by enforcing controller-level policies.
@@ -65,3 +65,75 @@ Reject unsafe or invalid AgentRuns before runtime submission by enforcing contro
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/agentctl-cli-resilience.md
+++ b/docs/agents/designs/agentctl-cli-resilience.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/agentctl-cli-resilience.md
+++ b/docs/agents/designs/agentctl-cli-resilience.md
@@ -1,6 +1,6 @@
 # agentctl CLI Resilience
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ CLI failures reduce operator trust and automation reliability.
 
 - CLI failures include actionable guidance.
 - Diagnose output includes controller health.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/api-pagination-and-watch.md
+++ b/docs/agents/designs/api-pagination-and-watch.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/api-pagination-and-watch.md
+++ b/docs/agents/designs/api-pagination-and-watch.md
@@ -1,6 +1,6 @@
 # API Pagination and Watch Behavior
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Large lists can overload the API and clients.
 
 - Large lists return paginated results.
 - Watch streams deliver incremental updates.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/approval-policy-gates.md
+++ b/docs/agents/designs/approval-policy-gates.md
@@ -1,6 +1,6 @@
 # Approval Policy Gates
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ High-risk runs should require approval before execution.
 
 - Runs pause on approval gates.
 - Approval resumes execution.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/approval-policy-gates.md
+++ b/docs/agents/designs/approval-policy-gates.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/artifact-storage-s3.md
+++ b/docs/agents/designs/artifact-storage-s3.md
@@ -1,6 +1,6 @@
 # Artifact Storage Integration
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Artifacts need durable storage at scale.
 
 - Artifacts persist outside the cluster.
 - Credentials are secret-based.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/artifact-storage-s3.md
+++ b/docs/agents/designs/artifact-storage-s3.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/artifacthub-oci-distribution.md
+++ b/docs/agents/designs/artifacthub-oci-distribution.md
@@ -1,6 +1,6 @@
 # Artifact Hub OCI Distribution
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Define how the Agents Helm chart is packaged, published as an OCI artifact, and surfaced on Artifact Hub.
@@ -64,3 +64,75 @@ Define how the Agents Helm chart is packaged, published as an OCI artifact, and 
 
 - Exercise the primary flow and confirm expected status, logs, or metrics.
 - Confirm no regression in existing workflows, CI checks, or chart rendering.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/artifacthub-oci-distribution.md
+++ b/docs/agents/designs/artifacthub-oci-distribution.md
@@ -88,7 +88,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/audit-logging.md
+++ b/docs/agents/designs/audit-logging.md
@@ -1,6 +1,6 @@
 # Audit Logging for Autonomous Actions
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ High scale PR automation needs traceable audit logs.
 
 - Audit logs include agentRun uid and repo.
 - Audit sink can be enabled by values.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/audit-logging.md
+++ b/docs/agents/designs/audit-logging.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -1,6 +1,6 @@
 # Branch Naming and Conflict Strategy
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Provide deterministic branch naming for automated PRs and avoid conflicts when multiple runs target the same repo.
@@ -53,3 +53,75 @@ defaults:
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -77,7 +77,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/budget-enforcement.md
+++ b/docs/agents/designs/budget-enforcement.md
@@ -1,6 +1,6 @@
 # Budget Enforcement
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Runs can exceed token or cost budgets without enforcement.
 
 - Budget violations block submission.
 - Status shows budget failure reason.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/budget-enforcement.md
+++ b/docs/agents/designs/budget-enforcement.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/cluster-cost-optimization.md
+++ b/docs/agents/designs/cluster-cost-optimization.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/cluster-cost-optimization.md
+++ b/docs/agents/designs/cluster-cost-optimization.md
@@ -1,6 +1,6 @@
 # Cluster Cost Optimization
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ High throughput can lead to wasted compute costs.
 
 - Operators can select sizing profiles.
 - Cost guidance is documented.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/control-plane-ui-filters.md
+++ b/docs/agents/designs/control-plane-ui-filters.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/control-plane-ui-filters.md
+++ b/docs/agents/designs/control-plane-ui-filters.md
@@ -1,6 +1,6 @@
 # Control Plane UI Filters
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Operators cannot easily filter high-volume runs.
 
 - UI filters affect list results immediately.
 - No polling introduced.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/controller-concurrency-tuning.md
+++ b/docs/agents/designs/controller-concurrency-tuning.md
@@ -1,6 +1,6 @@
 # Controller Concurrency Tuning
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -59,3 +59,75 @@ Default concurrency limits may not fit large clusters.
 
 - Operators can tune concurrency safely.
 - Metrics indicate saturation.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/controller-concurrency-tuning.md
+++ b/docs/agents/designs/controller-concurrency-tuning.md
@@ -83,7 +83,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/crd-lifecycle-upgrades.md
+++ b/docs/agents/designs/crd-lifecycle-upgrades.md
@@ -1,6 +1,6 @@
 # CRD Lifecycle Upgrades
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Define the lifecycle and upgrade flow for Agents CRDs, including generation, validation, packaging, rollout,
@@ -97,3 +97,75 @@ production-ready checklist.
 
 - When to introduce a formal `v1beta1` timeline and conversion webhook strategy.
 - Whether to add automated compatibility checks against previous CRD versions in CI.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/crd-lifecycle-upgrades.md
+++ b/docs/agents/designs/crd-lifecycle-upgrades.md
@@ -121,7 +121,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -148,3 +148,75 @@ argo submit \
 - Custom runtime uses `spec.runtime.config.payload` (if set) else `{agentRun, implementation, memory}`. It does not receive the resolved system prompt (after applying Agent defaults or reading refs) unless you include it explicitly.
 - No per-workflow-step system prompt overrides; workflow steps all share the resolved prompt.
 - `systemPrompt` is not injected into any additional contract metadata beyond the event payload and `systemPromptHash` status field.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -172,7 +172,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/data-migration-runbooks.md
+++ b/docs/agents/designs/data-migration-runbooks.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/data-migration-runbooks.md
+++ b/docs/agents/designs/data-migration-runbooks.md
@@ -1,6 +1,6 @@
 # Data Migration Runbooks
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Upgrades require clear migration instructions.
 
 - Runbooks exist for each breaking change.
 - Operators can roll back safely.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/disaster-recovery-backups.md
+++ b/docs/agents/designs/disaster-recovery-backups.md
@@ -1,6 +1,6 @@
 # Disaster Recovery and Backups
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ State loss can halt autonomous operations.
 
 - Backup and restore steps are documented.
 - Recovery tests are defined.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/disaster-recovery-backups.md
+++ b/docs/agents/designs/disaster-recovery-backups.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/github-app-auth-rotation.md
+++ b/docs/agents/designs/github-app-auth-rotation.md
@@ -86,7 +86,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/github-app-auth-rotation.md
+++ b/docs/agents/designs/github-app-auth-rotation.md
@@ -1,6 +1,6 @@
 # GitHub App Auth and Token Rotation
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Support GitHub App installation tokens for VCS operations, including safe rotation and caching.
@@ -62,3 +62,75 @@ Support GitHub App installation tokens for VCS operations, including safe rotati
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -1,6 +1,6 @@
 # GitOps and Argo CD Hooks
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -59,3 +59,75 @@ GitOps deployments need deterministic pre/post-sync behavior.
 
 - Hooks run successfully when enabled.
 - No hooks are created when disabled.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -83,7 +83,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/grpc-coverage-parity.md
+++ b/docs/agents/designs/grpc-coverage-parity.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/grpc-coverage-parity.md
+++ b/docs/agents/designs/grpc-coverage-parity.md
@@ -1,6 +1,6 @@
 # gRPC Coverage Parity for agentctl
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ gRPC endpoints lag behind REST and CLI features.
 
 - agentctl supports list/filter parity via gRPC.
 - gRPC schema matches REST capabilities.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/implementation-contract-enforcement.md
+++ b/docs/agents/designs/implementation-contract-enforcement.md
@@ -1,6 +1,6 @@
 # Implementation Contract Enforcement
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -59,3 +59,75 @@ Runs can fail if required metadata is missing.
 
 - Runs fail fast with clear missing keys.
 - Valid runs proceed.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/implementation-contract-enforcement.md
+++ b/docs/agents/designs/implementation-contract-enforcement.md
@@ -83,7 +83,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/integration-test-harness.md
+++ b/docs/agents/designs/integration-test-harness.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/integration-test-harness.md
+++ b/docs/agents/designs/integration-test-harness.md
@@ -1,6 +1,6 @@
 # Integration Test Harness
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ High-scale changes need reliable integration testing.
 
 - CI runs reproducible integration tests.
 - Failures provide actionable logs.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/job-gc-visibility.md
+++ b/docs/agents/designs/job-gc-visibility.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/job-gc-visibility.md
+++ b/docs/agents/designs/job-gc-visibility.md
@@ -1,6 +1,6 @@
 # Job GC Visibility and Retention
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Jobs may be deleted before status is collected, causing WorkflowJobMissing.
 
 - WorkflowJobMissing is rare and observable.
 - Operators can adjust TTL safely.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/leader-election-ha.md
+++ b/docs/agents/designs/leader-election-ha.md
@@ -1,6 +1,6 @@
 # Leader Election for HA (Jangar Controllers)
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Purpose
 Define how Jangar controllers use Kubernetes leader election to support safe horizontal scaling, prevent double
@@ -95,3 +95,75 @@ Map values into env vars consumed by the controller runtime, for example:
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/leader-election-ha.md
+++ b/docs/agents/designs/leader-election-ha.md
@@ -119,7 +119,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/load-testing-benchmarking.md
+++ b/docs/agents/designs/load-testing-benchmarking.md
@@ -1,6 +1,6 @@
 # Load Testing and Benchmarking
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -57,3 +57,75 @@ No standardized benchmark for 100-person throughput.
 
 - Load test outputs standard metrics.
 - Baseline numbers documented.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/load-testing-benchmarking.md
+++ b/docs/agents/designs/load-testing-benchmarking.md
@@ -81,7 +81,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/log-retention-shipper.md
+++ b/docs/agents/designs/log-retention-shipper.md
@@ -1,6 +1,6 @@
 # Log Retention and Shipping
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -57,3 +57,75 @@ Job logs are ephemeral and hard to retrieve after completion.
 
 - Logs are retrievable after job completion.
 - Retention policy is enforced.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/log-retention-shipper.md
+++ b/docs/agents/designs/log-retention-shipper.md
@@ -81,7 +81,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/metrics-otel-tracing.md
+++ b/docs/agents/designs/metrics-otel-tracing.md
@@ -1,6 +1,6 @@
 # Metrics and OpenTelemetry Tracing
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Without tracing, it is hard to debug end-to-end latency.
 
 - Traces span submission to job completion.
 - Metrics include runtime labels.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/metrics-otel-tracing.md
+++ b/docs/agents/designs/metrics-otel-tracing.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/multi-namespace-controller-guards.md
+++ b/docs/agents/designs/multi-namespace-controller-guards.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/multi-namespace-controller-guards.md
+++ b/docs/agents/designs/multi-namespace-controller-guards.md
@@ -1,6 +1,6 @@
 # Multi-Namespace Controller Guardrails
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Misconfigured namespaces can lead to missed resources or RBAC errors.
 
 - Misconfigurations are reported before reconcile.
 - Controllers start only with valid scopes.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/multi-provider-auth-deprecations.md
@@ -89,7 +89,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/multi-provider-auth-deprecations.md
@@ -1,6 +1,6 @@
 # Multi-Provider Auth Standards and Deprecations
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Normalize auth configuration across VCS providers and surface deprecated token types before they break.
@@ -65,3 +65,75 @@ Normalize auth configuration across VCS providers and surface deprecated token t
 
 - Misconfigured auth is rejected with clear `InvalidSpec` conditions.
 - Deprecated token types emit warnings without blocking runs.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/namespaced-install-matrix.md
+++ b/docs/agents/designs/namespaced-install-matrix.md
@@ -72,7 +72,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/namespaced-install-matrix.md
+++ b/docs/agents/designs/namespaced-install-matrix.md
@@ -1,6 +1,6 @@
 # Namespaced vs Cluster-Scoped Install Matrix
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Define the supported install modes and their RBAC implications for the Agents control plane.
@@ -48,3 +48,75 @@ Define the supported install modes and their RBAC implications for the Agents co
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/network-policy-egress.md
+++ b/docs/agents/designs/network-policy-egress.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/network-policy-egress.md
+++ b/docs/agents/designs/network-policy-egress.md
@@ -1,6 +1,6 @@
 # Network Policy Egress Control
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Autonomous agents require explicit egress controls for security.
 
 - NetworkPolicy renders correctly when enabled.
 - No policy created when disabled.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/observability-pack.md
+++ b/docs/agents/designs/observability-pack.md
@@ -83,7 +83,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/observability-pack.md
+++ b/docs/agents/designs/observability-pack.md
@@ -1,6 +1,6 @@
 # Observability Pack
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -59,3 +59,75 @@ Operators need metrics, logs, and dashboards to run at scale.
 
 - Prometheus can scrape metrics with minimal config.
 - Dashboards load with standard labels.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/pod-security-admission.md
+++ b/docs/agents/designs/pod-security-admission.md
@@ -1,6 +1,6 @@
 # Pod Security Admission Labels
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Allow optional Pod Security Admission (PSA) labels to be applied to the agents namespace during installation.
@@ -49,3 +49,75 @@ podSecurityAdmission:
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/pod-security-admission.md
+++ b/docs/agents/designs/pod-security-admission.md
@@ -73,7 +73,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/pr-rate-limits-batching.md
+++ b/docs/agents/designs/pr-rate-limits-batching.md
@@ -1,6 +1,6 @@
 # PR Rate Limits and Batching
 
-Status: Partial (2026-02-05)
+Status: Partial (2026-02-06)
 
 ## Purpose
 Respect VCS provider rate limits by throttling automated PR creation.
@@ -53,3 +53,75 @@ Respect VCS provider rate limits by throttling automated PR creation.
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/pr-rate-limits-batching.md
+++ b/docs/agents/designs/pr-rate-limits-batching.md
@@ -77,7 +77,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/queue-fairness-per-repo.md
+++ b/docs/agents/designs/queue-fairness-per-repo.md
@@ -87,7 +87,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/queue-fairness-per-repo.md
+++ b/docs/agents/designs/queue-fairness-per-repo.md
@@ -1,6 +1,6 @@
 # Queue Fairness per Repository
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -63,3 +63,75 @@ High-volume repos can starve smaller repos of capacity.
 
 - No single repo can exceed configured concurrency.
 - Other repos continue processing.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/repo-allow-deny-policy.md
+++ b/docs/agents/designs/repo-allow-deny-policy.md
@@ -1,6 +1,6 @@
 # Repository Allow and Deny Policy
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Constrain repository access for VCS operations using allow and deny lists on VersionControlProvider resources.
@@ -48,3 +48,75 @@ repositoryPolicy:
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/repo-allow-deny-policy.md
+++ b/docs/agents/designs/repo-allow-deny-policy.md
@@ -72,7 +72,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/resourcequota-limitrange.md
+++ b/docs/agents/designs/resourcequota-limitrange.md
@@ -1,6 +1,6 @@
 # ResourceQuota and LimitRange Integration
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -57,3 +57,75 @@ Clusters need quota enforcement for AgentRuns.
 
 - Resources render with correct values when enabled.
 - Disabled by default.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/resourcequota-limitrange.md
+++ b/docs/agents/designs/resourcequota-limitrange.md
@@ -81,7 +81,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -79,7 +79,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -1,6 +1,6 @@
 # Runner Image Defaults and Job TTL
 
-Status: Partial (2026-02-05)
+Status: Partial (2026-02-06)
 
 ## Purpose
 Provide reliable default runner images and safe Job TTLs so AgentRuns do not fail due to missing images or premature
@@ -55,3 +55,75 @@ cleanup.
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/schedule-cronjob-reliability.md
+++ b/docs/agents/designs/schedule-cronjob-reliability.md
@@ -1,6 +1,6 @@
 # Schedule and CronJob Reliability
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Schedule CRDs require reliable CronJob creation and cleanup.
 
 - CronJobs are created and updated from Schedule.
 - CronJobs are deleted when Schedule is removed.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/schedule-cronjob-reliability.md
+++ b/docs/agents/designs/schedule-cronjob-reliability.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/scheduler-affinity-priority.md
+++ b/docs/agents/designs/scheduler-affinity-priority.md
@@ -73,7 +73,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/scheduler-affinity-priority.md
+++ b/docs/agents/designs/scheduler-affinity-priority.md
@@ -1,6 +1,6 @@
 # Scheduler Affinity and Priority Defaults
 
-Status: Current (2026-02-05)
+Status: Current (2026-02-06)
 
 ## Purpose
 Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run overrides.
@@ -49,3 +49,75 @@ Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run 
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/secretbinding-guardrails.md
+++ b/docs/agents/designs/secretbinding-guardrails.md
@@ -1,6 +1,6 @@
 # SecretBinding Guardrails
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Runs can mount secrets without clear governance.
 
 - Unauthorized secrets are rejected.
 - Authorized secrets are allowed.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/secretbinding-guardrails.md
+++ b/docs/agents/designs/secretbinding-guardrails.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/security-sbom-signing.md
+++ b/docs/agents/designs/security-sbom-signing.md
@@ -1,6 +1,6 @@
 # Security: SBOM and Signing
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Supply chain integrity is required for production adoption.
 
 - SBOM artifacts are published per release.
 - Signatures are verified in CI.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/security-sbom-signing.md
+++ b/docs/agents/designs/security-sbom-signing.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/signal-delivery-retries.md
+++ b/docs/agents/designs/signal-delivery-retries.md
@@ -1,6 +1,6 @@
 # Signal Delivery Retries
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -57,3 +57,75 @@ SignalDelivery failures can leave workflows stuck.
 
 - Failed deliveries retry and eventually succeed or fail terminally.
 - Status includes attempt metadata.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/signal-delivery-retries.md
+++ b/docs/agents/designs/signal-delivery-retries.md
@@ -81,7 +81,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/staging-prod-values-overlays.md
+++ b/docs/agents/designs/staging-prod-values-overlays.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/staging-prod-values-overlays.md
+++ b/docs/agents/designs/staging-prod-values-overlays.md
@@ -1,6 +1,6 @@
 # Staging and Production Values Overlays
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Operators need consistent overlays for staging and prod.
 
 - Environment overlays render without warnings.
 - Docs include guidance for overrides.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/supply-chain-attestations.md
+++ b/docs/agents/designs/supply-chain-attestations.md
@@ -1,6 +1,6 @@
 # Supply Chain Attestations
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -57,3 +57,75 @@ Regulated environments require provenance attestations.
 
 - Attestations published for each release.
 - Documentation covers verification.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/supply-chain-attestations.md
+++ b/docs/agents/designs/supply-chain-attestations.md
@@ -81,7 +81,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/throughput-backpressure-quotas.md
+++ b/docs/agents/designs/throughput-backpressure-quotas.md
@@ -1,6 +1,6 @@
 # Throughput Backpressure and Admission Control
 
-Status: Partial (2026-02-05)
+Status: Partial (2026-02-06)
 
 ## Purpose
 Prevent high-volume AgentRuns from overwhelming the controller or the cluster by enforcing concurrency, queue, and
@@ -75,3 +75,75 @@ These should map to:
 
 - Misconfiguration can cause deployment or runtime regressions; mitigate with schema validation and safe defaults.
 - Additional load or latency can impact controller throughput or CI runtime; mitigate with caps and monitoring.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/throughput-backpressure-quotas.md
+++ b/docs/agents/designs/throughput-backpressure-quotas.md
@@ -99,7 +99,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/toolrun-runtime-isolation.md
+++ b/docs/agents/designs/toolrun-runtime-isolation.md
@@ -1,6 +1,6 @@
 # ToolRun Runtime Isolation
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -57,3 +57,75 @@ Tool runs need consistent isolation and resource limits.
 
 - ToolRun jobs honor resource limits.
 - Dedicated service accounts are supported.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/toolrun-runtime-isolation.md
+++ b/docs/agents/designs/toolrun-runtime-isolation.md
@@ -81,7 +81,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/topology-spread-defaults.md
+++ b/docs/agents/designs/topology-spread-defaults.md
@@ -83,7 +83,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/topology-spread-defaults.md
+++ b/docs/agents/designs/topology-spread-defaults.md
@@ -1,6 +1,6 @@
 # Topology Spread Defaults
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -59,3 +59,75 @@ Workloads can stack on a single node without spread rules.
 
 - Jobs spread across nodes when configured.
 - Invalid JSON is ignored with warnings.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/values-schema-readme-automation.md
+++ b/docs/agents/designs/values-schema-readme-automation.md
@@ -1,6 +1,6 @@
 # Values Schema and README Automation
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Purpose
 Keep `charts/agents/README.md` and `charts/agents/values.schema.json` in lock-step with
@@ -62,3 +62,75 @@ Some constraints cannot be inferred from YAML alone. Encode them via inline comm
 - Running the generator script updates README and `values.schema.json` deterministically.
 - CI fails when README/schema drift from `values.yaml`.
 - Contributors have a single documented command to refresh outputs.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/values-schema-readme-automation.md
+++ b/docs/agents/designs/values-schema-readme-automation.md
@@ -86,7 +86,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/webhook-ingestion-scaling.md
+++ b/docs/agents/designs/webhook-ingestion-scaling.md
@@ -1,6 +1,6 @@
 # Webhook Ingestion Scaling
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -59,3 +59,75 @@ Webhook bursts can overload reconciliation.
 
 - Webhook bursts do not drop events.
 - Backoff does not block other reconciliation.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/webhook-ingestion-scaling.md
+++ b/docs/agents/designs/webhook-ingestion-scaling.md
@@ -83,7 +83,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/workflow-step-timeouts.md
+++ b/docs/agents/designs/workflow-step-timeouts.md
@@ -82,7 +82,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/workflow-step-timeouts.md
+++ b/docs/agents/designs/workflow-step-timeouts.md
@@ -1,6 +1,6 @@
 # Workflow Step Timeouts and Retries
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -58,3 +58,75 @@ Long-running steps can block workflows without clear timeout handling.
 
 - Steps time out deterministically.
 - Retries respect backoff settings.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+

--- a/docs/agents/designs/workspace-pvc-lifecycle.md
+++ b/docs/agents/designs/workspace-pvc-lifecycle.md
@@ -81,7 +81,7 @@ As of 2026-02-06 (repo `main`):
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 
-Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
 
 ```bash
 kubectl get application -n argocd agents

--- a/docs/agents/designs/workspace-pvc-lifecycle.md
+++ b/docs/agents/designs/workspace-pvc-lifecycle.md
@@ -1,6 +1,6 @@
 # Workspace PVC Lifecycle
 
-Status: Draft (2026-02-05)
+Status: Draft (2026-02-06)
 
 ## Current State
 
@@ -57,3 +57,75 @@ Workspaces can leak storage without cleanup policies.
 
 - PVCs created for workspace resources.
 - PVCs deleted after workspace cleanup.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+
+Note: this workspace does not ship a kubeconfig; treat the above as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+


### PR DESCRIPTION
## Summary

- Refresh all `docs/agents/designs/*.md` to reflect the current `charts/agents` values/env wiring and GitOps-declared cluster state.
- Add a consistent handoff appendix to every design doc (repo pointers, values→env mapping, rollout plan, validation commands).
- Bump doc status timestamps to 2026-02-06 for traceability.

## Related Issues

None

## Testing

- N/A (documentation-only change).

## Breaking Changes

None
