### PR TITLE
docs(temporal-bun-sdk): nondeterminism guardrails design docs

### DIFF
--- a/docs/temporal-bun-sdk/README.md
+++ b/docs/temporal-bun-sdk/README.md
@@ -8,6 +8,16 @@ acceptance criteria.
 ## Index
 - `testing-environment.md` - Bun-native test environment with time skipping and
   ephemeral server orchestration.
+- `nondeterminism-guardrails.md` - Defense-in-depth plan to prevent production
+  nondeterministic workflow failures (versioning policy, runtime guards, linting,
+  and replay CI gates).
+- `workflow-runtime-sandbox.md` - Runtime “sandbox” guards that make common
+  nondeterministic APIs deterministic (Date/Math.random) or fail fast (fetch/fs/etc)
+  when executed in workflow context.
+- `workflow-linting.md` - Build-time checks for workflow source imports and banned
+  APIs; CLI contract and configuration for enforcement in CI and `temporal-bun init`.
+- `replay-ci-gate.md` - CI gate that replays golden workflow histories and blocks
+  merges that would introduce nondeterminism without version guards.
 - `schedules-and-search-attributes.md` - Schedule client + typed search
   attributes with schema validation.
 - `nexus-operations.md` - Nexus task polling, handler runtime, and client helpers.

