### PR TITLE
Torghut: ClickHouse disk guardrails + alerts + pause-TA runbook

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -95,71 +95,53 @@ data:
             annotations:
               summary: Jangar SSE error rate elevated
               description: SSE error responses exceed 0.05/sec for 10 minutes across Jangar streams.
-      - name: torghut-clickhouse.guardrails
+      - name: torghut-clickhouse.guardrails.rules
         rules:
-          - alert: TorghutClickHouseDiskFreeLow
+          - alert: TorghutClickHouseDiskFreeLowWarning
             expr: |
-              (
-                kubelet_volume_stats_available_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"}
-                /
-                clamp_min(
-                  kubelet_volume_stats_capacity_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"},
-                  1
-                )
-              ) < 0.15
-            for: 15m
+              torghut_clickhouse_guardrails_disk_free_ratio{
+                namespace="torghut",
+                service="torghut-clickhouse-guardrails-exporter"
+              } < 0.15
+            for: 10m
             labels:
               severity: warning
             annotations:
-              summary: Torghut ClickHouse PVC free space < 15%
+              summary: Torghut ClickHouse disk free < 15%
               description: |
-                ClickHouse PVC free space is below 15% for 15m. This commonly causes Flink TA JDBC sink failures and can
-                cascade into stale TA signals.
+                Torghut ClickHouse is below 15% free disk for 10 minutes.
 
-                Safe immediate action: pause TA writes (suspend FlinkDeployment/torghut-ta) to stop write pressure, then
-                reclaim disk / wait for TTL merges. Do not change trading safety gates.
+                First safe action: pause TA writes to stop the retry storm and prevent disk exhaustion.
               runbook_url: docs/torghut/design-system/v1/operations-pause-ta-writes.md
-          - alert: TorghutClickHouseDiskFreeCritical
+          - alert: TorghutClickHouseDiskFreeLowCritical
             expr: |
-              (
-                kubelet_volume_stats_available_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"}
-                /
-                clamp_min(
-                  kubelet_volume_stats_capacity_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"},
-                  1
-                )
-              ) < 0.05
-              or kubelet_volume_stats_available_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"} < 2 * 1024 * 1024 * 1024
+              torghut_clickhouse_guardrails_disk_free_ratio{
+                namespace="torghut",
+                service="torghut-clickhouse-guardrails-exporter"
+              } < 0.08
             for: 5m
             labels:
               severity: critical
             annotations:
-              summary: Torghut ClickHouse PVC free space critically low
+              summary: Torghut ClickHouse disk free < 8%
               description: |
-                ClickHouse PVC free space is critically low (<5% or <2Gi) for 5m. Writes may fail imminently or already
-                be failing.
+                Torghut ClickHouse is below 8% free disk for 5 minutes (imminent out-of-space risk).
 
-                Stop the bleeding: pause TA writes (suspend FlinkDeployment/torghut-ta), then remediate disk pressure.
-                Keep live trading gated/paper-by-default.
+                Stop the bleeding: immediately pause TA writes.
               runbook_url: docs/torghut/design-system/v1/operations-pause-ta-writes.md
           - alert: TorghutClickHouseReplicaReadOnly
             expr: |
-              max by (namespace, service) (
-                (
-                  ClickHouse_AsyncMetrics_ReadonlyReplica{job="torghut", namespace="torghut", service="torghut-clickhouse"} or
-                  clickhouse_asynchronous_metrics_readonly_replica{job="torghut", namespace="torghut", service="torghut-clickhouse"} or
-                  clickhouse_metrics_readonly_replica{job="torghut", namespace="torghut", service="torghut-clickhouse"}
-                )
-              ) > 0
-            for: 5m
+              torghut_clickhouse_guardrails_any_replica_readonly{
+                namespace="torghut",
+                service="torghut-clickhouse-guardrails-exporter"
+              } >= 1
+            for: 2m
             labels:
               severity: critical
             annotations:
               summary: Torghut ClickHouse replica is read-only
               description: |
-                ClickHouse reports one or more replicas are read-only. This blocks TA JDBC writes and usually indicates
-                Keeper metadata or storage pressure issues.
+                At least one Torghut ClickHouse replicated table reports read-only, which will cause TA JDBC writes to fail.
 
-                Recommended first action: pause TA writes to avoid retry storms, then follow the replica/keeper recovery
-                procedure (SYSTEM RESTORE REPLICA) once the underlying issue is fixed.
+                Stop the bleeding: pause TA writes first, then follow replica recovery (SYSTEM RESTORE REPLICA).
               runbook_url: docs/torghut/design-system/v1/operations-clickhouse-replica-and-keeper.md

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -95,3 +95,71 @@ data:
             annotations:
               summary: Jangar SSE error rate elevated
               description: SSE error responses exceed 0.05/sec for 10 minutes across Jangar streams.
