### PR TITLE
docs(agents): refresh design docs handoff appendix

### DIFF
--- a/docs/agents/designs/admission-control-policy.md
+++ b/docs/agents/designs/admission-control-policy.md
@@ -1,7 +1,6 @@
 # Admission Control Policy for AgentRuns
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Reject unsafe or invalid AgentRuns before runtime submission by enforcing controller-level policies.
 
@@ -73,35 +72,54 @@ Reject unsafe or invalid AgentRuns before runtime submission by enforcing contro
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -125,6 +143,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -132,8 +151,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/agentctl-cli-resilience.md
+++ b/docs/agents/designs/agentctl-cli-resilience.md
@@ -1,7 +1,6 @@
 # agentctl CLI Resilience
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: agentctl lives in services/jangar/agentctl; no retry/backoff logic is implemented in the CLI.
@@ -66,35 +65,54 @@ CLI failures reduce operator trust and automation reliability.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/api-pagination-and-watch.md
+++ b/docs/agents/designs/api-pagination-and-watch.md
@@ -1,7 +1,6 @@
 # API Pagination and Watch Behavior
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: /v1/agent-runs GET queries the database via getAgentRunsByAgent without pagination parameters.
@@ -66,35 +65,54 @@ Large lists can overload the API and clients.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/approval-policy-gates.md
+++ b/docs/agents/designs/approval-policy-gates.md
@@ -1,7 +1,6 @@
 # Approval Policy Gates
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: validatePolicies checks ApprovalPolicy state in orchestration-submit and /v1/agent-runs; direct AgentRun CRs bypass it.
@@ -66,35 +65,54 @@ High-risk runs should require approval before execution.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/artifact-storage-s3.md
+++ b/docs/agents/designs/artifact-storage-s3.md
@@ -1,7 +1,6 @@
 # Artifact Storage Integration
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: codex-judge fetches artifacts from S3 using JANGAR_CODEX_ARTIFACT_BUCKET/ARTIFACT_BUCKET.
@@ -66,35 +65,54 @@ Artifacts need durable storage at scale.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/artifacthub-oci-distribution.md
+++ b/docs/agents/designs/artifacthub-oci-distribution.md
@@ -1,7 +1,6 @@
 # Artifact Hub OCI Distribution
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Define how the Agents Helm chart is packaged, published as an OCI artifact, and surfaced on Artifact Hub.
 
@@ -72,35 +71,54 @@ Define how the Agents Helm chart is packaged, published as an OCI artifact, and 
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -124,6 +142,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -131,8 +150,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/audit-logging.md
+++ b/docs/agents/designs/audit-logging.md
@@ -1,7 +1,6 @@
 # Audit Logging for Autonomous Actions
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: audit_events table + createAuditEvent in primitives-store; used by orchestration-submit and /v1/agent-runs policy decisions.
@@ -66,35 +65,54 @@ High scale PR automation needs traceable audit logs.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -1,7 +1,6 @@
 # Branch Naming and Conflict Strategy
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Provide deterministic branch naming for automated PRs and avoid conflicts when multiple runs target the same repo.
 
@@ -61,35 +60,54 @@ defaults:
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -113,6 +131,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -120,8 +139,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/budget-enforcement.md
+++ b/docs/agents/designs/budget-enforcement.md
@@ -1,7 +1,6 @@
 # Budget Enforcement
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: validateBudget enforces Budget limits in orchestration-submit and /v1/agent-runs when budgetRef is supplied.
@@ -66,35 +65,54 @@ Runs can exceed token or cost budgets without enforcement.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/chart-canary-argo-rollouts.md
+++ b/docs/agents/designs/chart-canary-argo-rollouts.md
@@ -1,7 +1,6 @@
 # Chart Canary with Argo Rollouts (Optional Integration)
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Today the Agents chart uses Kubernetes Deployments. For safer production changes (especially to controllers), operators may want progressive delivery. This doc proposes a chart-compatible integration path with Argo Rollouts without making it a hard dependency.
 
@@ -68,3 +67,93 @@ kubectl -n agents get rollout
 ## References
 - Argo Rollouts documentation: https://argo-rollouts.readthedocs.io/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-config-checksum-rollouts.md
+++ b/docs/agents/designs/chart-config-checksum-rollouts.md
@@ -1,7 +1,6 @@
 # Chart Config Checksum Rollouts
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Kubernetes does not automatically restart pods when referenced Secrets/ConfigMaps change (especially when referenced via env vars). In GitOps environments, this frequently leads to “updated Secret, pods still using old value” incidents.
 
@@ -66,3 +65,93 @@ kubectl -n agents get deploy agents -o jsonpath='{.spec.template.metadata.annota
 ## References
 - Kubernetes ConfigMaps/Secrets update behavior: https://kubernetes.io/docs/concepts/configuration/configmap/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
+++ b/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
@@ -1,7 +1,6 @@
 # Chart Controller Namespaces: Empty Semantics
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Controllers reconcile CRDs in a set of namespaces. The chart exposes `controller.namespaces`, but it is not documented what an empty list means (disabled? all namespaces? release namespace only?). Ambiguity here creates production risk.
 
@@ -48,7 +47,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_AGENTS_CONTROLLER_NAMESPACES\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_AGENTS_CONTROLLER_NAMESPACES\"
 kubectl -n agents logs deploy/agents-controllers | rg -n \"NAMESPACES|namespace\"
 ```
 
@@ -64,3 +63,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"NAMESPACES|namespace\
 ## References
 - Kubernetes controller patterns (namespace scoping best practices): https://kubernetes.io/docs/concepts/architecture/controller/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controllers-hpa.md
+++ b/docs/agents/designs/chart-controllers-hpa.md
@@ -1,7 +1,6 @@
 # Chart Controllers HorizontalPodAutoscaler
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart’s HPA template targets only the control plane Deployment (`agents`). Controllers are deployed as a separate Deployment (`agents-controllers`) but do not have autoscaling support. Controllers workload is often bursty (reconcile storms, webhook bursts), and lack of scaling can cause backlog and delayed reconciliation.
 
@@ -57,3 +56,94 @@ kubectl -n agents get hpa
 
 ## References
 - Kubernetes HPA v2: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controllers-image-override-precedence.md
+++ b/docs/agents/designs/chart-controllers-image-override-precedence.md
@@ -1,7 +1,6 @@
 # Chart Controllers Image Override Precedence
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents chart can run controllers as a separate Deployment (`agents-controllers`) with its own image. Operators need a clear contract for how `controllers.image.*` relates to the root `image.*` and the control plane `controlPlane.image.*`.
 
@@ -46,7 +45,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"name: agents-controllers|image:\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"name: agents-controllers|image:\"
 kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spec.containers[0].image}'; echo
 ```
 
@@ -61,3 +60,93 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spe
 ## References
 - Kubernetes container images: https://kubernetes.io/docs/concepts/containers/images/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controllers-pdb.md
+++ b/docs/agents/designs/chart-controllers-pdb.md
@@ -1,7 +1,6 @@
 # Chart Controllers PodDisruptionBudget
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart can deploy a separate controllers Deployment (`agents-controllers`), but the chart’s PodDisruptionBudget (PDB) template currently only targets the control plane pods. This creates an availability gap: controllers may all be evicted during node drains or cluster maintenance even when the control plane is protected.
 
@@ -60,3 +59,93 @@ kubectl -n agents get pdb
 ## References
 - Kubernetes PodDisruptionBudget: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controllers-service.md
+++ b/docs/agents/designs/chart-controllers-service.md
@@ -1,7 +1,6 @@
 # Chart Controllers Service (Optional)
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The controllers Deployment is currently internal-only and has no Service. That is usually fine, but it complicates:
 - NetworkPolicy authoring (targeting stable endpoints)
