### PR TITLE
docs(agents): document AgentRun creation prompt precedence

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -10,6 +10,7 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Operational/source-of-truth appendix (repo + chart + cluster): `designs/handoff-common.md`
 - Implementing the Helm chart and controllers (implementation-grade): `agents-helm-chart-implementation.md`
 - Chart intent and scope (high-level design): `agents-helm-chart-design.md`
+- Creating AgentRuns safely (prompt precedence): `agentrun-creation-guide.md`
 - How to validate changes in CI: `ci-validation-plan.md`
 - How to install/upgrade/debug (ops): `runbooks.md`
 - Security baseline: `threat-model.md`
@@ -71,6 +72,7 @@ If you are changing behavior, update 1-3 first, then ensure 4-5 describe the res
 
 ### Top-Level (`docs/agents/*.md`)
 
+- [agentrun-creation-guide.md](agentrun-creation-guide.md)
 - [agent-run-retention-design.md](agent-run-retention-design.md)
 - [agentctl-cli-design.md](agentctl-cli-design.md)
 - [agentctl-grpc-coverage.md](agentctl-grpc-coverage.md)

--- a/docs/agents/agentrun-creation-guide.md
+++ b/docs/agents/agentrun-creation-guide.md
@@ -1,0 +1,143 @@
+# AgentRun Creation Guide (Prompt Precedence)
+
+Status: Current (2026-02-07)
+
+Docs index: [README](README.md)
+
+## Purpose
+
+Create AgentRuns that actually execute the intended ImplementationSpec without accidentally narrowing scope (for example,
+turning a “ship code + chart” task into a docs-only PR).
+
+This guide focuses on prompt precedence and the minimum fields needed for reliable runs.
+
+## Prompt Precedence (The Common Failure Mode)
+
+The Codex runner ultimately receives a single “user prompt” string in the generated run payload (`run.json.prompt`).
+
+Precedence (highest first):
+
+1. `AgentRun.spec.parameters.prompt` (if set)
+2. `ImplementationSpec.spec.text` (when `spec.implementationSpecRef` is used)
+3. `AgentRun.spec.implementation.inline.text` (when inline implementations are used)
+
+Rule:
+
+If you are running an ImplementationSpec, do not set `AgentRun.spec.parameters.prompt` unless you intentionally want to
+override the ImplementationSpec text.
+
+Why:
+
+`parameters.prompt` is treated as authoritative. If you set it to something like “Implement docs/...”, the runner will
+optimize for that smaller scope even if the referenced ImplementationSpec asks for code, chart, and validation changes.
+
+## Minimal AgentRun (Reference An ImplementationSpec, No Prompt Override)
+
+Example: run an existing `ImplementationSpec` and let the spec’s `text` drive the work.
+
+```yaml
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: leader-election-implementation-20260207-run
+  namespace: agents
+spec:
+  agentRef:
+    name: codex-agent
+  implementationSpecRef:
+    name: leader-election-design-20260207
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/agents/leader-election-implementation-20260207
+    issueNumber: "0"
+    issueTitle: Implement leader election (code + chart)
+    issueUrl: https://github.com/proompteng/lab/blob/main/docs/agents/leader-election-design.md
+    stage: implementation
+  runtime:
+    type: workflow
+    config:
+      ttlSecondsAfterFinished: 7200
+  secrets:
+  - codex-github-token
+  - codex-openai-key
+  workflow:
+    steps:
+    - name: implement
+      parameters:
+        stage: implement
+      timeoutSeconds: 7200
+  workload:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1024Mi
+```
+
+Notes:
+
+- The `head` branch must be writable by the configured VCS provider and should follow the repo’s conventions
+  (this repo typically uses `codex/...` prefixes).
+- Secrets are cluster- and provider-specific. If you reference a Secret (directly or via `systemPromptRef`) it must be
+  allowed by policy and often must be listed in `spec.secrets` (see `docs/agents/rbac-matrix.md`).
+
+## Verify The Run Is Using The Spec Text
+
+After `kubectl apply`:
+
+```bash
+kubectl get agentrun -n agents leader-election-implementation-20260207-run -o yaml
+
+# Inspect the generated run payload written by the controller
+kubectl get cm -n agents -l agents.proompteng.ai/agent-run=leader-election-implementation-20260207-run -o name
+kubectl get cm -n agents <run-spec-configmap> -o yaml | rg -n 'run.json:|\"prompt\"' -n
+```
+
+If `run.json.prompt` contains your ImplementationSpec `text`, you did not override the prompt.
+
+If `run.json.prompt` contains your `parameters.prompt`, you did override it.
+
+## Monitor Execution
+
+```bash
+kubectl get agentrun -n agents leader-election-implementation-20260207-run
+kubectl get job -n agents -l agents.proompteng.ai/agent-run=leader-election-implementation-20260207-run -o name
+kubectl logs -n agents job/<job-name> -f
+```
+
+## When To Use `parameters.prompt` (And When Not To)
+
+Use `parameters.prompt` when:
+
+- You are doing an ad-hoc run without an ImplementationSpec, or you are intentionally overriding the spec’s text for a
+  narrow one-off (for example, “summarize logs”).
+
+Avoid `parameters.prompt` when:
+
+- The ImplementationSpec is the source of truth for deliverables (code + chart + validation).
+- You are using a “design doc” ImplementationSpec and want it implemented as written.
+
+## System Prompt Versus User Prompt
+
+System prompt:
+
+- Configures “how the agent behaves” (process, constraints, formatting, safety).
+- Comes from Agent defaults and optional per-run overrides.
+- See `docs/agents/designs/custom-system-prompt-agent-runs.md`.
+
+User prompt:
+
+- Describes “what to do” for this run.
+- Comes from `parameters.prompt` or `ImplementationSpec.spec.text` (depending on what you set).
+
+Do not use system prompt customization to compensate for an incorrect user prompt.
+
+## Common Pitfalls Checklist
+
+- You set `spec.parameters.prompt` and unintentionally narrowed the task scope.
+- You referenced the wrong `ImplementationSpec` (check `spec.implementationSpecRef.name`).
+- You used a head branch that conflicts with another active run (see `docs/agents/version-control-provider-design.md`).
+- Required secrets were not allowlisted or not included in `spec.secrets`.
+- The repo is not in the allowlist configured for the controllers deployment.
+- You expected “followers not-ready” behavior without having implemented leader election in code and chart.
+


### PR DESCRIPTION
## Summary

- Add `docs/agents/agentrun-creation-guide.md` covering AgentRun prompt precedence (avoid `parameters.prompt` overrides for spec-driven runs).
- Link the guide from `docs/agents/README.md`.

## Related Issues

None

## Testing

- N/A (docs-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
