### PR TITLE
docs(torghut): add v2 autonomy research pack

### DIFF
--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -30,6 +30,10 @@ The v1 documents are written to stay consistent with:
 - `docs/torghut/design-system/v1/torghut-autonomous-trading-system.md`
 
 ## Design doc set
+
+- `v2/` - research and profitability blueprint for a more autonomous system (not production-facing; may drift).
+  - Entry point: `docs/torghut/design-system/v2/00-index.md`
+
 - `v1/` - first cohesive design-system pass aligned to production reality as of **2026-02-08**.
 
 ### v1 Index

--- a/docs/torghut/design-system/v2/00-index.md
+++ b/docs/torghut/design-system/v2/00-index.md
@@ -1,0 +1,54 @@
+# Torghut Design System v2 (Research): Profitable Autonomous Trading + Intelligence Layer
+
+## Status
+- Version: `v2` (research / proposal)
+- Last updated: **2026-02-10**
+- Relationship to v1: `docs/torghut/design-system/v1/` remains the production-facing source of truth.
+
+## Purpose
+Capture a research-backed blueprint for evolving Torghut from a safe paper-first automated trading loop into a more
+robust, higher-signal, more profitable autonomous trading system with a bounded intelligence layer.
+
+This is not investment advice and does not guarantee profitability. The goal is to reduce common failure modes
+(overfitting, hidden costs, regime breaks, unsafe autonomy) and increase the probability of positive expectancy.
+
+## How To Use This Pack
+- Read `01-profitability-discipline.md` first.
+- For strategy research, use `02-strategy-universe-2026.md` plus the strategy-specific docs (`11-15`).
+- For system extension, focus on `03-10`, `16-19`.
+
+## v2 Document List
+- `01-profitability-discipline.md`
+- `02-strategy-universe-2026.md`
+- `03-data-pipeline-and-features.md`
+- `04-backtesting-and-walkforward.md`
+- `05-overfitting-and-statistical-validity.md`
+- `06-transaction-cost-and-capacity.md`
+- `07-execution-and-market-impact.md`
+- `08-portfolio-and-sizing.md`
+- `09-risk-controls-and-kill-switches-v2.md`
+- `10-regime-detection.md`
+- `11-time-series-momentum.md`
+- `12-mean-reversion-and-stat-arb.md`
+- `13-cross-sectional-factors.md`
+- `14-volatility-strategies.md`
+- `15-market-making.md`
+- `16-ml-stack-transformers-and-lob.md`
+- `17-rl-trading-and-execution.md`
+- `18-llm-intelligence-layer-architecture.md`
+- `19-governance-compliance-and-ops.md`
+
+## Design Constraints (Non-Negotiable)
+- Paper-by-default. Live requires explicit gate(s) and change control.
+- Deterministic risk controls remain final authority.
+- LLM/agent layer is advisory unless a separate, audited actuation path is intentionally built.
+- Every decision must be reproducible (inputs, config, model/prompt versions, and outputs).
+
+## Recommended Reading (Shortlist)
+- Trend following and crisis performance (managed futures): AQR overview and research links.
+- Market access risk controls (US): SEC 15c3-5 (Market Access Rule) summary.
+- Algo trading organizational requirements (EU): MiFID II RTS 6 delegated regulation.
+- LLM app security: OWASP Top 10 for LLM Applications.
+- GenAI risk management: NIST AI RMF GenAI Profile.
+
+(Each doc includes deeper references.)

