### PR TITLE
feat(atlas): add chunk-based code search

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: "16"
             - name: BUMBA_EMBEDDING_CONCURRENCY
               value: "4"
+            - name: BUMBA_ATLAS_CHUNK_INDEXING
+              value: "true"
             - name: OPENAI_EMBEDDING_MODEL
               value: qwen3-embedding-saigak:0.6b
             - name: OPENAI_EMBEDDING_DIMENSION

--- a/services/bumba/src/workflows/index.test.ts
+++ b/services/bumba/src/workflows/index.test.ts
@@ -304,11 +304,23 @@ test('enrichFile completes when all activities are resolved', async () => {
       'activity-10',
       {
         status: 'completed',
-        value: {},
+        value: {
+          skipped: true,
+          reason: 'disabled',
+          chunks: 0,
+          embedded: 0,
+        },
       },
     ],
     [
       'activity-11',
+      {
+        status: 'completed',
+        value: {},
+      },
+    ],
+    [
+      'activity-12',
       {
         status: 'completed',
         value: {
@@ -329,7 +341,7 @@ test('enrichFile completes when all activities are resolved', async () => {
     (command: Command) => command.commandType === CommandType.SCHEDULE_ACTIVITY_TASK,
   )
 
-  expect(scheduleCommands).toHaveLength(12)
+  expect(scheduleCommands).toHaveLength(13)
   expect(output.commands.at(-1)?.commandType).toBe(CommandType.COMPLETE_WORKFLOW_EXECUTION)
   expect(output.completion).toBe('completed')
   expect(output.result).toEqual({ id: 'enrichment-id', filename: input.filePath })
@@ -612,11 +624,23 @@ test('enrichFile schedules cleanup when force is enabled', async () => {
       'activity-11',
       {
         status: 'completed',
-        value: {},
+        value: {
+          skipped: true,
+          reason: 'disabled',
+          chunks: 0,
+          embedded: 0,
+        },
       },
     ],
     [
       'activity-12',
+      {
+        status: 'completed',
+        value: {},
+      },
+    ],
+    [
+      'activity-13',
       {
         status: 'completed',
         value: {
@@ -637,7 +661,7 @@ test('enrichFile schedules cleanup when force is enabled', async () => {
     (command: Command) => command.commandType === CommandType.SCHEDULE_ACTIVITY_TASK,
   )
 
-  expect(scheduleCommands).toHaveLength(13)
+  expect(scheduleCommands).toHaveLength(14)
   expect(output.commands.at(-1)?.commandType).toBe(CommandType.COMPLETE_WORKFLOW_EXECUTION)
   expect(output.completion).toBe('completed')
   expect(output.result).toEqual({ id: 'enrichment-id', filename: input.filePath })

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoriesRouteImport } from './routes/api/memories'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as ApiEnrichRouteImport } from './routes/api/enrich'
+import { Route as ApiCodeSearchRouteImport } from './routes/api/code-search'
 import { Route as AgentsGeneralRouteImport } from './routes/agents/general'
 import { Route as AgentsRunIdRouteImport } from './routes/agents/$runId'
 import { Route as TerminalsSessionIdIndexRouteImport } from './routes/terminals/$sessionId/index'
@@ -286,6 +287,11 @@ const ApiHealthRoute = ApiHealthRouteImport.update({
 const ApiEnrichRoute = ApiEnrichRouteImport.update({
   id: '/api/enrich',
   path: '/api/enrich',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiCodeSearchRoute = ApiCodeSearchRouteImport.update({
+  id: '/api/code-search',
+  path: '/api/code-search',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsGeneralRoute = AgentsGeneralRouteImport.update({
@@ -842,6 +848,7 @@ export interface FileRoutesByFullPath {
   '/ready': typeof ReadyRoute
   '/agents/$runId': typeof AgentsRunIdRoute
   '/agents/general': typeof AgentsGeneralRoute
+  '/api/code-search': typeof ApiCodeSearchRoute
   '/api/enrich': typeof ApiEnrichRoute
   '/api/health': typeof ApiHealthRoute
   '/api/memories': typeof ApiMemoriesRouteWithChildren
@@ -972,6 +979,7 @@ export interface FileRoutesByTo {
   '/ready': typeof ReadyRoute
   '/agents/$runId': typeof AgentsRunIdRoute
   '/agents/general': typeof AgentsGeneralRoute
+  '/api/code-search': typeof ApiCodeSearchRoute
   '/api/enrich': typeof ApiEnrichRoute
   '/api/health': typeof ApiHealthRoute
   '/api/memories': typeof ApiMemoriesRouteWithChildren
@@ -1101,6 +1109,7 @@ export interface FileRoutesById {
   '/ready': typeof ReadyRoute
   '/agents/$runId': typeof AgentsRunIdRoute
   '/agents/general': typeof AgentsGeneralRoute
+  '/api/code-search': typeof ApiCodeSearchRoute
   '/api/enrich': typeof ApiEnrichRoute
   '/api/health': typeof ApiHealthRoute
   '/api/memories': typeof ApiMemoriesRouteWithChildren
@@ -1233,6 +1242,7 @@ export interface FileRouteTypes {
     | '/ready'
     | '/agents/$runId'
     | '/agents/general'
+    | '/api/code-search'
     | '/api/enrich'
     | '/api/health'
     | '/api/memories'
@@ -1363,6 +1373,7 @@ export interface FileRouteTypes {
     | '/ready'
     | '/agents/$runId'
     | '/agents/general'
+    | '/api/code-search'
     | '/api/enrich'
     | '/api/health'
     | '/api/memories'
@@ -1491,6 +1502,7 @@ export interface FileRouteTypes {
     | '/ready'
     | '/agents/$runId'
     | '/agents/general'
+    | '/api/code-search'
     | '/api/enrich'
     | '/api/health'
     | '/api/memories'
@@ -1622,6 +1634,7 @@ export interface RootRouteChildren {
   ReadyRoute: typeof ReadyRoute
   AgentsRunIdRoute: typeof AgentsRunIdRoute
   AgentsGeneralRoute: typeof AgentsGeneralRoute
+  ApiCodeSearchRoute: typeof ApiCodeSearchRoute
   ApiEnrichRoute: typeof ApiEnrichRoute
   ApiHealthRoute: typeof ApiHealthRoute
   ApiMemoriesRoute: typeof ApiMemoriesRouteWithChildren
@@ -1925,6 +1938,13 @@ declare module '@tanstack/react-router' {
       path: '/api/enrich'
       fullPath: '/api/enrich'
       preLoaderRoute: typeof ApiEnrichRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/code-search': {
+      id: '/api/code-search'
+      path: '/api/code-search'
+      fullPath: '/api/code-search'
+      preLoaderRoute: typeof ApiCodeSearchRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/general': {
@@ -2844,6 +2864,7 @@ const rootRouteChildren: RootRouteChildren = {
   ReadyRoute: ReadyRoute,
   AgentsRunIdRoute: AgentsRunIdRoute,
   AgentsGeneralRoute: AgentsGeneralRoute,
+  ApiCodeSearchRoute: ApiCodeSearchRoute,
   ApiEnrichRoute: ApiEnrichRoute,
   ApiHealthRoute: ApiHealthRoute,
   ApiMemoriesRoute: ApiMemoriesRouteWithChildren,

--- a/services/jangar/src/routes/api/code-search.ts
+++ b/services/jangar/src/routes/api/code-search.ts
@@ -1,0 +1,139 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Duration, Effect, Layer, ManagedRuntime, pipe } from 'effect'
+
+import { Atlas, AtlasLive } from '~/server/atlas'
+import { DEFAULT_REF, MAX_SEARCH_LIMIT, parseAtlasCodeSearchInput } from '~/server/atlas-http'
+import type { AtlasCodeSearchMatch } from '~/server/atlas-store'
+
+type CodeSearchPayload = {
+  query?: string
+  limit?: number
+  repository?: string
+  ref?: string
+  pathPrefix?: string
+  language?: string
+}
+
+export const Route = createFileRoute('/api/code-search')({
+  server: {
+    handlers: {
+      GET: async () => new Response('Method Not Allowed', { status: 405 }),
+      POST: async ({ request }) => postCodeSearchHandler(request),
+    },
+  },
+})
+
+const handlerRuntime = ManagedRuntime.make(Layer.mergeAll(AtlasLive))
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const errorResponse = (message: string, status = 500) => jsonResponse({ ok: false, message, error: message }, status)
+
+const resolveServiceError = (message: string) => {
+  const normalized = message.toLowerCase()
+  if (message.includes('DATABASE_URL')) return errorResponse(message, 503)
+  if (message.includes('OPENAI_API_KEY')) return errorResponse(message, 503)
+  if (normalized.includes('timed out') || normalized.includes('timeout')) return errorResponse(message, 504)
+  return errorResponse(message, 500)
+}
+
+const resolveRequestError = (message: string) => {
+  if (message === 'invalid JSON body') return errorResponse(message, 400)
+  return resolveServiceError(message)
+}
+
+const parseJsonBody = async (request: Request): Promise<CodeSearchPayload> => {
+  try {
+    const json = (await request.json()) as unknown
+    if (!json || typeof json !== 'object' || Array.isArray(json)) {
+      throw new Error('invalid JSON body')
+    }
+    return json as CodeSearchPayload
+  } catch {
+    throw new Error('invalid JSON body')
+  }
+}
+
+const toItem = (match: AtlasCodeSearchMatch) => ({
+  repository: match.repository.name,
+  ref: match.fileVersion.repositoryRef,
+  commit: match.fileVersion.repositoryCommit ?? undefined,
+  path: match.fileKey.path,
+  startLine: match.chunk.startLine,
+  endLine: match.chunk.endLine,
+  score: match.score,
+  signals: match.signals,
+  snippet: match.chunk.content,
+})
+
+export const postCodeSearchHandlerEffect = (request: Request) =>
+  pipe(
+    Effect.gen(function* () {
+      const payload = yield* Effect.tryPromise({
+        try: () => parseJsonBody(request),
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      })
+
+      const parsed = parseAtlasCodeSearchInput(payload as Record<string, unknown>)
+      if (!parsed.ok) return errorResponse(parsed.message, 400)
+
+      const requestedLimit = parsed.value.limit ?? 10
+      const effectiveLimit = Math.min(Math.max(requestedLimit, 1), MAX_SEARCH_LIMIT)
+      const ref = parsed.value.ref ?? DEFAULT_REF
+
+      const atlas = yield* Atlas
+
+      let matches: AtlasCodeSearchMatch[]
+      try {
+        matches = yield* atlas.codeSearch({
+          ...parsed.value,
+          ref,
+          limit: Math.min(MAX_SEARCH_LIMIT, effectiveLimit),
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        const normalized = message.toLowerCase()
+        const looksLikeTransientDbBlip =
+          normalized.includes('econnrefused') ||
+          normalized.includes('connection terminated unexpectedly') ||
+          normalized.includes('server closed the connection unexpectedly')
+
+        if (!looksLikeTransientDbBlip) throw error
+
+        // Port-forwards can briefly restart (local listener down for ~1s). Retry once.
+        yield* Effect.sleep(Duration.millis(750))
+        matches = yield* atlas.codeSearch({
+          ...parsed.value,
+          ref,
+          limit: Math.min(MAX_SEARCH_LIMIT, effectiveLimit),
+        })
+      }
+
+      const items = matches.map(toItem)
+      return jsonResponse({ ok: true, matches, items, total: items.length })
+    }),
+    Effect.catchAll((error) => Effect.succeed(resolveRequestError(error.message))),
+  )
+
+export const postCodeSearchHandler = async (request: Request) => {
+  const timeoutMs = Number.parseInt(process.env.ATLAS_CODE_SEARCH_TIMEOUT_MS ?? '25000', 10)
+  const effectiveTimeoutMs = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 25_000
+
+  return Promise.race([
+    handlerRuntime.runPromise(postCodeSearchHandlerEffect(request)),
+    new Promise<Response>((resolve) => {
+      setTimeout(() => {
+        resolve(errorResponse(`atlas code search timed out after ${effectiveTimeoutMs}ms`, 504))
+      }, effectiveTimeoutMs)
+    }),
+  ])
+}

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -1403,7 +1403,7 @@ describe('agents controller reconcileAgentRun', () => {
       const agentRun = buildAgentRun()
       await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
 
-      const defaultTemplate = (lastJob?.spec as Record<string, unknown> | undefined)?.template as
+      const defaultTemplate = ((lastJob as any)?.spec as Record<string, unknown> | undefined)?.template as
         | Record<string, unknown>
         | undefined
       const defaultPodSpec = (defaultTemplate?.spec as Record<string, unknown> | undefined) ?? {}
@@ -1459,7 +1459,7 @@ describe('agents controller reconcileAgentRun', () => {
         0,
       )
 
-      const overrideTemplate = (lastJob?.spec as Record<string, unknown> | undefined)?.template as
+      const overrideTemplate = ((lastJob as any)?.spec as Record<string, unknown> | undefined)?.template as
         | Record<string, unknown>
         | undefined
       const overridePodSpec = (overrideTemplate?.spec as Record<string, unknown> | undefined) ?? {}
@@ -1538,7 +1538,7 @@ describe('agents controller reconcileAgentRun', () => {
       const agentRun = buildAgentRun()
       await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
 
-      const defaultTemplate = (lastJob?.spec as Record<string, unknown> | undefined)?.template as
+      const defaultTemplate = ((lastJob as any)?.spec as Record<string, unknown> | undefined)?.template as
         | Record<string, unknown>
         | undefined
       const defaultPodSpec = (defaultTemplate?.spec as Record<string, unknown> | undefined) ?? {}
@@ -1687,7 +1687,7 @@ describe('agents controller reconcileAgentRun', () => {
     expect(status.phase).toBe('Running')
     expect(status.systemPromptHash).toBe(createHash('sha256').update('workflow-prompt').digest('hex'))
 
-    const podTemplate = (lastJob?.spec as Record<string, unknown> | undefined)?.template as
+    const podTemplate = ((lastJob as any)?.spec as Record<string, unknown> | undefined)?.template as
       | Record<string, unknown>
       | undefined
     const podSpecSpec = (podTemplate?.spec as Record<string, unknown> | undefined) ?? {}

--- a/services/jangar/src/server/__tests__/mcp.test.ts
+++ b/services/jangar/src/server/__tests__/mcp.test.ts
@@ -72,6 +72,7 @@ const makeAtlasService = (): AtlasService => {
     listIndexedFiles: () => fail(),
     getAstPreview: () => fail(),
     search: () => fail(),
+    codeSearch: () => fail(),
     searchCount: () => fail(),
     stats: () => fail(),
     close: () => Effect.void,
@@ -111,6 +112,7 @@ describe('Memories MCP handler', () => {
       'retrieve_memory',
       'atlas_index',
       'atlas_search',
+      'atlas_code_search',
       'atlas_stats',
     ])
   })

--- a/services/jangar/src/server/atlas-http.ts
+++ b/services/jangar/src/server/atlas-http.ts
@@ -32,6 +32,15 @@ export type AtlasSearchInput = {
   kinds?: string[]
 }
 
+export type AtlasCodeSearchInput = {
+  query: string
+  limit?: number
+  repository?: string
+  ref?: string
+  pathPrefix?: string
+  language?: string
+}
+
 const normalizeRequiredText = (value: unknown, field: string, max: number, fallback?: string): string | null => {
   const raw = typeof value === 'string' ? value.trim() : ''
   const resolved = raw.length > 0 ? raw : (fallback ?? '')
@@ -148,6 +157,39 @@ export const parseAtlasSearchInput = (
     return {
       ok: false,
       message: error instanceof Error ? error.message : 'Invalid Atlas search input.',
+    }
+  }
+}
+
+export const parseAtlasCodeSearchInput = (
+  payload: Record<string, unknown>,
+  fallbackLimit = DEFAULT_LIMIT,
+): ValidationResult<AtlasCodeSearchInput> => {
+  try {
+    const query = normalizeRequiredText(payload.query, 'Query', MAX_QUERY_CHARS)
+    if (!query) return { ok: false, message: 'Query is required.' }
+
+    const limit = normalizeLimit(payload.limit, fallbackLimit)
+    const repository = normalizeOptionalText(payload.repository, MAX_REPOSITORY_CHARS)
+    const ref = normalizeOptionalText(payload.ref, MAX_REF_CHARS)
+    const pathPrefix = normalizeOptionalText(payload.pathPrefix, MAX_PATH_CHARS)
+    const language = normalizeOptionalText(payload.language, 100)
+
+    return {
+      ok: true,
+      value: {
+        query,
+        limit,
+        repository,
+        ref,
+        pathPrefix,
+        language,
+      },
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : 'Invalid Atlas code search input.',
     }
   }
 }

--- a/services/jangar/src/server/atlas.ts
+++ b/services/jangar/src/server/atlas.ts
@@ -2,6 +2,8 @@ import { Context, Effect, Layer, pipe } from 'effect'
 
 import {
   type AtlasAstPreview,
+  type AtlasCodeSearchInput,
+  type AtlasCodeSearchMatch,
   type AtlasIndexedFile,
   type AtlasSearchInput,
   type AtlasSearchMatch,
@@ -73,6 +75,7 @@ export type AtlasService = {
   getAstPreview: (input: { fileVersionId: string; limit?: number }) => Effect.Effect<AtlasAstPreview, Error>
   search: (input: AtlasSearchInput) => Effect.Effect<AtlasSearchMatch[], Error>
   searchCount: (input: AtlasSearchInput) => Effect.Effect<number, Error>
+  codeSearch: (input: AtlasCodeSearchInput) => Effect.Effect<AtlasCodeSearchMatch[], Error>
   stats: () => Effect.Effect<AtlasStats, Error>
   close: () => Effect.Effect<void, Error>
 }
@@ -149,6 +152,7 @@ export const AtlasLive = Layer.scoped(
       getAstPreview: (input) => wrap('atlas get ast preview failed', (resolved) => resolved.getAstPreview(input)),
       search: (input) => wrap('atlas search failed', (resolved) => resolved.search(input)),
       searchCount: (input) => wrap('atlas search count failed', (resolved) => resolved.searchCount(input)),
+      codeSearch: (input) => wrap('atlas code search failed', (resolved) => resolved.codeSearch(input)),
       stats: () => wrap('atlas stats failed', (resolved) => resolved.stats()),
       close: () =>
         pipe(

--- a/services/jangar/src/server/db.ts
+++ b/services/jangar/src/server/db.ts
@@ -47,8 +47,17 @@ type AtlasFileChunks = {
   start_line: number | null
   end_line: number | null
   content: string | null
+  text_tsvector: unknown | null
   token_count: number | null
   metadata: JsonValue
+  created_at: Generated<Timestamp>
+}
+
+type AtlasChunkEmbeddings = {
+  chunk_id: string
+  model: string
+  dimension: number
+  embedding: unknown
   created_at: Generated<Timestamp>
 }
 
@@ -558,6 +567,7 @@ export type Database = {
   'atlas.file_chunks': AtlasFileChunks
   'atlas.enrichments': AtlasEnrichments
   'atlas.embeddings': AtlasEmbeddings
+  'atlas.chunk_embeddings': AtlasChunkEmbeddings
   'atlas.tree_sitter_facts': AtlasTreeSitterFacts
   'atlas.symbols': AtlasSymbols
   'atlas.symbol_defs': AtlasSymbolDefs

--- a/services/jangar/src/server/github-review-actions.ts
+++ b/services/jangar/src/server/github-review-actions.ts
@@ -73,8 +73,8 @@ export const submitPullRequestReview = async (
     source: 'github-review-actions',
     repository,
   })
-  const actor = auditContext.actor
-  const requestId = auditContext.requestId ?? auditContext.correlationId
+  const actor = auditContext.actor ?? null
+  const requestId = auditContext.requestId ?? auditContext.correlationId ?? null
   const receivedAt = new Date().toISOString()
 
   try {
@@ -205,8 +205,8 @@ export const resolvePullRequestThread = async (
     source: 'github-review-actions',
     repository,
   })
-  const actor = auditContext.actor
-  const requestId = auditContext.requestId ?? auditContext.correlationId
+  const actor = auditContext.actor ?? null
+  const requestId = auditContext.requestId ?? auditContext.correlationId ?? null
   const receivedAt = new Date().toISOString()
   let resolvedThreadId: string | null = null
 
@@ -344,8 +344,8 @@ export const mergePullRequest = async (
     source: 'github-review-actions',
     repository,
   })
-  const actor = auditContext.actor
-  const requestId = auditContext.requestId ?? auditContext.correlationId
+  const actor = auditContext.actor ?? null
+  const requestId = auditContext.requestId ?? auditContext.correlationId ?? null
   const receivedAt = new Date().toISOString()
 
   try {

--- a/services/jangar/src/server/kysely-migrations.ts
+++ b/services/jangar/src/server/kysely-migrations.ts
@@ -14,6 +14,7 @@ import * as jangarPrimitivesMigration from '~/server/migrations/20260111_jangar_
 import * as jangarPrimitivesIndexesMigration from '~/server/migrations/20260111_jangar_primitives_indexes'
 import * as agentsControlPlaneCacheMigration from '~/server/migrations/20260205_agents_control_plane_cache'
 import * as jangarAgentRunIdempotencyMigration from '~/server/migrations/20260208_jangar_agentrun_idempotency'
+import * as atlasChunkSearchMigration from '~/server/migrations/20260209_atlas_chunk_search'
 
 type MigrationMap = Record<string, Migration>
 
@@ -41,6 +42,7 @@ const migrations: MigrationMap = {
   '20260111_jangar_primitives_indexes': jangarPrimitivesIndexesMigration,
   '20260205_agents_control_plane_cache': agentsControlPlaneCacheMigration,
   '20260208_jangar_agentrun_idempotency': jangarAgentRunIdempotencyMigration,
+  '20260209_atlas_chunk_search': atlasChunkSearchMigration,
 }
 
 const migrationProvider = new StaticMigrationProvider(migrations)

--- a/services/jangar/src/server/leader-election.ts
+++ b/services/jangar/src/server/leader-election.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 
-import type { V1Lease } from '@kubernetes/client-node'
+import { V1MicroTime, type V1Lease } from '@kubernetes/client-node'
 import { type Counter, metrics as otelMetrics } from '@proompteng/otel/api'
 
 export type LeaderElectionConfig = {
@@ -58,7 +58,7 @@ const globalState = globalThis as typeof globalThis & {
 }
 
 const nowIso = () => new Date().toISOString()
-const toMicroTime = (date: Date) => date.toISOString().replace(/\.(\d{3})Z$/, '.$1000Z')
+const toMicroTime = (date: Date) => new V1MicroTime(date.getTime())
 
 const parseBooleanEnv = (value: string | undefined, fallback: boolean) => {
   if (!value) return fallback
@@ -436,7 +436,6 @@ export const ensureLeaderElectionRuntime = (callbacks: LeaderElectionCallbacks) 
       lastError: null,
     } as LeaderElectionStatus,
     lastLease: null as V1Lease | null,
-    kube: undefined as { api: CoordinationV1Api } | undefined,
     metrics: undefined as { changesCounter: Counter } | undefined,
     stop: undefined as (() => void) | undefined,
   }

--- a/services/jangar/src/server/migrations/20260209_atlas_chunk_search.ts
+++ b/services/jangar/src/server/migrations/20260209_atlas_chunk_search.ts
@@ -1,0 +1,73 @@
+import { type Kysely, sql } from 'kysely'
+
+import type { Database } from '../db'
+
+const DEFAULT_OPENAI_API_BASE_URL = 'https://api.openai.com/v1'
+const DEFAULT_OPENAI_EMBEDDING_DIMENSION = 1536
+const DEFAULT_SELF_HOSTED_EMBEDDING_DIMENSION = 1024
+
+const isHostedOpenAiBaseUrl = (rawBaseUrl: string) => {
+  try {
+    return new URL(rawBaseUrl).hostname === 'api.openai.com'
+  } catch {
+    return rawBaseUrl.includes('api.openai.com')
+  }
+}
+
+const loadEmbeddingDimension = (fallback: number) => {
+  const dimension = Number.parseInt(process.env.OPENAI_EMBEDDING_DIMENSION ?? String(fallback), 10)
+  if (!Number.isFinite(dimension) || dimension <= 0) {
+    throw new Error('OPENAI_EMBEDDING_DIMENSION must be a positive integer')
+  }
+  return dimension
+}
+
+const resolveEmbeddingDimension = () => {
+  const apiBaseUrl = process.env.OPENAI_API_BASE_URL ?? process.env.OPENAI_API_BASE ?? DEFAULT_OPENAI_API_BASE_URL
+  const hosted = isHostedOpenAiBaseUrl(apiBaseUrl)
+  const fallback = hosted ? DEFAULT_OPENAI_EMBEDDING_DIMENSION : DEFAULT_SELF_HOSTED_EMBEDDING_DIMENSION
+  return loadEmbeddingDimension(fallback)
+}
+
+export const up = async (db: Kysely<Database>) => {
+  const embeddingDimension = resolveEmbeddingDimension()
+
+  await sql`
+    ALTER TABLE ${sql.ref('atlas.file_chunks')}
+    ADD COLUMN IF NOT EXISTS text_tsvector tsvector;
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_file_chunks_file_version_id_idx
+    ON ${sql.ref('atlas.file_chunks')} (file_version_id);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_file_chunks_text_tsvector_gin_idx
+    ON ${sql.ref('atlas.file_chunks')} USING gin (text_tsvector);
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS ${sql.ref('atlas.chunk_embeddings')} (
+      chunk_id UUID PRIMARY KEY REFERENCES atlas.file_chunks(id) ON DELETE CASCADE,
+      model TEXT NOT NULL,
+      dimension INT NOT NULL,
+      embedding vector(${sql.raw(String(embeddingDimension))}) NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_chunk_embeddings_model_dimension_idx
+    ON ${sql.ref('atlas.chunk_embeddings')} (model, dimension);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_chunk_embeddings_embedding_idx
+    ON ${sql.ref('atlas.chunk_embeddings')}
+    USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 100);
+  `.execute(db)
+}
+
+export const down = async (_db: Kysely<Database>) => {}


### PR DESCRIPTION
## Summary

- Add chunk-level indexing in Atlas (chunks + chunk embeddings + chunk lexical search) to enable precise semantic code search.
- Expose hybrid chunk search via Jangar `POST /api/code-search` and MCP tool `atlas_code_search` (alias `atlas.code_search`).
- Extend Bumba `enrichFile` to optionally write chunks + embeddings (`BUMBA_ATLAS_CHUNK_INDEXING`), plus route model calls to the `bumba-model` task queue and increase model timeouts to reduce Temporal failures.

## Related Issues

None

## Testing

- `bun run --cwd services/bumba test`
- `bun run --cwd services/bumba tsc`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar test -- src/server/__tests__/mcp.test.ts`
- `bun run --cwd services/jangar test -- src/server/__tests__/primitives-endpoints.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

- Adds a Jangar DB migration for `atlas.file_chunks.text_tsvector` and new table `atlas.chunk_embeddings`.
- Bumba chunk indexing is feature-flagged and schema-safe; rollout should deploy Jangar/migrations before expecting chunk rows to appear.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and follow-ups updated (see `docs/jangar/primitives/code-search.md`).
