### PR TITLE
chore(bumba): roll out sha-d26e1f9

### DIFF
--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - deployment-model.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: "sha-ebdbf24"
+    newTag: "sha-d26e1f9"


### PR DESCRIPTION
## Summary

- Roll `bumba`/`bumba-model` to image tag `sha-d26e1f9`.

## Related Issues

None

## Testing

- N/A (image build + Argo rollout validated post-merge)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
