### PR TITLE
chore(bumba): roll out sha-4a921d0

### DIFF
--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - deployment-model.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: "e0b47d63"
+    newTag: "sha-4a921d0"


### PR DESCRIPTION
## Summary

- Roll `bumba` + `bumba-model` to image tag `sha-4a921d0` (Temporal Bun SDK strict nondeterminism guards default in production).

## Related Issues

None

## Testing

- CI: Docker build and push for `services/bumba/Dockerfile`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
