### PR TITLE
chore(bumba): enable pinned worker versioning

### DIFF
--- a/argocd/applications/bumba/deployment-model.yaml
+++ b/argocd/applications/bumba/deployment-model.yaml
@@ -41,6 +41,12 @@ spec:
               value: default
             - name: TEMPORAL_TASK_QUEUE
               value: bumba-model
+            - name: TEMPORAL_WORKER_DEPLOYMENT_NAME
+              value: bumba-model-deployment
+            - name: TEMPORAL_WORKER_BUILD_ID
+              value: bumba-model@139e01e9
+            - name: TEMPORAL_WORKFLOW_GUARDS
+              value: warn
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "8"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY
@@ -167,4 +173,3 @@ spec:
         - name: workspace
           persistentVolumeClaim:
             claimName: jangar-workspace-rwx
-

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -43,6 +43,12 @@ spec:
               value: default
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
+            - name: TEMPORAL_WORKER_DEPLOYMENT_NAME
+              value: bumba-deployment
+            - name: TEMPORAL_WORKER_BUILD_ID
+              value: bumba@139e01e9
+            - name: TEMPORAL_WORKFLOW_GUARDS
+              value: warn
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "64"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/packages/temporal-bun-sdk/src/worker.ts
+++ b/packages/temporal-bun-sdk/src/worker.ts
@@ -5,6 +5,9 @@ import type { ActivityHandler, WorkerDeploymentConfig } from './worker/runtime'
 import { WorkerRuntime } from './worker/runtime'
 import type { WorkflowDefinitions } from './workflow/definition'
 
+export { WorkerVersioningMode } from './proto/temporal/api/enums/v1/deployment_pb'
+export { VersioningBehavior } from './proto/temporal/api/enums/v1/workflow_pb'
+
 export interface CreateWorkerOptions {
   config?: TemporalConfig
   taskQueue?: string

--- a/packages/temporal-bun-sdk/src/worker/index.ts
+++ b/packages/temporal-bun-sdk/src/worker/index.ts
@@ -1,3 +1,6 @@
+export { WorkerVersioningMode } from '../proto/temporal/api/enums/v1/deployment_pb'
+export { VersioningBehavior } from '../proto/temporal/api/enums/v1/workflow_pb'
+
 export type { BunWorkerHandle, CreateWorkerOptions } from '../worker'
 export { BunWorker, createWorker, runWorker } from '../worker'
 export type { WorkerPlugin, WorkerPluginContext } from './plugins'


### PR DESCRIPTION
## Summary

- Enable Temporal worker build ID versioning for `services/bumba` workers (deployment versioned + pinned).
- Configure Argo CD manifests to set `TEMPORAL_WORKER_BUILD_ID` (tied to image tag) and `TEMPORAL_WORKER_DEPLOYMENT_NAME`.
- Expose `WorkerVersioningMode` / `VersioningBehavior` from `@proompteng/temporal-bun-sdk/worker` so services can configure versioning without deep proto imports.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun run --filter @proompteng/bumba tsc`
- `bun run --filter @proompteng/temporal-bun-sdk test`

## Breaking Changes

None
