### PR TITLE
fix(temporal-bun-sdk): make strict guards default

### DIFF
--- a/apps/docs/content/docs/temporal-bun-sdk.mdx
+++ b/apps/docs/content/docs/temporal-bun-sdk.mdx
@@ -94,7 +94,6 @@ Environment variables supported by the config loader:
 | `TEMPORAL_TLS_SERVER_NAME` | _unset_ | Overrides TLS server name verification. |
 | `TEMPORAL_ALLOW_INSECURE` / `ALLOW_INSECURE_TLS` | `false` | Accepts `1/true/on` to skip certificate verification. |
 | `TEMPORAL_WORKER_IDENTITY_PREFIX` | `temporal-bun-worker` | Worker identity prefix (host and PID are appended). |
-| `TEMPORAL_WORKER_DEPLOYMENT_NAME` | _unset_ | Optional worker deployment name (defaults to `<task-queue>-deployment`). |
 | `TEMPORAL_WORKER_BUILD_ID` | _unset_ | Worker build ID; auto-derived when unset. |
 | `TEMPORAL_WORKFLOW_CONCURRENCY` | `4` | Workflow poller concurrency. |
 | `TEMPORAL_ACTIVITY_CONCURRENCY` | `4` | Activity poller concurrency. |
@@ -125,18 +124,19 @@ by hand.
 
 ## Worker build IDs and versioning
 
-Workers derive their build ID from `TEMPORAL_WORKER_BUILD_ID`, the package
-version, or the configured identity. When you enable worker versioning via
-`deployment.versioningMode` in `WorkerRuntimeOptions`, the runtime will:
+Workers derive their build ID (in priority order) from:
 
-1. Probe worker-versioning support with `GetWorkerBuildIdCompatibility`.
-2. Register the build ID with `UpdateWorkerBuildIdCompatibility` before pollers start.
-3. Warn and continue when the server does not implement worker versioning
-   (for example, the Temporal CLI dev server), so local runs stay green.
+1. `deployment.buildId` passed to `createWorker(...)` / `WorkerRuntime.create(...)`
+2. `TEMPORAL_WORKER_BUILD_ID`
+3. a derived value based on the configured workflow sources (`workflowsPath`)
 
-This behavior is wired into `createWorker`, `runWorkerApp`, and
-`WorkerRuntime.create()`, so your build IDs are registered automatically once
-versioning is enabled.
+When you enable worker versioning via `deployment.versioningMode`, the worker
+includes deployment metadata (deployment name + build ID) in poll/response
+requests so the server can route workflow tasks to the correct build.
+
+The Bun SDK does not call the deprecated Build ID Compatibility APIs (Version
+Set-based “worker versioning v0.1”), since they may be disabled on some
+namespaces.
 
 ## OpenTelemetry export
 

--- a/docs/temporal-bun-sdk/workflow-runtime-sandbox.md
+++ b/docs/temporal-bun-sdk/workflow-runtime-sandbox.md
@@ -66,7 +66,7 @@ If `ctx` is undefined, we are not in workflow context.
 
 ## Guard Modes
 
-Controlled by `TEMPORAL_WORKFLOW_GUARDS` / `WorkerRuntimeOptions.workflowGuards`:
+Controlled by `WorkerRuntimeOptions.workflowGuards` / `WorkflowExecutorOptions.workflowGuards`:
 
 - `strict`: throw on forbidden APIs
 - `warn`: log a structured warning and proceed
@@ -230,11 +230,11 @@ process lifetime.
 
 Strictness comes from:
 
-1. `WorkerRuntimeOptions.workflowGuards` if set
-2. `TEMPORAL_WORKFLOW_GUARDS` env var
-3. default based on `NODE_ENV`-style heuristics is not reliable under Bun
+1. `WorkerRuntimeOptions.workflowGuards` / `WorkflowExecutorOptions.workflowGuards` if set
+2. otherwise the SDK default (`strict`)
 
