### PR TITLE
fix(observability): load mimir ruler rules from local files

### DIFF
--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -37,16 +37,11 @@ mimir:
         insecure: true
         bucket_lookup_type: path
     ruler_storage:
-      backend: s3
-      s3:
-        endpoint: observability-minio.minio.svc.cluster.local:9000
-        bucket_name: mimir-ruler
-        access_key_id: ${MIMIR_S3_ACCESS_KEY_ID}
-        secret_access_key: ${MIMIR_S3_SECRET_ACCESS_KEY}
-        insecure: true
-        bucket_lookup_type: path
+      backend: local
+      local:
+        directory: /etc/mimir/rules
     ruler:
-      rule_path: /etc/mimir/rules/*.yaml
+      rule_path: /etc/mimir/rules
     usage_stats:
       enabled: false
       installation_mode: helm


### PR DESCRIPTION
## Problem
Mimir ruler currently has `ruler.rule_path: /etc/mimir/rules/*.yaml` and `ruler_storage: s3`, which results in **no rule groups loaded** (ruler API reports empty, logs show path cleanup on the glob path).

## Fix
- Switch `ruler_storage` to `local` and point it at `/etc/mimir/rules`.
- Set `ruler.rule_path` to `/etc/mimir/rules` (directory, not glob).

This matches the existing initContainer behavior that copies `graf-mimir-rules` ConfigMap contents into `/etc/mimir/rules` at startup.

## Rollout
Observability app is auto-sync; once applied, the ruler should report rule groups via `/prometheus/api/v1/rules`.
