### PR TITLE
chore(jangar): deploy c4be4253

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-07T07:58:42.902Z"
+    deploy.knative.dev/rollout: "2026-02-08T20:51:24.786Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -54,5 +54,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f978a078"
-    digest: sha256:20a3673362f11bd2674523d8f2a84ee0a86caef706f43d84181c70c00f1e4279
+    newTag: "c4be4253"
+    digest: sha256:a5a9d933e13c452df91e9184d8931082da0f8bafef1336ee8f7fb5b931176519


### PR DESCRIPTION
## Summary

- Built and pushed Jangar image for `c4be4253`.
- Updated `argocd/applications/jangar/kustomization.yaml` to pin the new tag + digest.
- Updated `argocd/applications/jangar/deployment.yaml` rollout annotation and deployed to the cluster.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/jangar/deploy-service.ts`
- `kubectl -n jangar rollout status deploy/jangar --timeout=5m`

## Breaking Changes

None