+      - name: torghut-clickhouse.guardrails
+        rules:
+          - alert: TorghutClickHouseDiskFreeLow
+            expr: |
+              (
+                kubelet_volume_stats_available_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"}
+                /
+                clamp_min(
+                  kubelet_volume_stats_capacity_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"},
+                  1
+                )
+              ) < 0.15
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut ClickHouse PVC free space < 15%
+              description: |
+                ClickHouse PVC free space is below 15% for 15m. This commonly causes Flink TA JDBC sink failures and can
+                cascade into stale TA signals.
+
+                Safe immediate action: pause TA writes (suspend FlinkDeployment/torghut-ta) to stop write pressure, then
+                reclaim disk / wait for TTL merges. Do not change trading safety gates.
+              runbook_url: docs/torghut/design-system/v1/operations-pause-ta-writes.md
+          - alert: TorghutClickHouseDiskFreeCritical
+            expr: |
+              (
+                kubelet_volume_stats_available_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"}
+                /
+                clamp_min(
+                  kubelet_volume_stats_capacity_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"},
+                  1
+                )
+              ) < 0.05
+              or kubelet_volume_stats_available_bytes{namespace="torghut", persistentvolumeclaim=~"chi-data-torghut-clickhouse.*"} < 2 * 1024 * 1024 * 1024
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut ClickHouse PVC free space critically low
+              description: |
+                ClickHouse PVC free space is critically low (<5% or <2Gi) for 5m. Writes may fail imminently or already
+                be failing.
+
+                Stop the bleeding: pause TA writes (suspend FlinkDeployment/torghut-ta), then remediate disk pressure.
+                Keep live trading gated/paper-by-default.
+              runbook_url: docs/torghut/design-system/v1/operations-pause-ta-writes.md
+          - alert: TorghutClickHouseReplicaReadOnly
+            expr: |
+              max by (namespace, service) (
+                (
+                  ClickHouse_AsyncMetrics_ReadonlyReplica{job="torghut", namespace="torghut", service="torghut-clickhouse"} or
+                  clickhouse_asynchronous_metrics_readonly_replica{job="torghut", namespace="torghut", service="torghut-clickhouse"} or
+                  clickhouse_metrics_readonly_replica{job="torghut", namespace="torghut", service="torghut-clickhouse"}
+                )
+              ) > 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut ClickHouse replica is read-only
+              description: |
+                ClickHouse reports one or more replicas are read-only. This blocks TA JDBC writes and usually indicates
+                Keeper metadata or storage pressure issues.
+
+                Recommended first action: pause TA writes to avoid retry storms, then follow the replica/keeper recovery
+                procedure (SYSTEM RESTORE REPLICA) once the underlying issue is fixed.
+              runbook_url: docs/torghut/design-system/v1/operations-clickhouse-replica-and-keeper.md

--- a/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
@@ -11,6 +11,16 @@ metadata:
 spec:
   configuration:
     files:
+      config.d/99-prometheus.xml: |-
+        <yandex>
+          <prometheus>
+            <endpoint>/metrics</endpoint>
+            <port>9363</port>
+            <metrics>true</metrics>
+            <events>true</events>
+            <asynchronous_metrics>true</asynchronous_metrics>
+          </prometheus>
+        </yandex>
       config.d/99-logging-overrides.xml: |-
         <yandex>
           <logger>

