### PR TITLE
docs(agents): refresh design docs handoff appendix

### DIFF
--- a/docs/agents/designs/admission-control-policy.md
+++ b/docs/agents/designs/admission-control-policy.md
@@ -85,7 +85,9 @@ Reject unsafe or invalid AgentRuns before runtime submission by enforcing contro
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/agentctl-cli-resilience.md
+++ b/docs/agents/designs/agentctl-cli-resilience.md
@@ -78,7 +78,9 @@ CLI failures reduce operator trust and automation reliability.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/api-pagination-and-watch.md
+++ b/docs/agents/designs/api-pagination-and-watch.md
@@ -78,7 +78,9 @@ Large lists can overload the API and clients.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/approval-policy-gates.md
+++ b/docs/agents/designs/approval-policy-gates.md
@@ -78,7 +78,9 @@ High-risk runs should require approval before execution.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/artifact-storage-s3.md
+++ b/docs/agents/designs/artifact-storage-s3.md
@@ -78,7 +78,9 @@ Artifacts need durable storage at scale.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/artifacthub-oci-distribution.md
+++ b/docs/agents/designs/artifacthub-oci-distribution.md
@@ -84,7 +84,9 @@ Define how the Agents Helm chart is packaged, published as an OCI artifact, and 
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/audit-logging.md
+++ b/docs/agents/designs/audit-logging.md
@@ -78,7 +78,9 @@ High scale PR automation needs traceable audit logs.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -73,7 +73,9 @@ defaults:
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/budget-enforcement.md
+++ b/docs/agents/designs/budget-enforcement.md
@@ -78,7 +78,9 @@ Runs can exceed token or cost budgets without enforcement.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/chart-canary-argo-rollouts.md
+++ b/docs/agents/designs/chart-canary-argo-rollouts.md
@@ -68,3 +68,61 @@ kubectl -n agents get rollout
 ## References
 - Argo Rollouts documentation: https://argo-rollouts.readthedocs.io/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-config-checksum-rollouts.md
+++ b/docs/agents/designs/chart-config-checksum-rollouts.md
@@ -66,3 +66,61 @@ kubectl -n agents get deploy agents -o jsonpath='{.spec.template.metadata.annota
 ## References
 - Kubernetes ConfigMaps/Secrets update behavior: https://kubernetes.io/docs/concepts/configuration/configmap/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
+++ b/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
@@ -3,11 +3,11 @@
 Status: Draft (2026-02-06)
 
 ## Overview
-Controllers reconcile CRDs in a set of namespaces. The chart exposes `controller.namespaces`, but it is not documented what an empty list means (disabled? all namespaces? release namespace only?). Ambiguity here creates production risk.
+Controllers reconcile CRDs in a set of namespaces. The chart exposes `controller.namespaces`, but it’s easy for operators to assume an empty list might mean “disabled” or “all namespaces”. In practice, the chart and controllers implement concrete (and mostly safe) defaulting rules, but they must be documented explicitly because namespace scoping is a primary safety boundary.
 
 ## Goals
-- Define an explicit meaning for `controller.namespaces: []`.
-- Prevent accidental cluster-wide reconciliation in namespaced installs.
+- Document the actual meaning for `controller.namespaces: []` / unset.
+- Prevent accidental cluster-wide reconciliation in namespaced installs (RBAC + wildcard).
 - Make namespace scope observable and testable.
 
 ## Non-Goals
