### PR TITLE
fix(build): allow turbo-pruned installs with agentctl workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "apps/*",
     "packages/*",
     "services/*",
-    "services/jangar/agentctl"
+    "services/jangar/*"
   ],
   "dependencies": {
     "@headlessui/react": "^2.2.9",


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- 
- 
- 

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- 

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.

## Summary
Fix Docker builds that use `turbo prune --docker` by making the nested `agentctl` workspace path a glob so Bun doesn't error when the pruned context omits it.

## Changes
- Update root `package.json` workspaces entry from `services/jangar/agentctl` to `services/jangar/*`.

## Testing
- `bun install --frozen-lockfile --ignore-scripts`
