### PR TITLE
fix(agents): prevent controllers crash when repo overrides unset

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -47,5 +47,8 @@ env:
     JANGAR_GRPC_HOST: 0.0.0.0
     JANGAR_GRPC_PORT: "50051"
     JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab
+    # Controllers image currently expects this env var to be present; when unset it can crash on startup.
+    # Safe default: no per-repo override map.
+    JANGAR_AGENTS_CONTROLLER_REPO_CONCURRENCY_OVERRIDES: "{}"
 envFromSecretRefs:
   - agents-github-token-env


### PR DESCRIPTION
## Summary

- Fix rollout blocker: ensure `JANGAR_AGENTS_CONTROLLER_REPO_CONCURRENCY_OVERRIDES` is always set (defaults to `{}`) in the Agents GitOps overlay.
- Prevents `agents-controllers` from crashing on startup due to `Object.entries(undefined)`.

## Related Issues

None

## Testing

- Rendered the ArgoCD desired install and confirmed the env var is present in both Deployments:
  - `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents | rg JANGAR_AGENTS_CONTROLLER_REPO_CONCURRENCY_OVERRIDES`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section not applicable.
- [x] Documentation updated (inline comment in values).
