### PR TITLE
fix(agents): add jobObservedAt to AgentRun CRD

### DIFF
--- a/charts/agents/crds/agents.proompteng.ai_agentruns.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_agentruns.yaml
@@ -580,6 +580,9 @@ spec:
                             uid:
                               type: string
                           type: object
+                        jobObservedAt:
+                          format: date-time
+                          type: string
                         lastTransitionTime:
                           format: date-time
                           type: string


### PR DESCRIPTION
## Summary

- Fix AgentRun status server-side apply failures by declaring `status.workflow.steps[].jobObservedAt` in the CRD schema.
- Unblocks agents controller reconciliation for workflow runs that set `jobObservedAt`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `rg -n "jobObservedAt" /tmp/agents-render.yaml`


## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
