### PR TITLE
docs(agents): refresh design docs handoff

### DIFF
--- a/docs/agents/designs/admission-control-policy.md
+++ b/docs/agents/designs/admission-control-policy.md
@@ -1,6 +1,6 @@
 # Admission Control Policy for AgentRuns
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Reject unsafe or invalid AgentRuns before runtime submission by enforcing controller-level policies.
@@ -16,7 +16,7 @@ Reject unsafe or invalid AgentRuns before runtime submission by enforcing contro
   - Auth secrets configured via `controller.authSecret` must be allowlisted by the Agent.
 - Enforcement lives in `services/jangar/src/server/agents-controller.ts` and sets `InvalidSpec` conditions when
   policy checks fail.
-- Cluster: the `agents` ArgoCD values do not set admission policy env vars, so the controller currently runs with
+- GitOps desired state: the `agents` ArgoCD values do not set admission policy env vars, so the controller currently runs with
   permissive defaults.
 
 ## Design
@@ -56,8 +56,7 @@ Reject unsafe or invalid AgentRuns before runtime submission by enforcing contro
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -82,10 +81,10 @@ Reject unsafe or invalid AgentRuns before runtime submission by enforcing contro
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/agentctl-cli-resilience.md
+++ b/docs/agents/designs/agentctl-cli-resilience.md
@@ -1,12 +1,12 @@
 # agentctl CLI Resilience
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: agentctl lives in services/jangar/agentctl; no retry/backoff logic is implemented in the CLI.
 - Transport: gRPC server in services/jangar/src/server/agentctl-grpc.ts is enabled in the agents deployment.
-- Cluster: gRPC service agents-grpc exists; kube mode remains the most complete interface.
+- GitOps desired state: gRPC service agents-grpc exists; kube mode remains the most complete interface.
 
 
 ## Problem
@@ -39,8 +39,7 @@ CLI failures reduce operator trust and automation reliability.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ CLI failures reduce operator trust and automation reliability.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/api-pagination-and-watch.md
+++ b/docs/agents/designs/api-pagination-and-watch.md
@@ -1,12 +1,12 @@
 # API Pagination and Watch Behavior
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: /v1/agent-runs GET queries the database via getAgentRunsByAgent without pagination parameters.
 - Code: control-plane SSE stream accepts a namespace param only and streams all primitive kinds.
-- Cluster: no API pagination config or limits beyond internal defaults (limit 50 in store).
+- GitOps desired state: no API pagination config or limits beyond internal defaults (limit 50 in store).
 
 
 ## Problem
@@ -39,8 +39,7 @@ Large lists can overload the API and clients.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Large lists can overload the API and clients.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/approval-policy-gates.md
+++ b/docs/agents/designs/approval-policy-gates.md
@@ -1,12 +1,12 @@
 # Approval Policy Gates
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: validatePolicies checks ApprovalPolicy state in orchestration-submit and /v1/agent-runs; direct AgentRun CRs bypass it.
 - CRD: approvalpolicies.approvals.proompteng.ai is installed via the chart.
-- Cluster: sample-approval-policy exists but is only enforced when referenced.
+- GitOps desired state: sample-approval-policy exists but is only enforced when referenced.
 
 
 ## Problem
@@ -39,8 +39,7 @@ High-risk runs should require approval before execution.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ High-risk runs should require approval before execution.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/artifact-storage-s3.md
+++ b/docs/agents/designs/artifact-storage-s3.md
@@ -1,12 +1,12 @@
 # Artifact Storage Integration
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: codex-judge fetches artifacts from S3 using JANGAR_CODEX_ARTIFACT_BUCKET/ARTIFACT_BUCKET.
 - Artifact CRD reconciliation only sets a status URI and does not provision storage backends.
-- Cluster: agents deployment does not set artifact bucket envs.
+- GitOps desired state: agents deployment does not set artifact bucket envs.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Artifacts need durable storage at scale.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Artifacts need durable storage at scale.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/artifacthub-oci-distribution.md
+++ b/docs/agents/designs/artifacthub-oci-distribution.md
@@ -1,6 +1,6 @@
 # Artifact Hub OCI Distribution
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Define how the Agents Helm chart is packaged, published as an OCI artifact, and surfaced on Artifact Hub.
@@ -14,7 +14,7 @@ Define how the Agents Helm chart is packaged, published as an OCI artifact, and 
   packages the chart, and pushes it to `oci://ghcr.io/proompteng/charts`.
 - Manual publishing: `packages/scripts/src/agents/publish-chart.ts` packages and pushes the chart, verifying that
   `artifacthub-pkg.yml` and `Chart.yaml` versions match.
-- Cluster: not applicable; this is a packaging and distribution workflow.
+- GitOps desired state: not applicable; this is a packaging and distribution workflow.
 
 ## Distribution Model
 
@@ -55,8 +55,7 @@ Define how the Agents Helm chart is packaged, published as an OCI artifact, and 
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -81,10 +80,10 @@ Define how the Agents Helm chart is packaged, published as an OCI artifact, and 
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/audit-logging.md
+++ b/docs/agents/designs/audit-logging.md
@@ -1,12 +1,12 @@
 # Audit Logging for Autonomous Actions
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: audit_events table + createAuditEvent in primitives-store; used by orchestration-submit and /v1/agent-runs policy decisions.
 - Chart: no audit sink configuration beyond the primary Jangar database.
-- Cluster: no dedicated audit pipeline configured.
+- GitOps desired state: no dedicated audit pipeline configured.
 
 
 ## Problem
@@ -39,8 +39,7 @@ High scale PR automation needs traceable audit logs.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ High scale PR automation needs traceable audit logs.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -1,6 +1,6 @@
 # Branch Naming and Conflict Strategy
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Provide deterministic branch naming for automated PRs and avoid conflicts when multiple runs target the same repo.
@@ -11,7 +11,7 @@ Provide deterministic branch naming for automated PRs and avoid conflicts when m
 - Template rendering uses `{{ path.to.value }}` with a simple dot-path resolver in
   `services/jangar/src/server/agents-controller.ts`.
 - Branch conflicts are detected against active AgentRuns in the same namespace with matching repository and branch.
-- Cluster: no `VersionControlProvider` resources are currently present, so defaults are not applied.
+- GitOps desired state includes `VersionControlProvider/github` (token auth) in `argocd/applications/agents/codex-versioncontrolprovider.yaml`, so defaults are applied to Codex runs unless overridden per-AgentRun.
 
 ## Template Context
 The following context is available to templates:
@@ -44,8 +44,7 @@ defaults:
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -70,10 +69,10 @@ defaults:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/budget-enforcement.md
+++ b/docs/agents/designs/budget-enforcement.md
@@ -1,12 +1,12 @@
 # Budget Enforcement
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: validateBudget enforces Budget limits in orchestration-submit and /v1/agent-runs when budgetRef is supplied.
 - Budgets are reconciled by supporting-primitives-controller (status + Ready conditions).
-- Cluster: sample-budget exists; enforcement only applies when referenced.
+- GitOps desired state: sample-budget exists; enforcement only applies when referenced.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Runs can exceed token or cost budgets without enforcement.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Runs can exceed token or cost budgets without enforcement.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/chart-canary-argo-rollouts.md
+++ b/docs/agents/designs/chart-canary-argo-rollouts.md
@@ -1,6 +1,6 @@
 # Chart Canary with Argo Rollouts (Optional Integration)
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Today the Agents chart uses Kubernetes Deployments. For safer production changes (especially to controllers), operators may want progressive delivery. This doc proposes a chart-compatible integration path with Argo Rollouts without making it a hard dependency.
@@ -67,4 +67,13 @@ kubectl -n agents get rollout
 
 ## References
 - Argo Rollouts documentation: https://argo-rollouts.readthedocs.io/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-config-checksum-rollouts.md
+++ b/docs/agents/designs/chart-config-checksum-rollouts.md
@@ -1,6 +1,6 @@
 # Chart Config Checksum Rollouts
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Kubernetes does not automatically restart pods when referenced Secrets/ConfigMaps change (especially when referenced via env vars). In GitOps environments, this frequently leads to “updated Secret, pods still using old value” incidents.
@@ -65,4 +65,13 @@ kubectl -n agents get deploy agents -o jsonpath='{.spec.template.metadata.annota
 
 ## References
 - Kubernetes ConfigMaps/Secrets update behavior: https://kubernetes.io/docs/concepts/configuration/configmap/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
+++ b/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
@@ -1,6 +1,6 @@
 # Chart Controller Namespaces: Empty Semantics
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Controllers reconcile CRDs in a set of namespaces. The chart exposes `controller.namespaces`, but it is not documented what an empty list means (disabled? all namespaces? release namespace only?). Ambiguity here creates production risk.
@@ -63,4 +63,13 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"NAMESPACES|namespace\
 
 ## References
 - Kubernetes controller patterns (namespace scoping best practices): https://kubernetes.io/docs/concepts/architecture/controller/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-controllers-hpa.md
+++ b/docs/agents/designs/chart-controllers-hpa.md
@@ -1,6 +1,6 @@
 # Chart Controllers HorizontalPodAutoscaler
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart’s HPA template targets only the control plane Deployment (`agents`). Controllers are deployed as a separate Deployment (`agents-controllers`) but do not have autoscaling support. Controllers workload is often bursty (reconcile storms, webhook bursts), and lack of scaling can cause backlog and delayed reconciliation.
@@ -57,3 +57,13 @@ kubectl -n agents get hpa
 
 ## References
 - Kubernetes HPA v2: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