-Recommendation: default to `warn`, and services flip to `strict` intentionally.
+In production (`NODE_ENV=production`), non-`strict` modes are rejected at
+runtime to avoid accidental nondeterminism.
 
 ### Wrapper behavior: `warn` vs `strict`
 
@@ -273,4 +273,3 @@ Add unit tests under `packages/temporal-bun-sdk/tests/`:
   (captured reference), linting must catch it. Example:
   `const realFetch = fetch;` then calling `realFetch` later.
   Mitigation: lint rules for capturing forbidden globals.
-

--- a/packages/temporal-bun-sdk/README.md
+++ b/packages/temporal-bun-sdk/README.md
@@ -49,7 +49,6 @@ A Bun-first Temporal SDK implemented entirely in TypeScript. It speaks gRPC over
    TEMPORAL_DETERMINISM_MARKER_MAX_DETAIL_BYTES=1800000  # optional – skip markers exceeding size limit
    TEMPORAL_ACTIVITY_HEARTBEAT_INTERVAL_MS=4000     # optional – heartbeat throttle interval in ms
    TEMPORAL_ACTIVITY_HEARTBEAT_RPC_TIMEOUT_MS=5000  # optional – heartbeat RPC timeout in ms
-   TEMPORAL_WORKER_DEPLOYMENT_NAME=replay-worker      # optional – worker deployment metadata
    TEMPORAL_WORKER_BUILD_ID=git-sha                 # optional – build-id for versioning
 ```
 
@@ -505,22 +504,15 @@ Pass your converter to both the worker and client factories to keep payload hand
 
 ## Worker versioning and build IDs
 
-Workers derive their build ID from `TEMPORAL_WORKER_BUILD_ID`, the package version, or the configured identity. When `deployment.versioningMode` is `WorkerVersioningMode.VERSIONED`, `WorkerRuntime.create()` now:
+Workers derive their build ID (in priority order) from:
 
-1. Calls `GetWorkerBuildIdCompatibility` to confirm the WorkflowService supports worker versioning for the namespace/task queue.
-2. Registers the build ID via `UpdateWorkerBuildIdCompatibility` before any pollers start, retrying transient `Unavailable`, `DeadlineExceeded`, `Aborted`, and `Internal` errors with incremental backoff.
-3. Emits an info log so deploy pipelines can trace which build IDs were registered.
+1. `deployment.buildId` passed to `createWorker(...)` / `WorkerRuntime.create(...)`
+2. `TEMPORAL_WORKER_BUILD_ID`
+3. a derived value based on the configured `workflowsPath` contents (recommended default)
 
-If the capability probe returns `Unimplemented` or `FailedPrecondition`, the runtime logs a warning and skips registration so local development servers (for example, the Temporal CLI dev server started via `bun scripts/start-temporal-cli.ts`) continue working even though they lack worker versioning APIs. Any other error aborts startup because versioned task queues will refuse to hand out work without a registered build ID.
+When `deployment.versioningMode` is `WorkerVersioningMode.VERSIONED`, the worker includes deployment metadata (deployment name + build ID) in poll/response requests so the server can route workflow tasks to the correct build.
 
-Example logs:
-
-```
-[temporal-bun-sdk] registered worker build ID replay-worker@1.2.3 for default/replay-fixtures
-[temporal-bun-sdk] skipping worker build ID registration for default/replay-fixtures: worker versioning API unavailable (Unimplemented (12)). If you are running against the Temporal CLI dev server via bun scripts/start-temporal-cli.ts this warning is expected because that server does not implement worker versioning APIs yet.
-```
-
-Production clusters should enable worker versioning, watch for the registration log during deploys, and alert on failures so versioned queues stay healthy.
+The Bun SDK does not call the deprecated Build ID Compatibility APIs (Version Set-based “worker versioning v0.1”), since they may be disabled on some namespaces.
 
 ## License
 MIT © ProomptEng AI

--- a/packages/temporal-bun-sdk/src/worker/runtime.ts
+++ b/packages/temporal-bun-sdk/src/worker/runtime.ts
@@ -308,6 +308,9 @@ export class WorkerRuntime {
 
     const identity = options.identity ?? config.workerIdentity
     const workflowGuards = options.workflowGuards ?? config.workflowGuards
+    if (process.env.NODE_ENV === 'production' && workflowGuards !== 'strict') {
+      throw new Error('workflowGuards must be strict in production')
+    }
 
     // Install workflow runtime guards before importing any workflow code so top-level module
     // initialization is protected (e.g. `fetch()` / `Date.now()` in module scope).

--- a/packages/temporal-bun-sdk/tests/integration/activity-lifecycle.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/activity-lifecycle.integration.test.ts
@@ -55,6 +55,7 @@ describeIntegration('Activity lifecycle integration', () => {
       taskQueue: CLI_CONFIG.taskQueue,
       namespace: CLI_CONFIG.namespace,
       stickyScheduling: true,
+      workflowGuards: 'warn',
     })
     runtimePromise = runtime.run()
   }, { timeout: hookTimeoutMs })

--- a/packages/temporal-bun-sdk/tests/integration/client-resilience.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/client-resilience.integration.test.ts
@@ -76,6 +76,7 @@ describeIntegration('Temporal client resilience', () => {
       taskQueue: CLI_CONFIG.taskQueue,
       namespace: CLI_CONFIG.namespace,
       stickyScheduling: true,
+      workflowGuards: 'warn',
     })
     runtimePromise = runtime.run()
 

--- a/packages/temporal-bun-sdk/tests/integration/interceptor-framework.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/interceptor-framework.integration.test.ts
@@ -81,6 +81,7 @@ describeIntegration('interceptor framework wiring', () => {
       taskQueue: CLI_CONFIG.taskQueue,
       namespace: CLI_CONFIG.namespace,
       interceptors: [captureWorkerInterceptor],
+      workflowGuards: 'warn',
     })
     runtimePromise = runtime.run()
 

--- a/packages/temporal-bun-sdk/tests/integration/load/runner.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.ts
@@ -66,6 +66,7 @@ export const runWorkerLoad = async (options: WorkerLoadRunnerOptions): Promise<W
     },
     stickyScheduling: true,
     schedulerHooks: createSchedulerHooks(stats),
+    workflowGuards: 'warn',
   })
 
   const runPromise = runtime.run().catch((error) => {

--- a/packages/temporal-bun-sdk/tests/integration/payload-codec.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/payload-codec.integration.test.ts
@@ -131,6 +131,7 @@ describeIntegration('payload codec E2E', () => {
       taskQueue: TASK_QUEUE,
       namespace: config.namespace,
       stickyScheduling: false,
+      workflowGuards: 'warn',
     })
     runtimePromise = runtime.run().catch((error) => {
       console.error('[temporal-bun-sdk] codec runtime exited', error)

--- a/packages/temporal-bun-sdk/tests/integration/query-only.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/query-only.integration.test.ts
@@ -61,6 +61,7 @@ describeIntegration('Query-only workflow tasks', () => {
       namespace: runtimeConfig.namespace,
       stickyScheduling: false,
       deployment: undefined,
+      workflowGuards: 'warn',
     })
     runtimePromise = runtime.run().catch((error) => {
       console.error('[temporal-bun-sdk] integration worker runtime exited', error)

--- a/packages/temporal-bun-sdk/tests/integration/signal-query.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/signal-query.integration.test.ts
@@ -61,6 +61,7 @@ describeIntegration('Signal + query integration', () => {
       namespace: runtimeConfig.namespace,
       stickyScheduling: false,
       deployment: undefined,
+      workflowGuards: 'warn',
     })
     runtimePromise = runtime.run().catch((error) => {
       console.error('[temporal-bun-sdk] integration worker runtime exited', error)

--- a/packages/temporal-bun-sdk/tests/integration/test-env.ts
+++ b/packages/temporal-bun-sdk/tests/integration/test-env.ts
@@ -93,6 +93,7 @@ const setupIntegrationTestEnv = async (): Promise<IntegrationTestEnv> => {
       workflows: integrationWorkflows,
       activities: integrationActivities,
       stickyCache,
+      workflowGuards: 'warn',
       deployment: {
         versioningMode: WorkerVersioningMode.UNVERSIONED,
         versioningBehavior: VersioningBehavior.UNSPECIFIED,

--- a/packages/temporal-bun-sdk/tests/integration/test-environment.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/test-environment.integration.test.ts
@@ -34,6 +34,7 @@ test('TestWorkflowEnvironment runs a worker end-to-end', { timeout: 30_000 }, as
       activities: integrationActivities,
       taskQueue,
       namespace: env.cliConfig.namespace,
+      workflowGuards: 'warn',
     })
 
     const workerPromise = worker.run()

--- a/packages/temporal-bun-sdk/tests/integration/worker.runtime.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/worker.runtime.integration.test.ts
@@ -101,6 +101,7 @@ describeIntegration('Temporal worker runtime integration', () => {
             namespace: config.namespace,
             concurrency: { workflow: 2 },
             stickyScheduling: false,
+            workflowGuards: 'warn',
             deployment: {
               versioningMode: WorkerVersioningMode.UNVERSIONED,
               versioningBehavior: VersioningBehavior.UNSPECIFIED,
@@ -272,6 +273,7 @@ describeIntegration('Temporal worker runtime integration', () => {
             stickyScheduling: true,
             workflowService,
             identity,
+            workflowGuards: 'warn',
             deployment: {
               name: deploymentName,
               buildId,
@@ -393,6 +395,7 @@ describeIntegration('Temporal worker runtime integration', () => {
             taskQueue,
             namespace: config.namespace,
             stickyScheduling: true,
+            workflowGuards: 'warn',
             deployment: {
               versioningMode: WorkerVersioningMode.UNVERSIONED,
               versioningBehavior: VersioningBehavior.UNSPECIFIED,

--- a/services/bumba/src/worker.ts
+++ b/services/bumba/src/worker.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http'
 import { fileURLToPath } from 'node:url'
 import { createTemporalClient, type TemporalConfig, temporalCallOptions } from '@proompteng/temporal-bun-sdk'
-import { createWorker, VersioningBehavior, WorkerVersioningMode } from '@proompteng/temporal-bun-sdk/worker'
+import { createWorker } from '@proompteng/temporal-bun-sdk/worker'
 
 import activities from './activities/index'
 
@@ -164,16 +164,9 @@ const startHealthServer = async (config: TemporalConfig): Promise<HealthServer> 
 }
 
 const main = async () => {
-  const versioningMode =
-    process.env.NODE_ENV === 'production' ? WorkerVersioningMode.VERSIONED : WorkerVersioningMode.UNVERSIONED
-
   const { worker, config } = await createWorker({
     workflowsPath: fileURLToPath(new URL('./workflows/index.ts', import.meta.url)),
     activities: activities as Record<string, ActivityHandler>,
-    deployment: {
-      versioningMode,
-      ...(versioningMode === WorkerVersioningMode.VERSIONED ? { versioningBehavior: VersioningBehavior.PINNED } : {}),
-    },
   })
 
   const health = await startHealthServer(config)


### PR DESCRIPTION
## Summary

- Remove `TEMPORAL_WORKFLOW_GUARDS` and `TEMPORAL_WORKER_DEPLOYMENT_NAME` env var support; guard behavior is configured programmatically only.
- Default workflow runtime guards to `strict` and reject non-`strict` modes at runtime when `NODE_ENV=production`.
- Update Temporal Bun SDK + docs to reflect worker deployment based versioning (no v0.1 Build ID Compatibility API calls).

## Related Issues

None

## Testing

- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun run --filter @proompteng/temporal-bun-sdk test`

## Breaking Changes

- `TEMPORAL_WORKFLOW_GUARDS` and `TEMPORAL_WORKER_DEPLOYMENT_NAME` are no longer read by `loadTemporalConfig()`.
- In production (`NODE_ENV=production`), `workflowGuards` must be `strict` (workers and the workflow executor will throw at startup otherwise).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