@@ -67,3 +66,93 @@ kubectl -n agents get endpoints agents-controllers
 ## References
 - Kubernetes Service type ClusterIP: https://kubernetes.io/docs/concepts/services-networking/service/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-controlplane-image-override-precedence.md
+++ b/docs/agents/designs/chart-controlplane-image-override-precedence.md
@@ -1,7 +1,6 @@
 # Chart Control Plane Image Override Precedence
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents control plane runs as the `agents` Deployment. The chart supports an explicit `controlPlane.image.*` override separate from `image.*`. This doc defines a contract for selecting that image and recommended promotion paths.
 
@@ -44,7 +43,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"kind: Deployment|name: agents$|image:\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"kind: Deployment|name: agents$|image:\"
 kubectl -n agents rollout status deploy/agents
 ```
 
@@ -59,3 +58,93 @@ kubectl -n agents rollout status deploy/agents
 ## References
 - Helm best practices for values: https://helm.sh/docs/chart_best_practices/values/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-database-url-secretref-precedence.md
+++ b/docs/agents/designs/chart-database-url-secretref-precedence.md
@@ -1,7 +1,6 @@
 # Chart Database URL vs SecretRef Precedence
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents chart supports multiple ways to provide `DATABASE_URL` to both the control plane and controllers. The precedence is currently implicit in templates; misconfiguration can lead to pods starting without a database connection or using an unintended database.
 
@@ -53,7 +52,7 @@ Rollback:
 ## Validation
 Render:
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"DATABASE_URL\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"DATABASE_URL\"
 ```
 
 Live:
@@ -75,3 +74,93 @@ kubectl -n agents get secret jangar-db-app -o yaml
 - Kubernetes Secrets as env vars: https://kubernetes.io/docs/concepts/configuration/secret/
 - Helm values best practices: https://helm.sh/docs/chart_best_practices/values/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
+++ b/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
@@ -1,7 +1,6 @@
 # Chart Deployment Strategy: RollingUpdate Tuning
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart currently relies on Kubernetes default `RollingUpdate` behavior for Deployments. For production, we should explicitly control surge/unavailable and optionally support safer strategies (e.g. `Recreate` for DB-migration-sensitive components).
 
@@ -74,3 +73,93 @@ kubectl -n agents rollout status deploy/agents
 ## References
 - Kubernetes Deployment strategy: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-env-vars-merge-precedence.md
+++ b/docs/agents/designs/chart-env-vars-merge-precedence.md
@@ -1,7 +1,6 @@
 # Chart Env Var Merge Precedence
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents Helm chart exposes multiple ways to set environment variables for the control plane and controllers. Today the precedence is implicit in templates, which makes it easy to unintentionally override critical defaults (e.g. migrations, gRPC enablement) or to believe a value is set when it is not.
 
@@ -64,7 +63,7 @@ Rollback:
 ## Validation
 Helm render:
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_MIGRATIONS|JANGAR_GRPC_ENABLED\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_MIGRATIONS|JANGAR_GRPC_ENABLED\"
 ```
 
 Cluster (desired/live):
@@ -87,3 +86,93 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_MIGRATI
 - Kubernetes environment variable precedence (explicit `env` vs `envFrom`): https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 - Helm chart best practices (values and templates): https://helm.sh/docs/chart_best_practices/values/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-envfrom-conflict-resolution.md
+++ b/docs/agents/designs/chart-envfrom-conflict-resolution.md
@@ -1,7 +1,6 @@
 # Chart envFrom Conflict Resolution
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents chart supports both explicit `env:` entries and bulk import via `envFrom` (Secrets/ConfigMaps). Kubernetes allows both, but precedence can be confusing: explicitly defined `env:` variables take precedence over values from `envFrom`.
 
@@ -56,7 +55,7 @@ Rollback:
 ## Validation
 Render:
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"envFrom:|secretRef:|configMapRef:\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"envFrom:|secretRef:|configMapRef:\"
 ```
 
 Live:
@@ -77,3 +76,93 @@ kubectl -n agents get deploy agents -o jsonpath='{.spec.template.spec.containers
 ## References
 - Kubernetes: define env vars and `envFrom`: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-extra-volumes-mounts-contract.md
+++ b/docs/agents/designs/chart-extra-volumes-mounts-contract.md
@@ -1,7 +1,6 @@
 # Chart Extra Volumes/Mounts Contract
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart supports `.Values.extraVolumes` and `.Values.extraVolumeMounts`, which are injected into both the control plane and controllers pod specs. This is a powerful escape hatch but needs a documented contract to prevent accidental conflicts with chart-managed volumes (e.g. DB CA cert).
 
@@ -51,7 +50,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"volumes:|volumeMounts:|db-ca-cert\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"volumes:|volumeMounts:|db-ca-cert\"
 kubectl -n agents get deploy agents -o yaml | rg -n \"extra|db-ca-cert|volumes:|volumeMounts:\"
 ```
 
@@ -67,3 +66,93 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"extra|db-ca-cert|volumes:|
 ## References
 - Kubernetes volumes: https://kubernetes.io/docs/concepts/storage/volumes/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
+++ b/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
@@ -1,7 +1,6 @@
 # Chart gRPC Enabled: Single Source of Truth
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart has `grpc.enabled` (controls Service + container port) while runtime can also be toggled with `JANGAR_GRPC_ENABLED` (via `env.vars`). When these disagree, the deployment can become confusing: a Service may exist without the server listening, or the server may listen without a Service/port.
 
@@ -49,7 +48,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"agents-grpc|containerPort: grpc|JANGAR_GRPC_ENABLED\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"agents-grpc|containerPort: grpc|JANGAR_GRPC_ENABLED\"
 kubectl -n agents get svc agents-grpc
 kubectl -n agents get endpointslice -l app.kubernetes.io/name=agents
 ```
@@ -65,3 +64,93 @@ kubectl -n agents get endpointslice -l app.kubernetes.io/name=agents
 ## References
 - Kubernetes Services: https://kubernetes.io/docs/concepts/services-networking/service/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-image-digest-tag-precedence.md
+++ b/docs/agents/designs/chart-image-digest-tag-precedence.md
@@ -1,7 +1,6 @@
 # Chart Image Digest/Tag Precedence
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents chart supports image tags and optional digests for both the control plane and controllers. In production GitOps, digests are preferred for immutability. The chart currently concatenates `repo:tag@digest` when a digest is provided, but the operational contract (and failure modes) are not documented.
 
@@ -55,7 +54,7 @@ Rollback:
 ## Validation
 Render:
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"image:|@sha256:\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"image:|@sha256:\"
 ```
 
 Live:
@@ -76,3 +75,93 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.spe
 ## References
 - Kubernetes container image names (tag/digest): https://kubernetes.io/docs/concepts/containers/images/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-kubernetesapi-host-port-override.md
+++ b/docs/agents/designs/chart-kubernetesapi-host-port-override.md
@@ -1,7 +1,6 @@
 # Chart Kubernetes API Host/Port Override
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart exposes `kubernetesApi.host` and `kubernetesApi.port` which map to `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT`. This is a sharp tool: it can help run outside-cluster or in unusual networking environments, but can also break in-cluster discovery if misused.
 
@@ -55,3 +54,93 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"KUBERNETES_SERVICE_HOST|KU
 ## References
 - Kubernetes in-cluster configuration: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
+++ b/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
@@ -1,7 +1,6 @@
 # Chart namespaceOverride vs Release Namespace Behavior
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart uses `namespaceOverride` to force all rendered resources into a namespace different from `.Release.Namespace`. This is useful in some GitOps setups but can be hazardous if only part of a release is overridden (e.g. CRDs are cluster-scoped, but Roles/RoleBindings are namespaced).
 
@@ -47,7 +46,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"namespace:\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"namespace:\"
 kubectl get ns agents
 ```
 
