### PR TITLE
chore(torghut): deploy v0.529.1 images

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca6b60ac27b15ac19fcf119570ac8861377f9b7ce5c5001d39aff3bd987aeece
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7a9d077da14fe334b9f36aa8653cb65209ac7f5eccff75c80cf9c444594cf513
           ports:
             - name: http1
               containerPort: 8181
@@ -128,9 +128,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.523.3
+              value: v0.529.1
             - name: TORGHUT_COMMIT
-              value: 14348305dfe4be8d192b1920eb72f093c73896ee
+              value: 312d4efc4375aa51f0b979d1f732619abba3bc59
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:81ee1d7eb7c6800e982cce477989f0816550dd5fc65e863989daea34de20d67b
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:a116a8161dc9f4cc5e091b4c1724671b1fd71ae4c26f2c83b367e24f2cbba83c
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -51,9 +51,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: v0.523.3
+              value: v0.529.1
             - name: TORGHUT_WS_COMMIT
-              value: 14348305dfe4be8d192b1920eb72f093c73896ee
+              value: 312d4efc4375aa51f0b979d1f732619abba3bc59
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary
- Bump `torghut` Knative Service image to `registry.ide-newton.ts.net/lab/torghut@sha256:7a9d077da14fe334b9f36aa8653cb65209ac7f5eccff75c80cf9c444594cf513`.
- Bump `torghut-ws` Deployment image to `registry.ide-newton.ts.net/lab/torghut-ws@sha256:a116a8161dc9f4cc5e091b4c1724671b1fd71ae4c26f2c83b367e24f2cbba83c`.
- Update `TORGHUT_VERSION`/`TORGHUT_COMMIT` and `TORGHUT_WS_VERSION`/`TORGHUT_WS_COMMIT` to `v0.529.1` / `312d4efc4375aa51f0b979d1f732619abba3bc59`.

## Related Issues
None

## Testing
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/torghut:sha-312d4ef`
- `docker buildx build --platform linux/arm64 -f services/dorvud/websockets/Dockerfile -t registry.ide-newton.ts.net/lab/torghut-ws:sha-312d4ef --push services/dorvud`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/torghut-ws:sha-312d4ef`

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
