### PR TITLE
docs(torghut): add v2 swarm guide and reading list

### DIFF
--- a/docs/torghut/design-system/v2/agent-swarm-implementation.md
+++ b/docs/torghut/design-system/v2/agent-swarm-implementation.md
@@ -1,0 +1,99 @@
+# Agent Swarm Implementation Guide (Codex + AgentRuns + Torghut)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Connect the existing Torghut production system, the repo's Agents (AgentRuns) platform, and a Codex-driven workflow to
+create a "swarm" of agents that can implement the v2 build-out safely.
+
+The goal is not "many agents". The goal is parallel execution without merge conflicts and without violating trading
+safety invariants.
+
+## What Exists Today (Production)
+Torghut already runs a full pipeline:
+- Ingest: `torghut-ws` (Kotlin) subscribes to Alpaca market data and writes to Kafka.
+- Compute: `torghut-ta` (Flink) computes TA and writes to ClickHouse.
+- Trade loop: `torghut` (FastAPI, Knative) reads ClickHouse signals, makes decisions, applies deterministic risk,
+  optionally runs LLM review, executes orders, reconciles, and persists audit state in Postgres.
+
+Canonical production docs:
+- `docs/torghut/design-system/v1/torghut-autonomous-trading-system.md`
+- `docs/torghut/design-system/v1/agentruns-handoff.md`
+
+## What Codex + AgentRuns Add
+The repo includes an AgentRuns platform:
+- `ImplementationSpec`: a durable "what to do" spec (text + required keys).
+- `AgentRun`: an execution instance that references an ImplementationSpec.
+
+Key rule (prompt precedence): do not set `AgentRun.spec.parameters.prompt` unless you want to override the spec text.
+See `docs/agents/agentrun-creation-guide.md`.
+
+## Swarm Model (Hub-And-Spoke)
+- Leader (orchestrator) run:
+  - breaks the roadmap into work items,
+  - creates ImplementationSpecs (or references existing ones),
+  - launches AgentRuns in parallel "lanes".
+- Worker runs:
+  - each owns a narrow file surface area,
+  - produces one PR per work item,
+  - includes validation steps.
+
+## Lanes (Avoid Conflicts)
+Assign one lane per major ownership boundary:
+
+- Lane A: Trading service core
+  - Owns: `services/torghut/app/trading/**`, `services/torghut/app/config.py`, `services/torghut/tests/**`
+
+- Lane B: Data / TA / features
+  - Owns: `services/dorvud/technical-analysis-flink/**`, `argocd/applications/torghut/ta/**`, ClickHouse DDL sources
+
+- Lane C: Infra + GitOps
+  - Owns: `argocd/applications/torghut/**`, `kubernetes/**`, `charts/**` (as needed)
+
+- Lane D: Research harness + scripts
+  - Owns: `packages/scripts/**` and any new replay/sim harness modules
+
+- Lane E: Observability + runbooks
+  - Owns: `docs/torghut/**`, dashboards manifests (if present), alert rules
+
+## Work Item Template (ImplementationSpec)
+Each work item must be small enough for a single PR and must include:
+- Objective
+- In-scope paths
+- Out-of-scope constraints
+- Acceptance criteria
+- Validation commands
+- Safety gates (paper-only, no credentials changes)
+
+Example required keys for PR-producing work:
+- `repository`, `base`, `head`, `stage`, `gitopsPath` (if relevant)
+
+## Hard Guardrails (Do Not Break These)
+- Paper trading is the default. Do not introduce live enablement paths without explicit gates.
+- Deterministic risk is final authority.
+- LLM layer must remain bounded and credential-less.
+- Every PR must preserve reproducibility: store versions (config/model/prompt) and inputs.
+
+## How To Operationalize The Swarm
+1. Convert roadmap sections into an issue list and ImplementationSpecs.
+2. Create AgentRuns per lane with non-overlapping `head` branches.
+3. Enforce PR checks:
+   - unit tests for touched code,
+   - lint/format,
+   - smoke tests (where applicable).
+4. Merge in dependency order:
+   - safety + order firewall first,
+   - backtesting validity + cost model next,
+   - execution planner and sizing next,
+   - strategy expansions last.
+
+## Suggested First Swarm Wave (High Value)
+- Add an "order firewall" module and a true kill switch contract (Lane A + Lane C).
+- Add a cost model MVP and persist realized slippage (Lane A).
+- Add replay/sim harness skeleton with deterministic fixtures (Lane D).
+- Add a research ledger schema + CI gates for strategy edits (Lane A).
+
+## References (Research Inputs)
+- `docs/torghut/design-system/v2/research-reading-list.md`

--- a/docs/torghut/design-system/v2/index.md
+++ b/docs/torghut/design-system/v2/index.md
@@ -33,6 +33,8 @@ Pick one initial alpha family:
 - `mean-reversion-and-stat-arb.md` (mean reversion)
 
 ## Next (Once MVP Is Stable)
