### PR TITLE
feat(jangar): add torghut trading history UI

### DIFF
--- a/services/jangar/src/components/app-sidebar.tsx
+++ b/services/jangar/src/components/app-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   IconActivity,
   IconBrain,
   IconChartCandle,
+  IconChartLine,
   IconDatabase,
   IconFileText,
   IconGitPullRequest,
@@ -96,6 +97,7 @@ const apiNav = [
 const torghutNav = [
   { to: '/torghut/symbols', label: 'Symbols', icon: IconList },
   { to: '/torghut/visuals', label: 'Visuals', icon: IconChartCandle },
+  { to: '/torghut/trading', label: 'Trading', icon: IconChartLine },
 ] as const
 
 export function AppSidebar() {

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as V1MemoriesRouteImport } from './routes/v1/memories'
 import { Route as V1AgentsRouteImport } from './routes/v1/agents'
 import { Route as V1AgentRunsRouteImport } from './routes/v1/agent-runs'
 import { Route as TorghutVisualsRouteImport } from './routes/torghut/visuals'
+import { Route as TorghutTradingRouteImport } from './routes/torghut/trading'
 import { Route as TorghutSymbolsRouteImport } from './routes/torghut/symbols'
 import { Route as TerminalsSessionIdRouteImport } from './routes/terminals/$sessionId'
 import { Route as GithubPullsRouteImport } from './routes/github/pulls'
@@ -108,6 +109,10 @@ import { Route as ApiAtlasFileRouteImport } from './routes/api/atlas/file'
 import { Route as ApiAtlasAstRouteImport } from './routes/api/atlas/ast'
 import { Route as ApiAgentsEventsRouteImport } from './routes/api/agents/events'
 import { Route as OpenaiV1ChatCompletionsRouteImport } from './routes/openai/v1/chat/completions'
+import { Route as ApiTorghutTradingSummaryRouteImport } from './routes/api/torghut/trading/summary'
+import { Route as ApiTorghutTradingStrategiesRouteImport } from './routes/api/torghut/trading/strategies'
+import { Route as ApiTorghutTradingExecutionsRouteImport } from './routes/api/torghut/trading/executions'
+import { Route as ApiTorghutTradingDecisionsRouteImport } from './routes/api/torghut/trading/decisions'
 import { Route as ApiTorghutTaSignalsRouteImport } from './routes/api/torghut/ta/signals'
 import { Route as ApiTorghutTaLatestRouteImport } from './routes/api/torghut/ta/latest'
 import { Route as ApiTorghutTaBarsRouteImport } from './routes/api/torghut/ta/bars'
@@ -217,6 +222,11 @@ const V1AgentRunsRoute = V1AgentRunsRouteImport.update({
 const TorghutVisualsRoute = TorghutVisualsRouteImport.update({
   id: '/torghut/visuals',
   path: '/torghut/visuals',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TorghutTradingRoute = TorghutTradingRouteImport.update({
+  id: '/torghut/trading',
+  path: '/torghut/trading',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TorghutSymbolsRoute = TorghutSymbolsRouteImport.update({
@@ -666,6 +676,30 @@ const OpenaiV1ChatCompletionsRoute = OpenaiV1ChatCompletionsRouteImport.update({
   path: '/openai/v1/chat/completions',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiTorghutTradingSummaryRoute =
+  ApiTorghutTradingSummaryRouteImport.update({
+    id: '/api/torghut/trading/summary',
+    path: '/api/torghut/trading/summary',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTorghutTradingStrategiesRoute =
+  ApiTorghutTradingStrategiesRouteImport.update({
+    id: '/api/torghut/trading/strategies',
+    path: '/api/torghut/trading/strategies',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTorghutTradingExecutionsRoute =
+  ApiTorghutTradingExecutionsRouteImport.update({
+    id: '/api/torghut/trading/executions',
+    path: '/api/torghut/trading/executions',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTorghutTradingDecisionsRoute =
+  ApiTorghutTradingDecisionsRouteImport.update({
+    id: '/api/torghut/trading/decisions',
+    path: '/api/torghut/trading/decisions',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiTorghutTaSignalsRoute = ApiTorghutTaSignalsRouteImport.update({
   id: '/api/torghut/ta/signals',
   path: '/api/torghut/ta/signals',
@@ -863,6 +897,7 @@ export interface FileRoutesByFullPath {
   '/github/pulls': typeof GithubPullsRouteWithChildren
   '/terminals/$sessionId': typeof TerminalsSessionIdRouteWithChildren
   '/torghut/symbols': typeof TorghutSymbolsRoute
+  '/torghut/trading': typeof TorghutTradingRoute
   '/torghut/visuals': typeof TorghutVisualsRoute
   '/v1/agent-runs': typeof V1AgentRunsRouteWithChildren
   '/v1/agents': typeof V1AgentsRouteWithChildren
@@ -958,6 +993,10 @@ export interface FileRoutesByFullPath {
   '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
   '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
+  '/api/torghut/trading/decisions': typeof ApiTorghutTradingDecisionsRoute
+  '/api/torghut/trading/executions': typeof ApiTorghutTradingExecutionsRoute
+  '/api/torghut/trading/strategies': typeof ApiTorghutTradingStrategiesRoute
+  '/api/torghut/trading/summary': typeof ApiTorghutTradingSummaryRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
@@ -992,6 +1031,7 @@ export interface FileRoutesByTo {
   '/codex/runs': typeof CodexRunsRoute
   '/codex/search': typeof CodexSearchRoute
   '/torghut/symbols': typeof TorghutSymbolsRoute
+  '/torghut/trading': typeof TorghutTradingRoute
   '/torghut/visuals': typeof TorghutVisualsRoute
   '/v1/agent-runs': typeof V1AgentRunsRouteWithChildren
   '/v1/agents': typeof V1AgentsRouteWithChildren
@@ -1087,6 +1127,10 @@ export interface FileRoutesByTo {
   '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
   '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
+  '/api/torghut/trading/decisions': typeof ApiTorghutTradingDecisionsRoute
+  '/api/torghut/trading/executions': typeof ApiTorghutTradingExecutionsRoute
+  '/api/torghut/trading/strategies': typeof ApiTorghutTradingStrategiesRoute
+  '/api/torghut/trading/summary': typeof ApiTorghutTradingSummaryRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
@@ -1124,6 +1168,7 @@ export interface FileRoutesById {
   '/github/pulls': typeof GithubPullsRouteWithChildren
   '/terminals/$sessionId': typeof TerminalsSessionIdRouteWithChildren
   '/torghut/symbols': typeof TorghutSymbolsRoute
+  '/torghut/trading': typeof TorghutTradingRoute
   '/torghut/visuals': typeof TorghutVisualsRoute
   '/v1/agent-runs': typeof V1AgentRunsRouteWithChildren
   '/v1/agents': typeof V1AgentsRouteWithChildren
@@ -1219,6 +1264,10 @@ export interface FileRoutesById {
   '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
   '/api/torghut/ta/signals': typeof ApiTorghutTaSignalsRoute
+  '/api/torghut/trading/decisions': typeof ApiTorghutTradingDecisionsRoute
+  '/api/torghut/trading/executions': typeof ApiTorghutTradingExecutionsRoute
+  '/api/torghut/trading/strategies': typeof ApiTorghutTradingStrategiesRoute
+  '/api/torghut/trading/summary': typeof ApiTorghutTradingSummaryRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
@@ -1257,6 +1306,7 @@ export interface FileRouteTypes {
     | '/github/pulls'
     | '/terminals/$sessionId'
     | '/torghut/symbols'
+    | '/torghut/trading'
     | '/torghut/visuals'
     | '/v1/agent-runs'
     | '/v1/agents'
@@ -1352,6 +1402,10 @@ export interface FileRouteTypes {
     | '/api/torghut/ta/bars'
     | '/api/torghut/ta/latest'
     | '/api/torghut/ta/signals'
+    | '/api/torghut/trading/decisions'
+    | '/api/torghut/trading/executions'
+    | '/api/torghut/trading/strategies'
+    | '/api/torghut/trading/summary'
     | '/openai/v1/chat/completions'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/github/pulls/$owner/$repo/$number'
@@ -1386,6 +1440,7 @@ export interface FileRouteTypes {
     | '/codex/runs'
     | '/codex/search'
     | '/torghut/symbols'
+    | '/torghut/trading'
     | '/torghut/visuals'
     | '/v1/agent-runs'
     | '/v1/agents'
@@ -1481,6 +1536,10 @@ export interface FileRouteTypes {
     | '/api/torghut/ta/bars'
     | '/api/torghut/ta/latest'
     | '/api/torghut/ta/signals'
+    | '/api/torghut/trading/decisions'
+    | '/api/torghut/trading/executions'
+    | '/api/torghut/trading/strategies'
+    | '/api/torghut/trading/summary'
     | '/openai/v1/chat/completions'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/github/pulls/$owner/$repo/$number'
@@ -1517,6 +1576,7 @@ export interface FileRouteTypes {
     | '/github/pulls'
     | '/terminals/$sessionId'
     | '/torghut/symbols'
+    | '/torghut/trading'
     | '/torghut/visuals'
     | '/v1/agent-runs'
     | '/v1/agents'
@@ -1612,6 +1672,10 @@ export interface FileRouteTypes {
     | '/api/torghut/ta/bars'
     | '/api/torghut/ta/latest'
     | '/api/torghut/ta/signals'
+    | '/api/torghut/trading/decisions'
+    | '/api/torghut/trading/executions'
+    | '/api/torghut/trading/strategies'
+    | '/api/torghut/trading/summary'
     | '/openai/v1/chat/completions'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/github/pulls/$owner/$repo/$number'
@@ -1649,6 +1713,7 @@ export interface RootRouteChildren {
   GithubPullsRoute: typeof GithubPullsRouteWithChildren
   TerminalsSessionIdRoute: typeof TerminalsSessionIdRouteWithChildren
   TorghutSymbolsRoute: typeof TorghutSymbolsRoute
+  TorghutTradingRoute: typeof TorghutTradingRoute
   TorghutVisualsRoute: typeof TorghutVisualsRoute
   V1AgentRunsRoute: typeof V1AgentRunsRouteWithChildren
   V1AgentsRoute: typeof V1AgentsRouteWithChildren
@@ -1724,6 +1789,10 @@ export interface RootRouteChildren {
   ApiTorghutTaBarsRoute: typeof ApiTorghutTaBarsRoute
   ApiTorghutTaLatestRoute: typeof ApiTorghutTaLatestRoute
   ApiTorghutTaSignalsRoute: typeof ApiTorghutTaSignalsRoute
+  ApiTorghutTradingDecisionsRoute: typeof ApiTorghutTradingDecisionsRoute
+  ApiTorghutTradingExecutionsRoute: typeof ApiTorghutTradingExecutionsRoute
+  ApiTorghutTradingStrategiesRoute: typeof ApiTorghutTradingStrategiesRoute
+  ApiTorghutTradingSummaryRoute: typeof ApiTorghutTradingSummaryRoute
   OpenaiV1ChatCompletionsRoute: typeof OpenaiV1ChatCompletionsRoute
   ApiAgentsImplementationSourcesWebhooksProviderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
 }
@@ -1840,6 +1909,13 @@ declare module '@tanstack/react-router' {
       path: '/torghut/visuals'
       fullPath: '/torghut/visuals'
       preLoaderRoute: typeof TorghutVisualsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/torghut/trading': {
+      id: '/torghut/trading'
+      path: '/torghut/trading'
+      fullPath: '/torghut/trading'
+      preLoaderRoute: typeof TorghutTradingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/torghut/symbols': {
@@ -2423,6 +2499,34 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OpenaiV1ChatCompletionsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/torghut/trading/summary': {
+      id: '/api/torghut/trading/summary'
+      path: '/api/torghut/trading/summary'
+      fullPath: '/api/torghut/trading/summary'
+      preLoaderRoute: typeof ApiTorghutTradingSummaryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/trading/strategies': {
+      id: '/api/torghut/trading/strategies'
+      path: '/api/torghut/trading/strategies'
+      fullPath: '/api/torghut/trading/strategies'
+      preLoaderRoute: typeof ApiTorghutTradingStrategiesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/trading/executions': {
+      id: '/api/torghut/trading/executions'
+      path: '/api/torghut/trading/executions'
+      fullPath: '/api/torghut/trading/executions'
+      preLoaderRoute: typeof ApiTorghutTradingExecutionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/trading/decisions': {
+      id: '/api/torghut/trading/decisions'
+      path: '/api/torghut/trading/decisions'
+      fullPath: '/api/torghut/trading/decisions'
+      preLoaderRoute: typeof ApiTorghutTradingDecisionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/torghut/ta/signals': {
       id: '/api/torghut/ta/signals'
       path: '/api/torghut/ta/signals'
@@ -2879,6 +2983,7 @@ const rootRouteChildren: RootRouteChildren = {
   GithubPullsRoute: GithubPullsRouteWithChildren,
   TerminalsSessionIdRoute: TerminalsSessionIdRouteWithChildren,
   TorghutSymbolsRoute: TorghutSymbolsRoute,
+  TorghutTradingRoute: TorghutTradingRoute,
   TorghutVisualsRoute: TorghutVisualsRoute,
   V1AgentRunsRoute: V1AgentRunsRouteWithChildren,
   V1AgentsRoute: V1AgentsRouteWithChildren,
@@ -2962,6 +3067,10 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTorghutTaBarsRoute: ApiTorghutTaBarsRoute,
   ApiTorghutTaLatestRoute: ApiTorghutTaLatestRoute,
   ApiTorghutTaSignalsRoute: ApiTorghutTaSignalsRoute,
+  ApiTorghutTradingDecisionsRoute: ApiTorghutTradingDecisionsRoute,
+  ApiTorghutTradingExecutionsRoute: ApiTorghutTradingExecutionsRoute,
+  ApiTorghutTradingStrategiesRoute: ApiTorghutTradingStrategiesRoute,
+  ApiTorghutTradingSummaryRoute: ApiTorghutTradingSummaryRoute,
   OpenaiV1ChatCompletionsRoute: OpenaiV1ChatCompletionsRoute,
   ApiAgentsImplementationSourcesWebhooksProviderRoute:
     ApiAgentsImplementationSourcesWebhooksProviderRoute,

--- a/services/jangar/src/routes/api/torghut/trading/decisions.ts
+++ b/services/jangar/src/routes/api/torghut/trading/decisions.ts
@@ -1,0 +1,49 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { listTorghutTradingRejectedDecisions, parseTorghutTradingStrategyId } from '~/server/torghut-trading'
+import { resolveTorghutDb } from '~/server/torghut-trading-db'
+import { resolveTradingDayInterval } from '~/server/torghut-trading-time'
+
+export const Route = createFileRoute('/api/torghut/trading/decisions')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getDecisionsHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getDecisionsHandler = async (request: Request) => {
+  const torghut = resolveTorghutDb()
+  if (!torghut.ok) return jsonResponse({ ok: false, disabled: true, message: torghut.message }, 503)
+
+  const url = new URL(request.url)
+  const intervalResult = resolveTradingDayInterval(url)
+  if (!intervalResult.ok) return jsonResponse({ ok: false, message: intervalResult.message }, 400)
+
+  const strategyIdResult = parseTorghutTradingStrategyId(url)
+  if (!strategyIdResult.ok) return jsonResponse({ ok: false, message: strategyIdResult.message }, 400)
+
+  try {
+    const items = await listTorghutTradingRejectedDecisions({
+      pool: torghut.pool,
+      startUtc: intervalResult.value.startUtc,
+      endUtc: intervalResult.value.endUtc,
+      strategyId: strategyIdResult.value,
+      limit: 2000,
+    })
+    return jsonResponse({ ok: true, interval: intervalResult.value, items })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Torghut query failed'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/trading/executions.ts
+++ b/services/jangar/src/routes/api/torghut/trading/executions.ts
@@ -1,0 +1,49 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { listTorghutTradingFilledExecutions, parseTorghutTradingStrategyId } from '~/server/torghut-trading'
+import { resolveTorghutDb } from '~/server/torghut-trading-db'
+import { resolveTradingDayInterval } from '~/server/torghut-trading-time'
+
+export const Route = createFileRoute('/api/torghut/trading/executions')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getExecutionsHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getExecutionsHandler = async (request: Request) => {
+  const torghut = resolveTorghutDb()
+  if (!torghut.ok) return jsonResponse({ ok: false, disabled: true, message: torghut.message }, 503)
+
+  const url = new URL(request.url)
+  const intervalResult = resolveTradingDayInterval(url)
+  if (!intervalResult.ok) return jsonResponse({ ok: false, message: intervalResult.message }, 400)
+
+  const strategyIdResult = parseTorghutTradingStrategyId(url)
+  if (!strategyIdResult.ok) return jsonResponse({ ok: false, message: strategyIdResult.message }, 400)
+
+  try {
+    const items = await listTorghutTradingFilledExecutions({
+      pool: torghut.pool,
+      startUtc: intervalResult.value.startUtc,
+      endUtc: intervalResult.value.endUtc,
+      strategyId: strategyIdResult.value,
+      limit: 2000,
+    })
+    return jsonResponse({ ok: true, interval: intervalResult.value, items })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Torghut query failed'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/trading/strategies.ts
+++ b/services/jangar/src/routes/api/torghut/trading/strategies.ts
@@ -1,0 +1,35 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { listTorghutTradingStrategies } from '~/server/torghut-trading'
+import { resolveTorghutDb } from '~/server/torghut-trading-db'
+
+export const Route = createFileRoute('/api/torghut/trading/strategies')({
+  server: {
+    handlers: {
+      GET: async () => getStrategiesHandler(),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getStrategiesHandler = async () => {
+  const torghut = resolveTorghutDb()
+  if (!torghut.ok) return jsonResponse({ ok: false, disabled: true, message: torghut.message }, 503)
+
+  try {
+    const items = await listTorghutTradingStrategies({ pool: torghut.pool, limit: 500 })
+    return jsonResponse({ ok: true, items })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Torghut query failed'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/trading/summary.ts
+++ b/services/jangar/src/routes/api/torghut/trading/summary.ts
@@ -1,0 +1,47 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { buildTorghutTradingSummary, parseTorghutTradingStrategyId } from '~/server/torghut-trading'
+import { resolveTorghutDb } from '~/server/torghut-trading-db'
+import { resolveTradingDayInterval } from '~/server/torghut-trading-time'
+
+export const Route = createFileRoute('/api/torghut/trading/summary')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getSummaryHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getSummaryHandler = async (request: Request) => {
+  const torghut = resolveTorghutDb()
+  if (!torghut.ok) return jsonResponse({ ok: false, disabled: true, message: torghut.message }, 503)
+
+  const url = new URL(request.url)
+  const intervalResult = resolveTradingDayInterval(url)
+  if (!intervalResult.ok) return jsonResponse({ ok: false, message: intervalResult.message }, 400)
+
+  const strategyIdResult = parseTorghutTradingStrategyId(url)
+  if (!strategyIdResult.ok) return jsonResponse({ ok: false, message: strategyIdResult.message }, 400)
+
+  try {
+    const summary = await buildTorghutTradingSummary({
+      pool: torghut.pool,
+      interval: intervalResult.value,
+      strategyId: strategyIdResult.value,
+    })
+    return jsonResponse({ ok: true, summary })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Torghut query failed'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/routes/torghut/trading.tsx
+++ b/services/jangar/src/routes/torghut/trading.tsx
@@ -1,0 +1,809 @@
+import {
+  Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+} from '@proompteng/design/ui'
+import { createFileRoute } from '@tanstack/react-router'
+import * as React from 'react'
+import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts'
+
+export const Route = createFileRoute('/torghut/trading')({
+  component: TorghutTrading,
+})
+
+type StrategyItem = {
+  id: string
+  name: string
+  enabled: boolean
+  baseTimeframe: string
+  universeSymbols: unknown
+}
+
+type Interval = {
+  tz: string
+  day: string
+  startUtc: string
+  endUtc: string
+}
+
+type TradingSummary = {
+  interval: Interval
+  strategy: { id: string; name: string } | null
+  realizedPnl: {
+    value: number
+    closedQty: number
+    winRate: number | null
+    winCount: number
+    lossCount: number
+    series: { ts: string; realizedPnl: number }[]
+    warnings: string[]
+  }
+  executions: { filledCount: number }
+  rejections: {
+    rejectedCount: number
+    topReasons: { reason: string; count: number }[]
+  }
+  equity: {
+    available: boolean
+    byAccount: { alpacaAccountLabel: string; delta: number; series: { ts: string; equity: number }[] }[]
+  }
+}
+
+type FilledExecution = {
+  executionId: string
+  tradeDecisionId: string | null
+  strategyId: string
+  strategyName: string | null
+  createdAt: string
+  symbol: string
+  side: string
+  filledQty: number
+  avgFillPrice: number | null
+  timeframe: string | null
+  alpacaAccountLabel: string | null
+}
+
+type RejectedDecision = {
+  id: string
+  createdAt: string
+  alpacaAccountLabel: string
+  symbol: string
+  timeframe: string
+  status: string
+  rationale: string | null
+  riskReasons: string[]
+  strategyId: string
+  strategyName: string
+}
+
+const DEFAULT_TZ = 'America/New_York'
+
+const formatEtDayToday = () => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: DEFAULT_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date())
+
+  const record: Record<string, string> = {}
+  for (const part of parts) {
+    if (part.type !== 'literal') record[part.type] = part.value
+  }
+  const year = record.year
+  const month = record.month
+  const day = record.day
+  if (!year || !month || !day) return new Date().toISOString().slice(0, 10)
+  return `${year}-${month}-${day}`
+}
+
+const currency = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })
+const compactNumber = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 })
+
+const formatTimestamp = (value: string): string => {
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) return value
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short',
+  }).format(new Date(parsed))
+}
+
+const getErrorMessage = (payload: unknown): string | null => {
+  if (!payload || typeof payload !== 'object') return null
+  const record = payload as { message?: unknown; error?: unknown }
+  if (typeof record.message === 'string' && record.message) return record.message
+  if (typeof record.error === 'string' && record.error) return record.error
+  return null
+}
+
+const isStrategiesPayload = (value: unknown): value is { ok: true; items: StrategyItem[] } => {
+  if (!value || typeof value !== 'object') return false
+  if (!('ok' in value) || !('items' in value)) return false
+  if ((value as { ok?: unknown }).ok !== true) return false
+  return Array.isArray((value as { items?: unknown }).items)
+}
+
+const isSummaryPayload = (value: unknown): value is { ok: true; summary: TradingSummary } => {
+  if (!value || typeof value !== 'object') return false
+  if (!('ok' in value) || !('summary' in value)) return false
+  return (value as { ok?: unknown }).ok === true
+}
+
+const isItemsPayload = <T,>(value: unknown): value is { ok: true; items: T[] } => {
+  if (!value || typeof value !== 'object') return false
+  if (!('items' in value)) return false
+  return Array.isArray((value as { items?: unknown }).items)
+}
+
+const reasonHistogramConfig = {
+  count: {
+    label: 'Count',
+    color: 'var(--chart-2)',
+  },
+} satisfies ChartConfig
+
+function TorghutTrading() {
+  const [day, setDay] = React.useState(() => formatEtDayToday())
+  const [strategies, setStrategies] = React.useState<StrategyItem[]>([])
+  const [strategyId, setStrategyId] = React.useState<string>('')
+  const [strategiesError, setStrategiesError] = React.useState<string | null>(null)
+  const [disabledMessage, setDisabledMessage] = React.useState<string | null>(null)
+
+  const [summary, setSummary] = React.useState<TradingSummary | null>(null)
+  const [summaryError, setSummaryError] = React.useState<string | null>(null)
+  const [executions, setExecutions] = React.useState<FilledExecution[]>([])
+  const [decisions, setDecisions] = React.useState<RejectedDecision[]>([])
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  const loadStrategies = React.useCallback(async () => {
+    setDisabledMessage(null)
+    setStrategiesError(null)
+    try {
+      const response = await fetch('/api/torghut/trading/strategies')
+      const payload = (await response.json().catch(() => null)) as unknown
+      if (!response.ok) {
+        const message = getErrorMessage(payload) ?? `Failed to load strategies (${response.status})`
+        const disabled = Boolean(payload && typeof payload === 'object' && 'disabled' in payload)
+        if (disabled) setDisabledMessage(message)
+        setStrategiesError(message)
+        setStrategies([])
+        return
+      }
+
+      if (!isStrategiesPayload(payload)) {
+        setStrategiesError('Unexpected strategies payload.')
+        setStrategies([])
+        return
+      }
+
+      const parsed = payload.items.filter(
+        (item) => item && typeof item.id === 'string' && typeof item.name === 'string',
+      )
+      setStrategies(parsed as StrategyItem[])
+      setStrategyId((current) => {
+        if (current && parsed.some((item) => item.id === current)) return current
+        return parsed[0]?.id ?? ''
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load strategies.'
+      setStrategiesError(message)
+      setStrategies([])
+    }
+  }, [])
+
+  const loadData = React.useCallback(async (params: { day: string; strategyId: string }) => {
+    setIsLoading(true)
+    setSummaryError(null)
+    setDisabledMessage(null)
+
+    const query = new URLSearchParams({ day: params.day, tz: DEFAULT_TZ })
+    if (params.strategyId) query.set('strategyId', params.strategyId)
+
+    try {
+      const [summaryRes, execRes, decRes] = await Promise.all([
+        fetch(`/api/torghut/trading/summary?${query}`),
+        fetch(`/api/torghut/trading/executions?${query}`),
+        fetch(`/api/torghut/trading/decisions?${query}`),
+      ])
+
+      const summaryPayload = (await summaryRes.json().catch(() => null)) as unknown
+      if (!summaryRes.ok) {
+        const message = getErrorMessage(summaryPayload) ?? `Failed to load summary (${summaryRes.status})`
+        const disabled = Boolean(summaryPayload && typeof summaryPayload === 'object' && 'disabled' in summaryPayload)
+        if (disabled) setDisabledMessage(message)
+        setSummaryError(message)
+        setSummary(null)
+        setExecutions([])
+        setDecisions([])
+        return
+      }
+
+      if (!isSummaryPayload(summaryPayload)) {
+        setSummaryError('Unexpected summary payload.')
+        setSummary(null)
+        setExecutions([])
+        setDecisions([])
+        return
+      }
+      setSummary(summaryPayload.summary)
+
+      const execPayload = (await execRes.json().catch(() => null)) as unknown
+      setExecutions(execRes.ok && isItemsPayload<FilledExecution>(execPayload) ? execPayload.items : [])
+
+      const decPayload = (await decRes.json().catch(() => null)) as unknown
+      setDecisions(decRes.ok && isItemsPayload<RejectedDecision>(decPayload) ? decPayload.items : [])
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load trading history.'
+      setSummaryError(message)
+      setSummary(null)
+      setExecutions([])
+      setDecisions([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    void loadStrategies()
+  }, [loadStrategies])
+
+  React.useEffect(() => {
+    if (!strategyId || !day) return
+    void loadData({ day, strategyId })
+  }, [day, strategyId, loadData])
+
+  const selectedStrategy = React.useMemo(
+    () => strategies.find((strategy) => strategy.id === strategyId) ?? null,
+    [strategies, strategyId],
+  )
+
+  const equityAccounts = summary?.equity.byAccount ?? []
+
+  return (
+    <main className="mx-auto w-full max-w-6xl space-y-6 p-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Torghut</p>
+          <h1 className="text-lg font-semibold">Trading</h1>
+          <p className="text-xs text-muted-foreground">
+            Filled executions, realized PnL (average-cost, long-only), and rejection diagnostics for a single ET trading
+            day.
+          </p>
+        </div>
+        <div className="flex items-start gap-2">
+          <Button variant="outline" onClick={() => void loadData({ day, strategyId })} disabled={isLoading || !day}>
+            Refresh
+          </Button>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader className="border-b">
+          <div className="space-y-1">
+            <CardTitle>Filters</CardTitle>
+            <CardDescription>America/New_York day buckets (backend computes UTC interval).</CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4 pt-4 md:grid-cols-3">
+          <div className="space-y-2">
+            <label className="text-xs font-medium" htmlFor="trading-day">
+              Trading day (ET)
+            </label>
+            <Input
+              id="trading-day"
+              type="date"
+              value={day}
+              onChange={(event) => setDay(event.target.value)}
+              min="2020-01-01"
+              max="2100-12-31"
+            />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-xs font-medium" htmlFor="trading-strategy">
+              Strategy
+            </label>
+            <Select value={strategyId} onValueChange={(value) => setStrategyId(value ?? '')}>
+              <SelectTrigger id="trading-strategy" className="w-full">
+                <SelectValue placeholder={strategies.length === 0 ? 'Loading strategies…' : 'Select strategy'} />
+              </SelectTrigger>
+              <SelectContent>
+                {strategies.length === 0 ? (
+                  <SelectItem value="none" disabled>
+                    No strategies
+                  </SelectItem>
+                ) : null}
+                {strategies.map((strategy) => (
+                  <SelectItem key={strategy.id} value={strategy.id}>
+                    <span>{strategy.name}</span>
+                    {strategy.enabled ? null : <span className="text-muted-foreground">disabled</span>}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {strategiesError ? (
+              <div className="text-xs text-destructive" aria-live="polite">
+                {strategiesError}
+              </div>
+            ) : null}
+          </div>
+        </CardContent>
+      </Card>
+
+      {disabledMessage ? (
+        <Card className="border-amber-500/40">
+          <CardHeader className="border-b">
+            <CardTitle>Trading History Disabled</CardTitle>
+            <CardDescription>This deployment does not have Torghut DB credentials configured.</CardDescription>
+          </CardHeader>
+          <CardContent className="pt-4 text-xs text-muted-foreground">
+            {disabledMessage}
+            <div className="mt-2">
+              Set <code className="text-[0.7rem]">TORGHUT_DB_DSN</code> on the Jangar runtime to enable read-only
+              queries.
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {summaryError ? (
+        <Card className="border-destructive/40">
+          <CardHeader className="border-b">
+            <CardTitle>Unable To Load Trading History</CardTitle>
+            <CardDescription>Fix the error below, then refresh.</CardDescription>
+          </CardHeader>
+          <CardContent className="pt-4 text-xs text-destructive" aria-live="polite">
+            {summaryError}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader className="border-b">
+            <CardTitle>Realized PnL</CardTitle>
+            <CardDescription>
+              {selectedStrategy ? (
+                <>
+                  Strategy <span className="font-medium text-foreground">{selectedStrategy.name}</span> (filled
+                  executions only)
+                </>
+              ) : (
+                'Filled executions only'
+              )}
+            </CardDescription>
+            <CardAction>
+              {isLoading ? <span className="text-xs text-muted-foreground">Loading…</span> : null}
+            </CardAction>
+          </CardHeader>
+          <CardContent className="space-y-3 pt-4">
+            {summary ? (
+              <>
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <div className="text-3xl font-medium tabular-nums">
+                    <span
+                      className={
+                        summary.realizedPnl.value > 0
+                          ? 'text-emerald-600'
+                          : summary.realizedPnl.value < 0
+                            ? 'text-rose-600'
+                            : undefined
+                      }
+                    >
+                      {currency.format(summary.realizedPnl.value)}
+                    </span>
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    Closed qty{' '}
+                    <span className="tabular-nums text-foreground">
+                      {compactNumber.format(summary.realizedPnl.closedQty)}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                  <div>
+                    Win rate{' '}
+                    <span className="tabular-nums text-foreground">
+                      {summary.realizedPnl.winRate === null ? '—' : `${Math.round(summary.realizedPnl.winRate * 100)}%`}
+                    </span>
+                  </div>
+                  <div>
+                    Wins <span className="tabular-nums text-foreground">{summary.realizedPnl.winCount}</span>
+                  </div>
+                  <div>
+                    Losses <span className="tabular-nums text-foreground">{summary.realizedPnl.lossCount}</span>
+                  </div>
+                </div>
+                {summary.realizedPnl.series.length > 1 ? (
+                  <RealizedPnlChart series={summary.realizedPnl.series} />
+                ) : null}
+                {summary.realizedPnl.warnings.length > 0 ? (
+                  <details className="rounded-none border bg-muted/20 p-3 text-xs text-muted-foreground">
+                    <summary className="cursor-pointer font-medium text-foreground">
+                      PnL warnings ({summary.realizedPnl.warnings.length})
+                    </summary>
+                    <ul className="mt-2 list-disc pl-4">
+                      {summary.realizedPnl.warnings.slice(0, 12).map((warning) => (
+                        <li key={warning}>{warning}</li>
+                      ))}
+                    </ul>
+                  </details>
+                ) : null}
+              </>
+            ) : (
+              <Skeleton className="h-24 w-full" />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="border-b">
+            <CardTitle>Equity Delta</CardTitle>
+            <CardDescription>Account-level curve from position snapshots (if available)</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 pt-4">
+            {summary ? (
+              equityAccounts.length > 0 ? (
+                <>
+                  <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    {equityAccounts.slice(0, 3).map((account) => (
+                      <span key={account.alpacaAccountLabel} className="rounded-none border border-border px-2 py-0.5">
+                        {account.alpacaAccountLabel}:{' '}
+                        <span
+                          className={
+                            account.delta > 0 ? 'text-emerald-600' : account.delta < 0 ? 'text-rose-600' : undefined
+                          }
+                        >
+                          {currency.format(account.delta)}
+                        </span>
+                      </span>
+                    ))}
+                    {equityAccounts.length > 3 ? (
+                      <span className="rounded-none border border-border px-2 py-0.5">
+                        +{equityAccounts.length - 3} more
+                      </span>
+                    ) : null}
+                  </div>
+                  <EquityChart accounts={equityAccounts} />
+                </>
+              ) : (
+                <div className="text-xs text-muted-foreground">No position snapshots found for this interval.</div>
+              )
+            ) : (
+              <Skeleton className="h-24 w-full" />
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader className="border-b">
+            <CardTitle>Counts</CardTitle>
+            <CardDescription>Fills vs rejections for the selected day</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 pt-4 md:grid-cols-2">
+            <div className="rounded-none border bg-card p-3">
+              <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                Filled executions
+              </div>
+              <div className="mt-2 text-2xl font-medium tabular-nums">
+                {summary ? summary.executions.filledCount : isLoading ? '…' : '—'}
+              </div>
+            </div>
+            <div className="rounded-none border bg-card p-3">
+              <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                Rejected decisions
+              </div>
+              <div className="mt-2 text-2xl font-medium tabular-nums">
+                {summary ? summary.rejections.rejectedCount : isLoading ? '…' : '—'}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="border-b">
+            <CardTitle>Top Rejection Reasons</CardTitle>
+            <CardDescription>From trade_decisions.decision_json.risk_reasons</CardDescription>
+          </CardHeader>
+          <CardContent className="pt-2">
+            {summary ? (
+              summary.rejections.topReasons.length > 0 ? (
+                <ChartContainer config={reasonHistogramConfig} className="h-56 w-full">
+                  <BarChart data={summary.rejections.topReasons} layout="vertical" margin={{ left: 0, right: 12 }}>
+                    <CartesianGrid horizontal={false} />
+                    <XAxis type="number" dataKey="count" hide />
+                    <YAxis
+                      dataKey="reason"
+                      type="category"
+                      width={150}
+                      tickLine={false}
+                      axisLine={false}
+                      tickMargin={8}
+                      tickFormatter={(value: string) => truncateLabel(value)}
+                    />
+                    <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+                    <Bar dataKey="count" fill="var(--color-count)" radius={4} />
+                  </BarChart>
+                </ChartContainer>
+              ) : (
+                <div className="p-4 text-xs text-muted-foreground">No rejection reasons recorded.</div>
+              )
+            ) : (
+              <Skeleton className="h-56 w-full" />
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle>Query Interval</CardTitle>
+          <CardDescription>
+            Backend uses <span className="font-medium text-foreground">{DEFAULT_TZ}</span> day buckets and queries
+            Torghut Postgres with computed UTC bounds.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-4 text-xs text-muted-foreground">
+          {summary ? (
+            <div className="space-y-1">
+              <div>
+                Day (ET) <span className="tabular-nums text-foreground">{summary.interval.day}</span>
+              </div>
+              <div>
+                Start UTC <span className="tabular-nums text-foreground">{summary.interval.startUtc}</span>
+              </div>
+              <div>
+                End UTC <span className="tabular-nums text-foreground">{summary.interval.endUtc}</span>
+              </div>
+            </div>
+          ) : (
+            <span>{isLoading ? 'Loading…' : '—'}</span>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle>Filled Executions</CardTitle>
+          <CardDescription>Joined executions to trade_decisions and strategies.</CardDescription>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <ExecutionsTable items={executions} isLoading={isLoading} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle>Rejected Decisions</CardTitle>
+          <CardDescription>Decision-level diagnostics with risk reasons.</CardDescription>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <RejectedDecisionsTable items={decisions} isLoading={isLoading} />
+        </CardContent>
+      </Card>
+    </main>
+  )
+}
+
+const pnlChartConfig = {
+  realizedPnl: {
+    label: 'Realized PnL',
+    color: 'var(--chart-1)',
+  },
+} satisfies ChartConfig
+
+function RealizedPnlChart({ series }: { series: { ts: string; realizedPnl: number }[] }) {
+  return (
+    <ChartContainer config={pnlChartConfig} className="h-56 w-full">
+      <LineChart data={series} margin={{ left: 12, right: 12 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="ts"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={24}
+          tickFormatter={(value: string) => formatShortTime(value)}
+        />
+        <YAxis tickLine={false} axisLine={false} width={72} tickFormatter={(value: number) => currency.format(value)} />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+        <Line dataKey="realizedPnl" type="monotone" stroke="var(--color-realizedPnl)" strokeWidth={2} dot={false} />
+      </LineChart>
+    </ChartContainer>
+  )
+}
+
+const formatShortTime = (value: string) => {
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) return value
+  return new Intl.DateTimeFormat('en-US', { hour: '2-digit', minute: '2-digit' }).format(new Date(parsed))
+}
+
+function EquityChart({
+  accounts,
+}: {
+  accounts: { alpacaAccountLabel: string; delta: number; series: { ts: string; equity: number }[] }[]
+}) {
+  const seriesKeys = React.useMemo(() => {
+    const colors = ['var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)', 'var(--chart-1)', 'var(--chart-2)']
+    return accounts.slice(0, colors.length).map((account, index) => ({
+      key: `acct_${index}`,
+      label: account.alpacaAccountLabel,
+      color: colors[index] ?? 'var(--chart-1)',
+      series: account.series,
+    }))
+  }, [accounts])
+
+  const data = React.useMemo(() => {
+    const rowsByTs = new Map<string, Record<string, unknown>>()
+    for (const { key, series } of seriesKeys) {
+      for (const point of series) {
+        const row = rowsByTs.get(point.ts) ?? { ts: point.ts }
+        row[key] = point.equity
+        rowsByTs.set(point.ts, row)
+      }
+    }
+    return [...rowsByTs.values()].sort((a, b) => Date.parse(String(a.ts)) - Date.parse(String(b.ts)))
+  }, [seriesKeys])
+
+  const config = React.useMemo(() => {
+    const next: Record<string, { label: string; color: string }> = {}
+    for (const item of seriesKeys) {
+      next[item.key] = { label: item.label, color: item.color }
+    }
+    return next satisfies ChartConfig
+  }, [seriesKeys])
+
+  return (
+    <ChartContainer config={config} className="h-56 w-full">
+      <LineChart data={data} margin={{ left: 12, right: 12 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="ts"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={24}
+          tickFormatter={(value: string) => formatShortTime(value)}
+        />
+        <YAxis tickLine={false} axisLine={false} width={72} tickFormatter={(value: number) => currency.format(value)} />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+        {seriesKeys.map((item) => (
+          <Line
+            key={item.key}
+            dataKey={item.key}
+            type="monotone"
+            stroke={`var(--color-${item.key})`}
+            strokeWidth={2}
+            dot={false}
+          />
+        ))}
+      </LineChart>
+    </ChartContainer>
+  )
+}
+
+function ExecutionsTable({ items, isLoading }: { items: FilledExecution[]; isLoading: boolean }) {
+  if (isLoading && items.length === 0) return <Skeleton className="h-40 w-full" />
+  if (items.length === 0) return <div className="text-xs text-muted-foreground">No filled executions found.</div>
+
+  return (
+    <div className="overflow-hidden rounded-none border bg-card">
+      <table className="w-full text-xs">
+        <thead className="border-b bg-muted/30 text-muted-foreground">
+          <tr className="text-left uppercase tracking-widest">
+            <th className="px-3 py-2 font-medium">Time</th>
+            <th className="px-3 py-2 font-medium">Symbol</th>
+            <th className="px-3 py-2 font-medium">Side</th>
+            <th className="px-3 py-2 font-medium text-right">Qty</th>
+            <th className="px-3 py-2 font-medium text-right">Avg fill</th>
+            <th className="px-3 py-2 font-medium">Strategy</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.slice(0, 500).map((item) => (
+            <tr key={item.executionId} className="border-b last:border-b-0">
+              <td className="px-3 py-2 tabular-nums text-muted-foreground">{formatTimestamp(item.createdAt)}</td>
+              <td className="px-3 py-2 font-medium text-foreground">{item.symbol}</td>
+              <td className="px-3 py-2">
+                <span
+                  className={
+                    item.side.toLowerCase() === 'buy'
+                      ? 'text-emerald-600'
+                      : item.side.toLowerCase() === 'sell'
+                        ? 'text-rose-600'
+                        : 'text-muted-foreground'
+                  }
+                >
+                  {item.side}
+                </span>
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                {compactNumber.format(item.filledQty)}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                {item.avgFillPrice === null ? '—' : currency.format(item.avgFillPrice)}
+              </td>
+              <td className="px-3 py-2 text-muted-foreground">{item.strategyName ?? item.strategyId}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function RejectedDecisionsTable({ items, isLoading }: { items: RejectedDecision[]; isLoading: boolean }) {
+  if (isLoading && items.length === 0) return <Skeleton className="h-40 w-full" />
+  if (items.length === 0) return <div className="text-xs text-muted-foreground">No rejected decisions found.</div>
+
+  return (
+    <div className="overflow-hidden rounded-none border bg-card">
+      <table className="w-full text-xs">
+        <thead className="border-b bg-muted/30 text-muted-foreground">
+          <tr className="text-left uppercase tracking-widest">
+            <th className="px-3 py-2 font-medium">Time</th>
+            <th className="px-3 py-2 font-medium">Symbol</th>
+            <th className="px-3 py-2 font-medium">Timeframe</th>
+            <th className="px-3 py-2 font-medium">Reasons</th>
+            <th className="px-3 py-2 font-medium">Strategy</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.slice(0, 500).map((item) => (
+            <tr key={item.id} className="border-b last:border-b-0">
+              <td className="px-3 py-2 tabular-nums text-muted-foreground">{formatTimestamp(item.createdAt)}</td>
+              <td className="px-3 py-2 font-medium text-foreground">{item.symbol}</td>
+              <td className="px-3 py-2 text-muted-foreground">{item.timeframe}</td>
+              <td className="px-3 py-2">
+                <div className="flex flex-wrap gap-1">
+                  {item.riskReasons.length > 0 ? (
+                    item.riskReasons.slice(0, 6).map((reason) => (
+                      <span key={reason} className="rounded-none border border-border px-2 py-0.5 text-[11px]">
+                        {reason}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                  {item.riskReasons.length > 6 ? (
+                    <span className="rounded-none border border-border px-2 py-0.5 text-[11px] text-muted-foreground">
+                      +{item.riskReasons.length - 6}
+                    </span>
+                  ) : null}
+                </div>
+              </td>
+              <td className="px-3 py-2 text-muted-foreground">{item.strategyName}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+const truncateLabel = (value: string, max = 28) => {
+  if (value.length <= max) return value
+  return `${value.slice(0, Math.max(1, max - 1))}…`
+}

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -1403,9 +1403,8 @@ describe('agents controller reconcileAgentRun', () => {
       const agentRun = buildAgentRun()
       await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
 
-      const defaultTemplate = ((lastJob as any)?.spec as Record<string, unknown> | undefined)?.template as
-        | Record<string, unknown>
-        | undefined
+      const defaultTemplate = (((lastJob ?? {}) as { spec?: unknown }).spec as { template?: unknown } | undefined)
+        ?.template as Record<string, unknown> | undefined
       const defaultPodSpec = (defaultTemplate?.spec as Record<string, unknown> | undefined) ?? {}
       expect(defaultPodSpec.nodeSelector).toEqual({ disktype: 'ssd' })
       expect(defaultPodSpec.affinity).toEqual(defaultAffinity)
@@ -1459,9 +1458,8 @@ describe('agents controller reconcileAgentRun', () => {
         0,
       )
 
-      const overrideTemplate = ((lastJob as any)?.spec as Record<string, unknown> | undefined)?.template as
-        | Record<string, unknown>
-        | undefined
+      const overrideTemplate = (((lastJob ?? {}) as { spec?: unknown }).spec as { template?: unknown } | undefined)
+        ?.template as Record<string, unknown> | undefined
       const overridePodSpec = (overrideTemplate?.spec as Record<string, unknown> | undefined) ?? {}
       expect(overridePodSpec.nodeSelector).toEqual({ disktype: 'gpu' })
       expect(overridePodSpec.affinity).toEqual(overrideAffinity)
@@ -1538,9 +1536,8 @@ describe('agents controller reconcileAgentRun', () => {
       const agentRun = buildAgentRun()
       await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
 
-      const defaultTemplate = ((lastJob as any)?.spec as Record<string, unknown> | undefined)?.template as
-        | Record<string, unknown>
-        | undefined
+      const defaultTemplate = (((lastJob ?? {}) as { spec?: unknown }).spec as { template?: unknown } | undefined)
+        ?.template as Record<string, unknown> | undefined
       const defaultPodSpec = (defaultTemplate?.spec as Record<string, unknown> | undefined) ?? {}
       expect(defaultPodSpec.topologySpreadConstraints).toBeUndefined()
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS'))
@@ -1687,9 +1684,8 @@ describe('agents controller reconcileAgentRun', () => {
     expect(status.phase).toBe('Running')
     expect(status.systemPromptHash).toBe(createHash('sha256').update('workflow-prompt').digest('hex'))
 
-    const podTemplate = ((lastJob as any)?.spec as Record<string, unknown> | undefined)?.template as
-      | Record<string, unknown>
-      | undefined
+    const podTemplate = (((lastJob ?? {}) as { spec?: unknown }).spec as { template?: unknown } | undefined)
+      ?.template as Record<string, unknown> | undefined
     const podSpecSpec = (podTemplate?.spec as Record<string, unknown> | undefined) ?? {}
     const containers = (podSpecSpec.containers as Record<string, unknown>[] | undefined) ?? []
     const container = containers[0] ?? {}

--- a/services/jangar/src/server/__tests__/torghut-trading-pnl.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-trading-pnl.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeRealizedPnlAverageCostLongOnly } from '~/server/torghut-trading-pnl'
+
+describe('torghut trading pnl', () => {
+  it('computes realized pnl with average-cost model (single buy then sell)', () => {
+    const result = computeRealizedPnlAverageCostLongOnly([
+      {
+        executionId: 'e1',
+        tradeDecisionId: 'd1',
+        strategyId: 's1',
+        strategyName: 'S',
+        createdAt: '2026-02-10T14:30:00.000Z',
+        symbol: 'AAPL',
+        side: 'buy',
+        filledQty: 10,
+        avgFillPrice: 100,
+      },
+      {
+        executionId: 'e2',
+        tradeDecisionId: 'd2',
+        strategyId: 's1',
+        strategyName: 'S',
+        createdAt: '2026-02-10T15:30:00.000Z',
+        symbol: 'AAPL',
+        side: 'sell',
+        filledQty: 4,
+        avgFillPrice: 110,
+      },
+    ])
+
+    expect(result.realizedPnl).toBeCloseTo(40, 8)
+    expect(result.closedQty).toBeCloseTo(4, 8)
+    expect(result.winCount).toBe(1)
+    expect(result.lossCount).toBe(0)
+    expect(result.winRate).toBeCloseTo(1, 8)
+    expect(result.bySymbol.AAPL?.realizedPnl).toBeCloseTo(40, 8)
+    expect(result.bySymbol.AAPL?.closedQty).toBeCloseTo(4, 8)
+  })
+
+  it('uses average cost across multiple buys', () => {
+    const result = computeRealizedPnlAverageCostLongOnly([
+      {
+        executionId: 'e1',
+        tradeDecisionId: 'd1',
+        strategyId: 's1',
+        strategyName: 'S',
+        createdAt: '2026-02-10T14:00:00.000Z',
+        symbol: 'MSFT',
+        side: 'buy',
+        filledQty: 10,
+        avgFillPrice: 100,
+      },
+      {
+        executionId: 'e2',
+        tradeDecisionId: 'd2',
+        strategyId: 's1',
+        strategyName: 'S',
+        createdAt: '2026-02-10T14:01:00.000Z',
+        symbol: 'MSFT',
+        side: 'buy',
+        filledQty: 10,
+        avgFillPrice: 120,
+      },
+      {
+        executionId: 'e3',
+        tradeDecisionId: 'd3',
+        strategyId: 's1',
+        strategyName: 'S',
+        createdAt: '2026-02-10T15:00:00.000Z',
+        symbol: 'MSFT',
+        side: 'sell',
+        filledQty: 5,
+        avgFillPrice: 130,
+      },
+    ])
+
+    // avg cost = (10*100 + 10*120)/20 = 110
+    // realized pnl = (130-110)*5 = 100
+    expect(result.realizedPnl).toBeCloseTo(100, 8)
+    expect(result.closedQty).toBeCloseTo(5, 8)
+    expect(result.winRate).toBeCloseTo(1, 8)
+  })
+
+  it('clamps sells beyond current position and records a warning', () => {
+    const result = computeRealizedPnlAverageCostLongOnly([
+      {
+        executionId: 'e1',
+        tradeDecisionId: 'd1',
+        strategyId: 's1',
+        strategyName: 'S',
+        createdAt: '2026-02-10T14:00:00.000Z',
+        symbol: 'NVDA',
+        side: 'buy',
+        filledQty: 3,
+        avgFillPrice: 200,
+      },
+      {
+        executionId: 'e2',
+        tradeDecisionId: 'd2',
+        strategyId: 's1',
+        strategyName: 'S',
+        createdAt: '2026-02-10T14:30:00.000Z',
+        symbol: 'NVDA',
+        side: 'sell',
+        filledQty: 5,
+        avgFillPrice: 210,
+      },
+    ])
+
+    // realized qty clamps to 3
+    expect(result.realizedPnl).toBeCloseTo(30, 8)
+    expect(result.closedQty).toBeCloseTo(3, 8)
+    expect(result.warnings.some((warning) => warning.includes('exceeds position'))).toBe(true)
+  })
+})

--- a/services/jangar/src/server/__tests__/torghut-trading-time.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-trading-time.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveTradingDayInterval } from '~/server/torghut-trading-time'
+
+describe('torghut trading time', () => {
+  it('rejects invalid calendar dates', () => {
+    const url = new URL('https://example.test/api?tz=America%2FNew_York&day=2026-02-31')
+    const result = resolveTradingDayInterval(url)
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('accepts leap day on leap years', () => {
+    const url = new URL('https://example.test/api?tz=America%2FNew_York&day=2024-02-29')
+    const result = resolveTradingDayInterval(url)
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects leap day on non-leap years', () => {
+    const url = new URL('https://example.test/api?tz=America%2FNew_York&day=2025-02-29')
+    const result = resolveTradingDayInterval(url)
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('computes UTC bounds for an ET trading day', () => {
+    const url = new URL('https://example.test/api?tz=America%2FNew_York&day=2026-02-10')
+    const result = resolveTradingDayInterval(url)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.value.day).toBe('2026-02-10')
+    expect(result.value.startUtc).toBe('2026-02-10T05:00:00.000Z')
+    expect(result.value.endUtc).toBe('2026-02-11T05:00:00.000Z')
+  })
+})

--- a/services/jangar/src/server/leader-election.ts
+++ b/services/jangar/src/server/leader-election.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 
-import { V1MicroTime, type V1Lease } from '@kubernetes/client-node'
+import { type V1Lease, V1MicroTime } from '@kubernetes/client-node'
 import { type Counter, metrics as otelMetrics } from '@proompteng/otel/api'
 
 export type LeaderElectionConfig = {

--- a/services/jangar/src/server/torghut-trading-db.ts
+++ b/services/jangar/src/server/torghut-trading-db.ts
@@ -1,0 +1,36 @@
+import { Pool } from 'pg'
+
+type EnabledTorghutDb = { ok: true; pool: Pool }
+type DisabledTorghutDb = { ok: false; disabled: true; message: string }
+
+export type TorghutDbResult = EnabledTorghutDb | DisabledTorghutDb
+
+let cachedPool: Pool | null = null
+
+export const resolveTorghutDb = (): TorghutDbResult => {
+  const dsn = process.env.TORGHUT_DB_DSN?.trim()
+  if (!dsn) {
+    return {
+      ok: false,
+      disabled: true,
+      message: 'Torghut trading history is disabled because TORGHUT_DB_DSN is not configured.',
+    }
+  }
+
+  if (cachedPool) return { ok: true, pool: cachedPool }
+
+  // Do not log the DSN; it may contain secrets.
+  cachedPool = new Pool({
+    connectionString: dsn,
+    max: 2,
+    connectionTimeoutMillis: 3_000,
+    idleTimeoutMillis: 30_000,
+  })
+
+  cachedPool.on('error', () => {
+    // Avoid leaking connection strings in logs; reset so subsequent calls can retry.
+    cachedPool = null
+  })
+
+  return { ok: true, pool: cachedPool }
+}

--- a/services/jangar/src/server/torghut-trading-pnl.ts
+++ b/services/jangar/src/server/torghut-trading-pnl.ts
@@ -1,0 +1,134 @@
+export type FilledExecutionForPnl = {
+  executionId: string
+  tradeDecisionId: string | null
+  strategyId: string
+  strategyName: string | null
+  createdAt: string
+  symbol: string
+  side: string
+  filledQty: number
+  avgFillPrice: number | null
+}
+
+export type RealizedPnlPoint = {
+  ts: string
+  realizedPnl: number
+}
+
+export type RealizedPnlSummary = {
+  realizedPnl: number
+  closedQty: number
+  winCount: number
+  lossCount: number
+  winRate: number | null
+  bySymbol: Record<string, { realizedPnl: number; closedQty: number }>
+  series: RealizedPnlPoint[]
+  warnings: string[]
+}
+
+type PositionState = {
+  qty: number
+  avgCost: number
+}
+
+const normalizeSide = (value: string) => {
+  const side = value.trim().toLowerCase()
+  if (side === 'buy') return 'buy'
+  if (side === 'sell') return 'sell'
+  return null
+}
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+export const computeRealizedPnlAverageCostLongOnly = (executions: FilledExecutionForPnl[]): RealizedPnlSummary => {
+  const sorted = [...executions].sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt))
+  const positions = new Map<string, PositionState>()
+
+  let realizedPnl = 0
+  let closedQty = 0
+  let winCount = 0
+  let lossCount = 0
+  const bySymbol: Record<string, { realizedPnl: number; closedQty: number }> = {}
+  const series: RealizedPnlPoint[] = []
+  const warnings: string[] = []
+
+  for (const execution of sorted) {
+    const side = normalizeSide(execution.side)
+    if (!side) {
+      warnings.push(`Unknown side for execution ${execution.executionId}`)
+      continue
+    }
+
+    const qty = toFiniteNumber(execution.filledQty)
+    if (!qty || qty <= 0) continue
+
+    const price = execution.avgFillPrice === null ? null : toFiniteNumber(execution.avgFillPrice)
+    if (price === null || price <= 0) {
+      warnings.push(`Missing avgFillPrice for execution ${execution.executionId}`)
+      continue
+    }
+
+    const symbol = execution.symbol.trim().toUpperCase()
+    if (!symbol) continue
+
+    const key = `${execution.strategyId}:${symbol}`
+    const current = positions.get(key) ?? { qty: 0, avgCost: 0 }
+
+    if (side === 'buy') {
+      const nextQty = current.qty + qty
+      const nextCostBasis = current.avgCost * current.qty + price * qty
+      const nextAvgCost = nextQty > 0 ? nextCostBasis / nextQty : 0
+      positions.set(key, { qty: nextQty, avgCost: nextAvgCost })
+      series.push({ ts: execution.createdAt, realizedPnl })
+      continue
+    }
+
+    if (current.qty <= 0) {
+      warnings.push(`Sell without long position for ${symbol} (execution ${execution.executionId})`)
+      series.push({ ts: execution.createdAt, realizedPnl })
+      continue
+    }
+
+    const realizedQty = Math.min(qty, current.qty)
+    if (realizedQty < qty) {
+      warnings.push(`Sell qty exceeds position for ${symbol} (execution ${execution.executionId})`)
+    }
+
+    const pnlForFill = (price - current.avgCost) * realizedQty
+    realizedPnl += pnlForFill
+    closedQty += realizedQty
+
+    if (pnlForFill > 0) winCount += 1
+    else if (pnlForFill < 0) lossCount += 1
+
+    const existing = bySymbol[symbol] ?? { realizedPnl: 0, closedQty: 0 }
+    existing.realizedPnl += pnlForFill
+    existing.closedQty += realizedQty
+    bySymbol[symbol] = existing
+
+    const nextQty = current.qty - realizedQty
+    positions.set(key, { qty: nextQty, avgCost: nextQty > 0 ? current.avgCost : 0 })
+    series.push({ ts: execution.createdAt, realizedPnl })
+  }
+
+  const totalClosedTrades = winCount + lossCount
+  const winRate = totalClosedTrades > 0 ? winCount / totalClosedTrades : null
+
+  return {
+    realizedPnl,
+    closedQty,
+    winCount,
+    lossCount,
+    winRate,
+    bySymbol,
+    series,
+    warnings,
+  }
+}

--- a/services/jangar/src/server/torghut-trading-time.ts
+++ b/services/jangar/src/server/torghut-trading-time.ts
@@ -1,0 +1,135 @@
+const DEFAULT_TIMEZONE = 'America/New_York'
+
+export type TradingDayInterval = {
+  tz: string
+  day: string
+  startUtc: string
+  endUtc: string
+}
+
+const isIsoDay = (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value)
+
+const parseIntStrict = (value: string) => {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const formatPartsInTimeZone = (timeZone: string, date: Date) => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date)
+
+  const record: Record<string, string> = {}
+  for (const part of parts) {
+    if (part.type !== 'literal') record[part.type] = part.value
+  }
+
+  const year = record.year ? parseIntStrict(record.year) : null
+  const month = record.month ? parseIntStrict(record.month) : null
+  const day = record.day ? parseIntStrict(record.day) : null
+  const hour = record.hour ? parseIntStrict(record.hour) : null
+  const minute = record.minute ? parseIntStrict(record.minute) : null
+  const second = record.second ? parseIntStrict(record.second) : null
+
+  if (year === null || month === null || day === null || hour === null || minute === null || second === null) {
+    return null
+  }
+
+  return { year, month, day, hour, minute, second }
+}
+
+const clampIsoDayParts = (day: string) => {
+  if (!isIsoDay(day)) return null
+  const [y, m, d] = day.split('-')
+  const year = y ? parseIntStrict(y) : null
+  const month = m ? parseIntStrict(m) : null
+  const dayOfMonth = d ? parseIntStrict(d) : null
+  if (year === null || month === null || dayOfMonth === null) return null
+  if (month < 1 || month > 12) return null
+  if (dayOfMonth < 1 || dayOfMonth > 31) return null
+  return { year, month, day: dayOfMonth }
+}
+
+const addUtcDays = (day: { year: number; month: number; day: number }, deltaDays: number) => {
+  const base = Date.UTC(day.year, day.month - 1, day.day, 0, 0, 0)
+  const next = new Date(base + deltaDays * 24 * 60 * 60 * 1000)
+  return { year: next.getUTCFullYear(), month: next.getUTCMonth() + 1, day: next.getUTCDate() }
+}
+
+// Converts a wall-clock time in `timeZone` into a UTC instant, without relying on additional timezone libraries.
+// This iteration-based approach handles DST transitions correctly for the simple "local midnight" case we need.
+const zonedDateTimeToUtcIso = (params: {
+  timeZone: string
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+}) => {
+  const targetUtcFromParts = Date.UTC(
+    params.year,
+    params.month - 1,
+    params.day,
+    params.hour,
+    params.minute,
+    params.second,
+  )
+  let guess = new Date(targetUtcFromParts)
+
+  for (let i = 0; i < 6; i += 1) {
+    const observed = formatPartsInTimeZone(params.timeZone, guess)
+    if (!observed) break
+    const observedUtcFromParts = Date.UTC(
+      observed.year,
+      observed.month - 1,
+      observed.day,
+      observed.hour,
+      observed.minute,
+      observed.second,
+    )
+    const diffMs = targetUtcFromParts - observedUtcFromParts
+    if (diffMs === 0) return guess.toISOString()
+    guess = new Date(guess.getTime() + diffMs)
+  }
+
+  // Fallback: best-effort guess, still deterministic.
+  return guess.toISOString()
+}
+
+export const resolveTradingDayInterval = (
+  url: URL,
+): { ok: true; value: TradingDayInterval } | { ok: false; message: string } => {
+  const tzRaw = url.searchParams.get('tz')?.trim()
+  const tz = tzRaw && tzRaw.length > 0 ? tzRaw : DEFAULT_TIMEZONE
+  if (tz !== DEFAULT_TIMEZONE) {
+    return { ok: false, message: `tz must be ${DEFAULT_TIMEZONE}` }
+  }
+
+  const dayRaw = url.searchParams.get('day')?.trim()
+  if (!dayRaw) return { ok: false, message: 'day is required (YYYY-MM-DD)' }
+  const dayParts = clampIsoDayParts(dayRaw)
+  if (!dayParts) return { ok: false, message: 'day must be YYYY-MM-DD' }
+
+  const nextDay = addUtcDays(dayParts, 1)
+
+  const startUtc = zonedDateTimeToUtcIso({ timeZone: tz, ...dayParts, hour: 0, minute: 0, second: 0 })
+  const endUtc = zonedDateTimeToUtcIso({ timeZone: tz, ...nextDay, hour: 0, minute: 0, second: 0 })
+
+  return {
+    ok: true,
+    value: {
+      tz,
+      day: dayRaw,
+      startUtc,
+      endUtc,
+    },
+  }
+}

--- a/services/jangar/src/server/torghut-trading-time.ts
+++ b/services/jangar/src/server/torghut-trading-time.ts
@@ -54,6 +54,18 @@ const clampIsoDayParts = (day: string) => {
   if (year === null || month === null || dayOfMonth === null) return null
   if (month < 1 || month > 12) return null
   if (dayOfMonth < 1 || dayOfMonth > 31) return null
+
+  // Ensure the date is a real calendar day (e.g. reject 2026-02-31). Date.UTC normalizes overflow,
+  // so we round-trip through a UTC date and verify the components match the requested parts.
+  const normalized = new Date(Date.UTC(year, month - 1, dayOfMonth))
+  if (
+    normalized.getUTCFullYear() !== year ||
+    normalized.getUTCMonth() !== month - 1 ||
+    normalized.getUTCDate() !== dayOfMonth
+  ) {
+    return null
+  }
+
   return { year, month, day: dayOfMonth }
 }
 

--- a/services/jangar/src/server/torghut-trading.ts
+++ b/services/jangar/src/server/torghut-trading.ts
@@ -1,0 +1,369 @@
+import type { Pool } from 'pg'
+
+import { computeRealizedPnlAverageCostLongOnly, type FilledExecutionForPnl } from '~/server/torghut-trading-pnl'
+
+export type TorghutStrategyRow = {
+  id: string
+  name: string
+  enabled: boolean
+  baseTimeframe: string
+  universeSymbols: unknown
+}
+
+export type TorghutFilledExecutionRow = FilledExecutionForPnl & {
+  timeframe: string | null
+  alpacaAccountLabel: string | null
+}
+
+export type TorghutRejectedDecisionRow = {
+  id: string
+  createdAt: string
+  alpacaAccountLabel: string
+  symbol: string
+  timeframe: string
+  status: string
+  rationale: string | null
+  riskReasons: string[]
+  strategyId: string
+  strategyName: string
+}
+
+export type TorghutPositionSnapshotPoint = {
+  asOf: string
+  alpacaAccountLabel: string
+  equity: number
+  cash: number
+  buyingPower: number
+}
+
+const parseUuid = (value: string | null) => {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  // Accept canonical UUIDs only; avoids Postgres casts failing on arbitrary strings.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed)) return null
+  return trimmed
+}
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+const coerceStringArray = (value: unknown): string[] => {
+  if (!value) return []
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string')
+  if (typeof value === 'string') return [value]
+  return []
+}
+
+export const listTorghutTradingStrategies = async (params: { pool: Pool; limit?: number }) => {
+  const limit = Math.max(1, Math.min(params.limit ?? 200, 1000))
+  const result = await params.pool.query(
+    `
+      select
+        id::text as id,
+        name,
+        enabled,
+        base_timeframe,
+        universe_symbols
+      from strategies
+      order by name asc
+      limit $1
+    `,
+    [limit],
+  )
+
+  return result.rows.map((row) => ({
+    id: String(row.id),
+    name: String(row.name),
+    enabled: Boolean(row.enabled),
+    baseTimeframe: String(row.base_timeframe),
+    universeSymbols: row.universe_symbols ?? null,
+  })) satisfies TorghutStrategyRow[]
+}
+
+export const listTorghutTradingFilledExecutions = async (params: {
+  pool: Pool
+  startUtc: string
+  endUtc: string
+  strategyId?: string | null
+  limit?: number
+}) => {
+  const limit = Math.max(1, Math.min(params.limit ?? 500, 5000))
+  const strategyId = params.strategyId ?? null
+
+  const result = await params.pool.query(
+    `
+      select
+        e.id::text as execution_id,
+        e.created_at as execution_created_at,
+        e.symbol as symbol,
+        e.side as side,
+        e.filled_qty as filled_qty,
+        e.avg_fill_price as avg_fill_price,
+        td.id::text as trade_decision_id,
+        td.timeframe as timeframe,
+        td.alpaca_account_label as alpaca_account_label,
+        s.id::text as strategy_id,
+        s.name as strategy_name
+      from executions e
+      join trade_decisions td on td.id = e.trade_decision_id
+      join strategies s on s.id = td.strategy_id
+      where e.status = 'filled'
+        and e.created_at >= $1
+        and e.created_at < $2
+        and ($3::uuid is null or s.id = $3::uuid)
+      order by e.created_at asc
+      limit $4
+    `,
+    [params.startUtc, params.endUtc, strategyId, limit],
+  )
+
+  return result.rows
+    .map((row) => {
+      const filledQty = toNumber(row.filled_qty) ?? 0
+      const avgFillPrice = toNumber(row.avg_fill_price)
+      return {
+        executionId: String(row.execution_id),
+        tradeDecisionId: row.trade_decision_id ? String(row.trade_decision_id) : null,
+        strategyId: String(row.strategy_id),
+        strategyName: row.strategy_name ? String(row.strategy_name) : null,
+        createdAt: new Date(row.execution_created_at as string | Date).toISOString(),
+        symbol: String(row.symbol),
+        side: String(row.side),
+        filledQty,
+        avgFillPrice,
+        timeframe: row.timeframe ? String(row.timeframe) : null,
+        alpacaAccountLabel: row.alpaca_account_label ? String(row.alpaca_account_label) : null,
+      }
+    })
+    .filter((row) => row.filledQty > 0 && row.avgFillPrice !== null) satisfies TorghutFilledExecutionRow[]
+}
+
+export const listTorghutTradingRejectedDecisions = async (params: {
+  pool: Pool
+  startUtc: string
+  endUtc: string
+  strategyId?: string | null
+  limit?: number
+}) => {
+  const limit = Math.max(1, Math.min(params.limit ?? 500, 5000))
+  const strategyId = params.strategyId ?? null
+
+  const result = await params.pool.query(
+    `
+      select
+        td.id::text as id,
+        td.created_at as created_at,
+        td.alpaca_account_label as alpaca_account_label,
+        td.symbol as symbol,
+        td.timeframe as timeframe,
+        td.status as status,
+        td.rationale as rationale,
+        td.decision_json->'risk_reasons' as risk_reasons,
+        s.id::text as strategy_id,
+        s.name as strategy_name
+      from trade_decisions td
+      join strategies s on s.id = td.strategy_id
+      where td.status = 'rejected'
+        and td.created_at >= $1
+        and td.created_at < $2
+        and ($3::uuid is null or s.id = $3::uuid)
+      order by td.created_at desc
+      limit $4
+    `,
+    [params.startUtc, params.endUtc, strategyId, limit],
+  )
+
+  return result.rows.map((row) => ({
+    id: String(row.id),
+    createdAt: new Date(row.created_at as string | Date).toISOString(),
+    alpacaAccountLabel: String(row.alpaca_account_label),
+    symbol: String(row.symbol),
+    timeframe: String(row.timeframe),
+    status: String(row.status),
+    rationale: row.rationale ? String(row.rationale) : null,
+    riskReasons: coerceStringArray(row.risk_reasons),
+    strategyId: String(row.strategy_id),
+    strategyName: String(row.strategy_name),
+  })) satisfies TorghutRejectedDecisionRow[]
+}
+
+export const listTorghutTradingPositionSnapshots = async (params: {
+  pool: Pool
+  startUtc: string
+  endUtc: string
+  limit?: number
+}) => {
+  const limit = Math.max(1, Math.min(params.limit ?? 5000, 25_000))
+
+  const result = await params.pool.query(
+    `
+      select
+        as_of,
+        alpaca_account_label,
+        equity,
+        cash,
+        buying_power
+      from position_snapshots
+      where as_of >= $1
+        and as_of < $2
+      order by as_of asc
+      limit $3
+    `,
+    [params.startUtc, params.endUtc, limit],
+  )
+
+  return result.rows
+    .map((row) => {
+      const equity = toNumber(row.equity)
+      const cash = toNumber(row.cash)
+      const buyingPower = toNumber(row.buying_power)
+      if (equity === null || cash === null || buyingPower === null) return null
+      return {
+        asOf: new Date(row.as_of as string | Date).toISOString(),
+        alpacaAccountLabel: String(row.alpaca_account_label),
+        equity,
+        cash,
+        buyingPower,
+      }
+    })
+    .filter((row): row is TorghutPositionSnapshotPoint => row !== null)
+}
+
+export type TorghutTradingSummary = {
+  interval: { tz: string; day: string; startUtc: string; endUtc: string }
+  strategy: { id: string; name: string } | null
+  realizedPnl: {
+    value: number
+    closedQty: number
+    winRate: number | null
+    winCount: number
+    lossCount: number
+    series: { ts: string; realizedPnl: number }[]
+    warnings: string[]
+  }
+  executions: { filledCount: number }
+  rejections: {
+    rejectedCount: number
+    topReasons: { reason: string; count: number }[]
+  }
+  equity: {
+    available: boolean
+    byAccount: {
+      alpacaAccountLabel: string
+      delta: number
+      series: { ts: string; equity: number }[]
+    }[]
+  }
+}
+
+export const buildTorghutTradingSummary = async (params: {
+  pool: Pool
+  interval: { tz: string; day: string; startUtc: string; endUtc: string }
+  strategyId?: string | null
+}) => {
+  const strategyId = params.strategyId ?? null
+  const [executions, rejections, strategies, snapshots] = await Promise.all([
+    listTorghutTradingFilledExecutions({
+      pool: params.pool,
+      startUtc: params.interval.startUtc,
+      endUtc: params.interval.endUtc,
+      strategyId,
+      limit: 2000,
+    }),
+    listTorghutTradingRejectedDecisions({
+      pool: params.pool,
+      startUtc: params.interval.startUtc,
+      endUtc: params.interval.endUtc,
+      strategyId,
+      limit: 2000,
+    }),
+    listTorghutTradingStrategies({ pool: params.pool, limit: 500 }),
+    listTorghutTradingPositionSnapshots({
+      pool: params.pool,
+      startUtc: params.interval.startUtc,
+      endUtc: params.interval.endUtc,
+      limit: 25_000,
+    }),
+  ])
+
+  const selectedStrategyId = parseUuid(strategyId)
+  const selectedStrategyRow = selectedStrategyId
+    ? (strategies.find((strategy) => strategy.id.toLowerCase() === selectedStrategyId.toLowerCase()) ?? null)
+    : null
+  const selectedStrategy =
+    selectedStrategyId && selectedStrategyRow ? { id: selectedStrategyId, name: selectedStrategyRow.name } : null
+
+  const pnl = computeRealizedPnlAverageCostLongOnly(executions)
+
+  const reasonsCount = new Map<string, number>()
+  for (const decision of rejections) {
+    for (const reason of decision.riskReasons) {
+      const key = reason.trim()
+      if (!key) continue
+      reasonsCount.set(key, (reasonsCount.get(key) ?? 0) + 1)
+    }
+  }
+  const topReasons = [...reasonsCount.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 12)
+    .map(([reason, count]) => ({ reason, count }))
+
+  const snapshotsByAccount = new Map<string, TorghutPositionSnapshotPoint[]>()
+  for (const snap of snapshots) {
+    const key = snap.alpacaAccountLabel
+    const list = snapshotsByAccount.get(key) ?? []
+    list.push(snap)
+    snapshotsByAccount.set(key, list)
+  }
+
+  const equityByAccount = [...snapshotsByAccount.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([alpacaAccountLabel, points]) => {
+      const first = points[0]
+      const last = points[points.length - 1]
+      const delta = first && last ? last.equity - first.equity : 0
+      return {
+        alpacaAccountLabel,
+        delta,
+        series: points.map((point) => ({ ts: point.asOf, equity: point.equity })),
+      }
+    })
+
+  return {
+    interval: params.interval,
+    strategy: selectedStrategy,
+    realizedPnl: {
+      value: pnl.realizedPnl,
+      closedQty: pnl.closedQty,
+      winRate: pnl.winRate,
+      winCount: pnl.winCount,
+      lossCount: pnl.lossCount,
+      series: pnl.series,
+      warnings: pnl.warnings,
+    },
+    executions: { filledCount: executions.length },
+    rejections: {
+      rejectedCount: rejections.length,
+      topReasons,
+    },
+    equity: {
+      available: equityByAccount.length > 0,
+      byAccount: equityByAccount,
+    },
+  } satisfies TorghutTradingSummary
+}
+
+export const parseTorghutTradingStrategyId = (url: URL) => {
+  const strategyId = url.searchParams.get('strategyId')
+  if (!strategyId) return { ok: true as const, value: null }
+  const parsed = parseUuid(strategyId)
+  if (!parsed) return { ok: false as const, message: 'strategyId must be a UUID' }
+  return { ok: true as const, value: parsed }
+}


### PR DESCRIPTION
## Summary

- Add new Torghut trading history UI route at `/torghut/trading` with ET day + strategy filters, realized PnL summary, equity delta curve (if available), and fill/rejection diagnostics.
- Add read-only Torghut Postgres-backed API endpoints under `/api/torghut/trading/*` plus server query helpers and average-cost long-only realized PnL computation.
- Make the feature safe to deploy without Torghut credentials: when `TORGHUT_DB_DSN` is missing, APIs return a clear disabled response and the UI renders a disabled state.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/jangar lint`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/torghut-trading-pnl.test.ts`
- `bun run --filter @proompteng/jangar build`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