--- a/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml
@@ -1,0 +1,194 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: torghut-clickhouse-guardrails-exporter
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut-clickhouse-guardrails-exporter
+    app.kubernetes.io/part-of: torghut
+data:
+  exporter.py: |
+    import json
+    import os
+    import threading
+    import time
+    import urllib.parse
+    import urllib.request
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    CLICKHOUSE_URL = os.environ.get("CLICKHOUSE_URL", "http://torghut-clickhouse.torghut.svc.cluster.local:8123")
+    CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "torghut")
+    CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "")
+    DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "torghut")
+    EXPORTER_PORT = int(os.environ.get("EXPORTER_PORT", "9108"))
+    SCRAPE_INTERVAL_SECONDS = int(os.environ.get("SCRAPE_INTERVAL_SECONDS", "30"))
+
+    DEFAULT_DISK_NAME = os.environ.get("CLICKHOUSE_DISK_NAME", "default")
+    TABLES = os.environ.get("CLICKHOUSE_REPLICATED_TABLES", "ta_signals,ta_microbars").split(",")
+    TABLES = [t.strip() for t in TABLES if t.strip()]
+
+
+    def clickhouse_query(query: str) -> dict:
+        params = urllib.parse.urlencode({"query": query})
+        url = f"{CLICKHOUSE_URL.rstrip('/')}/?{params}"
+        headers = {}
+        if CLICKHOUSE_USER:
+            headers["X-ClickHouse-User"] = CLICKHOUSE_USER
+        if CLICKHOUSE_PASSWORD:
+            headers["X-ClickHouse-Key"] = CLICKHOUSE_PASSWORD
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8").strip()
+            if not body:
+                return {}
+            return json.loads(body)
+
+
+    class State:
+        def __init__(self):
+            self.lock = threading.Lock()
+            self.clickhouse_up = 0.0
+            self.disk_free_bytes = float("nan")
+            self.disk_total_bytes = float("nan")
+            self.disk_free_ratio = float("nan")
+            self.any_replica_readonly = float("nan")
+            self.last_scrape_success = 0.0
+            self.last_scrape_ts_seconds = 0.0
+            self.last_error = ""
+
+        def snapshot(self) -> dict:
+            with self.lock:
+                return {
+                    "clickhouse_up": self.clickhouse_up,
+                    "disk_free_bytes": self.disk_free_bytes,
+                    "disk_total_bytes": self.disk_total_bytes,
+                    "disk_free_ratio": self.disk_free_ratio,
+                    "any_replica_readonly": self.any_replica_readonly,
+                    "last_scrape_success": self.last_scrape_success,
+                    "last_scrape_ts_seconds": self.last_scrape_ts_seconds,
+                }
+
+
+    state = State()
+
+
+    def float_or_nan(value):
+        try:
+            return float(value)
+        except Exception:
+            return float("nan")
+
+
+    def scrape_once():
+        now = time.time()
+        try:
+            disk_query = (
+                "SELECT max(free_space) AS free_space, max(total_space) AS total_space "
+                "FROM system.disks "
+                f"WHERE name = {json.dumps(DEFAULT_DISK_NAME)} "
+                "FORMAT JSONEachRow"
+            )
+            disk_row = clickhouse_query(disk_query) or {}
+
+            readonly_query = (
+                "SELECT max(is_readonly) AS any_readonly "
+                "FROM system.replicas "
+                f"WHERE database = {json.dumps(DATABASE)} "
+                f"AND table IN ({', '.join(json.dumps(t) for t in TABLES)}) "
+                "FORMAT JSONEachRow"
+            )
+            readonly_row = clickhouse_query(readonly_query) or {}
+
+            free_space = float_or_nan(disk_row.get("free_space"))
+            total_space = float_or_nan(disk_row.get("total_space"))
+            ratio = float("nan")
+            if total_space and total_space > 0 and free_space == free_space:
+                ratio = free_space / total_space
+
+            any_readonly = float_or_nan(readonly_row.get("any_readonly"))
+
+            with state.lock:
+                state.clickhouse_up = 1.0
+                state.disk_free_bytes = free_space
+                state.disk_total_bytes = total_space
+                state.disk_free_ratio = ratio
+                state.any_replica_readonly = any_readonly
+                state.last_scrape_success = 1.0
+                state.last_scrape_ts_seconds = now
+                state.last_error = ""
+        except Exception as e:
+            with state.lock:
+                state.clickhouse_up = 0.0
+                state.last_scrape_success = 0.0
+                state.last_scrape_ts_seconds = now
+                state.last_error = str(e)
+
+
+    def scrape_loop():
+        while True:
+            scrape_once()
+            time.sleep(SCRAPE_INTERVAL_SECONDS)
+
+
+    def render_metrics(snapshot: dict) -> str:
+        lines = []
+        lines.append("# HELP torghut_clickhouse_guardrails_clickhouse_up 1 if ClickHouse is reachable for guardrail queries.")
+        lines.append("# TYPE torghut_clickhouse_guardrails_clickhouse_up gauge")
+        lines.append(f"torghut_clickhouse_guardrails_clickhouse_up {snapshot['clickhouse_up']}")
+
+        lines.append("# HELP torghut_clickhouse_guardrails_disk_free_bytes Free bytes on the ClickHouse default disk.")
+        lines.append("# TYPE torghut_clickhouse_guardrails_disk_free_bytes gauge")
+        lines.append(f"torghut_clickhouse_guardrails_disk_free_bytes {snapshot['disk_free_bytes']}")
+
+        lines.append("# HELP torghut_clickhouse_guardrails_disk_total_bytes Total bytes on the ClickHouse default disk.")
+        lines.append("# TYPE torghut_clickhouse_guardrails_disk_total_bytes gauge")
+        lines.append(f"torghut_clickhouse_guardrails_disk_total_bytes {snapshot['disk_total_bytes']}")
+
+        lines.append("# HELP torghut_clickhouse_guardrails_disk_free_ratio Free/total ratio on the ClickHouse default disk.")
+        lines.append("# TYPE torghut_clickhouse_guardrails_disk_free_ratio gauge")
+        lines.append(f"torghut_clickhouse_guardrails_disk_free_ratio {snapshot['disk_free_ratio']}")
+
+        lines.append(
+            "# HELP torghut_clickhouse_guardrails_any_replica_readonly 1 if any Torghut replicated table is read-only."
+        )
+        lines.append("# TYPE torghut_clickhouse_guardrails_any_replica_readonly gauge")
+        lines.append(f"torghut_clickhouse_guardrails_any_replica_readonly {snapshot['any_replica_readonly']}")
+
+        lines.append("# HELP torghut_clickhouse_guardrails_last_scrape_success 1 if the last scrape succeeded.")
+        lines.append("# TYPE torghut_clickhouse_guardrails_last_scrape_success gauge")
+        lines.append(f"torghut_clickhouse_guardrails_last_scrape_success {snapshot['last_scrape_success']}")
+
+        lines.append("# HELP torghut_clickhouse_guardrails_last_scrape_ts_seconds Unix timestamp of the last scrape attempt.")
+        lines.append("# TYPE torghut_clickhouse_guardrails_last_scrape_ts_seconds gauge")
+        lines.append(f"torghut_clickhouse_guardrails_last_scrape_ts_seconds {snapshot['last_scrape_ts_seconds']}")
+
+        lines.append("")
+        return "\n".join(lines)
+
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path not in ("/metrics", "/"):
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            snapshot = state.snapshot()
+            body = render_metrics(snapshot).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return
+
+
+    if __name__ == "__main__":
+        t = threading.Thread(target=scrape_loop, daemon=True)
+        t.start()
+
+        server = HTTPServer(("0.0.0.0", EXPORTER_PORT), Handler)
+        server.serve_forever()
+

--- a/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
@@ -38,6 +38,8 @@ spec:
                   key: torghut_password
             - name: CLICKHOUSE_DATABASE
               value: torghut
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
           ports:
             - name: metrics
               containerPort: 9108
@@ -52,6 +54,8 @@ spec:
             - name: app
               mountPath: /app
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /metrics
@@ -81,6 +85,8 @@ spec:
         - name: app
           configMap:
             name: torghut-clickhouse-guardrails-exporter
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service
@@ -98,4 +104,3 @@ spec:
     - name: metrics
       port: 9108
       targetPort: metrics
-

--- a/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: torghut-clickhouse-guardrails-exporter
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut-clickhouse-guardrails-exporter
+    app.kubernetes.io/part-of: torghut
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: torghut-clickhouse-guardrails-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: torghut-clickhouse-guardrails-exporter
+        app.kubernetes.io/part-of: torghut
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      containers:
+        - name: exporter
+          image: python:3.12-alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+            - /app/exporter.py
+          env:
+            - name: CLICKHOUSE_URL
+              value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
+            - name: CLICKHOUSE_USER
+              value: torghut
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-clickhouse-auth
+                  key: torghut_password
+            - name: CLICKHOUSE_DATABASE
+              value: torghut
+          ports:
+            - name: metrics
+              containerPort: 9108
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: app
+              mountPath: /app
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 2
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: app
+          configMap:
+            name: torghut-clickhouse-guardrails-exporter
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: torghut-clickhouse-guardrails-exporter
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut-clickhouse-guardrails-exporter
+    app.kubernetes.io/part-of: torghut
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: torghut-clickhouse-guardrails-exporter
+  ports:
+    - name: metrics
+      port: 9108
+      targetPort: metrics
+

--- a/argocd/applications/torghut/clickhouse/clickhouse-service.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-service.yaml
@@ -17,7 +17,9 @@ spec:
     - name: http
       port: 8123
       targetPort: 8123
