### PR TITLE
feat(torghut): add regime labels to evaluations

### DIFF
--- a/services/torghut/app/trading/regime.py
+++ b/services/torghut/app/trading/regime.py
@@ -1,0 +1,167 @@
+"""Deterministic regime classifier for evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable, Literal, Optional
+
+from .evaluation import WalkForwardDecision
+
+
+VolatilityBucket = Literal["low", "mid", "high", "unknown"]
+TrendBucket = Literal["up", "down", "flat", "unknown"]
+LiquidityFlag = Literal["liquid", "illiquid", "unknown"]
+
+
+@dataclass(frozen=True)
+class RegimeLabel:
+    volatility_bucket: VolatilityBucket
+    trend_bucket: TrendBucket
+    liquidity_flag: LiquidityFlag
+
+    def label(self) -> str:
+        return (
+            f"vol={self.volatility_bucket}|trend={self.trend_bucket}"
+            f"|liq={self.liquidity_flag}"
+        )
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "label": self.label(),
+            "volatility_bucket": self.volatility_bucket,
+            "trend_bucket": self.trend_bucket,
+            "liquidity_flag": self.liquidity_flag,
+        }
+
+
+def classify_regime(decisions: Iterable[WalkForwardDecision]) -> RegimeLabel:
+    ordered = sorted(
+        decisions,
+        key=lambda item: (
+            item.decision.event_ts,
+            item.decision.symbol,
+            item.decision.strategy_id,
+        ),
+    )
+    prices: list[Decimal] = []
+    volatilities: list[Decimal] = []
+    macd_diffs: list[Decimal] = []
+    missing_price = 0
+
+    for item in ordered:
+        features = item.features
+        if features.price is None:
+            missing_price += 1
+        else:
+            prices.append(features.price)
+        if features.volatility is not None:
+            volatilities.append(features.volatility)
+        if features.macd is not None and features.macd_signal is not None:
+            macd_diffs.append(features.macd - features.macd_signal)
+
+    volatility_bucket = _classify_volatility(volatilities, prices)
+    trend_bucket = _classify_trend(prices, macd_diffs)
+    liquidity_flag = _classify_liquidity(prices, missing_price, len(ordered))
+    return RegimeLabel(
+        volatility_bucket=volatility_bucket,
+        trend_bucket=trend_bucket,
+        liquidity_flag=liquidity_flag,
+    )
+
+
+def _classify_volatility(
+    volatilities: list[Decimal],
+    prices: list[Decimal],
+) -> VolatilityBucket:
+    if volatilities:
+        avg_vol = _decimal_mean(volatilities)
+        if avg_vol < Decimal("0.01"):
+            return "low"
+        if avg_vol < Decimal("0.03"):
+            return "mid"
+        return "high"
+
+    price_vol = _average_abs_pct_change(prices)
+    if price_vol is None:
+        return "unknown"
+    if price_vol < Decimal("0.002"):
+        return "low"
+    if price_vol < Decimal("0.01"):
+        return "mid"
+    return "high"
+
+
+def _classify_trend(
+    prices: list[Decimal],
+    macd_diffs: list[Decimal],
+) -> TrendBucket:
+    if len(prices) >= 2:
+        start = prices[0]
+        end = prices[-1]
+        if start == 0:
+            return "unknown"
+        change = (end - start) / start
+        if change >= Decimal("0.002"):
+            return "up"
+        if change <= Decimal("-0.002"):
+            return "down"
+        return "flat"
+
+    if macd_diffs:
+        avg_macd = _decimal_mean(macd_diffs)
+        if avg_macd >= Decimal("0.05"):
+            return "up"
+        if avg_macd <= Decimal("-0.05"):
+            return "down"
+        return "flat"
+
+    return "unknown"
+
+
+def _classify_liquidity(
+    prices: list[Decimal],
+    missing_price: int,
+    total: int,
+) -> LiquidityFlag:
+    if total == 0:
+        return "unknown"
+    missing_ratio = Decimal(str(missing_price)) / Decimal(str(total))
+    if missing_ratio > Decimal("0.5"):
+        return "illiquid"
+
+    price_vol = _average_abs_pct_change(prices)
+    if price_vol is None:
+        return "unknown"
+    if price_vol > Decimal("0.05"):
+        return "illiquid"
+    return "liquid"
+
+
+def _average_abs_pct_change(prices: list[Decimal]) -> Optional[Decimal]:
+    if len(prices) < 2:
+        return None
+    changes: list[Decimal] = []
+    for prev, current in zip(prices, prices[1:]):
+        if prev == 0:
+            continue
+        changes.append(abs((current - prev) / prev))
+    if not changes:
+        return None
+    return _decimal_mean(changes)
+
+
+def _decimal_mean(values: list[Decimal]) -> Decimal:
+    if not values:
+        return Decimal("0")
+    total = sum(values, Decimal("0"))
+    return total / Decimal(str(len(values)))
+
+
+__all__ = [
+    "LiquidityFlag",
+    "RegimeLabel",
+    "TrendBucket",
+    "VolatilityBucket",
+    "classify_regime",
+]

--- a/services/torghut/tests/test_regime_classifier.py
+++ b/services/torghut/tests/test_regime_classifier.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import TestCase
+
+from app.models import Strategy
+from app.trading.decisions import DecisionEngine
+from app.trading.evaluation import FixtureSignalSource, generate_walk_forward_folds, run_walk_forward
+from app.trading.regime import classify_regime
+
+
+class TestRegimeClassifier(TestCase):
+    def test_regime_classifier_is_deterministic(self) -> None:
+        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
+        source = FixtureSignalSource.from_path(fixture_path)
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 1, 0, 4, tzinfo=timezone.utc)
+        folds = generate_walk_forward_folds(
+            start,
+            end,
+            train_window=timedelta(minutes=1),
+            test_window=timedelta(minutes=2),
+            step=timedelta(minutes=2),
+        )
+
+        strategy = Strategy(
+            name='wf-regime',
+            description=None,
+            enabled=True,
+            base_timeframe='1Min',
+            universe_type='static',
+            universe_symbols=['AAPL'],
+            max_position_pct_equity=None,
+            max_notional_per_trade=None,
+        )
+
+        results = run_walk_forward(
+            folds,
+            strategies=[strategy],
+            signal_source=source,
+            decision_engine=DecisionEngine(),
+        )
+        decisions = results.folds[0].decisions
+
+        label_one = classify_regime(decisions)
+        label_two = classify_regime(decisions)
+
+        self.assertEqual(label_one, label_two)
+        self.assertEqual(label_one.label(), 'vol=high|trend=up|liq=liquid')

--- a/services/torghut/tests/test_robustness_report.py
+++ b/services/torghut/tests/test_robustness_report.py
@@ -62,6 +62,7 @@ class TestRobustnessReport(TestCase):
         self.assertEqual(report.robustness.best_fold_net_pnl, Decimal('1'))
         self.assertEqual(report.robustness.negative_fold_count, 0)
         self.assertEqual(report.robustness.folds[0].net_pnl, Decimal('1'))
+        self.assertEqual(report.robustness.folds[0].regime.label(), 'vol=high|trend=up|liq=liquid')
 
         self.assertTrue(report.multiple_testing.warning_triggered)
         self.assertIn('variant_count_exceeds_threshold', report.multiple_testing.warnings)


### PR DESCRIPTION
## Summary
- add deterministic regime classifier for walk-forward evaluations
- include regime labels in fold robustness metrics payloads
- add unit coverage for regime stability and report expectations

## Related Issues
None

## Testing
- cd services/torghut && uv run python -m unittest tests/test_regime_classifier.py tests/test_robustness_report.py

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
