### PR TITLE
chore(bumba): bake Temporal build ID into images

### DIFF
--- a/.github/workflows/docker-build-common.yaml
+++ b/.github/workflows/docker-build-common.yaml
@@ -98,6 +98,8 @@ jobs:
           platforms: ${{ inputs.platforms }}
           context: ${{ steps.prune.outputs.context || (inputs.external_repository && 'external_repo' || inputs.context) }}
           file: ${{ inputs.external_repository && 'external_repo/' || '' }}${{ inputs.dockerfile }}
+          build-args: |
+            LAB_GIT_SHA=${{ inputs.new_tag }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true

--- a/argocd/applications/bumba/deployment-model.yaml
+++ b/argocd/applications/bumba/deployment-model.yaml
@@ -43,8 +43,6 @@ spec:
               value: bumba-model
             - name: TEMPORAL_WORKER_DEPLOYMENT_NAME
               value: bumba-model-deployment
-            - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba-model@139e01e9
             - name: TEMPORAL_WORKFLOW_GUARDS
               value: warn
             - name: TEMPORAL_WORKFLOW_CONCURRENCY

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -45,8 +45,6 @@ spec:
               value: bumba
             - name: TEMPORAL_WORKER_DEPLOYMENT_NAME
               value: bumba-deployment
-            - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@139e01e9
             - name: TEMPORAL_WORKFLOW_GUARDS
               value: warn
             - name: TEMPORAL_WORKFLOW_CONCURRENCY

--- a/services/bumba/Dockerfile
+++ b/services/bumba/Dockerfile
@@ -2,6 +2,7 @@
 # This Dockerfile is intended to be built from a Turbo-pruned context:
 # `bunx turbo prune --scope=@proompteng/bumba --docker --out-dir <dir>`
 ARG BUN_VERSION=1.3.5
+ARG LAB_GIT_SHA=dev
 
 FROM oven/bun:${BUN_VERSION} AS deps
 WORKDIR /app
@@ -31,6 +32,8 @@ RUN --mount=type=cache,target=/root/.cache/bun \
 FROM oven/bun:${BUN_VERSION} AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+ARG LAB_GIT_SHA=dev
+ENV TEMPORAL_WORKER_BUILD_ID=bumba@${LAB_GIT_SHA}
 RUN --mount=type=cache,target=/var/cache/apt \
   --mount=type=cache,target=/var/lib/apt/lists \
   set -eux; \


### PR DESCRIPTION
## Summary

- Pass `LAB_GIT_SHA` into Docker builds via `docker-build-common.yaml`.
- Bake `TEMPORAL_WORKER_BUILD_ID=bumba@${LAB_GIT_SHA}` into the `bumba` image to keep Temporal build IDs aligned with deployed code.
- Remove hardcoded `TEMPORAL_WORKER_BUILD_ID` from `argocd/applications/bumba/*` to avoid drift when images are updated.

## Related Issues

None

## Testing

- CI only (Dockerfile / GitHub Actions workflow changes).

## Breaking Changes

None
