### PR TITLE
docs(agents): refresh design docs for current chart + GitOps

### DIFF
--- a/docs/agents/designs/admission-control-policy.md
+++ b/docs/agents/designs/admission-control-policy.md
@@ -72,7 +72,7 @@ Reject unsafe or invalid AgentRuns before runtime submission by enforcing contro
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -82,24 +82,35 @@ Reject unsafe or invalid AgentRuns before runtime submission by enforcing contro
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -130,10 +141,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/agentctl-cli-resilience.md
+++ b/docs/agents/designs/agentctl-cli-resilience.md
@@ -65,7 +65,7 @@ CLI failures reduce operator trust and automation reliability.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ CLI failures reduce operator trust and automation reliability.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/api-pagination-and-watch.md
+++ b/docs/agents/designs/api-pagination-and-watch.md
@@ -65,7 +65,7 @@ Large lists can overload the API and clients.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Large lists can overload the API and clients.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/approval-policy-gates.md
+++ b/docs/agents/designs/approval-policy-gates.md
@@ -65,7 +65,7 @@ High-risk runs should require approval before execution.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ High-risk runs should require approval before execution.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/artifact-storage-s3.md
+++ b/docs/agents/designs/artifact-storage-s3.md
@@ -65,7 +65,7 @@ Artifacts need durable storage at scale.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Artifacts need durable storage at scale.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/artifacthub-oci-distribution.md
+++ b/docs/agents/designs/artifacthub-oci-distribution.md
@@ -71,7 +71,7 @@ Define how the Agents Helm chart is packaged, published as an OCI artifact, and 
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -81,24 +81,35 @@ Define how the Agents Helm chart is packaged, published as an OCI artifact, and 
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -129,10 +140,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/audit-logging.md
+++ b/docs/agents/designs/audit-logging.md
@@ -65,7 +65,7 @@ High scale PR automation needs traceable audit logs.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ High scale PR automation needs traceable audit logs.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -60,7 +60,7 @@ defaults:
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -70,24 +70,35 @@ defaults:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -118,10 +129,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/budget-enforcement.md
+++ b/docs/agents/designs/budget-enforcement.md
@@ -65,7 +65,7 @@ Runs can exceed token or cost budgets without enforcement.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Runs can exceed token or cost budgets without enforcement.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/chart-canary-argo-rollouts.md
+++ b/docs/agents/designs/chart-canary-argo-rollouts.md
@@ -68,3 +68,71 @@ kubectl -n agents get rollout
 ## References
 - Argo Rollouts documentation: https://argo-rollouts.readthedocs.io/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-config-checksum-rollouts.md
+++ b/docs/agents/designs/chart-config-checksum-rollouts.md
@@ -66,3 +66,71 @@ kubectl -n agents get deploy agents -o jsonpath='{.spec.template.metadata.annota
 ## References
 - Kubernetes ConfigMaps/Secrets update behavior: https://kubernetes.io/docs/concepts/configuration/configmap/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
+++ b/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
@@ -64,3 +64,71 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"NAMESPACES|namespace\
 ## References
 - Kubernetes controller patterns (namespace scoping best practices): https://kubernetes.io/docs/concepts/architecture/controller/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-controllers-hpa.md
+++ b/docs/agents/designs/chart-controllers-hpa.md
@@ -57,3 +57,72 @@ kubectl -n agents get hpa
 
 ## References
 - Kubernetes HPA v2: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-controllers-image-override-precedence.md
+++ b/docs/agents/designs/chart-controllers-image-override-precedence.md
@@ -61,3 +61,71 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spe
 ## References
 - Kubernetes container images: https://kubernetes.io/docs/concepts/containers/images/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-controllers-pdb.md
+++ b/docs/agents/designs/chart-controllers-pdb.md
@@ -60,3 +60,71 @@ kubectl -n agents get pdb
 ## References
 - Kubernetes PodDisruptionBudget: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-controllers-service.md
+++ b/docs/agents/designs/chart-controllers-service.md
@@ -67,3 +67,71 @@ kubectl -n agents get endpoints agents-controllers
 ## References
 - Kubernetes Service type ClusterIP: https://kubernetes.io/docs/concepts/services-networking/service/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-controlplane-image-override-precedence.md
+++ b/docs/agents/designs/chart-controlplane-image-override-precedence.md
@@ -59,3 +59,71 @@ kubectl -n agents rollout status deploy/agents
 ## References
 - Helm best practices for values: https://helm.sh/docs/chart_best_practices/values/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-database-url-secretref-precedence.md
