### PR TITLE
fix(torghut-ws): improve readiness diagnostics

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -354,7 +354,11 @@ class ForwarderApp(
                   authOk = false
                   subscribedOk = false
                   updateWsReady()
-                  throw RuntimeException("alpaca auth error code=${msg.code} msg=${msg.msg}")
+                  val errorClass = ReadinessClassifier.classifyAlpacaError(msg.code, msg.msg)
+                  metrics.recordWsConnectError(errorClass)
+                  setReadinessError(errorClass)
+                  logger.error { "alpaca auth error code=${msg.code} msg=${msg.msg} error_class=${errorClass.id}" }
+                  throw RuntimeException("alpaca auth error code=${msg.code} msg=${msg.msg} error_class=${errorClass.id}")
                 }
                 else -> {}
               }
@@ -556,6 +560,7 @@ class ForwarderApp(
               val errorClass = ReadinessErrorClass.AlpacaAuth
               metrics.recordWsConnectError(errorClass)
               setReadinessError(errorClass)
+              logger.error { "alpaca trade_updates auth failed status=$status error_class=${errorClass.id}" }
               updateReady()
             }
           }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ReadinessClassifierTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ReadinessClassifierTest.kt
@@ -24,6 +24,22 @@ class ReadinessClassifierTest {
   }
 
   @Test
+  fun `alpaca message-only 406 maps to connection-limit class`() {
+    assertEquals(
+      ReadinessErrorClass.Alpaca406SecondConnection,
+      ReadinessClassifier.classifyAlpacaError(null, "http 406 connection limit exceeded"),
+    )
+  }
+
+  @Test
+  fun `alpaca message-only forbidden maps to auth class`() {
+    assertEquals(
+      ReadinessErrorClass.AlpacaAuth,
+      ReadinessClassifier.classifyAlpacaError(null, "forbidden"),
+    )
+  }
+
+  @Test
   fun `kafka sasl auth maps to kafka_auth`() {
     val ex = SaslAuthenticationException("bad credentials")
     assertEquals(


### PR DESCRIPTION
## Summary
- classify Alpaca auth/connection-limit failures during initial WS auth and trade_updates auth
- record readiness/WS connect error metrics for those failures with stable error_class
- add readiness classifier tests for message-only Alpaca errors

## Related Issues
- None

## Testing
- cd services/dorvud && ./gradlew :websockets:test

## Screenshots (if applicable)
- None

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