--- a/docs/torghut/design-system/v2/01-profitability-discipline.md
+++ b/docs/torghut/design-system/v2/01-profitability-discipline.md
@@ -1,0 +1,62 @@
+# Profitability Discipline (Reality Checklist)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Define the discipline required to build a trading system that can be both autonomous and profitable over time.
+
+This document focuses on what makes systems fail in practice: overfitting, hidden transaction costs, regime breaks,
+unsafe scaling, and silent production drift.
+
+## What "Profitable" Means Operationally
+A profitable autonomous system is one that:
+- Has positive expectancy after realistic costs.
+- Maintains acceptable drawdowns for its mandate.
+- Survives regime changes via risk controls and adaptive allocation.
+- Produces audit-grade evidence explaining where PnL came from.
+
+## Core Loop (Research -> Production)
+- Hypothesis: define the edge source (behavioral, structural, microstructure).
+- Dataset: define training, validation, and strict out-of-sample.
+- Backtest: include realistic fills, spreads, slippage, and latency assumptions.
+- Robustness: walk-forward, stress tests, parameter sensitivity.
+- Paper: shadow and/or paper trading with full logging.
+- Live: slow ramp with hard limits and kill switches.
+
+## Minimum "Go Live" Evidence
+- Stability under walk-forward:
+  - Similar performance distribution across folds.
+  - No single period dominates total PnL.
+- Cost realism:
+  - PnL remains positive under pessimistic transaction cost multipliers.
+- Capacity check:
+  - Estimated impact grows slower than expected edge.
+- Operational safety:
+  - Verified kill switch cancels open orders and blocks new submissions.
+
+## Torghut Extensions Required
+- Stronger transaction cost model (see `06-transaction-cost-and-capacity.md`).
+- Execution quality improvements (see `07-execution-and-market-impact.md`).
+- Regime-aware risk throttles (see `10-regime-detection.md`).
+- Always-on, reproducible decision store (inputs + outputs) for attribution.
+
+## Common Profit-Killers
+- Data leakage (lookahead, survivorship bias, using revised data).
+- Implicit fill assumptions (market orders at mid).
+- Neglecting borrow costs, fees, and shortability.
+- Ignoring trading halts and market hours.
+- Strategy overlap (correlated alphas) leading to hidden concentration.
+
+## Implementation Notes (Torghut)
+- Encode "profitability gates" as deterministic controls:
+  - Max daily loss, max drawdown, max order rate.
+  - Staleness gates for signals and prices.
+  - Degrade modes (paper only, no new positions, flatten).
+- Store enough data to perform daily attribution:
+  - decision -> execution -> fill -> position snapshot -> PnL decomposition.
+
+## References
+- Managed futures / trend following overview: AQR Managed Futures page: https://www.aqr.com/Insights/Strategies/Alternative-Thinking/Managed-Futures
+- US Market Access Rule (risk management controls): SEC 15c3-5 summary: https://www.sec.gov/rules-regulations/2011/06/risk-management-controls-brokers-or-dealers-market-access

--- a/docs/torghut/design-system/v2/02-strategy-universe-2026.md
+++ b/docs/torghut/design-system/v2/02-strategy-universe-2026.md
@@ -1,0 +1,49 @@
+# Strategy Universe (2026): Quant Strategy Map For Torghut
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Provide a strategy taxonomy and selection framework to avoid random experimentation.
+
+Torghut should support multiple strategies, but each should be explicitly labeled by:
+- holding period,
+- data requirements,
+- capacity constraints,
+- typical regime behavior,
+- failure modes.
+
+## Strategy Taxonomy
+- Trend / time-series momentum (medium horizon, crisis convexity potential).
+- Mean reversion (intraday to multi-day; sensitive to regime shifts).
+- Cross-sectional momentum / factor tilts (portfolio-level).
+- Volatility targeting and defensive overlays.
+- Market making / liquidity provision (microstructure intensive; higher operational risk).
+- Event-driven (usually needs alternative data; higher complexity).
+
+## Selection Criteria
+- Edge plausibility: why should it persist?
+- Cost sensitivity: does it survive spread and impact?
+- Capacity: can it scale to desired notional?
+- Robustness: does it work across symbols and regimes?
+- Explainability: can we attribute PnL?
+
+## How This Maps To Torghut
+Torghut is currently a "signals from ClickHouse" system with a periodic loop, so it naturally supports:
+- low-to-medium frequency intraday strategies,
+- multi-asset portfolio strategies (if signals exist),
+- disciplined execution using limit orders.
+
+High-frequency market making is possible but would require:
+- order book data ingestion,
+- sub-second decisioning,
+- more sophisticated execution safety and latency control.
+
+## Initial Recommended Portfolio (Paper)
+- One trend strategy and one mean-reversion strategy with strict risk caps.
+- A volatility targeting overlay to keep risk stable.
+- A regime filter controlling when each strategy is active.
+
+## References
+- Trend following and drawdowns framing: Man Group article (2024): https://www.man.com/maninstitute/why-do-trend-following-strategies-suffer-drawdowns

