### PR TITLE
chore(jangar): bump image

### DIFF
--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -54,5 +54,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "19448656"
-    digest: sha256:15380bb91e2a1bb4e7c59dce041859c117ceb52a873d18c9120727c8e921f25c
+    newTag: "5436c9d2"
+    digest: sha256:d673055eb54af663963dedfee69e63de46059254b830eca2a52e97e641f00349


### PR DESCRIPTION
## Summary
- Bump `argocd/jangar` pinned `registry.ide-newton.ts.net/lab/jangar` image to `5436c9d2` (digest pinned).

## Why
- Roll out the runner/controller changes to the `jangar` namespace as well.