+++ b/docs/agents/designs/chart-database-url-secretref-precedence.md
@@ -45,7 +45,7 @@ This doc formalizes the precedence rules and recommended operational patterns.
 ## Rollout Plan
 1. Add docs + README clarifying precedence.
 2. Add `values.schema.json` constraints: if `database.createSecret.enabled=true`, require `database.url`.
-3. Add `templates/validation.yaml` rules for production profiles (render-time failure).
+3. Add `charts/agents/templates/validation.yaml` rules for production profiles (render-time failure).
 
 Rollback:
 - Disable validation rules; do not change existing Secret references.
@@ -75,3 +75,71 @@ kubectl -n agents get secret jangar-db-app -o yaml
 - Kubernetes Secrets as env vars: https://kubernetes.io/docs/concepts/configuration/secret/
 - Helm values best practices: https://helm.sh/docs/chart_best_practices/values/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
+++ b/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
@@ -74,3 +74,71 @@ kubectl -n agents rollout status deploy/agents
 ## References
 - Kubernetes Deployment strategy: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-env-vars-merge-precedence.md
+++ b/docs/agents/designs/chart-env-vars-merge-precedence.md
@@ -87,3 +87,71 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_MIGRATI
 - Kubernetes environment variable precedence (explicit `env` vs `envFrom`): https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 - Helm chart best practices (values and templates): https://helm.sh/docs/chart_best_practices/values/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-envfrom-conflict-resolution.md
+++ b/docs/agents/designs/chart-envfrom-conflict-resolution.md
@@ -77,3 +77,71 @@ kubectl -n agents get deploy agents -o jsonpath='{.spec.template.spec.containers
 ## References
 - Kubernetes: define env vars and `envFrom`: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-extra-volumes-mounts-contract.md
+++ b/docs/agents/designs/chart-extra-volumes-mounts-contract.md
@@ -67,3 +67,71 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"extra|db-ca-cert|volumes:|
 ## References
 - Kubernetes volumes: https://kubernetes.io/docs/concepts/storage/volumes/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
+++ b/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
@@ -65,3 +65,71 @@ kubectl -n agents get endpointslice -l app.kubernetes.io/name=agents
 ## References
 - Kubernetes Services: https://kubernetes.io/docs/concepts/services-networking/service/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-image-digest-tag-precedence.md
+++ b/docs/agents/designs/chart-image-digest-tag-precedence.md
@@ -76,3 +76,71 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spe
 ## References
 - Kubernetes container image names (tag/digest): https://kubernetes.io/docs/concepts/containers/images/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-kubernetesapi-host-port-override.md
+++ b/docs/agents/designs/chart-kubernetesapi-host-port-override.md
@@ -55,3 +55,71 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"KUBERNETES_SERVICE_HOST|KU
 ## References
 - Kubernetes in-cluster configuration: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
+++ b/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
@@ -62,3 +62,71 @@ kubectl get ns agents
 ## References
 - Helm template rendering concepts: https://helm.sh/docs/chart_template_guide/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-pod-annotations-merging.md
+++ b/docs/agents/designs/chart-pod-annotations-merging.md
@@ -66,3 +66,71 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.met
 ## References
 - Kubernetes pod template metadata: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-probes-configuration-contract.md
+++ b/docs/agents/designs/chart-probes-configuration-contract.md
@@ -67,3 +67,71 @@ kubectl -n agents describe pod -l app.kubernetes.io/name=agents | rg -n \"Livene
 ## References
 - Kubernetes probes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
+++ b/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
@@ -67,3 +67,71 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_RBAC_CL
 ## References
 - Kubernetes RBAC overview: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-resources-component-overrides.md
+++ b/docs/agents/designs/chart-resources-component-overrides.md
@@ -72,3 +72,71 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"resources:\"
 ## References
 - Kubernetes resource requests/limits: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-rollback-helm-behavior.md
+++ b/docs/agents/designs/chart-rollback-helm-behavior.md
@@ -63,3 +63,71 @@ kubectl -n agents rollout status deploy/agents-controllers
 ## References
 - Helm template guide: https://helm.sh/docs/chart_template_guide/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
+++ b/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
@@ -67,3 +67,71 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_AGENT_R
 ## References
 - Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-serviceaccount-name-resolution.md
+++ b/docs/agents/designs/chart-serviceaccount-name-resolution.md
@@ -72,3 +72,71 @@ kubectl -n agents get sa
 ## References
 - Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/chart-termination-grace-prestop.md
