### PR TITLE
chore(argocd): disable agents-ci

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -122,7 +122,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
                 automation: auto
-                enabled: true
+                enabled: false
               - name: bumba
                 path: argocd/applications/bumba
                 namespace: jangar


### PR DESCRIPTION
## Summary

- Disable `agents-ci` in the `product` ApplicationSet (CI now runs on kind).
- Prevent Argo from re-creating the `agents-ci` namespace and its runner RBAC.
- Cleanly remove the `agents-ci` Argo Application via ApplicationSet pruning.

## Related Issues

None

## Testing

- `kubectl get application -n argocd agents-ci` (expected NotFound)
- `kubectl get ns agents-ci` (expected NotFound)

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
