### PR TITLE
feat(observability): torghut alerts and freshness metrics

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -170,3 +170,208 @@ data:
             annotations:
               summary: Torghut ClickHouse guardrails scrape failing
               description: Guardrails exporter is up but cannot query ClickHouse successfully.
+      - name: torghut-ws.rules
+        rules:
+          - alert: TorghutWSForwarderDown
+            expr: |
+              up{
+                job="torghut",
+                namespace="torghut",
+                service="torghut-ws"
+              } == 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut WS forwarder is down
+              description: |
+                torghut-ws is not being scraped (up=0) for 5 minutes. Market data will not flow into Kafka, and TA will stall.
+              runbook_url: docs/torghut/design-system/v1/operations-ws-connection-limit-and-auth.md
+          - alert: TorghutWSForwarderNotReady
+            expr: |
+              torghut_ws_readyz_status{
+                namespace="torghut",
+                service="torghut-ws"
+              } == 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut WS forwarder not ready
+              description: |
+                torghut-ws /readyz is failing for 5 minutes (Alpaca/Kafka gates not healthy).
+              runbook_url: docs/torghut/design-system/v1/operations-ws-connection-limit-and-auth.md
+          - alert: TorghutWSKafkaSendErrors
+            expr: |
+              rate(
+                torghut_ws_kafka_send_errors_total{
+                  namespace="torghut",
+                  service="torghut-ws"
+                }[5m]
+              ) > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut WS Kafka send errors
+              description: torghut-ws is reporting Kafka send errors over the last 10 minutes.
+          - alert: TorghutWSKafkaSendsStalledDuringMarketHours
+            expr: |
+              (
+                sum(
+                  rate(
+                    torghut_ws_kafka_send_latency_seconds_count{
+                      namespace="torghut",
+                      service="torghut-ws"
+                    }[5m]
+                  )
+                ) == bool 0
+              )
+              * on() group_left()
+              vector(
+                (day_of_week() >= 1)
+                * (day_of_week() <= 5)
+                * (hour() >= 14)
+                * (hour() < 21)
+              ) > 0
+            for: 15m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut WS is not publishing Kafka records (market hours)
+              description: |
+                torghut-ws has published 0 records/sec for 15 minutes during market hours (UTC schedule).
+
+                This usually means the Alpaca WS isn't receiving events or subscriptions are broken.
+              runbook_url: docs/torghut/design-system/v1/operations-ws-connection-limit-and-auth.md
+      - name: torghut-ta.rules
+        rules:
+          - alert: TorghutTAJobmanagerDown
+            expr: |
+              up{
+                job="torghut",
+                namespace="torghut",
+                service="torghut-ta"
+              } == 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut TA jobmanager metrics endpoint is down
+              description: TA jobmanager is not being scraped (up=0) for 5 minutes.
+              runbook_url: docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+          - alert: TorghutTACheckpointsStalled
+            expr: |
+              (
+                time()
+                - max(
+                  flink_jobmanager_job_lastCheckpointCompletedTimestamp{
+                    namespace="torghut",
+                    service="torghut-ta"
+                  }
+                ) / 1000
+              ) > 180
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut TA checkpoints appear stalled
+              description: |
+                Flink last checkpoint completed timestamp is older than 3 minutes for 10 minutes.
+                This strongly indicates the TA job is stuck or failing to checkpoint.
+              runbook_url: docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+      - name: torghut-trading.rules
+        rules:
+          - alert: TorghutTradingRevisionMetricsMissing
+            expr: |
+              absent(
+                up{
+                  job="torghut",
+                  namespace="torghut",
+                  service=~"torghut-[0-9]{5}-private"
+                }
+              ) == 1
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut trading revision metrics missing
+              description: |
+                No active Knative private revision service metrics are being scraped for torghut.
+                If torghut should be running, this may indicate revision readiness failures or scrape config drift.
+              runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
+          - alert: TorghutTradingRevisionMetricsDown
+            expr: |
+              max(
+                up{
+                  job="torghut",
+                  namespace="torghut",
+                  service=~"torghut-[0-9]{5}-private"
+                }
+              ) == 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut trading revision metrics endpoint is down
+              description: |
+                The active Knative private revision for torghut is being scraped but up=0 for 5 minutes.
+              runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
+      - name: torghut-freshness.rules
+        rules:
+          - alert: TorghutSignalsStaleDuringMarketHours
+            expr: |
+              (
+                time()
+                - max(
+                  torghut_clickhouse_guardrails_ta_signals_max_event_ts_seconds{
+                    namespace="torghut",
+                    service="torghut-clickhouse-guardrails-exporter"
+                  }
+                )
+              ) > bool 900
+              * on() group_left()
+              vector(
+                (day_of_week() >= 1)
+                * (day_of_week() <= 5)
+                * (hour() >= 14)
+                * (hour() < 21)
+              ) > 0
+            for: 15m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut signals are stale (market hours)
+              description: |
+                ClickHouse ta_signals max(event_ts) is older than 15 minutes during market hours (UTC schedule).
+
+                First checks:
+                - torghut-ws readiness and Kafka publishing
+                - torghut-ta checkpointing and ClickHouse JDBC sink health
+              runbook_url: docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+          - alert: TorghutMicrobarsStaleDuringMarketHours
+            expr: |
+              (
+                time()
+                - max(
+                  torghut_clickhouse_guardrails_ta_microbars_max_window_end_seconds{
+                    namespace="torghut",
+                    service="torghut-clickhouse-guardrails-exporter"
+                  }
+                )
+              ) > bool 300
+              * on() group_left()
+              vector(
+                (day_of_week() >= 1)
+                * (day_of_week() <= 5)
+                * (hour() >= 14)
+                * (hour() < 21)
+              ) > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut microbars are stale (market hours)
+              description: |
+                ClickHouse ta_microbars max(window_end) is older than 5 minutes during market hours (UTC schedule).
+              runbook_url: docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md