--- a/docs/torghut/design-system/v2/03-data-pipeline-and-features.md
+++ b/docs/torghut/design-system/v2/03-data-pipeline-and-features.md
@@ -1,0 +1,37 @@
+# Data Pipeline and Features (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Specify data requirements for profitable strategies and an intelligence layer.
+
+## Data Layers
+- Level 0: trades/quotes/bars (already in Torghut).
+- Level 1: derived microbars and indicators (already in ClickHouse).
+- Level 2: enriched features (needs v2 work):
+  - realized volatility, intraday seasonality,
+  - spread/imbalance proxies,
+  - market regime features,
+  - cross-asset factor features.
+
+## Order Book Data (Optional, High Value)
+To support market making and microstructure-aware execution, add L2/L3 order book ingestion.
+
+Design requirements:
+- store top-of-book and aggregated depth features,
+- maintain strict timestamp alignment,
+- validate feed integrity and handle out-of-order messages.
+
+## Feature Store Design (Pragmatic)
+- Store computed features in ClickHouse with TTL and partitioning.
+- Keep a version tag for feature definitions.
+- Ensure features are computable in streaming and reproducible offline.
+
+## Torghut Extensions
+- Extend Flink TA to produce a v2 "feature table" in ClickHouse.
+- Add a schema evolution policy for features.
+
+## References
+- Example of modern order-book modeling direction (Transformer-based LOB forecasting): https://arxiv.org/abs/2406.05317

--- a/docs/torghut/design-system/v2/04-backtesting-and-walkforward.md
+++ b/docs/torghut/design-system/v2/04-backtesting-and-walkforward.md
@@ -1,0 +1,39 @@
+# Backtesting and Walk-Forward (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Define a backtesting framework that is credible enough to trust for capital allocation.
+
+## Key Requirements
+- Strict out-of-sample evaluation with walk-forward splits.
+- Purged splits when using overlapping labels or lookback windows.
+- Transaction costs and realistic execution assumptions.
+- Portfolio-level simulation (not just per-trade).
+
+## Minimum Backtest Modes
+- Unit backtests: strategy logic on fixed fixtures.
+- Integration replay: Kafka replay -> TA -> ClickHouse -> trading loop (paper only).
+- Offline simulator: deterministic re-run of decisions and fills with a cost model.
+
+## Walk-Forward Protocol
+- Train window: fit parameters (if any) and calibrate cost model.
+- Validation window: select variants with multiple-testing correction.
+- Test window: frozen selection, report results.
+
+## Torghut Extensions
+- Add a replay harness that can:
+  - ingest historical events into Kafka with correct keys,
+  - run TA and materialize features into ClickHouse,
+  - run trading loop in "simulate" mode where the execution engine uses a fill simulator.
+- Persist all inputs used by the backtest so results are reproducible.
+
+## Failure Modes
+- Lookahead bias: using future bars to decide current trades.
+- Survivorship bias: testing only current winners.
+- Execution fantasy: fills at mid with no slippage.
+
+## References
+- Probability of backtest overfitting (PBO) and CSCV: https://scholarworks.wmich.edu/math_pubs/42/

--- a/docs/torghut/design-system/v2/05-overfitting-and-statistical-validity.md
+++ b/docs/torghut/design-system/v2/05-overfitting-and-statistical-validity.md
@@ -1,0 +1,33 @@
+# Overfitting and Statistical Validity (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Make overfitting hard by default.
+
+## Multiple-Testing Reality
+If you try hundreds of variants (symbols, parameters, features), the best backtest is often a false positive.
+
+## Controls
+- Pre-register strategy families and limit degrees of freedom.
+- Use walk-forward with purging/embargo.
+- Track the total number of variants tested.
+- Prefer simpler strategies until proven otherwise.
+
+## Metrics To Report
+- Distribution across folds, not just a single Sharpe.
+- Drawdown statistics, tail risk, and worst-case period behavior.
+- Turnover and cost sensitivity.
+
+## Torghut Extensions
+- Store a "research ledger" (runs, parameters, code hash, data versions, results).
+- Build CI gates for strategy changes:
+  - unit tests,
+  - deterministic replay smoke tests,
+  - minimum risk constraints.
+
+## References
+- Probability of backtest overfitting (PBO): https://scholarworks.wmich.edu/math_pubs/42/
+- Deflated Sharpe Ratio (selection bias correction): https://www.pm-research.com/content/iijpormgmt/40/5/94

