### PR TITLE
docs(agents): GitOps handoff for design docs

### DIFF
--- a/docs/agents/designs/admission-control-policy.md
+++ b/docs/agents/designs/admission-control-policy.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Reject unsafe or invalid AgentRuns before runtime submission by enforcing controller-level policies.
 

--- a/docs/agents/designs/agentctl-cli-resilience.md
+++ b/docs/agents/designs/agentctl-cli-resilience.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: agentctl lives in services/jangar/agentctl; no retry/backoff logic is implemented in the CLI.

--- a/docs/agents/designs/api-pagination-and-watch.md
+++ b/docs/agents/designs/api-pagination-and-watch.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: /v1/agent-runs GET queries the database via getAgentRunsByAgent without pagination parameters.

--- a/docs/agents/designs/approval-policy-gates.md
+++ b/docs/agents/designs/approval-policy-gates.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: validatePolicies checks ApprovalPolicy state in orchestration-submit and /v1/agent-runs; direct AgentRun CRs bypass it.

--- a/docs/agents/designs/artifact-storage-s3.md
+++ b/docs/agents/designs/artifact-storage-s3.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: codex-judge fetches artifacts from S3 using JANGAR_CODEX_ARTIFACT_BUCKET/ARTIFACT_BUCKET.

--- a/docs/agents/designs/artifacthub-oci-distribution.md
+++ b/docs/agents/designs/artifacthub-oci-distribution.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Define how the Agents Helm chart is packaged, published as an OCI artifact, and surfaced on Artifact Hub.
 

--- a/docs/agents/designs/audit-logging.md
+++ b/docs/agents/designs/audit-logging.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: audit_events table + createAuditEvent in primitives-store; used by orchestration-submit and /v1/agent-runs policy decisions.

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Provide deterministic branch naming for automated PRs and avoid conflicts when multiple runs target the same repo.
 

--- a/docs/agents/designs/budget-enforcement.md
+++ b/docs/agents/designs/budget-enforcement.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: validateBudget enforces Budget limits in orchestration-submit and /v1/agent-runs when budgetRef is supplied.

--- a/docs/agents/designs/chart-canary-argo-rollouts.md
+++ b/docs/agents/designs/chart-canary-argo-rollouts.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Today the Agents chart uses Kubernetes Deployments. For safer production changes (especially to controllers), operators may want progressive delivery. This doc proposes a chart-compatible integration path with Argo Rollouts without making it a hard dependency.
 

--- a/docs/agents/designs/chart-config-checksum-rollouts.md
+++ b/docs/agents/designs/chart-config-checksum-rollouts.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Kubernetes does not automatically restart pods when referenced Secrets/ConfigMaps change (especially when referenced via env vars). In GitOps environments, this frequently leads to “updated Secret, pods still using old value” incidents.
 

--- a/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
+++ b/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Controllers reconcile CRDs in a set of namespaces. The chart exposes `controller.namespaces`, but it is not documented what an empty list means (disabled? all namespaces? release namespace only?). Ambiguity here creates production risk.
 

--- a/docs/agents/designs/chart-controllers-hpa.md
+++ b/docs/agents/designs/chart-controllers-hpa.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart’s HPA template targets only the control plane Deployment (`agents`). Controllers are deployed as a separate Deployment (`agents-controllers`) but do not have autoscaling support. Controllers workload is often bursty (reconcile storms, webhook bursts), and lack of scaling can cause backlog and delayed reconciliation.
 

--- a/docs/agents/designs/chart-controllers-image-override-precedence.md
+++ b/docs/agents/designs/chart-controllers-image-override-precedence.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents chart can run controllers as a separate Deployment (`agents-controllers`) with its own image. Operators need a clear contract for how `controllers.image.*` relates to the root `image.*` and the control plane `controlPlane.image.*`.
 

--- a/docs/agents/designs/chart-controllers-pdb.md
+++ b/docs/agents/designs/chart-controllers-pdb.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart can deploy a separate controllers Deployment (`agents-controllers`), but the chart’s PodDisruptionBudget (PDB) template currently only targets the control plane pods. This creates an availability gap: controllers may all be evicted during node drains or cluster maintenance even when the control plane is protected.
 

