### PR TITLE
docs(torghut): align AI docs with deployed shadow config

### DIFF
--- a/docs/torghut/design-system/v1/ai-layer-circuit-breakers-and-fallbacks.md
+++ b/docs/torghut/design-system/v1/ai-layer-circuit-breakers-and-fallbacks.md
@@ -44,10 +44,13 @@ stateDiagram-v2
 | `LLM_FAIL_MODE` | on-error behavior | `veto` |
 
 ## Fallback policy (v1)
-- **Paper mode:** Prefer deterministic pass-through when AI errors, unless explicitly configured to veto.
-- **Live mode:** Fail-closed (veto) when AI is enabled but errors occur.
+- **Live mode (`TRADING_MODE=live`):** Always fail-closed (veto) when AI is enabled but errors occur or the circuit is open.
+- **Paper mode (`TRADING_MODE=paper`):** Fallback behavior is controlled by `LLM_FAIL_MODE`:
+  - `LLM_FAIL_MODE=veto` (current default in `services/torghut/app/config.py`) fails-closed.
+  - `LLM_FAIL_MODE=pass_through` allows deterministic pass-through on AI errors.
 
 Note: Live mode is itself gated by `TRADING_LIVE_ENABLED=true`; this document assumes that is rare and carefully reviewed.
+Current deployed paper configuration (2026-02-09) sets `LLM_FAIL_MODE=pass_through` (see `argocd/applications/torghut/knative-service.yaml`).
 
 ## Failure modes and recovery
 | Failure | Symptoms | Detection | Recovery |
@@ -57,11 +60,10 @@ Note: Live mode is itself gated by `TRADING_LIVE_ENABLED=true`; this document as
 
 ## Security considerations
 - Circuit breakers protect against provider-induced DoS and runaway retries.
-- Keep AI disabled by default; enable only with explicit review.
+- In new environments, keep AI disabled by default; in production, prefer shadow-first enablement with bounded policies.
 
 ## Decisions (ADRs)
 ### ADR-38-1: Circuit breaker is mandatory when AI enabled
 - **Decision:** AI calls must be guarded by circuit breaker + timeouts.
 - **Rationale:** Prevent cascading failures and preserve system stability.
 - **Consequences:** AI may be skipped during transient issues; audit must record skips.
-

--- a/docs/torghut/design-system/v1/ai-layer-overview.md
+++ b/docs/torghut/design-system/v1/ai-layer-overview.md
@@ -44,7 +44,9 @@ flowchart LR
 ```
 
 ## Safety invariants (v1)
-- `LLM_ENABLED` defaults to `false` (`services/torghut/app/config.py`).
+- Code default: `LLM_ENABLED=false` (`services/torghut/app/config.py`).
+- As deployed (see `argocd/applications/torghut/knative-service.yaml` as of 2026-02-09): `LLM_ENABLED=true` in **shadow mode**
+  (`LLM_SHADOW_MODE=true`) with `LLM_FAIL_MODE=pass_through` while `TRADING_MODE=paper`.
 - AI never calls broker APIs.
 - AI outputs must parse as strict schema and pass policy guard.
 - Deterministic risk engine remains the final gate.
@@ -55,11 +57,15 @@ From `services/torghut/app/config.py`:
 | Env var | Purpose | Safe default |
 | --- | --- | --- |
 | `LLM_ENABLED` | enable AI advisory | `false` |
-| `LLM_SHADOW_MODE` | observe only | `false` (set true for evaluation) |
-| `LLM_FAIL_MODE` | behavior on AI error | `veto` (fail-closed for live) |
+| `LLM_SHADOW_MODE` | observe only | `false` |
+| `LLM_FAIL_MODE` | behavior on AI error | `veto` |
 | `LLM_ADJUSTMENT_ALLOWED` | allow adjustments | `false` |
 | `LLM_MIN_CONFIDENCE` | confidence gate | `0.5` |
 | `LLM_TIMEOUT_SECONDS` | request timeout | `20` |
+
+Operational note:
+- In production paper mode, prefer `LLM_SHADOW_MODE=true` and `LLM_FAIL_MODE=pass_through` until the AI layer is validated.
+- In live mode, keep `LLM_FAIL_MODE=veto` (fail-closed).
 
 ## Failure modes and recovery
 | Failure | Symptoms | Detection | Recovery |
@@ -77,4 +83,3 @@ From `services/torghut/app/config.py`:
 - **Decision:** AI is optional, advisory-only, and always bounded by deterministic policy.
 - **Rationale:** Reduces risk from non-determinism and adversarial input.
 - **Consequences:** AI’s “value add” must be measurable without increasing system risk.
-

--- a/docs/torghut/design-system/v1/cost-model-and-budgets.md
+++ b/docs/torghut/design-system/v1/cost-model-and-budgets.md
@@ -47,7 +47,9 @@ flowchart TD
 
 ### AI
 Use explicit caps:
-- `LLM_ENABLED=false` by default.
+- Code default is `LLM_ENABLED=false` (see `services/torghut/app/config.py`).
+- In production (paper), AI may be enabled in shadow mode to measure value safely:
+  - `LLM_ENABLED=true`, `LLM_SHADOW_MODE=true`, `LLM_FAIL_MODE=pass_through` (see `argocd/applications/torghut/knative-service.yaml`).
 - `LLM_MAX_TOKENS` and request timeouts.
 - Circuit breaker to prevent runaway retries.
 
@@ -66,4 +68,3 @@ Use explicit caps:
 - **Decision:** Prefer spending modestly on disk headroom and observability to avoid TA outages and operational churn.
 - **Rationale:** Repeated incidents are more expensive than baseline capacity.
 - **Consequences:** Budgets must include headroom for growth and merges.
-


### PR DESCRIPTION
## Summary

- Align Torghut v1 AI docs with the currently deployed Knative env (shadow + pass-through in paper mode).
- Clarify AI fallback semantics (paper controlled by `LLM_FAIL_MODE`, live always fail-closed).
- Fix broken pipeline code fence in `docs/torghut/automated-trading.md`.

## Related Issues

None

## Testing

- Docs-only change; no runtime validation. Verified deployed values referenced exist in `argocd/applications/torghut/knative-service.yaml`.

## Breaking Changes

None


## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
