### PR TITLE
chore(deploy): roll out bumba 139e01e9

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: bumba
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-09T01:50:24.393Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-09T02:09:45.972Z"
     spec:
       containers:
         - name: bumba

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - deployment-model.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: "befec799"
+    newTag: "139e01e9"


### PR DESCRIPTION
Rolls out bumba image tag 139e01e9 (includes running chunk indexing before model enrichment so lexical code search can work during model outages).