### PR TITLE
fix(bumba): make chunk indexing best-effort

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: bumba
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-08T23:14:43.682Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-09T01:44:46.451Z"
     spec:
       containers:
         - name: bumba

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - deployment-model.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: "3d8b27f1"
+    newTag: "373404ce"

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-08T20:56:17.065Z"
+    deploy.knative.dev/rollout: "2026-02-09T01:43:16.644Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -54,5 +54,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "2f466157"
-    digest: sha256:8c3788508e2fcb97c4ae551b6ee463f8368532167a7cc25e114de589d2727ab1
+    newTag: "373404ce"
+    digest: sha256:08057026a7fdadeca6a88f6b42883e187caca15069ba265ff19b4ced3a2c3f8d


### PR DESCRIPTION
## Summary

- Make `indexFileChunks` best-effort: persist chunks even when embeddings fail, and never fail `enrichFile` due to chunk indexing errors.
- Commit rollout manifest updates for Jangar + Bumba to image tag `373404ce` and updated restart/rollout annotations.

## Related Issues

None

## Testing

- `bun run --cwd services/bumba tsc`
- `bun run --cwd services/bumba test`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and follow-ups updated or tracked.
