### PR TITLE
fix(build): unblock docker builds on frozen lockfile

### DIFF
--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -14,7 +14,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-COPY --parents services/jangar/agentctl/package.json ./
+# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+COPY --parents services/jangar/*/package.json ./
 RUN bun install --frozen-lockfile --ignore-scripts
 
 FROM deps AS builder

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -14,7 +14,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-COPY --parents services/jangar/agentctl/package.json ./
+# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+COPY --parents services/jangar/*/package.json ./
 RUN bun install --frozen-lockfile --ignore-scripts
 
 FROM deps AS builder

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -17,7 +17,7 @@ COPY packages ./packages
 COPY services ./services
 
 ENV HUSKY=0
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
 
 FROM deps AS builder
 WORKDIR /app

--- a/apps/kitty-krew/Dockerfile
+++ b/apps/kitty-krew/Dockerfile
@@ -13,6 +13,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
+# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+COPY --parents services/jangar/*/package.json ./
 
 # Copy the kitty-krew workspace source
 COPY apps/kitty-krew ./apps/kitty-krew

--- a/apps/landing/Dockerfile
+++ b/apps/landing/Dockerfile
@@ -14,6 +14,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
+# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+COPY --parents services/jangar/*/package.json ./
 RUN bun install --frozen-lockfile --ignore-scripts
 
 FROM deps AS builder

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "prebuild": "bun run --filter @proompteng/backend codegen",
+    "prebuild": "bash -lc 'if [ -n \"${CONVEX_DEPLOYMENT:-}\" ]; then bun run --filter @proompteng/backend codegen; elif [ -d ../../packages/backend/convex/_generated ]; then echo \"Skipping Convex codegen (CONVEX_DEPLOYMENT not set; using committed _generated).\"; else echo \"Missing packages/backend/convex/_generated and CONVEX_DEPLOYMENT is not set.\" >&2; exit 1; fi'",
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "bunx biome check",


### PR DESCRIPTION
## Summary

- Fix `apps/landing` and other Bun-based Dockerfiles to include nested `services/jangar/*` workspace manifests so `bun install --frozen-lockfile` is stable.
- Make `apps/docs` Docker deps install skip install scripts to avoid Alpine/node-gyp script failures during `bun install`.
- Make `apps/landing` prebuild Convex codegen conditional (use committed `packages/backend/convex/_generated` when `CONVEX_DEPLOYMENT` is not set).

## Related Issues

None

## Testing

- `docker build --no-cache --target deps -f apps/landing/Dockerfile .`
- `docker build -f apps/docs/Dockerfile .`
- `docker build -f apps/landing/Dockerfile .`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
