### PR TITLE
chore(deploy): roll out bumba befec799

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: bumba
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-09T01:44:46.451Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-09T01:50:24.393Z"
     spec:
       containers:
         - name: bumba

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - deployment-model.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: "373404ce"
+    newTag: "befec799"


### PR DESCRIPTION
## Summary

- Update Bumba image tag to `befec799` and bump rollout annotation (post-merge deploy).

## Related Issues

None

## Testing

- N/A (manifest-only rollout tag bump)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and follow-ups updated or tracked.
