### PR TITLE
docs(agents): add docs index links and mermaid diagrams

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,207 @@
+# Agents Docs (Index)
+
+Status: Current (2026-02-07)
+
+This is the hub for `docs/agents/**`. It is intended to make the Agents documentation set composable:
+clear entrypoints, clear “source of truth”, and a complete catalog of related documents.
+
+## Start Here
+
+- Operational/source-of-truth appendix (repo + chart + cluster): `designs/handoff-common.md`
+- Implementing the Helm chart and controllers (implementation-grade): `agents-helm-chart-implementation.md`
+- Chart intent and scope (high-level design): `agents-helm-chart-design.md`
+- How to validate changes in CI: `ci-validation-plan.md`
+- How to install/upgrade/debug (ops): `runbooks.md`
+- Security baseline: `threat-model.md`
+- RBAC requirements: `rbac-matrix.md`
+- Production bar (non-negotiables): `production-readiness-design.md`
+
+## Source Of Truth And Precedence
+
+When documents disagree, use this precedence order:
+
+1. GitOps desired state: `argocd/applications/agents/` (what the cluster should converge to).
+2. Helm chart and CRDs: `charts/agents/` (`templates/`, `values.yaml`, `values.schema.json`, `crds/`).
+3. Controller/runtime code: `services/jangar/src/server/**` and API types in `services/jangar/api/**`.
+4. “Current” docs in `docs/agents/` (implementation-grade and current requirements).
+5. “Draft/Partial” docs in `docs/agents/designs/` (proposals; may describe current behavior but are not always enforced).
+
+If you are changing behavior, update 1-3 first, then ensure 4-5 describe the resulting system accurately.
+
+## How The Docs Compose
+
+- Platform requirements and guardrails:
+  - `production-readiness-design.md`, `threat-model.md`, `rbac-matrix.md`
+- Chart + GitOps packaging and install surface:
+  - `agents-helm-chart-design.md`, `agents-helm-chart-implementation.md`, chart-level docs in `docs/agents/designs/chart-*.md`
+- API and schema:
+  - CRD generation/spec: `crd-best-practices.md`, `crd-yaml-spec.md`, plus `docs/agents/designs/crd-*.md`
+- Controllers and runtime behavior:
+  - `jangar-controller-design.md`, `leader-election-design.md`, plus `docs/agents/designs/controller-*.md`
+- Validation and operations:
+  - `ci-validation-plan.md`, `runbooks.md`, plus `docs/agents/designs/*runbook*.md`
+- Distribution:
+  - `market-readiness-and-distribution.md`, plus `docs/agents/designs/artifacthub-oci-distribution.md`
+- CLI:
+  - `agentctl.md` and `agentctl-*.md`, plus `docs/agents/designs/agentctl-*.md`
+
+## Common Change Flows
+
+### Changing CRDs
+
+- Update Go types (Agents primitives): `services/jangar/api/agents/v1alpha1/**`
+- Regenerate CRDs: `charts/agents/crds/`
+- Validate: `scripts/agents/validate-agents.sh`
+- Update examples if needed: `charts/agents/examples/**`
+- Ensure chart metadata stays accurate: `charts/agents/Chart.yaml` (CRD listings/examples)
+
+### Changing Chart Values Or Templates
+
+- Update: `charts/agents/values.yaml`, `charts/agents/values.schema.json`, `charts/agents/templates/**`
+- Update production overlay (if needed): `argocd/applications/agents/values.yaml`
+- Render the GitOps desired install: see `designs/handoff-common.md`
+
+### Changing Controller Behavior
+
+- Update: `services/jangar/src/server/**`
+- Verify env var/value mapping remains correct: `docs/agents/designs/chart-env-vars-merge-precedence.md`
+- Validate end-to-end with `scripts/agents/validate-agents.sh` and a smoke run
+
+## Catalog (All Documents)
+
+### Top-Level (`docs/agents/*.md`)
+
+- [agent-run-retention-design.md](agent-run-retention-design.md)
+- [agentctl-cli-design.md](agentctl-cli-design.md)
+- [agentctl-grpc-coverage.md](agentctl-grpc-coverage.md)
+- [agentctl-release.md](agentctl-release.md)
+- [agentctl-status-watch.md](agentctl-status-watch.md)
+- [agentctl.md](agentctl.md)
+- [agents-helm-chart-design.md](agents-helm-chart-design.md)
+- [agents-helm-chart-implementation.md](agents-helm-chart-implementation.md)
+- [ci-validation-plan.md](ci-validation-plan.md)
+- [crd-best-practices.md](crd-best-practices.md)
+- [crd-yaml-spec.md](crd-yaml-spec.md)
+- [jangar-controller-design.md](jangar-controller-design.md)
+- [leader-election-design.md](leader-election-design.md)
+- [market-readiness-and-distribution.md](market-readiness-and-distribution.md)
+- [production-readiness-design.md](production-readiness-design.md)
+- [rbac-matrix.md](rbac-matrix.md)
+- [runbooks.md](runbooks.md)
+- [threat-model.md](threat-model.md)
+- [topology-spread-constraints.md](topology-spread-constraints.md)
+- [version-control-provider-design.md](version-control-provider-design.md)
+
+### Designs (`docs/agents/designs/*.md`)
+
+- [designs/admission-control-policy.md](designs/admission-control-policy.md)
+- [designs/agentctl-cli-resilience.md](designs/agentctl-cli-resilience.md)
+- [designs/api-pagination-and-watch.md](designs/api-pagination-and-watch.md)
+- [designs/approval-policy-gates.md](designs/approval-policy-gates.md)
+- [designs/artifact-storage-s3.md](designs/artifact-storage-s3.md)
+- [designs/artifacthub-oci-distribution.md](designs/artifacthub-oci-distribution.md)
+- [designs/audit-logging.md](designs/audit-logging.md)
+- [designs/branch-naming-conflict-strategy.md](designs/branch-naming-conflict-strategy.md)
+- [designs/budget-enforcement.md](designs/budget-enforcement.md)
+- [designs/chart-canary-argo-rollouts.md](designs/chart-canary-argo-rollouts.md)
+- [designs/chart-config-checksum-rollouts.md](designs/chart-config-checksum-rollouts.md)
+- [designs/chart-controller-namespaces-empty-semantics.md](designs/chart-controller-namespaces-empty-semantics.md)
+- [designs/chart-controllers-hpa.md](designs/chart-controllers-hpa.md)
+- [designs/chart-controllers-image-override-precedence.md](designs/chart-controllers-image-override-precedence.md)
+- [designs/chart-controllers-pdb.md](designs/chart-controllers-pdb.md)
+- [designs/chart-controllers-service.md](designs/chart-controllers-service.md)
+- [designs/chart-controlplane-image-override-precedence.md](designs/chart-controlplane-image-override-precedence.md)
+- [designs/chart-database-url-secretref-precedence.md](designs/chart-database-url-secretref-precedence.md)
+- [designs/chart-deployment-strategy-rollingupdate.md](designs/chart-deployment-strategy-rollingupdate.md)
+- [designs/chart-env-vars-merge-precedence.md](designs/chart-env-vars-merge-precedence.md)
+- [designs/chart-envfrom-conflict-resolution.md](designs/chart-envfrom-conflict-resolution.md)
+- [designs/chart-extra-volumes-mounts-contract.md](designs/chart-extra-volumes-mounts-contract.md)
+- [designs/chart-grpc-enabled-source-of-truth.md](designs/chart-grpc-enabled-source-of-truth.md)
+- [designs/chart-image-digest-tag-precedence.md](designs/chart-image-digest-tag-precedence.md)
+- [designs/chart-kubernetesapi-host-port-override.md](designs/chart-kubernetesapi-host-port-override.md)
+- [designs/chart-namespaceoverride-namespace-behavior.md](designs/chart-namespaceoverride-namespace-behavior.md)
+- [designs/chart-pod-annotations-merging.md](designs/chart-pod-annotations-merging.md)
+- [designs/chart-probes-configuration-contract.md](designs/chart-probes-configuration-contract.md)
+- [designs/chart-rbac-clusterscoped-guardrails.md](designs/chart-rbac-clusterscoped-guardrails.md)
+- [designs/chart-resources-component-overrides.md](designs/chart-resources-component-overrides.md)
+- [designs/chart-rollback-helm-behavior.md](designs/chart-rollback-helm-behavior.md)
+- [designs/chart-runner-serviceaccount-defaulting.md](designs/chart-runner-serviceaccount-defaulting.md)
+- [designs/chart-serviceaccount-name-resolution.md](designs/chart-serviceaccount-name-resolution.md)
+- [designs/chart-termination-grace-prestop.md](designs/chart-termination-grace-prestop.md)
+- [designs/cluster-cost-optimization.md](designs/cluster-cost-optimization.md)
+- [designs/control-plane-ui-filters.md](designs/control-plane-ui-filters.md)
+- [designs/controller-auth-secret-mount-rotation.md](designs/controller-auth-secret-mount-rotation.md)
+- [designs/controller-concurrency-tuning.md](designs/controller-concurrency-tuning.md)
+- [designs/controller-condition-type-taxonomy.md](designs/controller-condition-type-taxonomy.md)
+- [designs/controller-controllers-deployment-grpc-off.md](designs/controller-controllers-deployment-grpc-off.md)
+- [designs/controller-controllers-deployment-migrations-skip.md](designs/controller-controllers-deployment-migrations-skip.md)
+- [designs/controller-failed-reconcile-events.md](designs/controller-failed-reconcile-events.md)
+- [designs/controller-finalizer-conventions.md](designs/controller-finalizer-conventions.md)
+- [designs/controller-kubectl-version-compat.md](designs/controller-kubectl-version-compat.md)
+- [designs/controller-namespace-scope-parse-validate.md](designs/controller-namespace-scope-parse-validate.md)
+- [designs/controller-orchestration-submit-dedup.md](designs/controller-orchestration-submit-dedup.md)
+- [designs/controller-postgres-ca-rootcert.md](designs/controller-postgres-ca-rootcert.md)
+- [designs/controller-reconcile-timeout-budget.md](designs/controller-reconcile-timeout-budget.md)
+- [designs/controller-resourceversion-conflict-retry.md](designs/controller-resourceversion-conflict-retry.md)
+- [designs/controller-server-side-apply-ownership.md](designs/controller-server-side-apply-ownership.md)
+- [designs/controller-status-timestamps-generation.md](designs/controller-status-timestamps-generation.md)
+- [designs/controller-webhook-signature-verification.md](designs/controller-webhook-signature-verification.md)
+- [designs/crd-agent-config-schema.md](designs/crd-agent-config-schema.md)
+- [designs/crd-agentrun-artifacts-limits.md](designs/crd-agentrun-artifacts-limits.md)
+- [designs/crd-agentrun-idempotency.md](designs/crd-agentrun-idempotency.md)
+- [designs/crd-agentrun-spec-immutability.md](designs/crd-agentrun-spec-immutability.md)
+- [designs/crd-implementationsource-webhook-cel.md](designs/crd-implementationsource-webhook-cel.md)
+- [designs/crd-implementationspec-config-constraints.md](designs/crd-implementationspec-config-constraints.md)
+- [designs/crd-lifecycle-upgrades.md](designs/crd-lifecycle-upgrades.md)
+- [designs/crd-memory-retention-compaction.md](designs/crd-memory-retention-compaction.md)
+- [designs/crd-orchestration-dag.md](designs/crd-orchestration-dag.md)
+- [designs/crd-orchestrationrun-cancel-propagation.md](designs/crd-orchestrationrun-cancel-propagation.md)
+- [designs/crd-versioncontrolprovider-ssh-knownhosts.md](designs/crd-versioncontrolprovider-ssh-knownhosts.md)
+- [designs/custom-system-prompt-agent-runs.md](designs/custom-system-prompt-agent-runs.md)
+- [designs/data-migration-runbooks.md](designs/data-migration-runbooks.md)
+- [designs/disaster-recovery-backups.md](designs/disaster-recovery-backups.md)
+- [designs/github-app-auth-rotation.md](designs/github-app-auth-rotation.md)
+- [designs/gitops-argocd-hooks.md](designs/gitops-argocd-hooks.md)
+- [designs/grpc-coverage-parity.md](designs/grpc-coverage-parity.md)
+- [designs/handoff-common.md](designs/handoff-common.md)
+- [designs/implementation-contract-enforcement.md](designs/implementation-contract-enforcement.md)
+- [designs/integration-test-harness.md](designs/integration-test-harness.md)
+- [designs/job-gc-visibility.md](designs/job-gc-visibility.md)
+- [designs/leader-election-ha.md](designs/leader-election-ha.md)
+- [designs/load-testing-benchmarking.md](designs/load-testing-benchmarking.md)
+- [designs/log-retention-shipper.md](designs/log-retention-shipper.md)
+- [designs/metrics-otel-tracing.md](designs/metrics-otel-tracing.md)
+- [designs/multi-namespace-controller-guards.md](designs/multi-namespace-controller-guards.md)
+- [designs/multi-provider-auth-deprecations.md](designs/multi-provider-auth-deprecations.md)
+- [designs/namespaced-install-matrix.md](designs/namespaced-install-matrix.md)
+- [designs/network-policy-egress.md](designs/network-policy-egress.md)
+- [designs/observability-pack.md](designs/observability-pack.md)
+- [designs/pod-security-admission.md](designs/pod-security-admission.md)
+- [designs/pr-rate-limits-batching.md](designs/pr-rate-limits-batching.md)
+- [designs/queue-fairness-per-repo.md](designs/queue-fairness-per-repo.md)
+- [designs/repo-allow-deny-policy.md](designs/repo-allow-deny-policy.md)
+- [designs/resourcequota-limitrange.md](designs/resourcequota-limitrange.md)
+- [designs/runner-image-defaults-job-ttl.md](designs/runner-image-defaults-job-ttl.md)
+- [designs/schedule-cronjob-reliability.md](designs/schedule-cronjob-reliability.md)
+- [designs/scheduler-affinity-priority.md](designs/scheduler-affinity-priority.md)
+- [designs/secretbinding-guardrails.md](designs/secretbinding-guardrails.md)
+- [designs/security-sbom-signing.md](designs/security-sbom-signing.md)
+- [designs/signal-delivery-retries.md](designs/signal-delivery-retries.md)
+- [designs/staging-prod-values-overlays.md](designs/staging-prod-values-overlays.md)
+- [designs/supply-chain-attestations.md](designs/supply-chain-attestations.md)
+- [designs/throughput-backpressure-quotas.md](designs/throughput-backpressure-quotas.md)
+- [designs/toolrun-runtime-isolation.md](designs/toolrun-runtime-isolation.md)
+- [designs/topology-spread-defaults.md](designs/topology-spread-defaults.md)
+- [designs/values-schema-readme-automation.md](designs/values-schema-readme-automation.md)
+- [designs/webhook-ingestion-scaling.md](designs/webhook-ingestion-scaling.md)
+- [designs/workflow-step-timeouts.md](designs/workflow-step-timeouts.md)
+- [designs/workspace-pvc-lifecycle.md](designs/workspace-pvc-lifecycle.md)
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Agents Docs (Index)"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/agent-run-retention-design.md
+++ b/docs/agents/agent-run-retention-design.md
@@ -2,6 +2,8 @@
 
 Status: Draft (2026-01-28)
 