--- a/docs/temporal-bun-sdk/nondeterminism-guardrails.md
+++ b/docs/temporal-bun-sdk/nondeterminism-guardrails.md
@@ -1,0 +1,225 @@
+# Nondeterminism Guardrails (Production Design)
+
+This document defines a defense-in-depth plan for making nondeterministic Workflow
+Task failures effectively impossible in production for workflows authored against
+`@proompteng/temporal-bun-sdk`.
+
+Temporal’s core guarantee is durability via replay. If workflow code changes in a
+way that would emit different commands for the same history, the server will fail
+workflow tasks with `WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR`.
+
+We cannot make nondeterminism “impossible” for arbitrary TypeScript. We can make
+it operationally impossible to hit in production by enforcing these invariants:
+
+1. Old runs never execute new workflow code (worker build ID versioning, pinned).
+2. Workflow code cannot accidentally depend on nondeterministic sources (runtime
+   guards and build-time linting).
+3. Releases are blocked if they break replay on known histories (replay CI gate).
+
+## Problem Statement
+
+Teams regularly hit nondeterminism in production because:
+
+- A workflow is edited without adding a versioning branch.
+- A transitive dependency uses nondeterministic APIs (time, randomness, I/O).
+- A workflow mistakenly performs I/O directly in workflow context.
+- CI does not replay histories from older versions.
+
+The failure mode is expensive: stuck or failing workflow tasks and operational
+recovery work (resets, patches, or emergency worker pinning).
+
+## Goals
+
+- Prevent production nondeterminism by default, without relying on every engineer
+  to remember Temporal’s replay rules.
+- When a workflow change requires a version branch, surface that requirement at
+  PR time (lint and replay gate), not after deploy.
+- Provide deterministic shims for common APIs (time, randomness) so “doing the
+  obvious thing” stays safe.
+- Provide failure messages and diagnostics that are actionable and point to the
+  correct remediation.
+
+## Non-Goals
+
+- Implementing a full isolate-based workflow sandbox.
+- Preventing nondeterminism in intentionally bypassed code paths.
+- Eliminating nondeterminism errors caused by cross-version histories when worker
+  versioning is explicitly disabled.
+
+## Existing Mechanisms In The Repo
+
+- Determinism ledger and mismatch detection: `packages/temporal-bun-sdk/src/workflow/determinism.ts`
+- History replay reconstruction and diffing: `packages/temporal-bun-sdk/src/workflow/replay.ts`
+- Worker-side nondeterminism enrichment and retry: `packages/temporal-bun-sdk/src/worker/runtime.ts`
+- Worker build ID compatibility registration: `packages/temporal-bun-sdk/src/worker/build-id.ts`
+- Workflow versioning helpers surfaced to users:
+  `packages/temporal-bun-sdk/src/workflow/context.ts` (`determinism.getVersion`, `determinism.patched`, `determinism.sideEffect`)
+
+## Proposal Overview
+
+We introduce four guardrail layers plus improved diagnostics.
+
+### Layer A: Production Worker Versioning Policy (Mandatory)
+
+In production, all workers that can run workflows must be versioned and pinned:
+
+- `WorkerVersioningMode.VERSIONED`
+- `VersioningBehavior.PINNED`
+- `buildId` is a stable, deploy-derived identifier (git sha, semver, etc.)
+
+In strict mode, the worker fails fast if:
+
+- Worker versioning APIs are unsupported by the server.
+- Build ID registration is skipped.
+- Build ID is missing or looks accidental (e.g. equals identity).
+
+Rationale: this makes it operationally impossible for old workflow runs to ever
+load new workflow code, which is the single most important guardrail.
+
+See `worker-ops-and-versioning.md` for the existing user-facing API surface.
+
+### Layer B: Runtime Workflow Guards (Default On In Production)
+
+At runtime, the SDK installs process-wide wrappers for key globals that check:
+“are we executing in workflow context right now?” using AsyncLocalStorage.
+
+If not in workflow context, behavior is unchanged.
+
+If in workflow context:
+
+- Time and randomness are made deterministic by routing through the determinism
+  guard.
+- Side-effectful APIs (I/O, timers, subprocess) throw immediately with a message
+  describing the safe alternative (activities, timers, `determinism.sideEffect`).
+
+This prevents accidental nondeterminism from:
+
+- `Date.now()`, `Math.random()`, `performance.now()`
+- `fetch()`, `WebSocket`, filesystem access
+- `setTimeout`/`setInterval` in workflow context (workflows must use workflow
+  timer commands instead)
+
+See `workflow-runtime-sandbox.md`.
+
+### Layer C: Build-Time Workflow Lint (Default On In CI)
+
+Add a workflow lint command that runs on workflow sources before merging:
+
+- Detect disallowed imports for workflow code.
+- Detect direct usage of banned globals and patterns.
+- Enforce that workflow entrypoints are labeled and analyzable.
+
+See `workflow-linting.md`.
+
+### Layer D: Replay CI Gate (Golden Histories)
+
+Any change to workflow code must pass deterministic replay against a curated set
+of histories (fixtures plus optionally staging/prod exports).
+
+The gate is “red” unless:
+
+- Replay is deterministic, or
+- The workflow change is explicitly guarded (`getVersion` / `patched`) and the
+  new code path is pinned to a new build ID.
+
+See `replay-ci-gate.md`.
+
+### Diagnostics Improvements
+
+When a mismatch still occurs (SDK bug, misconfiguration, or explicit opt-out),
+errors must become actionable:
+
+- `WorkflowNondeterminismError.details` should include:
+  - the first mismatch index (command/time/random)
+  - a stable signature of the expected vs received intent
+  - the last applied determinism marker (event ID, marker version)
+  - remediation hints:
+    - enable build ID versioning
+    - add `determinism.getVersion` / `determinism.patched`
+    - move I/O into activities
+
+## Configuration
+
+Add a strictness knob in config and as runtime options.
+
+### Env Vars
+
+- `TEMPORAL_WORKFLOW_GUARDS=strict|warn|off`
+  - `strict`: block side effects + enforce versioning policy at startup
+  - `warn`: log violations but do not throw (safe for gradual rollout)
+  - `off`: no runtime wrappers (not recommended)
+- `TEMPORAL_WORKFLOW_LINT=strict|warn|off` (controls CLI lint default behavior)
+- `TEMPORAL_REPLAY_GATE_REQUIRED=1` (CI convenience toggle; defaults to enabled
+  for repos that declare workflows)
+
+### Programmatic Options
+
+Extend `WorkerRuntimeOptions`:
+
+```ts
+type WorkerRuntimeOptions = {
+  workflowGuards?: 'strict' | 'warn' | 'off'
+  workflowLint?: 'strict' | 'warn' | 'off'
+  // existing fields...
+}
+```
+
+## Rollout Plan
+
+1. Introduce runtime guards in `warn` mode by default. Validate on one service.
+2. Introduce lint in `warn` mode in CI. Track violations, fix workflows.
+3. Enable build ID versioning and PINNED behavior in production environments.
+4. Flip runtime guards to `strict` in production.
+5. Flip lint to `strict` for workflow packages.
+6. Add replay gate with a small golden set, then expand over time.
+
+## Backwards Compatibility
+
+- Local development against `temporal server start-dev` often lacks versioning
+  APIs. In strict mode we must allow an explicit opt-out for local dev.
+- Runtime wrappers must be implemented as “context aware” wrappers that are
+  no-ops outside workflow execution.
+- Lint must allow escape hatches with explicit annotations for rare legitimate
+  cases, but must require an allowlist comment and an issue reference.
+
+## Implementation Notes (For Agent Runs)
+
+This section is deliberately concrete so an agent run can implement without
+re-planning.
+
+1. Add workflow execution context ALS distinct from logging context, or reuse
+   the existing `WorkflowLogContext`:
+   - `packages/temporal-bun-sdk/src/workflow/log.ts`
+2. Add guard installer and wrappers:
+   - new module: `packages/temporal-bun-sdk/src/workflow/guards.ts`
+   - wire into `packages/temporal-bun-sdk/src/workflow/executor.ts` so it installs
+     once per process and is active during execution.
+   - add `// TODO(TBS-NDG-001): ...` markers for each wrapper.
+3. Update worker startup policy:
+   - `packages/temporal-bun-sdk/src/worker/runtime.ts`
+   - if `workflowGuards === 'strict'`, require versioning APIs to be supported
+     and build ID registration to succeed when `deployment.versioningMode === VERSIONED`.
+   - add `// TODO(TBS-NDG-002): enforce strict versioning policy`.
+4. Add CLI lint command:
+   - new: `packages/temporal-bun-sdk/src/bin/lint-workflows-command.ts`
+   - update CLI router: `packages/temporal-bun-sdk/src/bin/temporal-bun.ts`
+   - add `// TODO(TBS-NDG-003): lint-workflows` markers.
+5. Add replay gate documentation and a sample CI workflow snippet:
+   - `docs/temporal-bun-sdk/replay-ci-gate.md`
+6. Add tests:
+   - new tests under `packages/temporal-bun-sdk/tests/` covering wrappers.
+
+## Acceptance Criteria
+
+1. With `workflowGuards=strict`, calling `Date.now()` or `Math.random()` in a
+   workflow produces deterministic values tied to the determinism ledger.
+2. With `workflowGuards=strict`, calling `fetch()` in workflow context fails with
+   an error message that suggests moving the call to an activity.
+3. With `workflowGuards=strict`, using `setTimeout` in workflow context fails and
+   points to workflow timers.
+4. With build ID versioning enabled and pinned, deploying a new build cannot
+   cause nondeterminism for existing runs on the same task queue.
+5. `temporal-bun lint-workflows` detects banned imports and banned APIs.
+6. Replay gate blocks a change that removes a previously-emitted command unless
+   a version branch is added.
+