--- a/docs/agents/designs/chart-controllers-service.md
+++ b/docs/agents/designs/chart-controllers-service.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The controllers Deployment is currently internal-only and has no Service. That is usually fine, but it complicates:
 - NetworkPolicy authoring (targeting stable endpoints)

--- a/docs/agents/designs/chart-controlplane-image-override-precedence.md
+++ b/docs/agents/designs/chart-controlplane-image-override-precedence.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents control plane runs as the `agents` Deployment. The chart supports an explicit `controlPlane.image.*` override separate from `image.*`. This doc defines a contract for selecting that image and recommended promotion paths.
 

--- a/docs/agents/designs/chart-database-url-secretref-precedence.md
+++ b/docs/agents/designs/chart-database-url-secretref-precedence.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents chart supports multiple ways to provide `DATABASE_URL` to both the control plane and controllers. The precedence is currently implicit in templates; misconfiguration can lead to pods starting without a database connection or using an unintended database.
 

--- a/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
+++ b/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart currently relies on Kubernetes default `RollingUpdate` behavior for Deployments. For production, we should explicitly control surge/unavailable and optionally support safer strategies (e.g. `Recreate` for DB-migration-sensitive components).
 

--- a/docs/agents/designs/chart-env-vars-merge-precedence.md
+++ b/docs/agents/designs/chart-env-vars-merge-precedence.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents Helm chart exposes multiple ways to set environment variables for the control plane and controllers. Today the precedence is implicit in templates, which makes it easy to unintentionally override critical defaults (e.g. migrations, gRPC enablement) or to believe a value is set when it is not.
 

--- a/docs/agents/designs/chart-envfrom-conflict-resolution.md
+++ b/docs/agents/designs/chart-envfrom-conflict-resolution.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents chart supports both explicit `env:` entries and bulk import via `envFrom` (Secrets/ConfigMaps). Kubernetes allows both, but precedence can be confusing: explicitly defined `env:` variables take precedence over values from `envFrom`.
 

--- a/docs/agents/designs/chart-extra-volumes-mounts-contract.md
+++ b/docs/agents/designs/chart-extra-volumes-mounts-contract.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart supports `.Values.extraVolumes` and `.Values.extraVolumeMounts`, which are injected into both the control plane and controllers pod specs. This is a powerful escape hatch but needs a documented contract to prevent accidental conflicts with chart-managed volumes (e.g. DB CA cert).
 

--- a/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
+++ b/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart has `grpc.enabled` (controls Service + container port) while runtime can also be toggled with `JANGAR_GRPC_ENABLED` (via `env.vars`). When these disagree, the deployment can become confusing: a Service may exist without the server listening, or the server may listen without a Service/port.
 

--- a/docs/agents/designs/chart-image-digest-tag-precedence.md
+++ b/docs/agents/designs/chart-image-digest-tag-precedence.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents chart supports image tags and optional digests for both the control plane and controllers. In production GitOps, digests are preferred for immutability. The chart currently concatenates `repo:tag@digest` when a digest is provided, but the operational contract (and failure modes) are not documented.
 

--- a/docs/agents/designs/chart-kubernetesapi-host-port-override.md
+++ b/docs/agents/designs/chart-kubernetesapi-host-port-override.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart exposes `kubernetesApi.host` and `kubernetesApi.port` which map to `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT`. This is a sharp tool: it can help run outside-cluster or in unusual networking environments, but can also break in-cluster discovery if misused.
 

--- a/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
+++ b/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart uses `namespaceOverride` to force all rendered resources into a namespace different from `.Release.Namespace`. This is useful in some GitOps setups but can be hazardous if only part of a release is overridden (e.g. CRDs are cluster-scoped, but Roles/RoleBindings are namespaced).
 

