### PR TITLE
fix(observability): stop mimir ruler rule sync crashloop

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -228,12 +228,12 @@ data:
                 ) == bool 0
               )
               * on() group_left()
-              vector(
-                (day_of_week() >= 1)
-                * (day_of_week() <= 5)
-                * (hour() >= 14)
-                * (hour() < 21)
-              ) > 0
+              (
+                (day_of_week(vector(time())) >= bool 1)
+                * (day_of_week(vector(time())) <= bool 5)
+                * (hour(vector(time())) >= bool 14)
+                * (hour(vector(time())) < bool 21)
+              )
             for: 15m
             labels:
               severity: critical

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -99,7 +99,13 @@ ruler:
           set -eu
           rm -rf /etc/mimir/rules/*
           mkdir -p /etc/mimir/rules/anonymous
-          cp -a /etc/mimir/rules-src/. /etc/mimir/rules/anonymous/
+          # ConfigMap mounts use symlinks + timestamped dirs (..data/..2026_...).
+          # Copy dereferenced files into the tenant directory without trying to preserve ownership.
+          for f in /etc/mimir/rules-src/*.yml /etc/mimir/rules-src/*.yaml; do
+            if [ -f "$f" ]; then
+              cp -Lf "$f" /etc/mimir/rules/anonymous/
+            fi
+          done
   extraVolumes:
     - name: graf-mimir-rules
       configMap:


### PR DESCRIPTION
## Summary
- Fix invalid PromQL in `TorghutWSKafkaSendsStalledDuringMarketHours` that crashlooped Mimir ruler during initial rule sync.
- Copy `graf-mimir-rules` into the `anonymous` tenant dir without `cp -a` (avoid ownership/symlink/timestamped ConfigMap paths).
- Keep ruler `rule_path` separated from local storage dir so ruler can start and evaluate rules.

## Related Issues
None

## Testing
- kubectl -n observability logs pod/<mimir-ruler-pod> (confirmed previous crash cause; expect no PromQL parse error after rollout)
- kubectl -n observability get --raw "/api/v1/namespaces/observability/services/observability-mimir-nginx:80/proxy/prometheus/api/v1/rules" (expect non-empty groups after rollout)

## Breaking Changes
None