--- a/docs/temporal-bun-sdk/replay-ci-gate.md
+++ b/docs/temporal-bun-sdk/replay-ci-gate.md
@@ -1,0 +1,146 @@
+# Replay CI Gate (Design)
+
+This document defines a CI gate that prevents merging workflow code changes that
+would introduce nondeterminism when replaying known workflow histories.
+
+The Bun SDK already ships `temporal-bun replay` and a determinism diff pipeline.
+The missing piece is policy and automation:
+
+- which histories are required
+- when the gate runs
+- what “pass” means
+- how engineers remediate failures
+
+## Goals
+
+- Block workflow changes that would fail replay for older histories.
+- Make “safe changes” easy and fast to validate.
+- Provide actionable mismatch reports as CI artifacts.
+
+## Non-Goals
+
+- Replaying the entire production history corpus on every PR.
+- Proving determinism for unseen histories.
+
+## Inputs
+
+The gate replays one or both of:
+
+1. **Repository fixtures** (always available):
+   - `packages/temporal-bun-sdk/tests/replay/fixtures/*.json`
+2. **Golden histories** (curated exports, optional):
+   - stored under `docs/replay-runbook.md` procedures
+   - sourced from staging or a production sampling job
+
+Golden histories must:
+
+- include the workflow type and identifying metadata
+- be stable (avoid workflows with nondeterministic markers from older SDKs)
+- be small enough to replay within CI budgets
+
+## When The Gate Runs
+
+The gate runs when:
+
+- any file under a configured workflow root changes
+- or the SDK workflow runtime changes (`packages/temporal-bun-sdk/src/workflow/**`)
+
+CI can derive this from the git diff.
+
+## “Pass” Criteria
+
+The gate is green when:
+
+- every required history replays deterministically (`temporal-bun replay` exit code `0`)
+
+If a replay mismatch occurs, the gate is red unless the change is explicitly
+versioned and deployment-pinned:
+
+- The workflow code includes a branch via `determinism.getVersion` or `determinism.patched`.
+- The worker is deployed with build ID pinning so old runs keep executing the
+  old code. (See `nondeterminism-guardrails.md`.)
+
+Note: CI cannot fully verify “old runs stay on old code” without connecting to a
+cluster. The gate enforces that versioning helpers are present when a mismatch
+is detected, and requires a human acknowledgement for pinning.
+
+## Command Contract
+
+Baseline command:
+
+```bash
+bunx temporal-bun replay --history-file <path> --json
+```
+
+CI wrapper:
+
+- runs replay for each fixture
+- collects JSON outputs
+- summarizes mismatches by workflow type and mismatch category
+
+Artifacts:
+
+- `replay-report.json` (merged)
+- `replay-report/*.json` (per history)
+
+## CI Integration Sketch
+
+Example (conceptual) GitHub Actions step:
+
+```bash
+changed=$(git diff --name-only origin/main...HEAD)
+if echo \"$changed\" | rg -q \"(src/workflows|packages/temporal-bun-sdk/src/workflow)\"; then
+  bunx temporal-bun replay --history-dir ./ci/golden-histories --json --out ./artifacts/replay
+fi
+```
+
+## How To Curate Golden Histories
+
+Golden histories are a deliberate sampling set, not an ever-growing dump.
+
+Selection guidelines:
+
+- critical workflows (payment, provisioning, enrichment)
+- workflows with signals and updates
+- workflows with timers and child workflows
+- a representative set of older histories across releases
+
+Size guidelines:
+
+- total replay budget per PR: 2-5 minutes
+- per-history budget: < 10 seconds
+
+## Remediation Playbook (What Engineers Do When Red)
+
+1. If the change is intended to be compatible:
+   - fix the code so it emits the same command intent sequence
+2. If the change is intentionally breaking:
+   - add a version branch using `determinism.getVersion` or `determinism.patched`
+   - ensure deployment uses build ID pinning
+   - add/adjust fixtures to lock in the new behavior
+
+## Implementation Notes (For Agent Runs)
+
+1. Extend `temporal-bun replay` to support directory replay with stable output:
+   - `packages/temporal-bun-sdk/src/bin/replay-command.ts`
+2. Add a CI helper script:
+   - `packages/temporal-bun-sdk/scripts/replay-ci-gate.ts`
+3. Add docs and sample config:
+   - store golden histories under `docs/temporal-bun-sdk/golden-histories/` or
+     a repo-specific location
+4. Add tests:
+   - `packages/temporal-bun-sdk/tests/cli/temporal-bun-replay-ci-gate.test.ts`
+
+Use TODO markers:
+
+- `// TODO(TBS-NDG-004): replay CI gate runner`
+
+## Acceptance Criteria
+
+1. CI gate replays fixtures deterministically on main.
+2. A PR that changes a workflow to emit a different command sequence fails the gate.
+3. CI artifacts include per-history mismatch details with:
+   - command mismatch signatures
+   - missing time/random values
+   - last determinism marker metadata
+

