### PR TITLE
fix: stabilize oirat build and Jangar embedding timeout

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -227,6 +227,8 @@ spec:
               value: qwen3-embedding-saigak:0.6b
             - name: OPENAI_EMBEDDING_DIMENSION
               value: "1024"
+            - name: OPENAI_EMBEDDING_TIMEOUT_MS
+              value: "60000"
           ports:
             - name: http
               containerPort: 8080

--- a/services/oirat/Dockerfile
+++ b/services/oirat/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /app
 ENV HUSKY=0
 COPY json/ .
 COPY tsconfig.base.json ./
+# Turbo prune keeps the root workspace list; drop entries that don't exist in the pruned context.
+RUN bun -e "const fs = require('fs'); const p = 'package.json'; const pkg = JSON.parse(fs.readFileSync(p, 'utf8')); if (Array.isArray(pkg.workspaces)) { pkg.workspaces = pkg.workspaces.filter((entry) => entry !== 'services/jangar/*' && entry !== 'services/jangar/agentctl'); fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\\n'); }"
 RUN --mount=type=cache,target=/root/.cache/bun \
   bun install --no-save --frozen-lockfile --ignore-scripts --filter @proompteng/oirat
 
@@ -20,6 +22,7 @@ WORKDIR /app
 ENV HUSKY=0
 COPY json/ .
 COPY tsconfig.base.json ./
+RUN bun -e "const fs = require('fs'); const p = 'package.json'; const pkg = JSON.parse(fs.readFileSync(p, 'utf8')); if (Array.isArray(pkg.workspaces)) { pkg.workspaces = pkg.workspaces.filter((entry) => entry !== 'services/jangar/*' && entry !== 'services/jangar/agentctl'); fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\\n'); }"
 RUN --mount=type=cache,target=/root/.cache/bun \
   bun install --no-save --production --frozen-lockfile --ignore-scripts --filter @proompteng/oirat
 


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- Increase Jangar embedding request timeout to 60s via OPENAI_EMBEDDING_TIMEOUT_MS (self-hosted Ollama endpoint).
- Make services/oirat Docker build resilient to Turbo-pruned contexts by dropping missing Jangar workspaces before bun install.
- Keeps docker-build workflow unchanged; fix is localized to the Dockerfile/deployment config.

## Related Issues

None

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- bun run lint:argocd
- docker build using turbo-pruned context for oirat

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