+++ b/docs/agents/designs/chart-termination-grace-prestop.md
@@ -64,3 +64,71 @@ kubectl -n agents rollout restart deploy/agents-controllers
 ## References
 - Kubernetes container lifecycle hooks: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart behavior: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/`
+- Chart render-time validation: `charts/agents/templates/validation.yaml`
+- GitOps desired state:
+  - `agents` app (CRDs + controllers + service): `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+  - `jangar` app (product deployment + primitives): `argocd/applications/jangar/kustomization.yaml`
+  - Product enablement: `argocd/applicationsets/product.yaml`
+
+### Values → env var mapping (chart)
+- Control plane env var merge + rendering: `charts/agents/templates/deployment.yaml`
+- Controllers env var merge + rendering: `charts/agents/templates/deployment-controllers.yaml`
+- Common pattern: `.Values.env.vars` are merged with component-specific vars (control plane: `.Values.controlPlane.env.vars`, controllers: `.Values.controllers.env.vars`). Component-specific keys win.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Change chart templates/values/schema in `charts/agents/**`.
+2. If the chart `version:` changes, keep `charts/agents/Chart.yaml` and `argocd/applications/agents/kustomization.yaml` in sync.
+3. Validate rendering locally (no cluster access required):
+
+```bash
+mise exec helm@3.15.4 -- helm lint charts/agents
+mise exec helm@3.15.4 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml --include-crds > /tmp/agents.helm.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+scripts/agents/validate-agents.sh
+```
+
+4. Merge to `main`; Argo CD reconciles.
+
+### Validation (post-merge)
+- Confirm Argo sync + workloads healthy:
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200
+```

--- a/docs/agents/designs/cluster-cost-optimization.md
+++ b/docs/agents/designs/cluster-cost-optimization.md
@@ -65,7 +65,7 @@ High throughput can lead to wasted compute costs.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ High throughput can lead to wasted compute costs.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/control-plane-ui-filters.md
+++ b/docs/agents/designs/control-plane-ui-filters.md
@@ -65,7 +65,7 @@ Operators cannot easily filter high-volume runs.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Operators cannot easily filter high-volume runs.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/controller-auth-secret-mount-rotation.md
+++ b/docs/agents/designs/controller-auth-secret-mount-rotation.md
@@ -66,3 +66,65 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"AUTH_SECRET\"
 ## References
 - Kubernetes Secrets: https://kubernetes.io/docs/concepts/configuration/secret/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-concurrency-tuning.md
+++ b/docs/agents/designs/controller-concurrency-tuning.md
@@ -66,7 +66,7 @@ Default concurrency limits may not fit large clusters.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -76,24 +76,35 @@ Default concurrency limits may not fit large clusters.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -124,10 +135,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/controller-condition-type-taxonomy.md
+++ b/docs/agents/designs/controller-condition-type-taxonomy.md
@@ -68,3 +68,65 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[?(@.type=
 ## References
 - Kubernetes API conventions (Conditions): https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-controllers-deployment-grpc-off.md
+++ b/docs/agents/designs/controller-controllers-deployment-grpc-off.md
@@ -64,3 +64,65 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"gRPC|Agentctl\"
 ## References
 - gRPC basics: https://grpc.io/docs/what-is-grpc/introduction/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
+++ b/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
@@ -61,3 +61,65 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"migration|migrations\
 ## References
 - Kubernetes init containers and migration patterns: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-failed-reconcile-events.md
+++ b/docs/agents/designs/controller-failed-reconcile-events.md
@@ -63,3 +63,65 @@ kubectl -n agents describe agentrun <name> | rg -n \"Events:\"
 ## References
 - Kubernetes Events: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#event-v1-core
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-finalizer-conventions.md
+++ b/docs/agents/designs/controller-finalizer-conventions.md
@@ -63,3 +63,65 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.deletionTimestamp}
 ## References
 - Kubernetes finalizers: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-kubectl-version-compat.md
+++ b/docs/agents/designs/controller-kubectl-version-compat.md
@@ -58,3 +58,65 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"kubectl\"
 ## References
 - Kubernetes version skew policy: https://kubernetes.io/releases/version-skew-policy/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-namespace-scope-parse-validate.md
+++ b/docs/agents/designs/controller-namespace-scope-parse-validate.md
@@ -67,3 +67,65 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"namespaces\"
 ## References
 - Kubernetes namespace naming: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-orchestration-submit-dedup.md
+++ b/docs/agents/designs/controller-orchestration-submit-dedup.md
@@ -62,3 +62,66 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"deliveryId|idempotent
 
 ## References
 - HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-postgres-ca-rootcert.md
+++ b/docs/agents/designs/controller-postgres-ca-rootcert.md
@@ -62,3 +62,65 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"PGSSLROOTCERT|db-ca-cert\"
 ## References
 - Kubernetes Secrets volumes: https://kubernetes.io/docs/concepts/storage/volumes/#secret
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-reconcile-timeout-budget.md
+++ b/docs/agents/designs/controller-reconcile-timeout-budget.md
@@ -66,3 +66,65 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Timeout:\"
 ## References
 - Kubernetes API timeouts (client-side considerations): https://kubernetes.io/docs/reference/using-api/api-concepts/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-resourceversion-conflict-retry.md
+++ b/docs/agents/designs/controller-resourceversion-conflict-retry.md
@@ -64,3 +64,65 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Conflict|409\"
 ## References
 - Kubernetes optimistic concurrency control: https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-server-side-apply-ownership.md
+++ b/docs/agents/designs/controller-server-side-apply-ownership.md
@@ -63,3 +63,65 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.managedFields[*].m
 ## References
 - Kubernetes Server-Side Apply: https://kubernetes.io/docs/reference/using-api/server-side-apply/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-status-timestamps-generation.md
+++ b/docs/agents/designs/controller-status-timestamps-generation.md
@@ -68,3 +68,65 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.generation} {.stat
 ## References
 - Kubernetes generation and status patterns: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/controller-webhook-signature-verification.md
+++ b/docs/agents/designs/controller-webhook-signature-verification.md
@@ -77,3 +77,65 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Invalid webhook signa
 - GitHub webhook signature docs: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
 - Linear webhook security docs: https://developers.linear.app/docs/graphql/webhooks
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Controller implementation: `services/jangar/src/server/agents-controller.ts`
+- Supporting controllers:
+  - Orchestration: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks: `services/jangar/src/server/primitives-policy.ts`
+- Chart env var wiring (controllers deployment): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps desired state: `argocd/applications/agents/values.yaml` (inputs to chart)
+
+### Values → env var mapping (controllers)
+- `controller.*` values in `charts/agents/values.yaml` map to `JANGAR_AGENTS_CONTROLLER_*` env vars in `charts/agents/templates/deployment-controllers.yaml`.
+- The controller reads env via helpers like `parseEnvStringList`, `parseEnvRecord`, `parseJsonEnv` in `services/jangar/src/server/agents-controller.ts`.
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan
+1. Update controller code under `services/jangar/src/server/`.
+2. Build/push image(s) (out of scope in this doc set); then update GitOps pins:
+   - `argocd/applications/agents/values.yaml` (controllers/control plane images)
+   - `argocd/applications/jangar/kustomization.yaml` (product `jangar` image)
+3. Merge to `main`; Argo CD reconciles.
+
+### Validation
+- Unit tests (fast): `bun run --filter jangar test`
+- Render desired manifests (no cluster needed):
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+```
+
+- Live cluster (requires kubeconfig): see commands in “Current cluster state” above.

