### PR TITLE
fix(dorvud-ws): refine readiness diagnostics

### DIFF
--- a/docs/torghut/design-system/v1/observability-metrics-logs-traces.md
+++ b/docs/torghut/design-system/v1/observability-metrics-logs-traces.md
@@ -41,6 +41,7 @@ flowchart LR
 - `ws_connect_success_total`, `ws_connect_error_total` (by error_class)
 - `kafka_produce_success_total`, `kafka_produce_error_total` (by topic)
 - `torghut_ws_readyz_error_class` (gauge by error_class; 1 for the current readiness failure class, else 0)
+- `torghut_ws_readyz_gate_status` (gauge by gate; 1 when gate is healthy, else 0)
 - `subscriptions_active` (gauge)
 - `readyz_status` (0/1), `healthz_status` (0/1)
 

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ReadinessDiagnostics.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ReadinessDiagnostics.kt
@@ -64,13 +64,9 @@ internal object ReadinessClassifier {
   ): ReadinessErrorClass? {
     if (ready) return null
     return when {
-      !gates.alpacaWs -> alpacaErrorClass ?: fallbackErrorClass ?: ReadinessErrorClass.Unknown
-      !gates.kafka -> kafkaErrorClass ?: fallbackErrorClass ?: ReadinessErrorClass.Unknown
-      !gates.tradeUpdates ->
-        tradeUpdatesErrorClass
-          ?: alpacaErrorClass
-          ?: fallbackErrorClass
-          ?: ReadinessErrorClass.Unknown
+      !gates.alpacaWs -> alpacaErrorClass ?: ReadinessErrorClass.Unknown
+      !gates.kafka -> kafkaErrorClass ?: ReadinessErrorClass.Unknown
+      !gates.tradeUpdates -> tradeUpdatesErrorClass ?: ReadinessErrorClass.Unknown
       else -> fallbackErrorClass ?: ReadinessErrorClass.Unknown
     }
   }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ReadinessClassifierTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ReadinessClassifierTest.kt
@@ -104,6 +104,27 @@ class ReadinessClassifierTest {
   }
 
   @Test
+  fun `readiness error does not fall back to other classes when alpaca gate is false`() {
+    val gates =
+      ReadinessGates(
+        alpacaWs = false,
+        kafka = true,
+        tradeUpdates = true,
+      )
+    assertEquals(
+      ReadinessErrorClass.Unknown,
+      ReadinessClassifier.readinessErrorClassForGates(
+        ready = false,
+        gates = gates,
+        alpacaErrorClass = null,
+        kafkaErrorClass = ReadinessErrorClass.KafkaAuth,
+        tradeUpdatesErrorClass = null,
+        fallbackErrorClass = ReadinessErrorClass.KafkaAuth,
+      ),
+    )
+  }
+
+  @Test
   fun `readiness error uses kafka class when kafka gate is false`() {
     val gates =
       ReadinessGates(


### PR DESCRIPTION
## Summary

- Refine readiness error-class selection to avoid misleading cross-gate fallbacks.
- Emit readiness gate status metrics for alpaca/kafka/trade_updates.
- Add classifier coverage and document the new readiness gate metric.

## Related Issues

None.

## Testing

- ./gradlew :websockets:test

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