--- a/argocd/applications/torghut/alloy-configmap.yaml
+++ b/argocd/applications/torghut/alloy-configmap.yaml
@@ -51,7 +51,7 @@ data:
 
       rule {
         source_labels = ["__meta_kubernetes_endpoint_port_name"]
-        regex         = "(?i)metrics"
+        regex         = "(?i)metric(s)?"
         action        = "keep"
       }
 

--- a/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml
@@ -125,6 +125,18 @@ data:
                     "FORMAT JSONEachRow"
                 )
 
+            signals_freshness_query = (
+                "SELECT ifNull(toUnixTimestamp64Milli(max(event_ts)), 0) AS max_event_ts_ms "
+                f"FROM {DATABASE}.ta_signals "
+                "FORMAT JSONEachRow"
+            )
+
+            microbars_freshness_query = (
+                "SELECT ifNull(toUnixTimestamp64Milli(max(window_end)), 0) AS max_window_end_ms "
+                f"FROM {DATABASE}.ta_microbars "
+                "FORMAT JSONEachRow"
+            )
+
             replicas: dict[str, dict] = {}
             scrape_errors: list[str] = []
 
@@ -143,6 +155,18 @@ data:
                             raise RuntimeError("readonly query returned no rows")
                         readonly_row = readonly_rows[0]
 
+                    signals_rows = clickhouse_query_rows(replica_url, signals_freshness_query)
+                    if not signals_rows:
+                        raise RuntimeError("signals freshness query returned no rows")
+                    signals_row = signals_rows[0]
+                    max_event_ts_ms = float_or_nan(signals_row.get("max_event_ts_ms", 0.0))
+
+                    microbars_rows = clickhouse_query_rows(replica_url, microbars_freshness_query)
+                    if not microbars_rows:
+                        raise RuntimeError("microbars freshness query returned no rows")
+                    microbars_row = microbars_rows[0]
+                    max_window_end_ms = float_or_nan(microbars_row.get("max_window_end_ms", 0.0))
+
                     free_space = float_or_nan(disk_row.get("free_space"))
                     total_space = float_or_nan(disk_row.get("total_space"))
                     ratio = float("nan")
