### PR TITLE
feat(torghut): add self-hosted completion fallback

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -18,14 +18,14 @@ spec:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
-        client.knative.dev/updateTimestamp: 2026-02-09T02:53:30.000Z
+        client.knative.dev/updateTimestamp: 2026-02-10T06:36:37.036Z
     spec:
       containerConcurrency: 0
       timeoutSeconds: 60
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7cd901027afbddef45c7ba96f4255353f3be8f9cf1c6306e241672abe059da12
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca6b60ac27b15ac19fcf119570ac8861377f9b7ce5c5001d39aff3bd987aeece
           ports:
             - name: http1
               containerPort: 8181
@@ -58,7 +58,7 @@ spec:
             - name: CLICKHOUSE_HOST
               value: torghut-clickhouse.torghut.svc.cluster.local
             - name: CLICKHOUSE_PORT
-              value: '8123'
+              value: "8123"
             - name: CLICKHOUSE_DATABASE
               value: torghut
             - name: CLICKHOUSE_USERNAME
@@ -69,31 +69,31 @@ spec:
                   name: torghut-clickhouse-auth
                   key: torghut_password
             - name: CLICKHOUSE_SECURE
-              value: 'false'
+              value: "false"
             - name: CLICKHOUSE_TIMEOUT_SECONDS
-              value: '10'
+              value: "10"
             - name: TRADING_ENABLED
-              value: 'true'
+              value: "true"
             - name: TRADING_MODE
               value: paper
             - name: TRADING_LIVE_ENABLED
-              value: 'false'
+              value: "false"
             - name: TRADING_SIGNAL_SOURCE
               value: clickhouse
             - name: TRADING_SIGNAL_TABLE
               value: torghut.ta_signals
             - name: TRADING_SIGNAL_LOOKBACK_MINUTES
-              value: '15'
+              value: "15"
             - name: TRADING_POLL_MS
-              value: '5000'
+              value: "5000"
             - name: TRADING_RECONCILE_MS
-              value: '15000'
+              value: "15000"
             - name: TRADING_STRATEGY_CONFIG_PATH
               value: /etc/torghut/strategies.yaml
             - name: TRADING_STRATEGY_CONFIG_MODE
               value: sync
             - name: TRADING_STRATEGY_RELOAD_SECONDS
-              value: '10'
+              value: "10"
             - name: TRADING_UNIVERSE_SOURCE
               value: static
             - name: TRADING_STATIC_SYMBOLS
@@ -105,11 +105,15 @@ spec:
             - name: LLM_PROVIDER
               value: jangar
             - name: LLM_ENABLED
-              value: 'true'
+              value: "true"
             - name: LLM_SHADOW_MODE
-              value: 'true'
+              value: "true"
             - name: LLM_FAIL_MODE
               value: pass_through
+            - name: LLM_SELF_HOSTED_BASE_URL
+              value: http://192.168.1.190:11434/v1
+            - name: LLM_SELF_HOSTED_MODEL
+              value: qwen3-coder-saigak:30b-a3b-q4_K_M
             - name: TA_CLICKHOUSE_URL
               value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
             - name: TA_CLICKHOUSE_USERNAME
@@ -120,11 +124,11 @@ spec:
                   name: torghut-clickhouse-auth
                   key: torghut_password
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
-              value: '10'
+              value: "10"
             - name: TORGHUT_VERSION
-              value: v0.519.0-6-g2de76d18
+              value: v0.523.3
             - name: TORGHUT_COMMIT
-              value: 2de76d18170e650a6ab72da459b478bb35bd75b1
+              value: 14348305dfe4be8d192b1920eb72f093c73896ee
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:7e5923ae1e2f74ddc6f360759e2ff6d4596144b677939687d6f220bc41caabd7
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:5c6a23dde129d6e041bde539dd5409941d0cee3d6fc04001b8f9e9d1692c96cd
   imagePullPolicy: IfNotPresent
   restartNonce: 1
   flinkVersion: v2_0
@@ -154,9 +154,9 @@ spec:
                   name: observability-minio-creds
                   key: secretkey
             - name: TORGHUT_TA_VERSION
-              value: v0.519.0-6-g2de76d18
+              value: v0.523.3
             - name: TORGHUT_TA_COMMIT
-              value: 2de76d18170e650a6ab72da459b478bb35bd75b1
+              value: 14348305dfe4be8d192b1920eb72f093c73896ee
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    # Alpaca WS enforces low per-key connection limits; avoid deadlock during rolling updates.
     type: Recreate
   selector:
     matchLabels:
@@ -18,7 +17,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2026-02-09T02:01:10.149Z
+        kubectl.kubernetes.io/restartedAt: 2026-02-10T06:36:37.043Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:
@@ -28,7 +27,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:4c2c19754e9d9aed14e3f90e5c9605efa4a0223f1dcd2d63929f8cde62b334e2
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:81ee1d7eb7c6800e982cce477989f0816550dd5fc65e863989daea34de20d67b
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -52,9 +51,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: v0.519.0-6-g2de76d18
+              value: v0.523.3
             - name: TORGHUT_WS_COMMIT