+

--- a/docs/agents/designs/chart-controllers-image-override-precedence.md
+++ b/docs/agents/designs/chart-controllers-image-override-precedence.md
@@ -1,6 +1,6 @@
 # Chart Controllers Image Override Precedence
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents chart can run controllers as a separate Deployment (`agents-controllers`) with its own image. Operators need a clear contract for how `controllers.image.*` relates to the root `image.*` and the control plane `controlPlane.image.*`.
@@ -60,4 +60,13 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spe
 
 ## References
 - Kubernetes container images: https://kubernetes.io/docs/concepts/containers/images/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-controllers-pdb.md
+++ b/docs/agents/designs/chart-controllers-pdb.md
@@ -1,6 +1,6 @@
 # Chart Controllers PodDisruptionBudget
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart can deploy a separate controllers Deployment (`agents-controllers`), but the chart’s PodDisruptionBudget (PDB) template currently only targets the control plane pods. This creates an availability gap: controllers may all be evicted during node drains or cluster maintenance even when the control plane is protected.
@@ -59,4 +59,13 @@ kubectl -n agents get pdb
 
 ## References
 - Kubernetes PodDisruptionBudget: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-controllers-service.md
+++ b/docs/agents/designs/chart-controllers-service.md
@@ -1,6 +1,6 @@
 # Chart Controllers Service (Optional)
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The controllers Deployment is currently internal-only and has no Service. That is usually fine, but it complicates:
@@ -66,4 +66,13 @@ kubectl -n agents get endpoints agents-controllers
 
 ## References
 - Kubernetes Service type ClusterIP: https://kubernetes.io/docs/concepts/services-networking/service/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-controlplane-image-override-precedence.md
+++ b/docs/agents/designs/chart-controlplane-image-override-precedence.md
@@ -1,6 +1,6 @@
 # Chart Control Plane Image Override Precedence
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents control plane runs as the `agents` Deployment. The chart supports an explicit `controlPlane.image.*` override separate from `image.*`. This doc defines a contract for selecting that image and recommended promotion paths.
@@ -58,4 +58,13 @@ kubectl -n agents rollout status deploy/agents
 
 ## References
 - Helm best practices for values: https://helm.sh/docs/chart_best_practices/values/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-database-url-secretref-precedence.md
+++ b/docs/agents/designs/chart-database-url-secretref-precedence.md
@@ -1,6 +1,6 @@
 # Chart Database URL vs SecretRef Precedence
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents chart supports multiple ways to provide `DATABASE_URL` to both the control plane and controllers. The precedence is currently implicit in templates; misconfiguration can lead to pods starting without a database connection or using an unintended database.
@@ -74,4 +74,13 @@ kubectl -n agents get secret jangar-db-app -o yaml
 ## References
 - Kubernetes Secrets as env vars: https://kubernetes.io/docs/concepts/configuration/secret/
 - Helm values best practices: https://helm.sh/docs/chart_best_practices/values/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
+++ b/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
@@ -1,6 +1,6 @@
 # Chart Deployment Strategy: RollingUpdate Tuning
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart currently relies on Kubernetes default `RollingUpdate` behavior for Deployments. For production, we should explicitly control surge/unavailable and optionally support safer strategies (e.g. `Recreate` for DB-migration-sensitive components).
@@ -73,4 +73,13 @@ kubectl -n agents rollout status deploy/agents
 
 ## References
 - Kubernetes Deployment strategy: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-env-vars-merge-precedence.md
+++ b/docs/agents/designs/chart-env-vars-merge-precedence.md
@@ -1,6 +1,6 @@
 # Chart Env Var Merge Precedence
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents Helm chart exposes multiple ways to set environment variables for the control plane and controllers. Today the precedence is implicit in templates, which makes it easy to unintentionally override critical defaults (e.g. migrations, gRPC enablement) or to believe a value is set when it is not.
@@ -86,4 +86,13 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_MIGRATI
 ## References
 - Kubernetes environment variable precedence (explicit `env` vs `envFrom`): https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 - Helm chart best practices (values and templates): https://helm.sh/docs/chart_best_practices/values/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-envfrom-conflict-resolution.md
+++ b/docs/agents/designs/chart-envfrom-conflict-resolution.md
@@ -1,6 +1,6 @@
 # Chart envFrom Conflict Resolution
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents chart supports both explicit `env:` entries and bulk import via `envFrom` (Secrets/ConfigMaps). Kubernetes allows both, but precedence can be confusing: explicitly defined `env:` variables take precedence over values from `envFrom`.
@@ -76,4 +76,13 @@ kubectl -n agents get deploy agents -o jsonpath='{.spec.template.spec.containers
 
 ## References
 - Kubernetes: define env vars and `envFrom`: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-extra-volumes-mounts-contract.md
+++ b/docs/agents/designs/chart-extra-volumes-mounts-contract.md
@@ -1,6 +1,6 @@
 # Chart Extra Volumes/Mounts Contract
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart supports `.Values.extraVolumes` and `.Values.extraVolumeMounts`, which are injected into both the control plane and controllers pod specs. This is a powerful escape hatch but needs a documented contract to prevent accidental conflicts with chart-managed volumes (e.g. DB CA cert).
@@ -66,4 +66,13 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"extra|db-ca-cert|volumes:|
 
 ## References
 - Kubernetes volumes: https://kubernetes.io/docs/concepts/storage/volumes/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
+++ b/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
@@ -1,6 +1,6 @@
 # Chart gRPC Enabled: Single Source of Truth
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart has `grpc.enabled` (controls Service + container port) while runtime can also be toggled with `JANGAR_GRPC_ENABLED` (via `env.vars`). When these disagree, the deployment can become confusing: a Service may exist without the server listening, or the server may listen without a Service/port.
@@ -64,4 +64,13 @@ kubectl -n agents get endpointslice -l app.kubernetes.io/name=agents
 
 ## References
 - Kubernetes Services: https://kubernetes.io/docs/concepts/services-networking/service/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-image-digest-tag-precedence.md
+++ b/docs/agents/designs/chart-image-digest-tag-precedence.md
@@ -1,6 +1,6 @@
 # Chart Image Digest/Tag Precedence
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents chart supports image tags and optional digests for both the control plane and controllers. In production GitOps, digests are preferred for immutability. The chart currently concatenates `repo:tag@digest` when a digest is provided, but the operational contract (and failure modes) are not documented.
@@ -75,4 +75,13 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spe
 
 ## References
 - Kubernetes container image names (tag/digest): https://kubernetes.io/docs/concepts/containers/images/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-kubernetesapi-host-port-override.md
+++ b/docs/agents/designs/chart-kubernetesapi-host-port-override.md
@@ -1,6 +1,6 @@
 # Chart Kubernetes API Host/Port Override
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart exposes `kubernetesApi.host` and `kubernetesApi.port` which map to `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT`. This is a sharp tool: it can help run outside-cluster or in unusual networking environments, but can also break in-cluster discovery if misused.
@@ -54,4 +54,13 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"KUBERNETES_SERVICE_HOST|KU
 
 ## References
 - Kubernetes in-cluster configuration: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
+++ b/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
@@ -1,6 +1,6 @@
 # Chart namespaceOverride vs Release Namespace Behavior
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart uses `namespaceOverride` to force all rendered resources into a namespace different from `.Release.Namespace`. This is useful in some GitOps setups but can be hazardous if only part of a release is overridden (e.g. CRDs are cluster-scoped, but Roles/RoleBindings are namespaced).
@@ -61,4 +61,13 @@ kubectl get ns agents
 
 ## References
 - Helm template rendering concepts: https://helm.sh/docs/chart_template_guide/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-pod-annotations-merging.md
+++ b/docs/agents/designs/chart-pod-annotations-merging.md
@@ -1,6 +1,6 @@
 # Chart Pod Annotations Merging
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart applies `.Values.podAnnotations` and `.Values.podLabels` to both the control plane pod template and the controllers pod template. Operators often need different annotations per component (e.g., different scraping, sidecar settings, or rollout controls). Today that requires global annotations that may not be appropriate for both.
@@ -65,4 +65,13 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.met
 
 ## References
 - Kubernetes pod template metadata: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-probes-configuration-contract.md
+++ b/docs/agents/designs/chart-probes-configuration-contract.md
@@ -1,6 +1,6 @@
 # Chart Probes Configuration Contract
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart exposes HTTP liveness/readiness probe settings for the control plane, but probes may not be appropriate for controllers (which may not expose HTTP) and there is no startup probe for long initialization (e.g., cache warmup).
@@ -66,4 +66,13 @@ kubectl -n agents describe pod -l app.kubernetes.io/name=agents | rg -n \"Livene
 
 ## References
 - Kubernetes probes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
+++ b/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
@@ -1,6 +1,6 @@
 # Chart RBAC Cluster-Scoped Guardrails
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents chart can run with cluster-scoped RBAC (`rbac.clusterScoped=true`) or namespaced RBAC (`false`). Misconfiguration can lead to controller errors (insufficient permissions) or excessive permissions (overbroad access).
@@ -66,4 +66,13 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_RBAC_CL
 
 ## References
 - Kubernetes RBAC overview: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-resources-component-overrides.md