--- a/docs/agents/designs/crd-agent-config-schema.md
+++ b/docs/agents/designs/crd-agent-config-schema.md
@@ -77,3 +77,63 @@ kubectl -n agents get agent <name> -o yaml | rg -n \"configSchemaRef|InvalidConf
 ## References
 - Kubernetes CRD validation: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-agentrun-artifacts-limits.md
+++ b/docs/agents/designs/crd-agentrun-artifacts-limits.md
@@ -69,3 +69,63 @@ kubectl -n agents get agentrun <name> -o yaml | rg -n \"artifacts:\"
 ## References
 - Kubernetes object size limits (etcd considerations): https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-agentrun-idempotency.md
+++ b/docs/agents/designs/crd-agentrun-idempotency.md
@@ -61,3 +61,64 @@ kubectl -n agents get agentrun -o json | rg -n \"idempotencyKey\"
 
 ## References
 - HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-agentrun-spec-immutability.md
+++ b/docs/agents/designs/crd-agentrun-spec-immutability.md
@@ -70,3 +70,63 @@ kubectl -n agents get agentrun <name> -o yaml | rg -n \"SpecImmutableViolation|s
 ## References
 - Kubernetes immutability patterns (general objects): https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-implementationsource-webhook-cel.md
+++ b/docs/agents/designs/crd-implementationsource-webhook-cel.md
@@ -58,3 +58,63 @@ kubectl -n agents apply -f charts/agents/examples/implementationsource-github.ya
 ## References
 - Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-implementationspec-config-constraints.md
