### PR TITLE
fix(torghut): reduce clickhouse log noise

### DIFF
--- a/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
@@ -23,7 +23,8 @@ spec:
         </yandex>
       config.d/99-logging-overrides.xml: |-
         <yandex>
-          <logger replace="1">
+          <!-- Override verbosity without wiping out default log/errorlog settings. -->
+          <logger>
             <level>information</level>
           </logger>
           <!-- Keep system tables from growing without bound on small PVCs. -->


### PR DESCRIPTION
## Summary
- Fix ClickHouse logging override to avoid `logger.log` / `logger.errorlog` "Not found" startup exceptions.
- Keep log verbosity lowered (information) without replacing the whole `<logger>` subtree.

## Related Issues
None

## Testing
- kubectl -n torghut logs pod/chi-torghut-clickhouse-default-0-0-0 --tail=80 (expect the startup `logger.log`/`logger.errorlog` exceptions to disappear after rollout)

## Breaking Changes
None