--- a/docs/agents/designs/chart-pod-annotations-merging.md
+++ b/docs/agents/designs/chart-pod-annotations-merging.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart applies `.Values.podAnnotations` and `.Values.podLabels` to both the control plane pod template and the controllers pod template. Operators often need different annotations per component (e.g., different scraping, sidecar settings, or rollout controls). Today that requires global annotations that may not be appropriate for both.
 

--- a/docs/agents/designs/chart-probes-configuration-contract.md
+++ b/docs/agents/designs/chart-probes-configuration-contract.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart exposes HTTP liveness/readiness probe settings for the control plane, but probes may not be appropriate for controllers (which may not expose HTTP) and there is no startup probe for long initialization (e.g., cache warmup).
 

--- a/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
+++ b/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents chart can run with cluster-scoped RBAC (`rbac.clusterScoped=true`) or namespaced RBAC (`false`). Misconfiguration can lead to controller errors (insufficient permissions) or excessive permissions (overbroad access).
 

--- a/docs/agents/designs/chart-resources-component-overrides.md
+++ b/docs/agents/designs/chart-resources-component-overrides.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents chart exposes `resources` as a global default and also supports component-specific overrides (`controlPlane.resources`, `controllers.resources`). These overrides are implemented in templates but not explicitly documented, which increases the chance of accidentally starving controllers or the control plane in production.
 

--- a/docs/agents/designs/chart-rollback-helm-behavior.md
+++ b/docs/agents/designs/chart-rollback-helm-behavior.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 In GitOps, “rollback” typically means reverting values/manifests and letting Argo CD sync. Operators still rely on Helm semantics when debugging template behavior or when performing emergency rollbacks in non-GitOps contexts.
 

--- a/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
+++ b/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Agents controllers schedule Kubernetes Jobs for agent runs. The chart includes a `runnerServiceAccount` block and multiple runtime defaults (`runtime.scheduleServiceAccount`, workload defaults, and controller env vars). The defaulting hierarchy must be explicit so operators can ensure jobs run with the intended permissions.
 

--- a/docs/agents/designs/chart-serviceaccount-name-resolution.md
+++ b/docs/agents/designs/chart-serviceaccount-name-resolution.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The Agents chart supports `serviceAccount.create` and `serviceAccount.name`, plus a separate `runnerServiceAccount` for jobs created by controllers. The naming and resolution rules must be explicit so operators can safely integrate with external IAM (IRSA, Workload Identity) and cluster policy.
 

--- a/docs/agents/designs/chart-termination-grace-prestop.md
+++ b/docs/agents/designs/chart-termination-grace-prestop.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The control plane and controllers handle active requests and ongoing reconciliations. During rollout or node drain, pods should stop accepting new work and drain in-flight tasks before termination. The chart currently does not expose termination grace or preStop hooks.
 

--- a/docs/agents/designs/cluster-cost-optimization.md
+++ b/docs/agents/designs/cluster-cost-optimization.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: no explicit cost-optimization logic beyond concurrency limits and resource requests.

--- a/docs/agents/designs/control-plane-ui-filters.md
+++ b/docs/agents/designs/control-plane-ui-filters.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: /api/agents/control-plane/stream supports namespace selection only; no server-side label/phase filters.

--- a/docs/agents/designs/controller-auth-secret-mount-rotation.md
+++ b/docs/agents/designs/controller-auth-secret-mount-rotation.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The controllers deployment supports an “auth secret” for agentctl gRPC authentication via `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_*`. The chart can mount the Secret and set env vars, but the operational contract for rotation is not documented.
 

--- a/docs/agents/designs/controller-concurrency-tuning.md
+++ b/docs/agents/designs/controller-concurrency-tuning.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: agents-controller enforces per-agent/per-namespace/cluster concurrency; `/v1/agent-runs` admission checks

--- a/docs/agents/designs/controller-condition-type-taxonomy.md
+++ b/docs/agents/designs/controller-condition-type-taxonomy.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Agents CRDs expose Kubernetes-style conditions (e.g. `Ready`, `Succeeded`, `Blocked`). Without a consistent taxonomy, automation and operator expectations diverge between resources.
 

