### PR TITLE
chore(torghut): deploy latest main

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -18,14 +18,14 @@ spec:
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
-        client.knative.dev/updateTimestamp: 2026-02-10T16:38:50.112Z
+        client.knative.dev/updateTimestamp: 2026-02-10T17:00:24.101Z
     spec:
       containerConcurrency: 0
       timeoutSeconds: 60
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2668c766e049140880a138f922d2d2a1022e3f0781d454305035aabb1c6e48af
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0d9bf959ff06655db16be18262a2de45a650ad5e87309396e72eaf4d0232daa5
           ports:
             - name: http1
               containerPort: 8181
@@ -128,9 +128,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.529.1
+              value: v0.529.2
             - name: TORGHUT_COMMIT
-              value: 312d4efc4375aa51f0b979d1f732619abba3bc59
+              value: 9e421ad9491bfce13eecbb4a68e8bad6ccfab2d8
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
- Build/push updated `torghut` image and bump the pinned digest in GitOps.
- Update `TORGHUT_VERSION`/`TORGHUT_COMMIT` to match the deployed image.

## Related Issues
None

## Testing
- `uv run python -m unittest -q tests.test_portfolio_sizing` (on PR #2997 branch)
- `uv run python -m unittest -q tests.test_robustness_report tests.test_evaluation_report` (on PR #2998 branch)

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
