### PR TITLE
fix(argocd): use semver tag for app image

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    newTag: "f093c815"
+    newTag: "0.523.4"
     newName: registry.ide-newton.ts.net/lab/app


### PR DESCRIPTION
## Summary

- Fix `apps/app` rollout tag to use the semver image tag produced by the Docker build workflow.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None