--- a/docs/temporal-bun-sdk/workflow-linting.md
+++ b/docs/temporal-bun-sdk/workflow-linting.md
@@ -1,0 +1,154 @@
+# Workflow Linting (Design)
+
+This document defines a build-time “workflow lint” command for
+`@proompteng/temporal-bun-sdk` that prevents common nondeterminism sources from
+entering workflow code.
+
+Runtime guards catch many issues, but they cannot reliably detect:
+
+- captured references (`const now = Date.now;`)
+- nondeterministic imports deep in dependency graphs
+- `process.env` reads and other hard-to-wrap property access
+
+Linting is the primary enforcement mechanism for these.
+
+## Goals
+
+- Detect and block nondeterministic workflow code in CI before it ships.
+- Provide actionable messages that identify the file, symbol, and fix.
+- Be fast enough to run on every PR for workflow packages.
+
+## Non-Goals
+
+- Full type-aware static analysis.
+- Proving determinism for arbitrary JS.
+
+## CLI Contract
+
+Add:
+
+```bash
+temporal-bun lint-workflows [options]
+```
+
+Exit codes:
+
+- `0`: no issues (or issues below threshold in warn mode)
+- `1`: lint violations
+
+Options:
+
+- `--workflows <path-or-glob>` (repeatable)
+- `--mode strict|warn|off` (default from `TEMPORAL_WORKFLOW_LINT`, otherwise `strict` in CI, `warn` locally)
+- `--format text|json` (default `text`)
+- `--config <path>` (default `.temporal-bun-workflows.json` at repo root if present)
+- `--changed-only` (CI mode; only lint workflows impacted by the diff)
+
+Output:
+
+- `text`: human-readable grouped errors
+- `json`: machine-readable list of violations for CI annotations
+
+## Configuration File
+
+`.temporal-bun-workflows.json` (JSON, no JS execution in CI) defines:
+
+```json
+{
+  "entries": [
+    "services/bumba/src/workflows/index.ts",
+    "packages/*/src/workflows/**/*.ts"
+  ],
+  "allow": {
+    "imports": ["effect", "@effect/schema"],
+    "globals": ["TextEncoder", "TextDecoder"]
+  },
+  "deny": {
+    "imports": ["@proompteng/temporal-bun-sdk/client", "@proompteng/temporal-bun-sdk/worker"],
+    "globals": ["fetch", "WebSocket", "Bun.spawn"],
+    "memberExpressions": ["process.env", "Bun.env"]
+  }
+}
+```
+
+The allowlist is additive. The denylist is authoritative.
+
+## Rules
+
+Rules fall into two categories.
+
+### 1) Import Rules (Dependency Graph)
+
+For workflow entrypoints and all reachable modules:
+
+- Deny imports of known side-effect modules:
+  - `@proompteng/temporal-bun-sdk/client`
+  - `@proompteng/temporal-bun-sdk/worker`
+  - `node:fs`, `node:net`, `node:http`, `node:https`, `node:child_process`, etc.
+- Deny imports of packages known to perform I/O at import time (configurable).
+- Deny dynamic imports unless explicitly allowlisted.
+
+Implementation approach:
+
+- Parse import/export statements from each module.
+- Resolve relative imports and continue traversal.
+- For bare package imports, apply deny rules and do not attempt to traverse into
+  `node_modules` in v1 (optional future enhancement).
+
+### 2) AST Pattern Rules (Local File)
+
+Detect banned identifiers and patterns in workflow modules:
+
+- Direct use of forbidden globals:
+  - `fetch(...)`, `new WebSocket(...)`
+  - `setTimeout`, `setInterval`
+  - `Bun.spawn`, `Deno.run`
+- Member expressions:
+  - `process.env`
+  - `Bun.env`
+- Capturing forbidden globals:
+  - `const f = fetch`
+  - `const now = Date.now`
+
+Allow safe alternatives:
+
+- `ctx.determinism.now()`, `ctx.determinism.random()`
+- `ctx.determinism.sideEffect({ compute })`
+- `ctx.activities.schedule(...)`
+- `ctx.timers.start(...)`
+
+## Parser Choice
+
+Use TypeScript’s parser (already a dev dependency of the SDK):
+
+- `typescript.createSourceFile(...)` for fast AST generation without type-checking.
+- No program-wide type analysis in v1.
+
+This keeps the tool self-contained and predictable in CI.
+
+## Implementation Notes (For Agent Runs)
+
+1. Add command implementation:
+   - `packages/temporal-bun-sdk/src/bin/lint-workflows-command.ts`
+2. Wire into CLI:
+   - `packages/temporal-bun-sdk/src/bin/temporal-bun.ts`
+3. Add config loader:
+   - `packages/temporal-bun-sdk/src/bin/workflow-lint/config.ts`
+4. Add dependency traversal + AST rules:
+   - `packages/temporal-bun-sdk/src/bin/workflow-lint/graph.ts`
+   - `packages/temporal-bun-sdk/src/bin/workflow-lint/rules.ts`
+5. Add tests:
+   - `packages/temporal-bun-sdk/tests/cli/temporal-bun-lint-workflows.test.ts`
+
+Use TODO markers:
+
+- `// TODO(TBS-NDG-003): implement workflow lint CLI`
+
+## Acceptance Criteria
+
+1. Lint fails on `fetch()` in a workflow module.
+2. Lint fails on `process.env.X` access in a workflow module.
+3. Lint fails on `const now = Date.now` in a workflow module.
+4. Lint fails when a workflow imports `@proompteng/temporal-bun-sdk/client`.
+5. `--format json` emits stable output suitable for CI annotations.
+