@@ -62,3 +61,93 @@ kubectl get ns agents
 ## References
 - Helm template rendering concepts: https://helm.sh/docs/chart_template_guide/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-pod-annotations-merging.md
+++ b/docs/agents/designs/chart-pod-annotations-merging.md
@@ -1,7 +1,6 @@
 # Chart Pod Annotations Merging
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart applies `.Values.podAnnotations` and `.Values.podLabels` to both the control plane pod template and the controllers pod template. Operators often need different annotations per component (e.g., different scraping, sidecar settings, or rollout controls). Today that requires global annotations that may not be appropriate for both.
 
@@ -50,7 +49,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"annotations:\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"annotations:\"
 kubectl -n agents get deploy agents -o jsonpath='{.spec.template.metadata.annotations}'; echo
 kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.metadata.annotations}'; echo
 ```
@@ -66,3 +65,93 @@ kubectl -n agents get deploy agents-controllers -o jsonpath='{.spec.template.met
 ## References
 - Kubernetes pod template metadata: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-probes-configuration-contract.md
+++ b/docs/agents/designs/chart-probes-configuration-contract.md
@@ -1,7 +1,6 @@
 # Chart Probes Configuration Contract
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart exposes HTTP liveness/readiness probe settings for the control plane, but probes may not be appropriate for controllers (which may not expose HTTP) and there is no startup probe for long initialization (e.g., cache warmup).
 
@@ -67,3 +66,93 @@ kubectl -n agents describe pod -l app.kubernetes.io/name=agents | rg -n \"Livene
 ## References
 - Kubernetes probes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
+++ b/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
@@ -1,7 +1,6 @@
 # Chart RBAC Cluster-Scoped Guardrails
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents chart can run with cluster-scoped RBAC (`rbac.clusterScoped=true`) or namespaced RBAC (`false`). Misconfiguration can lead to controller errors (insufficient permissions) or excessive permissions (overbroad access).
 
@@ -52,7 +51,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"ClusterRole|Role|clusterScoped\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"ClusterRole|Role|clusterScoped\"
 kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_RBAC_CLUSTER_SCOPED\"
 ```
 
@@ -67,3 +66,93 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_RBAC_CL
 ## References
 - Kubernetes RBAC overview: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-resources-component-overrides.md
+++ b/docs/agents/designs/chart-resources-component-overrides.md
@@ -1,7 +1,6 @@
 # Chart Resources: Component Overrides
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents chart exposes `resources` as a global default and also supports component-specific overrides (`controlPlane.resources`, `controllers.resources`). These overrides are implemented in templates but not explicitly documented, which increases the chance of accidentally starving controllers or the control plane in production.
 
@@ -55,7 +54,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"resources:|requests:|limits:\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"resources:|requests:|limits:\"
 kubectl -n agents get deploy agents -o yaml | rg -n \"resources:\"
 kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"resources:\"
 ```
@@ -72,3 +71,93 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"resources:\"
 ## References
 - Kubernetes resource requests/limits: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-rollback-helm-behavior.md
+++ b/docs/agents/designs/chart-rollback-helm-behavior.md
@@ -1,7 +1,6 @@
 # Chart Rollback Behavior and Safe Defaults
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 In GitOps, “rollback” typically means reverting values/manifests and letting Argo CD sync. Operators still rely on Helm semantics when debugging template behavior or when performing emergency rollbacks in non-GitOps contexts.
 
@@ -47,7 +46,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml >/tmp/agents.yaml
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml >/tmp/agents.yaml
 kubectl -n agents rollout status deploy/agents
 kubectl -n agents rollout status deploy/agents-controllers
 ```
@@ -63,3 +62,93 @@ kubectl -n agents rollout status deploy/agents-controllers
 ## References
 - Helm template guide: https://helm.sh/docs/chart_template_guide/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
+++ b/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
@@ -1,7 +1,6 @@
 # Chart Runner ServiceAccount Defaulting
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Agents controllers schedule Kubernetes Jobs for agent runs. The chart includes a `runnerServiceAccount` block and multiple runtime defaults (`runtime.scheduleServiceAccount`, workload defaults, and controller env vars). The defaulting hierarchy must be explicit so operators can ensure jobs run with the intended permissions.
 
@@ -52,7 +51,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT|JANGAR_SCHEDULE_SERVICE_ACCOUNT\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT|JANGAR_SCHEDULE_SERVICE_ACCOUNT\"
 kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT|JANGAR_SCHEDULE_SERVICE_ACCOUNT\"
 ```
 
@@ -67,3 +66,93 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"JANGAR_AGENT_R
 ## References
 - Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-serviceaccount-name-resolution.md
+++ b/docs/agents/designs/chart-serviceaccount-name-resolution.md
@@ -1,7 +1,6 @@
 # Chart ServiceAccount Name Resolution
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The Agents chart supports `serviceAccount.create` and `serviceAccount.name`, plus a separate `runnerServiceAccount` for jobs created by controllers. The naming and resolution rules must be explicit so operators can safely integrate with external IAM (IRSA, Workload Identity) and cluster policy.
 
@@ -57,7 +56,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"kind: ServiceAccount|serviceAccountName\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"kind: ServiceAccount|serviceAccountName\"
 kubectl -n agents get sa
 ```
 
@@ -72,3 +71,93 @@ kubectl -n agents get sa
 ## References
 - Kubernetes ServiceAccounts: https://kubernetes.io/docs/concepts/security/service-accounts/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/chart-termination-grace-prestop.md
+++ b/docs/agents/designs/chart-termination-grace-prestop.md
@@ -1,7 +1,6 @@
 # Chart Termination Grace + preStop Hook
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The control plane and controllers handle active requests and ongoing reconciliations. During rollout or node drain, pods should stop accepting new work and drain in-flight tasks before termination. The chart currently does not expose termination grace or preStop hooks.
 
@@ -64,3 +63,93 @@ kubectl -n agents rollout restart deploy/agents-controllers
 ## References
 - Kubernetes container lifecycle hooks: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/cluster-cost-optimization.md
+++ b/docs/agents/designs/cluster-cost-optimization.md
@@ -1,7 +1,6 @@
 # Cluster Cost Optimization
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: no explicit cost-optimization logic beyond concurrency limits and resource requests.
@@ -66,35 +65,54 @@ High throughput can lead to wasted compute costs.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/control-plane-ui-filters.md
+++ b/docs/agents/designs/control-plane-ui-filters.md
@@ -1,7 +1,6 @@
 # Control Plane UI Filters
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: /api/agents/control-plane/stream supports namespace selection only; no server-side label/phase filters.
@@ -66,35 +65,54 @@ Operators cannot easily filter high-volume runs.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/controller-auth-secret-mount-rotation.md
+++ b/docs/agents/designs/controller-auth-secret-mount-rotation.md
@@ -1,7 +1,6 @@
 # Controller Auth Secret Mount and Rotation
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The controllers deployment supports an “auth secret” for agentctl gRPC authentication via `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_*`. The chart can mount the Secret and set env vars, but the operational contract for rotation is not documented.
 
@@ -51,7 +50,7 @@ Rollback:
 
 ## Validation
 ```bash
-helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"AUTH_SECRET\"
+mise exec helm@3 -- helm template agents charts/agents -f argocd/applications/agents/values.yaml | rg -n \"AUTH_SECRET\"
 kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"AUTH_SECRET\"
 ```
 
@@ -66,3 +65,93 @@ kubectl -n agents get deploy agents-controllers -o yaml | rg -n \"AUTH_SECRET\"
 ## References
 - Kubernetes Secrets: https://kubernetes.io/docs/concepts/configuration/secret/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-concurrency-tuning.md
