### PR TITLE
feat(torghut): add robustness reporting checks

### DIFF
--- a/services/torghut/scripts/run_walkforward.py
+++ b/services/torghut/scripts/run_walkforward.py
@@ -112,6 +112,13 @@ def main() -> int:
     parser.add_argument("--strategy-config", type=Path, help="Optional strategy config (YAML/JSON).")
     parser.add_argument("--strategy-timeframe", type=str, default="1Min", help="Timeframe for default strategy.")
     parser.add_argument("--gate-policy", type=Path, help="Optional gate policy JSON file.")
+    parser.add_argument("--variants-tested", type=int, help="Total variants compared in this run.")
+    parser.add_argument(
+        "--variant-warning-threshold",
+        type=int,
+        default=25,
+        help="Warn when variants tested exceeds this threshold (default: 25).",
+    )
     parser.add_argument(
         "--promotion-target",
         choices=("shadow", "paper", "live"),
@@ -154,6 +161,8 @@ def main() -> int:
             git_sha=_resolve_git_sha(),
             run_id=args.run_id,
             strategy_config_path=str(args.strategy_config) if args.strategy_config else None,
+            variants_tested=args.variants_tested,
+            variant_warning_threshold=args.variant_warning_threshold,
         )
         gate_policy = EvaluationGatePolicy.from_path(args.gate_policy) if args.gate_policy else None
         report = generate_evaluation_report(


### PR DESCRIPTION
## Summary
- add fold-stability robustness metrics to evaluation reports
- track multiple-testing counts with warning thresholds in reports
- extend walk-forward CLI and add deterministic fixture test coverage

## Related Issues
None

## Testing
- cd services/torghut && .venv/bin/python -m pytest tests/test_evaluation_report.py

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