+++ b/docs/agents/designs/chart-resources-component-overrides.md
@@ -1,6 +1,6 @@
 # Chart Resources: Component Overrides
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents chart exposes `resources` as a global default and also supports component-specific overrides (`controlPlane.resources`, `controllers.resources`). These overrides are implemented in templates but not explicitly documented, which increases the chance of accidentally starving controllers or the control plane in production.
@@ -71,4 +71,13 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"resources:\"
 
 ## References
 - Kubernetes resource requests/limits: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-rollback-helm-behavior.md
+++ b/docs/agents/designs/chart-rollback-helm-behavior.md
@@ -1,6 +1,6 @@
 # Chart Rollback Behavior and Safe Defaults
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 In GitOps, “rollback” typically means reverting values/manifests and letting Argo CD sync. Operators still rely on Helm semantics when debugging template behavior or when performing emergency rollbacks in non-GitOps contexts.
@@ -62,4 +62,13 @@ kubectl -n agents rollout status deploy/agents-controllers
 
 ## References
 - Helm template guide: https://helm.sh/docs/chart_template_guide/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
+++ b/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
@@ -1,6 +1,6 @@
 # Chart Runner ServiceAccount Defaulting
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Agents controllers schedule Kubernetes Jobs for agent runs. The chart includes a `runnerServiceAccount` block and multiple runtime defaults (`runtime.scheduleServiceAccount`, workload defaults, and controller env vars). The defaulting hierarchy must be explicit so operators can ensure jobs run with the intended permissions.
@@ -66,4 +66,13 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_AGENT_R
 
 ## References
 - Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-serviceaccount-name-resolution.md
+++ b/docs/agents/designs/chart-serviceaccount-name-resolution.md
@@ -1,6 +1,6 @@
 # Chart ServiceAccount Name Resolution
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The Agents chart supports `serviceAccount.create` and `serviceAccount.name`, plus a separate `runnerServiceAccount` for jobs created by controllers. The naming and resolution rules must be explicit so operators can safely integrate with external IAM (IRSA, Workload Identity) and cluster policy.
@@ -71,4 +71,13 @@ kubectl -n agents get sa
 
 ## References
 - Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/chart-termination-grace-prestop.md
+++ b/docs/agents/designs/chart-termination-grace-prestop.md
@@ -1,6 +1,6 @@
 # Chart Termination Grace + preStop Hook
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The control plane and controllers handle active requests and ongoing reconciliations. During rollout or node drain, pods should stop accepting new work and drain in-flight tasks before termination. The chart currently does not expose termination grace or preStop hooks.
@@ -63,4 +63,13 @@ kubectl -n agents rollout restart deploy/agents-controllers
 
 ## References
 - Kubernetes container lifecycle hooks: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Helm chart: `charts/agents/`
+- Primary templates: `charts/agents/templates/` (see the doc’s **Current State** section for the exact files)
+- Values + schema: `charts/agents/values.yaml`, `charts/agents/values.schema.json`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/cluster-cost-optimization.md
+++ b/docs/agents/designs/cluster-cost-optimization.md
@@ -1,12 +1,12 @@
 # Cluster Cost Optimization
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: no explicit cost-optimization logic beyond concurrency limits and resource requests.
 - Chart: autoscaling is disabled in argocd values (replicaCount=1, autoscaling.enabled=false).
-- Cluster: no ResourceQuota or LimitRange in the agents namespace.
+- GitOps desired state: no ResourceQuota or LimitRange in the agents namespace.
 
 
 ## Problem
@@ -39,8 +39,7 @@ High throughput can lead to wasted compute costs.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ High throughput can lead to wasted compute costs.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/control-plane-ui-filters.md
+++ b/docs/agents/designs/control-plane-ui-filters.md
@@ -1,12 +1,12 @@
 # Control Plane UI Filters
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: /api/agents/control-plane/stream supports namespace selection only; no server-side label/phase filters.
 - Control-plane stream debounces status updates and emits all primitive kinds.
-- Cluster: UI behavior is driven by SSE; no filter config in values.
+- GitOps desired state: UI behavior is driven by SSE; no filter config in values.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Operators cannot easily filter high-volume runs.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Operators cannot easily filter high-volume runs.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/controller-auth-secret-mount-rotation.md
+++ b/docs/agents/designs/controller-auth-secret-mount-rotation.md
@@ -1,6 +1,6 @@
 # Controller Auth Secret Mount and Rotation
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The controllers deployment supports an “auth secret” for agentctl gRPC authentication via `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_*`. The chart can mount the Secret and set env vars, but the operational contract for rotation is not documented.
@@ -65,4 +65,12 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"AUTH_SECRET\"
 
 ## References
 - Kubernetes Secrets: https://kubernetes.io/docs/concepts/configuration/secret/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-concurrency-tuning.md
+++ b/docs/agents/designs/controller-concurrency-tuning.md
@@ -1,13 +1,13 @@
 # Controller Concurrency Tuning
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: agents-controller enforces per-agent/per-namespace/cluster concurrency; `/v1/agent-runs` admission checks
   namespace/cluster concurrency plus queue/rate limits for API submissions.
 - Chart: controller.concurrency values map to JANGAR_AGENTS_CONTROLLER_CONCURRENCY_* envs.
-- Cluster: envs are set to 10/5/100 in the agents deployment.
+- GitOps desired state: envs are set to 10/5/100 in the agents deployment.
 
 
 ## Problem
