### PR TITLE
fix(torghut-ws): add static symbols fallback

### DIFF
--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -8,6 +8,8 @@ data:
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
   ALPACA_BASE_URL: "https://data.alpaca.markets"
   JANGAR_SYMBOLS_URL: "http://jangar.jangar.svc.cluster.local/api/torghut/symbols"
+  # Fallback so the ws forwarder can become ready if Jangar has no ready endpoints.
+  SYMBOLS: "CRWD,MU,NVDA"
   SYMBOLS_POLL_INTERVAL_MS: "30000"
   SUBSCRIBE_BATCH_SIZE: "200"
   SHARD_COUNT: "1"

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2026-02-10T06:36:37.043Z
+        kubectl.kubernetes.io/restartedAt: 2026-02-10T09:28:58Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:


### PR DESCRIPTION
## Summary
- Add `SYMBOLS` fallback in `torghut-ws-config` so the websocket forwarder can become Ready when `jangar` has no ready endpoints.
- Bump `kubectl.kubernetes.io/restartedAt` on `torghut-ws` to roll pods onto the updated config.

## Related Issues
None

## Testing
- `kubectl -n torghut logs deploy/torghut-ws` (verified prior failure mode was empty symbols when Jangar had 0 ready endpoints)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