--- a/docs/agents/designs/controller-controllers-deployment-grpc-off.md
+++ b/docs/agents/designs/controller-controllers-deployment-grpc-off.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart renders a separate controllers deployment that forces `JANGAR_GRPC_ENABLED=0` unless explicitly overridden. This is a good safety default (controllers do not need to expose gRPC externally), but it is undocumented and can be surprising when operators expect agentctl gRPC to be available everywhere.
 

--- a/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
+++ b/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Database migrations are potentially disruptive and should not be run by the controllers deployment. The chart enforces this by defaulting `JANGAR_MIGRATIONS=skip` in the controllers Deployment unless explicitly overridden. This behavior should be documented and protected by validation.
 

--- a/docs/agents/designs/controller-failed-reconcile-events.md
+++ b/docs/agents/designs/controller-failed-reconcile-events.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 When reconciles fail, the current primary signal is logs (and possibly status conditions). Kubernetes Events are a useful operational tool (visible via `kubectl describe`) and can improve MTTR, especially for failures like missing secrets, RBAC, or invalid spec fields.
 

--- a/docs/agents/designs/controller-finalizer-conventions.md
+++ b/docs/agents/designs/controller-finalizer-conventions.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Finalizers ensure controllers can perform cleanup before an object is fully deleted (e.g., deleting external runtimes). Inconsistent finalizer naming and behavior can cause stuck deletions or skipped cleanup.
 

--- a/docs/agents/designs/controller-kubectl-version-compat.md
+++ b/docs/agents/designs/controller-kubectl-version-compat.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Controllers interact with the Kubernetes API by spawning the `kubectl` binary (`primitives-kube.ts` and `kube-watch.ts`). This implicitly makes controller correctness dependent on the `kubectl` version baked into the image. We should document and enforce a compatibility policy.
 

--- a/docs/agents/designs/controller-namespace-scope-parse-validate.md
+++ b/docs/agents/designs/controller-namespace-scope-parse-validate.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Namespace scoping is a primary safety control for Agents controllers. The controllers accept a namespaces list via env vars (`JANGAR_AGENTS_CONTROLLER_NAMESPACES`, `JANGAR_PRIMITIVES_NAMESPACES`). Invalid JSON or ambiguous inputs can lead to unexpected reconciliation scope.
 

--- a/docs/agents/designs/controller-orchestration-submit-dedup.md
+++ b/docs/agents/designs/controller-orchestration-submit-dedup.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Orchestration run submission is triggered by external events (e.g., webhooks). Duplicate deliveries are common. The current system deduplicates submissions by `deliveryId` using the primitives store.
 

--- a/docs/agents/designs/controller-postgres-ca-rootcert.md
+++ b/docs/agents/designs/controller-postgres-ca-rootcert.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The chart supports mounting a Postgres CA bundle via `database.caSecret` and sets `PGSSLROOTCERT` to the mounted path. This is essential for production TLS, but it needs a documented contract (secret key naming, mount paths, rotation).
 

--- a/docs/agents/designs/controller-reconcile-timeout-budget.md
+++ b/docs/agents/designs/controller-reconcile-timeout-budget.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Agents controllers perform multiple external operations during reconciliation (Kubernetes API calls via `kubectl`, VCS calls, webhook parsing, database operations). Today, timeouts are mostly implicit (subprocess defaults, library defaults), which makes tail-latency and hung reconciles hard to diagnose.
 

--- a/docs/agents/designs/controller-resourceversion-conflict-retry.md
+++ b/docs/agents/designs/controller-resourceversion-conflict-retry.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Controllers patch and apply resources that may also be updated by other actors (users, GitOps, other controllers). Conflicts (HTTP 409) and optimistic concurrency failures should be handled predictably: retry when safe, fail fast when not.
 

--- a/docs/agents/designs/controller-server-side-apply-ownership.md
+++ b/docs/agents/designs/controller-server-side-apply-ownership.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Controllers currently use `kubectl apply` (client-side) for many operations, and `kubectl apply --server-side --subresource=status` for status updates. Server-side apply (SSA) provides clear field ownership and reduces merge conflicts when multiple actors mutate the same objects.
 

