### PR TITLE
feat(torghut): tighten ClickHouse guardrail alerts

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -99,10 +99,12 @@ data:
         rules:
           - alert: TorghutClickHouseDiskFreeLowWarning
             expr: |
-              torghut_clickhouse_guardrails_disk_free_ratio{
-                namespace="torghut",
-                service="torghut-clickhouse-guardrails-exporter"
-              } < 0.15
+              min by (namespace, service) (
+                torghut_clickhouse_guardrails_disk_free_ratio{
+                  namespace="torghut",
+                  service="torghut-clickhouse-guardrails-exporter"
+                }
+              ) < 0.15
             for: 10m
             labels:
               severity: warning
@@ -112,13 +114,16 @@ data:
                 Torghut ClickHouse is below 15% free disk for 10 minutes.
 
                 First safe action: pause TA writes to stop the retry storm and prevent disk exhaustion.
+                Follow-up guidance: v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md.
               runbook_url: docs/torghut/design-system/v1/operations-pause-ta-writes.md
           - alert: TorghutClickHouseDiskFreeLowCritical
             expr: |
-              torghut_clickhouse_guardrails_disk_free_ratio{
-                namespace="torghut",
-                service="torghut-clickhouse-guardrails-exporter"
-              } < 0.08
+              min by (namespace, service) (
+                torghut_clickhouse_guardrails_disk_free_ratio{
+                  namespace="torghut",
+                  service="torghut-clickhouse-guardrails-exporter"
+                }
+              ) < 0.08
             for: 5m
             labels:
               severity: critical
@@ -131,10 +136,12 @@ data:
               runbook_url: docs/torghut/design-system/v1/operations-pause-ta-writes.md
           - alert: TorghutClickHouseReplicaReadOnly
             expr: |
-              torghut_clickhouse_guardrails_any_replica_readonly{
-                namespace="torghut",
-                service="torghut-clickhouse-guardrails-exporter"
-              } >= 1
+              max by (namespace, service) (
+                torghut_clickhouse_guardrails_any_replica_readonly{
+                  namespace="torghut",
+                  service="torghut-clickhouse-guardrails-exporter"
+                }
+              ) >= 1
             for: 2m
             labels:
               severity: critical
@@ -143,7 +150,8 @@ data:
               description: |
                 At least one Torghut ClickHouse replicated table reports read-only, which will cause TA JDBC writes to fail.
 
-                Stop the bleeding: pause TA writes first, then follow replica recovery (SYSTEM RESTORE REPLICA).
+                Stop the bleeding: pause TA writes first (v1/operations-pause-ta-writes.md), then follow replica recovery
+                (v1/operations-clickhouse-replica-and-keeper.md).
               runbook_url: docs/torghut/design-system/v1/operations-clickhouse-replica-and-keeper.md
           - alert: TorghutClickHouseGuardrailsExporterDown
             expr: |

--- a/docs/torghut/design-system/v1/alerting-slos-and-oncall.md
+++ b/docs/torghut/design-system/v1/alerting-slos-and-oncall.md
@@ -42,7 +42,8 @@ flowchart TD
 ### Paging alerts (examples)
 - `torghut-ws` readiness 503 for > N minutes.
 - FlinkDeployment `FAILED` or not `RUNNING/STABLE`.
-- ClickHouse disk free bytes below critical threshold.
+- ClickHouse disk free bytes below critical threshold (`TorghutClickHouseDiskFreeLowWarning/Critical`).
+- ClickHouse replica read-only (`TorghutClickHouseReplicaReadOnly`).
 - Trading service crashloop (Knative revision not Ready).
 
 ### Ticket alerts (examples)
@@ -62,6 +63,7 @@ flowchart TD
 | --- | --- | --- |
 | WS readiness 503 | check Alpaca 401/406, Kafka SASL | restart WS forwarder; keep single replica |
 | ClickHouse disk low | check merges, TTL, recent writes | pause TA writes; reclaim disk; restart TA |
+| ClickHouse replica read-only | check keeper/replica status | pause TA writes; restore replica; restart TA |
 | Knative revision failing | check logs for UUID JSON bug | roll back revision; apply serialization fix |
 
 ## Security considerations

--- a/docs/torghut/design-system/v1/operations-pause-ta-writes.md
+++ b/docs/torghut/design-system/v1/operations-pause-ta-writes.md
@@ -17,6 +17,8 @@ without taking risky actions.
 ## Safety invariants (do not violate)
 - Do **not** enable live trading. Keep `TRADING_LIVE_ENABLED=false`.
 - Prefer keeping trading paused (`TRADING_ENABLED=false`) while TA is paused or signals are stale.
+- If trading was enabled, disable it via the GitOps procedure in
+  `v1/torghut-autonomous-trading-system.md` ("Procedure: Pause trading (GitOps-first)").
 
 ## When to use
 Use this procedure when any of the following are true:


### PR DESCRIPTION
## Summary
- aggregate ClickHouse disk/readonly guardrail alerts to reduce per-replica noise
- add actionable runbook guidance for ClickHouse disk pressure and read-only incidents
- clarify pause-TA safety guidance to keep trading gated during incidents

## Related Issues
None

## Testing
- scripts/argo-lint.sh
- scripts/kubeconform.sh argocd

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
