### PR TITLE
chore(agents): roll out controller HA + leader election

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
-replicaCount: 1
+replicaCount: 2
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f978a078
-  digest: sha256:b239fd568287aa7e366607ae1e96f3b61e73a2391021fd148aaa6c7a2f3b2664
+  tag: 3671d447
+  digest: sha256:515e03dfe27dd186cf5fcaebbb1eb9bcc773f1236bc89fc523eb0134b9e9794b
   pullPolicy: IfNotPresent
 controlPlane:
   image:


### PR DESCRIPTION
## Summary

- Roll out controller HA by scaling `agents-controllers` to 2 replicas.
- Pin the controller image to `registry.ide-newton.ts.net/lab/jangar:3671d447@sha256:515e03dfe27dd186cf5fcaebbb1eb9bcc773f1236bc89fc523eb0134b9e9794b`.
- Keeps control-plane + runner images pinned to existing digests.

## Related Issues

None

## Testing

- `bun run agents:deploy --no-apply` (build + push + update digest in `argocd/applications/agents/values.yaml`)
- `scripts/agents/validate-agents.sh`

## Breaking Changes

None