+    - name: metrics
+      port: 9363
+      targetPort: 9363
     - name: native
       port: 9000
       targetPort: 9000
-

--- a/argocd/applications/torghut/clickhouse/kustomization.yaml
+++ b/argocd/applications/torghut/clickhouse/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - clickhouse-keeper.yaml
   - keeper-pdb.yaml
   - sealed-secret.yaml
+  - clickhouse-guardrails-exporter-configmap.yaml
+  - clickhouse-guardrails-exporter.yaml
   - clickhouse-cluster.yaml
   - clickhouse-pdb.yaml
   - clickhouse-service.yaml

--- a/docs/jangar/primitives/README.md
+++ b/docs/jangar/primitives/README.md
@@ -30,6 +30,7 @@ Jangar APIs; Jangar creates and manages the underlying CRDs and reconciles statu
 ## Documents
 
 - `agent.md`
+- `code-search.md`
 - `memory.md`
 - `orchestration.md`
 - `supporting-primitives.md`

--- a/docs/jangar/primitives/code-search.md
+++ b/docs/jangar/primitives/code-search.md
@@ -1,0 +1,299 @@
+# Code Search Primitive (Atlas)
+
+## Purpose
+
+The Code Search primitive provides a durable, queryable index over one or more Git repositories so agents can:
+
+- Find the right code to read or modify (with precise file + line pointers).
+- Search by intent (semantic) and by identifiers (lexical) with strong recall.
+- Filter results by repo/ref/path/language and remain access-controlled by Jangar.
+
+Jangar is the control plane for all Code Search resources and APIs.
+
+## Grounding In The Current Platform (As Of 2026-02-08)
+
+This repository already has an Atlas-backed indexing pipeline that writes into the `jangar-db` CNPG cluster:
+
+- CNPG cluster: `jangar/jangar-db` (Postgres 17, healthy)
+- Database: `jangar`
+- Schema: `atlas`
+
+Observed table state:
+
+- `atlas.file_versions`: ~24.9k rows
+- `atlas.enrichments` (`kind=model_enrichment`): ~19.3k rows
+- `atlas.embeddings`: ~19.2k rows (dominantly `qwen3-embedding-saigak:0.6b`, 1024d)
+- `atlas.tree_sitter_facts`: ~1.78M rows
+- `atlas.file_chunks`: 0 rows (exists but not used yet)
+
+Implication:
+
+- Today, semantic search is effectively file-level (embedding/enrichment per file), not function/class-level.
+- Tree-sitter facts are available and can be leveraged to produce stable, syntax-aware chunks.
+
+Related design doc (existing): `docs/atlas-indexing.md`
+
+## Goals
+
+- Add chunk-level indexing (functions/classes/config blocks) while preserving existing file-level indexing.
+- Provide a single agent-friendly API for retrieval with stable pointers (`path`, `commit`, `start_line`, `end_line`).
+- Implement hybrid retrieval (vector + lexical) with predictable filtering and access control.
+- Support incremental updates (webhooks/changed files) and backfills (full repository refs).
+- Keep model-heavy work isolated from the rest of the platform (dedicated workers/task queues).
+
+## Non-Goals
+
+- A full cross-repo dependency graph (nice-to-have, not required for search MVP).
+- Replacing memories; code search is a retrieval tool, not a durable narrative store.
+- Perfect reranking on day 1; start with hybrid recall + heuristic rerank, then iterate.
+
+## Primitive Contract
+
+### CodeIndex (claim)
+
+Namespace-scoped claim for an indexed codebase. This is a platform primitive like Memory/Agent/Orchestration.
+
+```yaml
+apiVersion: atlas.proompteng.ai/v1alpha1
+kind: CodeIndex
+metadata:
+  name: lab-main
+  namespace: jangar
+spec:
+  providerRef:
+    name: postgres-default
+  repository:
+    nameWithOwner: proompteng/lab
+  ref:
+    type: branch
+    name: main
+  indexing:
+    mode: incremental
+    chunking:
+      enabled: true
+      strategy: tree-sitter
+      fallback:
+        type: fixed_lines
+        linesPerChunk: 80
+    embeddings:
+      enabled: true
+      model: qwen3-embedding-saigak:0.6b
+      dimension: 1024
+    lexical:
+      enabled: true
+      tokenizer: postgres_tsvector
+  access:
+    readerRole: atlas_reader
+    writerRole: atlas_writer
+```
+
+Notes:
+
+- `providerRef` keeps the primitive provider-decoupled. The first provider is Postgres/pgvector in `jangar-db`.
+- `ref` must support both “main branch” and “commit SHA” indexing. Agents frequently need commit-specific retrieval.
+
+### CodeIndexStore (internal)
+
+Composite/internal resource binding the claim to a concrete provider dataset (similar to `MemoryStore`).
+
+## Data Model
+
+See `docs/atlas-indexing.md` for the baseline schema. This document focuses on the delta required to make the index
+agent-grade.
+
+### Current Model (Already In Use)
+
+- `file_versions`: versioned snapshots keyed by repo ref + commit + hash.
+- `enrichments`: model output per file version.
+- `embeddings`: vector embeddings attached to enrichments.
+- `tree_sitter_facts`: structured AST matches (high volume).
+
+### Required Additions For Chunk-Level Retrieval
+
+1. Persist chunks into `atlas.file_chunks`.
+
+`atlas.file_chunks` already exists, but currently has 0 rows. The ingestion pipeline should populate it for each
+indexed `file_version`.
+
+2. Add chunk-level embeddings.
+
+Add a new table:
+
+```sql
+-- New table (recommended) to avoid overloading atlas.embeddings with mixed identity types.
+CREATE TABLE atlas.chunk_embeddings (
+  chunk_id uuid PRIMARY KEY REFERENCES atlas.file_chunks(id) ON DELETE CASCADE,
+  model text NOT NULL,
+  dimension int NOT NULL,
+  embedding vector(1024) NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+Add an HNSW index:
+
+```sql
+CREATE INDEX chunk_embeddings_embedding_hnsw
+  ON atlas.chunk_embeddings
+  USING hnsw (embedding vector_cosine_ops);
+```
+
+3. Add lexical search support for chunks.
+
+Add a `tsvector` column (stored or computed) and a `GIN` index:
+
+```sql
+ALTER TABLE atlas.file_chunks
+  ADD COLUMN text_tsvector tsvector;
+
+CREATE INDEX file_chunks_text_tsvector_gin
+  ON atlas.file_chunks
+  USING gin (text_tsvector);
+```
+
+Populate `text_tsvector` on write using `to_tsvector('simple', content)` and optionally include symbol names from
+metadata.
+
+## Ingestion And Freshness
+
+### Incremental indexing (default)
+
+Trigger on GitHub webhook (or equivalent) with a file list:
+
+1. Upsert repository, file key, and file version.
+2. Extract tree-sitter facts (already working today).
+3. Persist `file_chunks` for the file version (new).
+4. Generate:
+   - File-level enrichment + embedding (keep existing behavior).
+   - Chunk-level embeddings (new).
+
+Idempotency rules:
+
+- Use `file_versions.content_hash` to skip work for unchanged file content.
+- Use `(file_version_id, chunk_index)` + a chunk content hash (in `file_chunks.metadata`) to skip chunk recompute.
+
+### Backfill indexing
+
+Backfill is required because `file_chunks` is currently empty. A backfill workflow should:
+
+- Iterate `atlas.file_versions` for `(repo_ref, repo_commit)` pairs.
+- Populate chunks and chunk embeddings for each file version.
+- Be rate limited by GPU capacity (prefer dedicated task queues/workers).
+
+## Query API (What Agents Use)
+
+Agents should not query Postgres directly. They call Jangar.
+
+### Endpoint
+
+`POST /api/code-search`
+
+Request:
+
+```json
+{
+  "repository": "proompteng/lab",
+  "ref": "main",
+  "query": "where is TEMPORAL_TASK_QUEUE set for bumba workers?",
+  "filters": {
+    "pathPrefix": "argocd/applications/bumba",
+    "language": null,
+    "chunkType": null
+  },
+  "k": 12
+}
+```
+
+Response (shape):
+
+```json
+{
+  "results": [
+    {
+      "repository": "proompteng/lab",
+      "ref": "main",
+      "commit": "91a766394ea8d8469071d8463ec8979f7da80956",
+      "path": "argocd/applications/bumba/deployment-model.yaml",
+      "startLine": 35,
+      "endLine": 75,
+      "symbol": null,
+      "score": 0.83,
+      "signals": {
+        "semanticScore": 0.83,
+        "lexicalScore": 0.22,
+        "matchedIdentifiers": ["TEMPORAL_TASK_QUEUE"]
+      },
+      "snippet": "...\n- name: TEMPORAL_TASK_QUEUE\n  value: bumba-model\n..."
+    }
+  ]
+}
+```
+
+### Retrieval algorithm (MVP)
+
+Hybrid retrieval with deterministic filtering:
+
+1. Vector candidates: search `atlas.chunk_embeddings` (and optionally file-level embeddings for fallback).
+2. Lexical candidates: search `atlas.file_chunks.text_tsvector`.
+3. Merge + rerank:
+   - Boost exact identifier hits (from query tokens).
+   - Boost path matches if `pathPrefix` is present.
+   - Prefer smaller spans (chunk hits) over whole-file hits when scores are similar.
+
+### Access control
+
+- Jangar authorizes `(caller, repository, ref/commit)` before returning any snippet.
+- In multi-tenant mode, enforce row-level filtering at query time.
+
+## Agent Usage Guide
+
+### When to use Code Search
+
+- Before changing code, run Code Search to locate the best edit site.
+- When asked “where is X implemented?”, start with Code Search, then open the files and read the surrounding context.
+
+### Query tips (practical)
+
+- Include identifiers when you have them: `"TEMPORAL_TASK_QUEUE"` or `enrichWithModel`.
+- If you’re not sure, ask conceptually: “where is the Temporal task queue configured for bumba model worker”.
+- Use `pathPrefix` early to cut noise when you know the area.
+
+### Minimal agent loop (recommended)
+
+1. `code_search(query, repo, ref, filters)`
+2. Open top 3-8 snippets in the workspace.
+3. Only then reason/implement changes.
+
+This avoids guessing and reduces the number of “search -> wrong file -> search again” cycles.
+
+## Operational Notes
+
+- Keep model-heavy enrichment isolated (dedicated workers/task queues). Do not let model latency starve the rest of
+  the indexing pipeline.
+- Track:
+  - ingestion backlog by task queue
+  - embedding latency p50/p95
+  - query latency p50/p95
+  - recall proxies (how often agents open top-k results)
+- Backfills should be throttled; start with 1 embedding worker and scale cautiously.
+
+## Debugging With kubectl + CNPG (Current State)
+
+List top atlas tables:
+
+```bash
+kubectl cnpg psql -n jangar jangar-db -- -d jangar -c \\\n  \"SELECT nspname AS schema, relname AS table, pg_size_pretty(pg_total_relation_size(c.oid)) AS total_size\\\n   FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace\\\n   WHERE c.relkind='r' AND nspname NOT IN ('pg_catalog','information_schema')\\\n   ORDER BY pg_total_relation_size(c.oid) DESC LIMIT 30;\"\n```
+
+Check whether chunk indexing is enabled (it is not today):
+
+```bash
+kubectl cnpg psql -n jangar jangar-db -- -d jangar -c \\\n  \"SELECT count(*) FROM atlas.file_chunks;\"\n```
+
+## Rollout Plan (Recommended)
+
+1. Ship schema changes (chunk embeddings + tsvector) behind a feature flag.
+2. Update ingestion to write `atlas.file_chunks` and `atlas.chunk_embeddings` for new ingestions.
+3. Enable the Code Search API endpoint (hybrid retrieval) and integrate it as an agent tool.
+4. Backfill existing `file_versions` with rate limiting.
+5. Iterate on chunking and reranking based on real agent usage.
+