--- a/docs/agents/designs/controller-status-timestamps-generation.md
+++ b/docs/agents/designs/controller-status-timestamps-generation.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Many Agents CRDs include `status.updatedAt` and `status.observedGeneration`. Consistent semantics across controllers are essential for debugging, automation, and eventual UI/CLI behavior.
 

--- a/docs/agents/designs/controller-webhook-signature-verification.md
+++ b/docs/agents/designs/controller-webhook-signature-verification.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 ImplementationSource webhooks are an ingress boundary. Signature verification is implemented for GitHub (`x-hub-signature(-256)`) and Linear (`linear-signature`). This doc defines the operational contract: how secrets are stored, rotated, and validated, and how failure is surfaced safely.
 

--- a/docs/agents/designs/crd-agent-config-schema.md
+++ b/docs/agents/designs/crd-agent-config-schema.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 `Agent.spec.config` is currently an untyped map with `x-kubernetes-preserve-unknown-fields`. This gives flexibility but provides weak validation and poor UX: invalid keys/values are only discovered at runtime.
 

--- a/docs/agents/designs/crd-agentrun-artifacts-limits.md
+++ b/docs/agents/designs/crd-agentrun-artifacts-limits.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 AgentRun status can accumulate artifacts, logs, and metadata. Without limits and schema conventions, status can grow large, exceed Kubernetes object size limits, and create performance issues for controllers and clients.
 

--- a/docs/agents/designs/crd-agentrun-idempotency.md
+++ b/docs/agents/designs/crd-agentrun-idempotency.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 AgentRun includes `spec.idempotencyKey`. This field is intended to avoid duplicate runs when clients retry requests. Without a contract (scope, retention, collision handling), the field is under-specified.
 

--- a/docs/agents/designs/crd-agentrun-spec-immutability.md
+++ b/docs/agents/designs/crd-agentrun-spec-immutability.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 AgentRuns represent a concrete execution request. After a run is accepted and started, mutating most of `spec` should be prohibited to preserve auditability and avoid undefined behavior (e.g., swapping implementation mid-run).
 

--- a/docs/agents/designs/crd-implementationsource-webhook-cel.md
+++ b/docs/agents/designs/crd-implementationsource-webhook-cel.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 ImplementationSource supports webhook-driven ingestion. Certain fields must be present together (e.g., `webhook.enabled` implies a `secretRef`). Today, some of these invariants are enforced in code, but encoding them in CRD CEL rules provides immediate feedback at apply time.
 

--- a/docs/agents/designs/crd-implementationspec-config-constraints.md
+++ b/docs/agents/designs/crd-implementationspec-config-constraints.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 ImplementationSpec contains runtime configuration that is later executed by controllers/runners. Without constraints, it is easy to create specs that are invalid or unsafe (e.g., missing required fields, invalid enum values, or overly large embedded configs).
 

--- a/docs/agents/designs/crd-lifecycle-upgrades.md
+++ b/docs/agents/designs/crd-lifecycle-upgrades.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Define the lifecycle and upgrade flow for Agents CRDs, including generation, validation, packaging, rollout,
 compatibility rules, and CI enforcement. This design codifies the existing build and release workflow into a

--- a/docs/agents/designs/crd-memory-retention-compaction.md
+++ b/docs/agents/designs/crd-memory-retention-compaction.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 The `Memory` CRD represents stored context/embeddings. Without retention controls and compaction, memory stores can grow without bound, increasing storage cost and slowing queries. This doc defines retention and compaction semantics managed by controllers.
 

--- a/docs/agents/designs/crd-orchestration-dag.md
+++ b/docs/agents/designs/crd-orchestration-dag.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Orchestrations represent multi-step workflows. The current schema supports `spec.steps`, but the semantics around ordering, dependency graphs, and partial failure are not explicitly documented. This doc defines a DAG model that controllers can implement consistently.
 