--- a/docs/torghut/design-system/v2/06-transaction-cost-and-capacity.md
+++ b/docs/torghut/design-system/v2/06-transaction-cost-and-capacity.md
@@ -1,0 +1,32 @@
+# Transaction Costs and Capacity (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Ensure strategies remain profitable after costs and at scale.
+
+## Cost Components
+- Spread (half-spread paid on aggressive fills).
+- Fees and rebates.
+- Slippage from volatility during execution.
+- Market impact (temporary and permanent).
+- Borrow costs and shortability constraints.
+
+## Capacity
+Capacity is the notional you can deploy before impact erases edge.
+
+Practical proxy metrics:
+- participation rate,
+- average daily volume vs trade size,
+- expected impact per trade.
+
+## Torghut Extensions
+- Add a cost model module:
+  - inputs: spread estimates from quotes, volatility, ADV.
+  - outputs: expected cost bands used by risk engine and backtester.
+- Record realized slippage and compare to model predictions.
+
+## References
+- Optimal execution with impact (foundational): https://docslib.org/doc/1384720/optimal-execution-of-portfolio-transactions

--- a/docs/torghut/design-system/v2/07-execution-and-market-impact.md
+++ b/docs/torghut/design-system/v2/07-execution-and-market-impact.md
@@ -1,0 +1,28 @@
+# Execution and Market Impact (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Improve fills and reduce slippage while maintaining strict safety.
+
+## Execution Modes
+- Market (use rarely, strict slippage caps).
+- Limit with price bands.
+- TWAP/VWAP style slicing for larger orders.
+- Participation-of-volume (POV) with caps.
+
+## Execution Safety Controls
+- Hard max slippage (bps) vs recent price snapshot.
+- Max order rate per symbol.
+- Cancel/replace throttles.
+- Market hours and halt awareness.
+
+## Torghut Extensions
+- Introduce an ExecutionPlanner that outputs a schedule of child orders.
+- Store child order intent and link to parent decision hash.
+
+## References
+- RL for optimal execution (2025 survey): https://arxiv.org/abs/2508.06535
+- Optimal execution with impact (foundational): https://docslib.org/doc/1384720/optimal-execution-of-portfolio-transactions

--- a/docs/torghut/design-system/v2/08-portfolio-and-sizing.md
+++ b/docs/torghut/design-system/v2/08-portfolio-and-sizing.md
@@ -1,0 +1,28 @@
+# Portfolio Construction and Position Sizing (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Translate signals into positions in a way that is robust and scalable.
+
+## Sizing Primitives
+- Volatility targeting: size positions so risk is stable.
+- Notional caps and position percent-of-equity caps.
+- Correlation-aware limits (avoid hidden concentration).
+
+## Portfolio Layer
+Even if each strategy is simple, the portfolio can be sophisticated:
+- allocate capital across strategies by risk budgets,
+- reduce exposure when correlations spike,
+- rebalance with turnover limits.
+
+## Torghut Extensions
+- Add a PortfolioAllocator stage after strategy decisions:
+  - input: per-symbol decisions + confidence + risk estimates,
+  - output: final sizes per symbol constrained by portfolio limits.
+- Persist portfolio snapshots for attribution.
+
+## References
+- Trend following drawdown behavior is often portfolio-driven: https://www.man.com/maninstitute/why-do-trend-following-strategies-suffer-drawdowns

--- a/docs/torghut/design-system/v2/09-risk-controls-and-kill-switches-v2.md
+++ b/docs/torghut/design-system/v2/09-risk-controls-and-kill-switches-v2.md
@@ -1,0 +1,26 @@
+# Risk Controls and Kill Switches (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Upgrade from "toggle trading" to a true market-access safety layer.
+
+## Required Controls (Autonomous)
+- Pre-trade order firewall (single module allowed to place/cancel orders).
+- Max order size, max notional, max daily loss.
+- Max message rate, max cancel/replace rate.
+- Hard kill: cancel open orders + block new orders.
+- Per-strategy and per-symbol circuit breakers.
+
+## Torghut Extensions
+- Split responsibility:
+  - Strategy decides intent.
+  - Risk engine approves intent.
+  - Order firewall executes and can unilaterally reject.
+- Add a broker-side kill path (cancel all open orders) that is callable without deploying code.
+
+## References
+- SEC Market Access Rule 15c3-5 (risk management controls): https://www.sec.gov/rules-regulations/2011/06/risk-management-controls-brokers-or-dealers-market-access
+- MiFID II RTS 6 (algo trading controls and kill functionality): https://eur-lex.europa.eu/eli/reg_del/2017/589/oj/eng