--- a/docs/torghut/design-system/v1/alerting-slos-and-oncall.md
+++ b/docs/torghut/design-system/v1/alerting-slos-and-oncall.md
@@ -52,6 +52,7 @@ flowchart TD
 
 ## Operations links
 - TA recovery: `v1/operations-ta-replay-and-recovery.md`
+- Pause TA writes (stop the bleeding): `v1/operations-pause-ta-writes.md`
 - WS connection/auth: `v1/operations-ws-connection-limit-and-auth.md`
 - ClickHouse replica/keeper: `v1/operations-clickhouse-replica-and-keeper.md`
 - Knative revision failures: `v1/operations-knative-revision-failures.md`

--- a/docs/torghut/design-system/v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md
+++ b/docs/torghut/design-system/v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md
@@ -73,7 +73,8 @@ storage or reducing retention rather than “tuning around” persistent disk sc
 1) **Confirm** it is disk pressure (not auth):
    - Check ClickHouse disk free.
 2) **Reduce write pressure**:
-   - Temporarily scale/stop TA job (`FlinkDeployment`) to prevent thrash.
+   - Temporarily pause TA writes by suspending `FlinkDeployment/torghut-ta` to prevent thrash.
+   - Runbook: `v1/operations-pause-ta-writes.md`
 3) **Reclaim disk**:
    - Drop old partitions if TTL cannot catch up fast enough.
    - Reduce retention TTLs *only via code-reviewed DDL change*.