+++ b/docs/agents/designs/crd-implementationspec-config-constraints.md
@@ -60,3 +60,63 @@ kubectl -n agents get implementationspec -o yaml | rg -n \"spec:|x-kubernetes-va
 ## References
 - Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-lifecycle-upgrades.md
+++ b/docs/agents/designs/crd-lifecycle-upgrades.md
@@ -104,7 +104,7 @@ production-ready checklist.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -114,24 +114,35 @@ production-ready checklist.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -162,10 +173,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/crd-memory-retention-compaction.md
+++ b/docs/agents/designs/crd-memory-retention-compaction.md
@@ -71,3 +71,63 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"compaction|retention\
 ## References
 - Kubernetes controllers (background reconciliation): https://kubernetes.io/docs/concepts/architecture/controller/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-orchestration-dag.md
+++ b/docs/agents/designs/crd-orchestration-dag.md
@@ -68,3 +68,64 @@ kubectl -n agents get orchestrationrun -o yaml | rg -n \"phase:|Skipped|Dependen
 
 ## References
 - Argo Workflows DAG concepts (widely used Kubernetes DAG runtime): https://argo-workflows.readthedocs.io/en/latest/walk-through/dag/
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
+++ b/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
@@ -62,3 +62,63 @@ kubectl -n agents get orchestrationrun <name> -o yaml | rg -n \"Cancelled|phase\
 ## References
 - Kubernetes graceful termination concepts: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
+++ b/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
@@ -68,3 +68,63 @@ kubectl -n agents get configmap | rg known-hosts
 - OpenSSH `known_hosts` format: https://man.openbsd.org/sshd.8#SSH_KNOWN_HOSTS_FILE_FORMAT
 - Git over SSH: https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Go API types: `services/jangar/api/agents/v1alpha1/types.go`