--- a/docs/torghut/design-system/v2/10-regime-detection.md
+++ b/docs/torghut/design-system/v2/10-regime-detection.md
@@ -1,0 +1,32 @@
+# Regime Detection and Risk-On/Risk-Off Controls (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Reduce drawdowns by recognizing when a strategy's assumptions are failing.
+
+## Regime Signals (Pragmatic)
+- Volatility level and change rate.
+- Correlation spikes across symbols.
+- Trend strength metrics vs choppy conditions.
+- Liquidity proxies: spread widening and gap frequency.
+
+## Control Actions
+- Throttle size (reduce risk budgets).
+- Stop opening new positions.
+- Flatten high-risk symbols.
+- Switch strategies (trend vs mean reversion) when a regime flips.
+
+## Torghut Extensions
+- Add a RegimeService that writes a low-frequency regime state to Postgres.
+- Expose regime state in `/trading/status`.
+- Make risk engine aware of regime state (hard clamps).
+
+## Failure Modes
+- Overfitting the regime classifier.
+- Flip-flopping (too sensitive), causing churn.
+
+## References
+- Managed futures discussion of trend behavior across cycles: https://www.aqr.com/Insights/Strategies/Alternative-Thinking/Managed-Futures

--- a/docs/torghut/design-system/v2/11-time-series-momentum.md
+++ b/docs/torghut/design-system/v2/11-time-series-momentum.md
@@ -1,0 +1,32 @@
+# Time-Series Momentum and Trend Following (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Implement a robust trend strategy with strong risk controls.
+
+## Common Variants
+- Moving average crossovers (multi-horizon).
+- Breakout systems (Donchian channels).
+- Time-series momentum: sign(lookback return) * risk-targeted position.
+
+## Why It Can Work
+Trend strategies can benefit from persistence in price moves and may perform well in crisis regimes, but they can
+experience long drawdowns in sideways markets.
+
+## Torghut Implementation Sketch
+- Signals:
+  - multi-horizon returns (1d, 5d, 20d) and volatility,
+  - trend strength score.
+- Positioning:
+  - volatility targeting,
+  - per-symbol max risk.
+- Execution:
+  - limit orders with bands to avoid chasing.
+
+## References
+- Time Series Momentum (foundational): https://pages.stern.nyu.edu/~lpederse/papers/TimeSeriesMomentum.pdf
+- Managed futures / trend following overview: https://www.aqr.com/Insights/Strategies/Alternative-Thinking/Managed-Futures
+- Trend drawdowns perspective (2024): https://www.man.com/maninstitute/why-do-trend-following-strategies-suffer-drawdowns

--- a/docs/torghut/design-system/v2/12-mean-reversion-and-stat-arb.md
+++ b/docs/torghut/design-system/v2/12-mean-reversion-and-stat-arb.md
@@ -1,0 +1,29 @@
+# Mean Reversion and Statistical Arbitrage (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Implement controlled mean-reversion strategies that are cost-aware and regime-aware.
+
+## Common Variants
+- Intraday reversal (short horizon).
+- Pairs trading / cointegration.
+- Bollinger-band style reversion on z-scores.
+
+## Why It Fails
+- Regime breaks (trends) can overwhelm reversion assumptions.
+- Costs dominate at high turnover.
+
+## Torghut Implementation Sketch
+- Signals:
+  - z-score of returns vs rolling mean,
+  - spread/volatility gating,
+  - cointegration residuals for pairs.
+- Controls:
+  - disable in strong trend regimes,
+  - strict stop-loss and max holding time.
+
+## References
+- Backtest overfitting risk is high for mean reversion due to many degrees of freedom: https://scholarworks.wmich.edu/math_pubs/42/

