### PR TITLE
feat(agents): add controllers HPA

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -14,6 +14,8 @@ controlPlane:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 controllers:
   enabled: true
+  autoscaling:
+    enabled: false
 resources:
   requests:
     cpu: 200m

--- a/charts/agents/templates/deployment-controllers.yaml
+++ b/charts/agents/templates/deployment-controllers.yaml
@@ -18,6 +18,7 @@
 {{- $imagePullSecrets := $controllersImage.pullSecrets | default .Values.image.pullSecrets -}}
 {{- $replicas := .Values.controllers.replicaCount | default 1 -}}
 {{- $resources := .Values.controllers.resources | default .Values.resources -}}
+{{- $autoscaling := .Values.controllers.autoscaling | default dict -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,7 +27,9 @@ metadata:
   labels:
     {{- include "agents.labels" . | nindent 4 }}
 spec:
+  {{- if not $autoscaling.enabled }}
   replicas: {{ $replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "agents.controllersSelectorLabels" . | nindent 6 }}
@@ -414,4 +417,3 @@ spec:
           {{- toYaml .volume | nindent 10 }}
         {{- end }}
 {{- end }}
-

--- a/charts/agents/templates/hpa-controllers.yaml
+++ b/charts/agents/templates/hpa-controllers.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.controllers.enabled .Values.controllers.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agents.fullname" . }}-controllers
+  namespace: {{ .Values.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "agents.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agents.fullname" . }}-controllers
+  minReplicas: {{ .Values.controllers.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controllers.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controllers.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.controllers.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controllers.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -67,6 +67,17 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "replicaCount": { "type": "integer", "minimum": 1 },
+        "autoscaling": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minReplicas": { "type": "integer", "minimum": 1 },
+            "maxReplicas": { "type": "integer", "minimum": 1 },
+            "targetCPUUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 },
+            "targetMemoryUtilizationPercentage": { "type": ["integer", "null"], "minimum": 1, "maximum": 100 }
+          },
+          "additionalProperties": false
+        },
         "resources": {
           "type": "object",
           "properties": {

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -32,6 +32,12 @@ controlPlane:
 controllers:
   enabled: false
   replicaCount: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: null
   image:
     repository: ""
     tag: ""

--- a/docs/agents/designs/chart-controllers-hpa.md
+++ b/docs/agents/designs/chart-controllers-hpa.md
@@ -21,7 +21,6 @@ The chart’s HPA template targets only the control plane Deployment (`agents`).
 ## Design
 ### Proposed values
 Add:
-- `controlPlane.autoscaling` (defaults to existing `autoscaling`)
 - `controllers.autoscaling` (new)
 
 ### Defaults
@@ -58,4 +57,3 @@ kubectl -n agents get hpa
 
 ## References
 - Kubernetes HPA v2: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
-


### PR DESCRIPTION
## Summary

- Add `controllers.autoscaling.*` chart values (disabled by default) to autoscale `agents-controllers` independently.
- Render a controllers HPA and omit controller `spec.replicas` when autoscaling is enabled.
- Update `values.schema.json`, the design doc, and the GitOps values example.

## Related Issues

Resolves #2862

## Testing

- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