-              value: 2de76d18170e650a6ab72da459b478bb35bd75b1
+              value: 14348305dfe4be8d192b1920eb72f093c73896ee
           ports:
             - containerPort: 8080
               name: http

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -86,6 +86,11 @@ class Settings(BaseSettings):
     llm_enabled: bool = Field(default=False, alias="LLM_ENABLED")
     llm_provider: Literal["jangar", "openai"] = Field(default="openai", alias="LLM_PROVIDER")
     llm_model: str = Field(default="gpt-5.3-codex", alias="LLM_MODEL")
+    # Used only when `LLM_PROVIDER=jangar` and the Jangar request fails.
+    # This should point at an OpenAI-compatible endpoint (e.g. vLLM, Ollama, llama.cpp server).
+    llm_self_hosted_base_url: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_BASE_URL")
+    llm_self_hosted_api_key: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_API_KEY")
+    llm_self_hosted_model: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_MODEL")
     llm_prompt_version: str = Field(default="v1", alias="LLM_PROMPT_VERSION")
     llm_temperature: float = Field(default=0.2, alias="LLM_TEMPERATURE")
     llm_max_tokens: int = Field(default=300, alias="LLM_MAX_TOKENS")
@@ -113,6 +118,8 @@ class Settings(BaseSettings):
             self.trading_account_label = self.trading_mode
         if self.jangar_base_url:
             self.jangar_base_url = self.jangar_base_url.strip().rstrip("/")
+        if self.llm_self_hosted_base_url:
+            self.llm_self_hosted_base_url = self.llm_self_hosted_base_url.strip().rstrip("/")
         if "llm_provider" not in self.model_fields_set and self.jangar_base_url:
             self.llm_provider = "jangar"
 

--- a/services/torghut/tests/test_llm_jangar_client.py
+++ b/services/torghut/tests/test_llm_jangar_client.py
@@ -1,6 +1,9 @@
 import io
 import unittest
+from unittest.mock import patch
 
+from app.config import settings
+from app.trading.llm.client import LLMClient, LLMClientResponse
 from app.trading.llm.client import _parse_jangar_sse
 
 
@@ -45,6 +48,54 @@ data: [DONE]
             _parse_jangar_sse(stream)
 
 
+class TestJangarFallbackChain(unittest.TestCase):
+    def setUp(self) -> None:
+        self._orig_provider = settings.llm_provider
+        self._orig_trading_mode = settings.trading_mode
+
+    def tearDown(self) -> None:
+        settings.llm_provider = self._orig_provider
+        settings.trading_mode = self._orig_trading_mode
+
+    def test_falls_back_to_self_hosted_when_jangar_fails(self) -> None:
+        settings.llm_provider = "jangar"
+        settings.trading_mode = "paper"
+
+        client = LLMClient(model="gpt-test", timeout_seconds=1)
+        expected = LLMClientResponse(content='{"verdict":"approve","confidence":1,"rationale":"ok","risk_flags":[]}', usage=None)
+
+        with patch.object(LLMClient, "_request_review_via_jangar", side_effect=RuntimeError("nope")) as primary:
+            with patch.object(LLMClient, "_request_review_via_self_hosted", return_value=expected) as fallback:
+                response = client.request_review(messages=[], temperature=0.2, max_tokens=10)
+
+        self.assertTrue(primary.called)
+        self.assertTrue(fallback.called)
+        self.assertEqual(response.content, expected.content)
+
+    def test_returns_passthrough_when_all_providers_fail_in_paper_mode(self) -> None:
+        settings.llm_provider = "jangar"
+        settings.trading_mode = "paper"
+
+        client = LLMClient(model="gpt-test", timeout_seconds=1)
+
+        with patch.object(LLMClient, "_request_review_via_jangar", side_effect=RuntimeError("nope")):
+            with patch.object(LLMClient, "_request_review_via_self_hosted", side_effect=RuntimeError("nope2")):
+                response = client.request_review(messages=[], temperature=0.2, max_tokens=10)
+
+        self.assertIn('"verdict":"approve"', response.content.replace(" ", ""))
+        self.assertIn("llm_passthrough", response.content)
+
+    def test_raises_when_all_providers_fail_in_live_mode(self) -> None:
+        settings.llm_provider = "jangar"
+        settings.trading_mode = "live"
+
+        client = LLMClient(model="gpt-test", timeout_seconds=1)
+
+        with patch.object(LLMClient, "_request_review_via_jangar", side_effect=RuntimeError("nope")):
+            with patch.object(LLMClient, "_request_review_via_self_hosted", side_effect=RuntimeError("nope2")):
+                with self.assertRaises(RuntimeError):
+                    client.request_review(messages=[], temperature=0.2, max_tokens=10)
+
+
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary

- Torghut LLM: when using Jangar for chat completions, fall back to a self-hosted OpenAI-compatible endpoint, then to approve passthrough in paper trading.
- Added self-hosted fallback config knobs: `LLM_SELF_HOSTED_BASE_URL`, `LLM_SELF_HOSTED_API_KEY`, `LLM_SELF_HOSTED_MODEL`.
- Wired prod paper Knative env to use the Saigak Ollama proxy base URL + qwen3-coder model alias.


## Related Issues

None


## Testing

- `cd services/torghut && uv run python -m unittest`
- `bun run deploy:torghut`
- `kubectl -n torghut get ksvc torghut`
- `kubectl -n torghut get deploy torghut-ws`


## Breaking Changes

None


## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