+Docs index: [README](README.md)
+
 ## Problem
 AgentRun resources can accumulate indefinitely in production clusters. This increases etcd pressure, slows list/watch
 operations, and bloats the control plane over time. Kubernetes only provides TTL cleanup for built-in resources like
@@ -52,3 +54,12 @@ Jobs, so Agents needs a first-class retention policy for its CRDs.
 - Completed AgentRuns are automatically deleted after the configured retention window.
 - Running runs are never deleted by retention logic.
 - Helm chart exposes the retention configuration and passes schema validation.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["AgentRun Retention & Cleanup"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/agentctl-cli-design.md
+++ b/docs/agents/agentctl-cli-design.md
@@ -2,6 +2,8 @@
 
 Status: Current (2026-01-30)
 
+Docs index: [README](README.md)
+
 Location: `services/jangar/agentctl` (ships with the Jangar service; **not** a separate product or service).
 
 ## Purpose
@@ -220,3 +222,13 @@ grpc                     agents     healthy   127.0.0.1:50051
 - Default transport is Kubernetes API; gRPC is optional for direct Jangar access.
 - `agentctl` lives under `services/jangar/**` and is bundled for Node; optional Bun binaries can be published for convenience.
 - Secrets referenced by name only; values never printed.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  User["Operator"] --> CLI["agentctl"]
+  CLI -->|"kube mode (default)"| Kube["Kubernetes API"]
+  CLI -->|"gRPC (optional)"| GRPC["Service/agents-grpc"]
+  GRPC --> CP["Jangar control plane"]
+```

--- a/docs/agents/agentctl-grpc-coverage.md
+++ b/docs/agents/agentctl-grpc-coverage.md
@@ -2,6 +2,8 @@
 
 Status: Draft (2026-01-30)
 
+Docs index: [README](README.md)
+
 ## Problem
 `agentctl` supports gRPC as an optional transport, but coverage is uneven relative to the Kubernetes API mode. The CLI
 exposes list/watch/describe/apply/delete and run/log/status workflows for most Agents primitives (with newer or
@@ -174,3 +176,13 @@ Adopt `google.rpc.Status` with details to allow CLI-friendly errors:
 - Should gRPC list responses return typed protobuf resources instead of JSON strings?
 - Do we want a single `WatchResources` RPC to reduce proto bloat?
 - Should `Apply` accept JSON/YAML and server-side apply options for merges?
+
+## Diagram
+
+```mermaid
+flowchart LR
+  User["Operator"] --> CLI["agentctl"]
+  CLI -->|"kube mode (default)"| Kube["Kubernetes API"]
+  CLI -->|"gRPC (optional)"| GRPC["Service/agents-grpc"]
+  GRPC --> CP["Jangar control plane"]
+```

--- a/docs/agents/agentctl-release.md
+++ b/docs/agents/agentctl-release.md
@@ -1,5 +1,7 @@
 # agentctl release process
 
+Docs index: [README](README.md)
+
 This document describes how to build and publish `agentctl` (bundled with the Jangar service) for npm and Homebrew.
 For install/usage guidance, see `docs/agents/agentctl.md`.
 `agentctl` ships with Jangar and defaults to Kubernetes API access (gRPC optional).
@@ -108,4 +110,14 @@ Push a semver tag with the `agentctl-` prefix (e.g. `agentctl-v0.1.0`) to trigge
 ```bash
 git tag agentctl-v0.1.0
 git push origin agentctl-v0.1.0
+```
+
+## Diagram
+
+```mermaid
+flowchart LR
+  User["Operator"] --> CLI["agentctl"]
+  CLI -->|"kube mode (default)"| Kube["Kubernetes API"]
+  CLI -->|"gRPC (optional)"| GRPC["Service/agents-grpc"]
+  GRPC --> CP["Jangar control plane"]
 ```

--- a/docs/agents/agentctl-status-watch.md
+++ b/docs/agents/agentctl-status-watch.md
@@ -2,6 +2,8 @@
 
 Status: Draft (2026-01-30)
 
+Docs index: [README](README.md)
+
 ## Overview
 This document proposes a streaming status watch for the agent control plane, exposed via `agentctl` and backed by
 Jangar APIs. The goal is to let operators watch health changes (controllers, runtimes, CRDs, and dependencies)
@@ -197,3 +199,13 @@ Response event:
 - Should the `diagnose` alias use a different default output format?
 - Do we need server-side aggregation to reduce event noise (debounce window)?
 - Should we persist a rolling status timeline for audit or debugging?
+
+## Diagram
+
+```mermaid
+flowchart LR
+  User["Operator"] --> CLI["agentctl"]
+  CLI -->|"kube mode (default)"| Kube["Kubernetes API"]
+  CLI -->|"gRPC (optional)"| GRPC["Service/agents-grpc"]
+  GRPC --> CP["Jangar control plane"]
+```

--- a/docs/agents/agentctl.md
+++ b/docs/agents/agentctl.md
@@ -1,5 +1,7 @@
 # agentctl CLI
 
+Docs index: [README](README.md)
+
 `agentctl` is the CLI for managing Agents primitives. By default it talks directly to the Kubernetes API
 using your current kube context (argocd/virtctl-style). gRPC is optional and can be used when you need to
 reach Jangar directly.
@@ -98,3 +100,13 @@ bun run --filter @proompteng/agentctl build:bin
 
 The build produces `services/jangar/agentctl/dist/agentctl.js` (Node-bundled CLI). The optional
 `build:bin` step also produces a host binary at `services/jangar/agentctl/dist/agentctl`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  User["Operator"] --> CLI["agentctl"]
+  CLI -->|"kube mode (default)"| Kube["Kubernetes API"]
+  CLI -->|"gRPC (optional)"| GRPC["Service/agents-grpc"]
+  GRPC --> CP["Jangar control plane"]
+```

--- a/docs/agents/agents-helm-chart-design.md
+++ b/docs/agents/agents-helm-chart-design.md
@@ -2,6 +2,13 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
+See also:
+- `README.md` (index)
+- `agents-helm-chart-implementation.md` (implementation-grade checklist)
+- `designs/handoff-common.md` (repo/chart/cluster source-of-truth + validation commands)
+
 ## Context
 The current `charts/agents` chart bundles control-plane deployment plus CRDs and several optional add-ons.
 Today it:

--- a/docs/agents/ci-validation-plan.md
+++ b/docs/agents/ci-validation-plan.md
@@ -2,6 +2,13 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
+See also:
+- `README.md` (docs index)
+- `designs/handoff-common.md` (local render + validation commands)
+- `agents-helm-chart-implementation.md` (what CI is validating)
+
 ## CRD Validation
 - Generate **Agents** CRDs from Go types and verify:
   - Structural schema
@@ -38,3 +45,14 @@ Status: Current (2026-01-19)
 ## Security
 - SBOM generation and vulnerability scan.
 - Image signature verification checks.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Change["Change (CRDs/chart/controllers)"] --> Validate["scripts/agents/validate-agents.sh"]
+  Validate --> CRDGen["CRD generation drift check"]
+  Validate --> Kubeconform["kubeconform CRDs + examples"]
+  Validate --> Helm["helm lint + template render"]
+  Validate --> Pass["Pass/fail gate"]
+```

--- a/docs/agents/crd-best-practices.md
+++ b/docs/agents/crd-best-practices.md
@@ -2,6 +2,8 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
 ## Sources Mapped
 - Workflow engines: generate CRDs from Go types, post-process for size, validate examples.
 - Pipeline systems: keep CRDs as YAML, patch schema with controller-gen, enforce size limits, conversion webhook.
@@ -52,3 +54,13 @@ Status: Current (2026-01-19)
 - [ ] Validate examples against CRDs.
 - [ ] Update printer columns if user-visible fields change.
 - [ ] Review CEL rules for cost and correctness.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Types["Go types / static YAML"] --> Gen["controller-gen (when applicable)"]
+  Gen --> CRD["CRDs in charts/agents/crds"]
+  CRD --> Helm["Helm installs CRDs"]
+  Helm --> API["Kubernetes API server"]
+```

--- a/docs/agents/crd-yaml-spec.md
+++ b/docs/agents/crd-yaml-spec.md
@@ -2,6 +2,8 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
 ## Required CRDs
 - Agent
 - AgentRun
@@ -65,3 +67,13 @@ Status: Current (2026-01-19)
 
 ## Status Conditions (standard)
 - All CRDs include `status.conditions[]` with `type`, `status`, `reason`, `message`, `lastTransitionTime`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Types["Go types / static YAML"] --> Gen["controller-gen (when applicable)"]
+  Gen --> CRD["CRDs in charts/agents/crds"]
+  CRD --> Helm["Helm installs CRDs"]
+  Helm --> API["Kubernetes API server"]
+```

--- a/docs/agents/designs/admission-control-policy.md
+++ b/docs/agents/designs/admission-control-policy.md
@@ -1,6 +1,8 @@
 # Admission Control Policy for AgentRuns
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Reject unsafe or invalid AgentRuns before runtime submission by enforcing controller-level policies.
 
@@ -155,3 +157,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Admission Control Policy for AgentRuns"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/agentctl-cli-resilience.md
+++ b/docs/agents/designs/agentctl-cli-resilience.md
@@ -1,6 +1,8 @@
 # agentctl CLI Resilience
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: agentctl lives in services/jangar/agentctl; no retry/backoff logic is implemented in the CLI.
@@ -148,3 +150,13 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  User["Operator"] --> CLI["agentctl"]
+  CLI -->|"kube mode (default)"| Kube["Kubernetes API"]
+  CLI -->|"gRPC (optional)"| GRPC["Service/agents-grpc"]
+  GRPC --> CP["Jangar control plane"]
+```

--- a/docs/agents/designs/api-pagination-and-watch.md
+++ b/docs/agents/designs/api-pagination-and-watch.md
@@ -1,6 +1,8 @@
 # API Pagination and Watch Behavior
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: /v1/agent-runs GET queries the database via getAgentRunsByAgent without pagination parameters.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["API Pagination and Watch Behavior"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/approval-policy-gates.md
+++ b/docs/agents/designs/approval-policy-gates.md
@@ -1,6 +1,8 @@
 # Approval Policy Gates
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: validatePolicies checks ApprovalPolicy state in orchestration-submit and /v1/agent-runs; direct AgentRun CRs bypass it.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Approval Policy Gates"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/artifact-storage-s3.md
+++ b/docs/agents/designs/artifact-storage-s3.md
@@ -1,6 +1,8 @@
 # Artifact Storage Integration
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: codex-judge fetches artifacts from S3 using JANGAR_CODEX_ARTIFACT_BUCKET/ARTIFACT_BUCKET.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Artifact Storage Integration"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/artifacthub-oci-distribution.md
+++ b/docs/agents/designs/artifacthub-oci-distribution.md
@@ -1,6 +1,8 @@
 # Artifact Hub OCI Distribution
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Define how the Agents Helm chart is packaged, published as an OCI artifact, and surfaced on Artifact Hub.
 
@@ -154,3 +156,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Artifact Hub OCI Distribution"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/audit-logging.md
+++ b/docs/agents/designs/audit-logging.md
@@ -1,6 +1,8 @@
 # Audit Logging for Autonomous Actions
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: audit_events table + createAuditEvent in primitives-store; used by orchestration-submit and /v1/agent-runs policy decisions.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Audit Logging for Autonomous Actions"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -1,6 +1,8 @@
 # Branch Naming and Conflict Strategy
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Provide deterministic branch naming for automated PRs and avoid conflicts when multiple runs target the same repo.
 
@@ -143,3 +145,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Branch Naming and Conflict Strategy"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/budget-enforcement.md
+++ b/docs/agents/designs/budget-enforcement.md
@@ -1,6 +1,8 @@
 # Budget Enforcement
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: validateBudget enforces Budget limits in orchestration-submit and /v1/agent-runs when budgetRef is supplied.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Budget Enforcement"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/chart-canary-argo-rollouts.md
+++ b/docs/agents/designs/chart-canary-argo-rollouts.md
@@ -1,6 +1,8 @@
 # Chart Canary with Argo Rollouts (Optional Integration)
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Today the Agents chart uses Kubernetes Deployments. For safer production changes (especially to controllers), operators may want progressive delivery. This doc proposes a chart-compatible integration path with Argo Rollouts without making it a hard dependency.
 
@@ -157,3 +159,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-config-checksum-rollouts.md
+++ b/docs/agents/designs/chart-config-checksum-rollouts.md
@@ -1,6 +1,8 @@
 # Chart Config Checksum Rollouts
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Kubernetes does not automatically restart pods when referenced Secrets/ConfigMaps change (especially when referenced via env vars). In GitOps environments, this frequently leads to “updated Secret, pods still using old value” incidents.
 
@@ -155,3 +157,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
+++ b/docs/agents/designs/chart-controller-namespaces-empty-semantics.md
@@ -1,6 +1,8 @@
 # Chart Controller Namespaces: Empty Semantics
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Controllers reconcile CRDs in a set of namespaces. The chart exposes `controller.namespaces`, but it is not documented what an empty list means (disabled? all namespaces? release namespace only?). Ambiguity here creates production risk.
 
@@ -153,3 +155,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-controllers-hpa.md
+++ b/docs/agents/designs/chart-controllers-hpa.md
@@ -1,6 +1,8 @@
 # Chart Controllers HorizontalPodAutoscaler
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart’s HPA template targets only the control plane Deployment (`agents`). Controllers are deployed as a separate Deployment (`agents-controllers`) but do not have autoscaling support. Controllers workload is often bursty (reconcile storms, webhook bursts), and lack of scaling can cause backlog and delayed reconciliation.
 
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-controllers-image-override-precedence.md
+++ b/docs/agents/designs/chart-controllers-image-override-precedence.md
@@ -1,6 +1,8 @@
 # Chart Controllers Image Override Precedence
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents chart can run controllers as a separate Deployment (`agents-controllers`) with its own image. Operators need a clear contract for how `controllers.image.*` relates to the root `image.*` and the control plane `controlPlane.image.*`.
 
@@ -150,3 +152,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-controllers-pdb.md
+++ b/docs/agents/designs/chart-controllers-pdb.md
@@ -1,6 +1,8 @@
 # Chart Controllers PodDisruptionBudget
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart can deploy a separate controllers Deployment (`agents-controllers`), but the chart’s PodDisruptionBudget (PDB) template currently only targets the control plane pods. This creates an availability gap: controllers may all be evicted during node drains or cluster maintenance even when the control plane is protected.
 
@@ -149,3 +151,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-controllers-service.md
+++ b/docs/agents/designs/chart-controllers-service.md
@@ -1,6 +1,8 @@
 # Chart Controllers Service (Optional)
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The controllers Deployment is currently internal-only and has no Service. That is usually fine, but it complicates:
 - NetworkPolicy authoring (targeting stable endpoints)
@@ -156,3 +158,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-controlplane-image-override-precedence.md
+++ b/docs/agents/designs/chart-controlplane-image-override-precedence.md
@@ -1,6 +1,8 @@
 # Chart Control Plane Image Override Precedence
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents control plane runs as the `agents` Deployment. The chart supports an explicit `controlPlane.image.*` override separate from `image.*`. This doc defines a contract for selecting that image and recommended promotion paths.
 
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-database-url-secretref-precedence.md
+++ b/docs/agents/designs/chart-database-url-secretref-precedence.md
@@ -1,6 +1,8 @@
 # Chart Database URL vs SecretRef Precedence
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents chart supports multiple ways to provide `DATABASE_URL` to both the control plane and controllers. The precedence is currently implicit in templates; misconfiguration can lead to pods starting without a database connection or using an unintended database.
 
@@ -164,3 +166,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
+++ b/docs/agents/designs/chart-deployment-strategy-rollingupdate.md
@@ -1,6 +1,8 @@
 # Chart Deployment Strategy: RollingUpdate Tuning
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart currently relies on Kubernetes default `RollingUpdate` behavior for Deployments. For production, we should explicitly control surge/unavailable and optionally support safer strategies (e.g. `Recreate` for DB-migration-sensitive components).
 
@@ -163,3 +165,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-env-vars-merge-precedence.md
+++ b/docs/agents/designs/chart-env-vars-merge-precedence.md
@@ -1,6 +1,8 @@
 # Chart Env Var Merge Precedence
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents Helm chart exposes multiple ways to set environment variables for the control plane and controllers. Today the precedence is implicit in templates, which makes it easy to unintentionally override critical defaults (e.g. migrations, gRPC enablement) or to believe a value is set when it is not.
 
@@ -176,3 +178,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-envfrom-conflict-resolution.md
+++ b/docs/agents/designs/chart-envfrom-conflict-resolution.md
@@ -1,6 +1,8 @@
 # Chart envFrom Conflict Resolution
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents chart supports both explicit `env:` entries and bulk import via `envFrom` (Secrets/ConfigMaps). Kubernetes allows both, but precedence can be confusing: explicitly defined `env:` variables take precedence over values from `envFrom`.
 
@@ -166,3 +168,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-extra-volumes-mounts-contract.md
+++ b/docs/agents/designs/chart-extra-volumes-mounts-contract.md
@@ -1,6 +1,8 @@
 # Chart Extra Volumes/Mounts Contract
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart supports `.Values.extraVolumes` and `.Values.extraVolumeMounts`, which are injected into both the control plane and controllers pod specs. This is a powerful escape hatch but needs a documented contract to prevent accidental conflicts with chart-managed volumes (e.g. DB CA cert).
 
@@ -156,3 +158,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
+++ b/docs/agents/designs/chart-grpc-enabled-source-of-truth.md
@@ -1,6 +1,8 @@
 # Chart gRPC Enabled: Single Source of Truth
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart has `grpc.enabled` (controls Service + container port) while runtime can also be toggled with `JANGAR_GRPC_ENABLED` (via `env.vars`). When these disagree, the deployment can become confusing: a Service may exist without the server listening, or the server may listen without a Service/port.
 
@@ -154,3 +156,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-image-digest-tag-precedence.md
+++ b/docs/agents/designs/chart-image-digest-tag-precedence.md
@@ -1,6 +1,8 @@
 # Chart Image Digest/Tag Precedence
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents chart supports image tags and optional digests for both the control plane and controllers. In production GitOps, digests are preferred for immutability. The chart currently concatenates `repo:tag@digest` when a digest is provided, but the operational contract (and failure modes) are not documented.
 
@@ -165,3 +167,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-kubernetesapi-host-port-override.md
+++ b/docs/agents/designs/chart-kubernetesapi-host-port-override.md
@@ -1,6 +1,8 @@
 # Chart Kubernetes API Host/Port Override
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart exposes `kubernetesApi.host` and `kubernetesApi.port` which map to `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT`. This is a sharp tool: it can help run outside-cluster or in unusual networking environments, but can also break in-cluster discovery if misused.
 
@@ -144,3 +146,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
+++ b/docs/agents/designs/chart-namespaceoverride-namespace-behavior.md
@@ -1,6 +1,8 @@
 # Chart namespaceOverride vs Release Namespace Behavior
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart uses `namespaceOverride` to force all rendered resources into a namespace different from `.Release.Namespace`. This is useful in some GitOps setups but can be hazardous if only part of a release is overridden (e.g. CRDs are cluster-scoped, but Roles/RoleBindings are namespaced).
 
@@ -151,3 +153,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-pod-annotations-merging.md
+++ b/docs/agents/designs/chart-pod-annotations-merging.md
@@ -1,6 +1,8 @@
 # Chart Pod Annotations Merging
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart applies `.Values.podAnnotations` and `.Values.podLabels` to both the control plane pod template and the controllers pod template. Operators often need different annotations per component (e.g., different scraping, sidecar settings, or rollout controls). Today that requires global annotations that may not be appropriate for both.
 
@@ -155,3 +157,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-probes-configuration-contract.md
+++ b/docs/agents/designs/chart-probes-configuration-contract.md
@@ -1,6 +1,8 @@
 # Chart Probes Configuration Contract
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart exposes HTTP liveness/readiness probe settings for the control plane, but probes may not be appropriate for controllers (which may not expose HTTP) and there is no startup probe for long initialization (e.g., cache warmup).
 
@@ -156,3 +158,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
+++ b/docs/agents/designs/chart-rbac-clusterscoped-guardrails.md
@@ -1,6 +1,8 @@
 # Chart RBAC Cluster-Scoped Guardrails
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents chart can run with cluster-scoped RBAC (`rbac.clusterScoped=true`) or namespaced RBAC (`false`). Misconfiguration can lead to controller errors (insufficient permissions) or excessive permissions (overbroad access).
 
@@ -156,3 +158,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-resources-component-overrides.md
+++ b/docs/agents/designs/chart-resources-component-overrides.md
@@ -1,6 +1,8 @@
 # Chart Resources: Component Overrides
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents chart exposes `resources` as a global default and also supports component-specific overrides (`controlPlane.resources`, `controllers.resources`). These overrides are implemented in templates but not explicitly documented, which increases the chance of accidentally starving controllers or the control plane in production.
 
@@ -161,3 +163,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-rollback-helm-behavior.md
+++ b/docs/agents/designs/chart-rollback-helm-behavior.md
@@ -1,6 +1,8 @@
 # Chart Rollback Behavior and Safe Defaults
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 In GitOps, “rollback” typically means reverting values/manifests and letting Argo CD sync. Operators still rely on Helm semantics when debugging template behavior or when performing emergency rollbacks in non-GitOps contexts.
 
@@ -152,3 +154,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
+++ b/docs/agents/designs/chart-runner-serviceaccount-defaulting.md
@@ -1,6 +1,8 @@
 # Chart Runner ServiceAccount Defaulting
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Agents controllers schedule Kubernetes Jobs for agent runs. The chart includes a `runnerServiceAccount` block and multiple runtime defaults (`runtime.scheduleServiceAccount`, workload defaults, and controller env vars). The defaulting hierarchy must be explicit so operators can ensure jobs run with the intended permissions.
 
@@ -156,3 +158,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-serviceaccount-name-resolution.md
+++ b/docs/agents/designs/chart-serviceaccount-name-resolution.md
@@ -1,6 +1,8 @@
 # Chart ServiceAccount Name Resolution
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The Agents chart supports `serviceAccount.create` and `serviceAccount.name`, plus a separate `runnerServiceAccount` for jobs created by controllers. The naming and resolution rules must be explicit so operators can safely integrate with external IAM (IRSA, Workload Identity) and cluster policy.
 
@@ -161,3 +163,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/chart-termination-grace-prestop.md
+++ b/docs/agents/designs/chart-termination-grace-prestop.md
@@ -1,6 +1,8 @@
 # Chart Termination Grace + preStop Hook
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The control plane and controllers handle active requests and ongoing reconciliations. During rollout or node drain, pods should stop accepting new work and drain in-flight tasks before termination. The chart currently does not expose termination grace or preStop hooks.
 
@@ -153,3 +155,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Values["Helm values"] --> Render["Chart templates"]
+  Render --> Manifest["Rendered manifests"]
+  Manifest --> Live["Live objects"]
+```

--- a/docs/agents/designs/cluster-cost-optimization.md
+++ b/docs/agents/designs/cluster-cost-optimization.md
@@ -1,6 +1,8 @@
 # Cluster Cost Optimization
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: no explicit cost-optimization logic beyond concurrency limits and resource requests.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Cluster Cost Optimization"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/control-plane-ui-filters.md
+++ b/docs/agents/designs/control-plane-ui-filters.md
@@ -1,6 +1,8 @@
 # Control Plane UI Filters
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: /api/agents/control-plane/stream supports namespace selection only; no server-side label/phase filters.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Control Plane UI Filters"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/controller-auth-secret-mount-rotation.md
+++ b/docs/agents/designs/controller-auth-secret-mount-rotation.md
@@ -1,6 +1,8 @@
 # Controller Auth Secret Mount and Rotation
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The controllers deployment supports an “auth secret” for agentctl gRPC authentication via `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_*`. The chart can mount the Secret and set env vars, but the operational contract for rotation is not documented.
 
@@ -155,3 +157,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-concurrency-tuning.md
+++ b/docs/agents/designs/controller-concurrency-tuning.md
@@ -1,6 +1,8 @@
 # Controller Concurrency Tuning
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: agents-controller enforces per-agent/per-namespace/cluster concurrency; `/v1/agent-runs` admission checks
@@ -149,3 +151,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-condition-type-taxonomy.md
+++ b/docs/agents/designs/controller-condition-type-taxonomy.md
@@ -1,6 +1,8 @@
 # Controller Condition Type Taxonomy
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Agents CRDs expose Kubernetes-style conditions (e.g. `Ready`, `Succeeded`, `Blocked`). Without a consistent taxonomy, automation and operator expectations diverge between resources.
 
@@ -157,3 +159,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-controllers-deployment-grpc-off.md
+++ b/docs/agents/designs/controller-controllers-deployment-grpc-off.md
@@ -1,6 +1,8 @@
 # Controllers Deployment: gRPC Disabled by Default
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart renders a separate controllers deployment that forces `JANGAR_GRPC_ENABLED=0` unless explicitly overridden. This is a good safety default (controllers do not need to expose gRPC externally), but it is undocumented and can be surprising when operators expect agentctl gRPC to be available everywhere.
 
@@ -153,3 +155,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
+++ b/docs/agents/designs/controller-controllers-deployment-migrations-skip.md
@@ -1,6 +1,8 @@
 # Controllers Deployment: Migrations Skipped by Default
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Database migrations are potentially disruptive and should not be run by the controllers deployment. The chart enforces this by defaulting `JANGAR_MIGRATIONS=skip` in the controllers Deployment unless explicitly overridden. This behavior should be documented and protected by validation.
 
@@ -150,3 +152,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-failed-reconcile-events.md
+++ b/docs/agents/designs/controller-failed-reconcile-events.md
@@ -1,6 +1,8 @@
 # Controller Failed Reconcile: Kubernetes Events
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 When reconciles fail, the current primary signal is logs (and possibly status conditions). Kubernetes Events are a useful operational tool (visible via `kubectl describe`) and can improve MTTR, especially for failures like missing secrets, RBAC, or invalid spec fields.
 
@@ -152,3 +154,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-finalizer-conventions.md
+++ b/docs/agents/designs/controller-finalizer-conventions.md
@@ -1,6 +1,8 @@
 # Controller Finalizer Conventions
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Finalizers ensure controllers can perform cleanup before an object is fully deleted (e.g., deleting external runtimes). Inconsistent finalizer naming and behavior can cause stuck deletions or skipped cleanup.
 
@@ -152,3 +154,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-kubectl-version-compat.md
+++ b/docs/agents/designs/controller-kubectl-version-compat.md
@@ -1,6 +1,8 @@
 # Controller kubectl Version Compatibility
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Controllers interact with the Kubernetes API by spawning the `kubectl` binary (`primitives-kube.ts` and `kube-watch.ts`). This implicitly makes controller correctness dependent on the `kubectl` version baked into the image. We should document and enforce a compatibility policy.
 
@@ -147,3 +149,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-namespace-scope-parse-validate.md
+++ b/docs/agents/designs/controller-namespace-scope-parse-validate.md
@@ -1,6 +1,8 @@
 # Controller Namespace Scope: Parse + Validate
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Namespace scoping is a primary safety control for Agents controllers. The controllers accept a namespaces list via env vars (`JANGAR_AGENTS_CONTROLLER_NAMESPACES`, `JANGAR_PRIMITIVES_NAMESPACES`). Invalid JSON or ambiguous inputs can lead to unexpected reconciliation scope.
 
@@ -156,3 +158,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-orchestration-submit-dedup.md
+++ b/docs/agents/designs/controller-orchestration-submit-dedup.md
@@ -1,6 +1,8 @@
 # Orchestration Submit Deduplication (Delivery ID)
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Orchestration run submission is triggered by external events (e.g., webhooks). Duplicate deliveries are common. The current system deduplicates submissions by `deliveryId` using the primitives store.
 
@@ -152,3 +154,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-postgres-ca-rootcert.md
+++ b/docs/agents/designs/controller-postgres-ca-rootcert.md
@@ -1,6 +1,8 @@
 # Postgres TLS: PGSSLROOTCERT Wiring and Validation
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The chart supports mounting a Postgres CA bundle via `database.caSecret` and sets `PGSSLROOTCERT` to the mounted path. This is essential for production TLS, but it needs a documented contract (secret key naming, mount paths, rotation).
 
@@ -151,3 +153,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-reconcile-timeout-budget.md
+++ b/docs/agents/designs/controller-reconcile-timeout-budget.md
@@ -1,6 +1,8 @@
 # Controller Reconcile Timeout Budget
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Agents controllers perform multiple external operations during reconciliation (Kubernetes API calls via `kubectl`, VCS calls, webhook parsing, database operations). Today, timeouts are mostly implicit (subprocess defaults, library defaults), which makes tail-latency and hung reconciles hard to diagnose.
 
@@ -155,3 +157,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-resourceversion-conflict-retry.md
+++ b/docs/agents/designs/controller-resourceversion-conflict-retry.md
@@ -1,6 +1,8 @@
 # Controller ResourceVersion Conflicts and Retry Strategy
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Controllers patch and apply resources that may also be updated by other actors (users, GitOps, other controllers). Conflicts (HTTP 409) and optimistic concurrency failures should be handled predictably: retry when safe, fail fast when not.
 
@@ -153,3 +155,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-server-side-apply-ownership.md
+++ b/docs/agents/designs/controller-server-side-apply-ownership.md
@@ -1,6 +1,8 @@
 # Controller Server-Side Apply and Field Ownership
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Controllers currently use `kubectl apply` (client-side) for many operations, and `kubectl apply --server-side --subresource=status` for status updates. Server-side apply (SSA) provides clear field ownership and reduces merge conflicts when multiple actors mutate the same objects.
 
@@ -152,3 +154,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-status-timestamps-generation.md
+++ b/docs/agents/designs/controller-status-timestamps-generation.md
@@ -1,6 +1,8 @@
 # Controller Status: Timestamps + observedGeneration
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Many Agents CRDs include `status.updatedAt` and `status.observedGeneration`. Consistent semantics across controllers are essential for debugging, automation, and eventual UI/CLI behavior.
 
@@ -157,3 +159,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/controller-webhook-signature-verification.md
+++ b/docs/agents/designs/controller-webhook-signature-verification.md
@@ -1,6 +1,8 @@
 # Webhook Signature Verification: ImplementationSource
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 ImplementationSource webhooks are an ingress boundary. Signature verification is implemented for GitHub (`x-hub-signature(-256)`) and Linear (`linear-signature`). This doc defines the operational contract: how secrets are stored, rotated, and validated, and how failure is surfaced safely.
 
@@ -166,3 +168,18 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Custom Resource
+  participant C as Controller
+  participant K as Kubernetes API
+
+  CR->>C: watch event
+  C->>K: get/patch resources
+  K-->>C: response
+  C-->>CR: status update
+```

--- a/docs/agents/designs/crd-agent-config-schema.md
+++ b/docs/agents/designs/crd-agent-config-schema.md
@@ -1,6 +1,8 @@
 # CRD: Agent `spec.config` Schema and Validation
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 `Agent.spec.config` is currently an untyped map with `x-kubernetes-preserve-unknown-fields`. This gives flexibility but provides weak validation and poor UX: invalid keys/values are only discovered at runtime.
 
@@ -166,3 +168,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-agentrun-artifacts-limits.md
+++ b/docs/agents/designs/crd-agentrun-artifacts-limits.md
@@ -1,6 +1,8 @@
 # CRD: AgentRun Artifacts Limits and Schema
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 AgentRun status can accumulate artifacts, logs, and metadata. Without limits and schema conventions, status can grow large, exceed Kubernetes object size limits, and create performance issues for controllers and clients.
 
@@ -158,3 +160,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-agentrun-idempotency.md
+++ b/docs/agents/designs/crd-agentrun-idempotency.md
@@ -1,6 +1,8 @@
 # CRD: AgentRun Idempotency Key Contract
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 AgentRun includes `spec.idempotencyKey`. This field is intended to avoid duplicate runs when clients retry requests. Without a contract (scope, retention, collision handling), the field is under-specified.
 
@@ -151,3 +153,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-agentrun-spec-immutability.md
+++ b/docs/agents/designs/crd-agentrun-spec-immutability.md
@@ -1,6 +1,8 @@
 # CRD: AgentRun Spec Immutability Rules
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 AgentRuns represent a concrete execution request. After a run is accepted and started, mutating most of `spec` should be prohibited to preserve auditability and avoid undefined behavior (e.g., swapping implementation mid-run).
 
@@ -159,3 +161,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-implementationsource-webhook-cel.md
+++ b/docs/agents/designs/crd-implementationsource-webhook-cel.md
@@ -1,6 +1,8 @@
 # CRD: ImplementationSource Webhook CEL Invariants
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 ImplementationSource supports webhook-driven ingestion. Certain fields must be present together (e.g., `webhook.enabled` implies a `secretRef`). Today, some of these invariants are enforced in code, but encoding them in CRD CEL rules provides immediate feedback at apply time.
 
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-implementationspec-config-constraints.md
+++ b/docs/agents/designs/crd-implementationspec-config-constraints.md
@@ -1,6 +1,8 @@
 # CRD: ImplementationSpec Runtime Config Constraints
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 ImplementationSpec contains runtime configuration that is later executed by controllers/runners. Without constraints, it is easy to create specs that are invalid or unsafe (e.g., missing required fields, invalid enum values, or overly large embedded configs).
 
@@ -149,3 +151,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-lifecycle-upgrades.md
+++ b/docs/agents/designs/crd-lifecycle-upgrades.md
@@ -1,6 +1,8 @@
 # CRD Lifecycle Upgrades
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Define the lifecycle and upgrade flow for Agents CRDs, including generation, validation, packaging, rollout,
 compatibility rules, and CI enforcement. This design codifies the existing build and release workflow into a
@@ -187,3 +189,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-memory-retention-compaction.md
+++ b/docs/agents/designs/crd-memory-retention-compaction.md
@@ -1,6 +1,8 @@
 # CRD: Memory Retention and Compaction
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 The `Memory` CRD represents stored context/embeddings. Without retention controls and compaction, memory stores can grow without bound, increasing storage cost and slowing queries. This doc defines retention and compaction semantics managed by controllers.
 
@@ -160,3 +162,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-orchestration-dag.md
+++ b/docs/agents/designs/crd-orchestration-dag.md
@@ -1,6 +1,8 @@
 # CRD: Orchestration DAG Semantics
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Orchestrations represent multi-step workflows. The current schema supports `spec.steps`, but the semantics around ordering, dependency graphs, and partial failure are not explicitly documented. This doc defines a DAG model that controllers can implement consistently.
 
@@ -158,3 +160,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
+++ b/docs/agents/designs/crd-orchestrationrun-cancel-propagation.md
@@ -1,6 +1,8 @@
 # CRD: OrchestrationRun Cancel Propagation
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 Operators need reliable cancellation semantics for OrchestrationRuns. Cancelling should propagate to all active underlying runtimes (Jobs/Workflows/etc) and update status/conditions in a predictable way.
 
@@ -151,3 +153,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
+++ b/docs/agents/designs/crd-versioncontrolprovider-ssh-knownhosts.md
@@ -1,6 +1,8 @@
 # CRD: VersionControlProvider SSH and known_hosts
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Overview
 VersionControlProvider supports SSH configuration (host, user, private key secret, known_hosts ConfigMap ref). This is operationally sensitive: incorrect known_hosts handling can lead to MITM risk, and missing known_hosts can break cloning.
 
@@ -157,3 +159,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Spec["spec (user intent)"] --> Validate["schema + CEL (when used)"]
+  Validate --> Reconcile["controller reconcile"]
+  Reconcile --> Status["status + conditions"]
+```

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -2,6 +2,8 @@
 
 Status: Implemented (2026-02-07)
 
+Docs index: [README](../README.md)
+
 Note: Clusters will accept/run the new fields once the updated `charts/agents` CRDs and the relevant controller/runtime deployments (plus Argo templates, if used) are rolled out.
 
 ## Summary
@@ -239,3 +241,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Custom System Prompt for Agent Runs"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/data-migration-runbooks.md
+++ b/docs/agents/designs/data-migration-runbooks.md
@@ -1,6 +1,8 @@
 # Data Migration Runbooks
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: migrations live under services/jangar/src/server/migrations; no dedicated runbooks in docs/agents.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Data Migration Runbooks"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/disaster-recovery-backups.md
+++ b/docs/agents/designs/disaster-recovery-backups.md
@@ -1,6 +1,8 @@
 # Disaster Recovery and Backups
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: no backup/restore automation in Jangar services.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Disaster Recovery and Backups"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/github-app-auth-rotation.md
+++ b/docs/agents/designs/github-app-auth-rotation.md
@@ -1,6 +1,8 @@
 # GitHub App Auth and Token Rotation
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Support GitHub App installation tokens for VCS operations, including safe rotation and caching.
 
@@ -152,3 +154,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["GitHub App Auth and Token Rotation"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -1,6 +1,8 @@
 # GitOps and Argo CD Hooks
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Chart: argocdHooks templates support PreSync cleanup and PostSync smoke AgentRun.
@@ -149,3 +151,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["GitOps and Argo CD Hooks"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/grpc-coverage-parity.md
+++ b/docs/agents/designs/grpc-coverage-parity.md
@@ -1,6 +1,8 @@
 # gRPC Coverage Parity for agentctl
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: gRPC server in services/jangar/src/server/agentctl-grpc.ts exposes a subset of kube-mode operations; watch streams are missing.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["gRPC Coverage Parity for agentctl"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/handoff-common.md
+++ b/docs/agents/designs/handoff-common.md
@@ -2,8 +2,12 @@
 
 Status: Current (2026-02-07)
 
+Docs index: [README](../README.md)
+
 This document centralizes the “always the same” operational facts for the Agents stack so individual design docs
 can stay focused on their specific topic.
+
+See also: `../README.md` (docs index)
 
 ## Production / GitOps (source of truth)
 
@@ -120,3 +124,12 @@ When changing behavior that affects runtime (CRDs, controllers, chart templates,
    - `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents > /tmp/agents.yaml`
 3. If new config is needed in prod, update `argocd/applications/agents/values.yaml`.
 4. Merge to `main`; Argo CD will reconcile automatically.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Agents: Shared Handoff Appendix (Repo + Chart + Cluster)"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/implementation-contract-enforcement.md
+++ b/docs/agents/designs/implementation-contract-enforcement.md
@@ -1,6 +1,8 @@
 # Implementation Contract Enforcement
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: validateImplementationContract enforces required metadata keys on AgentRuns and workflow steps.
@@ -149,3 +151,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Implementation Contract Enforcement"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/integration-test-harness.md
+++ b/docs/agents/designs/integration-test-harness.md
@@ -1,6 +1,8 @@
 # Integration Test Harness
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Scripts: scripts/agents/kind-e2e.sh, scripts/agents/native-workflow-e2e.sh, scripts/agents/validate-agents.sh.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Integration Test Harness"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/job-gc-visibility.md
+++ b/docs/agents/designs/job-gc-visibility.md
@@ -1,6 +1,8 @@
 # Job GC Visibility and Retention
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: AgentRun retention via ttlSecondsAfterFinished or JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS; Job TTL via JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS; ToolRun TTL supported.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Job GC Visibility and Retention"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/leader-election-ha.md
+++ b/docs/agents/designs/leader-election-ha.md
@@ -1,6 +1,8 @@
 # Leader Election for HA (Jangar Controllers)
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Define how Jangar controllers use Kubernetes leader election to support safe horizontal scaling, prevent double
 reconciliation, and provide predictable failover behavior.
@@ -185,3 +187,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Leader Election for HA (Jangar Controllers)"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/load-testing-benchmarking.md
+++ b/docs/agents/designs/load-testing-benchmarking.md
@@ -1,6 +1,8 @@
 # Load Testing and Benchmarking
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: no load-testing harness in repo.
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Load Testing and Benchmarking"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/log-retention-shipper.md
+++ b/docs/agents/designs/log-retention-shipper.md
@@ -1,6 +1,8 @@
 # Log Retention and Shipping
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: no log shipping or retention management in Jangar services.
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Log Retention and Shipping"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/metrics-otel-tracing.md
+++ b/docs/agents/designs/metrics-otel-tracing.md
@@ -1,6 +1,8 @@
 # Metrics and OpenTelemetry Tracing
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: OTEL metrics export is implemented in services/jangar/src/server/metrics.ts (OTLP HTTP exporter).
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Metrics and OpenTelemetry Tracing"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/multi-namespace-controller-guards.md
+++ b/docs/agents/designs/multi-namespace-controller-guards.md
@@ -1,6 +1,8 @@
 # Multi-Namespace Controller Guardrails
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: namespace-scope.assertClusterScopedForWildcard enforces rbac.clusterScoped for '*' in agents-controller and webhook ingestion.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Multi-Namespace Controller Guardrails"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/multi-provider-auth-deprecations.md
+++ b/docs/agents/designs/multi-provider-auth-deprecations.md
@@ -1,6 +1,8 @@
 # Multi-Provider Auth Standards and Deprecations
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Normalize auth configuration across VCS providers and surface deprecated token types before they break.
 
@@ -155,3 +157,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Multi-Provider Auth Standards and Deprecations"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/namespaced-install-matrix.md
+++ b/docs/agents/designs/namespaced-install-matrix.md
@@ -1,6 +1,8 @@
 # Namespaced vs Cluster-Scoped Install Matrix
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Define the supported install modes and their RBAC implications for the Agents control plane.
 
@@ -138,3 +140,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Namespaced vs Cluster-Scoped Install Matrix"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/network-policy-egress.md
+++ b/docs/agents/designs/network-policy-egress.md
@@ -1,6 +1,8 @@
 # Network Policy Egress Control
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Chart: networkPolicy template supports ingress/egress lists; disabled by default.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Network Policy Egress Control"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/observability-pack.md
+++ b/docs/agents/designs/observability-pack.md
@@ -1,6 +1,8 @@
 # Observability Pack
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: OTEL metrics export exists; SSE metrics and queue depth histograms are recorded.
@@ -149,3 +151,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Observability Pack"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/pod-security-admission.md
+++ b/docs/agents/designs/pod-security-admission.md
@@ -1,6 +1,8 @@
 # Pod Security Admission Labels
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Allow optional Pod Security Admission (PSA) labels to be applied to the agents namespace during installation.
 
@@ -139,3 +141,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Pod Security Admission Labels"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/pr-rate-limits-batching.md
+++ b/docs/agents/designs/pr-rate-limits-batching.md
@@ -2,6 +2,8 @@
 
 Status: Partial (2026-02-07)
 
+Docs index: [README](../README.md)
+
 ## Purpose
 Respect VCS provider rate limits by throttling automated PR creation.
 
@@ -144,3 +146,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["PR Rate Limits and Batching"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/queue-fairness-per-repo.md
+++ b/docs/agents/designs/queue-fairness-per-repo.md
@@ -1,6 +1,8 @@
 # Queue Fairness per Repository
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: `/v1/agent-runs` admission enforces queue caps per namespace/cluster/repo and returns 429 when exceeded. It
@@ -153,3 +155,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Queue Fairness per Repository"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/repo-allow-deny-policy.md
+++ b/docs/agents/designs/repo-allow-deny-policy.md
@@ -1,6 +1,8 @@
 # Repository Allow and Deny Policy
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Constrain repository access for VCS operations using allow and deny lists on VersionControlProvider resources.
 
@@ -138,3 +140,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Repository Allow and Deny Policy"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/resourcequota-limitrange.md
+++ b/docs/agents/designs/resourcequota-limitrange.md
@@ -1,6 +1,8 @@
 # ResourceQuota and LimitRange Integration
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Chart: resourceQuota and limitRange templates exist and are disabled by default.
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["ResourceQuota and LimitRange Integration"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -2,6 +2,8 @@
 
 Status: Partial (2026-02-07)
 
+Docs index: [README](../README.md)
+
 ## Purpose
 Provide reliable default runner images and safe Job TTLs so AgentRuns do not fail due to missing images or premature
 cleanup.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Runner Image Defaults and Job TTL"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/schedule-cronjob-reliability.md
+++ b/docs/agents/designs/schedule-cronjob-reliability.md
@@ -1,6 +1,8 @@
 # Schedule and CronJob Reliability
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: supporting controller materializes Schedule CRs as CronJobs and watches CronJob status.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Schedule and CronJob Reliability"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/scheduler-affinity-priority.md
+++ b/docs/agents/designs/scheduler-affinity-priority.md
@@ -1,6 +1,8 @@
 # Scheduler Affinity and Priority Defaults
 
 Status: Current (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Provide consistent scheduling defaults for AgentRun Jobs while allowing per-run overrides.
 
@@ -139,3 +141,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Scheduler Affinity and Priority Defaults"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/secretbinding-guardrails.md
+++ b/docs/agents/designs/secretbinding-guardrails.md
@@ -1,6 +1,8 @@
 # SecretBinding Guardrails
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: supporting controller validates SecretBindings; agents-controller and /v1/agent-runs enforce allowlists.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["SecretBinding Guardrails"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/security-sbom-signing.md
+++ b/docs/agents/designs/security-sbom-signing.md
@@ -1,6 +1,8 @@
 # Security: SBOM and Signing
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: no SBOM generation or signing pipeline in repo workflows.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Security: SBOM and Signing"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/signal-delivery-retries.md
+++ b/docs/agents/designs/signal-delivery-retries.md
@@ -1,6 +1,8 @@
 # Signal Delivery Retries
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: SignalDelivery reconciliation marks Delivered immediately; no retry/backoff logic.
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Signal Delivery Retries"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/staging-prod-values-overlays.md
+++ b/docs/agents/designs/staging-prod-values-overlays.md
@@ -1,6 +1,8 @@
 # Staging and Production Values Overlays
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Chart: values-dev.yaml, values-prod.yaml, values-ci.yaml, values-local.yaml, values-kind.yaml exist.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Staging and Production Values Overlays"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/supply-chain-attestations.md
+++ b/docs/agents/designs/supply-chain-attestations.md
@@ -1,6 +1,8 @@
 # Supply Chain Attestations
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: no attestations or provenance generation in workflows.
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Supply Chain Attestations"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/throughput-backpressure-quotas.md
+++ b/docs/agents/designs/throughput-backpressure-quotas.md
@@ -2,6 +2,8 @@
 
 Status: Partial (2026-02-07)
 
+Docs index: [README](../README.md)
+
 ## Purpose
 Prevent high-volume AgentRuns from overwhelming the controller or the cluster by enforcing concurrency, queue, and
 rate limits.
@@ -166,3 +168,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Throughput Backpressure and Admission Control"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/toolrun-runtime-isolation.md
+++ b/docs/agents/designs/toolrun-runtime-isolation.md
@@ -1,6 +1,8 @@
 # ToolRun Runtime Isolation
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: orchestration-controller submits ToolRun Jobs using tool.spec.image/command; isolation is limited to Kubernetes primitives.
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["ToolRun Runtime Isolation"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/topology-spread-defaults.md
+++ b/docs/agents/designs/topology-spread-defaults.md
@@ -1,6 +1,8 @@
 # Topology Spread Defaults
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: agents-controller applies topologySpreadConstraints from runtime config or JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS.
@@ -149,3 +151,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Topology Spread Defaults"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/values-schema-readme-automation.md
+++ b/docs/agents/designs/values-schema-readme-automation.md
@@ -1,6 +1,8 @@
 # Values Schema and README Automation
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Purpose
 Keep `charts/agents/README.md` and `charts/agents/values.schema.json` in lock-step with
 `charts/agents/values.yaml` by introducing deterministic generation and CI drift checks.
@@ -152,3 +154,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Values Schema and README Automation"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/webhook-ingestion-scaling.md
+++ b/docs/agents/designs/webhook-ingestion-scaling.md
@@ -1,6 +1,8 @@
 # Webhook Ingestion Scaling
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: implementation-source-webhooks handles GitHub/Linear webhooks, validates secrets, and writes ImplementationSpecs; no queueing layer.
@@ -149,3 +151,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Webhook Ingestion Scaling"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/workflow-step-timeouts.md
+++ b/docs/agents/designs/workflow-step-timeouts.md
@@ -1,6 +1,8 @@
 # Workflow Step Timeouts and Retries
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: orchestration-controller supports retries/backoff per step but no explicit timeout fields.
@@ -148,3 +150,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Workflow Step Timeouts and Retries"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/designs/workspace-pvc-lifecycle.md
+++ b/docs/agents/designs/workspace-pvc-lifecycle.md
@@ -1,6 +1,8 @@
 # Workspace PVC Lifecycle
 
 Status: Draft (2026-02-07)
+
+Docs index: [README](../README.md)
 ## Current State
 
 - Code: supporting controller creates PVCs for Workspace CRs and enforces TTL expiry.
@@ -147,3 +149,12 @@ Common mappings:
   - `kubectl -n agents get pods`
   - `kubectl -n agents logs deploy/agents-controllers --tail=200`
   - Apply a minimal `Agent`/`AgentRun` from `charts/agents/examples` and confirm it reaches `Succeeded`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Workspace PVC Lifecycle"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/jangar-controller-design.md
+++ b/docs/agents/jangar-controller-design.md
@@ -2,6 +2,8 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
 ## Purpose
 Jangar is the control plane and controller for the Agents CRDs. It reconciles AgentRun, ImplementationSpec, ImplementationSource, Memory, and AgentProvider resources and drives execution via runtime adapters.
 
@@ -206,3 +208,14 @@ Rate limits and backoff:
 - Runtime schema: `spec.runtime.type` (enum: `workflow|job|temporal|custom`) plus `spec.runtime.config` (schemaless map for adapter-specific settings).
 - ImplementationSpec text limit: 128KB max; larger payloads must be stored externally and referenced via `spec.source.url`.
 - Memory override: AgentRun may override via `spec.memoryRef`, otherwise it inherits Agent → default Memory.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  CRDs["CRDs (Agent/AgentRun/...)"] --> Ctrl["Jangar controllers"]
+  Ctrl --> CM["ConfigMaps (run spec/inputs)"]
+  Ctrl --> Job["Jobs (runner execution)"]
+  Job --> Ctrl
+  Ctrl --> Status["CR status/conditions"]
+```

--- a/docs/agents/leader-election-design.md
+++ b/docs/agents/leader-election-design.md
@@ -2,6 +2,8 @@
 
 Status: Current (2026-01-29)
 
+Docs index: [README](README.md)
+
 ## Purpose
 Define how Jangar controllers use Kubernetes leader election to support safe horizontal scaling, prevent double
 reconciliation, and provide predictable failover behavior.
@@ -80,3 +82,20 @@ Expose the following values under `controller.leaderElection`:
 - `docs/agents/agents-helm-chart-implementation.md`
 - `docs/agents/jangar-controller-design.md`
 - `docs/agents/production-readiness-design.md`
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant P1 as Pod A
+  participant P2 as Pod B
+  participant L as Lease (coordination.k8s.io)
+
+  P1->>L: acquire/renew lease
+  P2-->>L: observe lease held
+  Note over P2: follower stays not-ready
+  P1-->>L: renew until crash/partition
+  P1-xL: stop renewing
+  P2->>L: acquire lease after timeout
+```

--- a/docs/agents/market-readiness-and-distribution.md
+++ b/docs/agents/market-readiness-and-distribution.md
@@ -2,6 +2,8 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
 ## Artifact Hub Publishability (Required)
 ### Chart & Repo Metadata
 - `Chart.yaml` includes:
@@ -84,3 +86,12 @@ Status: Current (2026-01-19)
 - [ ] Artifact Hub annotations present.
 - [ ] Images signed + SBOM published.
 - [ ] Docs updated.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Chart["charts/agents"] --> Package["Package/publish"]
+  Package --> OCI["GHCR OCI registry"]
+  OCI --> Hub["Artifact Hub listing"]
+```

--- a/docs/agents/production-readiness-design.md
+++ b/docs/agents/production-readiness-design.md
@@ -2,6 +2,15 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
+See also:
+- `README.md` (docs index)
+- `threat-model.md` (security baseline)
+- `rbac-matrix.md` (least-privilege requirements)
+- `ci-validation-plan.md` (validation gate)
+- `runbooks.md` (ops requirements)
+
 ## API & Contracts
 - Full CRD schemas for all resources (spec + status) with defaults and validation rules.
 - Explicit size limits for large fields (ImplementationSpec text/description, summaries, acceptance criteria).
@@ -69,3 +78,15 @@ Status: Current (2026-01-19)
   parameters max 100 entries, 2KB per value.
 - Supply chain: images signed (cosign), SBOMs (SPDX) published per release.
 - Release cadence: monthly minor, patch releases as needed for security fixes.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  PRD["Production readiness"] --> API["API + contracts"]
+  PRD --> Rel["Reliability + scaling"]
+  PRD --> Sec["Security + compliance"]
+  PRD --> Obs["Observability"]
+  PRD --> Test["Testing + validation"]
+  PRD --> Ops["Operations + runbooks"]
+```

--- a/docs/agents/rbac-matrix.md
+++ b/docs/agents/rbac-matrix.md
@@ -2,6 +2,13 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
+See also:
+- `README.md` (docs index)
+- `runbooks.md` (install/upgrade flows that require these permissions)
+- `designs/chart-rbac-clusterscoped-guardrails.md` (multi-namespace/cluster-scoped guidance)
+
 ## Components
 - Jangar controller (namespaced)
 - agentctl (user client)
@@ -44,3 +51,12 @@ If adapters run outside Jangar:
 ## Security Notes
 - Secrets must be allowlisted by Agent or AgentRun.
 - No wildcard access to secrets.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  SA["ServiceAccount"] --> Bind["(Role|ClusterRole)Binding"]
+  Bind --> Role["(Role|ClusterRole)"]
+  Role --> Kube["Kubernetes API resources<br/>(CRDs, Jobs, ConfigMaps, Secrets, ...)"]
+```

--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -2,6 +2,13 @@
 
 Status: Current (2026-01-20)
 
+Docs index: [README](README.md)
+
+See also:
+- `README.md` (docs index)
+- `designs/handoff-common.md` (GitOps render + live verification commands)
+- `ci-validation-plan.md` (what to run before/after rollout)
+
 ## Install
 1. `helm install agents charts/agents -n agents --create-namespace`
 2. Verify CRDs: `kubectl get crd | rg agents.proompteng.ai`
@@ -169,3 +176,13 @@ Troubleshooting:
 ## CRD Missing
 - Reinstall chart or apply CRD YAMLs directly.
 - Verify `kubectl api-resources | rg agents`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Install["helm install / Argo CD sync"] --> Verify["kubectl get deploy,svc,crd"]
+  Verify --> Smoke["apply examples + wait for Job/AgentRun"]
+  Smoke --> Upgrade["helm upgrade / sync"]
+  Upgrade --> Rollback["helm rollback (if needed)"]
+```

--- a/docs/agents/threat-model.md
+++ b/docs/agents/threat-model.md
@@ -2,6 +2,13 @@
 
 Status: Current (2026-01-19)
 
+Docs index: [README](README.md)
+
+See also:
+- `README.md` (docs index)
+- `rbac-matrix.md` (permissions model)
+- `production-readiness-design.md` (security requirements checklist)
+
 ## Assets
 - Source code repositories and branches
 - Credentials/secrets (GitHub/Linear tokens, runtime credentials)
@@ -37,3 +44,15 @@ Status: Current (2026-01-19)
 ## Residual Risk
 - Large ImplementationSpec content may exhaust etcd or memory if limits ignored.
 - Provider outages cause delayed runs; bounded retries prevent overload.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Ext["External providers<br/>(GitHub/Linear/etc.)"] --> Webhook["Webhook ingestion"]
+  Webhook --> CP["Jangar control plane"]
+  CP --> Kube["Kubernetes API"]
+  CP --> Runs["Runner Jobs"]
+  Secrets["Secrets"] --> CP
+  Secrets --> Runs
+```

--- a/docs/agents/topology-spread-constraints.md
+++ b/docs/agents/topology-spread-constraints.md
@@ -2,6 +2,8 @@
 
 Status: Draft (2026-01-30)
 
+Docs index: [README](README.md)
+
 ## Context
 AgentRun workloads execute as Kubernetes Jobs created by Jangar. Those job pods already support scheduling controls such as node selectors, tolerations, and affinity. We want first-class topology spread constraints so operators can distribute AgentRun pods across zones, nodes, or other topology domains without changing controller code or hand-editing workloads.
 
@@ -125,3 +127,12 @@ spec:
 ## Open Questions
 - Do we want to add a top-level `topologySpreadConstraints` for the controller Deployment pod, or keep this scoped to AgentRun workloads only?
 - Should the chart surface a short helper example in `charts/agents/README.md` once the feature is promoted beyond design stage?
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Doc["Topology Spread Constraints for AgentRun Pods"] --> Purpose["Design/contract/behavior"]
+  Purpose --> Impl["Implementation"]
+  Purpose --> Validate["Validation"]
+```

--- a/docs/agents/version-control-provider-design.md
+++ b/docs/agents/version-control-provider-design.md
@@ -2,6 +2,8 @@
 
 Status: Implemented (2026-02-03)
 
+Docs index: [README](README.md)
+
 ## Problem
 Today GitHub credentials are implicitly assumed in multiple places (environment variables, secrets, and examples), but there is no explicit model for a version control provider. This couples the control plane and chart deployments to GitHub and makes it hard to:
 - Run agents without version control access.
@@ -299,3 +301,13 @@ spec:
 - Bitbucket project access tokens: https://support.atlassian.com/bitbucket-cloud/docs/using-project-access-tokens/
 - Bitbucket OAuth 2.0 tokens: https://developer.atlassian.com/cloud/bitbucket/oauth-2/
 - Gitea API authentication methods: https://docs.gitea.com/1.20/development/api-usage
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Intake["ImplementationSource<br/>(issue intake)"] --> Spec["ImplementationSpec"]
+  Spec --> Run["AgentRun"]
+  Run --> VCP["VersionControlProvider<br/>(repo operations)"]
+  VCP --> Git["clone/commit/push/PR"]
+```


### PR DESCRIPTION
## Summary

- Add an Agents docs hub at `docs/agents/README.md` with source-of-truth + composition guidance.
- Add a `Docs index` backlink and a Mermaid `## Diagram` section to every `docs/agents/**/*.md` file.
- Fix Mermaid rendering issues (newline-split node labels, unicode arrows) so diagrams render in Cursor/GitHub.

## Related Issues

None

## Testing

- Scripted checks:
  - Verified every `docs/agents/**/*.md` contains a ` ```mermaid` block.
  - Verified no Mermaid blocks contain unicode arrows or newline-split node labels.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section not applicable.
- [x] Documentation updated.