+- CRD generation entrypoint: `services/jangar/api/agents/generate.go`
+- Generated CRDs shipped with the chart: `charts/agents/crds/`
+- Examples used by CI/local validation: `charts/agents/examples/`
+
+### Regenerating CRDs
+
+```bash
+# Regenerates `charts/agents/crds/*` via controller-gen, then patches/normalizes CRDs.
+go generate ./services/jangar/api/agents
+
+# Validates CRDs + examples + rendered chart assumptions.
+scripts/agents/validate-agents.sh
+```
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
+
+Render the exact YAML Argo CD applies:
+
+```bash
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
+```
+
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
+
+### Rollout plan (GitOps)
+1. Regenerate CRDs and commit the updated `charts/agents/crds/*`.
+2. Update `charts/agents/Chart.yaml` `version:` if the CRD changes are shipped to users; keep GitOps pinned version in sync (`argocd/applications/agents/kustomization.yaml`).
+3. Merge to `main`; Argo CD applies updated CRDs (`includeCRDs: true`).
+
+### Validation
+- Local:
+  - `scripts/agents/validate-agents.sh`
+  - `mise exec helm@3.15.4 -- helm lint charts/agents`
+- Cluster (requires kubeconfig):
+  - `mise exec kubectl@1.30.6 -- kubectl get crd | rg 'agents\.proompteng\.ai|orchestration\.proompteng\.ai|approvals\.proompteng\.ai'`

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -155,7 +155,7 @@ argo submit \
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -165,24 +165,35 @@ argo submit \
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -213,10 +224,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/data-migration-runbooks.md
+++ b/docs/agents/designs/data-migration-runbooks.md
@@ -65,7 +65,7 @@ Upgrades require clear migration instructions.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Upgrades require clear migration instructions.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/disaster-recovery-backups.md
+++ b/docs/agents/designs/disaster-recovery-backups.md
@@ -65,7 +65,7 @@ State loss can halt autonomous operations.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ State loss can halt autonomous operations.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/github-app-auth-rotation.md
+++ b/docs/agents/designs/github-app-auth-rotation.md
@@ -69,7 +69,7 @@ Support GitHub App installation tokens for VCS operations, including safe rotati
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -79,24 +79,35 @@ Support GitHub App installation tokens for VCS operations, including safe rotati
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -127,10 +138,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -66,7 +66,7 @@ GitOps deployments need deterministic pre/post-sync behavior.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -76,24 +76,35 @@ GitOps deployments need deterministic pre/post-sync behavior.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -124,10 +135,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/grpc-coverage-parity.md
+++ b/docs/agents/designs/grpc-coverage-parity.md
@@ -65,7 +65,7 @@ gRPC endpoints lag behind REST and CLI features.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ gRPC endpoints lag behind REST and CLI features.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/implementation-contract-enforcement.md
+++ b/docs/agents/designs/implementation-contract-enforcement.md
@@ -66,7 +66,7 @@ Runs can fail if required metadata is missing.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -76,24 +76,35 @@ Runs can fail if required metadata is missing.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -124,10 +135,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/integration-test-harness.md
+++ b/docs/agents/designs/integration-test-harness.md
@@ -65,7 +65,7 @@ High-scale changes need reliable integration testing.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ High-scale changes need reliable integration testing.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/job-gc-visibility.md
+++ b/docs/agents/designs/job-gc-visibility.md
@@ -65,7 +65,7 @@ Jobs may be deleted before status is collected, causing WorkflowJobMissing.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Jobs may be deleted before status is collected, causing WorkflowJobMissing.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/leader-election-ha.md
+++ b/docs/agents/designs/leader-election-ha.md
@@ -102,7 +102,7 @@ Map values into env vars consumed by the controller runtime, for example:
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -112,24 +112,35 @@ Map values into env vars consumed by the controller runtime, for example:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -160,10 +171,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/load-testing-benchmarking.md
+++ b/docs/agents/designs/load-testing-benchmarking.md
@@ -64,7 +64,7 @@ No standardized benchmark for 100-person throughput.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -74,24 +74,35 @@ No standardized benchmark for 100-person throughput.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -122,10 +133,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/log-retention-shipper.md
+++ b/docs/agents/designs/log-retention-shipper.md
@@ -64,7 +64,7 @@ Job logs are ephemeral and hard to retrieve after completion.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -74,24 +74,35 @@ Job logs are ephemeral and hard to retrieve after completion.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -122,10 +133,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/metrics-otel-tracing.md
+++ b/docs/agents/designs/metrics-otel-tracing.md
@@ -65,7 +65,7 @@ Without tracing, it is hard to debug end-to-end latency.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Without tracing, it is hard to debug end-to-end latency.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/multi-namespace-controller-guards.md
+++ b/docs/agents/designs/multi-namespace-controller-guards.md
@@ -65,7 +65,7 @@ Misconfigured namespaces can lead to missed resources or RBAC errors.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Misconfigured namespaces can lead to missed resources or RBAC errors.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/multi-provider-auth-deprecations.md
@@ -72,7 +72,7 @@ Normalize auth configuration across VCS providers and surface deprecated token t
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -82,24 +82,35 @@ Normalize auth configuration across VCS providers and surface deprecated token t
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -130,10 +141,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/namespaced-install-matrix.md
+++ b/docs/agents/designs/namespaced-install-matrix.md
@@ -55,7 +55,7 @@ Define the supported install modes and their RBAC implications for the Agents co
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -65,24 +65,35 @@ Define the supported install modes and their RBAC implications for the Agents co
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -113,10 +124,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/network-policy-egress.md
+++ b/docs/agents/designs/network-policy-egress.md
@@ -65,7 +65,7 @@ Autonomous agents require explicit egress controls for security.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Autonomous agents require explicit egress controls for security.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/observability-pack.md
+++ b/docs/agents/designs/observability-pack.md
@@ -66,7 +66,7 @@ Operators need metrics, logs, and dashboards to run at scale.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -76,24 +76,35 @@ Operators need metrics, logs, and dashboards to run at scale.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -124,10 +135,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/pod-security-admission.md
+++ b/docs/agents/designs/pod-security-admission.md
@@ -56,7 +56,7 @@ podSecurityAdmission:
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -66,24 +66,35 @@ podSecurityAdmission:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -114,10 +125,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/pr-rate-limits-batching.md
+++ b/docs/agents/designs/pr-rate-limits-batching.md
@@ -60,7 +60,7 @@ Respect VCS provider rate limits by throttling automated PR creation.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -70,24 +70,35 @@ Respect VCS provider rate limits by throttling automated PR creation.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -118,10 +129,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/queue-fairness-per-repo.md
+++ b/docs/agents/designs/queue-fairness-per-repo.md
@@ -70,7 +70,7 @@ High-volume repos can starve smaller repos of capacity.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -80,24 +80,35 @@ High-volume repos can starve smaller repos of capacity.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -128,10 +139,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/repo-allow-deny-policy.md
+++ b/docs/agents/designs/repo-allow-deny-policy.md
@@ -55,7 +55,7 @@ repositoryPolicy:
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -65,24 +65,35 @@ repositoryPolicy:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -113,10 +124,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/resourcequota-limitrange.md
+++ b/docs/agents/designs/resourcequota-limitrange.md
@@ -64,7 +64,7 @@ Clusters need quota enforcement for AgentRuns.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -74,24 +74,35 @@ Clusters need quota enforcement for AgentRuns.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -122,10 +133,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -62,7 +62,7 @@ cleanup.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -72,24 +72,35 @@ cleanup.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -120,10 +131,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/schedule-cronjob-reliability.md
+++ b/docs/agents/designs/schedule-cronjob-reliability.md
@@ -65,7 +65,7 @@ Schedule CRDs require reliable CronJob creation and cleanup.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Schedule CRDs require reliable CronJob creation and cleanup.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/scheduler-affinity-priority.md
+++ b/docs/agents/designs/scheduler-affinity-priority.md
@@ -56,7 +56,7 @@ Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run 
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -66,24 +66,35 @@ Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run 
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -114,10 +125,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/secretbinding-guardrails.md
+++ b/docs/agents/designs/secretbinding-guardrails.md
@@ -65,7 +65,7 @@ Runs can mount secrets without clear governance.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Runs can mount secrets without clear governance.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/security-sbom-signing.md
+++ b/docs/agents/designs/security-sbom-signing.md
@@ -65,7 +65,7 @@ Supply chain integrity is required for production adoption.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Supply chain integrity is required for production adoption.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/signal-delivery-retries.md
+++ b/docs/agents/designs/signal-delivery-retries.md
@@ -64,7 +64,7 @@ SignalDelivery failures can leave workflows stuck.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -74,24 +74,35 @@ SignalDelivery failures can leave workflows stuck.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -122,10 +133,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/staging-prod-values-overlays.md
+++ b/docs/agents/designs/staging-prod-values-overlays.md
@@ -65,7 +65,7 @@ Operators need consistent overlays for staging and prod.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Operators need consistent overlays for staging and prod.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/supply-chain-attestations.md
+++ b/docs/agents/designs/supply-chain-attestations.md
@@ -64,7 +64,7 @@ Regulated environments require provenance attestations.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -74,24 +74,35 @@ Regulated environments require provenance attestations.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -122,10 +133,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/throughput-backpressure-quotas.md
+++ b/docs/agents/designs/throughput-backpressure-quotas.md
@@ -82,7 +82,7 @@ These should map to:
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -92,24 +92,35 @@ These should map to:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -140,10 +151,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/toolrun-runtime-isolation.md
+++ b/docs/agents/designs/toolrun-runtime-isolation.md
@@ -64,7 +64,7 @@ Tool runs need consistent isolation and resource limits.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -74,24 +74,35 @@ Tool runs need consistent isolation and resource limits.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -122,10 +133,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/topology-spread-defaults.md
+++ b/docs/agents/designs/topology-spread-defaults.md
@@ -66,7 +66,7 @@ Workloads can stack on a single node without spread rules.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -76,24 +76,35 @@ Workloads can stack on a single node without spread rules.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -124,10 +135,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/values-schema-readme-automation.md
+++ b/docs/agents/designs/values-schema-readme-automation.md
@@ -26,9 +26,9 @@ Keep `charts/agents/README.md` and `charts/agents/values.schema.json` in lock-st
 
 ## Proposed Repository Changes
 
-- Add `scripts/agents/generate-helm-docs.sh` to regenerate README and `values.schema.json`.
-- Add `scripts/agents/validate-helm-docs.sh` to diff generated outputs against the repo.
-- Add a CI job that runs `scripts/agents/validate-helm-docs.sh` on chart changes.
+- Pin `helm-docs` via `mise` (or a containerized tool) and add `helm-docs` markers to `charts/agents/README.md` so only the values table is regenerated.
+- Decide whether `charts/agents/values.schema.json` remains a reviewed/manual artifact (current state) or becomes generated; if generated, define the generator and make it deterministic.
+- Add a CI drift check that (at minimum) runs `helm lint charts/agents` and renders the GitOps install; if generation is adopted, CI should also fail when the generated README/schema differs from what is committed.
 
 ## Schema Constraints
 Some constraints cannot be inferred from YAML alone. Encode them via inline comments in `values.yaml`:
@@ -69,7 +69,7 @@ Some constraints cannot be inferred from YAML alone. Encode them via inline comm
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -79,24 +79,35 @@ Some constraints cannot be inferred from YAML alone. Encode them via inline comm
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -127,10 +138,9 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/webhook-ingestion-scaling.md
+++ b/docs/agents/designs/webhook-ingestion-scaling.md
@@ -66,7 +66,7 @@ Webhook bursts can overload reconciliation.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -76,24 +76,35 @@ Webhook bursts can overload reconciliation.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -124,10 +135,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/workflow-step-timeouts.md
+++ b/docs/agents/designs/workflow-step-timeouts.md
@@ -65,7 +65,7 @@ Long-running steps can block workflows without clear timeout handling.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -75,24 +75,35 @@ Long-running steps can block workflows without clear timeout handling.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -123,10 +134,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 

--- a/docs/agents/designs/workspace-pvc-lifecycle.md
+++ b/docs/agents/designs/workspace-pvc-lifecycle.md
@@ -64,7 +64,7 @@ Workspaces can leak storage without cleanup policies.
 - Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
-- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `services/jangar/api/agents/generate.go`, `scripts/agents/validate-agents.sh`
 - Controllers:
   - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
@@ -74,24 +74,35 @@ Workspaces can leak storage without cleanup policies.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
-- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
-- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
-- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+As of 2026-02-06 (repo `main`, desired state in Git):
+- `agents` Argo CD app (namespace `agents`) installs `charts/agents` via kustomize-helm (release `agents`, chart `version: 0.9.1`, `includeCRDs: true`). See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned for `agents`:
+  - Control plane (`deploy/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` (from `controlPlane.image.*`).
+  - Controllers (`deploy/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809` (from `image.*`).
+- Namespaced reconciliation: `controller.namespaces: [agents]`, `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- `jangar` Argo CD app (namespace `jangar`) deploys the product UI/control plane plus default “primitive” CRs (AgentProvider/Agent/Memory/etc). See `argocd/applications/jangar/kustomization.yaml`.
+- Jangar image pinned for `jangar` (`deploy/jangar`): `registry.ide-newton.ts.net/lab/jangar:19448656@sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c` (from `argocd/applications/jangar/kustomization.yaml`).
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Render the exact YAML Argo CD applies:
 
 ```bash
-kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
-kubectl get crd | rg 'proompteng\.ai'
-kubectl rollout status -n agents deploy/agents
-kubectl rollout status -n agents deploy/agents-controllers
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml
+mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml
 ```
 
+Verify live cluster state (requires kubeconfig):
+
+```bash
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd agents
+mise exec kubectl@1.30.6 -- kubectl get application -n argocd jangar
+mise exec kubectl@1.30.6 -- kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
+mise exec kubectl@1.30.6 -- kubectl get deploy -n agents
+mise exec kubectl@1.30.6 -- kubectl get deploy -n jangar
+mise exec kubectl@1.30.6 -- kubectl get crd | rg 'proompteng\.ai'
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents
+mise exec kubectl@1.30.6 -- kubectl rollout status -n agents deploy/agents-controllers
+mise exec kubectl@1.30.6 -- kubectl rollout status -n jangar deploy/jangar
+```
 ### Values → env var mapping (chart)
 Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
 
@@ -122,10 +133,10 @@ Common mappings:
 4. Merge to `main`; Argo CD reconciles the `agents` application.
 
 ### Validation (smoke)
-- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Render the full install (Helm via kustomize): `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
 - In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - `mise exec kubectl@1.30.6 -- kubectl get pods -n agents`
+  - `mise exec kubectl@1.30.6 -- kubectl logs -n agents deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
 


### PR DESCRIPTION
## Summary

- Refresh all `docs/agents/designs/*.md` to match current repo code and GitOps desired state.
- Standardize a production handoff appendix in every design doc (source-of-truth pointers, values/env mapping, rollout plan, validation commands).
- Fix stale/missing doc references (e.g. chart validation path + README/schema automation guidance).

## Related Issues

None

## Testing

- `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.rendered.yaml`
- `mise exec helm@3.15.4 kustomize@5.4.3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar.rendered.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots section removed (docs-only change).
- [x] Breaking Changes handled appropriately.
- [x] Documentation and follow-ups updated.
