### PR TITLE
fix(ci): label temporal-bun-sdk release PR by head branch

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -298,7 +298,7 @@ jobs:
         run: |
           set -euo pipefail
           branch="release-please--branches--main--components--temporal-bun-sdk"
-          pr_number=$(gh pr list --search "$branch" --state merged --limit 1 --json number --jq '.[0].number')
+          pr_number=$(gh pr list --head "$branch" --state merged --limit 1 --json number --jq '.[0].number')
           if [[ -n "$pr_number" ]]; then
             gh pr edit "$pr_number" --remove-label "autorelease: pending" --add-label "autorelease: tagged"
             echo "Updated labels on release PR #$pr_number"


### PR DESCRIPTION
## Summary

- Fix Temporal Bun SDK publish workflow to find the merged release PR by `--head` branch (instead of `--search`), so `autorelease: pending` is reliably flipped to `autorelease: tagged` after publish.

## Related Issues

None

## Testing

- N/A (workflow-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
