### PR TITLE
fix(observability): make mimir ruler load local rules correctly

### DIFF
--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -41,7 +41,10 @@ mimir:
       local:
         directory: /etc/mimir/rules
     ruler:
-      rule_path: /etc/mimir/rules
+      # Must not overlap ruler_storage.local.directory.
+      # /etc/mimir/rules is used as the read-only rule store (local backend),
+      # while /data/ruler is the writable working directory used by the ruler.
+      rule_path: /data/ruler
     usage_stats:
       enabled: false
       installation_mode: helm
@@ -84,7 +87,8 @@ query_scheduler:
 
 ruler:
   replicas: 1
-  extraInitContainers:
+  # mimir-distributed chart uses `initContainers` (not `extraInitContainers`).
+  initContainers:
     - name: copy-graf-rules
       image: docker.io/library/busybox:1.36
       imagePullPolicy: IfNotPresent
@@ -92,9 +96,10 @@ ruler:
         - /bin/sh
         - -c
         - |
-          set -euo pipefail
-          find /etc/mimir/rules -mindepth 1 -delete
-          cp -a /etc/mimir/rules-src/. /etc/mimir/rules/
+          set -eu
+          rm -rf /etc/mimir/rules/*
+          mkdir -p /etc/mimir/rules/anonymous
+          cp -a /etc/mimir/rules-src/. /etc/mimir/rules/anonymous/
   extraVolumes:
     - name: graf-mimir-rules
       configMap:


### PR DESCRIPTION
## Summary
- Fix Grafana Mimir ruler config so `ruler_storage: local` works (avoid `rule_path` overlap) and rules can actually load.
- Use the correct chart value key (`ruler.initContainers`) and copy the `graf-mimir-rules` ConfigMap into the `anonymous` tenant directory.

## Related Issues
None

## Testing
- Validated cluster symptoms pre-fix: `GET /prometheus/api/v1/rules` returned empty groups and ruler pods could crashloop with overlapping `rule_path`/`ruler_storage`.
- Post-merge: will validate in-cluster via `curl http://observability-mimir-nginx.observability.svc.cluster.local/prometheus/api/v1/rules` and ruler logs showing rule sync with non-empty groups.

## Screenshots (if applicable)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
