### PR TITLE
docs(torghut): record health report AgentRun completion

### DIFF
--- a/docs/torghut/design-system/v1/agentruns-handoff.md
+++ b/docs/torghut/design-system/v1/agentruns-handoff.md
@@ -190,6 +190,10 @@ Notes:
 - `ttlSecondsAfterFinished` is a top-level `AgentRun.spec` field (see `charts/agents/crds/agents.proompteng.ai_agentruns.yaml`).
 - Avoid setting `spec.parameters.prompt` unless you intend to override the ImplementationSpec text (prompt precedence is documented in `docs/agents/agentrun-creation-guide.md`).
 
+### Progress updates (post-2026-02-08)
+- **2026-02-10:** The read-only Torghut health report procedure was exercised successfully via:
+  `AgentRun/torghut-health-report-v1-20260210-2` in namespace `agents`.
+
 ## Build/test/release (for implementers)
 Concrete commands live in `docs/torghut/ci-cd.md`. Quick pointers:
 - WS forwarder image: `services/dorvud/websockets/Dockerfile`

--- a/docs/torghut/design-system/v1/current-state-and-gap-analysis-2026-02-08.md
+++ b/docs/torghut/design-system/v1/current-state-and-gap-analysis-2026-02-08.md
@@ -59,6 +59,11 @@ flowchart TD
 4) Improve forwarder readiness error classification to reduce “503 mystery” incidents.
 5) Produce an AgentRuns-friendly “Torghut health report” run (read-only) and a gated actuation runbook runner (see `v1/agentruns-handoff.md`).
 
+## Progress updates (post-2026-02-08)
+- **2026-02-10:** Read-only Torghut health report AgentRun executed successfully:
+  `AgentRun/torghut-health-report-v1-20260210-2` in namespace `agents`.
+  Remaining work for item (5): implement the **gated actuation runbook runner** described in `v1/agentruns-handoff.md`.
+
 ## Security considerations
 - Keep live trading gated; audit any changes to `TRADING_LIVE_ENABLED`.
 - Do not store secrets in docs; operational procedures must reference secret *names* only.


### PR DESCRIPTION
## Summary

- Documented that the read-only Torghut health report AgentRun completed successfully (2026-02-10).
- Clarified that the remaining work in "Do next" #5 is the gated actuation runbook runner.

## Related Issues

None

## Testing

- `kubectl -n agents get agentrun torghut-health-report-v1-20260210-2`

## Breaking Changes

None