--- a/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
+++ b/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 Operators need reliable cancellation semantics for OrchestrationRuns. Cancelling should propagate to all active underlying runtimes (Jobs/Workflows/etc) and update status/conditions in a predictable way.
 

--- a/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
+++ b/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Overview
 VersionControlProvider supports SSH configuration (host, user, private key secret, known_hosts ConfigMap ref). This is operationally sensitive: incorrect known_hosts handling can lead to MITM risk, and missing known_hosts can break cloning.
 

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -2,7 +2,45 @@
 
 Status: Implemented (2026-02-06)
 
-Note: Clusters will accept/run the new fields once the updated `charts/agents` CRDs and the relevant controller/runtime deployments (plus Argo templates, if used) are rolled out.
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
 
 ## Summary
 Agent runs now support per-run system prompts with Agent-level defaults. Prompts can be provided inline or by reference (Secret/ConfigMap). Codex runs apply the resolved prompt and record a SHA-256 hash for audit without logging prompt contents.

--- a/docs/agents/designs/data-migration-runbooks.md
+++ b/docs/agents/designs/data-migration-runbooks.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: migrations live under services/jangar/src/server/migrations; no dedicated runbooks in docs/agents.

--- a/docs/agents/designs/disaster-recovery-backups.md
+++ b/docs/agents/designs/disaster-recovery-backups.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: no backup/restore automation in Jangar services.

--- a/docs/agents/designs/github-app-auth-rotation.md
+++ b/docs/agents/designs/github-app-auth-rotation.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Support GitHub App installation tokens for VCS operations, including safe rotation and caching.
 

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Chart: argocdHooks templates support PreSync cleanup and PostSync smoke AgentRun.

--- a/docs/agents/designs/grpc-coverage-parity.md
+++ b/docs/agents/designs/grpc-coverage-parity.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: gRPC server in services/jangar/src/server/agentctl-grpc.ts exposes a subset of kube-mode operations; watch streams are missing.

--- a/docs/agents/designs/implementation-contract-enforcement.md
+++ b/docs/agents/designs/implementation-contract-enforcement.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: validateImplementationContract enforces required metadata keys on AgentRuns and workflow steps.

--- a/docs/agents/designs/integration-test-harness.md
+++ b/docs/agents/designs/integration-test-harness.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Scripts: scripts/agents/kind-e2e.sh, scripts/agents/native-workflow-e2e.sh, scripts/agents/validate-agents.sh.

--- a/docs/agents/designs/job-gc-visibility.md
+++ b/docs/agents/designs/job-gc-visibility.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: AgentRun retention via ttlSecondsAfterFinished or JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS; Job TTL via JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS; ToolRun TTL supported.

--- a/docs/agents/designs/leader-election-ha.md
+++ b/docs/agents/designs/leader-election-ha.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Define how Jangar controllers use Kubernetes leader election to support safe horizontal scaling, prevent double
 reconciliation, and provide predictable failover behavior.

--- a/docs/agents/designs/load-testing-benchmarking.md
+++ b/docs/agents/designs/load-testing-benchmarking.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: no load-testing harness in repo.

--- a/docs/agents/designs/log-retention-shipper.md
+++ b/docs/agents/designs/log-retention-shipper.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: no log shipping or retention management in Jangar services.

--- a/docs/agents/designs/metrics-otel-tracing.md
+++ b/docs/agents/designs/metrics-otel-tracing.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: OTEL metrics export is implemented in services/jangar/src/server/metrics.ts (OTLP HTTP exporter).

--- a/docs/agents/designs/multi-namespace-controller-guards.md
+++ b/docs/agents/designs/multi-namespace-controller-guards.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: namespace-scope.assertClusterScopedForWildcard enforces rbac.clusterScoped for '*' in agents-controller and webhook ingestion.

--- a/docs/agents/designs/multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/multi-provider-auth-deprecations.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Normalize auth configuration across VCS providers and surface deprecated token types before they break.
 

