### PR TITLE
docs(agents): generate 50 new design docs

### DIFF
--- a/docs/agents/designs/chart-canary-argo-rollouts.md
+++ b/docs/agents/designs/chart-canary-argo-rollouts.md
@@ -1,0 +1,70 @@
+# Chart Canary with Argo Rollouts (Optional Integration)
+
+Status: Draft (2026-02-06)
+
+## Overview
+Today the Agents chart uses Kubernetes Deployments. For safer production changes (especially to controllers), operators may want progressive delivery. This doc proposes a chart-compatible integration path with Argo Rollouts without making it a hard dependency.
+
+## Goals
+- Provide a supported canary rollout pattern for `agents` and `agents-controllers`.
+- Keep default behavior as plain Deployments.
+
+## Non-Goals
+- Replacing Argo CD as the GitOps orchestrator.
+- Adding bespoke rollout tooling.
+
+## Current State
+- Chart renders `kind: Deployment` only:
+  - `charts/agents/templates/deployment.yaml`
+  - `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state for install lives in:
+  - `argocd/applications/agents/application.yaml`
+  - `argocd/applications/agents/kustomization.yaml`
+
+## Design
+### Proposed values
+Add:
+- `progressiveDelivery.enabled` (default `false`)
+- `progressiveDelivery.provider: argo-rollouts`
+- `progressiveDelivery.canarySteps` (list)
+
+When enabled:
+- Render `kind: Rollout` (Argo Rollouts CRD) instead of `Deployment`.
+- Keep Services/selectors stable.
+
+### Safety defaults
+- Default to 1-step canary with manual pause.
+- Keep max surge/unavailable conservative.
+
+## Config Mapping
+| Helm value | Rendered object | Intended behavior |
+|---|---|---|
+| `progressiveDelivery.enabled=false` | `Deployment` | Current behavior. |
+| `progressiveDelivery.enabled=true` | `Rollout` | Progressive delivery driven by Argo Rollouts controller. |
+
+## Rollout Plan
+1. Add chart support behind `progressiveDelivery.enabled=false`.
+2. Install Argo Rollouts in a non-prod cluster; enable for controllers only.
+3. After stable, enable for control plane if desired.
+
+Rollback:
+- Disable `progressiveDelivery.enabled` to fall back to Deployments (requires careful migration; document as “one-time switch”).
+
+## Validation
+```bash
+helm template agents charts/agents --set progressiveDelivery.enabled=true | rg -n \"kind: Rollout\"
+kubectl get crd | rg \"rollouts\\.argoproj\\.io\"
+kubectl -n agents get rollout
+```
+
+## Failure Modes and Mitigations
+- Rollouts CRD not installed: mitigate by render-time validation when feature enabled.
+- Switching kinds breaks `kubectl rollout` workflows: mitigate by documenting operational differences and migration steps.
+
+## Acceptance Criteria
+- Enabling the flag renders valid manifests and does not break the default install path.
+- Controllers can be canaried progressively without changing Services.
+
+## References
+- Argo Rollouts documentation: https://argo-rollouts.readthedocs.io/
+

--- a/docs/agents/designs/chart-config-checksum-rollouts.md
+++ b/docs/agents/designs/chart-config-checksum-rollouts.md
@@ -1,0 +1,68 @@
+# Chart Config Checksum Rollouts
+
+Status: Draft (2026-02-06)
+
+## Overview
+Kubernetes does not automatically restart pods when referenced Secrets/ConfigMaps change (especially when referenced via env vars). In GitOps environments, this frequently leads to “updated Secret, pods still using old value” incidents.
+
+This doc proposes checksum annotations to trigger Deployment rollouts when selected config inputs change.
+
+## Goals
+- Provide an opt-in mechanism to restart control plane/controllers when key Secrets/ConfigMaps change.
+- Make the behavior explicit and easy to validate in Helm renders.
+
+## Non-Goals
+- Automatically restarting on all Secrets/ConfigMaps in the namespace.
+
+## Current State
+- Chart references:
+  - DB URL Secret: `charts/agents/templates/deployment.yaml` and `deployment-controllers.yaml`
+  - `envFromSecretRefs` / `envFromConfigMapRefs`: same templates
+- No checksum annotations exist in pod templates.
+
+## Design
+### Proposed values
+Add:
+- `rolloutChecksums.enabled` (default `false`)
+- `rolloutChecksums.secrets: []`
+- `rolloutChecksums.configMaps: []`
+
+When enabled, annotate pod templates with:
+- `checksum/secret/<name>: <sha256>`
+- `checksum/configmap/<name>: <sha256>`
+
+### Implementation detail
+- Hash the rendered Secret/ConfigMap data when defined in-chart, and the name only (or `lookup`) when managed externally.
+  - In GitOps, `lookup` behavior varies; prefer explicit operator-provided checksums when needed.
+
+## Config Mapping
+| Helm value | Rendered annotation | Intended behavior |
+|---|---|---|
+| `rolloutChecksums.enabled=true` | `checksum/*` annotations | Any change triggers a Deployment rollout. |
+| `rolloutChecksums.secrets=[\"agents-github-token-env\"]` | `checksum/secret/agents-github-token-env` | Restart when the referenced Secret changes. |
+
+## Rollout Plan
+1. Add feature behind `rolloutChecksums.enabled=false`.
+2. Enable in non-prod with one Secret (e.g. GitHub token) to validate.
+3. Enable in prod after validating rollout behavior and avoiding excessive restarts.
+
+Rollback:
+- Disable the flag; annotation removal stops checksum-triggered rollouts.
+
+## Validation
+```bash
+helm template agents charts/agents | rg -n \"checksum/\"
+kubectl -n agents get deploy agents -o jsonpath='{.spec.template.metadata.annotations}'; echo
+```
+
+## Failure Modes and Mitigations
+- Too many checksum sources cause frequent rollouts: mitigate with explicit allowlist and opt-in.
+- Checksum cannot be computed for external Secrets: mitigate by allowing user-provided checksum values.
+
+## Acceptance Criteria
+- Enabling the feature causes a deterministic rollout on config changes.
+- Operators can scope restarts to a small list of critical Secrets/ConfigMaps.
+
+## References
+- Kubernetes ConfigMaps/Secrets update behavior: https://kubernetes.io/docs/concepts/configuration/configmap/
+

--- a/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
+++ b/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
@@ -1,0 +1,66 @@
+# Chart Controller Namespaces: Empty Semantics
+
+Status: Draft (2026-02-06)
+
+## Overview
+Controllers reconcile CRDs in a set of namespaces. The chart exposes `controller.namespaces`, but it is not documented what an empty list means (disabled? all namespaces? release namespace only?). Ambiguity here creates production risk.
+
+## Goals
+- Define an explicit meaning for `controller.namespaces: []`.
+- Prevent accidental cluster-wide reconciliation in namespaced installs.
+- Make namespace scope observable and testable.
+
+## Non-Goals
+- Redesigning multi-namespace support (covered separately).
+
+## Current State
+- Values: `charts/agents/values.yaml` exposes `controller.namespaces: []`.
+- Template renders namespaces into env vars:
+  - `JANGAR_AGENTS_CONTROLLER_NAMESPACES`: `charts/agents/templates/deployment-controllers.yaml`
+  - helper: `charts/agents/templates/_helpers.tpl` (`agents.controllerNamespaces`)
+- Runtime parsing:
+  - `services/jangar/src/server/implementation-source-webhooks.ts` reads `process.env.JANGAR_AGENTS_CONTROLLER_NAMESPACES`.
+  - Controllers use namespace scoping utilities in `services/jangar/src/server/namespace-scope.ts`.
+- Cluster desired state sets `controller.namespaces: [agents]` in `argocd/applications/agents/values.yaml`.
+
+## Design
+### Semantics
+- `controller.namespaces` MUST be required when `rbac.clusterScoped=false`.
+- Empty list MUST mean “no namespaces configured” and controllers SHOULD refuse to start (fail-fast) to avoid a false sense of safety.
+- For `rbac.clusterScoped=true`, introduce an explicit value:
+  - `controller.namespaces: [\"*\"]` to mean “all namespaces”, rather than interpreting empty as all.
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controller.namespaces: [\"agents\"]` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=[\"agents\"]` | Reconcile only `agents` namespace resources. |
+| `controller.namespaces: []` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=[]` (or unset) | Fail-fast at startup unless clusterScoped=true and explicit wildcard used. |
+| `controller.namespaces: [\"*\"]` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=[\"*\"]` | (When clusterScoped=true) reconcile all namespaces. |
+
+## Rollout Plan
+1. Document semantics and recommend non-empty namespaces for prod.
+2. Add controller startup validation in `services/jangar/src/server/*`:
+   - If env var is empty/unset: exit with clear error.
+3. Add chart schema rule: when `controller.enabled=true`, require at least one namespace unless clusterScoped=true and wildcard is used.
+
+Rollback:
+- Disable fail-fast validation (code rollback).
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_AGENTS_CONTROLLER_NAMESPACES\"
+kubectl -n agents logs deploy/agents-controllers | rg -n \"NAMESPACES|namespace\"
+```
+
+## Failure Modes and Mitigations
+- Empty list interpreted as “all namespaces” unexpectedly: mitigate by banning that interpretation.
+- Controllers start but do nothing due to empty scope: mitigate with fail-fast.
+- Wildcard scope used with namespaced RBAC: mitigate by schema validation and startup checks.
+
+## Acceptance Criteria
+- Empty namespaces configuration is rejected with a clear, actionable error.
+- Wildcard all-namespaces requires explicit `\"*\"` and cluster-scoped RBAC.
+
+## References
+- Kubernetes controller patterns (namespace scoping best practices): https://kubernetes.io/docs/concepts/architecture/controller/
+

--- a/docs/agents/designs/chart-controllers-hpa.md
+++ b/docs/agents/designs/chart-controllers-hpa.md
@@ -1,0 +1,61 @@
+# Chart Controllers HorizontalPodAutoscaler
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart’s HPA template targets only the control plane Deployment (`agents`). Controllers are deployed as a separate Deployment (`agents-controllers`) but do not have autoscaling support. Controllers workload is often bursty (reconcile storms, webhook bursts), and lack of scaling can cause backlog and delayed reconciliation.
+
+## Goals
+- Add optional HPA support for `agents-controllers`.
+- Keep existing `autoscaling.*` behavior unchanged for the control plane.
+
+## Non-Goals
+- Implementing custom metrics autoscaling in this phase.
+
+## Current State
+- Existing HPA template: `charts/agents/templates/hpa.yaml`
+  - Targets `Deployment/{{ include "agents.fullname" . }}` only.
+- Values: `charts/agents/values.yaml` exposes a single `autoscaling.*`.
+- Controllers deployment: `charts/agents/templates/deployment-controllers.yaml`.
+
+## Design
+### Proposed values
+Add:
+- `controlPlane.autoscaling` (defaults to existing `autoscaling`)
+- `controllers.autoscaling` (new)
+
+### Defaults
+- `controllers.autoscaling.enabled=false`
+- Recommend `minReplicas: 1`, `maxReplicas: 3` initially, CPU-based scaling only.
+
+## Config Mapping
+| Helm value | Rendered object | Intended behavior |
+|---|---|---|
+| `autoscaling.*` | `HPA/agents` | Control plane HPA (existing). |
+| `controllers.autoscaling.enabled=true` | `HPA/agents-controllers` | Scales controllers Deployment based on CPU/memory. |
+
+## Rollout Plan
+1. Add new `controllers.autoscaling` keys with defaults disabled.
+2. Enable in non-prod and validate scale-up/down behavior.
+3. Enable in prod after ensuring PDB/strategy supports scaling safely.
+
+Rollback:
+- Disable `controllers.autoscaling.enabled`.
+
+## Validation
+```bash
+helm template agents charts/agents --set controllers.enabled=true --set controllers.autoscaling.enabled=true | rg -n \"kind: HorizontalPodAutoscaler\"
+kubectl -n agents get hpa
+```
+
+## Failure Modes and Mitigations
+- HPA scales down too aggressively and loses in-flight work: mitigate with conservative scale-down policies and controller graceful shutdown.
+- HPA not created due to missing metrics server: mitigate by documenting prerequisites and keeping disabled by default.
+
+## Acceptance Criteria
+- When enabled, `agents-controllers` has an HPA targeting the correct Deployment.
+- Operators can scale controllers independently of the control plane.
+
+## References
+- Kubernetes HPA v2: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+

--- a/docs/agents/designs/chart-controllers-image-override-precedence.md
+++ b/docs/agents/designs/chart-controllers-image-override-precedence.md
@@ -1,0 +1,63 @@
+# Chart Controllers Image Override Precedence
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents chart can run controllers as a separate Deployment (`agents-controllers`) with its own image. Operators need a clear contract for how `controllers.image.*` relates to the root `image.*` and the control plane `controlPlane.image.*`.
+
+## Goals
+- Define image selection precedence for `agents-controllers`.
+- Enable safe canarying controllers independently from the control plane.
+
+## Non-Goals
+- Supporting multiple controller images in a single release (one deployment only).
+
+## Current State
+- Controllers deployment template: `charts/agents/templates/deployment-controllers.yaml` computes:
+  - `$imageRepo := .Values.controllers.image.repository | default .Values.image.repository`
+  - similarly for `tag`, `digest`, `pullPolicy`, `pullSecrets`
+- Values surface: `charts/agents/values.yaml` under `controllers.image.*` and `image.*`.
+- GitOps currently pins both control plane and controller images in `argocd/applications/agents/values.yaml`.
+
+## Design
+### Precedence for controllers
+1. `controllers.image.*` (if field non-empty)
+2. `image.*` (root defaults)
+
+### Operational policy
+- For production: always set `controllers.image.digest` explicitly when `controllers.enabled=true`.
+- For canary: bump controllers digest first, validate, then bump control plane digest.
+
+## Config Mapping
+| Helm value | Rendered image for `agents-controllers` | Notes |
+|---|---|---|
+| `controllers.image.repository` | repo | Defaults to `image.repository` if empty. |
+| `controllers.image.tag` | tag | Defaults to `image.tag` if empty. |
+| `controllers.image.digest` | digest | Defaults to `image.digest` if empty. |
+| `controllers.image.pullSecrets` | imagePullSecrets | Defaults to `image.pullSecrets` if empty. |
+
+## Rollout Plan
+1. Add this contract to `charts/agents/README.md`.
+2. Add a CI check that `controllers.enabled=true` implies `controllers.image.digest` is non-empty in prod overlays.
+3. Use an Argo CD canary window (manual sync or progressive wave) before promoting.
+
+Rollback:
+- Revert `controllers.image.digest` to the prior known-good digest and re-sync.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"name: agents-controllers|image:\"
+kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spec.containers[0].image}'; echo
+```
+
+## Failure Modes and Mitigations
+- Controllers image accidentally inherits `image.tag=latest` without digest: mitigate via validation/enforcement in prod.
+- Canary controllers uses incompatible schema vs CRDs: mitigate by bundling CRD changes + controllers changes in one PR when APIs change.
+
+## Acceptance Criteria
+- Operators can canary `agents-controllers` without modifying the control plane deployment.
+- A prod overlay policy ensures controllers run by digest, not mutable tags.
+
+## References
+- Kubernetes container images: https://kubernetes.io/docs/concepts/containers/images/
+

--- a/docs/agents/designs/chart-controllers-pdb.md
+++ b/docs/agents/designs/chart-controllers-pdb.md
@@ -1,0 +1,62 @@
+# Chart Controllers PodDisruptionBudget
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart can deploy a separate controllers Deployment (`agents-controllers`), but the chart’s PodDisruptionBudget (PDB) template currently only targets the control plane pods. This creates an availability gap: controllers may all be evicted during node drains or cluster maintenance even when the control plane is protected.
+
+## Goals
+- Add optional PDB support for `agents-controllers`.
+- Keep backward compatibility for existing installs using `podDisruptionBudget.*`.
+
+## Non-Goals
+- Enforcing a single organization-wide disruption policy.
+
+## Current State
+- Existing PDB template: `charts/agents/templates/poddisruptionbudget.yaml`
+  - Selects `{{ include "agents.selectorLabels" . }}` (control plane).
+- Controllers selector labels differ: `charts/agents/templates/_helpers.tpl` (`agents.controllersSelectorLabels`).
+- Values: `charts/agents/values.yaml` exposes `podDisruptionBudget.*` (single set).
+- Cluster desired state: `argocd/applications/agents/values.yaml` does not enable a PDB.
+
+## Design
+### Proposed values
+Add component-scoped PDBs:
+- `controlPlane.podDisruptionBudget` (defaults to existing `podDisruptionBudget`)
+- `controllers.podDisruptionBudget` (new)
+
+### Defaults
+- Keep existing `podDisruptionBudget.enabled=false`.
+- When controllers are enabled, recommend enabling a PDB with `maxUnavailable: 1` for controllers.
+
+## Config Mapping
+| Helm value | Rendered object | Intended behavior |
+|---|---|---|
+| `podDisruptionBudget.*` | `PodDisruptionBudget/agents` | Backward compatible control plane PDB. |
+| `controllers.podDisruptionBudget.enabled=true` | `PodDisruptionBudget/agents-controllers` | Prevents full controller eviction during voluntary disruptions. |
+
+## Rollout Plan
+1. Add `controllers.podDisruptionBudget` with defaults (disabled).
+2. Enable in non-prod and validate node-drain behavior.
+3. Enable in prod after confirming controllers can roll without downtime.
+
+Rollback:
+- Disable `controllers.podDisruptionBudget.enabled`.
+
+## Validation
+```bash
+helm template agents charts/agents --set controllers.enabled=true --set controllers.podDisruptionBudget.enabled=true | rg -n \"kind: PodDisruptionBudget\"
+kubectl -n agents get pdb
+```
+
+## Failure Modes and Mitigations
+- PDB too strict blocks node drain: mitigate with `maxUnavailable: 1` and by matching replicas.
+- Selector mismatch means PDB protects nothing: mitigate with render-time tests and explicit selector labels.
+
+## Acceptance Criteria
+- When enabled, a PDB exists for `agents-controllers` selecting the correct pods.
+- Node drains do not evict all controller replicas at once.
+
+## References
+- Kubernetes PodDisruptionBudget: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+

--- a/docs/agents/designs/chart-controllers-service.md
+++ b/docs/agents/designs/chart-controllers-service.md
@@ -1,0 +1,69 @@
+# Chart Controllers Service (Optional)
+
+Status: Draft (2026-02-06)
+
+## Overview
+The controllers Deployment is currently internal-only and has no Service. That is usually fine, but it complicates:
+- NetworkPolicy authoring (targeting stable endpoints)
+- Debug access to health endpoints (if provided)
+- Future webhook endpoints or internal RPC
+
+This doc proposes an optional Service for controllers with a conservative default (disabled).
+
+## Goals
+- Provide an opt-in ClusterIP Service for `agents-controllers`.
+- Keep default behavior unchanged.
+
+## Non-Goals
+- Exposing controllers publicly.
+
+## Current State
+- Controllers Deployment exists when `controllers.enabled=true`: `charts/agents/templates/deployment-controllers.yaml`.
+- Services exist only for control plane HTTP and optional gRPC:
+  - `charts/agents/templates/service.yaml`
+  - `charts/agents/templates/service-grpc.yaml`
+- No Service selects `agents.controllersSelectorLabels`.
+
+## Design
+### Proposed values
+Add:
+- `controllers.service.enabled` (default `false`)
+- `controllers.service.port` (default `8080` if controllers expose HTTP health)
+- `controllers.service.annotations` / `labels`
+
+### Selector + ports
+- Selector MUST match `agents.controllersSelectorLabels`.
+- Port naming should align with container ports if present.
+
+## Config Mapping
+| Helm value | Rendered object | Intended behavior |
+|---|---|---|
+| `controllers.service.enabled=false` | none | Current behavior. |
+| `controllers.service.enabled=true` | `Service/agents-controllers` | Stable in-cluster endpoint for debug/health as needed. |
+
+## Rollout Plan
+1. Add values and template behind disabled default.
+2. Enable in non-prod to confirm selector and endpoints.
+3. Use as a dependency for any future controller webhooks or debug tooling.
+
+Rollback:
+- Disable `controllers.service.enabled`.
+
+## Validation
+```bash
+helm template agents charts/agents --set controllers.enabled=true --set controllers.service.enabled=true | rg -n \"kind: Service|agents-controllers\"
+kubectl -n agents get svc
+kubectl -n agents get endpoints agents-controllers
+```
+
+## Failure Modes and Mitigations
+- Service selects wrong pods: mitigate with stable selector helpers and render tests.
+- Service unintentionally exposed via mesh or gateway defaults: mitigate by ClusterIP default and explicit docs.
+
+## Acceptance Criteria
+- Enabling the value renders a Service selecting only controller pods.
+- Default install remains unchanged.
+
+## References
+- Kubernetes Service type ClusterIP: https://kubernetes.io/docs/concepts/services-networking/service/
+

--- a/docs/agents/designs/chart-controlplane-image-override-precedence.md
+++ b/docs/agents/designs/chart-controlplane-image-override-precedence.md
@@ -1,0 +1,61 @@
+# Chart Control Plane Image Override Precedence
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents control plane runs as the `agents` Deployment. The chart supports an explicit `controlPlane.image.*` override separate from `image.*`. This doc defines a contract for selecting that image and recommended promotion paths.
+
+## Goals
+- Clarify image selection rules for the control plane.
+- Support independent pinning/promotion between control plane and controllers.
+
+## Non-Goals
+- Supporting multiple control plane deployments per release.
+
+## Current State
+- Template: `charts/agents/templates/deployment.yaml` computes `$imageRepo/$imageTag/$imageDigest` using `controlPlane.image.*` with fallbacks to `image.*`.
+- Values: `charts/agents/values.yaml` under `controlPlane.image.*`.
+- GitOps pins the control plane image in `argocd/applications/agents/values.yaml`.
+
+## Design
+### Precedence for control plane image
+1. `controlPlane.image.*` (if field non-empty)
+2. `image.*` (root defaults)
+
+### Promotion policy
+- Canary controllers first (separate deployment), then promote control plane.
+- When changing API behavior that affects CRD reconciliation, promote controllers and control plane in lockstep (same git SHA + digest set).
+
+## Config Mapping
+| Helm value | Rendered image for `agents` | Notes |
+|---|---|---|
+| `controlPlane.image.repository` | repo | Defaults to `image.repository` if empty. |
+| `controlPlane.image.tag` | tag | Defaults to `image.tag` if empty. |
+| `controlPlane.image.digest` | digest | Defaults to `image.digest` if empty. |
+| `controlPlane.image.pullSecrets` | imagePullSecrets | Defaults to `image.pullSecrets` if empty. |
+
+## Rollout Plan
+1. Document contract in `charts/agents/README.md`.
+2. Add `imagePolicy.requireDigest` enforcement in prod (optional, see `chart-image-digest-tag-precedence.md`).
+3. Promote via GitOps value change; wait for rollout status.
+
+Rollback:
+- Revert digest and re-sync.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"kind: Deployment|name: agents$|image:\"
+kubectl -n agents rollout status deploy/agents
+```
+
+## Failure Modes and Mitigations
+- Control plane and controllers drift to incompatible versions: mitigate via CI rule enforcing same git SHA tag in prod overlays.
+- Digest omitted causes unexpected image pull changes: mitigate with digest enforcement.
+
+## Acceptance Criteria
+- Rendered image for `agents` is predictable from values.
+- Operators can roll back by reverting a single digest in GitOps.
+
+## References
+- Helm best practices for values: https://helm.sh/docs/chart_best_practices/values/
+

--- a/docs/agents/designs/chart-database-url-secretref-precedence.md
+++ b/docs/agents/designs/chart-database-url-secretref-precedence.md
@@ -1,0 +1,77 @@
+# Chart Database URL vs SecretRef Precedence
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents chart supports multiple ways to provide `DATABASE_URL` to both the control plane and controllers. The precedence is currently implicit in templates; misconfiguration can lead to pods starting without a database connection or using an unintended database.
+
+This doc formalizes the precedence rules and recommended operational patterns.
+
+## Goals
+- Make the `DATABASE_URL` source deterministic and auditable.
+- Support GitOps-friendly database secret management.
+- Provide clear failure behavior when database config is missing.
+
+## Non-Goals
+- Managing the database lifecycle itself (CNPG, RDS, etc.).
+- Automatic database provisioning.
+
+## Current State
+- Chart values: `charts/agents/values.yaml` under `database.*`.
+- Template renders `DATABASE_URL`:
+  - Control plane: `charts/agents/templates/deployment.yaml`
+  - Controllers: `charts/agents/templates/deployment-controllers.yaml`
+- Secret creation path: `charts/agents/templates/database-secret.yaml`.
+- Cluster desired state: `argocd/applications/agents/values.yaml` uses `database.secretRef`.
+
+## Design
+### Precedence (highest wins)
+1. `database.url` (inline literal in Helm values; not recommended for prod)
+2. `database.secretRef` (preferred; Secret managed outside chart)
+3. `database.createSecret.enabled` (chart creates Secret from `database.url`-like values; for dev only)
+4. Otherwise: omit `DATABASE_URL` and fail fast (application should refuse to start)
+
+### Required behavior
+- Chart SHOULD fail render if none of the above sources are configured for a production profile (e.g. `values-prod.yaml`).
+- Runtime SHOULD log a single line at startup indicating which source was used (inline vs Secret).
+
+## Config Mapping
+| Helm value | Rendered env var | Intended behavior |
+|---|---|---|
+| `database.url` | `DATABASE_URL` (literal) | Highest precedence; discouraged for prod GitOps. |
+| `database.secretRef.name` + `database.secretRef.key` | `DATABASE_URL` from `secretKeyRef` | Preferred production path. |
+| `database.createSecret.enabled=true` | `DATABASE_URL` from chart-created Secret | Dev/local convenience; avoid for prod. |
+
+## Rollout Plan
+1. Add docs + README clarifying precedence.
+2. Add `values.schema.json` constraints: if `database.createSecret.enabled=true`, require `database.url`.
+3. Add `templates/validation.yaml` rules for production profiles (render-time failure).
+
+Rollback:
+- Disable validation rules; do not change existing Secret references.
+
+## Validation
+Render:
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"DATABASE_URL\"
+```
+
+Live:
+```bash
+kubectl -n agents get deploy agents -o yaml | rg -n \"DATABASE_URL\"
+kubectl -n agents get secret jangar-db-app -o yaml
+```
+
+## Failure Modes and Mitigations
+- Both `database.url` and `database.secretRef` set: mitigate by documenting precedence and adding validation warnings.
+- Secret exists but key is wrong: mitigate by schema defaults (`key: url`) + startup error with clear message.
+- Missing database config causes CrashLoopBackOff: mitigate via render-time validation in prod profiles.
+
+## Acceptance Criteria
+- Operators can identify the effective `DATABASE_URL` source from Helm render output.
+- Production installs fail fast if database config is missing.
+
+## References
+- Kubernetes Secrets as env vars: https://kubernetes.io/docs/concepts/configuration/secret/
+- Helm values best practices: https://helm.sh/docs/chart_best_practices/values/
+

--- a/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
+++ b/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
@@ -1,0 +1,76 @@
+# Chart Deployment Strategy: RollingUpdate Tuning
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart currently relies on Kubernetes default `RollingUpdate` behavior for Deployments. For production, we should explicitly control surge/unavailable and optionally support safer strategies (e.g. `Recreate` for DB-migration-sensitive components).
+
+## Goals
+- Provide explicit, chart-configurable Deployment strategies for:
+  - `deploy/agents`
+  - `deploy/agents-controllers`
+- Enable safe canary/rollback patterns with predictable availability.
+
+## Non-Goals
+- Replacing GitOps rollout control (Argo CD) with Helm hooks.
+
+## Current State
+- Templates:
+  - Control plane Deployment: `charts/agents/templates/deployment.yaml` has no `spec.strategy`.
+  - Controllers Deployment: `charts/agents/templates/deployment-controllers.yaml` has no `spec.strategy`.
+- Values: no strategy knobs exist in `charts/agents/values.yaml`.
+
+## Design
+### Proposed values
+Add:
+- `controlPlane.deploymentStrategy`
+- `controllers.deploymentStrategy`
+- `deploymentStrategy` (global default)
+
+Each can accept:
+```yaml
+type: RollingUpdate
+rollingUpdate:
+  maxSurge: 25%
+  maxUnavailable: 0
+```
+
+### Defaults
+- Control plane:
+  - `maxUnavailable: 0` (prefer availability)
+- Controllers:
+  - `maxUnavailable: 1` (prefer continuity but allow roll)
+
+## Config Mapping
+| Helm value | Rendered field | Intended behavior |
+|---|---|---|
+| `deploymentStrategy` | `Deployment.spec.strategy` | Global default used if component overrides are absent. |
+| `controlPlane.deploymentStrategy` | `deploy/agents.spec.strategy` | Component-specific override. |
+| `controllers.deploymentStrategy` | `deploy/agents-controllers.spec.strategy` | Component-specific override. |
+
+## Rollout Plan
+1. Add new values with conservative defaults matching Kubernetes defaults (no behavior change).
+2. In production, set explicit `maxUnavailable`/`maxSurge` values.
+3. Validate rollout behavior during a canary image bump.
+
+Rollback:
+- Remove values; cluster falls back to defaults.
+
+## Validation
+```bash
+helm template agents charts/agents | rg -n \"strategy:\"
+kubectl -n agents get deploy agents -o yaml | rg -n \"strategy:\"
+kubectl -n agents rollout status deploy/agents
+```
+
+## Failure Modes and Mitigations
+- Too aggressive `maxUnavailable` causes downtime: mitigate by defaulting to `0` for control plane.
+- Surge causes resource pressure: mitigate by setting explicit `maxSurge` and sizing cluster capacity.
+
+## Acceptance Criteria
+- Operators can tune rollout availability without editing templates.
+- Both Deployments render with explicit strategy when configured.
+
+## References
+- Kubernetes Deployment strategy: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+

--- a/docs/agents/designs/chart-env-vars-merge-precedence.md
+++ b/docs/agents/designs/chart-env-vars-merge-precedence.md
@@ -1,0 +1,89 @@
+# Chart Env Var Merge Precedence
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents Helm chart exposes multiple ways to set environment variables for the control plane and controllers. Today the precedence is implicit in templates, which makes it easy to unintentionally override critical defaults (e.g. migrations, gRPC enablement) or to believe a value is set when it is not.
+
+This doc defines a production-safe, testable precedence order and the validation behavior the chart/controllers should implement.
+
+## Goals
+- Make env var precedence explicit and deterministic.
+- Prevent accidental overrides of chart-managed safety defaults.
+- Provide a single table operators can use to predict runtime behavior.
+
+## Non-Goals
+- Replacing env vars with a fully typed config file system.
+- Adding new runtime features beyond precedence/validation.
+
+## Current State
+- Chart templates:
+  - Control plane env merge: `charts/agents/templates/deployment.yaml` (merges `.Values.env.vars` with `.Values.controlPlane.env.vars`).
+  - Controllers env merge + forced defaults: `charts/agents/templates/deployment-controllers.yaml` (merges `.Values.env.vars` with `.Values.controllers.env.vars`, then sets defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when not explicitly provided).
+- Values surface area: `charts/agents/values.yaml` (`env.vars`, `env.extra`, `env.secrets`, `env.config`, `controlPlane.env.vars`, `controllers.env.vars`).
+- Controllers runtime reads many `process.env.JANGAR_*` variables: `services/jangar/src/server/agents-controller.ts` and `services/jangar/src/server/implementation-source-webhooks.ts`.
+- Cluster desired state (GitOps):
+  - `argocd/applications/agents/values.yaml` sets some env vars directly under `.env.vars` and control plane vars under `.controlPlane.env.vars`.
+
+## Design
+### Precedence order (highest wins)
+1. `.Values.controllers.env.vars` / `.Values.controlPlane.env.vars` (component-local explicit overrides)
+2. `.Values.env.vars` (global explicit overrides)
+3. Chart-implied defaults (template-set env vars like `JANGAR_MIGRATIONS=skip` for controllers)
+4. Application defaults (code defaults when env var is absent)
+
+### Conflict handling
+- If the same key is set in both `.Values.env.vars` and a component-local `*.env.vars`, the component-local value MUST win.
+- If the same key is set both via explicit `env:` entries (e.g. `.Values.env.extra`) and via `envFrom` (Secret/ConfigMap), behavior is Kubernetes-defined and can be surprising. The chart SHOULD:
+  - Prefer explicit `env:` for chart-managed defaults.
+  - Document that `envFrom` is “best effort” and may be overridden by explicit `env:`.
+
+### Controller-side validation (recommended)
+Add a lightweight startup check (controllers only) that:
+- Logs the effective source for critical vars (`JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`) at startup.
+- Refuses to start if `JANGAR_MIGRATIONS=auto` is set in the controllers deployment (to prevent surprise migrations from the controller pod).
+
+## Config Mapping
+| Helm value | Rendered env var | Default today | Intended behavior |
+|---|---|---:|---|
+| `env.vars.JANGAR_MIGRATIONS` | `JANGAR_MIGRATIONS` | `auto` | Control plane may run migrations; controllers should default to `skip`. |
+| `controllers.env.vars.JANGAR_MIGRATIONS` | `JANGAR_MIGRATIONS` | `skip` (template default) | If explicitly set, overrides template default; controllers MUST validate. |
+| `env.vars.JANGAR_GRPC_ENABLED` | `JANGAR_GRPC_ENABLED` | unset | Global opt-in/out for control plane; controllers should default to `0`. |
+| `controllers.env.vars.JANGAR_GRPC_ENABLED` | `JANGAR_GRPC_ENABLED` | `0` (template default) | Controllers may force-disable gRPC unless explicitly enabled. |
+| `controlPlane.env.vars.JANGAR_CONTROL_PLANE_CACHE_ENABLED` | `JANGAR_CONTROL_PLANE_CACHE_ENABLED` | unset | Control plane feature toggle; controllers default to `0` unless explicitly set. |
+
+## Rollout Plan
+1. Document precedence in `charts/agents/README.md` and values comments (no behavior change).
+2. Add startup logging/validation in `services/jangar/src/server/*` (controllers only) with a conservative default (warn-only first).
+3. Promote validation to fail-fast in a follow-up after a canary window.
+
+Rollback:
+- Revert controller-side validation (code-only rollback).
+- Keep doc updates; they are safe.
+
+## Validation
+Helm render:
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_MIGRATIONS|JANGAR_GRPC_ENABLED\"
+```
+
+Cluster (desired/live):
+```bash
+kubectl -n agents get deploy agents -o yaml | rg -n \"JANGAR_MIGRATIONS|JANGAR_GRPC_ENABLED\"
+kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_MIGRATIONS|JANGAR_GRPC_ENABLED\"
+```
+
+## Failure Modes and Mitigations
+- Env var appears “set” but is overridden by component-local vars: mitigate with explicit precedence docs and startup logging.
+- Controllers unexpectedly run migrations: mitigate by template default (`skip`) + controller fail-fast validation.
+- gRPC accidentally enabled in controllers: mitigate with explicit defaults and chart-level tests (golden manifest render).
+
+## Acceptance Criteria
+- Operators can predict the effective value of a given env var from Helm values alone.
+- Controllers deployment renders with `JANGAR_MIGRATIONS=skip` unless explicitly overridden.
+- A canary install surfaces any unexpected overrides via logs before enforcing fail-fast.
+
+## References
+- Kubernetes environment variable precedence (explicit `env` vs `envFrom`): https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+- Helm chart best practices (values and templates): https://helm.sh/docs/chart_best_practices/values/
+

--- a/docs/agents/designs/chart-envfrom-conflict-resolution.md
+++ b/docs/agents/designs/chart-envfrom-conflict-resolution.md
@@ -1,0 +1,79 @@
+# Chart envFrom Conflict Resolution
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents chart supports both explicit `env:` entries and bulk import via `envFrom` (Secrets/ConfigMaps). Kubernetes allows both, but precedence can be confusing: explicitly defined `env:` variables take precedence over values from `envFrom`.
+
+This doc defines how the chart should use these mechanisms safely and what operators should expect.
+
+## Goals
+- Make `envFrom` behavior predictable for production installs.
+- Avoid “silent overrides” of critical configuration.
+- Provide guidance for GitOps-managed Secret/ConfigMap injection.
+
+## Non-Goals
+- Building a full secret management system (use External Secrets, SOPS, etc.).
+- Adding new CRDs for configuration.
+
+## Current State
+- Chart templates render `envFrom` if `envFromSecretRefs` or `envFromConfigMapRefs` are non-empty:
+  - Control plane: `charts/agents/templates/deployment.yaml`
+  - Controllers: `charts/agents/templates/deployment-controllers.yaml`
+- The same templates also render explicit `env:` entries from:
+  - `.Values.env.vars` (template-generated list)
+  - `.Values.env.secrets`, `.Values.env.config`, `.Values.env.extra`
+- Cluster desired state uses `envFromSecretRefs` in `argocd/applications/agents/values.yaml`.
+
+## Design
+### Recommended contract
+- `envFromSecretRefs` / `envFromConfigMapRefs` are intended for:
+  - Provider credentials (non-chart-specific vars).
+  - Optional feature toggles that are safe to override.
+- Chart-managed “safety” vars MUST always be set via explicit `env:` so they win over `envFrom`.
+
+### Future improvement (chart-level validation)
+Add a Helm validation rule (in `charts/agents/templates/validation.yaml`) that:
+- Fails the render if `envFrom*` is used to set any reserved keys (a documented denylist), unless an explicit override value is also provided under `.Values.env.vars` or component-local `*.env.vars`.
+
+## Config Mapping
+| Helm value | Rendered pod spec | Behavior |
+|---|---|---|
+| `envFromSecretRefs: [\"agents-github-token-env\"]` | `envFrom.secretRef` | Imports all keys as env vars; may be overridden by explicit `env:`. |
+| `envFromConfigMapRefs: [\"agents-flags\"]` | `envFrom.configMapRef` | Imports all keys as env vars; may be overridden by explicit `env:`. |
+| `env.extra[{name,value}]` | explicit `env:` | Highest precedence; good for chart-managed defaults. |
+| `env.secrets[{name,secretName,key}]` | explicit `env:` via `secretKeyRef` | Highest precedence; used for specific, named secrets. |
+| `env.config[{name,configMapName,key}]` | explicit `env:` via `configMapKeyRef` | Highest precedence; used for specific, named config keys. |
+
+## Rollout Plan
+1. Document reserved keys + precedence in `charts/agents/README.md`.
+2. Add render-time validation (denylist) behind a new value `validation.reservedEnvKeysEnforced` default `false`.
+3. Enable enforcement in `values-prod.yaml` after a canary.
+
+Rollback:
+- Disable enforcement flag and re-sync Argo CD.
+
+## Validation
+Render:
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"envFrom:|secretRef:|configMapRef:\"
+```
+
+Live:
+```bash
+kubectl -n agents get deploy agents -o jsonpath='{.spec.template.spec.containers[0].envFrom}'
+kubectl -n agents get deploy agents -o jsonpath='{.spec.template.spec.containers[0].env}'
+```
+
+## Failure Modes and Mitigations
+- Secret injects a key that shadows a chart-managed key: mitigate with reserved-key validation + docs.
+- Operators expect `envFrom` to override `env:`: mitigate by making precedence explicit in design docs and chart README.
+- Large Secrets exceed env var limits: mitigate by using explicit `env.secrets` for the minimal set of keys.
+
+## Acceptance Criteria
+- A reserved-key denylist exists and is enforced in production.
+- Operators can safely add `envFrom*` without destabilizing chart defaults.
+
+## References
+- Kubernetes: define env vars and `envFrom`: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+

--- a/docs/agents/designs/chart-extra-volumes-mounts-contract.md
+++ b/docs/agents/designs/chart-extra-volumes-mounts-contract.md
@@ -1,0 +1,69 @@
+# Chart Extra Volumes/Mounts Contract
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart supports `.Values.extraVolumes` and `.Values.extraVolumeMounts`, which are injected into both the control plane and controllers pod specs. This is a powerful escape hatch but needs a documented contract to prevent accidental conflicts with chart-managed volumes (e.g. DB CA cert).
+
+## Goals
+- Define the intended use cases and constraints for extra volumes/mounts.
+- Prevent collisions with reserved volume names.
+- Make behavior consistent across control plane and controllers.
+
+## Non-Goals
+- Building a plugin system; extra volumes remain a low-level escape hatch.
+
+## Current State
+- Values: `charts/agents/values.yaml` exposes `extraVolumes` and `extraVolumeMounts`.
+- Templates:
+  - Control plane mounts/volumes: `charts/agents/templates/deployment.yaml`
+  - Controllers mounts/volumes: `charts/agents/templates/deployment-controllers.yaml`
+- Chart-managed volume today:
+  - `db-ca-cert` when `database.caSecret.name` is set (both deployments).
+
+## Design
+### Contract
+- Extra volume/mount entries MUST NOT use reserved names:
+  - `db-ca-cert` (and any future chart-managed names)
+- Extra volumes are applied to both deployments (current behavior). If operators need per-component volumes, add:
+  - `controlPlane.extraVolumes`, `controlPlane.extraVolumeMounts`
+  - `controllers.extraVolumes`, `controllers.extraVolumeMounts`
+
+### Validation
+- Add validation in `charts/agents/templates/validation.yaml`:
+  - Fail render if a reserved name is used.
+  - Fail render if a mount references a volume name that does not exist (best-effort check).
+
+## Config Mapping
+| Helm value | Rendered field | Behavior |
+|---|---|---|
+| `extraVolumes[].name` + `extraVolumes[].volume` | `spec.template.spec.volumes[]` | Appends volumes to both pod specs. |
+| `extraVolumeMounts[].name` + `mountPath` | `containers[].volumeMounts[]` | Appends mounts to both containers. |
+| `database.caSecret.*` | `db-ca-cert` secret volume + mount | Chart-managed reserved name. |
+
+## Rollout Plan
+1. Document reserved names and recommended usage in `charts/agents/README.md`.
+2. Add validation (warn-only first if Helm supports; otherwise gated by a values flag).
+3. Introduce per-component extras if required by production use-cases.
+
+Rollback:
+- Disable validation and/or remove per-component keys; existing global keys remain.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"volumes:|volumeMounts:|db-ca-cert\"
+kubectl -n agents get deploy agents -o yaml | rg -n \"extra|db-ca-cert|volumes:|volumeMounts:\"
+```
+
+## Failure Modes and Mitigations
+- Collision with `db-ca-cert` breaks DB TLS: mitigate with reserved-name validation.
+- Mount references missing volume: mitigate with render-time validation.
+- Extra volumes unintentionally affect both deployments: mitigate by adding component-scoped keys.
+
+## Acceptance Criteria
+- Chart fails render on reserved-name collisions.
+- Operators have a documented path for adding CA bundles, SSH known_hosts, or custom credentials.
+
+## References
+- Kubernetes volumes: https://kubernetes.io/docs/concepts/storage/volumes/
+

--- a/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
+++ b/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
@@ -1,0 +1,67 @@
+# Chart gRPC Enabled: Single Source of Truth
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart has `grpc.enabled` (controls Service + container port) while runtime can also be toggled with `JANGAR_GRPC_ENABLED` (via `env.vars`). When these disagree, the deployment can become confusing: a Service may exist without the server listening, or the server may listen without a Service/port.
+
+This doc defines a single-source-of-truth contract.
+
+## Goals
+- Ensure `grpc.enabled` and `JANGAR_GRPC_ENABLED` cannot drift.
+- Provide a safe migration path for existing installs.
+
+## Non-Goals
+- Changing the gRPC API surface area.
+
+## Current State
+- Chart:
+  - Service template: `charts/agents/templates/service-grpc.yaml` gated on `grpc.enabled`.
+  - Container port for gRPC is gated on `grpc.enabled`: `charts/agents/templates/deployment.yaml`.
+  - Controllers deployment defaults `JANGAR_GRPC_ENABLED=0`: `charts/agents/templates/deployment-controllers.yaml`.
+- GitOps:
+  - `argocd/applications/agents/values.yaml` sets `grpc.enabled: true` and also sets `JANGAR_GRPC_ENABLED: \"true\"` under `env.vars`.
+
+## Design
+### Contract
+- `grpc.enabled` MUST be the only control-plane switch.
+- The chart MUST render `JANGAR_GRPC_ENABLED` for the control plane based on `grpc.enabled` (and ignore user-provided overrides unless explicitly allowed).
+- Controllers deployment MUST continue to default-disable gRPC unless there is a concrete use-case.
+
+### Migration
+- Introduce `grpc.manageEnvVar` (default `true`):
+  - When `true`, template sets `JANGAR_GRPC_ENABLED` from `grpc.enabled`.
+  - When `false`, chart does not set it and operators can manage it manually.
+
+## Config Mapping
+| Helm value | Rendered env var / object | Intended behavior |
+|---|---|---|
+| `grpc.enabled=true` | `Service/agents-grpc` + `containerPort: grpc` + `JANGAR_GRPC_ENABLED=1` | Server listens and is reachable via Service. |
+| `grpc.enabled=false` | no gRPC Service/port + `JANGAR_GRPC_ENABLED=0` | Server does not expose/listen. |
+
+## Rollout Plan
+1. Add `grpc.manageEnvVar` default `true`, but accept existing `env.vars.JANGAR_GRPC_ENABLED` with a warning (no failure).
+2. Update GitOps values to remove redundant `JANGAR_GRPC_ENABLED`.
+3. After a canary, enforce: render fails if `grpc.manageEnvVar=true` and user sets `JANGAR_GRPC_ENABLED`.
+
+Rollback:
+- Set `grpc.manageEnvVar=false` and restore explicit env var management.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"agents-grpc|containerPort: grpc|JANGAR_GRPC_ENABLED\"
+kubectl -n agents get svc agents-grpc
+kubectl -n agents get endpointslice -l app.kubernetes.io/name=agents
+```
+
+## Failure Modes and Mitigations
+- gRPC Service exists but server not listening: mitigate by having chart manage the env var.
+- Server listens but no Service/port: mitigate by coupling the env var to `grpc.enabled`.
+
+## Acceptance Criteria
+- `grpc.enabled` reliably predicts whether gRPC is reachable.
+- GitOps values do not need to set `JANGAR_GRPC_ENABLED` manually for the control plane.
+
+## References
+- Kubernetes Services: https://kubernetes.io/docs/concepts/services-networking/service/
+

--- a/docs/agents/designs/chart-image-digest-tag-precedence.md
+++ b/docs/agents/designs/chart-image-digest-tag-precedence.md
@@ -1,0 +1,78 @@
+# Chart Image Digest/Tag Precedence
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents chart supports image tags and optional digests for both the control plane and controllers. In production GitOps, digests are preferred for immutability. The chart currently concatenates `repo:tag@digest` when a digest is provided, but the operational contract (and failure modes) are not documented.
+
+## Goals
+- Define a clear contract for tag + digest usage.
+- Prevent accidental drift (e.g. `tag: latest` without digest).
+- Provide a safe upgrade/rollback process.
+
+## Non-Goals
+- Introducing an image signing/verification system (covered elsewhere).
+
+## Current State
+- Values: `charts/agents/values.yaml` under `image.*`, `controlPlane.image.*`, `controllers.image.*`.
+- Template image rendering:
+  - Control plane: `charts/agents/templates/deployment.yaml`
+  - Controllers: `charts/agents/templates/deployment-controllers.yaml`
+- GitOps pins digests in `argocd/applications/agents/values.yaml`.
+
+## Design
+### Rendering rules
+- If `digest` is non-empty: render `repository:tag@digest`.
+- If `digest` is empty: render `repository:tag`.
+- Component-specific image blocks override the root `image.*` values for that component.
+
+### Production policy
+- Production profiles MUST set `digest` for all images.
+- `tag` remains required even when digest is set (for readability), but it is informational-only.
+
+### Chart validation
+Add optional enforcement:
+- `imagePolicy.requireDigest=true` (default `false`): when enabled, render fails if any enabled component lacks a digest.
+
+## Config Mapping
+| Helm value | Rendered field | Behavior |
+|---|---|---|
+| `image.repository` | `spec.template.spec.containers[].image` | Default repository for control plane and (if unset) controllers. |
+| `image.tag` | image string | Used when digest is absent; informational when digest is present. |
+| `image.digest` | image string | If set, pins an immutable manifest. |
+| `controlPlane.image.*` | control plane image string | Overrides root `image.*`. |
+| `controllers.image.*` | controllers image string | Overrides root `image.*`. |
+
+## Rollout Plan
+1. Add documentation + schema keys (no behavior change).
+2. Enable `imagePolicy.requireDigest=true` in non-prod first.
+3. Enable in prod after verifying image promotion pipeline always supplies digests.
+
+Rollback:
+- Disable `imagePolicy.requireDigest`.
+- Roll back values to prior digests; no template changes required.
+
+## Validation
+Render:
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"image:|@sha256:\"
+```
+
+Live:
+```bash
+kubectl -n agents get deploy agents -o jsonpath='{.spec.template.spec.containers[0].image}'; echo
+kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spec.containers[0].image}'; echo
+```
+
+## Failure Modes and Mitigations
+- Digest set with wrong tag: safe (digest wins); mitigate confusion by documenting tag informational-only.
+- Digest omitted in prod: mitigate via enforcement flag and CI checks on GitOps values.
+- Registry garbage-collects unreferenced manifests: mitigate by retaining digests used in GitOps history.
+
+## Acceptance Criteria
+- Production values pin digests for all enabled components.
+- Optional chart enforcement can be turned on without code changes.
+
+## References
+- Kubernetes container image names (tag/digest): https://kubernetes.io/docs/concepts/containers/images/
+

--- a/docs/agents/designs/chart-kubernetesapi-host-port-override.md
+++ b/docs/agents/designs/chart-kubernetesapi-host-port-override.md
@@ -1,0 +1,57 @@
+# Chart Kubernetes API Host/Port Override
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart exposes `kubernetesApi.host` and `kubernetesApi.port` which map to `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT`. This is a sharp tool: it can help run outside-cluster or in unusual networking environments, but can also break in-cluster discovery if misused.
+
+## Goals
+- Document when and how to use the override safely.
+- Add guardrails to prevent accidental use in normal in-cluster deployments.
+
+## Non-Goals
+- Providing full out-of-cluster deployment support.
+
+## Current State
+- Values: `charts/agents/values.yaml` includes `kubernetesApi.host` and `kubernetesApi.port`.
+- Templates set env vars for both deployments:
+  - `charts/agents/templates/deployment.yaml`
+  - `charts/agents/templates/deployment-controllers.yaml`
+- Default is empty (Kubernetes default service env vars apply).
+
+## Design
+### Contract
+- In-cluster installs SHOULD leave `kubernetesApi.*` empty.
+- If either `kubernetesApi.host` or `kubernetesApi.port` is set, both MUST be set.
+- The chart SHOULD validate the above in `values.schema.json`.
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `kubernetesApi.host` | `KUBERNETES_SERVICE_HOST` | Overrides API endpoint host. |
+| `kubernetesApi.port` | `KUBERNETES_SERVICE_PORT` | Overrides API endpoint port. |
+
+## Rollout Plan
+1. Add schema validation requiring both host and port together.
+2. Add README guidance and examples (in-cluster vs special cases).
+
+Rollback:
+- Clear the override values and re-sync.
+
+## Validation
+```bash
+helm template agents charts/agents | rg -n \"KUBERNETES_SERVICE_HOST|KUBERNETES_SERVICE_PORT\"
+kubectl -n agents get deploy agents -o yaml | rg -n \"KUBERNETES_SERVICE_HOST|KUBERNETES_SERVICE_PORT\"
+```
+
+## Failure Modes and Mitigations
+- Override breaks in-cluster API access: mitigate by default empty + schema guardrails.
+- Only host or port set causes confusing behavior: mitigate by schema enforcement.
+
+## Acceptance Criteria
+- It is impossible (via schema) to set only one of host/port.
+- Operators can identify overrides in rendered manifests.
+
+## References
+- Kubernetes in-cluster configuration: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/
+

--- a/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
+++ b/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
@@ -1,0 +1,64 @@
+# Chart namespaceOverride vs Release Namespace Behavior
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart uses `namespaceOverride` to force all rendered resources into a namespace different from `.Release.Namespace`. This is useful in some GitOps setups but can be hazardous if only part of a release is overridden (e.g. CRDs are cluster-scoped, but Roles/RoleBindings are namespaced).
+
+This doc defines safe usage and guardrails.
+
+## Goals
+- Make namespace selection behavior explicit for all chart resources.
+- Prevent accidental “split-brain” installs (resources in multiple namespaces).
+
+## Non-Goals
+- Supporting multi-namespace installs from a single Helm release.
+
+## Current State
+- Value: `charts/agents/values.yaml` → `namespaceOverride`.
+- Most templates set `metadata.namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}`:
+  - Examples: `charts/agents/templates/deployment.yaml`, `charts/agents/templates/service.yaml`, `charts/agents/templates/rbac.yaml`.
+- GitOps typically installs into namespace `agents` and does not set `namespaceOverride` explicitly.
+
+## Design
+### Contract
+- If `namespaceOverride` is set, it MUST be used consistently across all namespaced resources in the chart.
+- Chart MUST fail render if:
+  - `namespaceOverride` is set to an empty/whitespace string.
+  - `namespaceOverride` is set but `.Release.Namespace` differs and `createNamespace=false` (optional guardrail depending on GitOps practice).
+
+### Documentation requirement
+Add a README section:
+- “Do not set `namespaceOverride` unless Argo/Helm release namespace is locked.”
+
+## Config Mapping
+| Helm value | Rendered namespace | Intended behavior |
+|---|---|---|
+| `namespaceOverride: \"\"` | `.Release.Namespace` | Normal Helm behavior. |
+| `namespaceOverride: agents` | `agents` | Forces all namespaced resources into `agents`. |
+
+## Rollout Plan
+1. Document contract and guardrails.
+2. Add schema validation (`minLength: 1` when set).
+3. Add template validation for common foot-guns.
+
+Rollback:
+- Remove `namespaceOverride`; rely on `.Release.Namespace`.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"namespace:\"
+kubectl get ns agents
+```
+
+## Failure Modes and Mitigations
+- Resources created in unexpected namespace: mitigate via render review + guardrail validation.
+- Argo CD app sync fails due to namespace mismatch: mitigate by keeping release namespace and override aligned.
+
+## Acceptance Criteria
+- Rendered manifests place all namespaced resources in exactly one namespace.
+- Invalid override values are rejected at render time.
+
+## References
+- Helm template rendering concepts: https://helm.sh/docs/chart_template_guide/
+

--- a/docs/agents/designs/chart-pod-annotations-merging.md
+++ b/docs/agents/designs/chart-pod-annotations-merging.md
@@ -1,0 +1,68 @@
+# Chart Pod Annotations Merging
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart applies `.Values.podAnnotations` and `.Values.podLabels` to both the control plane pod template and the controllers pod template. Operators often need different annotations per component (e.g., different scraping, sidecar settings, or rollout controls). Today that requires global annotations that may not be appropriate for both.
+
+## Goals
+- Define current behavior and its limits.
+- Propose component-scoped pod metadata overrides without breaking existing installs.
+
+## Non-Goals
+- Standardizing on a specific mesh/observability stack.
+
+## Current State
+- Values: `charts/agents/values.yaml` includes `podAnnotations` and `podLabels` (global).
+- Templates:
+  - Control plane pod template: `charts/agents/templates/deployment.yaml`
+  - Controllers pod template: `charts/agents/templates/deployment-controllers.yaml`
+- No `controlPlane.podAnnotations` / `controllers.podAnnotations` values exist.
+
+## Design
+### Proposed values
+Add component-scoped fields:
+- `controlPlane.podAnnotations` / `controlPlane.podLabels`
+- `controllers.podAnnotations` / `controllers.podLabels`
+
+### Precedence
+1. Component-scoped annotations/labels (if set)
+2. Global `podAnnotations` / `podLabels`
+
+### Backward compatibility
+- Keep global keys working unchanged.
+- Implement component keys as additive overrides.
+
+## Config Mapping
+| Helm value | Pod template target | Behavior |
+|---|---|---|
+| `podAnnotations` | both Deployments | Global baseline annotations. |
+| `controlPlane.podAnnotations` | `deploy/agents` only | Overrides/extends globals for control plane. |
+| `controllers.podAnnotations` | `deploy/agents-controllers` only | Overrides/extends globals for controllers. |
+
+## Rollout Plan
+1. Add new values keys with no defaults (no behavior change).
+2. Update `values.schema.json` and README examples.
+3. Migrate any component-specific annotations from global to component keys in GitOps.
+
+Rollback:
+- Remove component keys and move annotations back to global.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"annotations:\"
+kubectl -n agents get deploy agents -o jsonpath='{.spec.template.metadata.annotations}'; echo
+kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.metadata.annotations}'; echo
+```
+
+## Failure Modes and Mitigations
+- Global annotation breaks controllers (or control plane): mitigate by component scoping.
+- Annotation changes do not trigger rollout: mitigate via checksum annotations (see separate design).
+
+## Acceptance Criteria
+- Component-scoped pod metadata can be set without affecting the other component.
+- Backward compatibility: existing installs using `podAnnotations` continue to work.
+
+## References
+- Kubernetes pod template metadata: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+

--- a/docs/agents/designs/chart-probes-configuration-contract.md
+++ b/docs/agents/designs/chart-probes-configuration-contract.md
@@ -1,0 +1,69 @@
+# Chart Probes Configuration Contract
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart exposes HTTP liveness/readiness probe settings for the control plane, but probes may not be appropriate for controllers (which may not expose HTTP) and there is no startup probe for long initialization (e.g., cache warmup).
+
+This doc defines probe semantics per component and proposes adding startup probes and per-component overrides.
+
+## Goals
+- Ensure probes correctly reflect component health.
+- Avoid flapping restarts due to aggressive liveness probes.
+- Support long startups without false negatives.
+
+## Non-Goals
+- Defining SLOs or alerting policies.
+
+## Current State
+- Values: `charts/agents/values.yaml` has `livenessProbe` and `readinessProbe`.
+- Templates:
+  - Control plane probes: `charts/agents/templates/deployment.yaml` (HTTP GET to `.Values.*Probe.path` on `port: http`).
+  - Controllers probes: currently inherited similarly (if present) depending on the template structure in `deployment-controllers.yaml` (needs explicit review when adding).
+- No startupProbe values exist.
+
+## Design
+### Component-specific probes
+Add:
+- `controlPlane.livenessProbe`, `controlPlane.readinessProbe`, `controlPlane.startupProbe`
+- `controllers.livenessProbe`, `controllers.readinessProbe`, `controllers.startupProbe`
+
+### Defaults
+- Control plane:
+  - readiness: `/health` (existing)
+  - liveness: `/health` (existing)
+  - startup: enabled with higher thresholds to tolerate migrations/cold start
+- Controllers:
+  - Prefer a simple HTTP `/health` endpoint if available; otherwise allow exec-based probe or disable probes explicitly.
+
+## Config Mapping
+| Helm value | Rendered probe | Intended behavior |
+|---|---|---|
+| `controlPlane.readinessProbe.path` | readinessProbe.httpGet.path | Control plane only. |
+| `controllers.startupProbe.*` | startupProbe (http/exec) | Prevent premature restarts during controller initialization. |
+
+## Rollout Plan
+1. Add new component probe keys; default them to current global values for control plane.
+2. Verify controllers have a stable health endpoint (or disable probes explicitly).
+3. Tune thresholds based on observed rollout behavior.
+
+Rollback:
+- Remove component overrides and rely on existing global probes.
+
+## Validation
+```bash
+helm template agents charts/agents | rg -n \"livenessProbe:|readinessProbe:|startupProbe:\"
+kubectl -n agents describe pod -l app.kubernetes.io/name=agents | rg -n \"Liveness|Readiness|Startup\"
+```
+
+## Failure Modes and Mitigations
+- Liveness probe too strict causes restart loops: mitigate with startupProbe + relaxed thresholds.
+- Readiness probe too lax sends traffic to an unready control plane: mitigate by tying readiness to dependency checks in code.
+
+## Acceptance Criteria
+- Control plane and controllers can be configured independently.
+- StartupProbe prevents false liveness failures during initialization.
+
+## References
+- Kubernetes probes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+

--- a/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
+++ b/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
@@ -1,0 +1,69 @@
+# Chart RBAC Cluster-Scoped Guardrails
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents chart can run with cluster-scoped RBAC (`rbac.clusterScoped=true`) or namespaced RBAC (`false`). Misconfiguration can lead to controller errors (insufficient permissions) or excessive permissions (overbroad access).
+
+This doc defines guardrails in chart schema and controller startup validation.
+
+## Goals
+- Prevent mismatched RBAC and controller namespace scope.
+- Provide predictable permission sets for production.
+- Make RBAC mode visible in runtime logs and `/health` output.
+
+## Non-Goals
+- Enforcing organization-wide RBAC standards beyond this chart.
+
+## Current State
+- Values: `charts/agents/values.yaml` has `rbac.clusterScoped`.
+- Chart templates:
+  - RBAC objects: `charts/agents/templates/rbac.yaml`
+  - Controllers deployment exports `JANGAR_RBAC_CLUSTER_SCOPED`: `charts/agents/templates/deployment-controllers.yaml`
+- Runtime uses `JANGAR_RBAC_CLUSTER_SCOPED` when deciding listing/watching behavior: `services/jangar/src/server/*` (notably `kube-watch.ts` and namespace helpers).
+- GitOps uses `rbac.clusterScoped: false` in `argocd/applications/agents/values.yaml`.
+
+## Design
+### Guardrail matrix
+- If `rbac.clusterScoped=false`:
+  - `controller.namespaces` MUST be non-empty and MUST NOT include `\"*\"`.
+- If `rbac.clusterScoped=true`:
+  - `controller.namespaces` MAY be wildcard `\"*\"` or a list (for partial scope), but RBAC remains cluster-wide.
+
+### Validation points
+- Chart render-time validation in `charts/agents/templates/validation.yaml`.
+- Controller startup validation:
+  - Log `clusterScoped` and resolved namespaces.
+  - If `clusterScoped=false` but namespaces is empty: exit non-zero with actionable error.
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `rbac.clusterScoped=false` | `JANGAR_RBAC_CLUSTER_SCOPED=false` | Controllers restrict API calls to configured namespaces only. |
+| `rbac.clusterScoped=true` | `JANGAR_RBAC_CLUSTER_SCOPED=true` | Controllers may list/watch across namespaces (when configured). |
+
+## Rollout Plan
+1. Add schema validation for common misconfigs (no behavior change for correct installs).
+2. Add controller startup log lines and warnings first.
+3. Promote warnings to fail-fast once canary confirms no hidden dependencies.
+
+Rollback:
+- Disable validation rules and keep RBAC objects unchanged.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"ClusterRole|Role|clusterScoped\"
+kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_RBAC_CLUSTER_SCOPED\"
+```
+
+## Failure Modes and Mitigations
+- Controllers get RBAC forbidden errors: mitigate by surfacing `clusterScoped` and scope in logs and health.
+- Overbroad RBAC accidentally enabled: mitigate by defaulting `clusterScoped=false` and adding schema warnings for prod overlays.
+
+## Acceptance Criteria
+- Invalid RBAC/scope combinations are rejected at render time.
+- Runtime logs clearly indicate RBAC mode and namespace scope.
+
+## References
+- Kubernetes RBAC overview: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+

--- a/docs/agents/designs/chart-resources-component-overrides.md
+++ b/docs/agents/designs/chart-resources-component-overrides.md
@@ -1,0 +1,74 @@
+# Chart Resources: Component Overrides
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents chart exposes `resources` as a global default and also supports component-specific overrides (`controlPlane.resources`, `controllers.resources`). These overrides are implemented in templates but not explicitly documented, which increases the chance of accidentally starving controllers or the control plane in production.
+
+## Goals
+- Document the current override behavior and make it explicit.
+- Recommend production defaults for control plane vs controllers.
+- Ensure resource settings are observable via Helm render and `kubectl`.
+
+## Non-Goals
+- Autosizing resources automatically.
+- Changing scheduling/affinity policies (handled separately).
+
+## Current State
+- Values:
+  - Global: `charts/agents/values.yaml` → `resources`
+  - Control plane override: `charts/agents/values.yaml` → `controlPlane.resources`
+  - Controllers override: `charts/agents/values.yaml` → `controllers.resources`
+- Template wiring:
+  - Control plane uses `$resources := .Values.controlPlane.resources | default .Values.resources` in `charts/agents/templates/deployment.yaml`.
+  - Controllers uses `$resources := .Values.controllers.resources | default .Values.resources` in `charts/agents/templates/deployment-controllers.yaml`.
+- Cluster desired state sets `resources.requests` globally in `argocd/applications/agents/values.yaml` but does not set per-component overrides.
+
+## Design
+### Contract
+- If a component override is an empty object (`{}`), it is treated as “unset” and the component inherits from global `resources`.
+- Production guidance:
+  - Controllers should have explicit requests/limits tuned for reconcile throughput.
+  - Control plane should have explicit requests/limits tuned for serving traffic and background tasks.
+
+### Recommended chart documentation
+Add a chart README section:
+- “Resource precedence” with examples showing:
+  - Global only
+  - Controllers-only override
+  - Control-plane-only override
+
+## Config Mapping
+| Helm value | Pod resources target | Behavior |
+|---|---|---|
+| `resources` | `deploy/agents` and `deploy/agents-controllers` | Baseline default for all components. |
+| `controlPlane.resources` | `deploy/agents` | Overrides global for control plane only. |
+| `controllers.resources` | `deploy/agents-controllers` | Overrides global for controllers only. |
+
+## Rollout Plan
+1. Document precedence (no behavior change).
+2. In GitOps, set explicit per-component requests for production.
+3. Add alerting to catch CPU throttling / OOMKilled during canary (operational follow-up).
+
+Rollback:
+- Revert values changes; chart behavior remains backward compatible.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"resources:|requests:|limits:\"
+kubectl -n agents get deploy agents -o yaml | rg -n \"resources:\"
+kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"resources:\"
+```
+
+## Failure Modes and Mitigations
+- Controllers starve and fall behind: mitigate by explicit controller requests and by monitoring reconcile lag.
+- Control plane throttles under API load: mitigate by explicit control plane requests and HPA (if enabled).
+- Values changes accidentally apply to both components: mitigate by using component overrides and validating rendered manifests.
+
+## Acceptance Criteria
+- Documentation clearly explains precedence and examples.
+- Production GitOps values can size controllers separately from the control plane.
+
+## References
+- Kubernetes resource requests/limits: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+

--- a/docs/agents/designs/chart-rollback-helm-behavior.md
+++ b/docs/agents/designs/chart-rollback-helm-behavior.md
@@ -1,0 +1,65 @@
+# Chart Rollback Behavior and Safe Defaults
+
+Status: Draft (2026-02-06)
+
+## Overview
+In GitOps, “rollback” typically means reverting values/manifests and letting Argo CD sync. Operators still rely on Helm semantics when debugging template behavior or when performing emergency rollbacks in non-GitOps contexts.
+
+This doc defines rollback-safe defaults and what must remain backward compatible across chart versions.
+
+## Goals
+- Ensure the chart is rollback-safe (values changes can be reverted cleanly).
+- Avoid one-way migrations in templates.
+- Document the operational rollback procedure for GitOps.
+
+## Non-Goals
+- Documenting full disaster recovery scenarios (handled elsewhere).
+
+## Current State
+- Chart includes CRDs under `charts/agents/crds/` and installs them when `includeCRDs: true` (GitOps).
+- GitOps desired state: `argocd/applications/agents/kustomization.yaml` (includes chart + CRDs).
+- Templates avoid Helm hooks by default; optional Argo CD hooks exist under `charts/agents/templates/argocd-hooks.yaml`.
+
+## Design
+### Rollback-safe principles
+- Never delete CRDs automatically on rollback.
+- Additive-only changes to templates by default (new resources gated behind flags).
+- Avoid renaming resources unless a migration plan exists.
+
+### GitOps rollback procedure
+1. Revert the GitOps values/manifests commit.
+2. Sync Argo CD application.
+3. Validate both Deployments rolled back to the prior image digests.
+
+## Config Mapping
+| Change type | Rollback risk | Mitigation |
+|---|---:|---|
+| New optional resource gated by flag | low | Default flag `false` and schema documentation. |
+| Rename of a Service/Deployment | high | Avoid; if required, provide migration doc + dual-write period. |
+| CRD schema breaking change | very high | Use versioned CRDs + conversion strategy (separate design). |
+
+## Rollout Plan
+1. Add a chart README section: “Rollback: what is safe to revert”.
+2. Add CI check ensuring new templates are gated behind feature flags when appropriate.
+
+Rollback:
+- Apply the GitOps rollback procedure above.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml >/tmp/agents.yaml
+kubectl -n agents rollout status deploy/agents
+kubectl -n agents rollout status deploy/agents-controllers
+```
+
+## Failure Modes and Mitigations
+- Rollback leaves new resources behind: mitigate by gating and by keeping selectors stable.
+- Rollback reintroduces old defaults unexpectedly: mitigate by documenting default changes and versioning values.
+
+## Acceptance Criteria
+- Rolling back GitOps values returns pods to prior images and behavior within one sync.
+- Chart upgrades do not require manual cleanup for optional features.
+
+## References
+- Helm template guide: https://helm.sh/docs/chart_template_guide/
+

--- a/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
+++ b/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
@@ -1,0 +1,69 @@
+# Chart Runner ServiceAccount Defaulting
+
+Status: Draft (2026-02-06)
+
+## Overview
+Agents controllers schedule Kubernetes Jobs for agent runs. The chart includes a `runnerServiceAccount` block and multiple runtime defaults (`runtime.scheduleServiceAccount`, workload defaults, and controller env vars). The defaulting hierarchy must be explicit so operators can ensure jobs run with the intended permissions.
+
+## Goals
+- Define a single, deterministic defaulting chain for runner Jobs.
+- Avoid accidental privilege escalation (jobs using a more-privileged SA than intended).
+
+## Non-Goals
+- Replacing per-run workload overrides in CRDs.
+
+## Current State
+- Values:
+  - `runnerServiceAccount.*` in `charts/agents/values.yaml`
+  - `runtime.scheduleServiceAccount` in `charts/agents/values.yaml`
+  - `controller.defaultWorkload.serviceAccountName` in `charts/agents/values.yaml`
+- Template mappings (controllers):
+  - `JANGAR_SCHEDULE_SERVICE_ACCOUNT` from `runtime.scheduleServiceAccount`: `charts/agents/templates/deployment-controllers.yaml`
+  - default workload SA: `JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT` from `controller.defaultWorkload.serviceAccountName`: `charts/agents/templates/deployment-controllers.yaml`
+- Runtime uses these env vars while creating Jobs: `services/jangar/src/server/agents-controller.ts`.
+
+## Design
+### Defaulting chain (recommended)
+1. `AgentRun.spec.workload.serviceAccountName` (per-run explicit)
+2. `Agent.spec.security.allowedServiceAccounts` (policy gate; deny if not allowed)
+3. `controller.defaultWorkload.serviceAccountName` (cluster/operator default)
+4. `runtime.scheduleServiceAccount` (legacy compatibility)
+5. Fallback: chart-created `runnerServiceAccount` when `runnerServiceAccount.setAsDefault=true`
+
+### Chart changes
+- Prefer a single chart value that maps to the controller default runner SA, e.g.:
+  - `runner.defaultServiceAccountName`
+and deprecate `runtime.scheduleServiceAccount` for job execution.
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controller.defaultWorkload.serviceAccountName` | `JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT` | Primary default SA for agent-run Jobs. |
+| `runtime.scheduleServiceAccount` | `JANGAR_SCHEDULE_SERVICE_ACCOUNT` | Legacy/secondary default; should be deprecated for Jobs. |
+| `runnerServiceAccount.setAsDefault` | (chart behavior) | If enabled, set the above to created runner SA name. |
+
+## Rollout Plan
+1. Document the defaulting chain in chart README and in controller logs.
+2. Add warnings when legacy `runtime.scheduleServiceAccount` is used for Jobs.
+3. Introduce the new `runner.defaultServiceAccountName` value and migrate GitOps values.
+
+Rollback:
+- Keep both env vars supported; revert to legacy configuration.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT|JANGAR_SCHEDULE_SERVICE_ACCOUNT\"
+kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT|JANGAR_SCHEDULE_SERVICE_ACCOUNT\"
+```
+
+## Failure Modes and Mitigations
+- Job runs under an unintended SA: mitigate by making the defaulting chain explicit and enforcing allowed-service-accounts policy.
+- Missing SA causes Job create failure: mitigate with schema validation and chart-created SA defaults.
+
+## Acceptance Criteria
+- Render output shows exactly one “default runner SA” configured for controllers.
+- Controller logs indicate the SA used for each created Job.
+
+## References
+- Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
+

--- a/docs/agents/designs/chart-serviceaccount-name-resolution.md
+++ b/docs/agents/designs/chart-serviceaccount-name-resolution.md
@@ -1,0 +1,74 @@
+# Chart ServiceAccount Name Resolution
+
+Status: Draft (2026-02-06)
+
+## Overview
+The Agents chart supports `serviceAccount.create` and `serviceAccount.name`, plus a separate `runnerServiceAccount` for jobs created by controllers. The naming and resolution rules must be explicit so operators can safely integrate with external IAM (IRSA, Workload Identity) and cluster policy.
+
+## Goals
+- Define deterministic ServiceAccount naming and selection for:
+  - Control plane pods
+  - Controllers pods
+  - Runner jobs (if enabled)
+- Avoid accidental reuse of default ServiceAccounts.
+
+## Non-Goals
+- Cloud-provider-specific IAM automation.
+
+## Current State
+- Values: `charts/agents/values.yaml` under `serviceAccount.*` and `runnerServiceAccount.*`.
+- Templates:
+  - ServiceAccount: `charts/agents/templates/serviceaccount.yaml`
+  - Runner ServiceAccount: `charts/agents/templates/runner-serviceaccount.yaml`
+  - Pods use `serviceAccountName: {{ include "agents.serviceAccountName" . }}` in both deployments:
+    - `charts/agents/templates/deployment.yaml`
+    - `charts/agents/templates/deployment-controllers.yaml`
+- Runner RBAC: `charts/agents/templates/runner-rbac.yaml`.
+
+## Design
+### Naming contract
+- If `serviceAccount.create=true` and `serviceAccount.name` is empty:
+  - Chart creates `ServiceAccount/<release fullname>`.
+- If `serviceAccount.name` is set:
+  - Chart uses that name and does not create a new ServiceAccount unless explicitly requested.
+
+### Runner ServiceAccount contract
+- If `runnerServiceAccount.create=true`:
+  - Chart creates `ServiceAccount/<release fullname>-runner` unless `runnerServiceAccount.name` is set.
+- If `runnerServiceAccount.setAsDefault=true`:
+  - Controllers default runner jobs to that ServiceAccount via env var mapping (see `charts/agents/templates/deployment-controllers.yaml` for `JANGAR_SCHEDULE_SERVICE_ACCOUNT` and workload defaults).
+
+## Config Mapping
+| Helm value | Rendered object/field | Behavior |
+|---|---|---|
+| `serviceAccount.create=true` | `ServiceAccount` | Create control plane/controllers ServiceAccount. |
+| `serviceAccount.name` | `spec.serviceAccountName` | Explicit override of SA used by Deployments. |
+| `runnerServiceAccount.create=true` | `ServiceAccount` | Create SA intended for runner Jobs. |
+| `runnerServiceAccount.setAsDefault=true` | controller env/runtime | Sets default runner job SA when workload spec omits it. |
+
+## Rollout Plan
+1. Document naming in `charts/agents/README.md`.
+2. Add chart validation:
+   - If `runnerServiceAccount.rbac.create=true`, require `runnerServiceAccount.create=true` or a non-empty name.
+3. Add controller-side logging of chosen runner ServiceAccount per Job.
+
+Rollback:
+- Revert values; existing ServiceAccounts are safe to keep.
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"kind: ServiceAccount|serviceAccountName\"
+kubectl -n agents get sa
+```
+
+## Failure Modes and Mitigations
+- Deployments run as `default` SA unexpectedly: mitigate with schema validation and documented defaults.
+- Runner jobs fail RBAC due to SA mismatch: mitigate with explicit runner SA + explicit RoleBindings.
+
+## Acceptance Criteria
+- Helm render shows a single, predictable ServiceAccount per component.
+- Runner job SA selection is observable in logs and Job specs.
+
+## References
+- Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
+

--- a/docs/agents/designs/chart-termination-grace-prestop.md
+++ b/docs/agents/designs/chart-termination-grace-prestop.md
@@ -1,0 +1,66 @@
+# Chart Termination Grace + preStop Hook
+
+Status: Draft (2026-02-06)
+
+## Overview
+The control plane and controllers handle active requests and ongoing reconciliations. During rollout or node drain, pods should stop accepting new work and drain in-flight tasks before termination. The chart currently does not expose termination grace or preStop hooks.
+
+## Goals
+- Add configurable `terminationGracePeriodSeconds`.
+- Add optional `preStop` hooks to support graceful shutdown.
+
+## Non-Goals
+- Implementing full “drain queues before exit” semantics in the chart alone (requires controller code support).
+
+## Current State
+- Templates:
+  - `charts/agents/templates/deployment.yaml` and `deployment-controllers.yaml` do not set `terminationGracePeriodSeconds` or lifecycle hooks.
+- Runtime shutdown behavior is code-defined and may be abrupt if SIGTERM is not handled carefully:
+  - Controllers: `services/jangar/src/server/agents-controller.ts` (shutdown path)
+  - Control plane: server entrypoints under `services/jangar/src/server/*`
+
+## Design
+### Proposed values
+Add:
+- `terminationGracePeriodSeconds` (global default)
+- `controlPlane.terminationGracePeriodSeconds`
+- `controllers.terminationGracePeriodSeconds`
+- `controlPlane.lifecycle.preStop`
+- `controllers.lifecycle.preStop`
+
+### Recommended defaults
+- Control plane: 30s
+- Controllers: 60s (to finish reconcile loops)
+
+## Config Mapping
+| Helm value | Rendered field | Intended behavior |
+|---|---|---|
+| `controllers.terminationGracePeriodSeconds` | `deploy/agents-controllers.spec.template.spec.terminationGracePeriodSeconds` | Gives controllers time to stop cleanly. |
+| `controlPlane.lifecycle.preStop` | `containers[].lifecycle.preStop` | Stop accepting traffic before termination. |
+
+## Rollout Plan
+1. Ship values with conservative defaults.
+2. Add controller/control plane logs on SIGTERM (“draining”).
+3. Tune grace periods based on observed shutdown times.
+
+Rollback:
+- Remove lifecycle settings; Kubernetes defaults apply.
+
+## Validation
+```bash
+helm template agents charts/agents | rg -n \"terminationGracePeriodSeconds|preStop\"
+kubectl -n agents rollout restart deploy/agents
+kubectl -n agents rollout restart deploy/agents-controllers
+```
+
+## Failure Modes and Mitigations
+- Grace period too short causes dropped requests or partial reconciliation: mitigate by conservative defaults and observability of shutdown durations.
+- Grace period too long slows rollouts: mitigate by tuning and adding early-drain behavior in code.
+
+## Acceptance Criteria
+- Pods drain predictably during rollouts and node drains.
+- Termination settings are configurable per component.
+
+## References
+- Kubernetes container lifecycle hooks: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+

--- a/docs/agents/designs/controller-auth-secret-mount-rotation.md
+++ b/docs/agents/designs/controller-auth-secret-mount-rotation.md
@@ -1,0 +1,68 @@
+# Controller Auth Secret Mount and Rotation
+
+Status: Draft (2026-02-06)
+
+## Overview
+The controllers deployment supports an “auth secret” for agentctl gRPC authentication via `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_*`. The chart can mount the Secret and set env vars, but the operational contract for rotation is not documented.
+
+## Goals
+- Document the auth secret format, mount path, and rotation behavior.
+- Ensure safe defaults (auth disabled unless explicitly configured).
+
+## Non-Goals
+- Replacing auth with a full identity provider (OIDC, mTLS).
+
+## Current State
+- Chart values: `charts/agents/values.yaml` → `controller.authSecret.{name,key,mountPath}`.
+- Template wiring (controllers):
+  - `charts/agents/templates/deployment-controllers.yaml` sets:
+    - `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME`
+    - `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_KEY`
+    - `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH`
+  - It also mounts the secret volume (see the same template for volume/volumeMounts).
+- Runtime resolves config and path in `services/jangar/src/server/agents-controller.ts`:
+  - `resolveAuthSecretConfig()`, `buildAuthSecretPath()`.
+- Tests cover the env var behavior: `services/jangar/src/server/__tests__/agents-controller.test.ts`.
+
+## Design
+### Contract
+- If `controller.authSecret.name` is empty:
+  - Auth is disabled (no secret read).
+- If set:
+  - Secret MUST contain `key` (default `auth.json`).
+  - Secret is mounted read-only at `mountPath` (default `/root/.codex`).
+- Rotation:
+  - Update the Secret data, then trigger a rollout (checksum annotation or manual restart) so controllers reload.
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controller.authSecret.name` | `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME` | Enables auth secret loading when non-empty. |
+| `controller.authSecret.key` | `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_KEY` | Secret data key to read. |
+| `controller.authSecret.mountPath` | `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH` | Directory path for mounted secret file. |
+
+## Rollout Plan
+1. Document the secret schema and rotation steps.
+2. Add checksum rollouts for the auth Secret (opt-in).
+3. Add controller startup log: “auth secret enabled/disabled” (without printing secret contents).
+
+Rollback:
+- Clear `controller.authSecret.name` and re-sync; controller runs unauthenticated (ensure network access controls).
+
+## Validation
+```bash
+helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"AUTH_SECRET\"
+kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"AUTH_SECRET\"
+```
+
+## Failure Modes and Mitigations
+- Secret is missing or key mismatch: mitigate with render-time validation and clear startup errors.
+- Rotation happens but pod does not restart: mitigate with checksum-triggered rollouts.
+
+## Acceptance Criteria
+- Auth secret enablement is explicit and observable.
+- Rotation steps are documented and testable.
+
+## References
+- Kubernetes Secrets: https://kubernetes.io/docs/concepts/configuration/secret/
+

--- a/docs/agents/designs/controller-condition-type-taxonomy.md
+++ b/docs/agents/designs/controller-condition-type-taxonomy.md
@@ -1,0 +1,70 @@
+# Controller Condition Type Taxonomy
+
+Status: Draft (2026-02-06)
+
+## Overview
+Agents CRDs expose Kubernetes-style conditions (e.g. `Ready`, `Succeeded`, `Blocked`). Without a consistent taxonomy, automation and operator expectations diverge between resources.
+
+This doc defines a minimal, consistent condition set and naming conventions.
+
+## Goals
+- Standardize condition types and meanings across Agents CRDs.
+- Ensure conditions are stable, machine-consumable signals (not free-form logs).
+
+## Non-Goals
+- Defining every possible controller-specific reason code.
+
+## Current State
+- CRD types use `[]metav1.Condition`:
+  - `services/jangar/api/agents/v1alpha1/types.go`
+- Controllers construct and upsert conditions:
+  - `services/jangar/src/server/agents-controller.ts` (`buildConditions`, `upsertCondition` usage for `Accepted`, `InProgress`, `Blocked`, etc.)
+  - ImplementationSource webhook controller sets conditions similarly: `services/jangar/src/server/implementation-source-webhooks.ts`.
+- No centralized spec exists for condition types and transitions.
+
+## Design
+### Recommended condition types
+Across reconciled resources:
+- `Ready`: resource is valid and reconciled.
+- For run-like resources:
+  - `Accepted`: controller accepted the run.
+  - `InProgress`: work in progress.
+  - `Succeeded`: terminal success.
+  - `Failed`: terminal failure.
+  - `Cancelled`: terminal cancellation (when applicable).
+- Optional:
+  - `Blocked`: policy/concurrency blocked.
+
+### Transition rules
+- Only one terminal condition (`Succeeded`/`Failed`/`Cancelled`) may be `True` at a time.
+- `Ready` should be `False` when terminal failure is reached, or be omitted if not meaningful.
+
+## Config Mapping
+| Surface | Behavior |
+|---|---|
+| (code only) | Condition taxonomy is a controller contract; enforce via tests and docs. |
+
+## Rollout Plan
+1. Document the taxonomy and update controller code to match.
+2. Add unit tests that validate terminal condition exclusivity and stable type names.
+
+Rollback:
+- Revert controller changes; keep doc and tests for future alignment.
+
+## Validation
+```bash
+kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[*].type}'; echo
+kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[?(@.type==\"Succeeded\")].status}'; echo
+```
+
+## Failure Modes and Mitigations
+- Multiple terminal conditions become true: mitigate with a shared condition helper enforcing exclusivity.
+- Controllers use inconsistent type strings: mitigate by constants and tests.
+
+## Acceptance Criteria
+- Condition types are consistent across CRDs and reconciler code.
+- Automation can reliably determine run state from conditions alone.
+
+## References
+- Kubernetes API conventions (Conditions): https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+

--- a/docs/agents/designs/controller-controllers-deployment-grpc-off.md
+++ b/docs/agents/designs/controller-controllers-deployment-grpc-off.md
@@ -1,0 +1,66 @@
+# Controllers Deployment: gRPC Disabled by Default
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart renders a separate controllers deployment that forces `JANGAR_GRPC_ENABLED=0` unless explicitly overridden. This is a good safety default (controllers do not need to expose gRPC externally), but it is undocumented and can be surprising when operators expect agentctl gRPC to be available everywhere.
+
+This doc defines the intended behavior and introduces a controlled enablement path if needed.
+
+## Goals
+- Document why gRPC is disabled in controllers.
+- Provide a safe opt-in for controller gRPC only when required.
+
+## Non-Goals
+- Making controllers gRPC publicly accessible.
+
+## Current State
+- Chart forces defaults in `charts/agents/templates/deployment-controllers.yaml`:
+  - Sets `JANGAR_GRPC_ENABLED` to `"0"` unless present in `controllers.env.vars`.
+- Control plane gRPC behavior is implemented in:
+  - `services/jangar/src/server/control-plane-grpc.ts`
+  - `services/jangar/src/server/agentctl-grpc.ts`
+- Cluster desired state sets gRPC enabled for control plane in `argocd/applications/agents/values.yaml`.
+
+## Design
+### Contract
+- Controllers gRPC remains disabled by default.
+- If controller gRPC is needed (e.g., for internal debugging), enable it explicitly with:
+  - `controllers.env.vars.JANGAR_GRPC_ENABLED: "true"`
+and require `controllers.service.enabled=true` (see chart design) to avoid “listening but unreachable” states.
+
+### Additional guardrails
+- Add a startup log line in controllers indicating whether gRPC server started.
+- Add chart validation: if `controllers.env.vars.JANGAR_GRPC_ENABLED=true`, require `controllers.service.enabled=true`.
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_GRPC_ENABLED` | `JANGAR_GRPC_ENABLED` | Explicit opt-in for controllers gRPC server. |
+| (unset) | `JANGAR_GRPC_ENABLED=0` | Default: controllers do not start gRPC server. |
+
+## Rollout Plan
+1. Document current forced default.
+2. Add guardrails and optional Service support.
+3. If needed, canary-enable controller gRPC in non-prod only.
+
+Rollback:
+- Remove the explicit env var and disable controller Service.
+
+## Validation
+```bash
+helm template agents charts/agents --set controllers.enabled=true | rg -n \"JANGAR_GRPC_ENABLED\"
+kubectl -n agents logs deploy/agents-controllers | rg -n \"gRPC|Agentctl\"
+```
+
+## Failure Modes and Mitigations
+- Operators think gRPC is enabled due to `grpc.enabled=true`: mitigate by documenting that it affects only the control plane.
+- gRPC enabled without Service: mitigate with render-time validation and an opt-in Service template.
+
+## Acceptance Criteria
+- It is clear (from values + render) whether controllers will run gRPC.
+- Enabling controller gRPC requires explicit opt-in and is not accidental.
+
+## References
+- gRPC basics: https://grpc.io/docs/what-is-grpc/introduction/
+

--- a/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
+++ b/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
@@ -1,0 +1,63 @@
+# Controllers Deployment: Migrations Skipped by Default
+
+Status: Draft (2026-02-06)
+
+## Overview
+Database migrations are potentially disruptive and should not be run by the controllers deployment. The chart enforces this by defaulting `JANGAR_MIGRATIONS=skip` in the controllers Deployment unless explicitly overridden. This behavior should be documented and protected by validation.
+
+## Goals
+- Keep migrations in the control plane only (or in a dedicated migration job).
+- Ensure controllers never run migrations accidentally.
+
+## Non-Goals
+- Redesigning the migration system (Kysely/SQL).
+
+## Current State
+- Chart sets default in `charts/agents/templates/deployment-controllers.yaml`:
+  - If `JANGAR_MIGRATIONS` is not present in `controllers.env.vars`, set it to `"skip"`.
+- Migration behavior is implemented in `services/jangar/src/server/kysely-migrations.ts`:
+  - `resolveMigrationsMode()` treats missing/unknown as `auto`, explicit “skip/disabled/false/0/off” as `skip`.
+- Control plane default in `charts/agents/values.yaml` is `env.vars.JANGAR_MIGRATIONS: auto`.
+
+## Design
+### Contract
+- Controllers MUST always run with migrations disabled (skip).
+- Control plane may run migrations (`auto`) OR migrations may be moved to an init Job (future).
+
+### Validation
+- Chart validation:
+  - Fail render if `controllers.env.vars.JANGAR_MIGRATIONS` is set to any non-skip value.
+- Controller startup validation:
+  - If `JANGAR_MIGRATIONS` resolves to `auto`, exit non-zero with an actionable error.
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `env.vars.JANGAR_MIGRATIONS=auto` | `JANGAR_MIGRATIONS` | Control plane may apply migrations. |
+| `controllers.env.vars.JANGAR_MIGRATIONS=skip` | `JANGAR_MIGRATIONS` | Controllers never run migrations. |
+
+## Rollout Plan
+1. Add documentation and chart validation (initially warning-only if needed).
+2. Add controller startup fail-fast validation.
+3. Optionally move migrations to a dedicated Job later.
+
+Rollback:
+- Revert controller startup validation (code rollback) if it blocks an unexpected environment.
+
+## Validation
+```bash
+helm template agents charts/agents --set controllers.enabled=true | rg -n \"JANGAR_MIGRATIONS\"
+kubectl -n agents logs deploy/agents-controllers | rg -n \"migration|migrations\"
+```
+
+## Failure Modes and Mitigations
+- Controllers run migrations during rollout: mitigate by chart defaults + strict validation.
+- Control plane migration failures block startup: mitigate by allowing operators to set `JANGAR_MIGRATIONS=skip` on control plane as an emergency fallback.
+
+## Acceptance Criteria
+- Controllers cannot be configured (via Helm) to run migrations.
+- The effective mode is visible in rendered manifests and logs.
+
+## References
+- Kubernetes init containers and migration patterns: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+

--- a/docs/agents/designs/controller-failed-reconcile-events.md
+++ b/docs/agents/designs/controller-failed-reconcile-events.md
@@ -1,0 +1,65 @@
+# Controller Failed Reconcile: Kubernetes Events
+
+Status: Draft (2026-02-06)
+
+## Overview
+When reconciles fail, the current primary signal is logs (and possibly status conditions). Kubernetes Events are a useful operational tool (visible via `kubectl describe`) and can improve MTTR, especially for failures like missing secrets, RBAC, or invalid spec fields.
+
+## Goals
+- Emit Kubernetes Events for actionable reconcile failures.
+- Avoid noisy event storms for transient errors.
+
+## Non-Goals
+- Replacing logs or status conditions.
+
+## Current State
+- Controllers update status for many CRDs via `setStatus(...)` helpers:
+  - `services/jangar/src/server/agents-controller.ts`
+  - `services/jangar/src/server/implementation-source-webhooks.ts` (status updates)
+- Kubernetes client wrapper currently supports listing Events but not creating them:
+  - `services/jangar/src/server/primitives-kube.ts` includes `listEvents(...)` but no `createEvent(...)`.
+- The chart does not configure event emission.
+
+## Design
+### Event emission rules
+- For non-retryable spec/config errors:
+  - Emit `Warning` event with a stable reason (e.g. `InvalidSpec`, `MissingSecret`, `Forbidden`).
+- For transient errors:
+  - Update status condition + log; emit an event only on first occurrence and then rate-limit (per-object).
+
+### Implementation approach
+- Extend `KubernetesClient` in `primitives-kube.ts` to support creating Events:
+  - Use `events.k8s.io/v1` if available; fall back to `v1` Events if necessary.
+- Add an event helper in controllers to avoid duplication and to enforce rate limiting.
+
+## Config Mapping
+| Helm value (proposed) | Env var (proposed) | Intended behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_CONTROLLER_EVENTS_ENABLED` | `JANGAR_CONTROLLER_EVENTS_ENABLED` | Enables/disables event emission (default `true`). |
+| `controllers.env.vars.JANGAR_CONTROLLER_EVENTS_RATE_LIMIT_PER_MIN` | `JANGAR_CONTROLLER_EVENTS_RATE_LIMIT_PER_MIN` | Caps event spam per object. |
+
+## Rollout Plan
+1. Add event emission behind `JANGAR_CONTROLLER_EVENTS_ENABLED=true` with conservative rate limits.
+2. Canary in non-prod and confirm event volume is manageable.
+3. Enable in prod; document common reasons in runbooks.
+
+Rollback:
+- Set `JANGAR_CONTROLLER_EVENTS_ENABLED=false`.
+
+## Validation
+```bash
+kubectl -n agents get events --sort-by=.metadata.creationTimestamp | tail -n 50
+kubectl -n agents describe agentrun <name> | rg -n \"Events:\"
+```
+
+## Failure Modes and Mitigations
+- Event storms during reconcile loops: mitigate with strict per-object rate limiting and “first occurrence only” logic.
+- Events leak sensitive info: mitigate by sanitizing messages and never including secret values.
+
+## Acceptance Criteria
+- Non-retryable spec errors produce a Kubernetes Event with a stable reason.
+- Event volume remains bounded under failure conditions.
+
+## References
+- Kubernetes Events: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#event-v1-core
+

--- a/docs/agents/designs/controller-finalizer-conventions.md
+++ b/docs/agents/designs/controller-finalizer-conventions.md
@@ -1,0 +1,65 @@
+# Controller Finalizer Conventions
+
+Status: Draft (2026-02-06)
+
+## Overview
+Finalizers ensure controllers can perform cleanup before an object is fully deleted (e.g., deleting external runtimes). Inconsistent finalizer naming and behavior can cause stuck deletions or skipped cleanup.
+
+This doc defines naming conventions and lifecycle behavior for Agents controllers.
+
+## Goals
+- Standardize finalizer naming and behavior.
+- Ensure deletion cleanup is best-effort but does not deadlock deletion.
+
+## Non-Goals
+- Guaranteeing cleanup success in all cases (network outages, permission failures).
+
+## Current State
+- AgentRun uses a runtime cleanup finalizer:
+  - `services/jangar/src/server/agents-controller.ts` uses finalizer `agents.proompteng.ai/runtime-cleanup`.
+- Cleanup attempts call `cancelRuntime(...)` and then remove the finalizer via patch.
+- Other CRDs may not use finalizers consistently.
+
+## Design
+### Naming
+- Format: `<group>/<purpose>` under the API group domain, e.g.:
+  - `agents.proompteng.ai/runtime-cleanup`
+  - `orchestration.proompteng.ai/runtime-cleanup` (if needed)
+
+### Behavior
+- On deletion timestamp:
+  - Attempt cleanup with bounded timeouts.
+  - Never re-add finalizers once deletion has started.
+  - Always remove the finalizer after cleanup attempt, even on failure (log error).
+
+## Config Mapping
+| Proposed env var | Intended behavior |
+|---|---|
+| `JANGAR_CONTROLLER_FINALIZER_CLEANUP_TIMEOUT_MS` | Upper bound for cleanup steps before removing finalizer anyway. |
+
+## Rollout Plan
+1. Document naming conventions and current AgentRun behavior.
+2. Add bounded-time cleanup and ensure finalizer removal happens even on failure.
+3. Add tests covering deletion paths for AgentRun (and others if applicable).
+
+Rollback:
+- Revert cleanup timeout logic; keep naming conventions.
+
+## Validation
+```bash
+kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.finalizers}'; echo
+kubectl -n agents delete agentrun <name> --wait=false
+kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.deletionTimestamp}'; echo
+```
+
+## Failure Modes and Mitigations
+- Finalizer never removed, object stuck deleting: mitigate with bounded cleanup time and “remove anyway” behavior.
+- Cleanup fails silently: mitigate with explicit logs/events on cleanup failure.
+
+## Acceptance Criteria
+- Deleting an AgentRun does not deadlock due to cleanup failures.
+- Finalizer names are consistent and documented.
+
+## References
+- Kubernetes finalizers: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
+

--- a/docs/agents/designs/controller-kubectl-version-compat.md
+++ b/docs/agents/designs/controller-kubectl-version-compat.md
@@ -1,0 +1,60 @@
+# Controller kubectl Version Compatibility
+
+Status: Draft (2026-02-06)
+
+## Overview
+Controllers interact with the Kubernetes API by spawning the `kubectl` binary (`primitives-kube.ts` and `kube-watch.ts`). This implicitly makes controller correctness dependent on the `kubectl` version baked into the image. We should document and enforce a compatibility policy.
+
+## Goals
+- Define a supported `kubectl` version skew policy for controller images.
+- Make it easy to verify which `kubectl` version is running.
+
+## Non-Goals
+- Migrating controllers to a full Kubernetes client SDK in this phase.
+
+## Current State
+- `kubectl` is invoked directly:
+  - `services/jangar/src/server/primitives-kube.ts` calls `spawn('kubectl', ...)`
+  - `services/jangar/src/server/kube-watch.ts` calls `spawn('kubectl', ['get', ..., '--watch', ...])`
+- Helm chart does not surface or validate the kubectl version.
+- Cluster Kubernetes version is not tracked in this repo; GitOps manifests do not pin it.
+
+## Design
+### Compatibility policy
+- Controller image must include `kubectl` within a supported skew of the cluster (documented per Kubernetes guidance).
+- Operationally: bake `kubectl` version into the image build and expose it via:
+  - `JANGAR_KUBECTL_VERSION` env var (build-time)
+  - or a startup log line running `kubectl version --client --short`
+
+### Chart changes (optional)
+- Add `controllers.env.vars.JANGAR_KUBECTL_VERSION` passthrough (documented).
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_KUBECTL_VERSION` | `JANGAR_KUBECTL_VERSION` | Exposes build-time kubectl version for debugging. |
+
+## Rollout Plan
+1. Add runtime logging of `kubectl version --client`.
+2. Add CI check that controller image build pins a known kubectl version (build pipeline work).
+
+Rollback:
+- Disable the logging; keep pinned version in images.
+
+## Validation
+```bash
+kubectl -n agents exec deploy/agents-controllers -- kubectl version --client --short
+kubectl -n agents logs deploy/agents-controllers | rg -n \"kubectl\"
+```
+
+## Failure Modes and Mitigations
+- kubectl/client-server incompatibility causes subtle failures: mitigate with a documented skew policy and proactive logging.
+- Missing kubectl binary in image: mitigate by adding a startup self-check that fails fast with a clear error.
+
+## Acceptance Criteria
+- Operators can determine the kubectl client version from logs or exec.
+- Controller images follow an explicit kubectl skew policy.
+
+## References
+- Kubernetes version skew policy: https://kubernetes.io/releases/version-skew-policy/
+

--- a/docs/agents/designs/controller-namespace-scope-parse-validate.md
+++ b/docs/agents/designs/controller-namespace-scope-parse-validate.md
@@ -1,0 +1,69 @@
+# Controller Namespace Scope: Parse + Validate
+
+Status: Draft (2026-02-06)
+
+## Overview
+Namespace scoping is a primary safety control for Agents controllers. The controllers accept a namespaces list via env vars (`JANGAR_AGENTS_CONTROLLER_NAMESPACES`, `JANGAR_PRIMITIVES_NAMESPACES`). Invalid JSON or ambiguous inputs can lead to unexpected reconciliation scope.
+
+This doc proposes strict parsing and validation rules plus chart-side guardrails.
+
+## Goals
+- Ensure namespace scope parsing is strict, deterministic, and observable.
+- Prevent accidental broad scopes due to parsing fallbacks.
+
+## Non-Goals
+- Multi-namespace controller architecture changes.
+
+## Current State
+- Chart renders namespace lists into env vars:
+  - `charts/agents/templates/deployment-controllers.yaml` sets `JANGAR_PRIMITIVES_NAMESPACES` and `JANGAR_AGENTS_CONTROLLER_NAMESPACES` via `agents.controllerNamespaces`.
+- Runtime parsing helpers exist in `services/jangar/src/server/agents-controller.ts`:
+  - `parseEnvArray`, `parseEnvList`, `parseEnvStringList`.
+- Namespace scoping helpers live in `services/jangar/src/server/namespace-scope.ts`.
+
+## Design
+### Accepted formats
+Support exactly:
+- JSON array: `["agents","agents-ci"]`
+- Comma-separated list: `agents,agents-ci`
+
+### Validation rules (fail-fast)
+- Empty list is invalid unless `rbac.clusterScoped=true` and wildcard `*` is explicitly present.
+- Reject invalid JSON (do not silently fall back to CSV).
+- Reject namespaces with whitespace or invalid DNS label characters.
+
+### Observability
+- Log the resolved namespace list at startup.
+- Expose it via a controller health endpoint (if available).
+
+## Config Mapping
+| Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controller.namespaces` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES` | Canonical scope for agents reconciliation. |
+| `controller.namespaces` | `JANGAR_PRIMITIVES_NAMESPACES` | Canonical scope for primitives reconciliation. |
+
+## Rollout Plan
+1. Add strict parsing behind a feature flag (warn-only mode).
+2. Canary in non-prod by intentionally injecting invalid values and confirming rejection.
+3. Promote to fail-fast in prod.
+
+Rollback:
+- Disable strict parsing flag.
+
+## Validation
+```bash
+kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_AGENTS_CONTROLLER_NAMESPACES|JANGAR_PRIMITIVES_NAMESPACES\"
+kubectl -n agents logs deploy/agents-controllers | rg -n \"namespaces\"
+```
+
+## Failure Modes and Mitigations
+- Silent fallback expands scope: mitigate by rejecting invalid JSON rather than falling back.
+- Mis-typed namespace blocks controllers startup: mitigate by clear error messages and GitOps revertability.
+
+## Acceptance Criteria
+- Invalid namespace scope config results in a clear startup failure.
+- Resolved namespaces are logged and testable.
+
+## References
+- Kubernetes namespace naming: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+

--- a/docs/agents/designs/controller-orchestration-submit-dedup.md
+++ b/docs/agents/designs/controller-orchestration-submit-dedup.md
@@ -1,0 +1,64 @@
+# Orchestration Submit Deduplication (Delivery ID)
+
+Status: Draft (2026-02-06)
+
+## Overview
+Orchestration run submission is triggered by external events (e.g., webhooks). Duplicate deliveries are common. The current system deduplicates submissions by `deliveryId` using the primitives store.
+
+This doc formalizes the dedupe contract and proposes chart/controller knobs to keep it safe in production.
+
+## Goals
+- Guarantee idempotent orchestration submissions per `(namespace, orchestrationRef, deliveryId)`.
+- Ensure dedupe state is durable across controller restarts.
+
+## Non-Goals
+- Exactly-once processing across multiple clusters.
+
+## Current State
+- Submission code: `services/jangar/src/server/orchestration-submit.ts`
+  - Looks up `store.getOrchestrationRunByDeliveryId(input.deliveryId)` and returns existing run if present.
+  - Applies an `OrchestrationRun` resource with label `jangar.proompteng.ai/delivery-id`.
+- Store layer: `services/jangar/src/server/primitives-store.ts` (durable DB-backed store).
+- Chart wiring for DB URL is required for controllers: `charts/agents/templates/deployment-controllers.yaml`.
+
+## Design
+### Contract
+- `deliveryId` MUST be treated as globally unique per provider.
+- If a duplicate `deliveryId` is received:
+  - Return the existing `OrchestrationRun` record and (if present) the external CR state.
+- Dedupe retention:
+  - Keep dedupe records for a minimum window (e.g. 7 days) to handle delayed retries.
+
+### Proposed config
+- `JANGAR_ORCHESTRATION_DEDUPE_RETENTION_DAYS` (default `7`)
+- Store cleanup job (optional) to prune old dedupe rows.
+
+## Config Mapping
+| Proposed Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_ORCHESTRATION_DEDUPE_RETENTION_DAYS` | `JANGAR_ORCHESTRATION_DEDUPE_RETENTION_DAYS` | How long to retain dedupe records. |
+
+## Rollout Plan
+1. Document dedupe semantics and label usage.
+2. Add retention config and a safe default.
+3. Add a periodic cleanup job (optional) once validated in staging.
+
+Rollback:
+- Disable cleanup job and keep retention high.
+
+## Validation
+```bash
+kubectl -n agents get orchestrationrun -l jangar.proompteng.ai/delivery-id --show-labels
+kubectl -n agents logs deploy/agents-controllers | rg -n \"deliveryId|idempotent\"
+```
+
+## Failure Modes and Mitigations
+- Dedupe table grows unbounded: mitigate with retention + cleanup job.
+- deliveryId collisions between providers: mitigate by namespacing deliveryId with provider prefix if needed.
+
+## Acceptance Criteria
+- Duplicate deliveries do not create duplicate orchestration runs.
+- Dedupe state survives controller restarts.
+
+## References
+- HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods

--- a/docs/agents/designs/controller-postgres-ca-rootcert.md
+++ b/docs/agents/designs/controller-postgres-ca-rootcert.md
@@ -1,0 +1,64 @@
+# Postgres TLS: PGSSLROOTCERT Wiring and Validation
+
+Status: Draft (2026-02-06)
+
+## Overview
+The chart supports mounting a Postgres CA bundle via `database.caSecret` and sets `PGSSLROOTCERT` to the mounted path. This is essential for production TLS, but it needs a documented contract (secret key naming, mount paths, rotation).
+
+## Goals
+- Ensure TLS CA mounting is consistent for both deployments.
+- Provide clear rotation and rollback guidance.
+- Validate misconfigurations at render time.
+
+## Non-Goals
+- Managing Postgres certificates themselves (CNPG/cert-manager concerns).
+
+## Current State
+- Values: `charts/agents/values.yaml` → `database.caSecret.name`, `database.caSecret.key`.
+- Templates:
+  - Mount secret to `/etc/jangar/ca` and set `PGSSLROOTCERT`: `charts/agents/templates/deployment.yaml` and `deployment-controllers.yaml`.
+  - Secret volume name is `db-ca-cert` (reserved).
+- Runtime relies on libpq behavior; TLS settings are implied by `DATABASE_URL` parameters + `PGSSLROOTCERT`.
+
+## Design
+### Contract
+- If `database.caSecret.name` is set:
+  - Chart MUST mount the Secret as a read-only volume.
+  - Chart MUST set `PGSSLROOTCERT` to `/etc/jangar/ca/<key>`.
+- The Secret MUST contain the key specified by `database.caSecret.key` (default `ca.crt`).
+
+### Validation
+- Render-time validation should fail if:
+  - `database.caSecret.name` is set but `database.caSecret.key` is empty.
+
+## Config Mapping
+| Helm value | Rendered field/env | Intended behavior |
+|---|---|---|
+| `database.caSecret.name` | Secret volume + mount | Enables CA bundle injection. |
+| `database.caSecret.key` | `PGSSLROOTCERT=/etc/jangar/ca/<key>` | Points libpq to the CA cert file. |
+
+## Rollout Plan
+1. Add documentation for required Secret contents and examples.
+2. Canary-enable CA secret in non-prod, verify DB connects with TLS.
+3. Rotate CA by updating Secret; if using checksum rollouts, pods restart automatically.
+
+Rollback:
+- Remove `database.caSecret.*` values and revert Secret to prior version.
+
+## Validation
+```bash
+helm template agents charts/agents --set database.caSecret.name=my-ca --set database.caSecret.key=ca.crt | rg -n \"PGSSLROOTCERT|db-ca-cert\"
+kubectl -n agents get deploy agents -o yaml | rg -n \"PGSSLROOTCERT|db-ca-cert\"
+```
+
+## Failure Modes and Mitigations
+- Wrong key name causes connection failures: mitigate with validation and clear error logs.
+- CA rotation requires pod restart: mitigate with checksum-triggered rollouts.
+
+## Acceptance Criteria
+- Both deployments mount the CA secret identically when enabled.
+- Render-time validation prevents empty key configurations.
+
+## References
+- Kubernetes Secrets volumes: https://kubernetes.io/docs/concepts/storage/volumes/#secret
+

--- a/docs/agents/designs/controller-reconcile-timeout-budget.md
+++ b/docs/agents/designs/controller-reconcile-timeout-budget.md
@@ -1,0 +1,68 @@
+# Controller Reconcile Timeout Budget
+
+Status: Draft (2026-02-06)
+
+## Overview
+Agents controllers perform multiple external operations during reconciliation (Kubernetes API calls via `kubectl`, VCS calls, webhook parsing, database operations). Today, timeouts are mostly implicit (subprocess defaults, library defaults), which makes tail-latency and hung reconciles hard to diagnose.
+
+This doc proposes explicit, configurable timeout budgets for key controller operations.
+
+## Goals
+- Make controller timeouts explicit and configurable.
+- Prevent a single hung subprocess/API call from stalling reconciliation.
+- Provide clear failure behavior and retry guidance.
+
+## Non-Goals
+- Changing controller concurrency/throughput policies (covered elsewhere).
+
+## Current State
+- Kubernetes calls are executed via spawned `kubectl` processes:
+  - `services/jangar/src/server/primitives-kube.ts` (`runCommand`, `kubectl(...)`)
+  - Watch loop uses `kubectl get --watch`: `services/jangar/src/server/kube-watch.ts` (uses `--request-timeout=0`)
+- Controllers orchestration submission touches the DB store and Kubernetes: `services/jangar/src/server/orchestration-submit.ts`.
+- Helm templates do not set any timeout env vars beyond existing feature toggles: `charts/agents/templates/deployment-controllers.yaml`.
+
+## Design
+### Proposed env vars (controllers only)
+- `JANGAR_CONTROLLER_KUBECTL_TIMEOUT_MS` (default `30000`)
+- `JANGAR_CONTROLLER_DB_TIMEOUT_MS` (default `15000`)
+- `JANGAR_CONTROLLER_EXTERNAL_TIMEOUT_MS` (default `30000`) for provider calls/webhooks where applicable
+
+### Implementation sketch
+- Wrap `runCommand()` in `primitives-kube.ts` with an `AbortController`/timer and kill the child process on timeout.
+- Ensure timeout errors:
+  - Have a stable `reason`/prefix (e.g. `Timeout: kubectl apply exceeded ...`) for log filtering.
+  - Are classified as retryable vs non-retryable (see Failure Modes).
+
+## Config Mapping
+| Helm value (proposed) | Env var | Intended behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_CONTROLLER_KUBECTL_TIMEOUT_MS` | `JANGAR_CONTROLLER_KUBECTL_TIMEOUT_MS` | Upper bound for `kubectl` subprocess calls. |
+| `controllers.env.vars.JANGAR_CONTROLLER_DB_TIMEOUT_MS` | `JANGAR_CONTROLLER_DB_TIMEOUT_MS` | Upper bound for DB operations in controller flows. |
+
+## Rollout Plan
+1. Add env var support with defaults that match current practical behavior (no effective change).
+2. Canary in non-prod by injecting an artificial delay and confirming timeouts trip.
+3. Tune defaults based on observed p95/p99.
+
+Rollback:
+- Set timeouts to a high value (or remove env vars) to approximate current behavior.
+
+## Validation
+```bash
+helm template agents charts/agents --set controllers.enabled=true | rg -n \"JANGAR_CONTROLLER_.*TIMEOUT\"
+kubectl -n agents logs deploy/agents-controllers | rg -n \"Timeout:\"
+```
+
+## Failure Modes and Mitigations
+- Timeout too low causes flakey reconciles: mitigate by conservative defaults + per-environment overrides.
+- Timeout too high hides hangs: mitigate by explicit budgets and warnings at 80% of budget.
+- `kubectl` process leaks on timeout: mitigate by kill + wait + defensive cleanup.
+
+## Acceptance Criteria
+- A hung `kubectl` call cannot stall reconciliation indefinitely.
+- Operators can tune timeout budgets via Helm values.
+
+## References
+- Kubernetes API timeouts (client-side considerations): https://kubernetes.io/docs/reference/using-api/api-concepts/
+

--- a/docs/agents/designs/controller-resourceversion-conflict-retry.md
+++ b/docs/agents/designs/controller-resourceversion-conflict-retry.md
@@ -1,0 +1,66 @@
+# Controller ResourceVersion Conflicts and Retry Strategy
+
+Status: Draft (2026-02-06)
+
+## Overview
+Controllers patch and apply resources that may also be updated by other actors (users, GitOps, other controllers). Conflicts (HTTP 409) and optimistic concurrency failures should be handled predictably: retry when safe, fail fast when not.
+
+## Goals
+- Define a retry policy for resourceVersion conflicts on:
+  - status writes
+  - metadata patches (finalizers/labels)
+- Avoid infinite retry loops.
+
+## Non-Goals
+- Solving every conflict scenario; some must surface as errors.
+
+## Current State
+- Controllers patch and set status frequently:
+  - `services/jangar/src/server/agents-controller.ts` uses `kube.patch(...)` and `setStatus(...)`.
+- `kube.patch` uses `kubectl patch --type=merge`:
+  - `services/jangar/src/server/primitives-kube.ts`
+- Conflict handling is not centralized; retries are largely implicit (if reconciliation loops run again).
+
+## Design
+### Retry policy
+- For status updates:
+  - Use SSA where possible (reduces conflicts) and retry up to N times with jitter on conflict.
+- For metadata patches (finalizers):
+  - Retry up to N times on conflict; if still conflicting, re-fetch and recompute finalizers.
+- N defaults to 3, configurable via env var.
+
+### Implementation approach
+- Add a `withConflictRetry` helper used by:
+  - finalizer patch paths in `agents-controller.ts`
+  - status apply paths (if not already resilient)
+
+## Config Mapping
+| Proposed Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_CONTROLLER_CONFLICT_RETRY_ATTEMPTS` | `JANGAR_CONTROLLER_CONFLICT_RETRY_ATTEMPTS` | Max retries on 409/conflict (default `3`). |
+| `controllers.env.vars.JANGAR_CONTROLLER_CONFLICT_RETRY_BASE_MS` | `JANGAR_CONTROLLER_CONFLICT_RETRY_BASE_MS` | Base backoff delay (default `200`). |
+
+## Rollout Plan
+1. Add helper + defaults (no config needed).
+2. Canary in non-prod by simulating concurrent updates and confirming convergence.
+
+Rollback:
+- Disable retries by setting attempts to `0` (or reverting code).
+
+## Validation
+```bash
+kubectl -n agents get agentrun <name> -o yaml | rg -n \"resourceVersion:\"
+kubectl -n agents logs deploy/agents-controllers | rg -n \"Conflict|409\"
+```
+
+## Failure Modes and Mitigations
+- Retry loops amplify load: mitigate with small N and jitter.
+- Conflicts hide real logic bugs: mitigate by logging a structured warning after the final retry.
+
+## Acceptance Criteria
+- Common conflict cases converge without operator intervention.
+- Conflict retries are bounded and observable.
+
+## References
+- Kubernetes optimistic concurrency control: https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
+

--- a/docs/agents/designs/controller-server-side-apply-ownership.md
+++ b/docs/agents/designs/controller-server-side-apply-ownership.md
@@ -1,0 +1,65 @@
+# Controller Server-Side Apply and Field Ownership
+
+Status: Draft (2026-02-06)
+
+## Overview
+Controllers currently use `kubectl apply` (client-side) for many operations, and `kubectl apply --server-side --subresource=status` for status updates. Server-side apply (SSA) provides clear field ownership and reduces merge conflicts when multiple actors mutate the same objects.
+
+This doc proposes standardizing SSA usage and setting explicit field managers.
+
+## Goals
+- Use SSA for status updates consistently (already present).
+- Evaluate SSA for spec/apply operations where multiple writers exist.
+- Reduce conflicts and improve auditability of field ownership.
+
+## Non-Goals
+- Rewriting controllers to use the Kubernetes Go client.
+
+## Current State
+- Kubernetes operations are executed via `kubectl`:
+  - `services/jangar/src/server/primitives-kube.ts`
+- SSA is currently used only for status apply:
+  - `applyStatus`: `kubectl apply --server-side --subresource=status ...`
+- Regular `apply` uses `kubectl apply -f -` without SSA.
+
+## Design
+### SSA policy
+- Continue SSA for status with a stable field manager:
+  - Add `--field-manager=jangar-controllers` to SSA calls.
+- For spec/apply operations:
+  - Use SSA only when controllers should own specific fields and conflicts are likely.
+  - Otherwise keep client-side apply to reduce surprise conflicts.
+
+### Implementation changes
+- Update `applyStatus` in `primitives-kube.ts` to include `--field-manager`.
+- Add an alternate `applyServerSide` method (optional) with the same field manager.
+
+## Config Mapping
+| Proposed Helm value | Env var | Intended behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_KUBECTL_FIELD_MANAGER` | `JANGAR_KUBECTL_FIELD_MANAGER` | Allows overriding the field manager name (default `jangar-controllers`). |
+
+## Rollout Plan
+1. Add field-manager to SSA status apply (low risk).
+2. Canary in non-prod and check managedFields in CR status updates.
+3. Evaluate SSA for spec apply paths case-by-case.
+
+Rollback:
+- Remove the `--field-manager` flag; SSA still works with default manager.
+
+## Validation
+```bash
+kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.managedFields[*].manager}'; echo
+```
+
+## Failure Modes and Mitigations
+- Field ownership conflicts prevent apply: mitigate with targeted SSA usage and explicit field manager.
+- ManagedFields growth increases object size: mitigate by avoiding SSA where unnecessary.
+
+## Acceptance Criteria
+- Status updates use a stable field manager name.
+- Operators can inspect managed fields to understand what controllers own.
+
+## References
+- Kubernetes Server-Side Apply: https://kubernetes.io/docs/reference/using-api/server-side-apply/
+

--- a/docs/agents/designs/controller-status-timestamps-generation.md
+++ b/docs/agents/designs/controller-status-timestamps-generation.md
@@ -1,0 +1,70 @@
+# Controller Status: Timestamps + observedGeneration
+
+Status: Draft (2026-02-06)
+
+## Overview
+Many Agents CRDs include `status.updatedAt` and `status.observedGeneration`. Consistent semantics across controllers are essential for debugging, automation, and eventual UI/CLI behavior.
+
+This doc defines a consistent contract and identifies places in code that should be aligned.
+
+## Goals
+- Define consistent meanings for:
+  - `status.observedGeneration`
+  - `status.updatedAt`
+  - `status.startedAt` / `status.finishedAt` where relevant
+- Ensure controllers update these fields in a predictable way.
+
+## Non-Goals
+- Redesigning full status schemas for every CRD.
+
+## Current State
+- CRD types include these fields in Go:
+  - `services/jangar/api/agents/v1alpha1/types.go` (e.g. `AgentStatus`, `AgentRunStatus`)
+- Controllers update status using helpers (varies by resource):
+  - `services/jangar/src/server/agents-controller.ts` uses `setStatus(...)` patterns and sets `observedGeneration` and timestamps in many flows.
+  - Webhook status updates in `services/jangar/src/server/implementation-source-webhooks.ts` set `observedGeneration` for ImplementationSource.
+- Chart does not map any values for this behavior (code-defined).
+
+## Design
+### Contract
+- `observedGeneration`:
+  - Set to `.metadata.generation` of the last reconciled spec that produced the current status.
+- `updatedAt`:
+  - Update whenever the controller writes status (even if phase unchanged).
+- `startedAt` / `finishedAt`:
+  - `startedAt`: first transition into Running.
+  - `finishedAt`: first transition into a terminal phase.
+  - Must be immutable once set.
+
+### Implementation alignment
+- Add a shared helper module for timestamp/observedGeneration updates and use it across controllers.
+- Add unit tests to lock semantics (parallel to existing `agents-controller.test.ts`).
+
+## Config Mapping
+| Config surface | Behavior |
+|---|---|
+| (code only) | Status semantics are not configurable; must be consistent by convention and tests. |
+
+## Rollout Plan
+1. Document semantics and add tests enforcing immutability of startedAt/finishedAt.
+2. Refactor controllers to use shared helpers.
+
+Rollback:
+- Revert refactor; keep tests/docs.
+
+## Validation
+```bash
+kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.generation} {.status.observedGeneration} {.status.startedAt} {.status.finishedAt} {.status.updatedAt}'; echo
+```
+
+## Failure Modes and Mitigations
+- observedGeneration lag makes status misleading: mitigate by updating observedGeneration on every successful reconcile of spec.
+- updatedAt not updated hides active reconciliation: mitigate with shared helper and tests.
+
+## Acceptance Criteria
+- All controllers follow the same semantics for observedGeneration and timestamps.
+- startedAt/finishedAt are immutable once set.
+
+## References
+- Kubernetes generation and status patterns: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
+

--- a/docs/agents/designs/controller-webhook-signature-verification.md
+++ b/docs/agents/designs/controller-webhook-signature-verification.md
@@ -1,0 +1,79 @@
+# Webhook Signature Verification: ImplementationSource
+
+Status: Draft (2026-02-06)
+
+## Overview
+ImplementationSource webhooks are an ingress boundary. Signature verification is implemented for GitHub (`x-hub-signature(-256)`) and Linear (`linear-signature`). This doc defines the operational contract: how secrets are stored, rotated, and validated, and how failure is surfaced safely.
+
+## Goals
+- Ensure webhook signatures are verified whenever webhook ingestion is enabled.
+- Provide safe secret rotation without downtime.
+- Make failure modes explicit and observable.
+
+## Non-Goals
+- Replacing webhook auth with mTLS or OIDC.
+
+## Current State
+- Signature verification code:
+  - GitHub: `verifyGitHubSignature(...)` in `services/jangar/src/server/implementation-source-webhooks.ts`
+  - Linear: `verifyLinearSignature(...)` in the same file
+  - Verification selects candidate ImplementationSources and checks secrets: `selectVerifiedSources(...)`
+- Secret lookup:
+  - Reads secret data via Kubernetes client (kubectl): `getSecretData(...)` in `implementation-source-webhooks.ts` and `services/jangar/src/server/primitives-kube.ts`.
+- On invalid signature, responds 401: `implementation-source-webhooks.ts` (e.g. “Invalid webhook signature”).
+- Chart does not provide first-class values for webhook signing secrets (they are referenced in CRDs).
+
+## Design
+### Contract
+- If `ImplementationSource.spec.webhook.enabled=true`:
+  - `spec.webhook.secretRef` MUST be set.
+  - Requests MUST be rejected with 401 if signature is missing/invalid.
+- Secret rotation:
+  - Support dual-secret window by allowing multiple secret refs (future CRD enhancement) OR by temporarily accepting both sha1 and sha256 (already supported for GitHub).
+
+### Proposed CRD evolution (optional)
+Add to ImplementationSource:
+```yaml
+spec:
+  webhook:
+    secretRefs:
+      - name: old
+        key: token
+      - name: new
+        key: token
+```
+and verify against any.
+
+## Config Mapping
+| Config surface | Key | Intended behavior |
+|---|---|---|
+| ImplementationSource CR | `spec.webhook.secretRef` | Points to Secret used for signature verification. |
+| ImplementationSource CR | `spec.webhook.enabled` | Enables signature verification and webhook processing. |
+
+## Rollout Plan
+1. Document required headers + secret formats for GitHub/Linear.
+2. Add validation: if enabled but secretRef missing, set `Ready=False` and emit an error.
+3. Implement dual-secret support for rotation if needed.
+
+Rollback:
+- Revert to single-secret verification; rotate back to old secret.
+
+## Validation
+```bash
+kubectl -n agents get implementationsource -o yaml | rg -n \"webhook:|secretRef:\"
+kubectl -n agents logs deploy/agents-controllers | rg -n \"Invalid webhook signature|signature\"
+```
+
+## Failure Modes and Mitigations
+- Missing signature headers cause false rejects: mitigate by documenting provider setup steps and returning a clear 401 message.
+- Secret missing blocks ingestion: mitigate via status conditions and clear errors.
+- Rotation causes downtime: mitigate with dual-secret support or staggered rotation windows.
+
+## Acceptance Criteria
+- Webhooks are rejected unless signatures verify against configured secrets.
+- Rotation can be performed with a documented, testable procedure.
+
+## References
+- GitHub webhook signature docs: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+- Linear webhook security docs: https://developers.linear.app/docs/graphql/webhooks
+

--- a/docs/agents/designs/crd-agent-config-schema.md
+++ b/docs/agents/designs/crd-agent-config-schema.md
@@ -1,0 +1,79 @@
+# CRD: Agent `spec.config` Schema and Validation
+
+Status: Draft (2026-02-06)
+
+## Overview
+`Agent.spec.config` is currently an untyped map with `x-kubernetes-preserve-unknown-fields`. This gives flexibility but provides weak validation and poor UX: invalid keys/values are only discovered at runtime.
+
+This doc proposes a production-safe pattern to progressively add validation without breaking existing Agents.
+
+## Goals
+- Reduce runtime failures due to invalid Agent config.
+- Provide a migration path from untyped config to validated config.
+
+## Non-Goals
+- Hard-coding provider-specific schemas into the core Agent CRD immediately.
+
+## Current State
+- Go type preserves unknown fields:
+  - `services/jangar/api/agents/v1alpha1/types.go` → `AgentSpec.Config map[string]apiextensionsv1.JSON` with pruning preserve unknown fields.
+- Generated CRD preserves unknown fields:
+  - `charts/agents/crds/agents.proompteng.ai_agents.yaml` → `.spec.versions[].schema.openAPIV3Schema.properties.spec.properties.config`.
+- Controller consumes config dynamically (provider-specific):
+  - Primary reconcile loop: `services/jangar/src/server/agents-controller.ts` (Agent/AgentRun reconciliation).
+
+## Design
+### Phase 1: “Config schema reference” (optional)
+Add a field:
+```yaml
+spec:
+  configSchemaRef:
+    kind: ConfigMap
+    name: agent-config-schema
+    key: schema.json
+```
+Where `schema.json` is a JSON Schema (draft-07 or Kubernetes-compatible subset).
+
+Controllers validate `spec.config` against the referenced schema when present:
+- If validation fails: set `Ready=False` with reason `InvalidConfig` and do not schedule runs.
+
+### Phase 2: Provider-specific typed subfields
+Introduce `spec.providerConfig` as a `oneOf` in a future CRD version once schemas stabilize.
+
+## Config Mapping
+| Helm value / env var | Effect | Behavior |
+|---|---|---|
+| `controller.enabled` / `JANGAR_AGENTS_CONTROLLER_ENABLED` | toggles Agent reconciliation | Validation is only enforced when controllers are running. |
+| `controller.namespaces` / `JANGAR_AGENTS_CONTROLLER_NAMESPACES` | scope | Determines where Agent config validation applies. |
+
+## Rollout Plan
+1. Implement schema-ref validation as opt-in (no behavior change for existing Agents).
+2. Add documentation + examples in `charts/agents/examples/agent-sample.yaml`.
+3. Add a canary Agent with a schemaRef in non-prod and validate status behavior.
+
+Rollback:
+- Remove `spec.configSchemaRef` from Agents; controller falls back to permissive behavior.
+
+## Validation
+Helm/template (ensure CRD includes new field if added):
+```bash
+helm template agents charts/agents --include-crds | rg -n \"configSchemaRef\"
+```
+
+kubectl:
+```bash
+kubectl -n agents apply -f charts/agents/examples/agent-sample.yaml
+kubectl -n agents get agent <name> -o yaml | rg -n \"configSchemaRef|InvalidConfig|conditions\"
+```
+
+## Failure Modes and Mitigations
+- Schema too strict breaks existing Agents: mitigate by making validation opt-in via schemaRef.
+- Schema unavailable (missing ConfigMap/Secret): mitigate by setting `Ready=False` with clear reason and message.
+
+## Acceptance Criteria
+- When a schemaRef is provided, invalid configs are rejected before scheduling runs.
+- Existing Agents without schemaRef continue to work unchanged.
+
+## References
+- Kubernetes CRD validation: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
+

--- a/docs/agents/designs/crd-agentrun-artifacts-limits.md
+++ b/docs/agents/designs/crd-agentrun-artifacts-limits.md
@@ -1,0 +1,71 @@
+# CRD: AgentRun Artifacts Limits and Schema
+
+Status: Draft (2026-02-06)
+
+## Overview
+AgentRun status can accumulate artifacts, logs, and metadata. Without limits and schema conventions, status can grow large, exceed Kubernetes object size limits, and create performance issues for controllers and clients.
+
+This doc defines size and count limits plus a recommended artifact schema.
+
+## Goals
+- Bound AgentRun status size.
+- Keep artifact references lightweight (store large content externally).
+- Provide predictable retrieval patterns for operators.
+
+## Non-Goals
+- Designing the external artifact store (handled elsewhere).
+
+## Current State
+- AgentRun status includes `artifacts []Artifact` in Go types:
+  - `services/jangar/api/agents/v1alpha1/types.go`
+- Controller writes artifacts into status during run reconciliation:
+  - `services/jangar/src/server/agents-controller.ts`
+- CRD schema is generated in `charts/agents/crds/agents.proompteng.ai_agentruns.yaml`.
+
+## Design
+### Limits (recommended)
+- `status.artifacts`:
+  - Max entries: 50
+  - Max per-entry URL length: 2048
+  - No inline binary data
+- Enforce limits by:
+  - Dropping oldest artifacts beyond limit, or
+  - Storing only pointers (S3 URL, object key) in status.
+
+### Schema conventions
+Each artifact entry should include:
+- `type` (e.g. `log`, `diff`, `report`)
+- `uri` (external location)
+- `contentType`
+- `sizeBytes` (optional)
+
+## Config Mapping
+| Helm value / env var (proposed) | Effect | Behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_AGENTRUN_ARTIFACTS_MAX` | bound | Caps artifact list length in status. |
+| `controllers.env.vars.JANGAR_AGENTRUN_ARTIFACTS_STRICT` | strictness | If true, fail run when artifacts exceed limits (default false). |
+
+## Rollout Plan
+1. Implement soft caps (drop oldest) and emit a warning condition.
+2. Add optional strict mode for CI environments.
+
+Rollback:
+- Disable caps by setting max high (not recommended) or reverting code.
+
+## Validation
+```bash
+kubectl -n agents get agentrun <name> -o jsonpath='{.status.artifacts}' | wc -c
+kubectl -n agents get agentrun <name> -o yaml | rg -n \"artifacts:\"
+```
+
+## Failure Modes and Mitigations
+- Status exceeds object size limits: mitigate by pointer-only artifacts and strict caps.
+- Operators lose needed history due to trimming: mitigate by ensuring external store retains full artifact history.
+
+## Acceptance Criteria
+- AgentRun status stays under safe size limits under sustained use.
+- Artifacts in status are always external references, not large inline payloads.
+
+## References
+- Kubernetes object size limits (etcd considerations): https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+

--- a/docs/agents/designs/crd-agentrun-idempotency.md
+++ b/docs/agents/designs/crd-agentrun-idempotency.md
@@ -1,0 +1,63 @@
+# CRD: AgentRun Idempotency Key Contract
+
+Status: Draft (2026-02-06)
+
+## Overview
+AgentRun includes `spec.idempotencyKey`. This field is intended to avoid duplicate runs when clients retry requests. Without a contract (scope, retention, collision handling), the field is under-specified.
+
+This doc defines idempotency behavior and how controllers should implement it.
+
+## Goals
+- Ensure a given idempotency key creates at most one effective execution per scope.
+- Provide predictable behavior for retries and duplicates.
+
+## Non-Goals
+- Exactly-once execution across cluster failures.
+
+## Current State
+- Field exists in Go types: `services/jangar/api/agents/v1alpha1/types.go` (`AgentRunSpec.IdempotencyKey`).
+- Controller currently deduplicates webhook-driven orchestration submissions via DB store (`orchestration-submit.ts`), but AgentRun idempotency is not explicitly implemented/documented.
+
+## Design
+### Scope
+- Idempotency key scope is `(namespace, agentRef.name, idempotencyKey)`.
+
+### Behavior
+- On creating a new AgentRun:
+  - If another AgentRun exists with same scope and is non-terminal: reject creation with a clear error.
+  - If terminal: return the existing run reference (or allow new run only if `force=true` via a separate mechanism).
+
+### Implementation approach
+- Add an index (DB-side) or controller cache keyed by the tuple above.
+- Prefer durable store (DB) so restarts don’t break idempotency.
+
+## Config Mapping
+| Helm value / env var (proposed) | Effect | Behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_AGENTRUN_IDEMPOTENCY_ENABLED` | toggle | Allows phased rollout (default `true`). |
+| `controllers.env.vars.JANGAR_AGENTRUN_IDEMPOTENCY_RETENTION_DAYS` | retention | How long to remember keys after terminal completion. |
+
+## Rollout Plan
+1. Implement as best-effort in-controller cache (warn-only) in non-prod.
+2. Promote to durable store-based enforcement in prod.
+
+Rollback:
+- Disable enforcement and rely on client-side de-dupe.
+
+## Validation
+```bash
+kubectl -n agents apply -f charts/agents/examples/agentrun-sample.yaml
+kubectl -n agents apply -f charts/agents/examples/agentrun-sample.yaml
+kubectl -n agents get agentrun -o json | rg -n \"idempotencyKey\"
+```
+
+## Failure Modes and Mitigations
+- Key collisions across unrelated workloads: mitigate by scoping to agentRef and namespace.
+- Retention too short allows duplicates: mitigate by conservative default retention and pruning.
+
+## Acceptance Criteria
+- Duplicate creates with same idempotency key do not create duplicate effective runs.
+- Behavior is consistent across controller restarts.
+
+## References
+- HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods

--- a/docs/agents/designs/crd-agentrun-spec-immutability.md
+++ b/docs/agents/designs/crd-agentrun-spec-immutability.md
@@ -1,0 +1,72 @@
+# CRD: AgentRun Spec Immutability Rules
+
+Status: Draft (2026-02-06)
+
+## Overview
+AgentRuns represent a concrete execution request. After a run is accepted and started, mutating most of `spec` should be prohibited to preserve auditability and avoid undefined behavior (e.g., swapping implementation mid-run).
+
+This doc defines which fields are mutable vs immutable and how controllers should enforce that.
+
+## Goals
+- Prevent unsafe spec mutations after acceptance/start.
+- Provide clear, actionable errors for attempted mutations.
+
+## Non-Goals
+- Adding a full admission webhook; controller-side enforcement is sufficient initially.
+
+## Current State
+- AgentRun schema: `services/jangar/api/agents/v1alpha1/types.go` and `charts/agents/crds/agents.proompteng.ai_agentruns.yaml`.
+- Controller reconciles AgentRuns and transitions phases/conditions:
+  - `services/jangar/src/server/agents-controller.ts` (reconcileAgentRun, runtime submission, status updates).
+- No explicit immutability enforcement is documented.
+
+## Design
+### Immutable after `Accepted=True` or `status.phase != Pending`
+- `spec.agentRef`
+- `spec.implementationSpecRef` / `spec.implementation`
+- `spec.runtime` (type/config)
+- `spec.workflow` steps (if present)
+- `spec.secrets`
+- `spec.systemPrompt` / `spec.systemPromptRef`
+- `spec.vcsRef`, `spec.memoryRef`
+
+### Mutable always (safe metadata-only)
+- `metadata.labels` and annotations (except controller-owned labels)
+
+### Enforcement
+- Controller records a hash of the immutable spec fields in status at accept time, e.g.:
+  - `status.specHash`
+- On subsequent reconciles, if immutable fields differ:
+  - Set `Succeeded=False`/`Ready=False` (resource-specific) and `phase=Failed` with reason `SpecImmutableViolation`.
+  - Emit a Kubernetes Event (see controller events design).
+
+## Config Mapping
+| Helm value / env var (proposed) | Effect | Behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED` | toggle | Allows phased rollout (default `true` in prod). |
+
+## Rollout Plan
+1. Implement in warn-only mode (log + condition) in non-prod.
+2. Promote to fail/terminal failure in prod.
+
+Rollback:
+- Set `JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED=false` to revert to warn-only.
+
+## Validation
+```bash
+kubectl -n agents apply -f charts/agents/examples/agentrun-sample.yaml
+kubectl -n agents patch agentrun <name> --type=merge -p '{\"spec\":{\"parameters\":{\"x\":\"y\"}}}'
+kubectl -n agents get agentrun <name> -o yaml | rg -n \"SpecImmutableViolation|specHash|conditions\"
+```
+
+## Failure Modes and Mitigations
+- Users rely on mutating pending runs: mitigate by allowing mutation only before acceptance and documenting clearly.
+- Controller mis-identifies a harmless change: mitigate with a clearly defined immutable field set and tests.
+
+## Acceptance Criteria
+- Once accepted/started, spec mutations are rejected with a clear condition/reason.
+- Before acceptance, allowed fields can still be updated safely.
+
+## References
+- Kubernetes immutability patterns (general objects): https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
+

--- a/docs/agents/designs/crd-implementationsource-webhook-cel.md
+++ b/docs/agents/designs/crd-implementationsource-webhook-cel.md
@@ -1,0 +1,60 @@
+# CRD: ImplementationSource Webhook CEL Invariants
+
+Status: Draft (2026-02-06)
+
+## Overview
+ImplementationSource supports webhook-driven ingestion. Certain fields must be present together (e.g., `webhook.enabled` implies a `secretRef`). Today, some of these invariants are enforced in code, but encoding them in CRD CEL rules provides immediate feedback at apply time.
+
+## Goals
+- Encode basic webhook invariants as CRD CEL rules.
+- Reduce runtime “misconfigured source” errors.
+
+## Non-Goals
+- Encoding provider-specific rules that require external calls.
+
+## Current State
+- CRD exists: `charts/agents/crds/agents.proompteng.ai_implementationsources.yaml`.
+- Webhook runtime logic: `services/jangar/src/server/implementation-source-webhooks.ts`.
+- Signature verification expects a secret when webhook enabled (see `selectVerifiedSources(...)`).
+
+## Design
+### Proposed CEL validations
+- If `spec.webhook.enabled == true` then `spec.webhook.secretRef.name` and `.key` must be non-empty.
+- If provider is GitHub, require that `spec.webhook.events` includes the expected event types (optional).
+
+Example CEL:
+```yaml
+x-kubernetes-validations:
+  - rule: '!(has(self.spec.webhook) && self.spec.webhook.enabled) || (has(self.spec.webhook.secretRef) && self.spec.webhook.secretRef.name != "" && self.spec.webhook.secretRef.key != "")'
+    message: "webhook.enabled requires webhook.secretRef.{name,key}"
+```
+
+## Config Mapping
+| Helm value / env var | Effect | Behavior |
+|---|---|---|
+| `controller.enabled` / `JANGAR_AGENTS_CONTROLLER_ENABLED` | toggles reconciliation | CEL rules validate at API server on apply, independent of controller runtime. |
+
+## Rollout Plan
+1. Add CEL rules in CRD generation (Go markers) and regenerate `charts/agents/crds`.
+2. Canary in non-prod by applying misconfigured ImplementationSources and confirming rejection.
+
+Rollback:
+- Revert CRD validation rules (requires CRD management plan).
+
+## Validation
+```bash
+helm template agents charts/agents --include-crds | rg -n \"implementationsources|x-kubernetes-validations\"
+kubectl -n agents apply -f charts/agents/examples/implementationsource-github.yaml
+```
+
+## Failure Modes and Mitigations
+- Validation is too strict for legacy objects: mitigate by introducing rules only when fields exist, and by staging rollouts.
+- Cluster API server older than CEL support level: mitigate by checking Kubernetes version and gating rules accordingly.
+
+## Acceptance Criteria
+- Misconfigured webhook-enabled ImplementationSources are rejected at apply time.
+- Valid sources continue to work without modification.
+
+## References
+- Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
+

--- a/docs/agents/designs/crd-implementationspec-config-constraints.md
+++ b/docs/agents/designs/crd-implementationspec-config-constraints.md
@@ -1,0 +1,62 @@
+# CRD: ImplementationSpec Runtime Config Constraints
+
+Status: Draft (2026-02-06)
+
+## Overview
+ImplementationSpec contains runtime configuration that is later executed by controllers/runners. Without constraints, it is easy to create specs that are invalid or unsafe (e.g., missing required fields, invalid enum values, or overly large embedded configs).
+
+This doc defines validation constraints and how to phase them in safely.
+
+## Goals
+- Improve CRD validation so invalid ImplementationSpecs fail fast.
+- Avoid breaking existing specs via opt-in validation phases.
+
+## Non-Goals
+- Building a full policy engine for ImplementationSpecs.
+
+## Current State
+- Go types: `services/jangar/api/agents/v1alpha1/types.go` (ImplementationSpec types live in the same API package).
+- Generated CRD: `charts/agents/crds/agents.proompteng.ai_implementationspecs.yaml`.
+- Controller uses ImplementationSpecs during run submission:
+  - `services/jangar/src/server/agents-controller.ts` (resolves ImplementationSpecRef / inline implementation).
+
+## Design
+### Validation constraints (examples)
+- Enums for runtime type already exist for AgentRun runtime (`workflow|job|temporal|custom`); extend similarly where needed.
+- Add size limits:
+  - `maxProperties` on config maps
+  - `maxLength` on strings that can grow unbounded
+- Add CEL rules to enforce mutual exclusivity patterns (like existing systemPrompt vs systemPromptRef).
+
+### Phased enforcement
+- Add new validations as warnings first (controller condition) before baking into CRD schema.
+- Once confirmed, move into CRD `x-kubernetes-validations` (CEL).
+
+## Config Mapping
+| Helm value / env var (proposed) | Effect | Behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_IMPLEMENTATIONSPEC_VALIDATE_STRICT` | strictness | If true, invalid specs are marked Ready=False and blocked from execution. |
+
+## Rollout Plan
+1. Add controller-side validations + Ready=False conditions.
+2. After a canary window, promote the most important constraints into the CRD schema.
+
+Rollback:
+- Disable strict validation env var and revert schema change if needed (requires CRD management plan).
+
+## Validation
+```bash
+kubectl -n agents get implementationspec -o yaml | rg -n \"spec:|x-kubernetes-validations\"
+```
+
+## Failure Modes and Mitigations
+- Schema changes reject previously accepted objects: mitigate by phased controller-first validation and careful CRD upgrades.
+- Overly strict constraints block legitimate use: mitigate by documenting intent and providing escape hatches when safe.
+
+## Acceptance Criteria
+- Invalid ImplementationSpecs are rejected or clearly marked not-ready before execution.
+- The most common spec errors are caught by CRD validation, not runtime failures.
+
+## References
+- Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
+

--- a/docs/agents/designs/crd-memory-retention-compaction.md
+++ b/docs/agents/designs/crd-memory-retention-compaction.md
@@ -1,0 +1,73 @@
+# CRD: Memory Retention and Compaction
+
+Status: Draft (2026-02-06)
+
+## Overview
+The `Memory` CRD represents stored context/embeddings. Without retention controls and compaction, memory stores can grow without bound, increasing storage cost and slowing queries. This doc defines retention and compaction semantics managed by controllers.
+
+## Goals
+- Provide per-Memory retention policy.
+- Define compaction behavior and safety controls.
+
+## Non-Goals
+- Defining embedding model selection (separate concern).
+
+## Current State
+- Memory CRD exists:
+  - Go: `services/jangar/api/agents/v1alpha1/types.go` (Memory types)
+  - CRD: `charts/agents/crds/agents.proompteng.ai_memories.yaml`
+- Memory runtime and storage code lives in:
+  - `services/jangar/src/server/memories.ts`
+  - `services/jangar/src/server/memories-store.ts`
+- Chart values do not expose memory retention controls.
+
+## Design
+### API shape
+Add to Memory spec:
+```yaml
+spec:
+  retention:
+    maxItems: 10000
+    maxAgeDays: 90
+  compaction:
+    enabled: true
+    strategy: "drop-oldest"
+```
+
+### Controller behavior
+- Periodically scan Memory objects and enforce:
+  - Drop items older than `maxAgeDays`
+  - Drop oldest beyond `maxItems`
+- Emit conditions/events when compaction occurs.
+
+## Config Mapping
+| Helm value / env var (proposed) | Effect | Behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_MEMORY_COMPACTION_ENABLED` | toggle | Enables background compaction loop. |
+| `controllers.env.vars.JANGAR_MEMORY_COMPACTION_INTERVAL` | schedule | Controls how often compaction runs. |
+
+## Rollout Plan
+1. Add API fields with defaults that preserve current behavior (no compaction unless enabled).
+2. Canary in non-prod with a small Memory and verify compaction.
+3. Enable in prod with conservative defaults and monitoring.
+
+Rollback:
+- Disable compaction loop; stop enforcing retention fields.
+
+## Validation
+```bash
+kubectl -n agents get memory -o yaml | rg -n \"retention:|compaction:|conditions\"
+kubectl -n agents logs deploy/agents-controllers | rg -n \"compaction|retention\"
+```
+
+## Failure Modes and Mitigations
+- Over-aggressive retention deletes useful context: mitigate with conservative defaults and “dry-run mode” first.
+- Compaction loop increases DB load: mitigate with interval controls and batching.
+
+## Acceptance Criteria
+- Memory growth can be bounded by policy.
+- Compaction is observable and reversible (disable loop).
+
+## References
+- Kubernetes controllers (background reconciliation): https://kubernetes.io/docs/concepts/architecture/controller/
+

--- a/docs/agents/designs/crd-orchestration-dag.md
+++ b/docs/agents/designs/crd-orchestration-dag.md
@@ -1,0 +1,70 @@
+# CRD: Orchestration DAG Semantics
+
+Status: Draft (2026-02-06)
+
+## Overview
+Orchestrations represent multi-step workflows. The current schema supports `spec.steps`, but the semantics around ordering, dependency graphs, and partial failure are not explicitly documented. This doc defines a DAG model that controllers can implement consistently.
+
+## Goals
+- Define step dependency semantics (DAG, not just list).
+- Define failure handling and step skipping rules.
+
+## Non-Goals
+- Replacing the underlying runtime (workflow/job/temporal).
+
+## Current State
+- Orchestration CRD exists:
+  - `charts/agents/crds/orchestration.proompteng.ai_orchestrations.yaml`
+  - Controller: `services/jangar/src/server/orchestration-controller.ts`
+- Submission path creates OrchestrationRun CRs:
+  - `services/jangar/src/server/orchestration-submit.ts`
+- There is no design-level contract for step dependencies beyond the raw schema.
+
+## Design
+### API shape (incremental)
+Extend step schema:
+```yaml
+spec:
+  steps:
+    - name: build
+      dependsOn: []
+    - name: test
+      dependsOn: ["build"]
+```
+
+### Execution semantics
+- A step becomes runnable when all `dependsOn` steps are terminal success.
+- If a dependency fails:
+  - Dependent steps become `Skipped` with reason `DependencyFailed`.
+- Support `continueOnFailure` (optional) for best-effort steps.
+
+## Config Mapping
+| Helm value / env var | Effect | Behavior |
+|---|---|---|
+| `orchestrationController.enabled` | `JANGAR_ORCHESTRATION_CONTROLLER_ENABLED` (existing pattern) | Enables orchestration DAG execution logic. |
+| `orchestrationController.namespaces` | `JANGAR_ORCHESTRATION_CONTROLLER_NAMESPACES` | Scope of orchestration reconciliation. |
+
+## Rollout Plan
+1. Add API fields with backward compatibility:
+  - If `dependsOn` absent, treat steps as sequential list.
+2. Canary in non-prod with a 2-step DAG example.
+
+Rollback:
+- Remove `dependsOn` fields; controllers fall back to sequential behavior.
+
+## Validation
+```bash
+kubectl -n agents get orchestration -o yaml | rg -n \"steps:|dependsOn\"
+kubectl -n agents get orchestrationrun -o yaml | rg -n \"phase:|Skipped|DependencyFailed\"
+```
+
+## Failure Modes and Mitigations
+- Cycles in dependsOn: mitigate with controller-side validation (reject with Ready=False).
+- Missing dependency name: mitigate with validation and clear errors.
+
+## Acceptance Criteria
+- DAG execution is deterministic and documented.
+- Sequential orchestrations continue to work unchanged.
+
+## References
+- Argo Workflows DAG concepts (widely used Kubernetes DAG runtime): https://argo-workflows.readthedocs.io/en/latest/walk-through/dag/

--- a/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
+++ b/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
@@ -1,0 +1,64 @@
+# CRD: OrchestrationRun Cancel Propagation
+
+Status: Draft (2026-02-06)
+
+## Overview
+Operators need reliable cancellation semantics for OrchestrationRuns. Cancelling should propagate to all active underlying runtimes (Jobs/Workflows/etc) and update status/conditions in a predictable way.
+
+## Goals
+- Define cancel request API and status transitions.
+- Ensure cancel propagates to underlying resources best-effort.
+
+## Non-Goals
+- Guaranteeing immediate termination in all runtimes.
+
+## Current State
+- OrchestrationRun CRD exists:
+  - `charts/agents/crds/orchestration.proompteng.ai_orchestrationruns.yaml`
+- Controller: `services/jangar/src/server/orchestration-controller.ts`
+- Orchestration submission stores externalRunId in DB: `services/jangar/src/server/orchestration-submit.ts`.
+
+## Design
+### API shape
+Add:
+```yaml
+spec:
+  cancel: true
+```
+or a `spec.desiredState: Cancelled`.
+
+### Controller behavior
+- If cancel requested:
+  - Attempt to delete/terminate underlying runtime resources.
+  - Set `status.phase=Cancelled` and condition `Cancelled=True` once cancellation is acknowledged.
+  - If already terminal success/failure: ignore cancel request (no-op) and record a condition reason.
+
+## Config Mapping
+| Helm value / env var (proposed) | Effect | Behavior |
+|---|---|---|
+| `controllers.env.vars.JANGAR_ORCHESTRATION_CANCEL_TIMEOUT_MS` | bound | Upper bound for cancellation attempts before marking cancelled anyway. |
+
+## Rollout Plan
+1. Implement cancel semantics in controller with a feature flag.
+2. Canary in non-prod by cancelling a running orchestration and confirming propagation.
+
+Rollback:
+- Disable cancel support flag; rely on manual deletion of underlying resources.
+
+## Validation
+```bash
+kubectl -n agents patch orchestrationrun <name> --type=merge -p '{\"spec\":{\"cancel\":true}}'
+kubectl -n agents get orchestrationrun <name> -o yaml | rg -n \"Cancelled|phase\"
+```
+
+## Failure Modes and Mitigations
+- Underlying runtime ignores deletion: mitigate by best-effort termination + clear status messaging.
+- Cancel flips terminal success incorrectly: mitigate by making cancel a no-op for terminal runs.
+
+## Acceptance Criteria
+- Cancelling a running OrchestrationRun results in a terminal Cancelled state and best-effort runtime termination.
+- Cancel is a no-op for already terminal runs.
+
+## References
+- Kubernetes graceful termination concepts: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+

--- a/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
+++ b/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
@@ -1,0 +1,70 @@
+# CRD: VersionControlProvider SSH and known_hosts
+
+Status: Draft (2026-02-06)
+
+## Overview
+VersionControlProvider supports SSH configuration (host, user, private key secret, known_hosts ConfigMap ref). This is operationally sensitive: incorrect known_hosts handling can lead to MITM risk, and missing known_hosts can break cloning.
+
+This doc defines a secure-by-default contract for SSH usage.
+
+## Goals
+- Make SSH clone behavior secure by default (host key verification).
+- Provide a clear configuration and rotation process for known_hosts and keys.
+
+## Non-Goals
+- Implementing a new SSH client; rely on standard Git/SSH behavior in runner images.
+
+## Current State
+- Chart values include SSH fields under `versionControlProvider.auth.ssh.*`:
+  - `charts/agents/values.yaml`
+- Example manifests exist:
+  - `charts/agents/examples/versioncontrolprovider-github.yaml`
+  - `charts/agents/examples/versioncontrolprovider-github-app.yaml`
+- CRD exists:
+  - `charts/agents/crds/agents.proompteng.ai_versioncontrolproviders.yaml`
+
+## Design
+### Contract
+- If SSH is used (`cloneProtocol: ssh` or similar):
+  - `knownHostsConfigMapRef` MUST be provided (no disabling host key checking by default).
+  - Private key Secret must be mounted into runner jobs in a controlled, read-only path.
+
+### Rotation
+- known_hosts rotation:
+  - Update ConfigMap contents and trigger runner job restart on next run (no long-lived pods).
+- key rotation:
+  - Update Secret, then re-run jobs.
+
+## Config Mapping
+| Config surface | Field | Intended behavior |
+|---|---|---|
+| VersionControlProvider CR | `spec.auth.ssh.knownHostsConfigMapRef` | Source of known_hosts data for host key verification. |
+| VersionControlProvider CR | `spec.auth.ssh.privateKeySecretRef` | Source of SSH private key used by runner jobs. |
+
+## Rollout Plan
+1. Document required known_hosts config and provide an example ConfigMap.
+2. Add controller-side validation:
+   - If SSH auth selected but knownHosts missing, set Ready=False and block execution.
+
+Rollback:
+- Switch provider to HTTPS token auth temporarily if SSH path breaks.
+
+## Validation
+```bash
+kubectl -n agents get versioncontrolprovider -o yaml | rg -n \"ssh:|knownHosts|privateKey\"
+kubectl -n agents get configmap | rg known-hosts
+```
+
+## Failure Modes and Mitigations
+- Missing known_hosts causes clone failure: mitigate by validation + examples.
+- Host key changes break cloning: mitigate by documented rotation workflow and staging.
+- Disabling host key checking introduces MITM risk: mitigate by forbidding it by default.
+
+## Acceptance Criteria
+- SSH usage requires explicit known_hosts configuration.
+- Controllers surface misconfigurations as Ready=False with actionable messages.
+
+## References
+- OpenSSH `known_hosts` format: https://man.openbsd.org/sshd.8#SSH_KNOWN_HOSTS_FILE_FORMAT
+- Git over SSH: https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
+


### PR DESCRIPTION
## Summary

- Add 50 new production-ready design docs for the Agents chart/controllers/CRDs under `docs/agents/designs/`.
- Each doc includes current-state repo pointers, design details, config mapping, rollout/rollback, validation commands, failure modes, and acceptance criteria.
- Verified the Agents chart still renders cleanly.

## Related Issues

Resolves #2860

## Testing

- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