+++ b/docs/agents/designs/controller-concurrency-tuning.md
@@ -1,7 +1,6 @@
 # Controller Concurrency Tuning
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: agents-controller enforces per-agent/per-namespace/cluster concurrency; `/v1/agent-runs` admission checks
@@ -67,35 +66,54 @@ Default concurrency limits may not fit large clusters.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -119,6 +137,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -126,8 +145,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/controller-condition-type-taxonomy.md
+++ b/docs/agents/designs/controller-condition-type-taxonomy.md
@@ -1,7 +1,6 @@
 # Controller Condition Type Taxonomy
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Agents CRDs expose Kubernetes-style conditions (e.g. `Ready`, `Succeeded`, `Blocked`). Without a consistent taxonomy, automation and operator expectations diverge between resources.
 
@@ -68,3 +67,93 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.status.conditions[?(@.type=
 ## References
 - Kubernetes API conventions (Conditions): https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-controllers-deployment-grpc-off.md
+++ b/docs/agents/designs/controller-controllers-deployment-grpc-off.md
@@ -1,7 +1,6 @@
 # Controllers Deployment: gRPC Disabled by Default
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart renders a separate controllers deployment that forces `JANGAR_GRPC_ENABLED=0` unless explicitly overridden. This is a good safety default (controllers do not need to expose gRPC externally), but it is undocumented and can be surprising when operators expect agentctl gRPC to be available everywhere.
 
@@ -64,3 +63,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"gRPC|Agentctl\"
 ## References
 - gRPC basics: https://grpc.io/docs/what-is-grpc/introduction/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
+++ b/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
@@ -1,7 +1,6 @@
 # Controllers Deployment: Migrations Skipped by Default
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Database migrations are potentially disruptive and should not be run by the controllers deployment. The chart enforces this by defaulting `JANGAR_MIGRATIONS=skip` in the controllers Deployment unless explicitly overridden. This behavior should be documented and protected by validation.
 
@@ -61,3 +60,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"migration|migrations\
 ## References
 - Kubernetes init containers and migration patterns: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-failed-reconcile-events.md
+++ b/docs/agents/designs/controller-failed-reconcile-events.md
@@ -1,7 +1,6 @@
 # Controller Failed Reconcile: Kubernetes Events
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 When reconciles fail, the current primary signal is logs (and possibly status conditions). Kubernetes Events are a useful operational tool (visible via `kubectl describe`) and can improve MTTR, especially for failures like missing secrets, RBAC, or invalid spec fields.
 
@@ -63,3 +62,93 @@ kubectl -n agents describe agentrun <name> | rg -n \"Events:\"
 ## References
 - Kubernetes Events: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#event-v1-core
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-finalizer-conventions.md
+++ b/docs/agents/designs/controller-finalizer-conventions.md
@@ -1,7 +1,6 @@
 # Controller Finalizer Conventions
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Finalizers ensure controllers can perform cleanup before an object is fully deleted (e.g., deleting external runtimes). Inconsistent finalizer naming and behavior can cause stuck deletions or skipped cleanup.
 
@@ -63,3 +62,93 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.deletionTimestamp}
 ## References
 - Kubernetes finalizers: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-kubectl-version-compat.md
+++ b/docs/agents/designs/controller-kubectl-version-compat.md
@@ -1,7 +1,6 @@
 # Controller kubectl Version Compatibility
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Controllers interact with the Kubernetes API by spawning the `kubectl` binary (`primitives-kube.ts` and `kube-watch.ts`). This implicitly makes controller correctness dependent on the `kubectl` version baked into the image. We should document and enforce a compatibility policy.
 
@@ -58,3 +57,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"kubectl\"
 ## References
 - Kubernetes version skew policy: https://kubernetes.io/releases/version-skew-policy/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-namespace-scope-parse-validate.md
+++ b/docs/agents/designs/controller-namespace-scope-parse-validate.md
@@ -1,7 +1,6 @@
 # Controller Namespace Scope: Parse + Validate
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Namespace scoping is a primary safety control for Agents controllers. The controllers accept a namespaces list via env vars (`JANGAR_AGENTS_CONTROLLER_NAMESPACES`, `JANGAR_PRIMITIVES_NAMESPACES`). Invalid JSON or ambiguous inputs can lead to unexpected reconciliation scope.
 
@@ -67,3 +66,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"namespaces\"
 ## References
 - Kubernetes namespace naming: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-orchestration-submit-dedup.md
+++ b/docs/agents/designs/controller-orchestration-submit-dedup.md
@@ -1,7 +1,6 @@
 # Orchestration Submit Deduplication (Delivery ID)
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Orchestration run submission is triggered by external events (e.g., webhooks). Duplicate deliveries are common. The current system deduplicates submissions by `deliveryId` using the primitives store.
 
@@ -62,3 +61,94 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"deliveryId|idempotent
 
 ## References
 - HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-postgres-ca-rootcert.md
+++ b/docs/agents/designs/controller-postgres-ca-rootcert.md
@@ -1,7 +1,6 @@
 # Postgres TLS: PGSSLROOTCERT Wiring and Validation
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The chart supports mounting a Postgres CA bundle via `database.caSecret` and sets `PGSSLROOTCERT` to the mounted path. This is essential for production TLS, but it needs a documented contract (secret key naming, mount paths, rotation).
 
@@ -62,3 +61,93 @@ kubectl -n agents get deploy agents -o yaml | rg -n \"PGSSLROOTCERT|db-ca-cert\"
 ## References
 - Kubernetes Secrets volumes: https://kubernetes.io/docs/concepts/storage/volumes/#secret
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-reconcile-timeout-budget.md
+++ b/docs/agents/designs/controller-reconcile-timeout-budget.md
@@ -1,7 +1,6 @@
 # Controller Reconcile Timeout Budget
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Agents controllers perform multiple external operations during reconciliation (Kubernetes API calls via `kubectl`, VCS calls, webhook parsing, database operations). Today, timeouts are mostly implicit (subprocess defaults, library defaults), which makes tail-latency and hung reconciles hard to diagnose.
 
@@ -66,3 +65,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Timeout:\"
 ## References
 - Kubernetes API timeouts (client-side considerations): https://kubernetes.io/docs/reference/using-api/api-concepts/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-resourceversion-conflict-retry.md
+++ b/docs/agents/designs/controller-resourceversion-conflict-retry.md
@@ -1,7 +1,6 @@
 # Controller ResourceVersion Conflicts and Retry Strategy
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Controllers patch and apply resources that may also be updated by other actors (users, GitOps, other controllers). Conflicts (HTTP 409) and optimistic concurrency failures should be handled predictably: retry when safe, fail fast when not.
 
@@ -64,3 +63,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Conflict|409\"
 ## References
 - Kubernetes optimistic concurrency control: https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-server-side-apply-ownership.md
+++ b/docs/agents/designs/controller-server-side-apply-ownership.md
@@ -1,7 +1,6 @@
 # Controller Server-Side Apply and Field Ownership
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Controllers currently use `kubectl apply` (client-side) for many operations, and `kubectl apply --server-side --subresource=status` for status updates. Server-side apply (SSA) provides clear field ownership and reduces merge conflicts when multiple actors mutate the same objects.
 
@@ -63,3 +62,93 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.managedFields[*].m
 ## References
 - Kubernetes Server-Side Apply: https://kubernetes.io/docs/reference/using-api/server-side-apply/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-status-timestamps-generation.md
+++ b/docs/agents/designs/controller-status-timestamps-generation.md
@@ -1,7 +1,6 @@
 # Controller Status: Timestamps + observedGeneration
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Many Agents CRDs include `status.updatedAt` and `status.observedGeneration`. Consistent semantics across controllers are essential for debugging, automation, and eventual UI/CLI behavior.
 
@@ -68,3 +67,93 @@ kubectl -n agents get agentrun <name> -o jsonpath='{.metadata.generation} {.stat
 ## References
 - Kubernetes generation and status patterns: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/controller-webhook-signature-verification.md
+++ b/docs/agents/designs/controller-webhook-signature-verification.md
@@ -1,7 +1,6 @@
 # Webhook Signature Verification: ImplementationSource
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 ImplementationSource webhooks are an ingress boundary. Signature verification is implemented for GitHub (`x-hub-signature(-256)`) and Linear (`linear-signature`). This doc defines the operational contract: how secrets are stored, rotated, and validated, and how failure is surfaced safely.
 
@@ -77,3 +76,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"Invalid webhook signa
 - GitHub webhook signature docs: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
 - Linear webhook security docs: https://developers.linear.app/docs/graphql/webhooks
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-agent-config-schema.md
+++ b/docs/agents/designs/crd-agent-config-schema.md
@@ -1,7 +1,6 @@
 # CRD: Agent `spec.config` Schema and Validation
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 `Agent.spec.config` is currently an untyped map with `x-kubernetes-preserve-unknown-fields`. This gives flexibility but provides weak validation and poor UX: invalid keys/values are only discovered at runtime.
 
@@ -77,3 +76,93 @@ kubectl -n agents get agent <name> -o yaml | rg -n \"configSchemaRef|InvalidConf
 ## References
 - Kubernetes CRD validation: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-agentrun-artifacts-limits.md
+++ b/docs/agents/designs/crd-agentrun-artifacts-limits.md
@@ -1,7 +1,6 @@
 # CRD: AgentRun Artifacts Limits and Schema
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 AgentRun status can accumulate artifacts, logs, and metadata. Without limits and schema conventions, status can grow large, exceed Kubernetes object size limits, and create performance issues for controllers and clients.
 
@@ -69,3 +68,93 @@ kubectl -n agents get agentrun <name> -o yaml | rg -n \"artifacts:\"
 ## References
 - Kubernetes object size limits (etcd considerations): https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-agentrun-idempotency.md
+++ b/docs/agents/designs/crd-agentrun-idempotency.md
@@ -1,7 +1,6 @@
 # CRD: AgentRun Idempotency Key Contract
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 AgentRun includes `spec.idempotencyKey`. This field is intended to avoid duplicate runs when clients retry requests. Without a contract (scope, retention, collision handling), the field is under-specified.
 
@@ -61,3 +60,94 @@ kubectl -n agents get agentrun -o json | rg -n \"idempotencyKey\"
 
 ## References
 - HTTP request idempotency (general definition): https://www.rfc-editor.org/rfc/rfc9110.html#name-idempotent-methods
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-agentrun-spec-immutability.md
+++ b/docs/agents/designs/crd-agentrun-spec-immutability.md
@@ -1,7 +1,6 @@
 # CRD: AgentRun Spec Immutability Rules
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 AgentRuns represent a concrete execution request. After a run is accepted and started, mutating most of `spec` should be prohibited to preserve auditability and avoid undefined behavior (e.g., swapping implementation mid-run).
 
@@ -70,3 +69,93 @@ kubectl -n agents get agentrun <name> -o yaml | rg -n \"SpecImmutableViolation|s
 ## References
 - Kubernetes immutability patterns (general objects): https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-implementationsource-webhook-cel.md
+++ b/docs/agents/designs/crd-implementationsource-webhook-cel.md
@@ -1,7 +1,6 @@
 # CRD: ImplementationSource Webhook CEL Invariants
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 ImplementationSource supports webhook-driven ingestion. Certain fields must be present together (e.g., `webhook.enabled` implies a `secretRef`). Today, some of these invariants are enforced in code, but encoding them in CRD CEL rules provides immediate feedback at apply time.
 
@@ -58,3 +57,93 @@ kubectl -n agents apply -f charts/agents/examples/implementationsource-github.ya
 ## References
 - Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-implementationspec-config-constraints.md
+++ b/docs/agents/designs/crd-implementationspec-config-constraints.md
@@ -1,7 +1,6 @@
 # CRD: ImplementationSpec Runtime Config Constraints
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 ImplementationSpec contains runtime configuration that is later executed by controllers/runners. Without constraints, it is easy to create specs that are invalid or unsafe (e.g., missing required fields, invalid enum values, or overly large embedded configs).
 
@@ -60,3 +59,93 @@ kubectl -n agents get implementationspec -o yaml | rg -n \"spec:|x-kubernetes-va
 ## References
 - Kubernetes CRD validation rules (CEL): https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-lifecycle-upgrades.md
+++ b/docs/agents/designs/crd-lifecycle-upgrades.md
@@ -1,7 +1,6 @@
 # CRD Lifecycle Upgrades
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Define the lifecycle and upgrade flow for Agents CRDs, including generation, validation, packaging, rollout,
 compatibility rules, and CI enforcement. This design codifies the existing build and release workflow into a
@@ -105,35 +104,54 @@ production-ready checklist.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -157,6 +175,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -164,8 +183,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/crd-memory-retention-compaction.md
+++ b/docs/agents/designs/crd-memory-retention-compaction.md
@@ -1,7 +1,6 @@
 # CRD: Memory Retention and Compaction
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 The `Memory` CRD represents stored context/embeddings. Without retention controls and compaction, memory stores can grow without bound, increasing storage cost and slowing queries. This doc defines retention and compaction semantics managed by controllers.
 
@@ -71,3 +70,93 @@ kubectl -n agents logs deploy/agents-controllers | rg -n \"compaction|retention\
 ## References
 - Kubernetes controllers (background reconciliation): https://kubernetes.io/docs/concepts/architecture/controller/
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-orchestration-dag.md
+++ b/docs/agents/designs/crd-orchestration-dag.md
@@ -1,7 +1,6 @@
 # CRD: Orchestration DAG Semantics
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Orchestrations represent multi-step workflows. The current schema supports `spec.steps`, but the semantics around ordering, dependency graphs, and partial failure are not explicitly documented. This doc defines a DAG model that controllers can implement consistently.
 
@@ -68,3 +67,94 @@ kubectl -n agents get orchestrationrun -o yaml | rg -n \"phase:|Skipped|Dependen
 
 ## References
 - Argo Workflows DAG concepts (widely used Kubernetes DAG runtime): https://argo-workflows.readthedocs.io/en/latest/walk-through/dag/
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
+++ b/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
@@ -1,7 +1,6 @@
 # CRD: OrchestrationRun Cancel Propagation
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 Operators need reliable cancellation semantics for OrchestrationRuns. Cancelling should propagate to all active underlying runtimes (Jobs/Workflows/etc) and update status/conditions in a predictable way.
 
@@ -62,3 +61,93 @@ kubectl -n agents get orchestrationrun <name> -o yaml | rg -n \"Cancelled|phase\
 ## References
 - Kubernetes graceful termination concepts: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
+++ b/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
@@ -1,7 +1,6 @@
 # CRD: VersionControlProvider SSH and known_hosts
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Overview
 VersionControlProvider supports SSH configuration (host, user, private key secret, known_hosts ConfigMap ref). This is operationally sensitive: incorrect known_hosts handling can lead to MITM risk, and missing known_hosts can break cloning.
 
@@ -68,3 +67,93 @@ kubectl -n agents get configmap | rg known-hosts
 - OpenSSH `known_hosts` format: https://man.openbsd.org/sshd.8#SSH_KNOWN_HOSTS_FILE_FORMAT
 - Git over SSH: https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
 
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+- Helm chart: `charts/agents` (`Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `crds/`)
+- GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
+- Product appset enablement: `argocd/applicationsets/product.yaml`
+- CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
+  - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
+  - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
+  - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
+- Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
+- Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
+
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
+- Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
+- Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
+- Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
+
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
+
+```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
+kubectl get application -n argocd agents
+kubectl get crd | rg 'proompteng\.ai'
+
+kubectl rollout status -n agents deploy/agents
+kubectl rollout status -n agents deploy/agents-controllers
+```
+
+### Values → env var mapping (chart)
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
+
+Common mappings:
+- `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
+- `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
+- `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
+- `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
+- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
+- `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
+- `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
+- `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
+- `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
+- `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
+- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
+
+### Rollout plan (GitOps)
+1. Update code + chart + CRDs in one PR when changing APIs:
+   - Go types (`services/jangar/api/agents/v1alpha1/types.go`) → regenerate CRDs → `charts/agents/crds/`.
+2. Validate locally:
+   - `scripts/agents/validate-agents.sh`
+   - `scripts/argo-lint.sh`
+   - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+3. Update the GitOps overlay if rollout requires new values:
+   - `argocd/applications/agents/values.yaml`
+4. Merge to `main`; Argo CD reconciles the `agents` application.
+
+### Validation (smoke)
+- Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
+- Schema + example validation: `scripts/agents/validate-agents.sh`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
+  - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -1,6 +1,6 @@
 # Custom System Prompt for Agent Runs
 
-Status: Implemented (2026-02-06)
+Status: Implemented (2026-02-07)
 
 Note: Clusters will accept/run the new fields once the updated `charts/agents` CRDs and the relevant controller/runtime deployments (plus Argo templates, if used) are rolled out.
 
@@ -156,35 +156,54 @@ argo submit \
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -208,6 +227,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -215,8 +235,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/data-migration-runbooks.md
+++ b/docs/agents/designs/data-migration-runbooks.md
@@ -1,7 +1,6 @@
 # Data Migration Runbooks
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: migrations live under services/jangar/src/server/migrations; no dedicated runbooks in docs/agents.
@@ -66,35 +65,54 @@ Upgrades require clear migration instructions.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/disaster-recovery-backups.md
+++ b/docs/agents/designs/disaster-recovery-backups.md
@@ -1,7 +1,6 @@
 # Disaster Recovery and Backups
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: no backup/restore automation in Jangar services.
@@ -66,35 +65,54 @@ State loss can halt autonomous operations.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/github-app-auth-rotation.md
+++ b/docs/agents/designs/github-app-auth-rotation.md
@@ -1,7 +1,6 @@
 # GitHub App Auth and Token Rotation
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Support GitHub App installation tokens for VCS operations, including safe rotation and caching.
 
@@ -70,35 +69,54 @@ Support GitHub App installation tokens for VCS operations, including safe rotati
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -122,6 +140,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -129,8 +148,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -1,7 +1,6 @@
 # GitOps and Argo CD Hooks
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Chart: argocdHooks templates support PreSync cleanup and PostSync smoke AgentRun.
@@ -67,35 +66,54 @@ GitOps deployments need deterministic pre/post-sync behavior.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -119,6 +137,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -126,8 +145,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/grpc-coverage-parity.md
+++ b/docs/agents/designs/grpc-coverage-parity.md
@@ -1,7 +1,6 @@
 # gRPC Coverage Parity for agentctl
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: gRPC server in services/jangar/src/server/agentctl-grpc.ts exposes a subset of kube-mode operations; watch streams are missing.
@@ -66,35 +65,54 @@ gRPC endpoints lag behind REST and CLI features.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/implementation-contract-enforcement.md
+++ b/docs/agents/designs/implementation-contract-enforcement.md
@@ -1,7 +1,6 @@
 # Implementation Contract Enforcement
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: validateImplementationContract enforces required metadata keys on AgentRuns and workflow steps.
@@ -67,35 +66,54 @@ Runs can fail if required metadata is missing.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -119,6 +137,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -126,8 +145,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/integration-test-harness.md
+++ b/docs/agents/designs/integration-test-harness.md
@@ -1,7 +1,6 @@
 # Integration Test Harness
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Scripts: scripts/agents/kind-e2e.sh, scripts/agents/native-workflow-e2e.sh, scripts/agents/validate-agents.sh.
@@ -66,35 +65,54 @@ High-scale changes need reliable integration testing.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/job-gc-visibility.md
+++ b/docs/agents/designs/job-gc-visibility.md
@@ -1,7 +1,6 @@
 # Job GC Visibility and Retention
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: AgentRun retention via ttlSecondsAfterFinished or JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS; Job TTL via JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS; ToolRun TTL supported.
@@ -66,35 +65,54 @@ Jobs may be deleted before status is collected, causing WorkflowJobMissing.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/leader-election-ha.md
+++ b/docs/agents/designs/leader-election-ha.md
@@ -1,7 +1,6 @@
 # Leader Election for HA (Jangar Controllers)
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Purpose
 Define how Jangar controllers use Kubernetes leader election to support safe horizontal scaling, prevent double
 reconciliation, and provide predictable failover behavior.
@@ -103,35 +102,54 @@ Map values into env vars consumed by the controller runtime, for example:
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -155,6 +173,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -162,8 +181,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/load-testing-benchmarking.md
+++ b/docs/agents/designs/load-testing-benchmarking.md
@@ -1,7 +1,6 @@
 # Load Testing and Benchmarking
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: no load-testing harness in repo.
@@ -65,35 +64,54 @@ No standardized benchmark for 100-person throughput.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -117,6 +135,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -124,8 +143,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/log-retention-shipper.md
+++ b/docs/agents/designs/log-retention-shipper.md
@@ -1,7 +1,6 @@
 # Log Retention and Shipping
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: no log shipping or retention management in Jangar services.
@@ -65,35 +64,54 @@ Job logs are ephemeral and hard to retrieve after completion.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -117,6 +135,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -124,8 +143,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/metrics-otel-tracing.md
+++ b/docs/agents/designs/metrics-otel-tracing.md
@@ -1,7 +1,6 @@
 # Metrics and OpenTelemetry Tracing
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: OTEL metrics export is implemented in services/jangar/src/server/metrics.ts (OTLP HTTP exporter).
@@ -66,35 +65,54 @@ Without tracing, it is hard to debug end-to-end latency.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/multi-namespace-controller-guards.md
+++ b/docs/agents/designs/multi-namespace-controller-guards.md
@@ -1,7 +1,6 @@
 # Multi-Namespace Controller Guardrails
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: namespace-scope.assertClusterScopedForWildcard enforces rbac.clusterScoped for '*' in agents-controller and webhook ingestion.
@@ -66,35 +65,54 @@ Misconfigured namespaces can lead to missed resources or RBAC errors.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/multi-provider-auth-deprecations.md
@@ -1,7 +1,6 @@
 # Multi-Provider Auth Standards and Deprecations
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Normalize auth configuration across VCS providers and surface deprecated token types before they break.
 
@@ -73,35 +72,54 @@ Normalize auth configuration across VCS providers and surface deprecated token t
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -125,6 +143,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -132,8 +151,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/namespaced-install-matrix.md
+++ b/docs/agents/designs/namespaced-install-matrix.md
@@ -1,7 +1,6 @@
 # Namespaced vs Cluster-Scoped Install Matrix
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Define the supported install modes and their RBAC implications for the Agents control plane.
 
@@ -56,35 +55,54 @@ Define the supported install modes and their RBAC implications for the Agents co
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -108,6 +126,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -115,8 +134,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/network-policy-egress.md
+++ b/docs/agents/designs/network-policy-egress.md
@@ -1,7 +1,6 @@
 # Network Policy Egress Control
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Chart: networkPolicy template supports ingress/egress lists; disabled by default.
@@ -66,35 +65,54 @@ Autonomous agents require explicit egress controls for security.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/observability-pack.md
+++ b/docs/agents/designs/observability-pack.md
@@ -1,7 +1,6 @@
 # Observability Pack
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: OTEL metrics export exists; SSE metrics and queue depth histograms are recorded.
@@ -67,35 +66,54 @@ Operators need metrics, logs, and dashboards to run at scale.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -119,6 +137,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -126,8 +145,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/pod-security-admission.md
+++ b/docs/agents/designs/pod-security-admission.md
@@ -1,7 +1,6 @@
 # Pod Security Admission Labels
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Allow optional Pod Security Admission (PSA) labels to be applied to the agents namespace during installation.
 
@@ -57,35 +56,54 @@ podSecurityAdmission:
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -109,6 +127,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -116,8 +135,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/pr-rate-limits-batching.md
+++ b/docs/agents/designs/pr-rate-limits-batching.md
@@ -1,6 +1,6 @@
 # PR Rate Limits and Batching
 
-Status: Partial (2026-02-06)
+Status: Partial (2026-02-07)
 
 ## Purpose
 Respect VCS provider rate limits by throttling automated PR creation.
@@ -61,35 +61,54 @@ Respect VCS provider rate limits by throttling automated PR creation.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -113,6 +132,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -120,8 +140,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/queue-fairness-per-repo.md
+++ b/docs/agents/designs/queue-fairness-per-repo.md
@@ -1,7 +1,6 @@
 # Queue Fairness per Repository
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: `/v1/agent-runs` admission enforces queue caps per namespace/cluster/repo and returns 429 when exceeded. It
@@ -71,35 +70,54 @@ High-volume repos can starve smaller repos of capacity.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -123,6 +141,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -130,8 +149,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/repo-allow-deny-policy.md
+++ b/docs/agents/designs/repo-allow-deny-policy.md
@@ -1,7 +1,6 @@
 # Repository Allow and Deny Policy
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Constrain repository access for VCS operations using allow and deny lists on VersionControlProvider resources.
 
@@ -56,35 +55,54 @@ repositoryPolicy:
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -108,6 +126,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -115,8 +134,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/resourcequota-limitrange.md
+++ b/docs/agents/designs/resourcequota-limitrange.md
@@ -1,7 +1,6 @@
 # ResourceQuota and LimitRange Integration
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Chart: resourceQuota and limitRange templates exist and are disabled by default.
@@ -65,35 +64,54 @@ Clusters need quota enforcement for AgentRuns.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -117,6 +135,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -124,8 +143,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -1,6 +1,6 @@
 # Runner Image Defaults and Job TTL
 
-Status: Partial (2026-02-06)
+Status: Partial (2026-02-07)
 
 ## Purpose
 Provide reliable default runner images and safe Job TTLs so AgentRuns do not fail due to missing images or premature
@@ -63,35 +63,54 @@ cleanup.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -115,6 +134,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -122,8 +142,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/schedule-cronjob-reliability.md
+++ b/docs/agents/designs/schedule-cronjob-reliability.md
@@ -1,7 +1,6 @@
 # Schedule and CronJob Reliability
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: supporting controller materializes Schedule CRs as CronJobs and watches CronJob status.
@@ -66,35 +65,54 @@ Schedule CRDs require reliable CronJob creation and cleanup.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/scheduler-affinity-priority.md
+++ b/docs/agents/designs/scheduler-affinity-priority.md
@@ -1,7 +1,6 @@
 # Scheduler Affinity and Priority Defaults
 
-Status: Current (2026-02-06)
-
+Status: Current (2026-02-07)
 ## Purpose
 Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run overrides.
 
@@ -57,35 +56,54 @@ Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run 
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -109,6 +127,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -116,8 +135,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/secretbinding-guardrails.md
+++ b/docs/agents/designs/secretbinding-guardrails.md
@@ -1,7 +1,6 @@
 # SecretBinding Guardrails
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: supporting controller validates SecretBindings; agents-controller and /v1/agent-runs enforce allowlists.
@@ -66,35 +65,54 @@ Runs can mount secrets without clear governance.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/security-sbom-signing.md
+++ b/docs/agents/designs/security-sbom-signing.md
@@ -1,7 +1,6 @@
 # Security: SBOM and Signing
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: no SBOM generation or signing pipeline in repo workflows.
@@ -66,35 +65,54 @@ Supply chain integrity is required for production adoption.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/signal-delivery-retries.md
+++ b/docs/agents/designs/signal-delivery-retries.md
@@ -1,7 +1,6 @@
 # Signal Delivery Retries
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: SignalDelivery reconciliation marks Delivered immediately; no retry/backoff logic.
@@ -65,35 +64,54 @@ SignalDelivery failures can leave workflows stuck.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -117,6 +135,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -124,8 +143,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/staging-prod-values-overlays.md
+++ b/docs/agents/designs/staging-prod-values-overlays.md
@@ -1,7 +1,6 @@
 # Staging and Production Values Overlays
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Chart: values-dev.yaml, values-prod.yaml, values-ci.yaml, values-local.yaml, values-kind.yaml exist.
@@ -66,35 +65,54 @@ Operators need consistent overlays for staging and prod.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/supply-chain-attestations.md
+++ b/docs/agents/designs/supply-chain-attestations.md
@@ -1,7 +1,6 @@
 # Supply Chain Attestations
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: no attestations or provenance generation in workflows.
@@ -65,35 +64,54 @@ Regulated environments require provenance attestations.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -117,6 +135,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -124,8 +143,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/throughput-backpressure-quotas.md
+++ b/docs/agents/designs/throughput-backpressure-quotas.md
@@ -1,6 +1,6 @@
 # Throughput Backpressure and Admission Control
 
-Status: Partial (2026-02-06)
+Status: Partial (2026-02-07)
 
 ## Purpose
 Prevent high-volume AgentRuns from overwhelming the controller or the cluster by enforcing concurrency, queue, and
@@ -83,35 +83,54 @@ These should map to:
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -135,6 +154,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -142,8 +162,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/toolrun-runtime-isolation.md
+++ b/docs/agents/designs/toolrun-runtime-isolation.md
@@ -1,7 +1,6 @@
 # ToolRun Runtime Isolation
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: orchestration-controller submits ToolRun Jobs using tool.spec.image/command; isolation is limited to Kubernetes primitives.
@@ -65,35 +64,54 @@ Tool runs need consistent isolation and resource limits.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -117,6 +135,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -124,8 +143,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/topology-spread-defaults.md
+++ b/docs/agents/designs/topology-spread-defaults.md
@@ -1,7 +1,6 @@
 # Topology Spread Defaults
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: agents-controller applies topologySpreadConstraints from runtime config or JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS.
@@ -67,35 +66,54 @@ Workloads can stack on a single node without spread rules.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -119,6 +137,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -126,8 +145,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/values-schema-readme-automation.md
+++ b/docs/agents/designs/values-schema-readme-automation.md
@@ -1,7 +1,6 @@
 # Values Schema and README Automation
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Purpose
 Keep `charts/agents/README.md` and `charts/agents/values.schema.json` in lock-step with
 `charts/agents/values.yaml` by introducing deterministic generation and CI drift checks.
@@ -70,35 +69,54 @@ Some constraints cannot be inferred from YAML alone. Encode them via inline comm
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -122,6 +140,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -129,8 +148,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/webhook-ingestion-scaling.md
+++ b/docs/agents/designs/webhook-ingestion-scaling.md
@@ -1,7 +1,6 @@
 # Webhook Ingestion Scaling
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: implementation-source-webhooks handles GitHub/Linear webhooks, validates secrets, and writes ImplementationSpecs; no queueing layer.
@@ -67,35 +66,54 @@ Webhook bursts can overload reconciliation.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -119,6 +137,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -126,8 +145,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/workflow-step-timeouts.md
+++ b/docs/agents/designs/workflow-step-timeouts.md
@@ -1,7 +1,6 @@
 # Workflow Step Timeouts and Retries
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: orchestration-controller supports retries/backoff per step but no explicit timeout fields.
@@ -66,35 +65,54 @@ Long-running steps can block workflows without clear timeout handling.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -118,6 +136,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -125,8 +144,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-

--- a/docs/agents/designs/workspace-pvc-lifecycle.md
+++ b/docs/agents/designs/workspace-pvc-lifecycle.md
@@ -1,7 +1,6 @@
 # Workspace PVC Lifecycle
 
-Status: Draft (2026-02-06)
-
+Status: Draft (2026-02-07)
 ## Current State
 
 - Code: supporting controller creates PVCs for Workspace CRs and enforces TTL expiry.
@@ -65,35 +64,54 @@ Workspaces can leak storage without cleanup policies.
 - GitOps application (desired state): `argocd/applications/agents/application.yaml`, `argocd/applications/agents/kustomization.yaml`, `argocd/applications/agents/values.yaml`
 - Product appset enablement: `argocd/applicationsets/product.yaml`
 - CRD Go types and codegen: `services/jangar/api/agents/v1alpha1/types.go`, `scripts/agents/validate-agents.sh`
-- Controllers:
-  - Agents/AgentRuns: `services/jangar/src/server/agents-controller.ts`
+- Control plane + controllers code:
+  - Server entrypoints: `services/jangar/src/server/index.ts`, `services/jangar/src/server/app.ts`
+  - Agents/AgentRuns controller: `services/jangar/src/server/agents-controller.ts`
   - Orchestrations: `services/jangar/src/server/orchestration-controller.ts`, `services/jangar/src/server/orchestration-submit.ts`
   - Supporting primitives: `services/jangar/src/server/supporting-primitives-controller.ts`
   - Policy checks (budgets/approval/etc): `services/jangar/src/server/primitives-policy.ts`
 - Codex runners (when applicable): `services/jangar/scripts/codex/codex-implement.ts`, `packages/codex/src/runner.ts`
 - Argo WorkflowTemplates used by Codex (when applicable): `argocd/applications/froussard/*.yaml` (typically in namespace `jangar`)
 
-### Current cluster state (from GitOps manifests)
-As of 2026-02-06 (repo `main`):
+### Current cluster state (GitOps desired + live API server)
+As of 2026-02-07 (repo `main`):
+- Kubernetes API server (live): `v1.35.0+k3s1` (from `kubectl get --raw /version`).
 - Argo CD app: `agents` deploys Helm chart `charts/agents` (release `agents`) into namespace `agents` with `includeCRDs: true`. See `argocd/applications/agents/kustomization.yaml`.
 - Chart version pinned by GitOps: `0.9.1`. See `argocd/applications/agents/kustomization.yaml`.
-- Images pinned by GitOps: control plane `registry.ide-newton.ts.net/lab/jangar:4327b1dc@sha256:b836d07da13886d52b79c55178d11724e4a2d6ed8bf2748bcd9e6768bb90da8a` and controllers `registry.ide-newton.ts.net/lab/jangar-control-plane:4327b1dc@sha256:9a6df7a440b7264a5517e07e061c9647864a695e3afa002b06068ac4e6c4d494`. See `argocd/applications/agents/values.yaml`.
+- Images pinned by GitOps (see `argocd/applications/agents/values.yaml`):
+  - Control plane (`Deployment/agents`): `registry.ide-newton.ts.net/lab/jangar-control-plane:5b72ee1e@sha256:e24ef112b615401150220dc303553f47a3cefe793c0c6c28781e9575b98ab9ae`
+  - Controllers (`Deployment/agents-controllers`): `registry.ide-newton.ts.net/lab/jangar:5b72ee1e@sha256:96e72f5e649b1738ba4a48f9e786f5cdcb2ad5d63838d4009f5c71c80c2e6809`
 - Namespaced reconciliation: `controller.namespaces: [agents]` and `rbac.clusterScoped: false`. See `argocd/applications/agents/values.yaml`.
-- Runner RBAC for CI: `agents-ci` namespace resources in `argocd/applications/agents-ci/`.
+- Database connectivity: `database.secretRef.name: jangar-db-app` / `key: uri`. See `argocd/applications/agents/values.yaml`.
+- gRPC enabled: `grpc.enabled: true` on port `50051`. See `argocd/applications/agents/values.yaml`.
+- Repo allowlist: `env.vars.JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab`. See `argocd/applications/agents/values.yaml`.
+- Runner auth (GitHub token): `envFromSecretRefs: [agents-github-token-env]`. See `argocd/applications/agents/values.yaml`.
 
-Note: Treat `charts/agents/**` and `argocd/applications/**` as the desired state. To verify live cluster state, run:
+Note: This repo’s GitOps manifests are the desired state. Live verification requires a kubectl context/SA with list/get access in `agents` (and cluster-scoped access for CRDs).
+
+To verify live cluster state (requires sufficient RBAC), run:
 
 ```bash
+kubectl version --short
+kubectl get --raw /version
+
+kubectl -n agents auth can-i list deploy
+kubectl -n agents get deploy
+kubectl -n agents get pods
+
 kubectl get application -n argocd agents
-kubectl get ns | rg '^(agents|agents-ci|jangar)\b'
-kubectl get deploy -n agents
 kubectl get crd | rg 'proompteng\.ai'
+
 kubectl rollout status -n agents deploy/agents
 kubectl rollout status -n agents deploy/agents-controllers
 ```
 
 ### Values → env var mapping (chart)
-Rendered primarily by `charts/agents/templates/deployment.yaml` and `charts/agents/templates/deployment-controllers.yaml`.
+Rendered primarily by `charts/agents/templates/deployment.yaml` (control plane) and `charts/agents/templates/deployment-controllers.yaml` (controllers).
+
+Env var merge/precedence (see also `docs/agents/designs/chart-env-vars-merge-precedence.md`):
+- Control plane: `.Values.env.vars` merged with `.Values.controlPlane.env.vars` (control-plane keys win).
+- Controllers: `.Values.env.vars` merged with `.Values.controllers.env.vars` (controllers keys win), plus template defaults for `JANGAR_MIGRATIONS`, `JANGAR_GRPC_ENABLED`, and `JANGAR_CONTROL_PLANE_CACHE_ENABLED` when unset.
 
 Common mappings:
 - `controller.namespaces` → `JANGAR_AGENTS_CONTROLLER_NAMESPACES` (and also `JANGAR_PRIMITIVES_NAMESPACES`)
@@ -117,6 +135,7 @@ Common mappings:
    - `scripts/agents/validate-agents.sh`
    - `scripts/argo-lint.sh`
    - `scripts/kubeconform.sh argocd`
+   - Render the app: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. Update the GitOps overlay if rollout requires new values:
    - `argocd/applications/agents/values.yaml`
 4. Merge to `main`; Argo CD reconciles the `agents` application.
@@ -124,8 +143,7 @@ Common mappings:
 ### Validation (smoke)
 - Render the full install (Helm via kustomize): `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 - Schema + example validation: `scripts/agents/validate-agents.sh`
-- In-cluster (if you have access):
-  - `kubectl get pods -n agents`
-  - `kubectl logs -n agents deploy/agents-controllers --tail=200`
+- In-cluster (requires sufficient RBAC):
+  - `kubectl -n agents get pods`
+  - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
-


### PR DESCRIPTION
## Summary
- Refreshes all `docs/agents/designs/*.md` with a standardized, handoff-ready appendix.
- Updates GitOps-pinned images/digests and cluster/API-server version (as of 2026-02-07).
- Adds explicit repo/code/chart pointers, values→env precedence notes, rollout steps, and validation commands to every design doc.

## Related Issues
None

## Testing
- `mise exec helm@3 -- ./scripts/agents/validate-agents.sh`
- `./scripts/argo-lint.sh`
- `./scripts/kubeconform.sh argocd`
- `kubectl get --raw /version`

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Documentation is updated.