--- a/docs/torghut/design-system/v1/operations-clickhouse-replica-and-keeper.md
+++ b/docs/torghut/design-system/v1/operations-clickhouse-replica-and-keeper.md
@@ -59,6 +59,7 @@ curl -fsS 'http://localhost:8123/?query=SELECT%201%20FORMAT%20JSONEachRow' \\
 ### Steps (operator)
 0) Reduce write pressure first (recommended):
    - Pause TA writes by suspending `FlinkDeployment/torghut-ta` (GitOps-first; direct `kubectl patch` is emergency-only).
+   - Runbook: `v1/operations-pause-ta-writes.md`
 1) Verify keeper is healthy:
    - Check keeper pods/service and logs.
 2) Inspect replica state:

--- a/docs/torghut/design-system/v1/operations-pause-ta-writes.md
+++ b/docs/torghut/design-system/v1/operations-pause-ta-writes.md
@@ -1,0 +1,66 @@
+# Operations: Pause TA Writes (Suspend `torghut-ta`)
+
+## Status
+- Version: `v1`
+- Last updated: **2026-02-08**
+- Source of truth (config): `argocd/applications/torghut/**`
+
+## Purpose
+Provide an explicit, safe-by-default “stop the bleeding” procedure that an oncall can execute quickly to reduce write
+pressure on ClickHouse during incidents (disk pressure, replica read-only, Keeper instability) by suspending the Flink TA
+job.
+
+This procedure **does not** change trading safety gates; trading remains paper-by-default and live trading remains gated
+by `TRADING_LIVE_ENABLED=false`.
+
+## When to use
+- ClickHouse disk pressure alerts (PVC free space low/critical).
+- ClickHouse replica read-only alerts.
+- Flink TA job failing due to ClickHouse JDBC write errors / retry storms.
+
+## Inputs
+- Namespace: `torghut`
+- FlinkDeployment: `flinkdeployment/torghut-ta`
+- GitOps manifest: `argocd/applications/torghut/ta/flinkdeployment.yaml`
+
+## Procedure A (recommended): GitOps-first suspend/resume
+### Suspend (pause TA writes)
+1) Edit `argocd/applications/torghut/ta/flinkdeployment.yaml`:
+   - set `spec.job.state: suspended`
+2) Let Argo CD sync, then verify:
+   - `kubectl -n torghut get flinkdeployment torghut-ta`
+   - Job state is `SUSPENDED` (or not `RUNNING`) and no new writes occur.
+
+### Resume (restore TA writes)
+1) Edit `argocd/applications/torghut/ta/flinkdeployment.yaml`:
+   - set `spec.job.state: running`
+   - bump `spec.restartNonce` (integer) if a restart is required
+2) Let Argo CD sync, then verify:
+   - `kubectl -n torghut get flinkdeployment torghut-ta`
+   - ClickHouse `max(event_ts)` for `torghut.ta_signals` advances.
+
+## Procedure B (emergency): Direct patch (not source of truth)
+Use only if GitOps is blocked and you need to immediately stop write pressure.
+
+Suspend:
+```bash
+kubectl -n torghut patch flinkdeployment torghut-ta --type merge -p '{"spec":{"job":{"state":"suspended"}}}'
+```
+
+Resume:
+```bash
+kubectl -n torghut patch flinkdeployment torghut-ta --type merge -p '{"spec":{"job":{"state":"running"}}}'
+```
+
+Follow-up requirements:
+- Immediately open a GitOps PR to reconcile `argocd/applications/torghut/ta/flinkdeployment.yaml` to the desired state.
+- Record a short incident note (what triggered the pause, when resumed).
+
+## Safety notes
+- Pausing TA may cause signal freshness to degrade (expected); keep trading paused if freshness is uncertain.
+- Do **not** relax `TRADING_LIVE_ENABLED` or other live-trading gates as part of this procedure.
+
+## Related runbooks
+- Disk guardrails: `v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md`
+- Replica read-only / Keeper recovery: `v1/operations-clickhouse-replica-and-keeper.md`
+

--- a/docs/torghut/design-system/v1/operations-ws-connection-limit-and-auth.md
+++ b/docs/torghut/design-system/v1/operations-ws-connection-limit-and-auth.md
@@ -33,6 +33,19 @@ Forwarder readiness is a hard gate on “can make progress”:
 2) Kafka must be reachable (metadata calls for all configured topics succeed).
 3) If trade-updates streaming is enabled, that stream must also be healthy.
 
