### PR TITLE
docs(torghut): add gated actuation runner

### DIFF
--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -64,6 +64,7 @@ The v1 documents are written to stay consistent with:
 | `v1/operations-ws-connection-limit-and-auth.md` | Operations: WS connection limit and auth |
 | `v1/operations-clickhouse-replica-and-keeper.md` | Operations: ClickHouse replica and keeper |
 | `v1/operations-knative-revision-failures.md` | Operations: Knative revision failures |
+| `v1/operations-actuation-runner.md` | Operations: gated actuation runner |
 | `v1/security-threat-model.md` | Security: threat model |
 | `v1/security-secrets-rotation.md` | Security: secrets rotation |
 | `v1/security-network-and-rbac.md` | Security: network and RBAC |

--- a/docs/torghut/design-system/v1/agentruns-handoff.md
+++ b/docs/torghut/design-system/v1/agentruns-handoff.md
@@ -81,6 +81,9 @@ If the AgentRun is “changing state”, prefer it to:
 2) let ArgoCD reconcile,
 instead of directly mutating live objects.
 
+See `docs/torghut/design-system/v1/operations-actuation-runner.md` for the **gated** actuation runner details,
+supported procedures, and exact patch shapes.
+
 ### AgentRuns templates (copy/paste)
 These are minimal skeletons. Customize:
 - `metadata.namespace` (where your Agents system is installed),
@@ -118,7 +121,7 @@ spec:
     cnpgCluster: torghut-db
 ```
 
-GitOps actuation AgentRun (opens PR; read-write VCS required):
+GitOps actuation AgentRun (opens PR; read-write VCS required, confirmation enforced):
 ```yaml
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
@@ -132,7 +135,7 @@ spec:
   agentRef:
     name: <agent-name>
   implementationSpecRef:
-    name: <implementation-spec-name>
+    name: torghut-actuation-runner-v1
   runtime:
     type: workflow
   ttlSecondsAfterFinished: 7200
@@ -144,10 +147,12 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: agentruns/torghut-ops
+    head: agentruns/torghut-actuation-<yyyymmdd-hhmm>
     torghutNamespace: torghut
     gitopsPath: argocd/applications/torghut
-    change: <pause-trading|restart-ws|bump-ta-group|rollback-image>
+    change: <pause-trading|restart-ws|suspend-ta|resume-ta>
+    reason: <short-human-justification>
+    confirm: ACTUATE_TORGHUT
 ```
 
 ImplementationSpec skeletons (so the AgentRuns above are actually runnable once applied):
@@ -193,6 +198,8 @@ Notes:
 ### Progress updates (post-2026-02-08)
 - **2026-02-10:** The read-only Torghut health report procedure was exercised successfully via:
   `AgentRun/torghut-health-report-v1-20260210-2` in namespace `agents`.
+- **2026-02-10:** Gated actuation runner documented and templated:
+  `docs/torghut/design-system/v1/operations-actuation-runner.md`.
 
 ## Build/test/release (for implementers)
 Concrete commands live in `docs/torghut/ci-cd.md`. Quick pointers:

--- a/docs/torghut/design-system/v1/argo-gitops-and-overlays.md
+++ b/docs/torghut/design-system/v1/argo-gitops-and-overlays.md
@@ -37,6 +37,10 @@ sequenceDiagram
   K8s-->>Argo: health/status
 ```
 
+For **actuation automation**, the same flow applies: the runner opens a PR against
+`argocd/applications/torghut/**` and Argo reconciles after merge (see
+`docs/torghut/design-system/v1/operations-actuation-runner.md`).
+
 ## Overlay guidance (v1)
 If/when environment overlays exist:
 - Keep topic names and schemas consistent across envs.
@@ -62,4 +66,3 @@ If/when environment overlays exist:
 - **Decision:** Operational changes happen via PRs and Argo sync.
 - **Rationale:** Repeatability, auditability, reduced drift.
 - **Consequences:** Requires disciplined incident procedures and fast rollback process.
-

--- a/docs/torghut/design-system/v1/current-state-and-gap-analysis-2026-02-08.md
+++ b/docs/torghut/design-system/v1/current-state-and-gap-analysis-2026-02-08.md
@@ -2,7 +2,7 @@
 
 ## Status
 - Version: `v1`
-- Last updated: **2026-02-08**
+- Last updated: **2026-02-10**
 - Source of truth (config): `argocd/applications/torghut/**`
 
 ## Purpose
