### PR TITLE
chore(torghut): deploy latest main

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a60545cb900271d22e0269f27c55579ec0d64e199d91373d072907802da3c482
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5415e6395688b3250636e7e0331925b7fd8b8ef529abc755d8d6d5e133d147d5
           ports:
             - name: http1
               containerPort: 8181
@@ -128,9 +128,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.533.0-4-g71f4419d
+              value: v0.536.1-1-g512274e1
             - name: TORGHUT_COMMIT
-              value: 71f4419d3c1d99ab20b3b14448d5cc11cddbdec4
+              value: 512274e18a8256ba19648dcf46a39254450a76ba
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
- Update `torghut` Knative service image to digest built from merged PR commit `71f4419`.
- Update `torghut-ws` deployment image to digest built from `main` commit `33e27f0`.
- Refresh runtime version/commit envs for traceability (`TORGHUT_*`, `TORGHUT_WS_*`).

## Related Issues

None

## Testing
- Resolved image digests directly from registry API for immutable pinning.
- Triggered and verified GitHub Actions run `21890692552` (`torghut-ws-build-push.yaml`) completed successfully.

## Breaking Changes

None