--- a/docs/torghut/design-system/v2/13-cross-sectional-factors.md
+++ b/docs/torghut/design-system/v2/13-cross-sectional-factors.md
@@ -1,0 +1,25 @@
+# Cross-Sectional Factors and Multi-Asset Allocation (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Add portfolio-level strategies that allocate across symbols based on relative signals.
+
+## Factor Ideas
+- Momentum (relative strength).
+- Low volatility.
+- Quality/profitability (if fundamentals are available).
+- Value (if fundamentals are available).
+
+## Torghut Implementation Sketch
+- Start with price-only cross-sectional momentum across a curated universe.
+- Normalize signals, cap exposures, and apply turnover limits.
+
+## Required System Work
+- PortfolioAllocator (see `08-portfolio-and-sizing.md`).
+- Better universe management (avoid survivorship bias).
+
+## References
+- Managed futures can be seen as an allocation problem across instruments: https://www.aqr.com/Insights/Strategies/Alternative-Thinking/Managed-Futures

--- a/docs/torghut/design-system/v2/14-volatility-strategies.md
+++ b/docs/torghut/design-system/v2/14-volatility-strategies.md
@@ -1,0 +1,23 @@
+# Volatility Strategies and Volatility Targeting (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Control risk in a way that increases robustness across regimes.
+
+## Practical Approaches Without Options
+- Volatility targeting (scale positions to keep vol stable).
+- Drawdown-based de-risking.
+- Correlation-aware risk budgets.
+
+## Optional (If Options Added Later)
+- Volatility carry and hedging overlays.
+
+## Torghut Implementation Sketch
+- Compute realized volatility per symbol and for the portfolio.
+- Scale target exposures each rebalance tick.
+
+## References
+- Trend drawdowns and volatility dynamics often co-move: https://www.man.com/maninstitute/why-do-trend-following-strategies-suffer-drawdowns

--- a/docs/torghut/design-system/v2/15-market-making.md
+++ b/docs/torghut/design-system/v2/15-market-making.md
@@ -1,0 +1,25 @@
+# Market Making and Liquidity Provision (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Describe what it would take to add market making safely.
+
+## Warning
+Market making is operationally and model-risk intensive. It requires order-book data, low latency, and strong
+inventory and adverse selection controls.
+
+## Core Concepts
+- Quote around a reservation price.
+- Control inventory risk and widen spreads as inventory grows.
+- Detect toxic flow and pull quotes in stress.
+
+## Torghut Extensions Needed
+- Order-book ingestion and feature generation (see `03-data-pipeline-and-features.md`).
+- Sub-second loop and deterministic throttles.
+- Inventory-aware risk engine extensions.
+
+## References
+- Avellaneda-Stoikov model (foundational): https://people.orie.cornell.edu/sfs33/LimitOrderBook.pdf

--- a/docs/torghut/design-system/v2/16-ml-stack-transformers-and-lob.md
+++ b/docs/torghut/design-system/v2/16-ml-stack-transformers-and-lob.md
@@ -1,0 +1,27 @@
+# ML Stack: Trees, Deep Learning, Transformers, and LOB Models (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Summarize a practical ML modeling stack for trading signals and execution signals.
+
+## Pragmatic Model Ladder
+- Baseline: linear models and simple rules.
+- Strong tabular baseline: gradient-boosted trees (feature discipline).
+- Deep learning: sequence models for time series.
+- Transformers: multi-resolution temporal modeling, order-book forecasting.
+
+## Where ML Fits In Torghut
+- Signal generation: enrich ClickHouse signals with ML-based forecasts.
+- Risk: classify anomaly conditions (stale feed, toxicity proxies).
+- Execution: predict short-term slippage/spread and choose execution style.
+
+## Engineering Requirements
+- Strict feature versioning and offline/online parity.
+- Deterministic inference paths (same model weights, same preprocessing).
+- Model drift monitoring and rollback.
+
+## References
+- Transformer for limit order books (TLOB, 2024): https://arxiv.org/abs/2406.05317

--- a/docs/torghut/design-system/v2/17-rl-trading-and-execution.md
+++ b/docs/torghut/design-system/v2/17-rl-trading-and-execution.md
@@ -1,0 +1,27 @@
+# Reinforcement Learning (RL) in Trading and Execution (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Describe where RL can be useful, and where it is often a trap.
+
+## Where RL Has A Clearer Fit
+- Optimal execution (choosing slicing and aggressiveness under constraints).
+- Inventory control problems (market making), if the environment is realistic.
+
+## Where RL Is Risky
+- Direct "trade the market" policies without credible simulators.
+- Overfitting to historical paths with poor generalization.
+
+## Torghut Approach
+- Use RL first for execution policy selection, not alpha discovery.
+- Keep RL behind deterministic safety:
+  - RL proposes, risk engine approves.
+
+## References
+- RL for optimal execution (2025 survey): https://arxiv.org/abs/2508.06535
+- Deep RL for technical analysis and trading systems (ACM, 2025): https://dl.acm.org/doi/10.1145/3731899
+- 100x more data improves RL for optimal execution (2025): https://arxiv.org/abs/2505.20271
+- RLHF for trading (2025): https://arxiv.org/abs/2506.02830