@@ -155,6 +179,8 @@ data:
                         "disk_total_bytes": total_space,
                         "disk_free_ratio": ratio,
                         "any_replica_readonly": float_or_nan(readonly_row.get("any_readonly", 0.0)),
+                        "ta_signals_max_event_ts_seconds": max_event_ts_ms / 1000.0,
+                        "ta_microbars_max_window_end_seconds": max_window_end_ms / 1000.0,
                     }
                 except Exception as e:
                     scrape_errors.append(f"{replica}: {e}")
@@ -164,6 +190,8 @@ data:
                         "disk_total_bytes": float("nan"),
                         "disk_free_ratio": float("nan"),
                         "any_replica_readonly": float("nan"),
+                        "ta_signals_max_event_ts_seconds": float("nan"),
+                        "ta_microbars_max_window_end_seconds": float("nan"),
                     }
 
             last_scrape_success = 1.0 if scrape_errors == [] else 0.0
@@ -233,6 +261,26 @@ data:
             label = prom_label_value(replica)
             lines.append(
                 f'torghut_clickhouse_guardrails_any_replica_readonly{{replica="{label}"}} {metrics["any_replica_readonly"]}'
+            )
+
+        lines.append(
+            "# HELP torghut_clickhouse_guardrails_ta_signals_max_event_ts_seconds Max event_ts for ta_signals (per replica, seconds since epoch)."
+        )
+        lines.append("# TYPE torghut_clickhouse_guardrails_ta_signals_max_event_ts_seconds gauge")
+        for replica, metrics in snapshot["replicas"].items():
+            label = prom_label_value(replica)
+            lines.append(
+                f'torghut_clickhouse_guardrails_ta_signals_max_event_ts_seconds{{replica="{label}"}} {metrics["ta_signals_max_event_ts_seconds"]}'
+            )
+
+        lines.append(
+            "# HELP torghut_clickhouse_guardrails_ta_microbars_max_window_end_seconds Max window_end for ta_microbars (per replica, seconds since epoch)."
+        )
+        lines.append("# TYPE torghut_clickhouse_guardrails_ta_microbars_max_window_end_seconds gauge")
+        for replica, metrics in snapshot["replicas"].items():
+            label = prom_label_value(replica)
+            lines.append(
+                f'torghut_clickhouse_guardrails_ta_microbars_max_window_end_seconds{{replica="{label}"}} {metrics["ta_microbars_max_window_end_seconds"]}'
             )
 
         lines.append("# HELP torghut_clickhouse_guardrails_last_scrape_success 1 if the last scrape succeeded.")


### PR DESCRIPTION
## What
- Adds Torghut alert rules to Mimir ruler (observability GitOps): WS readiness/publishing, TA checkpointing, trading revision scrape, and ClickHouse freshness.
- Extends the Torghut ClickHouse guardrails exporter to emit `ta_signals`/`ta_microbars` max timestamp gauges.
- Updates Torghut Alloy scrape port-name filter to include Knative `*-metric` ports (not just `*-metrics`).

## Why
Matches `docs/torghut/design-system/v1/alerting-slos-and-oncall.md`: freshness is the primary SLO and oncall needs paging signals for WS/TA/ClickHouse failure modes.

## Rollout
- Observability app auto-syncs, but the Mimir ruler needs a restart to recopy rules from the ConfigMap.
- Torghut app is manual sync; for immediate rollout use kubectl restarts after manifests apply.

## Verification
- `bun run lint:argocd`
- `scripts/kubeconform.sh argocd`