@@ -15,36 +15,41 @@ Controllers reconcile CRDs in a set of namespaces. The chart exposes `controller
 
 ## Current State
 - Values: `charts/agents/values.yaml` exposes `controller.namespaces: []`.
-- Template renders namespaces into env vars:
-  - `JANGAR_AGENTS_CONTROLLER_NAMESPACES`: `charts/agents/templates/deployment-controllers.yaml`
-  - helper: `charts/agents/templates/_helpers.tpl` (`agents.controllerNamespaces`)
-- Runtime parsing:
-  - `services/jangar/src/server/implementation-source-webhooks.ts` reads `process.env.JANGAR_AGENTS_CONTROLLER_NAMESPACES`.
-  - Controllers use namespace scoping utilities in `services/jangar/src/server/namespace-scope.ts`.
-- Cluster desired state sets `controller.namespaces: [agents]` in `argocd/applications/agents/values.yaml`.
+- Template defaulting (chart source of truth):
+  - `charts/agents/templates/_helpers.tpl` (`agents.controllerNamespaces`) treats an empty/absent list as “the release namespace” (or `namespaceOverride` if set) and joins namespaces as a comma-separated string.
+  - That helper is used to render:
+    - `JANGAR_AGENTS_CONTROLLER_NAMESPACES`: `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`
+    - `JANGAR_PRIMITIVES_NAMESPACES`: same templates
+- Runtime parsing (controller source of truth):
+  - `services/jangar/src/server/agents-controller.ts:260` parses `JANGAR_AGENTS_CONTROLLER_NAMESPACES` as a comma-separated list and defaults to `DEFAULT_NAMESPACES=['agents']` only when the env var is missing/empty.
+  - Wildcard semantics: `services/jangar/src/server/agents-controller.ts:278` supports `'*'` (list namespaces via kubectl) and enforces `rbac.clusterScoped=true` via `services/jangar/src/server/namespace-scope.ts:11`.
+- Cluster desired state (GitOps): `argocd/applications/agents/values.yaml` sets `controller.namespaces: [agents]` explicitly.
 
 ## Design
 ### Semantics
-- `controller.namespaces` MUST be required when `rbac.clusterScoped=false`.
-- Empty list MUST mean “no namespaces configured” and controllers SHOULD refuse to start (fail-fast) to avoid a false sense of safety.
-- For `rbac.clusterScoped=true`, introduce an explicit value:
-  - `controller.namespaces: [\"*\"]` to mean “all namespaces”, rather than interpreting empty as all.
+- **Empty/unset** `controller.namespaces` means: “use the release namespace” (or `namespaceOverride`). This is the current behavior implemented by `agents.controllerNamespaces` and is the recommended safe default for namespaced installs.
+- **Explicit list** means: reconcile only those namespaces.
+- **Wildcard** `'*'` means: reconcile all namespaces, but only when `rbac.clusterScoped=true` (enforced at runtime).
+
+If future behavior changes are desired, do not reinterpret the empty list. Instead:
+- Introduce an explicit disable flag (e.g. `controller.enabled=false`) or a dedicated “none” sentinel.
+- Keep wildcard as the only “all namespaces” mechanism and continue to require cluster-scoped RBAC.
 
 ## Config Mapping
 | Helm value | Env var | Intended behavior |
 |---|---|---|
-| `controller.namespaces: [\"agents\"]` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=[\"agents\"]` | Reconcile only `agents` namespace resources. |
-| `controller.namespaces: []` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=[]` (or unset) | Fail-fast at startup unless clusterScoped=true and explicit wildcard used. |
-| `controller.namespaces: [\"*\"]` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=[\"*\"]` | (When clusterScoped=true) reconcile all namespaces. |
+| `controller.namespaces: ['agents']` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=agents` | Reconcile only `agents` namespace resources. |
+| `controller.namespaces: []` (or unset) | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=<release-namespace>` | Reconcile only the release namespace (or `namespaceOverride`). |
+| `controller.namespaces: ['*']` | `JANGAR_AGENTS_CONTROLLER_NAMESPACES=*` | (When `rbac.clusterScoped=true`) reconcile all namespaces (runtime lists namespaces via kubectl). |
 
 ## Rollout Plan
-1. Document semantics and recommend non-empty namespaces for prod.
-2. Add controller startup validation in `services/jangar/src/server/*`:
-   - If env var is empty/unset: exit with clear error.
-3. Add chart schema rule: when `controller.enabled=true`, require at least one namespace unless clusterScoped=true and wildcard is used.
+1. Document semantics (this doc) and point operators to the actual helper and runtime parsing functions.
+2. (Optional hardening) Add chart schema constraints in `charts/agents/values.schema.json`:
+   - Reject `controller.namespaces: ['*']` when `rbac.clusterScoped=false`.
+   - Prefer explicit `controller.namespaces` in GitOps overlays for clarity (even though empty defaults safely).
 
 Rollback:
-- Disable fail-fast validation (code rollback).
+- N/A (doc/schema-only).
 
 ## Validation
 ```bash
@@ -53,14 +58,71 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"NAMESPACES|namespace\
 ```
 
 ## Failure Modes and Mitigations
-- Empty list interpreted as “all namespaces” unexpectedly: mitigate by banning that interpretation.
-- Controllers start but do nothing due to empty scope: mitigate with fail-fast.
-- Wildcard scope used with namespaced RBAC: mitigate by schema validation and startup checks.
+- Empty list assumed to mean “all namespaces”: mitigate by documenting the real behavior and avoiding implicit wildcarding.
+- Wildcard scope used with namespaced RBAC: mitigate by runtime guard (`assertClusterScopedForWildcard`) and (optional) schema validation.
 
 ## Acceptance Criteria
-- Empty namespaces configuration is rejected with a clear, actionable error.
-- Wildcard all-namespaces requires explicit `\"*\"` and cluster-scoped RBAC.
+- Empty/unset namespaces behavior is explicitly documented and matches `agents.controllerNamespaces` (release namespace defaulting).
+- Wildcard all-namespaces requires explicit `'*'` and cluster-scoped RBAC (runtime-enforced).
 
 ## References
 - Kubernetes controller patterns (namespace scoping best practices): https://kubernetes.io/docs/concepts/architecture/controller/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controllers-hpa.md
+++ b/docs/agents/designs/chart-controllers-hpa.md
@@ -57,3 +57,61 @@ kubectl -n agents get hpa
 
 ## References
 - Kubernetes HPA v2: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controllers-image-override-precedence.md
+++ b/docs/agents/designs/chart-controllers-image-override-precedence.md
@@ -61,3 +61,61 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spe
 ## References
 - Kubernetes container images: https://kubernetes.io/docs/concepts/containers/images/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controllers-pdb.md
+++ b/docs/agents/designs/chart-controllers-pdb.md
@@ -60,3 +60,61 @@ kubectl -n agents get pdb
 ## References
 - Kubernetes PodDisruptionBudget: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controllers-service.md
+++ b/docs/agents/designs/chart-controllers-service.md
@@ -67,3 +67,61 @@ kubectl -n agents get endpoints agents-controllers
 ## References
 - Kubernetes Service type ClusterIP: https://kubernetes.io/docs/concepts/services-networking/service/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controlplane-image-override-precedence.md
+++ b/docs/agents/designs/chart-controlplane-image-override-precedence.md
@@ -59,3 +59,61 @@ kubectl -n agents rollout status deploy/agents
 ## References
 - Helm best practices for values: https://helm.sh/docs/chart_best_practices/values/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-database-url-secretref-precedence.md
+++ b/docs/agents/designs/chart-database-url-secretref-precedence.md
@@ -75,3 +75,61 @@ kubectl -n agents get secret jangar-db-app -o yaml
 - Kubernetes Secrets as env vars: https://kubernetes.io/docs/concepts/configuration/secret/
 - Helm values best practices: https://helm.sh/docs/chart_best_practices/values/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
+++ b/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
@@ -74,3 +74,61 @@ kubectl -n agents rollout status deploy/agents
 ## References
 - Kubernetes Deployment strategy: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-env-vars-merge-precedence.md
+++ b/docs/agents/designs/chart-env-vars-merge-precedence.md
@@ -87,3 +87,61 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_MIGRATI
 - Kubernetes environment variable precedence (explicit `env` vs `envFrom`): https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 - Helm chart best practices (values and templates): https://helm.sh/docs/chart_best_practices/values/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-envfrom-conflict-resolution.md
+++ b/docs/agents/designs/chart-envfrom-conflict-resolution.md
@@ -77,3 +77,61 @@ kubectl -n agents get deploy agents -o jsonpath='{.spec.template.spec.containers
 ## References
 - Kubernetes: define env vars and `envFrom`: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-extra-volumes-mounts-contract.md
+++ b/docs/agents/designs/chart-extra-volumes-mounts-contract.md
@@ -67,3 +67,61 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"extra|db-ca-cert|volumes:|
 ## References
 - Kubernetes volumes: https://kubernetes.io/docs/concepts/storage/volumes/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
+++ b/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
@@ -65,3 +65,61 @@ kubectl -n agents get endpointslice -l app.kubernetes.io/name=agents
 ## References
 - Kubernetes Services: https://kubernetes.io/docs/concepts/services-networking/service/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-image-digest-tag-precedence.md
+++ b/docs/agents/designs/chart-image-digest-tag-precedence.md
@@ -76,3 +76,61 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spe
 ## References
 - Kubernetes container image names (tag/digest): https://kubernetes.io/docs/concepts/containers/images/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-kubernetesapi-host-port-override.md
+++ b/docs/agents/designs/chart-kubernetesapi-host-port-override.md
@@ -55,3 +55,61 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"KUBERNETES_SERVICE_HOST|KU
 ## References
 - Kubernetes in-cluster configuration: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
+++ b/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
@@ -62,3 +62,61 @@ kubectl get ns agents
 ## References
 - Helm template rendering concepts: https://helm.sh/docs/chart_template_guide/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-pod-annotations-merging.md
+++ b/docs/agents/designs/chart-pod-annotations-merging.md
@@ -66,3 +66,61 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.met
 ## References
 - Kubernetes pod template metadata: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-probes-configuration-contract.md
+++ b/docs/agents/designs/chart-probes-configuration-contract.md
@@ -67,3 +67,61 @@ kubectl -n agents describe pod -l app.kubernetes.io/name=agents | rg -n \"Livene
 ## References
 - Kubernetes probes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
+++ b/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
@@ -67,3 +67,61 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_RBAC_CL
 ## References
 - Kubernetes RBAC overview: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-resources-component-overrides.md
+++ b/docs/agents/designs/chart-resources-component-overrides.md
@@ -72,3 +72,61 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"resources:\"
 ## References
 - Kubernetes resource requests/limits: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-rollback-helm-behavior.md
+++ b/docs/agents/designs/chart-rollback-helm-behavior.md
@@ -63,3 +63,61 @@ kubectl -n agents rollout status deploy/agents-controllers
 ## References
 - Helm template guide: https://helm.sh/docs/chart_template_guide/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
+++ b/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
@@ -67,3 +67,61 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_AGENT_R
 ## References
 - Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-serviceaccount-name-resolution.md
+++ b/docs/agents/designs/chart-serviceaccount-name-resolution.md
@@ -72,3 +72,61 @@ kubectl -n agents get sa
 ## References
 - Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-termination-grace-prestop.md
+++ b/docs/agents/designs/chart-termination-grace-prestop.md
@@ -64,3 +64,61 @@ kubectl -n agents rollout restart deploy/agents-controllers
 ## References
 - Kubernetes container lifecycle hooks: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/cluster-cost-optimization.md
+++ b/docs/agents/designs/cluster-cost-optimization.md
@@ -78,7 +78,9 @@ High throughput can lead to wasted compute costs.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/control-plane-ui-filters.md
+++ b/docs/agents/designs/control-plane-ui-filters.md
@@ -78,7 +78,9 @@ Operators cannot easily filter high-volume runs.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/controller-auth-secret-mount-rotation.md
+++ b/docs/agents/designs/controller-auth-secret-mount-rotation.md
@@ -66,3 +66,61 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"AUTH_SECRET\"
 ## References
 - Kubernetes Secrets: https://kubernetes.io/docs/concepts/configuration/secret/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-concurrency-tuning.md
+++ b/docs/agents/designs/controller-concurrency-tuning.md
@@ -79,7 +79,9 @@ Default concurrency limits may not fit large clusters.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/controller-condition-type-taxonomy.md
+++ b/docs/agents/designs/controller-condition-type-taxonomy.md
@@ -68,3 +68,61 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[?(@.type=
 ## References
 - Kubernetes API conventions (Conditions): https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-controllers-deployment-grpc-off.md
+++ b/docs/agents/designs/controller-controllers-deployment-grpc-off.md
@@ -64,3 +64,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"gRPC|Agentctl\"
 ## References
 - gRPC basics: https://grpc.io/docs/what-is-grpc/introduction/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
+++ b/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
@@ -61,3 +61,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"migration|migrations\
 ## References
 - Kubernetes init containers and migration patterns: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-failed-reconcile-events.md
+++ b/docs/agents/designs/controller-failed-reconcile-events.md
@@ -63,3 +63,61 @@ kubectl -n agents describe agentrun <name> | rg -n \"Events:\"
 ## References
 - Kubernetes Events: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#event-v1-core
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-finalizer-conventions.md
+++ b/docs/agents/designs/controller-finalizer-conventions.md
@@ -63,3 +63,61 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.deletionTimestamp}
 ## References
 - Kubernetes finalizers: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-kubectl-version-compat.md
+++ b/docs/agents/designs/controller-kubectl-version-compat.md
@@ -58,3 +58,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"kubectl\"
 ## References
 - Kubernetes version skew policy: https://kubernetes.io/releases/version-skew-policy/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-namespace-scope-parse-validate.md
+++ b/docs/agents/designs/controller-namespace-scope-parse-validate.md
@@ -67,3 +67,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"namespaces\"
 ## References
 - Kubernetes namespace naming: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-orchestration-submit-dedup.md
+++ b/docs/agents/designs/controller-orchestration-submit-dedup.md
@@ -62,3 +62,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"deliveryId|idempotent
 
 ## References
 - HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-postgres-ca-rootcert.md
+++ b/docs/agents/designs/controller-postgres-ca-rootcert.md
@@ -62,3 +62,61 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"PGSSLROOTCERT|db-ca-cert\"
 ## References
 - Kubernetes Secrets volumes: https://kubernetes.io/docs/concepts/storage/volumes/#secret
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-reconcile-timeout-budget.md
+++ b/docs/agents/designs/controller-reconcile-timeout-budget.md
@@ -66,3 +66,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Timeout:\"
 ## References
 - Kubernetes API timeouts (client-side considerations): https://kubernetes.io/docs/reference/using-api/api-concepts/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-resourceversion-conflict-retry.md
+++ b/docs/agents/designs/controller-resourceversion-conflict-retry.md
@@ -64,3 +64,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Conflict|409\"
 ## References
 - Kubernetes optimistic concurrency control: https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-server-side-apply-ownership.md
+++ b/docs/agents/designs/controller-server-side-apply-ownership.md
@@ -63,3 +63,61 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.managedFields[*].m
 ## References
 - Kubernetes Server-Side Apply: https://kubernetes.io/docs/reference/using-api/server-side-apply/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-status-timestamps-generation.md
+++ b/docs/agents/designs/controller-status-timestamps-generation.md
@@ -68,3 +68,61 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.generation} {.stat
 ## References
 - Kubernetes generation and status patterns: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-webhook-signature-verification.md
+++ b/docs/agents/designs/controller-webhook-signature-verification.md
@@ -77,3 +77,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Invalid webhook signa
 - GitHub webhook signature docs: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
 - Linear webhook security docs: https://developers.linear.app/docs/graphql/webhooks
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-agent-config-schema.md
+++ b/docs/agents/designs/crd-agent-config-schema.md
@@ -77,3 +77,61 @@ kubectl -n agents get agent <name> -o yaml | rg -n \"configSchemaRef|InvalidConf
 ## References
 - Kubernetes CRD validation: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-agentrun-artifacts-limits.md
+++ b/docs/agents/designs/crd-agentrun-artifacts-limits.md
@@ -69,3 +69,61 @@ kubectl -n agents get agentrun <name> -o yaml | rg -n \"artifacts:\"
 ## References
 - Kubernetes object size limits (etcd considerations): https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-agentrun-idempotency.md
+++ b/docs/agents/designs/crd-agentrun-idempotency.md
@@ -61,3 +61,61 @@ kubectl -n agents get agentrun -o json | rg -n \"idempotencyKey\"
 
 ## References
 - HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-agentrun-spec-immutability.md
+++ b/docs/agents/designs/crd-agentrun-spec-immutability.md
@@ -70,3 +70,61 @@ kubectl -n agents get agentrun <name> -o yaml | rg -n \"SpecImmutableViolation|s
 ## References
 - Kubernetes immutability patterns (general objects): https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-implementationsource-webhook-cel.md
+++ b/docs/agents/designs/crd-implementationsource-webhook-cel.md
@@ -58,3 +58,61 @@ kubectl -n agents apply -f charts/agents/examples/implementationsource-github.ya
 ## References
 - Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-implementationspec-config-constraints.md
+++ b/docs/agents/designs/crd-implementationspec-config-constraints.md
@@ -60,3 +60,61 @@ kubectl -n agents get implementationspec -o yaml | rg -n \"spec:|x-kubernetes-va
 ## References
 - Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-lifecycle-upgrades.md
+++ b/docs/agents/designs/crd-lifecycle-upgrades.md
@@ -117,7 +117,9 @@ production-ready checklist.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/crd-memory-retention-compaction.md
+++ b/docs/agents/designs/crd-memory-retention-compaction.md
@@ -71,3 +71,61 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"compaction|retention\
 ## References
 - Kubernetes controllers (background reconciliation): https://kubernetes.io/docs/concepts/architecture/controller/
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-orchestration-dag.md
+++ b/docs/agents/designs/crd-orchestration-dag.md
@@ -68,3 +68,61 @@ kubectl -n agents get orchestrationrun -o yaml | rg -n \"phase:|Skipped|Dependen
 
 ## References
 - Argo Workflows DAG concepts (widely used Kubernetes DAG runtime): https://argo-workflows.readthedocs.io/en/latest/walk-through/dag/
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
+++ b/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
@@ -62,3 +62,61 @@ kubectl -n agents get orchestrationrun <name> -o yaml | rg -n \"Cancelled|phase\
 ## References
 - Kubernetes graceful termination concepts: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
+++ b/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
@@ -68,3 +68,61 @@ kubectl -n agents get configmap | rg known-hosts
 - OpenSSH `known_hosts` format: https://man.openbsd.org/sshd.8#SSH_KNOWN_HOSTS_FILE_FORMAT
 - Git over SSH: https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
 
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Controllers:
+  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml`, `argocd/applications/argo-workflows/*.yaml`
+
+### Current cluster state (from GitOps manifests)
+As of 2026-02-06 (repo `main`):
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Controllers enabled: `controllers.enabled: true` (separate `agents-controllers` deployment). See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: chart `grpc.enabled: true` and runtime `JANGAR_GRPC_ENABLED: "true"` in `.Values.env.vars`. See `argocd/applications/agents/values.yaml`.
+- Database configured via SecretRef: `database.secretRef.name: jangar-db-app` and `database.secretRef.key: uri` (rendered as `DATABASE_URL`). See `argocd/applications/agents/values.yaml` and `charts/agents/templates/deployment.yaml`.
+
+Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+
+```bash
+kubectl get application -n argocd agents
+kubectl get application -n argocd froussard
+kubectl get ns | rg '^(agents|agents-ci|jangar|froussard)\b'
+kubectl get deploy -n agents
+kubectl get crd | rg 'proompteng\.ai'
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (if you have access):
+  - `kubectl get pods -n agents`
+  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -168,7 +168,9 @@ argo submit \
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/data-migration-runbooks.md
+++ b/docs/agents/designs/data-migration-runbooks.md
@@ -78,7 +78,9 @@ Upgrades require clear migration instructions.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/disaster-recovery-backups.md
+++ b/docs/agents/designs/disaster-recovery-backups.md
@@ -78,7 +78,9 @@ State loss can halt autonomous operations.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/github-app-auth-rotation.md
+++ b/docs/agents/designs/github-app-auth-rotation.md
@@ -82,7 +82,9 @@ Support GitHub App installation tokens for VCS operations, including safe rotati
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -79,7 +79,9 @@ GitOps deployments need deterministic pre/post-sync behavior.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/grpc-coverage-parity.md
+++ b/docs/agents/designs/grpc-coverage-parity.md
@@ -78,7 +78,9 @@ gRPC endpoints lag behind REST and CLI features.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/implementation-contract-enforcement.md
+++ b/docs/agents/designs/implementation-contract-enforcement.md
@@ -79,7 +79,9 @@ Runs can fail if required metadata is missing.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/integration-test-harness.md
+++ b/docs/agents/designs/integration-test-harness.md
@@ -78,7 +78,9 @@ High-scale changes need reliable integration testing.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/job-gc-visibility.md
+++ b/docs/agents/designs/job-gc-visibility.md
@@ -78,7 +78,9 @@ Jobs may be deleted before status is collected, causing WorkflowJobMissing.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/leader-election-ha.md
+++ b/docs/agents/designs/leader-election-ha.md
@@ -115,7 +115,9 @@ Map values into env vars consumed by the controller runtime, for example:
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/load-testing-benchmarking.md
+++ b/docs/agents/designs/load-testing-benchmarking.md
@@ -77,7 +77,9 @@ No standardized benchmark for 100-person throughput.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/log-retention-shipper.md
+++ b/docs/agents/designs/log-retention-shipper.md
@@ -77,7 +77,9 @@ Job logs are ephemeral and hard to retrieve after completion.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/metrics-otel-tracing.md
+++ b/docs/agents/designs/metrics-otel-tracing.md
@@ -78,7 +78,9 @@ Without tracing, it is hard to debug end-to-end latency.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/multi-namespace-controller-guards.md
+++ b/docs/agents/designs/multi-namespace-controller-guards.md
@@ -78,7 +78,9 @@ Misconfigured namespaces can lead to missed resources or RBAC errors.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/multi-provider-auth-deprecations.md
@@ -85,7 +85,9 @@ Normalize auth configuration across VCS providers and surface deprecated token t
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/namespaced-install-matrix.md
+++ b/docs/agents/designs/namespaced-install-matrix.md
@@ -68,7 +68,9 @@ Define the supported install modes and their RBAC implications for the Agents co
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/network-policy-egress.md
+++ b/docs/agents/designs/network-policy-egress.md
@@ -78,7 +78,9 @@ Autonomous agents require explicit egress controls for security.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/observability-pack.md
+++ b/docs/agents/designs/observability-pack.md
@@ -79,7 +79,9 @@ Operators need metrics, logs, and dashboards to run at scale.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/pod-security-admission.md
+++ b/docs/agents/designs/pod-security-admission.md
@@ -69,7 +69,9 @@ podSecurityAdmission:
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/pr-rate-limits-batching.md
+++ b/docs/agents/designs/pr-rate-limits-batching.md
@@ -73,7 +73,9 @@ Respect VCS provider rate limits by throttling automated PR creation.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/queue-fairness-per-repo.md
+++ b/docs/agents/designs/queue-fairness-per-repo.md
@@ -83,7 +83,9 @@ High-volume repos can starve smaller repos of capacity.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/repo-allow-deny-policy.md
+++ b/docs/agents/designs/repo-allow-deny-policy.md
@@ -68,7 +68,9 @@ repositoryPolicy:
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/resourcequota-limitrange.md
+++ b/docs/agents/designs/resourcequota-limitrange.md
@@ -77,7 +77,9 @@ Clusters need quota enforcement for AgentRuns.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -75,7 +75,9 @@ cleanup.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/schedule-cronjob-reliability.md
+++ b/docs/agents/designs/schedule-cronjob-reliability.md
@@ -78,7 +78,9 @@ Schedule CRDs require reliable CronJob creation and cleanup.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/scheduler-affinity-priority.md
+++ b/docs/agents/designs/scheduler-affinity-priority.md
@@ -69,7 +69,9 @@ Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run 
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/secretbinding-guardrails.md
+++ b/docs/agents/designs/secretbinding-guardrails.md
@@ -78,7 +78,9 @@ Runs can mount secrets without clear governance.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/security-sbom-signing.md
+++ b/docs/agents/designs/security-sbom-signing.md
@@ -78,7 +78,9 @@ Supply chain integrity is required for production adoption.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/signal-delivery-retries.md
+++ b/docs/agents/designs/signal-delivery-retries.md
@@ -77,7 +77,9 @@ SignalDelivery failures can leave workflows stuck.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/staging-prod-values-overlays.md
+++ b/docs/agents/designs/staging-prod-values-overlays.md
@@ -78,7 +78,9 @@ Operators need consistent overlays for staging and prod.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/supply-chain-attestations.md
+++ b/docs/agents/designs/supply-chain-attestations.md
@@ -77,7 +77,9 @@ Regulated environments require provenance attestations.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/throughput-backpressure-quotas.md
+++ b/docs/agents/designs/throughput-backpressure-quotas.md
@@ -95,7 +95,9 @@ These should map to:
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/toolrun-runtime-isolation.md
+++ b/docs/agents/designs/toolrun-runtime-isolation.md
@@ -77,7 +77,9 @@ Tool runs need consistent isolation and resource limits.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/topology-spread-defaults.md
+++ b/docs/agents/designs/topology-spread-defaults.md
@@ -79,7 +79,9 @@ Workloads can stack on a single node without spread rules.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/values-schema-readme-automation.md
+++ b/docs/agents/designs/values-schema-readme-automation.md
@@ -82,7 +82,9 @@ Some constraints cannot be inferred from YAML alone. Encode them via inline comm
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/webhook-ingestion-scaling.md
+++ b/docs/agents/designs/webhook-ingestion-scaling.md
@@ -79,7 +79,9 @@ Webhook bursts can overload reconciliation.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/workflow-step-timeouts.md
+++ b/docs/agents/designs/workflow-step-timeouts.md
@@ -78,7 +78,9 @@ Long-running steps can block workflows without clear timeout handling.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/workspace-pvc-lifecycle.md
+++ b/docs/agents/designs/workspace-pvc-lifecycle.md
@@ -77,7 +77,9 @@ Workspaces can leak storage without cleanup policies.
 As of 2026-02-06 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`charts/agents/templates/deployment.yaml` via `.Values.controlPlane.image.*`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`charts/agents/templates/deployment-controllers.yaml` via `.Values.image.*` unless `.Values.controllers.image.*` is set): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 


### PR DESCRIPTION
## Summary
- Refreshes `docs/agents/designs/*.md` to match current GitOps desired state for the `agents` install (chart pin, images, key values).
- Adds a standardized handoff appendix (repo/code/chart pointers, rollout + validation commands) to every design doc.
- Fixes `chart-controller-namespaces-empty-semantics.md` to reflect the real chart + runtime namespace parsing semantics (comma-separated env var, release-namespace defaulting, wildcard guardrails).

## Related Issues
None

## Testing
- `python -c "from pathlib import Path; assert all('## Handoff Appendix (Repo + Chart + Cluster)' in p.read_text() for p in Path('docs/agents/designs').glob('*.md'))"`
- `rg -n "4327b1dc|b836d07d|9a6df7a4" docs/agents/designs` (ensures stale pinned-image strings removed)

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
