### PR TITLE
chore(deploy): roll out jangar 5b3e7941

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-09T01:43:16.644Z"
+    deploy.knative.dev/rollout: "2026-02-09T02:02:07.550Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -54,5 +54,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "373404ce"
-    digest: sha256:08057026a7fdadeca6a88f6b42883e187caca15069ba265ff19b4ced3a2c3f8d
+    newTag: "5b3e7941"
+    digest: sha256:512e65aa7f2bdae38f90c026dd0807b634d2e94caa9fae22ee3c599771a58cb3


### PR DESCRIPTION
Rolls out jangar image tag 5b3e7941 (includes lexical fallback for /api/code-search when embeddings are down).