--- a/docs/torghut/design-system/v2/18-llm-intelligence-layer-architecture.md
+++ b/docs/torghut/design-system/v2/18-llm-intelligence-layer-architecture.md
@@ -1,0 +1,36 @@
+# LLM Intelligence Layer Architecture (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Define a safe intelligence layer that improves decisions without becoming a new failure mode.
+
+## Principle
+LLMs are non-deterministic and vulnerable to prompt injection. Therefore:
+- LLM outputs must be strictly schema-validated.
+- Deterministic policy must clamp or veto.
+- The LLM must not have broker credentials.
+
+## Recommended Architecture
+- Deterministic decision engine emits a decision intent.
+- LLM review engine emits `approve|veto|adjust` with bounded fields.
+- Policy guard clamps adjustments.
+- Risk engine remains the final gate.
+
+## If You Build Tool-Using Agents
+Separate paths:
+- Trading path (high stakes): review-only; no tools that mutate state.
+- Ops path (medium stakes): GitOps PR generation, with explicit gates and RBAC.
+
+## Security Controls
+- Treat tool outputs as untrusted data, not instructions.
+- Disable free-form external retrieval for trading decisions.
+- Add prompt injection detection and red teaming.
+
+## References
+- OWASP Top 10 for LLM Applications: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+- NIST AI RMF GenAI Profile: https://www.nist.gov/publications/artificial-intelligence-risk-management-framework-generative-artificial-intelligence
+- Microsoft on indirect prompt injection defenses (2025): https://www.microsoft.com/en-us/msrc/blog/2025/07/how-microsoft-defends-against-indirect-prompt-injection-attacks/
+- Agent runtime constraints (AgentSpec, 2025): https://arxiv.org/abs/2503.18666

--- a/docs/torghut/design-system/v2/19-governance-compliance-and-ops.md
+++ b/docs/torghut/design-system/v2/19-governance-compliance-and-ops.md
@@ -1,0 +1,32 @@
+# Governance, Compliance, and Ops For Autonomous Trading (v2)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Describe the governance and operational controls needed for unattended trading.
+
+## Governance Must-Haves
+- Clear ownership of each strategy and each risk limit.
+- Change control for any configuration that can change trading behavior.
+- Periodic review of market access controls and logs.
+
+## Operational Must-Haves
+- Oncall-ready dashboards and alerts: signal freshness, reconcile lag, order reject taxonomy.
+- One-command kill (cancel open orders + stop new orders).
+- Post-incident review with exact reproduction artifacts.
+
+## Torghut Extensions
+- Add explicit "actuation" gating for automation (AgentRuns): separate diagnostics from changes.
+- Add a daily "audit report" job that summarizes:
+  - realized PnL,
+  - risk rejects,
+  - broker rejects,
+  - LLM veto/adjust stats,
+  - drift alerts.
+
+## References
+- SEC Market Access Rule 15c3-5 summary: https://www.sec.gov/rules-regulations/2011/06/risk-management-controls-brokers-or-dealers-market-access
+- MiFID II RTS 6 delegated regulation (algo trading controls): https://eur-lex.europa.eu/eli/reg_del/2017/589/oj/eng
+- BIS on AI and genAI risks in finance (2024): https://www.bis.org/fsi/publ/insights63.htm


### PR DESCRIPTION
## Summary

- Add Torghut v2 design-system research pack (20 docs) for building a more profitable autonomous trading system with a bounded intelligence layer.
- Cover strategy taxonomy, research discipline, backtesting validity, cost/capacity modeling, execution, portfolio, regimes, ML/RL, LLM safety, and governance.
- Link v2 entrypoint from the main design-system index without changing v1 production docs.

## Related Issues

None

## Testing

- Docs-only change.

## Breaking Changes

None


## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
