### PR TITLE
chore(jangar): deploy 2f466157

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-08T20:51:24.786Z"
+    deploy.knative.dev/rollout: "2026-02-08T20:56:17.065Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -54,5 +54,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c4be4253"
-    digest: sha256:a5a9d933e13c452df91e9184d8931082da0f8bafef1336ee8f7fb5b931176519
+    newTag: "2f466157"
+    digest: sha256:8c3788508e2fcb97c4ae551b6ee463f8368532167a7cc25e114de589d2727ab1


### PR DESCRIPTION
## Summary

- Updated Jangar Argo manifests to match the currently deployed image tag + digest.
- Bumped rollout annotation to force rollout tracking.

## Related Issues

None

## Testing

- `kubectl -n jangar rollout status deploy/jangar --timeout=2m`
- `kubectl -n jangar get deploy jangar -o jsonpath='{.spec.template.spec.containers[0].image}'`

## Breaking Changes

None
