### PR TITLE
build(torghut-ws): add docker build-and-push workflow

### DIFF
--- a/.github/workflows/torghut-ws-build-push.yaml
+++ b/.github/workflows/torghut-ws-build-push.yaml
@@ -1,0 +1,48 @@
+name: Torghut WS Docker Build and Push
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ['dorvud-ci']
+    types:
+      - completed
+
+jobs:
+  build-and-push:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    runs-on: arc-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: registry.ide-newton.ts.net/lab/torghut-ws
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/dorvud
+          file: services/dorvud/websockets/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ws:latest
+          cache-to: type=inline
+


### PR DESCRIPTION
## Summary
- Add a dedicated GitHub Actions workflow to build and push the `lab/torghut-ws` image.
- Trigger on successful `dorvud-ci` runs (and allow manual dispatch).
- Publish `branch`, `sha-*`, and `latest` tags for GitOps digest pinning.

## Related Issues

None

## Testing
- N/A (CI-only change; validated by workflow config parity with existing `torghut-build-push.yaml`)

## Breaking Changes

None
