### PR TITLE
ci(build): rebuild frontends when design changes

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -38,12 +38,15 @@ jobs:
           filters: |
             proompteng:
               - 'apps/landing/**'
+              - 'packages/design/**'
             app:
               - 'apps/app/**'
+              - 'packages/design/**'
             cms:
               - 'apps/cms/**'
             docs:
               - 'apps/docs/**'
+              - 'packages/design/**'
             kitty-krew:
               - 'apps/kitty-krew/**'
             reviseur:

--- a/packages/design/globals.css
+++ b/packages/design/globals.css
@@ -3,6 +3,7 @@
 
 /*
   Shared global theme for proompteng apps.
+  Tokens derived from Jangar and consumed across app/docs/landing.
   This is intentionally CSS-first (Tailwind v4) so consumers only need:
     @import "@proompteng/design/globals.css";
 */


### PR DESCRIPTION
## Summary

- Rebuild `proompteng`, `app`, and `docs` images when `packages/design` changes.
- Ensures shared design-token updates propagate without touching each app.
- Documents that shared globals tokens are derived from Jangar.

## Related Issues

None

## Testing

- `bunx biome check packages/design/globals.css`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