@@ -40,8 +40,7 @@ Default concurrency limits may not fit large clusters.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -76,10 +75,10 @@ Default concurrency limits may not fit large clusters.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/controller-condition-type-taxonomy.md
+++ b/docs/agents/designs/controller-condition-type-taxonomy.md
@@ -1,6 +1,6 @@
 # Controller Condition Type Taxonomy
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Agents CRDs expose Kubernetes-style conditions (e.g. `Ready`, `Succeeded`, `Blocked`). Without a consistent taxonomy, automation and operator expectations diverge between resources.
@@ -67,4 +67,12 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[?(@.type=
 
 ## References
 - Kubernetes API conventions (Conditions): https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-controllers-deployment-grpc-off.md
+++ b/docs/agents/designs/controller-controllers-deployment-grpc-off.md
@@ -1,6 +1,6 @@
 # Controllers Deployment: gRPC Disabled by Default
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart renders a separate controllers deployment that forces `JANGAR_GRPC_ENABLED=0` unless explicitly overridden. This is a good safety default (controllers do not need to expose gRPC externally), but it is undocumented and can be surprising when operators expect agentctl gRPC to be available everywhere.
@@ -63,4 +63,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"gRPC|Agentctl\"
 
 ## References
 - gRPC basics: https://grpc.io/docs/what-is-grpc/introduction/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
+++ b/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
@@ -1,6 +1,6 @@
 # Controllers Deployment: Migrations Skipped by Default
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Database migrations are potentially disruptive and should not be run by the controllers deployment. The chart enforces this by defaulting `JANGAR_MIGRATIONS=skip` in the controllers Deployment unless explicitly overridden. This behavior should be documented and protected by validation.
@@ -60,4 +60,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"migration|migrations\
 
 ## References
 - Kubernetes init containers and migration patterns: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-failed-reconcile-events.md
+++ b/docs/agents/designs/controller-failed-reconcile-events.md
@@ -1,6 +1,6 @@
 # Controller Failed Reconcile: Kubernetes Events
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 When reconciles fail, the current primary signal is logs (and possibly status conditions). Kubernetes Events are a useful operational tool (visible via `kubectl describe`) and can improve MTTR, especially for failures like missing secrets, RBAC, or invalid spec fields.
@@ -62,4 +62,12 @@ kubectl -n agents describe agentrun <name> | rg -n \"Events:\"
 
 ## References
 - Kubernetes Events: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#event-v1-core
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-finalizer-conventions.md
+++ b/docs/agents/designs/controller-finalizer-conventions.md
@@ -1,6 +1,6 @@
 # Controller Finalizer Conventions
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Finalizers ensure controllers can perform cleanup before an object is fully deleted (e.g., deleting external runtimes). Inconsistent finalizer naming and behavior can cause stuck deletions or skipped cleanup.
@@ -62,4 +62,12 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.deletionTimestamp}
 
 ## References
 - Kubernetes finalizers: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-kubectl-version-compat.md
+++ b/docs/agents/designs/controller-kubectl-version-compat.md
@@ -1,6 +1,6 @@
 # Controller kubectl Version Compatibility
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Controllers interact with the Kubernetes API by spawning the `kubectl` binary (`primitives-kube.ts` and `kube-watch.ts`). This implicitly makes controller correctness dependent on the `kubectl` version baked into the image. We should document and enforce a compatibility policy.
@@ -57,4 +57,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"kubectl\"
 
 ## References
 - Kubernetes version skew policy: https://kubernetes.io/releases/version-skew-policy/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-namespace-scope-parse-validate.md
+++ b/docs/agents/designs/controller-namespace-scope-parse-validate.md
@@ -1,6 +1,6 @@
 # Controller Namespace Scope: Parse + Validate
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Namespace scoping is a primary safety control for Agents controllers. The controllers accept a namespaces list via env vars (`JANGAR_AGENTS_CONTROLLER_NAMESPACES`, `JANGAR_PRIMITIVES_NAMESPACES`). Invalid JSON or ambiguous inputs can lead to unexpected reconciliation scope.
@@ -66,4 +66,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"namespaces\"
 
 ## References
 - Kubernetes namespace naming: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-orchestration-submit-dedup.md
+++ b/docs/agents/designs/controller-orchestration-submit-dedup.md
@@ -1,6 +1,6 @@
 # Orchestration Submit Deduplication (Delivery ID)
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Orchestration run submission is triggered by external events (e.g., webhooks). Duplicate deliveries are common. The current system deduplicates submissions by `deliveryId` using the primitives store.
@@ -62,3 +62,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"deliveryId|idempotent
 
 ## References
 - HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
+

--- a/docs/agents/designs/controller-postgres-ca-rootcert.md
+++ b/docs/agents/designs/controller-postgres-ca-rootcert.md
@@ -1,6 +1,6 @@
 # Postgres TLS: PGSSLROOTCERT Wiring and Validation
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The chart supports mounting a Postgres CA bundle via `database.caSecret` and sets `PGSSLROOTCERT` to the mounted path. This is essential for production TLS, but it needs a documented contract (secret key naming, mount paths, rotation).
@@ -61,4 +61,12 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"PGSSLROOTCERT|db-ca-cert\"
 
 ## References
 - Kubernetes Secrets volumes: https://kubernetes.io/docs/concepts/storage/volumes/#secret
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-reconcile-timeout-budget.md
+++ b/docs/agents/designs/controller-reconcile-timeout-budget.md
@@ -1,6 +1,6 @@
 # Controller Reconcile Timeout Budget
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Agents controllers perform multiple external operations during reconciliation (Kubernetes API calls via `kubectl`, VCS calls, webhook parsing, database operations). Today, timeouts are mostly implicit (subprocess defaults, library defaults), which makes tail-latency and hung reconciles hard to diagnose.
@@ -65,4 +65,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Timeout:\"
 
 ## References
 - Kubernetes API timeouts (client-side considerations): https://kubernetes.io/docs/reference/using-api/api-concepts/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-resourceversion-conflict-retry.md
+++ b/docs/agents/designs/controller-resourceversion-conflict-retry.md
@@ -1,6 +1,6 @@
 # Controller ResourceVersion Conflicts and Retry Strategy
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Controllers patch and apply resources that may also be updated by other actors (users, GitOps, other controllers). Conflicts (HTTP 409) and optimistic concurrency failures should be handled predictably: retry when safe, fail fast when not.
@@ -63,4 +63,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Conflict|409\"
 
 ## References
 - Kubernetes optimistic concurrency control: https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-server-side-apply-ownership.md
+++ b/docs/agents/designs/controller-server-side-apply-ownership.md
@@ -1,6 +1,6 @@
 # Controller Server-Side Apply and Field Ownership
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Controllers currently use `kubectl apply` (client-side) for many operations, and `kubectl apply --server-side --subresource=status` for status updates. Server-side apply (SSA) provides clear field ownership and reduces merge conflicts when multiple actors mutate the same objects.
@@ -62,4 +62,12 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.managedFields[*].m
 
 ## References
 - Kubernetes Server-Side Apply: https://kubernetes.io/docs/reference/using-api/server-side-apply/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-status-timestamps-generation.md
+++ b/docs/agents/designs/controller-status-timestamps-generation.md
@@ -1,6 +1,6 @@
 # Controller Status: Timestamps + observedGeneration
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Many Agents CRDs include `status.updatedAt` and `status.observedGeneration`. Consistent semantics across controllers are essential for debugging, automation, and eventual UI/CLI behavior.
@@ -67,4 +67,12 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.generation} {.stat
 
 ## References
 - Kubernetes generation and status patterns: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/controller-webhook-signature-verification.md
+++ b/docs/agents/designs/controller-webhook-signature-verification.md
@@ -1,6 +1,6 @@
 # Webhook Signature Verification: ImplementationSource
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 ImplementationSource webhooks are an ingress boundary. Signature verification is implemented for GitHub (`x-hub-signature(-256)`) and Linear (`linear-signature`). This doc defines the operational contract: how secrets are stored, rotated, and validated, and how failure is surfaced safely.
@@ -76,4 +76,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Invalid webhook signa
 ## References
 - GitHub webhook signature docs: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
 - Linear webhook security docs: https://developers.linear.app/docs/graphql/webhooks
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Controller code: `services/jangar/src/server/` (see the doc’s **Current State** section for the exact files)
+- Chart wiring (env/args/volumes): `charts/agents/templates/deployment-controllers.yaml`
+- GitOps overlay (prod): `argocd/applications/agents/values.yaml`
 

--- a/docs/agents/designs/crd-agent-config-schema.md
+++ b/docs/agents/designs/crd-agent-config-schema.md
@@ -1,6 +1,6 @@
 # CRD: Agent `spec.config` Schema and Validation
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 `Agent.spec.config` is currently an untyped map with `x-kubernetes-preserve-unknown-fields`. This gives flexibility but provides weak validation and poor UX: invalid keys/values are only discovered at runtime.
@@ -76,4 +76,12 @@ kubectl -n agents get agent <name> -o yaml | rg -n \"configSchemaRef|InvalidConf
 
 ## References
 - Kubernetes CRD validation: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
 

--- a/docs/agents/designs/crd-agentrun-artifacts-limits.md
+++ b/docs/agents/designs/crd-agentrun-artifacts-limits.md
@@ -1,6 +1,6 @@
 # CRD: AgentRun Artifacts Limits and Schema
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 AgentRun status can accumulate artifacts, logs, and metadata. Without limits and schema conventions, status can grow large, exceed Kubernetes object size limits, and create performance issues for controllers and clients.
@@ -68,4 +68,12 @@ kubectl -n agents get agentrun <name> -o yaml | rg -n \"artifacts:\"
 
 ## References
 - Kubernetes object size limits (etcd considerations): https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
 

--- a/docs/agents/designs/crd-agentrun-idempotency.md
+++ b/docs/agents/designs/crd-agentrun-idempotency.md
@@ -1,6 +1,6 @@
 # CRD: AgentRun Idempotency Key Contract
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 AgentRun includes `spec.idempotencyKey`. This field is intended to avoid duplicate runs when clients retry requests. Without a contract (scope, retention, collision handling), the field is under-specified.
@@ -61,3 +61,12 @@ kubectl -n agents get agentrun -o json | rg -n \"idempotencyKey\"
 
 ## References
 - HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
+

--- a/docs/agents/designs/crd-agentrun-spec-immutability.md
+++ b/docs/agents/designs/crd-agentrun-spec-immutability.md
@@ -1,6 +1,6 @@
 # CRD: AgentRun Spec Immutability Rules
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 AgentRuns represent a concrete execution request. After a run is accepted and started, mutating most of `spec` should be prohibited to preserve auditability and avoid undefined behavior (e.g., swapping implementation mid-run).
@@ -69,4 +69,12 @@ kubectl -n agents get agentrun <name> -o yaml | rg -n \"SpecImmutableViolation|s
 
 ## References
 - Kubernetes immutability patterns (general objects): https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
 

--- a/docs/agents/designs/crd-implementationsource-webhook-cel.md
+++ b/docs/agents/designs/crd-implementationsource-webhook-cel.md
@@ -1,6 +1,6 @@
 # CRD: ImplementationSource Webhook CEL Invariants
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 ImplementationSource supports webhook-driven ingestion. Certain fields must be present together (e.g., `webhook.enabled` implies a `secretRef`). Today, some of these invariants are enforced in code, but encoding them in CRD CEL rules provides immediate feedback at apply time.
@@ -57,4 +57,12 @@ kubectl -n agents apply -f charts/agents/examples/implementationsource-github.ya
 
 ## References
 - Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
 

--- a/docs/agents/designs/crd-implementationspec-config-constraints.md
+++ b/docs/agents/designs/crd-implementationspec-config-constraints.md
@@ -1,6 +1,6 @@
 # CRD: ImplementationSpec Runtime Config Constraints
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 ImplementationSpec contains runtime configuration that is later executed by controllers/runners. Without constraints, it is easy to create specs that are invalid or unsafe (e.g., missing required fields, invalid enum values, or overly large embedded configs).
@@ -59,4 +59,12 @@ kubectl -n agents get implementationspec -o yaml | rg -n \"spec:|x-kubernetes-va
 
 ## References
 - Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
 

--- a/docs/agents/designs/crd-lifecycle-upgrades.md
+++ b/docs/agents/designs/crd-lifecycle-upgrades.md
@@ -1,6 +1,6 @@
 # CRD Lifecycle Upgrades
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Define the lifecycle and upgrade flow for Agents CRDs, including generation, validation, packaging, rollout,
@@ -18,7 +18,7 @@ production-ready checklist.
 - Runtime checks: `services/jangar/src/server/agents-controller.ts` verifies required CRDs at startup by running
   `kubectl get <resource> -n <namespace>` and fails fast if they are missing or unauthorized. The required set
   expands when `JANGAR_AGENTS_CONTROLLER_VCS_PROVIDERS_ENABLED=true`.
-- Cluster: The agents namespace currently has CRDs for Agents, Orchestration, Tools, Signals, Budgets, Approval
+- GitOps desired state: The agents namespace currently has CRDs for Agents, Orchestration, Tools, Signals, Budgets, Approval
   Policies, SecretBindings, Workspaces, Schedules, Artifacts, and VersionControlProviders. The ArgoCD app is
   managing CRDs with ServerSideApply and is currently reporting some OutOfSync resources.
 
@@ -72,8 +72,7 @@ production-ready checklist.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -114,10 +113,10 @@ production-ready checklist.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/crd-memory-retention-compaction.md
+++ b/docs/agents/designs/crd-memory-retention-compaction.md
@@ -1,6 +1,6 @@
 # CRD: Memory Retention and Compaction
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 The `Memory` CRD represents stored context/embeddings. Without retention controls and compaction, memory stores can grow without bound, increasing storage cost and slowing queries. This doc defines retention and compaction semantics managed by controllers.
@@ -70,4 +70,12 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"compaction|retention\
 
 ## References
 - Kubernetes controllers (background reconciliation): https://kubernetes.io/docs/concepts/architecture/controller/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
 

--- a/docs/agents/designs/crd-orchestration-dag.md
+++ b/docs/agents/designs/crd-orchestration-dag.md
@@ -1,6 +1,6 @@
 # CRD: Orchestration DAG Semantics
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Orchestrations represent multi-step workflows. The current schema supports `spec.steps`, but the semantics around ordering, dependency graphs, and partial failure are not explicitly documented. This doc defines a DAG model that controllers can implement consistently.
@@ -68,3 +68,12 @@ kubectl -n agents get orchestrationrun -o yaml | rg -n \"phase:|Skipped|Dependen
 
 ## References
 - Argo Workflows DAG concepts (widely used Kubernetes DAG runtime): https://argo-workflows.readthedocs.io/en/latest/walk-through/dag/
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
+

--- a/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
+++ b/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
@@ -1,6 +1,6 @@
 # CRD: OrchestrationRun Cancel Propagation
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 Operators need reliable cancellation semantics for OrchestrationRuns. Cancelling should propagate to all active underlying runtimes (Jobs/Workflows/etc) and update status/conditions in a predictable way.
@@ -61,4 +61,12 @@ kubectl -n agents get orchestrationrun <name> -o yaml | rg -n \"Cancelled|phase\
 
 ## References
 - Kubernetes graceful termination concepts: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
 

--- a/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
+++ b/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
@@ -1,6 +1,6 @@
 # CRD: VersionControlProvider SSH and known_hosts
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Overview
 VersionControlProvider supports SSH configuration (host, user, private key secret, known_hosts ConfigMap ref). This is operationally sensitive: incorrect known_hosts handling can lead to MITM risk, and missing known_hosts can break cloning.
@@ -67,4 +67,12 @@ kubectl -n agents get configmap | rg known-hosts
 ## References
 - OpenSSH `known_hosts` format: https://man.openbsd.org/sshd.8#SSH_KNOWN_HOSTS_FILE_FORMAT
 - Git over SSH: https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- CRDs packaged by chart: `charts/agents/crds/`
+- Go types (when generated): `services/jangar/api/agents/v1alpha1/`
+- Validation pipeline: `scripts/agents/validate-agents.sh`
 

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -1,6 +1,6 @@
 # Custom System Prompt for Agent Runs
 
-Status: Implemented (2026-02-06)
+Status: Implemented (2026-02-07)
 
 Note: Clusters will accept/run the new fields once the updated `charts/agents` CRDs and the relevant controller/runtime deployments (plus Argo templates, if used) are rolled out.
 
@@ -165,10 +165,10 @@ argo submit \
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/data-migration-runbooks.md
+++ b/docs/agents/designs/data-migration-runbooks.md
@@ -1,12 +1,12 @@
 # Data Migration Runbooks
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: migrations live under services/jangar/src/server/migrations; no dedicated runbooks in docs/agents.
 - Chart: no migration job; JANGAR_MIGRATIONS=auto in the deployment.
-- Cluster: migrations run on startup (auto).
+- GitOps desired state: migrations run on startup (auto).
 
 
 ## Problem
@@ -39,8 +39,7 @@ Upgrades require clear migration instructions.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Upgrades require clear migration instructions.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/disaster-recovery-backups.md
+++ b/docs/agents/designs/disaster-recovery-backups.md
@@ -1,12 +1,12 @@
 # Disaster Recovery and Backups
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: no backup/restore automation in Jangar services.
 - Chart: no backup jobs or hooks.
-- Cluster: no backup Jobs or CronJobs are present in the agents namespace; backups are external to this chart.
+- GitOps desired state: no backup Jobs or CronJobs are present in the agents namespace; backups are external to this chart.
 
 
 ## Problem
@@ -39,8 +39,7 @@ State loss can halt autonomous operations.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ State loss can halt autonomous operations.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/github-app-auth-rotation.md
+++ b/docs/agents/designs/github-app-auth-rotation.md
@@ -1,6 +1,6 @@
 # GitHub App Auth and Token Rotation
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Support GitHub App installation tokens for VCS operations, including safe rotation and caching.
@@ -14,7 +14,7 @@ Support GitHub App installation tokens for VCS operations, including safe rotati
   - Caches tokens in memory keyed by `apiBaseUrl|installationId`.
   - Refreshes tokens before expiry using a refresh window (10% of TTL, min 30s, max 5 min).
   - Injects `VCS_TOKEN`, `GITHUB_TOKEN`, and `GH_TOKEN` into the agent runtime env.
-- Cluster: no `VersionControlProvider` resources are present today, so GitHub App auth is not currently in use.
+- GitOps desired state includes `VersionControlProvider/github` using token auth in `argocd/applications/agents/codex-versioncontrolprovider.yaml`; GitHub App auth is not enabled by default but can be introduced by changing the provider `spec.auth` and adding the required Secrets.
 
 ## Design
 
@@ -53,8 +53,7 @@ Support GitHub App installation tokens for VCS operations, including safe rotati
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -79,10 +78,10 @@ Support GitHub App installation tokens for VCS operations, including safe rotati
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -1,11 +1,11 @@
 # GitOps and Argo CD Hooks
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Chart: argocdHooks templates support PreSync cleanup and PostSync smoke AgentRun.
-- Cluster: argocd app values do not enable argocdHooks; no hook jobs present.
+- GitOps desired state: argocd app values do not enable argocdHooks; no hook jobs present.
 - Kustomize renders the chart with includeCRDs: true.
 
 
@@ -40,8 +40,7 @@ GitOps deployments need deterministic pre/post-sync behavior.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -76,10 +75,10 @@ GitOps deployments need deterministic pre/post-sync behavior.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/grpc-coverage-parity.md
+++ b/docs/agents/designs/grpc-coverage-parity.md
@@ -1,11 +1,11 @@
 # gRPC Coverage Parity for agentctl
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: gRPC server in services/jangar/src/server/agentctl-grpc.ts exposes a subset of kube-mode operations; watch streams are missing.
-- Cluster: gRPC is enabled and exposed via agents-grpc service.
+- GitOps desired state: gRPC is enabled and exposed via agents-grpc service.
 - CLI: agentctl can run in kube or gRPC mode; kube mode remains fuller coverage.
 
 
@@ -39,8 +39,7 @@ gRPC endpoints lag behind REST and CLI features.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ gRPC endpoints lag behind REST and CLI features.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/handoff-common.md
+++ b/docs/agents/designs/handoff-common.md
@@ -1,0 +1,114 @@
+# Agents: Shared Handoff Appendix (Repo + Chart + Cluster)
+
+Status: Current (2026-02-07)
+
+This document centralizes the “always the same” operational facts for the Agents stack so individual design docs
+can stay focused on their specific topic.
+
+## Source of truth (repo)
+
+- Helm chart (templates, CRDs, defaults): `charts/agents/`
+- Chart values + schema:
+  - Defaults: `charts/agents/values.yaml`
+  - Schema: `charts/agents/values.schema.json`
+  - Environment overlays (examples): `charts/agents/values-{dev,kind,local,prod,ci}.yaml`
+- GitOps desired state (production install):
+  - Argo CD Application: `argocd/applications/agents/application.yaml`
+  - Helm via kustomize: `argocd/applications/agents/kustomization.yaml`
+  - Values overlay: `argocd/applications/agents/values.yaml`
+  - Extra primitives (Agent/Provider/VCP/etc): `argocd/applications/agents/*.yaml`
+
+## Current cluster desired state (GitOps)
+
+As of 2026-02-07 (repo `main`), the repo declares:
+
+- Argo CD app `agents` deploys to namespace `agents`. See `argocd/applications/agents/application.yaml`.
+- Install mechanism: kustomize `helmCharts` with `includeCRDs: true` and Helm release name `agents`. See
+  `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`):
+  - Control plane (Deployment `agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (Deployment `agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Controllers enabled: `controllers.enabled: true`. See `argocd/applications/agents/values.yaml`.
+- Namespaced reconciliation (not cluster-scoped): `controller.namespaces: [agents]` and `rbac.clusterScoped: false`.
+  See `argocd/applications/agents/values.yaml`.
+- Database connection:
+  - `database.secretRef.name: jangar-db-app`
+  - `database.secretRef.key: uri`
+  See `argocd/applications/agents/values.yaml`.
+- gRPC is enabled and explicitly managed via both chart values and env vars:
+  - `grpc.enabled: true`
+  - `env.vars.JANGAR_GRPC_ENABLED: "true"`
+  See `argocd/applications/agents/values.yaml`.
+- GitHub VersionControlProvider is declared in GitOps as `VersionControlProvider/github`. See
+  `argocd/applications/agents/codex-versioncontrolprovider.yaml`.
+
+Note on “live cluster state”: this repo is GitOps-first, so treat `argocd/applications/**` + `charts/agents/**` as
+the desired state. Validate live state with the commands in the next section (requires read access to `argocd` and
+`agents` namespaces).
+
+## Validation commands (local render)
+
+Render the full desired install (Helm via kustomize, matching Argo CD):
+
+```bash
+mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml
+rg -n \"^kind: (Deployment|Service|CustomResourceDefinition)$\" /tmp/agents.yaml | head
+```
+
+Validate schema / examples / chart renderability (includes kubeconform and size checks):
+
+```bash
+scripts/agents/validate-agents.sh
+```
+
+Validate Argo CD manifests (basic structure + kubeconform):
+
+```bash
+scripts/argo-lint.sh
+scripts/kubeconform.sh argocd
+```
+
+If `kubectl` is not installed locally, use:
+
+```bash
+mise exec kubectl@1.30.0 -- kubectl version --client
+```
+
+## Validation commands (live cluster)
+
+These commands confirm the live cluster matches the GitOps desired state.
+
+```bash
+# Argo CD view (requires access to namespace argocd)
+kubectl get application -n argocd agents -o yaml | rg -n \"sync|health|revision\"
+
+# Workloads
+kubectl get deploy -n agents
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+
+# CRDs (cluster-scoped)
+kubectl get crd | rg 'proompteng\\.ai'
+```
+
+## Rollout discipline (GitOps)
+
+When changing behavior that affects runtime (CRDs, controllers, chart templates, or default values):
+
+1. Update code and chart together:
+   - Controllers/runtime: `services/jangar/src/server/**`
+   - CRD types: `services/jangar/api/agents/v1alpha1/**` → regenerate CRDs into `charts/agents/crds/`
+   - Chart templates/values: `charts/agents/templates/**`, `charts/agents/values*.yaml`, `charts/agents/values.schema.json`
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. If new config is needed in prod, update `argocd/applications/agents/values.yaml`.
+4. Merge to `main`; Argo CD will reconcile automatically.
+## Handoff Appendix (Repo + Chart + Cluster)
+
+Shared operational details (cluster desired state, render/validate commands): `docs/agents/designs/handoff-common.md`.
+
+### This design’s touchpoints
+- Repo source of truth: `charts/agents/` + `services/jangar/` + `argocd/applications/agents/`
+

--- a/docs/agents/designs/implementation-contract-enforcement.md
+++ b/docs/agents/designs/implementation-contract-enforcement.md
@@ -1,13 +1,13 @@
 # Implementation Contract Enforcement
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: validateImplementationContract enforces required metadata keys on AgentRuns and workflow steps.
 - Failures set AgentRun status InvalidSpec with MissingRequiredMetadata.
 - Chart: no values; enforcement is controller-driven.
-- Cluster: enforcement is always on in the agents deployment; no feature flag disables it.
+- GitOps desired state: enforcement is always on in the agents deployment; no feature flag disables it.
 
 
 ## Problem
@@ -40,8 +40,7 @@ Runs can fail if required metadata is missing.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -76,10 +75,10 @@ Runs can fail if required metadata is missing.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/integration-test-harness.md
+++ b/docs/agents/designs/integration-test-harness.md
@@ -1,12 +1,12 @@
 # Integration Test Harness
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Scripts: scripts/agents/kind-e2e.sh, scripts/agents/native-workflow-e2e.sh, scripts/agents/validate-agents.sh.
 - CI: agents-sync and validate workflows run helm lint and kustomize rendering.
-- Cluster: no test harness resources deployed by default.
+- GitOps desired state: no test harness resources deployed by default.
 
 
 ## Problem
@@ -39,8 +39,7 @@ High-scale changes need reliable integration testing.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ High-scale changes need reliable integration testing.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/job-gc-visibility.md
+++ b/docs/agents/designs/job-gc-visibility.md
@@ -1,12 +1,12 @@
 # Job GC Visibility and Retention
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: AgentRun retention via ttlSecondsAfterFinished or JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS; Job TTL via JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS; ToolRun TTL supported.
 - Chart: controller.jobTtlSecondsAfterFinished available with default 600s.
-- Cluster: retention env is set (~30d); job TTL env set to 600 seconds.
+- GitOps desired state: retention env is set (~30d); job TTL env set to 600 seconds.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Jobs may be deleted before status is collected, causing WorkflowJobMissing.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Jobs may be deleted before status is collected, causing WorkflowJobMissing.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/leader-election-ha.md
+++ b/docs/agents/designs/leader-election-ha.md
@@ -1,6 +1,6 @@
 # Leader Election for HA (Jangar Controllers)
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Purpose
 Define how Jangar controllers use Kubernetes leader election to support safe horizontal scaling, prevent double
@@ -12,7 +12,7 @@ reconciliation, and provide predictable failover behavior.
   `services/jangar/src/server/agent-comms-runtime.ts`, and readiness is not gated on leadership.
 - Chart: There is no `controller.leaderElection` configuration in `charts/agents/values.yaml` or the deployment
   template.
-- Cluster: The `agents` deployment runs `replicaCount: 1` from `argocd/applications/agents/values.yaml`, so HA is
+- GitOps desired state: The `agents` deployment runs `replicaCount: 1` from `argocd/applications/agents/values.yaml`, so HA is
   not active. The namespace includes a PDB named `agents` with `minAvailable: 1`, and gRPC is enabled on port 50051.
 
 ## Design Summary
@@ -112,10 +112,10 @@ Map values into env vars consumed by the controller runtime, for example:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/load-testing-benchmarking.md
+++ b/docs/agents/designs/load-testing-benchmarking.md
@@ -1,11 +1,11 @@
 # Load Testing and Benchmarking
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: no load-testing harness in repo.
-- Cluster: no load test Jobs or CronJobs are present in the agents namespace.
+- GitOps desired state: no load test Jobs or CronJobs are present in the agents namespace.
 
 
 ## Problem
@@ -38,8 +38,7 @@ No standardized benchmark for 100-person throughput.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -74,10 +73,10 @@ No standardized benchmark for 100-person throughput.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/log-retention-shipper.md
+++ b/docs/agents/designs/log-retention-shipper.md
@@ -1,11 +1,11 @@
 # Log Retention and Shipping
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: no log shipping or retention management in Jangar services.
-- Cluster: no log shipper sidecar is configured for the agents deployment.
+- GitOps desired state: no log shipper sidecar is configured for the agents deployment.
 
 
 ## Problem
@@ -38,8 +38,7 @@ Job logs are ephemeral and hard to retrieve after completion.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -74,10 +73,10 @@ Job logs are ephemeral and hard to retrieve after completion.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/metrics-otel-tracing.md
+++ b/docs/agents/designs/metrics-otel-tracing.md
@@ -1,12 +1,12 @@
 # Metrics and OpenTelemetry Tracing
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: OTEL metrics export is implemented in services/jangar/src/server/metrics.ts (OTLP HTTP exporter).
 - Tracing: no OpenTelemetry tracing setup found in services/jangar.
-- Cluster: no OTEL env variables set for the agents deployment.
+- GitOps desired state: no OTEL env variables set for the agents deployment.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Without tracing, it is hard to debug end-to-end latency.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Without tracing, it is hard to debug end-to-end latency.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/multi-namespace-controller-guards.md
+++ b/docs/agents/designs/multi-namespace-controller-guards.md
@@ -1,12 +1,12 @@
 # Multi-Namespace Controller Guardrails
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: namespace-scope.assertClusterScopedForWildcard enforces rbac.clusterScoped for '*' in agents-controller and webhook ingestion.
 - Chart: rbac.clusterScoped and controller.namespaces map to JANGAR_RBAC_CLUSTER_SCOPED and JANGAR_AGENTS_CONTROLLER_NAMESPACES.
-- Cluster: rbac.clusterScoped=false and controller.namespaces=[agents].
+- GitOps desired state: rbac.clusterScoped=false and controller.namespaces=[agents].
 
 
 ## Problem
@@ -39,8 +39,7 @@ Misconfigured namespaces can lead to missed resources or RBAC errors.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Misconfigured namespaces can lead to missed resources or RBAC errors.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/multi-provider-auth-deprecations.md
@@ -1,6 +1,6 @@
 # Multi-Provider Auth Standards and Deprecations
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Normalize auth configuration across VCS providers and surface deprecated token types before they break.
@@ -13,7 +13,7 @@ Normalize auth configuration across VCS providers and surface deprecated token t
   `VersionControlProvider` and `AgentRun` resources.
 - Chart configuration: `controller.vcsProviders.deprecatedTokenTypes` maps to
   `JANGAR_AGENTS_CONTROLLER_VCS_DEPRECATED_TOKEN_TYPES`.
-- Cluster: no `VersionControlProvider` resources are present, so provider defaults are not currently exercised.
+- GitOps desired state includes `VersionControlProvider/github` in `argocd/applications/agents/codex-versioncontrolprovider.yaml`, so provider defaults are exercised unless you remove/disable that resource.
 
 ## Provider Matrix
 
@@ -46,8 +46,7 @@ Normalize auth configuration across VCS providers and surface deprecated token t
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -82,10 +81,10 @@ Normalize auth configuration across VCS providers and surface deprecated token t
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/namespaced-install-matrix.md
+++ b/docs/agents/designs/namespaced-install-matrix.md
@@ -1,6 +1,6 @@
 # Namespaced vs Cluster-Scoped Install Matrix
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Define the supported install modes and their RBAC implications for the Agents control plane.
@@ -12,7 +12,7 @@ Define the supported install modes and their RBAC implications for the Agents co
   - `controller.namespaces` controls the namespaces reconciled by the agents controller.
 - Runtime enforcement: `services/jangar/src/server/namespace-scope.ts` rejects `controller.namespaces: ["*"]`
   unless `JANGAR_RBAC_CLUSTER_SCOPED=true`.
-- Cluster: The `agents` ArgoCD app sets `controller.namespaces: [agents]` and `rbac.clusterScoped: false`, so
+- GitOps desired state: The `agents` ArgoCD app sets `controller.namespaces: [agents]` and `rbac.clusterScoped: false`, so
   reconciliation is namespaced.
 
 ## Install Matrix
@@ -39,8 +39,7 @@ Define the supported install modes and their RBAC implications for the Agents co
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -65,10 +64,10 @@ Define the supported install modes and their RBAC implications for the Agents co
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/network-policy-egress.md
+++ b/docs/agents/designs/network-policy-egress.md
@@ -1,11 +1,11 @@
 # Network Policy Egress Control
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Chart: networkPolicy template supports ingress/egress lists; disabled by default.
-- Cluster: a tailscale-specific NetworkPolicy exists via argocd/applications/agents, not chart values.
+- GitOps desired state: a tailscale-specific NetworkPolicy exists via argocd/applications/agents, not chart values.
 - Values: networkPolicy.enabled is false in argocd values.
 
 
@@ -39,8 +39,7 @@ Autonomous agents require explicit egress controls for security.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Autonomous agents require explicit egress controls for security.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/observability-pack.md
+++ b/docs/agents/designs/observability-pack.md
@@ -1,12 +1,12 @@
 # Observability Pack
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: OTEL metrics export exists; SSE metrics and queue depth histograms are recorded.
 - Chart: no ServiceMonitor/dashboard templates; no metrics values in charts/agents.
-- Cluster: no OTEL env variables set; no Prometheus scrape config in chart.
+- GitOps desired state: no OTEL env variables set; no Prometheus scrape config in chart.
 
 
 ## Problem
@@ -40,8 +40,7 @@ Operators need metrics, logs, and dashboards to run at scale.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -76,10 +75,10 @@ Operators need metrics, logs, and dashboards to run at scale.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/pod-security-admission.md
+++ b/docs/agents/designs/pod-security-admission.md
@@ -1,6 +1,6 @@
 # Pod Security Admission Labels
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Allow optional Pod Security Admission (PSA) labels to be applied to the agents namespace during installation.
@@ -10,7 +10,7 @@ Allow optional Pod Security Admission (PSA) labels to be applied to the agents n
 - Chart values: `podSecurityAdmission.enabled`, `podSecurityAdmission.createNamespace`, and
   `podSecurityAdmission.labels`.
 - Template: `charts/agents/templates/namespace.yaml` creates a Namespace with PSA labels when enabled.
-- Cluster: the `agents` namespace only has the default `kubernetes.io/metadata.name` label; PSA labels are not
+- GitOps desired state: the `agents` namespace only has the default `kubernetes.io/metadata.name` label; PSA labels are not
   applied.
 
 ## Design
@@ -40,8 +40,7 @@ podSecurityAdmission:
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -66,10 +65,10 @@ podSecurityAdmission:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/pr-rate-limits-batching.md
+++ b/docs/agents/designs/pr-rate-limits-batching.md
@@ -1,6 +1,6 @@
 # PR Rate Limits and Batching
 
-Status: Partial (2026-02-06)
+Status: Partial (2026-02-07)
 
 ## Purpose
 Respect VCS provider rate limits by throttling automated PR creation.
@@ -13,7 +13,7 @@ Respect VCS provider rate limits by throttling automated PR creation.
   runtime as `VCS_PR_RATE_LIMITS`.
 - Enforcement: `services/jangar/scripts/codex-implement.ts` enforces rate limits during `gh pr create` using
   a local timestamp file (`/tmp/jangar-pr-rate-limits.json`).
-- Cluster: no `prRateLimits` are set in `argocd/applications/agents/values.yaml`.
+- GitOps desired state: no `prRateLimits` are set in `argocd/applications/agents/values.yaml`.
 
 ## Configuration Format
 `VCS_PR_RATE_LIMITS` expects a JSON object keyed by provider:
@@ -44,8 +44,7 @@ Respect VCS provider rate limits by throttling automated PR creation.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -70,10 +69,10 @@ Respect VCS provider rate limits by throttling automated PR creation.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/queue-fairness-per-repo.md
+++ b/docs/agents/designs/queue-fairness-per-repo.md
@@ -1,6 +1,6 @@
 # Queue Fairness per Repository
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
@@ -9,7 +9,7 @@ Status: Draft (2026-02-06)
 - Controller reconciliation enforces queue limits for direct AgentRun CRs; per-agent concurrency remains the only
   fairness control on that path.
 - Chart: `controller.queue.*` values map to `JANGAR_AGENTS_CONTROLLER_QUEUE_*` envs used by the API admission path.
-- Cluster: queue env vars are set (200/50/1000), so API admission uses explicit caps today.
+- GitOps desired state: queue env vars are set (200/50/1000), so API admission uses explicit caps today.
 
 ## Problem
 High-volume repos can starve smaller repos of capacity.
@@ -44,8 +44,7 @@ High-volume repos can starve smaller repos of capacity.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -80,10 +79,10 @@ High-volume repos can starve smaller repos of capacity.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/repo-allow-deny-policy.md
+++ b/docs/agents/designs/repo-allow-deny-policy.md
@@ -1,6 +1,6 @@
 # Repository Allow and Deny Policy
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Constrain repository access for VCS operations using allow and deny lists on VersionControlProvider resources.
@@ -10,7 +10,7 @@ Constrain repository access for VCS operations using allow and deny lists on Ver
 - Policy is implemented in `services/jangar/src/server/agents-controller.ts` during VCS resolution.
 - `VersionControlProvider.spec.repositoryPolicy.allow` and `.deny` accept wildcard patterns (`*`).
 - Repositories are normalized to lowercase before matching; patterns should be lowercase for consistent matches.
-- Cluster: no `VersionControlProvider` resources are currently present, so repository policy enforcement is not
+- GitOps desired state includes `VersionControlProvider/github` with `repositoryPolicy.allow` set in `argocd/applications/agents/codex-versioncontrolprovider.yaml`, so repository allow/deny is enforced for runs routed through that provider.
   active. `argocd/applications/agents/codex-versioncontrolprovider.yaml` defines an allowlist for
   `proompteng/lab`, but the resource is not applied in the cluster.
 
@@ -39,8 +39,7 @@ repositoryPolicy:
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -65,10 +64,10 @@ repositoryPolicy:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/resourcequota-limitrange.md
+++ b/docs/agents/designs/resourcequota-limitrange.md
@@ -1,11 +1,11 @@
 # ResourceQuota and LimitRange Integration
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Chart: resourceQuota and limitRange templates exist and are disabled by default.
-- Cluster: no ResourceQuota or LimitRange in the agents namespace.
+- GitOps desired state: no ResourceQuota or LimitRange in the agents namespace.
 
 
 ## Problem
@@ -38,8 +38,7 @@ Clusters need quota enforcement for AgentRuns.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -74,10 +73,10 @@ Clusters need quota enforcement for AgentRuns.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -1,6 +1,6 @@
 # Runner Image Defaults and Job TTL
 
-Status: Partial (2026-02-06)
+Status: Partial (2026-02-07)
 
 ## Purpose
 Provide reliable default runner images and safe Job TTLs so AgentRuns do not fail due to missing images or premature
@@ -19,7 +19,7 @@ cleanup.
   - `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS` defaults to 600 seconds.
   - `spec.runtime.config.ttlSecondsAfterFinished` overrides the env value.
   - TTL is clamped to `[30s, 7d]`.
-- Cluster: `JANGAR_AGENT_RUNNER_IMAGE` is set to `registry.ide-newton.ts.net/lab/codex-universal:latest` and
+- GitOps desired state: `JANGAR_AGENT_RUNNER_IMAGE` is set to `registry.ide-newton.ts.net/lab/codex-universal:latest` and
   `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS` is set to 600, matching chart defaults.
 
 ## Design
@@ -46,8 +46,7 @@ cleanup.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -72,10 +71,10 @@ cleanup.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/schedule-cronjob-reliability.md
+++ b/docs/agents/designs/schedule-cronjob-reliability.md
@@ -1,12 +1,12 @@
 # Schedule and CronJob Reliability
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: supporting controller materializes Schedule CRs as CronJobs and watches CronJob status.
 - Chart: runtime.scheduleRunnerImage and runtime.scheduleServiceAccount map to JANGAR_SCHEDULE_* envs.
-- Cluster: no Schedule resources present.
+- GitOps desired state: no Schedule resources present.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Schedule CRDs require reliable CronJob creation and cleanup.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Schedule CRDs require reliable CronJob creation and cleanup.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/scheduler-affinity-priority.md
+++ b/docs/agents/designs/scheduler-affinity-priority.md
@@ -1,6 +1,6 @@
 # Scheduler Affinity and Priority Defaults
 
-Status: Current (2026-02-06)
+Status: Current (2026-02-07)
 
 ## Purpose
 Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run overrides.
@@ -12,7 +12,7 @@ Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run 
 - Env wiring: `charts/agents/templates/deployment.yaml` maps defaults to `JANGAR_AGENT_RUNNER_*` env vars.
 - Runtime behavior: `services/jangar/src/server/agents-controller.ts` applies defaults unless overridden by
   `spec.runtime.config` on the AgentRun.
-- Cluster: `controller.defaultWorkload` is not set in ArgoCD values, so defaults are empty.
+- GitOps desired state: `controller.defaultWorkload` is not set in ArgoCD values, so defaults are empty.
 
 ## Default Fields
 
@@ -40,8 +40,7 @@ Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run 
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -66,10 +65,10 @@ Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run 
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/secretbinding-guardrails.md
+++ b/docs/agents/designs/secretbinding-guardrails.md
@@ -1,12 +1,12 @@
 # SecretBinding Guardrails
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: supporting controller validates SecretBindings; agents-controller and /v1/agent-runs enforce allowlists.
 - API: /v1/agent-runs requires secretBindingRef when secrets are requested.
-- Cluster: codex-github-token SecretBinding exists.
+- GitOps desired state: codex-github-token SecretBinding exists.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Runs can mount secrets without clear governance.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Runs can mount secrets without clear governance.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/security-sbom-signing.md
+++ b/docs/agents/designs/security-sbom-signing.md
@@ -1,12 +1,12 @@
 # Security: SBOM and Signing
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: no SBOM generation or signing pipeline in repo workflows.
 - Chart: no values for SBOM or signing.
-- Cluster: no admission policy or runtime verification is configured for signed images.
+- GitOps desired state: no admission policy or runtime verification is configured for signed images.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Supply chain integrity is required for production adoption.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Supply chain integrity is required for production adoption.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/signal-delivery-retries.md
+++ b/docs/agents/designs/signal-delivery-retries.md
@@ -1,11 +1,11 @@
 # Signal Delivery Retries
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: SignalDelivery reconciliation marks Delivered immediately; no retry/backoff logic.
-- Cluster: sample Signal exists; no SignalDelivery resources.
+- GitOps desired state: sample Signal exists; no SignalDelivery resources.
 
 
 ## Problem
@@ -38,8 +38,7 @@ SignalDelivery failures can leave workflows stuck.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -74,10 +73,10 @@ SignalDelivery failures can leave workflows stuck.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/staging-prod-values-overlays.md
+++ b/docs/agents/designs/staging-prod-values-overlays.md
@@ -1,12 +1,12 @@
 # Staging and Production Values Overlays
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Chart: values-dev.yaml, values-prod.yaml, values-ci.yaml, values-local.yaml, values-kind.yaml exist.
 - GitOps: argocd/applications/agents/values.yaml is the in-cluster overlay.
-- Cluster: the agents ArgoCD app currently applies only the in-repo values overlay.
+- GitOps desired state: the agents ArgoCD app currently applies only the in-repo values overlay.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Operators need consistent overlays for staging and prod.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Operators need consistent overlays for staging and prod.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/supply-chain-attestations.md
+++ b/docs/agents/designs/supply-chain-attestations.md
@@ -1,11 +1,11 @@
 # Supply Chain Attestations
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: no attestations or provenance generation in workflows.
-- Cluster: not configured.
+- GitOps desired state: not configured.
 
 
 ## Problem
@@ -38,8 +38,7 @@ Regulated environments require provenance attestations.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -74,10 +73,10 @@ Regulated environments require provenance attestations.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/throughput-backpressure-quotas.md
+++ b/docs/agents/designs/throughput-backpressure-quotas.md
@@ -1,6 +1,6 @@
 # Throughput Backpressure and Admission Control
 
-Status: Partial (2026-02-06)
+Status: Partial (2026-02-07)
 
 ## Purpose
 Prevent high-volume AgentRuns from overwhelming the controller or the cluster by enforcing concurrency, queue, and
@@ -19,7 +19,7 @@ rate limits.
 - Queue and rate settings exist in the chart (`controller.queue.*`, `controller.rate.*`) and are rendered into
   env vars in `charts/agents/templates/deployment.yaml`. They are enforced in API admission and by the controller
   for AgentRuns created directly as CRs.
-- Cluster: the `agents` deployment sets queue limits (200/50/1000) and rate limits (60s window, 120/30/600) via
+- GitOps desired state: the `agents` deployment sets queue limits (200/50/1000) and rate limits (60s window, 120/30/600) via
   env vars, so API admission uses explicit values.
 
 ## Design
@@ -66,8 +66,7 @@ These should map to:
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -92,10 +91,10 @@ These should map to:
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/toolrun-runtime-isolation.md
+++ b/docs/agents/designs/toolrun-runtime-isolation.md
@@ -1,11 +1,11 @@
 # ToolRun Runtime Isolation
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: orchestration-controller submits ToolRun Jobs using tool.spec.image/command; isolation is limited to Kubernetes primitives.
-- Cluster: no ToolRun resources present.
+- GitOps desired state: no ToolRun resources present.
 
 
 ## Problem
@@ -38,8 +38,7 @@ Tool runs need consistent isolation and resource limits.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -74,10 +73,10 @@ Tool runs need consistent isolation and resource limits.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/topology-spread-defaults.md
+++ b/docs/agents/designs/topology-spread-defaults.md
@@ -1,12 +1,12 @@
 # Topology Spread Defaults
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: agents-controller applies topologySpreadConstraints from runtime config or JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS.
 - Chart: controller.defaultWorkload.topologySpreadConstraints maps to env.
-- Cluster: defaultWorkload not set.
+- GitOps desired state: defaultWorkload not set.
 
 
 ## Problem
@@ -40,8 +40,7 @@ Workloads can stack on a single node without spread rules.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -76,10 +75,10 @@ Workloads can stack on a single node without spread rules.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/values-schema-readme-automation.md
+++ b/docs/agents/designs/values-schema-readme-automation.md
@@ -1,6 +1,6 @@
 # Values Schema and README Automation
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Purpose
 Keep `charts/agents/README.md` and `charts/agents/values.schema.json` in lock-step with
@@ -13,7 +13,7 @@ Keep `charts/agents/README.md` and `charts/agents/values.schema.json` in lock-st
 - No script currently regenerates either artifact.
 - CI validates CRDs and helm rendering via `scripts/agents/validate-agents.sh`, but it does not check README/schema
   drift.
-- Cluster: not applicable; README/schema generation is a repository-only workflow.
+- GitOps desired state: not applicable; README/schema generation is a repository-only workflow.
 
 ## Design
 
@@ -79,10 +79,10 @@ Some constraints cannot be inferred from YAML alone. Encode them via inline comm
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/webhook-ingestion-scaling.md
+++ b/docs/agents/designs/webhook-ingestion-scaling.md
@@ -1,11 +1,11 @@
 # Webhook Ingestion Scaling
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: implementation-source-webhooks handles GitHub/Linear webhooks, validates secrets, and writes ImplementationSpecs; no queueing layer.
-- Cluster: github-lab and github-lab-env ImplementationSources are Ready.
+- GitOps desired state: github-lab and github-lab-env ImplementationSources are Ready.
 - Chart: no scaling-specific knobs beyond controller.namespaces and deployment replicas.
 
 
@@ -40,8 +40,7 @@ Webhook bursts can overload reconciliation.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -76,10 +75,10 @@ Webhook bursts can overload reconciliation.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/workflow-step-timeouts.md
+++ b/docs/agents/designs/workflow-step-timeouts.md
@@ -1,12 +1,12 @@
 # Workflow Step Timeouts and Retries
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: orchestration-controller supports retries/backoff per step but no explicit timeout fields.
 - Chart: no timeout values.
-- Cluster: no deployment env vars or values configure workflow step timeouts.
+- GitOps desired state: no deployment env vars or values configure workflow step timeouts.
 
 
 ## Problem
@@ -39,8 +39,7 @@ Long-running steps can block workflows without clear timeout handling.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -75,10 +74,10 @@ Long-running steps can block workflows without clear timeout handling.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 

--- a/docs/agents/designs/workspace-pvc-lifecycle.md
+++ b/docs/agents/designs/workspace-pvc-lifecycle.md
@@ -1,11 +1,11 @@
 # Workspace PVC Lifecycle
 
-Status: Draft (2026-02-06)
+Status: Draft (2026-02-07)
 
 ## Current State
 
 - Code: supporting controller creates PVCs for Workspace CRs and enforces TTL expiry.
-- Cluster: no Workspace resources present.
+- GitOps desired state: no Workspace resources present.
 
 
 ## Problem
@@ -38,8 +38,7 @@ Workspaces can leak storage without cleanup policies.
 - Keep configuration in the appropriate control plane (Helm values, CI, or code) and document overrides.
 - Update runbooks with enable/disable steps, rollback guidance, and expected failure modes.
 
-## Rollout
-
+## Rollout Plan
 - Ship behind feature flags or conservative defaults; validate in non-prod or CI first.
 - Verify deployment health (CI checks, ArgoCD sync, logs/metrics) before widening rollout.
 
@@ -74,10 +73,10 @@ Workspaces can leak storage without cleanup policies.
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
 ### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+As of 2026-02-07 (repo `main`):
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (from `argocd/applications/agents/values.yaml`): control plane `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae` and controllers `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`.
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
 - Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
 


### PR DESCRIPTION
## Summary

- Refresh `docs/agents/designs/*.md` to reflect the current repo + GitOps desired state (2026-02-07).
- Add shared handoff appendix `docs/agents/designs/handoff-common.md` and link it from every design doc.
- Normalize rollout headings/cluster references and update pinned image/digest examples to match `argocd/applications/agents/values.yaml`.

## Related Issues

None

## Testing

- `scripts/agents/validate-agents.sh`
- `scripts/argo-lint.sh`
- `scripts/kubeconform.sh argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