--- a/docs/temporal-bun-sdk/workflow-runtime-sandbox.md
+++ b/docs/temporal-bun-sdk/workflow-runtime-sandbox.md
@@ -1,0 +1,276 @@
+# Workflow Runtime Sandbox Guards (Design)
+
+This document specifies runtime “sandbox guard” behavior for
+`@proompteng/temporal-bun-sdk` workflows.
+
+The Bun SDK runs workflow code in-process (not in a V8 isolate). That improves
+DX and deployment simplicity, but removes the default safety nets present in
+Temporal’s Node SDK (VM + bundler restrictions).
+
+We add lightweight, production-safe runtime wrappers that:
+
+1. Make common nondeterministic primitives deterministic when used in workflow
+   context.
+2. Fail fast on side effects that cannot be made deterministic.
+
+These wrappers are context-aware, based on AsyncLocalStorage:
+they only activate while workflow code is executing.
+
+## Design Constraints
+
+- Must not change behavior for activities, worker runtime, CLI tools, or user
+  services running in the same process.
+- Must be safe under concurrency (multiple workflows in the same worker).
+- Must not rely on per-workflow global mutation (we cannot swap `Date` per
+  workflow).
+- Must support “query mode” execution where commands/time/random advances are
+  disallowed.
+- Must be cheap: wrappers should be O(1) per call and avoid allocations.
+
+## Workflow Execution Context
+
+We define “workflow context” as:
+
+- Code executed while `WorkflowExecutor.execute` is evaluating a workflow
+  definition handler and update handlers.
+- Code executed while evaluating workflow queries (query mode).
+
+We can detect that state via AsyncLocalStorage.
+
+### Context Source Of Truth
+
+We already maintain an ALS in `packages/temporal-bun-sdk/src/workflow/log.ts`
+(`WorkflowLogContext`) containing:
+
+- `info: WorkflowInfo`
+- `guard: DeterminismGuard`
+- `logger: WorkflowLogger`
+
+This is sufficient for guards, but we may want to add:
+
+- `mode: 'workflow' | 'query'`
+
+Implementation option:
+
+- Extend `WorkflowLogContext` to include `mode`, set in
+  `packages/temporal-bun-sdk/src/workflow/executor.ts` based on `ExecuteWorkflowInput.mode`.
+
+The wrappers use:
+
+```ts
+import { currentWorkflowLogContext } from './log'
+const ctx = currentWorkflowLogContext()
+```
+
+If `ctx` is undefined, we are not in workflow context.
+
+## Guard Modes
+
+Controlled by `TEMPORAL_WORKFLOW_GUARDS` / `WorkerRuntimeOptions.workflowGuards`:
+
+- `strict`: throw on forbidden APIs
+- `warn`: log a structured warning and proceed
+- `off`: do nothing
+
+Runtime wrappers should be installed once per process, and behave according to
+the configured mode.
+
+## Deterministic Wrappers
+
+### `Date.now()`
+
+In workflow context:
+
+- `Date.now()` must route through `DeterminismGuard.nextTime`.
+- The underlying “real” time source should be the original `Date.now` captured
+  at install time.
+
+Pseudo-code:
+
+```ts
+const original = Date.now.bind(Date)
+Date.now = () => {
+  const ctx = currentWorkflowLogContext()
+  if (!ctx) return original()
+  return ctx.guard.nextTime(original)
+}
+```
+
+### `Math.random()`
+
+In workflow context:
+
+- Must route through `DeterminismGuard.nextRandom`.
+
+Pseudo-code:
+
+```ts
+const original = Math.random.bind(Math)
+Math.random = () => {
+  const ctx = currentWorkflowLogContext()
+  if (!ctx) return original()
+  return ctx.guard.nextRandom(original)
+}
+```
+
+### `performance.now()` and `Bun.nanoseconds()`
+
+These are high resolution and nondeterministic. Options:
+
+1. In strict mode, throw.
+2. In warn mode, log.
+3. Provide a deterministic value derived from `Date.now()` (lower resolution).
+
+Recommendation:
+
+- `performance.now()` returns a deterministic “monotonic” value derived from
+  `guard.nextTime(() => Date.now())` with a per-workflow base.
+- `Bun.nanoseconds()` is forbidden in workflow context (no stable semantics).
+
+If we implement deterministic `performance.now()`, it must be documented as:
+“workflow time, not wall clock monotonic time”.
+
+### `crypto.randomUUID()` and `crypto.getRandomValues()`
+
+These must not be used directly in workflow context.
+
+Strict mode behavior:
+
+- Throw with remediation:
+  - use `ctx.determinism.sideEffect({ compute: () => crypto.randomUUID() })`
+  - or derive IDs from workflow info and deterministic counters.
+
+Warn mode behavior:
+
+- Log and proceed.
+
+Rationale: UUIDs can be made deterministic via side effect markers, but a direct
+call without `sideEffect` is a common footgun.
+
+## Forbidden APIs (Fail Fast In Strict)
+
+These cannot be made deterministic and must be blocked in workflow context.
+
+### Network / I/O
+
+- `fetch`
+- `WebSocket`
+- filesystem access (`Bun.file`, `fs`, `node:fs`, etc.)
+- `Deno.*` style I/O if present
+
+Error message must include:
+
+- the API used
+- the workflow identity (`workflowType`, `workflowId`, `runId`)
+- the safe alternative:
+  - move the operation into an activity
+  - or use signals/updates to fetch data externally
+
+### Timers
+
+- `setTimeout`, `setInterval`, `queueMicrotask`, `setImmediate`
+
+In strict mode, these throw in workflow context and point to:
+
+- `ctx.timers.start` for workflow timers
+- `Effect` composition for sequencing
+
+Rationale: JS timers are scheduled by the host runtime and are not tied to
+workflow history. Workflow sleeps must materialize as timer commands.
+
+### Subprocesses / System
+
+- `Bun.spawn`, `child_process`, `Deno.run`
+- `process.exit`
+- `process.kill`
+
+### Environment and Host Introspection
+
+Reading environment variables at runtime is a common replay hazard. Runtime
+wrapping cannot reliably intercept arbitrary property reads (like `process.env.X`),
+so enforcement is primarily via lint. In strict runtime mode we still block
+common accessors:
+
+- `Bun.env` (if used)
+- `process.cwd`, `process.uptime`, `os.*` calls if they are reachable as globals
+
+## Logging
+
+Workflow log output is a side effect, but does not affect replay unless the
+workflow branches on it. We already track log count in `DeterminismGuard` when
+logs are emitted via the SDK logger (`packages/temporal-bun-sdk/src/workflow/log.ts`).
+
+We should:
+
+- Patch `console.*` methods to route through workflow logging when in workflow
+  context, so log volume is tracked consistently.
+- In query mode, logs should be suppressed (or tagged) to match existing
+  `recordLog` behavior.
+
+## Implementation Sketch
+
+### Module layout
+
+- New module: `packages/temporal-bun-sdk/src/workflow/guards.ts`
+  - `installWorkflowRuntimeGuards(options)`
+  - wrappers for each global API
+  - idempotent install
+  - relies on `currentWorkflowLogContext()`
+
+### Install timing
+
+Install guards on first workflow execution and keep them installed for the
+process lifetime.
+
+- Install entrypoint: `packages/temporal-bun-sdk/src/workflow/executor.ts`
+  - call `installWorkflowRuntimeGuards(...)` at the beginning of `execute()`
+  - ensure install is idempotent (static boolean)
+
+### Strictness resolution
+
+Strictness comes from:
+
+1. `WorkerRuntimeOptions.workflowGuards` if set
+2. `TEMPORAL_WORKFLOW_GUARDS` env var
+3. default based on `NODE_ENV`-style heuristics is not reliable under Bun
+
+Recommendation: default to `warn`, and services flip to `strict` intentionally.
+
+### Wrapper behavior: `warn` vs `strict`
+
+All forbidden wrappers call the same helper:
+
+```ts
+function violation(api: string, message: string): never | undefined
+```
+
+- In `warn`, log a structured event and return `undefined` or defer to original.
+- In `strict`, throw `WorkflowNondeterminismError` with a remediation hint.
+
+### Error types
+
+Use existing workflow error classes:
+
+- `WorkflowNondeterminismError` for workflow mode
+- `WorkflowQueryViolationError` for query mode
+
+## Test Plan
+
+Add unit tests under `packages/temporal-bun-sdk/tests/`:
+
+1. `Date.now` is deterministic in workflow context.
+2. `Math.random` is deterministic in workflow context.
+3. `fetch` throws in strict mode when called from workflow handler.
+4. `setTimeout` throws in strict mode when called from workflow handler.
+5. `console.log` in workflow context increments `logCount` (if console patching is implemented).
+
+## Failure Modes
+
+- If ALS context is lost across Effect boundaries, wrappers may incorrectly fall
+  back to nondeterministic behavior. This must be validated with tests that
+  cross async boundaries inside workflows.
+- If a forbidden wrapper is bypassed by importing a module-local binding
+  (captured reference), linting must catch it. Example:
+  `const realFetch = fetch;` then calling `realFetch` later.
+  Mitigation: lint rules for capturing forbidden globals.
+


### PR DESCRIPTION
## Summary

- Add production-grade design docs for nondeterminism guardrails in Temporal Bun SDK (versioning policy, runtime guards, workflow linting, replay CI gate).
- Add detailed workflow runtime sandbox wrapper design (ALS-based) for deterministic time/random and fail-fast side effects.
- Update Temporal Bun SDK docs index to include the new documents.

## Related Issues

None

## Testing

- `rg -n "nondeterminism-guardrails|workflow-runtime-sandbox|workflow-linting|replay-ci-gate" docs/temporal-bun-sdk/README.md`

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
