### PR TITLE
chore(bumba): roll out sha-ebdbf24

### DIFF
--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - deployment-model.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: "sha-4a921d0"
+    newTag: "sha-ebdbf24"


### PR DESCRIPTION
## Summary

- Roll `bumba` + `bumba-model` to image tag `sha-ebdbf24` (fixes worker versioning API PermissionDenied crash while keeping strict workflow nondeterminism guards default).

## Related Issues

None

## Testing

- CI: Docker build and push for `services/bumba/Dockerfile`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