+- `research-reading-list.md`
+- `agent-swarm-implementation.md`
 - `strategy-universe.md`
 - `data-pipeline-and-features.md`
 - `cross-sectional-factors.md`

--- a/docs/torghut/design-system/v2/research-reading-list.md
+++ b/docs/torghut/design-system/v2/research-reading-list.md
@@ -1,0 +1,78 @@
+# Research Reading List (LLM + Quant Trading Systems)
+
+## Status
+- Version: `v2`
+- Last updated: **2026-02-10**
+
+## Purpose
+Curate high-signal public material for designing and operating a production-grade autonomous trading system with a
+bounded intelligence layer.
+
+This is not investment advice. Most top trading firms do not publish their live strategies. Public material tends to be
+high-level and focuses on process, risk, and tooling rather than alpha specifics.
+
+## Top-Firm And Industry Research (Public)
+
+### Two Sigma (AI in investment management)
+- AI in Investment Management: 2026 Outlook (Part I) (2026-01-30)
+  - https://www.twosigma.com/articles/ai-in-investment-management-2026-outlook-part-i/
+  - Notes:
+    - Useful for framing agentic AI adoption as a disciplined engineering program.
+- AI in Investment Management: 2026 Outlook (Part II) (2026-01-31)
+  - https://www.twosigma.com/articles/ai-in-investment-management-2026-outlook-part-ii/
+
+### Man Group / Man Institute (systematic + ML)
+- A Regime-Switching Approach to Alternative Risk Premia (2025-03-27)
+  - https://www.man.com/maninstitute/a-regime-switching-approach-to-alternative-risk-premia
+- What AI Can (and Can't Yet) Do for Alpha (2025-11-13)
+  - https://www.man.com/maninstitute/what-ai-can-and-cant-yet-do-for-alpha
+  - Notes:
+    - Contains a concrete "AlphaGPT" pipeline concept (idea generation -> coding -> backtesting) that maps well to a
+      Torghut research lane, but still requires strong overfitting controls.
+
+### AQR (systematic investing + ML framing)
+- The Virtue of Complexity in Return Prediction (2024-03)
+  - https://www.aqr.com/Insights/Research/Journal-Article/The-Virtue-of-Complexity-in-Return-Prediction
+- Can Machines Build Better Stock Portfolios? (2024-11)
+  - https://www.aqr.com/Insights/Research/Journal-Article/Can-Machines-Build-Better-Stock-Portfolios
+- A New Paradigm in Active Equity? (2025-02)
+  - https://www.aqr.com/Insights/Research/Alternative-Thinking/A-New-Paradigm-in-Active-Equity
+  - Notes:
+    - Useful for setting expectations: ML and even LLMs can help, but production value comes from disciplined
+      deployment, governance, and evaluation.
+
+## LLM Safety And Agentic Systems
+- OWASP Top 10 for LLM Applications
+  - https://owasp.org/www-project-top-10-for-large-language-model-applications/
+- NIST AI RMF Generative AI Profile
+  - https://www.nist.gov/publications/artificial-intelligence-risk-management-framework-generative-artificial-intelligence
+- Microsoft: Defending against indirect prompt injection (2025-07-22)
+  - https://www.microsoft.com/en-us/msrc/blog/2025/07/how-microsoft-defends-against-indirect-prompt-injection-attacks/
+
+## Quant Research That Transfers To Production
+
+### Backtest validity and data snooping
+- White's Reality Check for data snooping (2000)
+  - https://www.econometricsociety.org/publications/econometrica/2000/09/01/reality-check-data-snooping
+- Probability of Backtest Overfitting (CSCV / PBO)
+  - https://scholarworks.wmich.edu/math_pubs/42/
+- Deflated Sharpe Ratio
+  - https://www.pm-research.com/content/iijpormgmt/40/5/94
+
+### Execution and market impact
+- Almgren-Chriss optimal execution (2001)
+  - https://www.math.nyu.edu/faculty/chriss/optliq_f.pdf
+
+### Trend / time-series momentum
+- Time Series Momentum (Moskowitz, Ooi, Pedersen)
+  - https://pages.stern.nyu.edu/~lpederse/papers/TimeSeriesMomentum.pdf
+
+## How This Maps To Torghut (Practical)
+- Use Two Sigma / AQR / Man material to set process expectations and governance.
+- Use the academic references to enforce validity and cost realism.
+- Do not treat LLM papers as an excuse to let models bypass deterministic controls.
+
+Suggested next internal deliverables:
+- A "research ledger" data model (runs, datasets, parameter search count, results).
+- A replay/simulation harness that can reproduce results deterministically.
+- A hardened order firewall + kill switch architecture.


### PR DESCRIPTION
## Summary

- Add a Torghut v2 AgentRuns + Codex swarm guide (lanes, guardrails, work-item template).
- Add a curated reading list for LLM safety and quant system design, including public research from AQR, Man Group, and Two Sigma.
- Link both docs from the v2 index.

## Related Issues

None

## Testing

- Docs-only change.

## Breaking Changes

None


## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