--- a/docs/agents/designs/namespaced-install-matrix.md
+++ b/docs/agents/designs/namespaced-install-matrix.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Define the supported install modes and their RBAC implications for the Agents control plane.
 

--- a/docs/agents/designs/network-policy-egress.md
+++ b/docs/agents/designs/network-policy-egress.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Chart: networkPolicy template supports ingress/egress lists; disabled by default.

--- a/docs/agents/designs/observability-pack.md
+++ b/docs/agents/designs/observability-pack.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: OTEL metrics export exists; SSE metrics and queue depth histograms are recorded.

--- a/docs/agents/designs/pod-security-admission.md
+++ b/docs/agents/designs/pod-security-admission.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Allow optional Pod Security Admission (PSA) labels to be applied to the agents namespace during installation.
 

--- a/docs/agents/designs/pr-rate-limits-batching.md
+++ b/docs/agents/designs/pr-rate-limits-batching.md
@@ -2,6 +2,46 @@
 
 Status: Partial (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Respect VCS provider rate limits by throttling automated PR creation.
 

--- a/docs/agents/designs/queue-fairness-per-repo.md
+++ b/docs/agents/designs/queue-fairness-per-repo.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: `/v1/agent-runs` admission enforces queue caps per namespace/cluster/repo and returns 429 when exceeded. It

--- a/docs/agents/designs/repo-allow-deny-policy.md
+++ b/docs/agents/designs/repo-allow-deny-policy.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Constrain repository access for VCS operations using allow and deny lists on VersionControlProvider resources.
 

--- a/docs/agents/designs/resourcequota-limitrange.md
+++ b/docs/agents/designs/resourcequota-limitrange.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Chart: resourceQuota and limitRange templates exist and are disabled by default.

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -2,6 +2,46 @@
 
 Status: Partial (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Provide reliable default runner images and safe Job TTLs so AgentRuns do not fail due to missing images or premature
 cleanup.

--- a/docs/agents/designs/schedule-cronjob-reliability.md
+++ b/docs/agents/designs/schedule-cronjob-reliability.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: supporting controller materializes Schedule CRs as CronJobs and watches CronJob status.

--- a/docs/agents/designs/scheduler-affinity-priority.md
+++ b/docs/agents/designs/scheduler-affinity-priority.md
@@ -2,6 +2,46 @@
 
 Status: Current (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run overrides.
 

--- a/docs/agents/designs/secretbinding-guardrails.md
+++ b/docs/agents/designs/secretbinding-guardrails.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: supporting controller validates SecretBindings; agents-controller and /v1/agent-runs enforce allowlists.

--- a/docs/agents/designs/security-sbom-signing.md
+++ b/docs/agents/designs/security-sbom-signing.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: no SBOM generation or signing pipeline in repo workflows.

--- a/docs/agents/designs/signal-delivery-retries.md
+++ b/docs/agents/designs/signal-delivery-retries.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: SignalDelivery reconciliation marks Delivered immediately; no retry/backoff logic.

--- a/docs/agents/designs/staging-prod-values-overlays.md
+++ b/docs/agents/designs/staging-prod-values-overlays.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Chart: values-dev.yaml, values-prod.yaml, values-ci.yaml, values-local.yaml, values-kind.yaml exist.

--- a/docs/agents/designs/supply-chain-attestations.md
+++ b/docs/agents/designs/supply-chain-attestations.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: no attestations or provenance generation in workflows.

--- a/docs/agents/designs/throughput-backpressure-quotas.md
+++ b/docs/agents/designs/throughput-backpressure-quotas.md
@@ -2,6 +2,46 @@
 
 Status: Partial (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Prevent high-volume AgentRuns from overwhelming the controller or the cluster by enforcing concurrency, queue, and
 rate limits.

--- a/docs/agents/designs/toolrun-runtime-isolation.md
+++ b/docs/agents/designs/toolrun-runtime-isolation.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: orchestration-controller submits ToolRun Jobs using tool.spec.image/command; isolation is limited to Kubernetes primitives.

--- a/docs/agents/designs/topology-spread-defaults.md
+++ b/docs/agents/designs/topology-spread-defaults.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: agents-controller applies topologySpreadConstraints from runtime config or JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS.

--- a/docs/agents/designs/values-schema-readme-automation.md
+++ b/docs/agents/designs/values-schema-readme-automation.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Purpose
 Keep `charts/agents/README.md` and `charts/agents/values.schema.json` in lock-step with
 `charts/agents/values.yaml` by introducing deterministic generation and CI drift checks.

--- a/docs/agents/designs/webhook-ingestion-scaling.md
+++ b/docs/agents/designs/webhook-ingestion-scaling.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: implementation-source-webhooks handles GitHub/Linear webhooks, validates secrets, and writes ImplementationSpecs; no queueing layer.

--- a/docs/agents/designs/workflow-step-timeouts.md
+++ b/docs/agents/designs/workflow-step-timeouts.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: orchestration-controller supports retries/backoff per step but no explicit timeout fields.

--- a/docs/agents/designs/workspace-pvc-lifecycle.md
+++ b/docs/agents/designs/workspace-pvc-lifecycle.md
@@ -2,6 +2,46 @@
 
 Status: Draft (2026-02-06)
 
+## Production / GitOps (source of truth)
+These design notes are kept consistent with the live *production desired state* (GitOps) and the in-repo `charts/agents` chart.
+
+### Current production deployment (desired state)
+- Namespace: `agents`
+- Argo CD app: `argocd/applications/agents/application.yaml`
+- Helm via kustomize: `argocd/applications/agents/kustomization.yaml` (chart `charts/agents`, chart version `0.9.1`, release `agents`)
+- Values overlay: `argocd/applications/agents/values.yaml` (pins images + digests, DB SecretRef, gRPC, and `envFromSecretRefs`)
+- Additional in-cluster resources (GitOps-managed): `argocd/applications/agents/*.yaml` (Agent/Provider, SecretBinding, VersionControlProvider, samples)
+
+### Chart + code (implementation)
+- Chart entrypoint: `charts/agents/Chart.yaml`
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- Templates: `charts/agents/templates/`
+- CRDs installed by the chart: `charts/agents/crds/`
+- Example CRs: `charts/agents/examples/`
+- Control plane + controllers code: `services/jangar/src/server/`
+
+### Values ↔ env mapping (common)
+- `.Values.env.vars` → base Pod `env:` for control plane + controllers (merged; component-local values win).
+- `.Values.controlPlane.env.vars` → control plane-only overrides.
+- `.Values.controllers.env.vars` → controllers-only overrides.
+- `.Values.envFromSecretRefs[]` → Pod `envFrom.secretRef` (Secret keys become env vars at runtime).
+
+### Rollout + validation (production)
+- Rollout path: edit `argocd/applications/agents/` (and/or `charts/agents/`), commit, and let Argo CD sync.
+- Render exactly like Argo CD (Helm v3 + kustomize):
+  ```bash
+  helm lint charts/agents
+  mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml
+  ```
+- Validate in-cluster (requires RBAC allowing reads in `agents`):
+  ```bash
+  kubectl -n agents get deploy,svc,pdb,cm
+  kubectl -n agents describe deploy agents
+  kubectl -n agents describe deploy agents-controllers || true
+  kubectl -n agents logs deploy/agents --tail=200
+  kubectl -n agents logs deploy/agents-controllers --tail=200 || true
+  ```
+
 ## Current State
 
 - Code: supporting controller creates PVCs for Workspace CRs and enforces TTL expiry.


### PR DESCRIPTION
## Summary
- Add a consistent “Production / GitOps (source of truth)” section to all `docs/agents/designs/*.md`.
- Document the repo + GitOps paths that define the deployed Agents control plane (`charts/agents` + `argocd/applications/agents`).
- Provide a standardized values↔env mapping plus rollout/validation commands for future AgentRuns.

## Related Issues
None

## Testing
- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 kustomize@5 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents.rendered.yaml`

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and follow-ups are updated.