+### Readiness response body (machine-parseable)
+When the forwarder is **not** Ready, `GET /readyz` returns `503` with a JSON body that includes a stable
+`error_class` for automation and oncall triage (no raw upstream/Kafka error strings):
+- `alpaca_406_second_connection`
+- `alpaca_auth`
+- `kafka_auth`
+- `kafka_metadata`
+- `kafka_produce`
+- `unknown`
+
+The response also includes boolean readiness gates (`gates.alpaca_ws`, `gates.kafka`, `gates.trade_updates`) to
+help distinguish upstream vs downstream causes.
+
 Implementation pointers:
 - Readiness endpoint: `services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/HealthServer.kt`
 - Readiness gates: `services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt`

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderMetrics.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderMetrics.kt
@@ -2,15 +2,24 @@ package ai.proompteng.dorvud.ws
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class ForwarderMetrics(
   private val registry: MeterRegistry,
 ) {
   private val dedupCounters = ConcurrentHashMap<String, Counter>()
+  private val readinessErrorCounters = ConcurrentHashMap<String, Counter>()
+  private val wsConnectErrorCounters = ConcurrentHashMap<String, Counter>()
+  private val kafkaProduceErrorCounters = ConcurrentHashMap<String, Counter>()
+  private val kafkaProduceSuccessCounters = ConcurrentHashMap<String, Counter>()
+  private val kafkaMetadataErrorCounters = ConcurrentHashMap<String, Counter>()
+
+  private val readinessStatus = AtomicInteger(0)
 
   private val lagSummary: DistributionSummary =
     DistributionSummary
@@ -26,6 +35,72 @@ internal class ForwarderMetrics(
 
   val reconnects: Counter = registry.counter("torghut_ws_reconnects_total")
   val kafkaSendErrors: Counter = registry.counter("torghut_ws_kafka_send_errors_total")
+  val wsConnectSuccess: Counter = registry.counter("torghut_ws_ws_connect_success_total")
+
+  init {
+    Gauge
+      .builder("torghut_ws_readyz_status", readinessStatus) { it.get().toDouble() }
+      .register(registry)
+  }
+
+  fun setReady(ready: Boolean) {
+    readinessStatus.set(if (ready) 1 else 0)
+  }
+
+  fun recordReadinessError(errorClass: ReadinessErrorClass) {
+    readinessErrorCounters
+      .computeIfAbsent(errorClass.id) { cls ->
+        Counter
+          .builder("torghut_ws_readiness_errors_total")
+          .tag("error_class", cls)
+          .register(registry)
+      }.increment()
+  }
+
+  fun recordWsConnectError(errorClass: ReadinessErrorClass) {
+    wsConnectErrorCounters
+      .computeIfAbsent(errorClass.id) { cls ->
+        Counter
+          .builder("torghut_ws_ws_connect_errors_total")
+          .tag("error_class", cls)
+          .register(registry)
+      }.increment()
+  }
+
+  fun recordKafkaProduceSuccess(topic: String) {
+    kafkaProduceSuccessCounters
+      .computeIfAbsent(topic) { t ->
+        Counter
+          .builder("torghut_ws_kafka_produce_success_total")
+          .tag("topic", t)
+          .register(registry)
+      }.increment()
+  }
+
+  fun recordKafkaProduceError(
+    topic: String,
+    errorClass: ReadinessErrorClass,
+  ) {
+    kafkaProduceErrorCounters
+      .computeIfAbsent("$topic|${errorClass.id}") { key ->
+        val parts = key.split("|", limit = 2)
+        Counter
+          .builder("torghut_ws_kafka_produce_errors_total")
+          .tag("topic", parts[0])
+          .tag("error_class", parts[1])
+          .register(registry)
+      }.increment()
+  }
+
+  fun recordKafkaMetadataError(errorClass: ReadinessErrorClass) {
+    kafkaMetadataErrorCounters
+      .computeIfAbsent(errorClass.id) { cls ->
+        Counter
+          .builder("torghut_ws_kafka_metadata_errors_total")
+          .tag("error_class", cls)
+          .register(registry)
+      }.increment()
+  }
 
   fun recordLagMs(lagMs: Long) {
     if (lagMs < 0) return

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/HealthServer.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/HealthServer.kt
@@ -11,6 +11,7 @@ import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.plugins.callloging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -65,7 +66,12 @@ class HealthServer(
     routing {
       get("/healthz") { call.respondText("ok") }
       get("/readyz") {
-        if (app.isReady()) call.respondText("ready") else call.respondText("not-ready", status = HttpStatusCode.ServiceUnavailable)
+        val info = app.readinessInfo()
+        if (info.ready) {
+          call.respond(info)
+        } else {
+          call.respond(HttpStatusCode.ServiceUnavailable, info)
+        }
       }
     }
   }

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ReadinessDiagnostics.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ReadinessDiagnostics.kt
@@ -1,0 +1,114 @@
+package ai.proompteng.dorvud.ws
+
+import io.ktor.client.plugins.ResponseException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.apache.kafka.common.errors.AuthenticationException
+import org.apache.kafka.common.errors.AuthorizationException
+import org.apache.kafka.common.errors.ClusterAuthorizationException
+import org.apache.kafka.common.errors.GroupAuthorizationException
+import org.apache.kafka.common.errors.LeaderNotAvailableException
+import org.apache.kafka.common.errors.NotLeaderOrFollowerException
+import org.apache.kafka.common.errors.SaslAuthenticationException
+import org.apache.kafka.common.errors.TimeoutException
+import org.apache.kafka.common.errors.TopicAuthorizationException
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+
+enum class ReadinessErrorClass(
+  val id: String,
+) {
+  Alpaca406SecondConnection("alpaca_406_second_connection"),
+  AlpacaAuth("alpaca_auth"),
+  KafkaAuth("kafka_auth"),
+  KafkaMetadata("kafka_metadata"),
+  KafkaProduce("kafka_produce"),
+  Unknown("unknown"),
+}
+
+@Serializable
+data class ReadinessGates(
+  @SerialName("alpaca_ws") val alpacaWs: Boolean,
+  val kafka: Boolean,
+  @SerialName("trade_updates") val tradeUpdates: Boolean,
+)
+
+@Serializable
+data class ReadinessInfo(
+  val status: String,
+  val ready: Boolean,
+  @SerialName("error_class") val errorClass: String? = null,
+  val gates: ReadinessGates,
+)
+
+internal enum class KafkaFailureContext {
+  Metadata,
+  Produce,
+}
+
+internal object ReadinessClassifier {
+  fun classifyAlpacaError(
+    code: Int?,
+    msg: String?,
+  ): ReadinessErrorClass {
+    if (code == 406) return ReadinessErrorClass.Alpaca406SecondConnection
+    if (code == 401 || code == 403) return ReadinessErrorClass.AlpacaAuth
+
+    val lowered = msg?.lowercase()
+    if (lowered != null) {
+      if (lowered.contains("406") || lowered.contains("connection limit")) {
+        return ReadinessErrorClass.Alpaca406SecondConnection
+      }
+      if (lowered.contains("401") || lowered.contains("403") || lowered.contains("unauthorized") || lowered.contains("forbidden")) {
+        return ReadinessErrorClass.AlpacaAuth
+      }
+    }
+
+    return ReadinessErrorClass.Unknown
+  }
+
+  fun classifyAlpacaHandshakeFailure(exception: Throwable): ReadinessErrorClass? {
+    val responseException = exception.findCause<ResponseException>() ?: return null
+    return when (responseException.response.status.value) {
+      401, 403 -> ReadinessErrorClass.AlpacaAuth
+      406 -> ReadinessErrorClass.Alpaca406SecondConnection
+      else -> null
+    }
+  }
+
+  fun classifyKafkaFailure(
+    exception: Throwable,
+    context: KafkaFailureContext,
+  ): ReadinessErrorClass {
+    if (exception.findCause<SaslAuthenticationException>() != null ||
+      exception.findCause<AuthenticationException>() != null ||
+      exception.findCause<AuthorizationException>() != null ||
+      exception.findCause<TopicAuthorizationException>() != null ||
+      exception.findCause<GroupAuthorizationException>() != null ||
+      exception.findCause<ClusterAuthorizationException>() != null
+    ) {
+      return ReadinessErrorClass.KafkaAuth
+    }
+
+    if (exception.findCause<TimeoutException>() != null ||
+      exception.findCause<UnknownTopicOrPartitionException>() != null ||
+      exception.findCause<LeaderNotAvailableException>() != null ||
+      exception.findCause<NotLeaderOrFollowerException>() != null
+    ) {
+      return ReadinessErrorClass.KafkaMetadata
+    }
+
+    return when (context) {
+      KafkaFailureContext.Metadata -> ReadinessErrorClass.KafkaMetadata
+      KafkaFailureContext.Produce -> ReadinessErrorClass.KafkaProduce
+    }
+  }
+
+  private inline fun <reified T : Throwable> Throwable.findCause(): T? {
+    var cursor: Throwable? = this
+    while (cursor != null) {
+      if (cursor is T) return cursor
+      cursor = cursor.cause
+    }
+    return null
+  }
+}

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ReadinessClassifierTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ReadinessClassifierTest.kt
@@ -1,0 +1,52 @@
+package ai.proompteng.dorvud.ws
+
+import org.apache.kafka.common.errors.RecordTooLargeException
+import org.apache.kafka.common.errors.SaslAuthenticationException
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ReadinessClassifierTest {
+  @Test
+  fun `alpaca 406 maps to connection-limit class`() {
+    assertEquals(
+      ReadinessErrorClass.Alpaca406SecondConnection,
+      ReadinessClassifier.classifyAlpacaError(406, "connection limit exceeded"),
+    )
+  }
+
+  @Test
+  fun `alpaca 401 maps to auth class`() {
+    assertEquals(
+      ReadinessErrorClass.AlpacaAuth,
+      ReadinessClassifier.classifyAlpacaError(401, "unauthorized"),
+    )
+  }
+
+  @Test
+  fun `kafka sasl auth maps to kafka_auth`() {
+    val ex = SaslAuthenticationException("bad credentials")
+    assertEquals(
+      ReadinessErrorClass.KafkaAuth,
+      ReadinessClassifier.classifyKafkaFailure(ex, KafkaFailureContext.Metadata),
+    )
+  }
+
+  @Test
+  fun `kafka unknown topic maps to kafka_metadata`() {
+    val ex = UnknownTopicOrPartitionException("missing topic")
+    assertEquals(
+      ReadinessErrorClass.KafkaMetadata,
+      ReadinessClassifier.classifyKafkaFailure(ex, KafkaFailureContext.Metadata),
+    )
+  }
+
+  @Test
+  fun `kafka produce failures map to kafka_produce by default`() {
+    val ex = RecordTooLargeException("too big")
+    assertEquals(
+      ReadinessErrorClass.KafkaProduce,
+      ReadinessClassifier.classifyKafkaFailure(ex, KafkaFailureContext.Produce),
+    )
+  }
+}


### PR DESCRIPTION
- Added Torghut ClickHouse guardrails exporter (GitOps) that exposes low-cardinality metrics for disk free ratio + “any replica read-only”.
- Wired new actionable Mimir ruler alerts for ClickHouse disk pressure + replica read-only, pointing at Torghut runbooks.
- Documented a safe-by-default “stop the bleeding” procedure to pause TA writes by suspending `flinkdeployment/torghut-ta`.

**Tests**
- `bun run lint:argocd` (pass)

**PR**
- https://github.com/proompteng/lab/pull/2916

**Blockers**
- `codex-nats-publish` failed with `nats: Authorization Violation` (couldn’t publish workflow/general status updates).
- Memories save failed: `persist memory failed: connect ECONNREFUSED ...:5432` (memories DB unreachable).