### PR TITLE
chore(argocd): bump jangar to 4acded88

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-09T02:02:07.550Z"
+    deploy.knative.dev/rollout: "2026-02-10T09:25:35.854Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -54,5 +54,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "5b3e7941"
-    digest: sha256:512e65aa7f2bdae38f90c026dd0807b634d2e94caa9fae22ee3c599771a58cb3
+    newTag: "4acded88"
+    digest: sha256:bd911be112de8997faa95c38d54bf2f86da81f5c34797d3a799bf91a9d15f473


### PR DESCRIPTION
## Summary

- Pin Jangar image to `4acded88` (digest `sha256:bd911be112de8997faa95c38d54bf2f86da81f5c34797d3a799bf91a9d15f473`).
- Force a rollout by bumping `deploy.knative.dev/rollout`.
- Rolls out the merged Torghut trading history UI changes (merged on 2026-02-10).

## Related Issues

None

## Testing

- `regctl manifest head registry.ide-newton.ts.net/lab/jangar:4acded88`
- `crane digest registry.ide-newton.ts.net/lab/jangar:4acded88`

## Breaking Changes

None