@@ -62,7 +62,8 @@ flowchart TD
 ## Progress updates (post-2026-02-08)
 - **2026-02-10:** Read-only Torghut health report AgentRun executed successfully:
   `AgentRun/torghut-health-report-v1-20260210-2` in namespace `agents`.
-  Remaining work for item (5): implement the **gated actuation runbook runner** described in `v1/agentruns-handoff.md`.
+- **2026-02-10:** Gated actuation runner documented and templated (GitOps-first) in
+  `docs/torghut/design-system/v1/operations-actuation-runner.md`.
 
 ## Security considerations
 - Keep live trading gated; audit any changes to `TRADING_LIVE_ENABLED`.

--- a/docs/torghut/design-system/v1/operations-actuation-runner.md
+++ b/docs/torghut/design-system/v1/operations-actuation-runner.md
@@ -1,0 +1,189 @@
+# Operations: Gated Actuation Runner (GitOps-First)
+
+## Status
+- Version: `v1`
+- Last updated: **2026-02-10**
+- Source of truth (config): `argocd/applications/torghut/**`
+
+## Purpose
+Define a **gated actuation runner** that performs common Torghut recovery actions **via GitOps PRs** (not direct
+kubectl mutations). This is the production-safe counterpart to the read-only health report.
+
+## Guardrails (non-negotiable)
+- **GitOps-first only:** actuation must open PRs against `argocd/applications/torghut/**`.
+- **Explicit gating:** actuation runs must carry the label gate and confirmation parameters.
+- **No safety regressions:** paper/live defaults remain unchanged unless a separate audited change is approved.
+- **No secrets:** do not add or expose secret values in PRs, logs, or AgentRun parameters.
+- **Minimal diffs:** prefer single-file, single-field patches for auditability.
+
+## Gating requirements (make actuation hard to do accidentally)
+Actuation runs must meet **all** of the following:
+- AgentRun labels:
+  - `torghut.proompteng.ai/purpose=actuation`
+  - `torghut.proompteng.ai/actuation="true"`
+- VCS policy: `required: true`, `mode: read-write`.
+- Required confirmation parameters:
+  - `change`: one of the supported procedures (see below).
+  - `reason`: short human justification.
+  - `confirm`: **exact** string `ACTUATE_TORGHUT`.
+
+## Supported actuation procedures (v1)
+Each procedure is GitOps-only and must map to a **single file** change.
+
+| Procedure | File to change | Patch shape | Rollback |
+| --- | --- | --- | --- |
+| Pause trading | `argocd/applications/torghut/knative-service.yaml` | `env[].name: TRADING_ENABLED` → `value: "false"` | Set `TRADING_ENABLED` back to `"true"` via PR (or `git revert`). |
+| Restart WS forwarder | `argocd/applications/torghut/ws/deployment.yaml` | Bump `spec.template.metadata.annotations.kubectl.kubernetes.io/restartedAt` to a new RFC3339 timestamp | `git revert` (no runtime rollback needed; annotation is a restart trigger). |
+| Suspend TA | `argocd/applications/torghut/ta/flinkdeployment.yaml` | Set `spec.job.state: suspended` | Set `spec.job.state: running` via PR (optionally bump `spec.restartNonce`). |
+| Resume TA | `argocd/applications/torghut/ta/flinkdeployment.yaml` | Set `spec.job.state: running` and increment `spec.restartNonce` by 1 if the job is stuck | Set `spec.job.state: suspended` via PR. |
+
+## Procedure details (exact patches)
+
+### Pause trading (GitOps PR)
+Target file: `argocd/applications/torghut/knative-service.yaml`
+
+Patch shape:
+```yaml
+- name: TRADING_ENABLED
+  value: "false"
+```
+
+Rollback:
+```yaml
+- name: TRADING_ENABLED
+  value: "true"
+```
+
+### Restart WS forwarder (GitOps PR)
+Target file: `argocd/applications/torghut/ws/deployment.yaml`
+
+Patch shape:
+```yaml
+spec:
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/restartedAt: 2026-02-10T12:34:56Z
+```
+
+Rollback:
+- `git revert` the PR (annotation change is a one-time restart trigger).
+
+### Suspend TA (GitOps PR)
+Target file: `argocd/applications/torghut/ta/flinkdeployment.yaml`
+
+Patch shape:
+```yaml
+spec:
+  job:
+    state: suspended
+```
+
+Rollback (resume):
+```yaml
+spec:
+  job:
+    state: running
+  restartNonce: <increment by 1 if the job needs a restart>
+```
+
+### Resume TA (GitOps PR)
+Target file: `argocd/applications/torghut/ta/flinkdeployment.yaml`
+
+Patch shape:
+```yaml
+spec:
+  job:
+    state: running
+  restartNonce: <increment by 1 if the job needs a restart>
+```
+
+Rollback (suspend):
+```yaml
+spec:
+  job:
+    state: suspended
+```
+
+## AgentRun template (gated actuation, GitOps PRs)
+This is intentionally **separate** from diagnostics. It should be rejected by admission policies unless the actuation
+label + confirmation parameters are present.
+
+```yaml
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: torghut-actuation-gitops
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/purpose: actuation
+    torghut.proompteng.ai/actuation: "true"
+spec:
+  agentRef:
+    name: <agent-name>
+  implementationSpecRef:
+    name: torghut-actuation-runner-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 7200
+  vcsRef:
+    name: <vcs-provider-name>
+  vcsPolicy:
+    required: true
+    mode: read-write
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: agentruns/torghut-actuation-<yyyymmdd-hhmm>
+    gitopsPath: argocd/applications/torghut
+    torghutNamespace: torghut
+    change: <pause-trading|restart-ws|suspend-ta|resume-ta>
+    reason: <short-human-justification>
+    confirm: ACTUATE_TORGHUT
+```
+
+## ImplementationSpec contract (actuation runner)
+The ImplementationSpec should **require** confirmation parameters so the run cannot proceed without explicit intent.
+
+```yaml
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: torghut-actuation-runner-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - repository
+      - base
+      - head
+      - gitopsPath
+      - torghutNamespace
+      - change
+      - reason
+      - confirm
+  text: |
+    Objective: Perform a single Torghut actuation change via GitOps PR.
+
+    Guardrails:
+    - Only modify files under ${gitopsPath}.
+    - Require confirm == ACTUATE_TORGHUT.
+    - Do not change TRADING_LIVE_ENABLED or TRADING_MODE.
+    - Do not expose secrets.
+
+    Steps:
+    1) Validate change in {pause-trading|restart-ws|suspend-ta|resume-ta}.
+    2) Apply the exact patch shape defined in docs/torghut/design-system/v1/operations-actuation-runner.md.
+    3) Open PR against ${repository} with base ${base} and head ${head}.
+    4) Output PR link and rollback instructions.
+```
+
+## Rollback guidance
+- Prefer `git revert` of the actuation PR for an auditable rollback.
+- For `pause-trading`, set `TRADING_ENABLED` back to `"true"` via a new PR if the incident is resolved.
+- For `suspend-ta`, set `spec.job.state` back to `running` and bump `restartNonce` if needed.
+
+## References
+- `docs/torghut/design-system/v1/agentruns-handoff.md`
+- `docs/torghut/design-system/v1/argo-gitops-and-overlays.md`
+- `docs/torghut/design-system/v1/torghut-autonomous-trading-system.md`

--- a/docs/torghut/design-system/v1/torghut-autonomous-trading-system.md
+++ b/docs/torghut/design-system/v1/torghut-autonomous-trading-system.md
@@ -183,6 +183,9 @@ Controls (from `services/torghut/app/config.py`):
 ## Operations as design (automation-ready procedures)
 These are part of the production design because they define how the system is safely operated under failure.
 
+Gated actuation runner: use the GitOps-first, confirmation-gated procedures in
+`docs/torghut/design-system/v1/operations-actuation-runner.md` for any state-changing automation.
+
 ### Procedure: Torghut health report (read-only)
 Goal: produce a single report with forwarder, TA, ClickHouse, and trading-service status.
 


### PR DESCRIPTION
## Summary
- add a gated GitOps actuation runner doc with explicit procedures, patch shapes, and rollback steps
- tighten AgentRun actuation templates to require confirmation/justification parameters and link to the runner
- update Torghut design-system docs and gap analysis to reflect the actuation runner status

## Related Issues
None

## Testing
- `bunx biome format --write docs/torghut/design-system/v1 docs/torghut/design-system/README.md` (fails: paths ignored by Biome config)
- `bun run format` (fails: `.codex-implementation-*.json` parse errors)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
