### PR TITLE
feat(torghut): add llm evaluation metrics

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -325,6 +325,91 @@ data:
               description: |
                 The active Knative private revision for torghut is being scraped but up=0 for 5 minutes.
               runbook_url: docs/torghut/design-system/v1/operations-knative-revision-failures.md
+      - name: torghut-llm.rules
+        rules:
+          - alert: TorghutLLMErrorRateHigh
+            expr: |
+              sum(
+                rate(
+                  torghut_llm_review_total{
+                    namespace="torghut",
+                    service="torghut",
+                    verdict="error"
+                  }[10m]
+                )
+              )
+              /
+              clamp_min(
+                sum(
+                  rate(
+                    torghut_llm_review_total{
+                      namespace="torghut",
+                      service="torghut"
+                    }[10m]
+                  )
+                ),
+                1
+              ) > 0.05
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM error rate is elevated
+              description: LLM error verdicts exceed 5% of reviews over the last 10 minutes.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-evaluation-and-benchmarks.md
+          - alert: TorghutLLMTokensSpike
+            expr: |
+              sum(
+                rate(
+                  torghut_llm_tokens_total{
+                    namespace="torghut",
+                    service="torghut"
+                  }[5m]
+                )
+              )
+              > 2
+              * sum(
+                rate(
+                  torghut_llm_tokens_total{
+                    namespace="torghut",
+                    service="torghut"
+                  }[1h]
+                )
+              )
+              and sum(
+                rate(
+                  torghut_llm_tokens_total{
+                    namespace="torghut",
+                    service="torghut"
+                  }[1h]
+                )
+              ) > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM token usage spiking
+              description: LLM token usage is >2x the 1h rate for 10 minutes.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-evaluation-and-benchmarks.md
+          - alert: TorghutLLMTelemetryMissing
+            expr: |
+              absent(
+                sum(
+                  rate(
+                    torghut_llm_review_total{
+                      namespace="torghut",
+                      service="torghut"
+                    }[30m]
+                  )
+                )
+              ) == 1
+            for: 30m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM telemetry missing
+              description: No LLM review metrics have been scraped for 30 minutes.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-evaluation-and-benchmarks.md
       - name: torghut-freshness.rules
         rules:
           - alert: TorghutSignalsStaleDuringMarketHours

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -329,87 +329,245 @@ data:
         rules:
           - alert: TorghutLLMErrorRateHigh
             expr: |
-              sum(
-                rate(
-                  torghut_llm_review_total{
-                    namespace="torghut",
-                    service="torghut",
-                    verdict="error"
-                  }[10m]
-                )
-              )
-              /
-              clamp_min(
-                sum(
-                  rate(
-                    torghut_llm_review_total{
-                      namespace="torghut",
-                      service="torghut"
-                    }[10m]
-                  )
-                ),
-                1
-              ) > 0.05
+              (
+                rate(torghut_llm_errors_total{namespace="torghut", service="torghut"}[10m])
+                /
+                clamp_min(rate(torghut_llm_requests_total{namespace="torghut", service="torghut"}[10m]), 1)
+              ) > 0.1
             for: 10m
             labels:
               severity: warning
             annotations:
               summary: Torghut LLM error rate is elevated
-              description: LLM error verdicts exceed 5% of reviews over the last 10 minutes.
-              runbook_url: docs/torghut/design-system/v1/ai-layer-evaluation-and-benchmarks.md
+              description: LLM review errors exceed 10% of requests for 10 minutes.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-circuit-breakers-and-fallbacks.md
           - alert: TorghutLLMTokensSpike
             expr: |
-              sum(
-                rate(
-                  torghut_llm_tokens_total{
-                    namespace="torghut",
-                    service="torghut"
-                  }[5m]
+              (
+                rate(torghut_llm_tokens_total{namespace="torghut", service="torghut"}[5m])
+                /
+                clamp_min(
+                  avg_over_time(rate(torghut_llm_tokens_total{namespace="torghut", service="torghut"}[5m])[1h]),
+                  1
                 )
-              )
-              > 2
-              * sum(
-                rate(
-                  torghut_llm_tokens_total{
-                    namespace="torghut",
-                    service="torghut"
-                  }[1h]
-                )
-              )
-              and sum(
-                rate(
-                  torghut_llm_tokens_total{
-                    namespace="torghut",
-                    service="torghut"
-                  }[1h]
-                )
+              ) > 3
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM token usage spiked
+              description: LLM token rate is >3x the trailing 1h baseline for 10 minutes.
+              runbook_url: docs/torghut/design-system/v1/cost-model-and-budgets.md
+          - alert: TorghutLLMTelemetryMissing
+            expr: |
+              absent(torghut_llm_requests_total{namespace="torghut", service="torghut"}) == 1
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM telemetry missing
+              description: torghut LLM review metrics are not being scraped for 15 minutes.
+              runbook_url: docs/torghut/design-system/v1/observability-metrics-logs-traces.md
+      - name: torghut-mrm.rules
+        rules:
+          - alert: TorghutLLMGuardrailsExporterDown
+            expr: |
+              max(
+                up{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }
+              ) == 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut LLM guardrails exporter is down
+              description: LLM guardrails metrics are not being scraped (up=0) for 5 minutes.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+          - alert: TorghutLLMGuardrailsScrapeFailing
+            expr: |
+              torghut_llm_guardrails_last_scrape_success{
+                job="torghut",
+                namespace="torghut",
+                service="torghut-llm-guardrails-exporter"
+              } == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM guardrails scrape failing
+              description: |
+                The LLM guardrails exporter cannot reach /trading/metrics or /trading/status.
+                Review torghut service health and network policies.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+          - alert: TorghutLLMGuardrailsBlocking
+            expr: |
+              increase(
+                torghut_llm_guardrail_block_total{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }[10m]
               ) > 0
             for: 10m
             labels:
               severity: warning
             annotations:
-              summary: Torghut LLM token usage spiking
-              description: LLM token usage is >2x the 1h rate for 10 minutes.
-              runbook_url: docs/torghut/design-system/v1/ai-layer-evaluation-and-benchmarks.md
-          - alert: TorghutLLMTelemetryMissing
+              summary: Torghut LLM guardrails are blocking reviews
+              description: |
+                Model risk management guardrails are blocking LLM review requests.
+                Check the configured evaluation evidence, inventory, and prompt version.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+          - alert: TorghutLLMParseErrorRateHigh
             expr: |
-              absent(
-                sum(
-                  rate(
-                    torghut_llm_review_total{
-                      namespace="torghut",
-                      service="torghut"
-                    }[30m]
-                  )
+              (
+                rate(
+                  torghut_llm_parse_error_total{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut-llm-guardrails-exporter"
+                  }[15m]
                 )
-              ) == 1
-            for: 30m
+                /
+                rate(
+                  torghut_llm_requests_total{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut-llm-guardrails-exporter"
+                  }[15m]
+                )
+              ) > 0.05
+              and
+              rate(
+                torghut_llm_requests_total{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }[15m]
+              ) > 0
+            for: 10m
             labels:
               severity: warning
             annotations:
-              summary: Torghut LLM telemetry missing
-              description: No LLM review metrics have been scraped for 30 minutes.
-              runbook_url: docs/torghut/design-system/v1/ai-layer-evaluation-and-benchmarks.md
+              summary: Torghut LLM parse error rate elevated
+              description: |
+                LLM responses are failing JSON parsing over the last 15 minutes.
+                This is a model risk incident; consider disabling LLM or tightening prompts.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+          - alert: TorghutLLMVetoRateSpike
+            expr: |
+              (
+                rate(
+                  torghut_llm_veto_total{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut-llm-guardrails-exporter"
+                  }[30m]
+                )
+                /
+                rate(
+                  torghut_llm_requests_total{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut-llm-guardrails-exporter"
+                  }[30m]
+                )
+              )
+              > (
+                max(
+                  torghut_llm_veto_rate_baseline{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut-llm-guardrails-exporter"
+                  }
+                ) * 1.5
+              )
+              and
+              rate(
+                torghut_llm_requests_total{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }[30m]
+              ) > 0
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM veto rate spiked versus baseline
+              description: |
+                LLM veto rate is 1.5x higher than baseline. Investigate drift, prompt changes,
+                or upstream signal integrity. Keep AI in shadow mode until resolved.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+          - alert: TorghutLLMCircuitOpened
+            expr: |
+              increase(
+                torghut_llm_circuit_open_total{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }[10m]
+              ) > 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM circuit breaker opened recently
+              description: Circuit breaker events indicate repeated LLM failures or timeouts in the last 10 minutes.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+          - alert: TorghutLLMTokenBudgetExceeded
+            expr: |
+              (
+                increase(
+                  torghut_llm_tokens_prompt_total{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut-llm-guardrails-exporter"
+                  }[30m]
+                )
+                +
+                increase(
+                  torghut_llm_tokens_completion_total{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut-llm-guardrails-exporter"
+                  }[30m]
+                )
+              )
+              /
+              increase(
+                torghut_llm_requests_total{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }[30m]
+              )
+              > max(
+                torghut_llm_tokens_per_request_budget{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }
+              )
+              and
+              increase(
+                torghut_llm_requests_total{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }[30m]
+              ) > 0
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM token budget exceeded
+              description: |
+                Average LLM tokens per request are above the configured budget.
+                Consider shortening prompts or lowering max tokens.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
       - name: torghut-freshness.rules
         rules:
           - alert: TorghutSignalsStaleDuringMarketHours

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0d9bf959ff06655db16be18262a2de45a650ad5e87309396e72eaf4d0232daa5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5415e6395688b3250636e7e0331925b7fd8b8ef529abc755d8d6d5e133d147d5
           ports:
             - name: http1
               containerPort: 8181
@@ -106,12 +106,18 @@ spec:
               value: http://jangar.jangar.svc.cluster.local
             - name: LLM_PROVIDER
               value: jangar
+            - name: LLM_MODEL
+              value: gpt-5.3-codex
+            - name: LLM_ALLOWED_MODELS
+              value: gpt-5.3-codex
             - name: LLM_ENABLED
               value: "true"
             - name: LLM_SHADOW_MODE
               value: "true"
             - name: LLM_FAIL_MODE
               value: pass_through
+            - name: LLM_ADJUSTMENT_APPROVED
+              value: "false"
             - name: LLM_SELF_HOSTED_BASE_URL
               value: http://192.168.1.190:11434/v1
             - name: LLM_SELF_HOSTED_MODEL
@@ -128,9 +134,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.529.2
+              value: v0.536.1-1-g512274e1
             - name: TORGHUT_COMMIT
-              value: 9e421ad9491bfce13eecbb4a68e8bad6ccfab2d8
+              value: 512274e18a8256ba19648dcf46a39254450a76ba
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
   - alloy-rbac.yaml
   - alloy-configmap.yaml
   - alloy-deployment.yaml
+  - llm-guardrails-exporter-configmap.yaml
+  - llm-guardrails-exporter.yaml
   - clickhouse
   - ws
   - ta

--- a/argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml
+++ b/argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: torghut-llm-guardrails-exporter
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut-llm-guardrails-exporter
+    app.kubernetes.io/part-of: torghut
+data:
+  exporter.py: |
+    import json
+    import os
+    import threading
+    import time
+    import urllib.request
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    TORGHUT_BASE_URL = os.environ.get("TORGHUT_BASE_URL", "http://torghut.torghut.svc.cluster.local")
+    METRICS_PATH = os.environ.get("TORGHUT_METRICS_PATH", "/trading/metrics")
+    STATUS_PATH = os.environ.get("TORGHUT_STATUS_PATH", "/trading/status")
+    EXPORTER_PORT = int(os.environ.get("EXPORTER_PORT", "9110"))
+    SCRAPE_INTERVAL_SECONDS = int(os.environ.get("SCRAPE_INTERVAL_SECONDS", "30"))
+    LLM_VETO_RATE_BASELINE = float(os.environ.get("LLM_VETO_RATE_BASELINE", "0.4"))
+    LLM_TOKENS_PER_REQUEST_BUDGET = float(os.environ.get("LLM_TOKENS_PER_REQUEST_BUDGET", "800"))
+
+
+    def fetch_json(path: str) -> dict:
+        url = f"{TORGHUT_BASE_URL.rstrip('/')}{path}"
+        req = urllib.request.Request(url, headers={"Accept": "application/json"}, method="GET")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8").strip()
+        if not body:
+            return {}
+        return json.loads(body)
+
+
+    class State:
+        def __init__(self):
+            self.lock = threading.Lock()
+            self.metrics: dict[str, object] = {}
+            self.llm: dict[str, object] = {}
+            self.last_scrape_success = 0.0
+            self.last_scrape_ts_seconds = 0.0
+            self.last_error = ""
+
+        def snapshot(self) -> dict:
+            with self.lock:
+                return {
+                    "metrics": dict(self.metrics),
+                    "llm": dict(self.llm),
+                    "last_scrape_success": self.last_scrape_success,
+                    "last_scrape_ts_seconds": self.last_scrape_ts_seconds,
+                    "last_error": self.last_error,
+                }
+
+
+    state = State()
+
+
+    def float_or_nan(value: object) -> float:
+        try:
+            return float(value)
+        except Exception:
+            return float("nan")
+
+
+    def scrape_once():
+        now = time.time()
+        try:
+            payload = fetch_json(METRICS_PATH)
+            metrics = payload.get("metrics", {})
+            if not isinstance(metrics, dict):
+                raise RuntimeError("metrics payload missing or invalid")
+            status_payload = fetch_json(STATUS_PATH)
+            llm = status_payload.get("llm", {})
+            if not isinstance(llm, dict):
+                llm = {}
+
+            with state.lock:
+                state.metrics = metrics
+                state.llm = llm
+                state.last_scrape_success = 1.0
+                state.last_scrape_ts_seconds = now
+                state.last_error = ""
+        except Exception as exc:
+            with state.lock:
+                state.last_scrape_success = 0.0
+                state.last_scrape_ts_seconds = now
+                state.last_error = str(exc)
+
+
+    def scrape_loop():
+        while True:
+            scrape_once()
+            time.sleep(SCRAPE_INTERVAL_SECONDS)
+
+
+    def render_metrics(snapshot: dict) -> str:
+        metrics = snapshot.get("metrics", {})
+        llm = snapshot.get("llm", {})
+        lines = []
+
+        lines.append("# HELP torghut_llm_guardrails_last_scrape_success 1 if the last scrape succeeded.")
+        lines.append("# TYPE torghut_llm_guardrails_last_scrape_success gauge")
+        lines.append(f"torghut_llm_guardrails_last_scrape_success {snapshot.get('last_scrape_success', 0.0)}")
+
+        lines.append("# HELP torghut_llm_guardrails_last_scrape_ts_seconds Unix timestamp of the last scrape attempt.")
+        lines.append("# TYPE torghut_llm_guardrails_last_scrape_ts_seconds gauge")
+        lines.append(f"torghut_llm_guardrails_last_scrape_ts_seconds {snapshot.get('last_scrape_ts_seconds', 0.0)}")
+
+        lines.append("# HELP torghut_llm_enabled 1 if LLM reviews are enabled.")
+        lines.append("# TYPE torghut_llm_enabled gauge")
+        lines.append(f"torghut_llm_enabled {1.0 if llm.get('enabled') else 0.0}")
+
+        lines.append("# HELP torghut_llm_shadow_mode 1 if LLM is running in shadow mode.")
+        lines.append("# TYPE torghut_llm_shadow_mode gauge")
+        lines.append(f"torghut_llm_shadow_mode {1.0 if llm.get('shadow_mode') else 0.0}")
+
+        lines.append("# HELP torghut_llm_veto_rate_baseline Baseline veto rate configured for guardrails alerts.")
+        lines.append("# TYPE torghut_llm_veto_rate_baseline gauge")
+        lines.append(f"torghut_llm_veto_rate_baseline {LLM_VETO_RATE_BASELINE}")
+
+        lines.append("# HELP torghut_llm_tokens_per_request_budget Budgeted total tokens per request for guardrails alerts.")
+        lines.append("# TYPE torghut_llm_tokens_per_request_budget gauge")
+        lines.append(f"torghut_llm_tokens_per_request_budget {LLM_TOKENS_PER_REQUEST_BUDGET}")
+
+        counters = [
+            "llm_requests_total",
+            "llm_approve_total",
+            "llm_veto_total",
+            "llm_adjust_total",
+            "llm_error_total",
+            "llm_parse_error_total",
+            "llm_validation_error_total",
+            "llm_circuit_open_total",
+            "llm_shadow_total",
+            "llm_guardrail_block_total",
+            "llm_guardrail_shadow_total",
+            "llm_tokens_prompt_total",
+            "llm_tokens_completion_total",
+        ]
+
+        for key in counters:
+            metric_name = f"torghut_{key}"
+            lines.append(f"# HELP {metric_name} Torghut trading LLM metric {key}.")
+            lines.append(f"# TYPE {metric_name} counter")
+            value = float_or_nan(metrics.get(key, 0))
+            lines.append(f"{metric_name} {value}")
+
+        return "\n".join(lines) + "\n"
+
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path not in ("/metrics", "/"):
+                self.send_response(404)
+                self.end_headers()
+                return
+            snapshot = state.snapshot()
+            body = render_metrics(snapshot).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return
+
+
+    def main():
+        thread = threading.Thread(target=scrape_loop, daemon=True)
+        thread.start()
+        server = HTTPServer(("0.0.0.0", EXPORTER_PORT), Handler)
+        server.serve_forever()
+
+
+    if __name__ == "__main__":
+        main()

--- a/argocd/applications/torghut/llm-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/llm-guardrails-exporter.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: torghut-llm-guardrails-exporter
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut-llm-guardrails-exporter
+    app.kubernetes.io/part-of: torghut
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: torghut-llm-guardrails-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: torghut-llm-guardrails-exporter
+        app.kubernetes.io/part-of: torghut
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      containers:
+        - name: exporter
+          image: python:3.12-alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+            - /app/exporter.py
+          env:
+            - name: TORGHUT_BASE_URL
+              value: http://torghut.torghut.svc.cluster.local
+            - name: TORGHUT_METRICS_PATH
+              value: /trading/metrics
+            - name: TORGHUT_STATUS_PATH
+              value: /trading/status
+            - name: LLM_VETO_RATE_BASELINE
+              value: "0.4"
+            - name: LLM_TOKENS_PER_REQUEST_BUDGET
+              value: "800"
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+          ports:
+            - name: metrics
+              containerPort: 9110
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: app
+              mountPath: /app
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 2
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: app
+          configMap:
+            name: torghut-llm-guardrails-exporter
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: torghut-llm-guardrails-exporter
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut-llm-guardrails-exporter
+    app.kubernetes.io/part-of: torghut
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: torghut-llm-guardrails-exporter
+  ports:
+    - name: metrics
+      port: 9110
+      targetPort: metrics

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:67d432dfca57bc6afc22de04d5b0d5c9b971a2be9c3f37502ab68466b4d89712
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:54b60a70ca6d5e416a0a093d9b02d5767935497ba6371856021acf63835e3fef
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -51,9 +51,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: v0.529.2
+              value: v0.533.0-5-g33e27f02
             - name: TORGHUT_WS_COMMIT
-              value: 487352919557f351f01d69c85d3b9929aa5d947f
+              value: 33e27f020b18b7693fee4799d66ddd193a6346be
           ports:
             - containerPort: 8080
               name: http

--- a/docs/torghut/design-system/v1/agentruns-handoff.md
+++ b/docs/torghut/design-system/v1/agentruns-handoff.md
@@ -2,7 +2,7 @@
 
 ## Status
 - Version: `v1`
-- Last updated: **2026-02-08**
+- Last updated: **2026-02-11**
 - Source of truth (config): `argocd/applications/torghut/**`
 - Intended audience: AgentRuns implementers and oncall automation engineers
 
@@ -194,6 +194,9 @@ spec:
 Notes:
 - `ttlSecondsAfterFinished` is a top-level `AgentRun.spec` field (see `charts/agents/crds/agents.proompteng.ai_agentruns.yaml`).
 - Avoid setting `spec.parameters.prompt` unless you intend to override the ImplementationSpec text (prompt precedence is documented in `docs/agents/agentrun-creation-guide.md`).
+- For design-doc implementation runs, prefer a single workflow step `implement`; add `plan` only when a separate planning phase is required.
+- Keep `AgentRun.metadata.name` <= 63 characters to avoid controller reconciliation failures on propagated label values.
+- Do not assume AgentRun parameters are shell env vars inside the runner; verify values via generated `run.json`/`agent-runner.json` payloads.
 
 ### Progress updates (post-2026-02-08)
 - **2026-02-10:** The read-only Torghut health report procedure was exercised successfully via:

--- a/docs/torghut/design-system/v1/ai-layer-circuit-breakers-and-fallbacks.md
+++ b/docs/torghut/design-system/v1/ai-layer-circuit-breakers-and-fallbacks.md
@@ -52,6 +52,12 @@ stateDiagram-v2
 Note: Live mode is itself gated by `TRADING_LIVE_ENABLED=true`; this document assumes that is rare and carefully reviewed.
 Current deployed paper configuration (2026-02-09) sets `LLM_FAIL_MODE=pass_through` (see `argocd/applications/torghut/knative-service.yaml`).
 
+## Provider fallback chain (v1)
+- Primary provider is set by `LLM_PROVIDER`.
+- When `LLM_PROVIDER=jangar`, failures trigger the self-hosted fallback (`LLM_SELF_HOSTED_*`) before surfacing an error.
+- If all providers fail or time out, the review is treated as an error: the circuit breaker records it and the scheduler applies
+  `LLM_FAIL_MODE` (paper) or veto (live).
+
 ## Failure modes and recovery
 | Failure | Symptoms | Detection | Recovery |
 | --- | --- | --- | --- |

--- a/docs/torghut/design-system/v1/ai-layer-evaluation-and-benchmarks.md
+++ b/docs/torghut/design-system/v1/ai-layer-evaluation-and-benchmarks.md
@@ -46,6 +46,14 @@ flowchart TD
 | p95 latency | < timeout/2 | avoid backpressure |
 | circuit open events | rare | provider stability |
 
+## Promotion checklist (v1)
+Before disabling shadow mode or enabling adjustments, set and verify:
+- `LLM_EVALUATION_REPORT` (evaluation evidence reference)
+- `LLM_EFFECTIVE_CHALLENGE_ID` (independent review reference)
+- `LLM_SHADOW_COMPLETED_AT` (timestamp after shadow evaluation)
+- `LLM_ALLOWED_MODELS` includes the active `LLM_MODEL`
+- `LLM_ADJUSTMENT_APPROVED=true` (only if adjustments are allowed)
+
 ## Failure modes and recovery
 | Failure | Symptoms | Detection | Recovery |
 | --- | --- | --- | --- |
@@ -61,4 +69,3 @@ flowchart TD
 - **Decision:** New AI versions run in `LLM_SHADOW_MODE=true` before influencing executions.
 - **Rationale:** Real data reveals edge cases and drift.
 - **Consequences:** Adds time before AI can affect outcomes.
-

--- a/docs/torghut/design-system/v1/ai-layer-llm-review-and-policy.md
+++ b/docs/torghut/design-system/v1/ai-layer-llm-review-and-policy.md
@@ -66,15 +66,21 @@ Outputs are validated against a strict schema and then clamped:
 | Env var | Purpose | Safe default |
 | --- | --- | --- |
 | `LLM_ADJUSTMENT_ALLOWED` | allow AI adjustments | `false` |
+| `LLM_ADJUSTMENT_APPROVED` | explicit approval for adjustments | `false` |
 | `LLM_MIN_QTY_MULTIPLIER` | lower clamp | `0.5` |
 | `LLM_MAX_QTY_MULTIPLIER` | upper clamp | `1.25` |
 | `LLM_MIN_CONFIDENCE` | confidence gate | `0.5` |
+| `LLM_ALLOWED_MODELS` | model inventory allowlist | empty (enforced before impact) |
 
 ## Failure modes and recovery
 | Failure | Symptoms | Detection | Recovery |
 | --- | --- | --- | --- |
 | AI suggests unsafe adjustment | qty too high | policy guard clamps; audit shows clamp | treat as model risk; tighten bounds; retrain/evaluate |
 | Schema mismatch | parse errors | llm_parse_error counters | revert prompt/schema; keep AI disabled |
+
+## Guardrail notes
+- Adjustments require both `LLM_ADJUSTMENT_ALLOWED=true` and `LLM_ADJUSTMENT_APPROVED=true`.
+- When `LLM_SHADOW_MODE=false`, model inventory and evaluation evidence are enforced before allowing AI impact.
 
 ## Security considerations
 - Prompt injection defenses: no untrusted text, strict output schema.
@@ -85,4 +91,3 @@ Outputs are validated against a strict schema and then clamped:
 - **Decision:** `LLM_ADJUSTMENT_ALLOWED=false` unless explicitly enabled.
 - **Rationale:** Veto/approve provides value without letting AI change trade sizing.
 - **Consequences:** Some potential improvements are unavailable until explicitly reviewed and enabled.
-

--- a/docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+++ b/docs/torghut/design-system/v1/ai-layer-model-risk-management.md
@@ -37,6 +37,21 @@ flowchart LR
 - Audit records for each review:
   - `llm_decision_reviews` table (`services/torghut/app/models/entities.py`)
 
+## Guardrail configuration (v1)
+These env vars are enforced by the trading service before AI output can influence execution:
+
+| Env var | Purpose | Safe default |
+| --- | --- | --- |
+| `LLM_ALLOWED_MODELS` | inventory allowlist (comma-separated) | empty (inventory required to disable shadow) |
+| `LLM_EVALUATION_REPORT` | evaluation evidence reference (report URL/id) | unset |
+| `LLM_EFFECTIVE_CHALLENGE_ID` | independent review reference | unset |
+| `LLM_SHADOW_COMPLETED_AT` | timestamp when shadow evaluation completed | unset |
+| `LLM_ADJUSTMENT_APPROVED` | explicit approval for adjustments | `false` |
+
+Enforcement behavior:
+- If `LLM_SHADOW_MODE=false` and any required evidence is missing, the service forces shadow mode and disables adjustments.
+- If the prompt template for `LLM_PROMPT_VERSION` is missing, LLM review is blocked and logged as a guardrail violation.
+
 ## Monitoring and incident response
 - Track:
   - veto rate vs baseline,
@@ -44,6 +59,22 @@ flowchart LR
   - circuit breaker activations,
   - cost metrics (tokens).
 - Treat spikes as incidents if they affect trading behavior (even paper).
+
+### Guardrails instrumentation (v1)
+- LLM guardrails exporter (Prometheus):
+  - Config: `argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml`
+  - Deployment/Service: `argocd/applications/torghut/llm-guardrails-exporter.yaml`
+- Torghut also exposes `GET /metrics` for direct scrape/debug (`torghut_trading_*` counters).
+- Key metrics (exporter output):
+  - `torghut_llm_veto_total`, `torghut_llm_requests_total` (veto rate)
+  - `torghut_llm_parse_error_total` (parse error rate)
+  - `torghut_llm_circuit_open_total` (circuit breaker events)
+  - `torghut_llm_tokens_prompt_total`, `torghut_llm_tokens_completion_total` (token cost)
+  - `torghut_llm_guardrail_block_total` (guardrail blocks)
+- Baselines (tunable env vars on exporter):
+  - `LLM_VETO_RATE_BASELINE`
+  - `LLM_TOKENS_PER_REQUEST_BUDGET`
+- Alerts live in `argocd/applications/observability/graf-mimir-rules.yaml` under `torghut-mrm.rules`.
 
 ## Security considerations
 - Prompt injection and output handling are MRM concerns (see `v1/security-threat-model.md`).
@@ -54,4 +85,3 @@ flowchart LR
 - **Decision:** Prompt/model changes require documented evaluation (offline + shadow) before affecting execution.
 - **Rationale:** Prevents silent regressions.
 - **Consequences:** Slower iteration; acceptable for safety.
-

--- a/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+++ b/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
@@ -46,11 +46,29 @@ flowchart LR
    - or Flink checkpoint storage issues (MinIO/S3).
 2) Confirm whether trading should be paused:
    - If signals are stale or uncertain, disable trading (`TRADING_ENABLED=false`) via GitOps.
+   - Do not change `TRADING_MODE` defaults; keep `TRADING_LIVE_ENABLED=false`.
 3) Confirm current TA consumer group and replay intent:
    - `TA_GROUP_ID` is set in `argocd/applications/torghut/ta/configmap.yaml`.
    - Replays should use a new group id (consumer-group isolation) unless you intend to advance the steady-state offsets.
 4) Decide whether the procedure is GitOps-first or emergency-only:
    - GitOps-first should be the default. Emergency-only `kubectl patch` should be followed by GitOps reconciliation.
+5) Record the required confirmation points in your ticket/incident:
+   - `REPLAY_ID` (unique id used in group id + backups), example `2026-02-09T0315Z-INC1234`
+   - `PREV_TA_GROUP_ID` (current steady-state group id)
+   - `PREV_TA_AUTO_OFFSET_RESET` (current steady-state offset reset policy)
+   - Replay start/end window is within Kafka retention and ClickHouse TTL (see below)
+   - Confirmation that replay window is feasible (Kafka retention vs ClickHouse TTL)
+   - Explicit approval if destructive Mode 2 is required
+
+## Replay window constraints (summary)
+Replay is limited by both Kafka retention (inputs) and ClickHouse TTL (outputs):
+- **Kafka retention is the hard limit** for replay/backfill. If events have aged out, TA cannot replay them.
+- v1 ingest retention is expected to be **7–30 days**; confirm broker settings for each topic before proceeding.
+- **ClickHouse TTL limits how long replayed results persist.** If replayed data is older than the TTL, merges may delete
+  it shortly after replay (v1 defaults: `ta_microbars` 30 days, `ta_signals` 14 days).
+See:
+- `docs/torghut/design-system/v1/component-kafka-topics-and-retention.md`
+- `docs/torghut/design-system/v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md`
 
 ## Procedure A: Flink TA job FAILED due to ClickHouse disk full
 This is a known production failure mode.
@@ -99,6 +117,12 @@ Follow that runbook for:
 - non-destructive vs destructive modes,
 - and rollback/recovery if replay fails.
 
+Required replay isolation inputs (do not skip):
+- `REPLAY_ID` (unique id); set `TA_GROUP_ID: "torghut-ta-replay-<REPLAY_ID>"`.
+- `TA_AUTO_OFFSET_RESET: "earliest"` for replay/backfill.
+- Preserve `PREV_TA_GROUP_ID` for rollback.
+- Preserve `PREV_TA_AUTO_OFFSET_RESET` for rollback.
+
 ## Automation (AgentRuns)
 AgentRuns should treat these procedures as two classes of automation:
 1) Read-only: collect state (`FlinkDeployment` status, logs, ClickHouse freshness, Kafka connectivity) and produce a single
@@ -106,11 +130,14 @@ AgentRuns should treat these procedures as two classes of automation:
 2) Actuation (gated): open a PR updating `argocd/applications/torghut/ta/**` (suspend/resume, new `TA_GROUP_ID`,
    restart nonce, image rollback), then trigger an Argo sync if your environment supports it.
 
-## Rollback
+## Rollback / recovery if replay fails
 - If a replay causes regressions or excessive lag, revert GitOps changes:
   - restore the previous `TA_GROUP_ID` in `argocd/applications/torghut/ta/configmap.yaml`,
+  - restore previous `TA_AUTO_OFFSET_RESET` if it was changed,
   - restore the previous image digest in `argocd/applications/torghut/ta/flinkdeployment.yaml`,
+  - bump `spec.restartNonce` and set `spec.job.state: running`,
   - and Argo sync.
+- If destructive Mode 2 was used (topics/state deleted), restore MinIO checkpoint/savepoint backups, then restart.
 - If ClickHouse data was deleted, rollback may require restoring from backups (see `v1/disaster-recovery-and-backups.md`).
 
 ## Verification checklist

--- a/packages/scripts/src/torghut/build-image.ts
+++ b/packages/scripts/src/torghut/build-image.ts
@@ -21,8 +21,15 @@ export const buildImage = async (options: BuildImageOptions = {}) => {
   const tag = options.tag ?? process.env.TORGHUT_IMAGE_TAG ?? 'latest'
   const context = resolve(repoRoot, options.context ?? 'services/torghut')
   const dockerfile = resolve(repoRoot, options.dockerfile ?? 'services/torghut/Dockerfile')
-  const platforms = options.platforms ??
-    process.env.TORGHUT_IMAGE_PLATFORMS?.split(',').map((p) => p.trim()) ?? ['linux/arm64']
+  const platformsEnv = process.env.TORGHUT_IMAGE_PLATFORMS
+  const platforms =
+    options.platforms ??
+    (platformsEnv
+      ? platformsEnv
+          .split(',')
+          .map((p) => p.trim())
+          .filter((p) => p.length > 0 && p.toLowerCase() !== 'none')
+      : ['linux/arm64'])
 
   const version = execGit(['describe', '--tags', '--always'])
   const commit = execGit(['rev-parse', 'HEAD'])

--- a/packages/scripts/src/torghut/deploy-service.ts
+++ b/packages/scripts/src/torghut/deploy-service.ts
@@ -302,7 +302,7 @@ const buildWebsocketImage = async () => {
   )
   const platforms = process.env.TORGHUT_WS_IMAGE_PLATFORMS?.split(',')
     .map((entry) => entry.trim())
-    .filter(Boolean) ?? ['linux/arm64']
+    .filter((entry) => entry.length > 0 && entry.toLowerCase() !== 'none') ?? ['linux/arm64']
   const codexAuthPath = process.env.TORGHUT_WS_CODEX_AUTH_PATH
 
   return buildAndPushDockerImage({
@@ -327,7 +327,7 @@ const buildTechnicalAnalysisImage = async () => {
   )
   const platforms = process.env.TORGHUT_TA_IMAGE_PLATFORMS?.split(',')
     .map((entry) => entry.trim())
-    .filter(Boolean) ?? ['linux/arm64']
+    .filter((entry) => entry.length > 0 && entry.toLowerCase() !== 'none') ?? ['linux/arm64']
   const codexAuthPath = process.env.TORGHUT_TA_CODEX_AUTH_PATH
 
   return buildAndPushDockerImage({

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -168,6 +168,11 @@ class Settings(BaseSettings):
     llm_circuit_max_errors: int = Field(default=3, alias="LLM_CIRCUIT_MAX_ERRORS")
     llm_circuit_window_seconds: int = Field(default=300, alias="LLM_CIRCUIT_WINDOW_SECONDS")
     llm_circuit_cooldown_seconds: int = Field(default=600, alias="LLM_CIRCUIT_COOLDOWN_SECONDS")
+    llm_allowed_models_raw: Optional[str] = Field(default=None, alias="LLM_ALLOWED_MODELS")
+    llm_evaluation_report: Optional[str] = Field(default=None, alias="LLM_EVALUATION_REPORT")
+    llm_effective_challenge_id: Optional[str] = Field(default=None, alias="LLM_EFFECTIVE_CHALLENGE_ID")
+    llm_shadow_completed_at: Optional[str] = Field(default=None, alias="LLM_SHADOW_COMPLETED_AT")
+    llm_adjustment_approved: bool = Field(default=False, alias="LLM_ADJUSTMENT_APPROVED")
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -185,6 +190,16 @@ class Settings(BaseSettings):
             self.llm_self_hosted_base_url = self.llm_self_hosted_base_url.strip().rstrip("/")
         if "llm_provider" not in self.model_fields_set and self.jangar_base_url:
             self.llm_provider = "jangar"
+        if self.llm_allowed_models_raw:
+            self.llm_allowed_models_raw = ",".join(
+                [item.strip() for item in self.llm_allowed_models_raw.split(",") if item.strip()]
+            )
+        if self.llm_evaluation_report:
+            self.llm_evaluation_report = self.llm_evaluation_report.strip()
+        if self.llm_effective_challenge_id:
+            self.llm_effective_challenge_id = self.llm_effective_challenge_id.strip()
+        if self.llm_shadow_completed_at:
+            self.llm_shadow_completed_at = self.llm_shadow_completed_at.strip()
 
     @property
     def sqlalchemy_dsn(self) -> str:
@@ -206,6 +221,12 @@ class Settings(BaseSettings):
         if not self.trading_static_symbols_raw:
             return []
         return [symbol.strip() for symbol in self.trading_static_symbols_raw.split(",") if symbol.strip()]
+
+    @property
+    def llm_allowed_models(self) -> set[str]:
+        if not self.llm_allowed_models_raw:
+            return set()
+        return {model.strip() for model in self.llm_allowed_models_raw.split(",") if model.strip()}
 
 
 @lru_cache(maxsize=1)

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -299,7 +299,7 @@ def _build_llm_evaluation_payload(session: Session) -> dict[str, object]:
         if risk_payload is None:
             continue
         if isinstance(risk_payload, list):
-            flags = []
+            flags: list[str] = []
             for flag in cast(list[object], risk_payload):
                 flag_str = str(flag).strip()
                 if flag_str:

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import case, func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+from typing import cast
 from zoneinfo import ZoneInfo
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -298,7 +299,11 @@ def _build_llm_evaluation_payload(session: Session) -> dict[str, object]:
         if risk_payload is None:
             continue
         if isinstance(risk_payload, list):
-            flags = [str(flag).strip() for flag in risk_payload if str(flag).strip()]
+            flags = []
+            for flag in cast(list[object], risk_payload):
+                flag_str = str(flag).strip()
+                if flag_str:
+                    flags.append(flag_str)
         elif isinstance(risk_payload, str):
             flags = [risk_payload.strip()] if risk_payload.strip() else []
         else:

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4,20 +4,21 @@ import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+from zoneinfo import ZoneInfo
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from .alpaca_client import TorghutAlpacaClient
 from .config import settings
 from .db import ensure_schema, get_session, ping
-from .models import Execution, TradeDecision
+from .models import Execution, LLMDecisionReview, TradeDecision
 from .trading import TradingScheduler
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,14 @@ def trading_status() -> dict[str, object]:
         "metrics": state.metrics.__dict__,
         "llm": scheduler.llm_status(),
     }
+
+
+@app.get("/trading/llm-evaluation")
+def trading_llm_evaluation(session: Session = Depends(get_session)) -> JSONResponse:
+    """Return today's LLM review evaluation metrics (America/New_York)."""
+
+    payload = _build_llm_evaluation_payload(session)
+    return JSONResponse(content=jsonable_encoder(payload))
 
 
 @app.get("/trading/metrics")
@@ -238,6 +247,91 @@ def _check_postgres(session: Session) -> dict[str, object]:
     except SQLAlchemyError as exc:
         return {"ok": False, "detail": f"postgres error: {exc}"}
     return {"ok": True, "detail": "ok"}
+
+
+def _build_llm_evaluation_payload(session: Session) -> dict[str, object]:
+    tz = ZoneInfo("America/New_York")
+    now_utc = datetime.now(timezone.utc)
+    now_local = now_utc.astimezone(tz)
+    start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_local = start_local + timedelta(days=1)
+    start_utc = start_local.astimezone(timezone.utc)
+    end_utc = end_local.astimezone(timezone.utc)
+
+    base_filter = (TradeDecision.created_at >= start_utc) & (TradeDecision.created_at < end_utc)
+
+    totals_query = (
+        select(
+            func.count(LLMDecisionReview.id),
+            func.sum(case((LLMDecisionReview.verdict == "error", 1), else_=0)),
+            func.avg(LLMDecisionReview.confidence),
+            func.coalesce(func.sum(LLMDecisionReview.tokens_prompt), 0),
+            func.coalesce(func.sum(LLMDecisionReview.tokens_completion), 0),
+        )
+        .select_from(LLMDecisionReview)
+        .join(TradeDecision, LLMDecisionReview.trade_decision_id == TradeDecision.id)
+        .where(base_filter)
+    )
+    total_reviews, error_count, avg_confidence, tokens_prompt, tokens_completion = session.execute(
+        totals_query
+    ).one()
+
+    verdict_rows = session.execute(
+        select(LLMDecisionReview.verdict, func.count(LLMDecisionReview.id))
+        .select_from(LLMDecisionReview)
+        .join(TradeDecision, LLMDecisionReview.trade_decision_id == TradeDecision.id)
+        .where(base_filter)
+        .group_by(LLMDecisionReview.verdict)
+    ).all()
+
+    verdict_counts: dict[str, int] = {verdict: int(count) for verdict, count in verdict_rows}
+
+    risk_rows = session.execute(
+        select(LLMDecisionReview.risk_flags)
+        .select_from(LLMDecisionReview)
+        .join(TradeDecision, LLMDecisionReview.trade_decision_id == TradeDecision.id)
+        .where(base_filter)
+    ).scalars()
+
+    risk_counts: dict[str, int] = {}
+    for risk_payload in risk_rows:
+        if risk_payload is None:
+            continue
+        if isinstance(risk_payload, list):
+            flags = [str(flag).strip() for flag in risk_payload if str(flag).strip()]
+        elif isinstance(risk_payload, str):
+            flags = [risk_payload.strip()] if risk_payload.strip() else []
+        else:
+            continue
+        for flag in flags:
+            risk_counts[flag] = risk_counts.get(flag, 0) + 1
+
+    top_risk_flags = [
+        {"flag": flag, "count": count}
+        for flag, count in sorted(risk_counts.items(), key=lambda item: (-item[1], item[0]))
+    ][:5]
+
+    total_reviews = int(total_reviews or 0)
+    error_count = int(error_count or 0)
+    error_rate = (error_count / total_reviews) if total_reviews else 0.0
+    avg_confidence_value = float(avg_confidence) if avg_confidence is not None else None
+
+    return {
+        "as_of": now_local.isoformat(),
+        "timezone": str(tz),
+        "window_start": start_local.isoformat(),
+        "window_end": end_local.isoformat(),
+        "totals": {
+            "reviews": total_reviews,
+            "errors": error_count,
+            "error_rate": error_rate,
+            "avg_confidence": avg_confidence_value,
+            "tokens_prompt": int(tokens_prompt or 0),
+            "tokens_completion": int(tokens_completion or 0),
+        },
+        "verdict_counts": verdict_counts,
+        "top_risk_flags": top_risk_flags,
+    }
 
 
 def _check_clickhouse() -> dict[str, object]:

--- a/services/torghut/app/metrics.py
+++ b/services/torghut/app/metrics.py
@@ -1,0 +1,23 @@
+"""Prometheus-formatted metrics for Torghut trading counters."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def render_trading_metrics(metrics: Mapping[str, object]) -> str:
+    lines: list[str] = []
+    for key, value in metrics.items():
+        if isinstance(value, bool):
+            continue
+        if not isinstance(value, (int, float)):
+            continue
+        metric_name = f"torghut_trading_{key}"
+        help_text = f"Torghut trading metric {key.replace('_', ' ')}."
+        lines.append(f"# HELP {metric_name} {help_text}")
+        lines.append(f"# TYPE {metric_name} counter")
+        lines.append(f"{metric_name} {value}")
+    return "\n".join(lines) + "\n"
+
+
+__all__ = ["render_trading_metrics"]

--- a/services/torghut/app/trading/llm/client.py
+++ b/services/torghut/app/trading/llm/client.py
@@ -7,6 +7,7 @@ so the service does not need direct OpenAI credentials.
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass
 from typing import Any, Optional, cast
 from urllib.error import HTTPError, URLError
@@ -22,20 +23,6 @@ from ...config import settings
 class LLMClientResponse:
     content: str
     usage: Optional[dict[str, int]]
-
-def _passthrough_payload() -> str:
-    # Must satisfy `LLMReviewResponse` validation to behave like a true pass-through,
-    # meaning "do not veto or adjust due to LLM unavailability".
-    return json.dumps(
-        {
-            "verdict": "approve",
-            "confidence": 1.0,
-            "rationale": "llm_passthrough",
-            "risk_flags": ["llm_passthrough"],
-        },
-        separators=(",", ":"),
-    )
-
 
 class LLMClient:
     """Thin wrapper around the OpenAI client to keep it mockable."""
@@ -55,16 +42,15 @@ class LLMClient:
         if self._provider == "jangar":
             try:
                 return self._request_review_via_jangar(messages, temperature=temperature, max_tokens=max_tokens)
-            except Exception:
+            except Exception as primary_exc:
                 try:
                     return self._request_review_via_self_hosted(messages, temperature=temperature, max_tokens=max_tokens)
-                except Exception:
-                    # In live trading we keep fail-closed semantics: if both Jangar and the
-                    # self-hosted fallback fail, bubble up so the scheduler can veto.
-                    if settings.trading_mode == "live":
-                        raise
-                    # For paper trading: allow the strategy decision to proceed unchanged.
-                    return LLMClientResponse(content=_passthrough_payload(), usage=None)
+                except Exception as fallback_exc:
+                    raise RuntimeError(
+                        "llm_fallback_exhausted "
+                        f"primary={type(primary_exc).__name__} "
+                        f"fallback={type(fallback_exc).__name__}"
+                    ) from fallback_exc
 
         if self._client is None:
             raise RuntimeError("LLM provider configured as openai but OpenAI client was not initialized")
@@ -157,7 +143,7 @@ class LLMClient:
                 if status < 200 or status >= 300:
                     raw = response.read().decode("utf-8", errors="replace")
                     raise RuntimeError(f"jangar completion request failed ({status}): {raw}")
-                content, usage = _parse_jangar_sse(response)
+                content, usage = _parse_jangar_sse(response, timeout_seconds=self._timeout_seconds)
                 return LLMClientResponse(content=content, usage=usage)
         except HTTPError as exc:
             raw = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else str(exc)
@@ -187,17 +173,22 @@ def _coerce_usage(usage: Any) -> Optional[dict[str, int]]:
     return out or None
 
 
-def _parse_jangar_sse(stream: Any) -> tuple[str, Optional[dict[str, int]]]:
+def _parse_jangar_sse(stream: Any, timeout_seconds: Optional[float] = None) -> tuple[str, Optional[dict[str, int]]]:
     """Parse Jangar's SSE stream and return the aggregated content + usage.
 
     Jangar emits OpenAI-like `data: {json}` frames plus a terminal `data: [DONE]`.
     It may emit an `error` frame (top-level `error` key) and an optional `usage` frame.
+    When `timeout_seconds` is set, the parser enforces a total read deadline.
     """
 
     content_parts: list[str] = []
     usage: Optional[dict[str, int]] = None
 
+    deadline = time.monotonic() + timeout_seconds if timeout_seconds is not None else None
+
     while True:
+        if deadline is not None and time.monotonic() >= deadline:
+            raise TimeoutError("jangar completion timed out")
         line_bytes = stream.readline()
         if not line_bytes:
             break

--- a/services/torghut/app/trading/llm/evaluation.py
+++ b/services/torghut/app/trading/llm/evaluation.py
@@ -1,0 +1,162 @@
+"""LLM evaluation metrics derived from Postgres audit tables."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, cast
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from ...models import LLMDecisionReview, TradeDecision
+
+DEFAULT_TIMEZONE = "America/New_York"
+TOP_RISK_FLAGS_LIMIT = 5
+
+
+def build_llm_evaluation_metrics(session: Session, now: datetime | None = None) -> dict[str, object]:
+    start_local, end_local, start_utc, end_utc = _resolve_today_window(now)
+    metrics = _query_llm_metrics(session, start_utc, end_utc)
+    return {
+        "ok": True,
+        "window": {
+            "timezone": DEFAULT_TIMEZONE,
+            "start": start_local.isoformat(),
+            "end": end_local.isoformat(),
+            "start_utc": start_utc.isoformat(),
+            "end_utc": end_utc.isoformat(),
+        },
+        "metrics": metrics,
+    }
+
+
+def _resolve_today_window(now: datetime | None) -> tuple[datetime, datetime, datetime, datetime]:
+    tz = ZoneInfo(DEFAULT_TIMEZONE)
+    if now is None:
+        now_local = datetime.now(tz)
+    elif now.tzinfo is None:
+        now_local = now.replace(tzinfo=tz)
+    else:
+        now_local = now.astimezone(tz)
+    start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_local = start_local + timedelta(days=1)
+    start_utc = start_local.astimezone(timezone.utc)
+    end_utc = end_local.astimezone(timezone.utc)
+    return start_local, end_local, start_utc, end_utc
+
+
+def _query_llm_metrics(session: Session, start_utc: datetime, end_utc: datetime) -> dict[str, object]:
+    filter_clause = [
+        TradeDecision.created_at >= start_utc,
+        TradeDecision.created_at < end_utc,
+    ]
+    total_reviews = _as_int(
+        session.execute(
+            select(func.count(LLMDecisionReview.id))
+            .join(TradeDecision, TradeDecision.id == LLMDecisionReview.trade_decision_id)
+            .where(*filter_clause)
+        ).scalar_one()
+    )
+    verdict_rows = session.execute(
+        select(LLMDecisionReview.verdict, func.count(LLMDecisionReview.id))
+        .join(TradeDecision, TradeDecision.id == LLMDecisionReview.trade_decision_id)
+        .where(*filter_clause)
+        .group_by(LLMDecisionReview.verdict)
+    ).all()
+    verdict_counts: dict[str, int] = {
+        "approve": 0,
+        "veto": 0,
+        "adjust": 0,
+        "error": 0,
+    }
+    for verdict, count in verdict_rows:
+        key = str(verdict)
+        verdict_counts[key] = _as_int(count)
+
+    error_count = verdict_counts.get("error", 0)
+    error_rate = error_count / total_reviews if total_reviews else 0.0
+
+    avg_confidence = session.execute(
+        select(func.avg(LLMDecisionReview.confidence))
+        .join(TradeDecision, TradeDecision.id == LLMDecisionReview.trade_decision_id)
+        .where(*filter_clause)
+    ).scalar_one()
+    avg_confidence_value = float(avg_confidence) if avg_confidence is not None else None
+
+    tokens_prompt = _as_int(
+        session.execute(
+            select(func.coalesce(func.sum(LLMDecisionReview.tokens_prompt), 0))
+            .join(TradeDecision, TradeDecision.id == LLMDecisionReview.trade_decision_id)
+            .where(*filter_clause)
+        ).scalar_one()
+    )
+    tokens_completion = _as_int(
+        session.execute(
+            select(func.coalesce(func.sum(LLMDecisionReview.tokens_completion), 0))
+            .join(TradeDecision, TradeDecision.id == LLMDecisionReview.trade_decision_id)
+            .where(*filter_clause)
+        ).scalar_one()
+    )
+
+    risk_flags_rows = session.execute(
+        select(LLMDecisionReview.risk_flags)
+        .join(TradeDecision, TradeDecision.id == LLMDecisionReview.trade_decision_id)
+        .where(*filter_clause)
+    ).all()
+    counter: Counter[str] = Counter()
+    for (raw_flags,) in risk_flags_rows:
+        for flag in _normalize_risk_flags(raw_flags):
+            counter[flag] += 1
+    top_risk_flags = [
+        {"flag": flag, "count": count}
+        for flag, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:TOP_RISK_FLAGS_LIMIT]
+    ]
+
+    return {
+        "total_reviews": total_reviews,
+        "verdict_counts": verdict_counts,
+        "error_rate": error_rate,
+        "avg_confidence": avg_confidence_value,
+        "tokens": {
+            "prompt": tokens_prompt,
+            "completion": tokens_completion,
+            "total": tokens_prompt + tokens_completion,
+        },
+        "top_risk_flags": top_risk_flags,
+    }
+
+
+def _normalize_risk_flags(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        flag = value.strip()
+        return [flag] if flag else []
+    if isinstance(value, list):
+        flags: list[str] = []
+        for item in cast(list[Any], value):
+            if item is None:
+                continue
+            flag = str(item).strip()
+            if flag:
+                flags.append(flag)
+        return flags
+    if isinstance(value, dict):
+        return [str(key).strip() for key in cast(dict[Any, Any], value).keys() if str(key).strip()]
+    return [str(value)]
+
+
+def _as_int(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, Decimal):
+        return int(value)
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return 0

--- a/services/torghut/app/trading/llm/guardrails.py
+++ b/services/torghut/app/trading/llm/guardrails.py
@@ -1,0 +1,69 @@
+"""Model risk management guardrails for the LLM advisory layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...config import settings
+
+
+@dataclass(frozen=True)
+class LLMRiskGuardrails:
+    allow_requests: bool
+    shadow_mode: bool
+    adjustment_allowed: bool
+    reasons: tuple[str, ...]
+
+
+def evaluate_llm_guardrails() -> LLMRiskGuardrails:
+    """Evaluate MRM guardrails and return the effective LLM policy surface."""
+
+    reasons: list[str] = []
+    allow_requests = True
+    shadow_mode = settings.llm_shadow_mode
+    adjustment_allowed = settings.llm_adjustment_allowed
+
+    if not _prompt_template_exists(settings.llm_prompt_version):
+        allow_requests = False
+        shadow_mode = True
+        adjustment_allowed = False
+        reasons.append("llm_prompt_template_missing")
+
+    if not settings.llm_shadow_mode:
+        evidence_missing: list[str] = []
+        allowed_models = settings.llm_allowed_models
+        if not allowed_models:
+            evidence_missing.append("llm_model_inventory_missing")
+        elif settings.llm_model not in allowed_models:
+            evidence_missing.append("llm_model_not_in_inventory")
+        if not settings.llm_evaluation_report:
+            evidence_missing.append("llm_evaluation_report_missing")
+        if not settings.llm_effective_challenge_id:
+            evidence_missing.append("llm_effective_challenge_missing")
+        if not settings.llm_shadow_completed_at:
+            evidence_missing.append("llm_shadow_completion_missing")
+        if evidence_missing:
+            shadow_mode = True
+            adjustment_allowed = False
+            reasons.extend(evidence_missing)
+
+    if adjustment_allowed and not settings.llm_adjustment_approved:
+        adjustment_allowed = False
+        reasons.append("llm_adjustment_not_approved")
+
+    return LLMRiskGuardrails(
+        allow_requests=allow_requests,
+        shadow_mode=shadow_mode,
+        adjustment_allowed=adjustment_allowed,
+        reasons=tuple(reasons),
+    )
+
+
+def _prompt_template_exists(version: str) -> bool:
+    templates_dir = Path(__file__).resolve().parent / "prompt_templates"
+    candidate = templates_dir / f"system_{version}.txt"
+    return candidate.exists()
+
+
+__all__ = ["LLMRiskGuardrails", "evaluate_llm_guardrails"]

--- a/services/torghut/app/trading/llm/review_engine.py
+++ b/services/torghut/app/trading/llm/review_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
@@ -35,6 +36,33 @@ _SYSTEM_PROMPT = (
     "Provide a concise rationale (<= 280 chars). "
     "Do not include chain-of-thought or extra keys."
 )
+
+_ALLOWED_DECISION_PARAMS = {
+    "macd",
+    "macd_signal",
+    "rsi",
+    "price",
+    "volatility",
+    "spread",
+    "price_snapshot",
+    "imbalance",
+    "sizing",
+}
+_ALLOWED_PRICE_SNAPSHOT_KEYS = {"as_of", "price", "spread", "source"}
+_ALLOWED_IMBALANCE_KEYS = {"spread"}
+_ALLOWED_SIZING_KEYS = {"method", "notional_budget", "price", "reason"}
+_ALLOWED_ACCOUNT_KEYS = {"equity", "cash", "buying_power"}
+_ALLOWED_POSITION_KEYS = {
+    "symbol",
+    "qty",
+    "side",
+    "market_value",
+    "avg_entry_price",
+    "current_price",
+    "unrealized_pl",
+    "unrealized_plpc",
+    "cost_basis",
+}
 
 
 @dataclass
@@ -142,7 +170,14 @@ class LLMReviewEngine:
         portfolio: PortfolioSnapshot,
         market: Optional[MarketSnapshot],
         recent_decisions: list[RecentDecisionSummary],
+        adjustment_allowed: Optional[bool] = None,
     ) -> LLMReviewRequest:
+        effective_adjustment_allowed = (
+            settings.llm_adjustment_allowed if adjustment_allowed is None else adjustment_allowed
+        )
+        sanitized_account = _sanitize_account(account)
+        sanitized_positions = _sanitize_positions(positions)
+        sanitized_params = _sanitize_decision_params(decision.params or {})
         return LLMReviewRequest(
             decision=LLMDecisionContext(
                 strategy_id=decision.strategy_id,
@@ -154,15 +189,15 @@ class LLMReviewEngine:
                 event_ts=decision.event_ts,
                 timeframe=decision.timeframe,
                 rationale=decision.rationale,
-                params=decision.params,
+                params=sanitized_params,
             ),
             portfolio=portfolio,
             market=market,
             recent_decisions=recent_decisions,
-            account=account,
-            positions=positions,
+            account=sanitized_account,
+            positions=sanitized_positions,
             policy=LLMPolicyContext(
-                adjustment_allowed=settings.llm_adjustment_allowed,
+                adjustment_allowed=effective_adjustment_allowed,
                 min_qty_multiplier=Decimal(str(settings.llm_min_qty_multiplier)),
                 max_qty_multiplier=Decimal(str(settings.llm_max_qty_multiplier)),
                 allowed_order_types=sorted(allowed_order_types(decision.order_type)),
@@ -235,3 +270,53 @@ def load_prompt_template(version: str) -> str:
     if candidate.exists():
         return candidate.read_text(encoding="utf-8")
     return _SYSTEM_PROMPT
+
+
+def _sanitize_account(account: dict[str, Any]) -> dict[str, str]:
+    sanitized: dict[str, str] = {}
+    for key in _ALLOWED_ACCOUNT_KEYS:
+        value = account.get(key)
+        if value is None:
+            continue
+        sanitized[key] = str(value)
+    return sanitized
+
+
+def _sanitize_positions(positions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    sanitized: list[dict[str, Any]] = []
+    for position in positions:
+        symbol = position.get("symbol")
+        if not symbol:
+            continue
+        cleaned: dict[str, Any] = {"symbol": str(symbol)}
+        for key in _ALLOWED_POSITION_KEYS:
+            if key == "symbol":
+                continue
+            value = position.get(key)
+            if value is None:
+                continue
+            cleaned[key] = value
+        sanitized.append(cleaned)
+    sanitized.sort(key=lambda item: item.get("symbol", ""))
+    return sanitized
+
+
+def _sanitize_decision_params(params: dict[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for key in _ALLOWED_DECISION_PARAMS:
+        value = params.get(key)
+        if value is None:
+            continue
+        if key == "price_snapshot" and isinstance(value, Mapping):
+            sanitized[key] = _sanitize_nested(cast(Mapping[str, Any], value), _ALLOWED_PRICE_SNAPSHOT_KEYS)
+        elif key == "imbalance" and isinstance(value, Mapping):
+            sanitized[key] = _sanitize_nested(cast(Mapping[str, Any], value), _ALLOWED_IMBALANCE_KEYS)
+        elif key == "sizing" and isinstance(value, Mapping):
+            sanitized[key] = _sanitize_nested(cast(Mapping[str, Any], value), _ALLOWED_SIZING_KEYS)
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
+def _sanitize_nested(payload: Mapping[str, Any], allowed_keys: set[str]) -> dict[str, Any]:
+    return {key: payload[key] for key in allowed_keys if key in payload and payload[key] is not None}

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -26,6 +26,7 @@ from .execution_policy import ExecutionPolicy
 from .firewall import OrderFirewall, OrderFirewallBlocked
 from .ingest import ClickHouseSignalIngestor
 from .llm import LLMReviewEngine, apply_policy
+from .llm.guardrails import evaluate_llm_guardrails
 from .models import SignalEnvelope, StrategyDecision
 from .portfolio import PortfolioSizingResult, sizer_from_settings
 from .prices import ClickHousePriceFetcher, MarketSnapshot, PriceFetcher
@@ -79,8 +80,14 @@ class TradingMetrics:
     llm_veto_total: int = 0
     llm_adjust_total: int = 0
     llm_error_total: int = 0
+    llm_parse_error_total: int = 0
+    llm_validation_error_total: int = 0
     llm_circuit_open_total: int = 0
     llm_shadow_total: int = 0
+    llm_guardrail_block_total: int = 0
+    llm_guardrail_shadow_total: int = 0
+    llm_tokens_prompt_total: int = 0
+    llm_tokens_completion_total: int = 0
 
 
 @dataclass
@@ -392,6 +399,20 @@ class TradingPipeline:
         if not settings.llm_enabled:
             return decision, None
 
+        guardrails = evaluate_llm_guardrails()
+        if not guardrails.allow_requests:
+            self.state.metrics.llm_guardrail_block_total += 1
+            return self._handle_llm_unavailable(
+                session,
+                decision,
+                decision_row,
+                account,
+                positions,
+                reason="llm_guardrail_blocked",
+                shadow_mode=True,
+                risk_flags=list(guardrails.reasons),
+            )
+
         engine = self.llm_review_engine or LLMReviewEngine()
         if engine.circuit_breaker.is_open():
             self.state.metrics.llm_circuit_open_total += 1
@@ -402,6 +423,7 @@ class TradingPipeline:
                 account,
                 positions,
                 reason="llm_circuit_open",
+                shadow_mode=guardrails.shadow_mode,
             )
         request_json: dict[str, Any] = {}
         try:
@@ -420,6 +442,7 @@ class TradingPipeline:
                 portfolio_snapshot,
                 market_snapshot,
                 recent_decisions,
+                adjustment_allowed=guardrails.adjustment_allowed,
             )
             request_json = request.model_dump(mode="json")
             outcome = engine.review(
@@ -431,12 +454,23 @@ class TradingPipeline:
                 market=market_snapshot,
                 recent_decisions=recent_decisions,
             )
-            policy_outcome = apply_policy(decision, outcome.response)
+            policy_outcome = apply_policy(
+                decision,
+                outcome.response,
+                adjustment_allowed=guardrails.adjustment_allowed,
+            )
 
-            response_json = dict(outcome.response_json)
+            response_json: dict[str, Any] = dict(outcome.response_json)
             if policy_outcome.reason:
                 response_json["policy_override"] = policy_outcome.reason
                 response_json["policy_verdict"] = policy_outcome.verdict
+            if guardrails.reasons:
+                response_json["mrm_guardrails"] = list(guardrails.reasons)
+
+            if outcome.tokens_prompt is not None:
+                self.state.metrics.llm_tokens_prompt_total += outcome.tokens_prompt
+            if outcome.tokens_completion is not None:
+                self.state.metrics.llm_tokens_completion_total += outcome.tokens_completion
 
             adjusted_qty = None
             adjusted_order_type = None
@@ -449,6 +483,11 @@ class TradingPipeline:
                 self.state.metrics.llm_approve_total += 1
             elif policy_outcome.verdict == "veto":
                 self.state.metrics.llm_veto_total += 1
+
+            if outcome.tokens_prompt is not None:
+                self.state.metrics.llm_tokens_prompt_total += outcome.tokens_prompt
+            if outcome.tokens_completion is not None:
+                self.state.metrics.llm_tokens_completion_total += outcome.tokens_completion
 
             self._persist_llm_review(
                 session=session,
@@ -468,8 +507,10 @@ class TradingPipeline:
             )
 
             engine.circuit_breaker.record_success()
-            if settings.llm_shadow_mode:
+            if guardrails.shadow_mode:
                 self.state.metrics.llm_shadow_total += 1
+                if not settings.llm_shadow_mode:
+                    self.state.metrics.llm_guardrail_shadow_total += 1
                 return decision, None
             if policy_outcome.verdict == "veto":
                 return decision, policy_outcome.reason or "llm_veto"
@@ -478,6 +519,11 @@ class TradingPipeline:
         except Exception as exc:
             engine.circuit_breaker.record_error()
             self.state.metrics.llm_error_total += 1
+            error_label = _classify_llm_error(exc)
+            if error_label == "llm_response_not_json":
+                self.state.metrics.llm_parse_error_total += 1
+            elif error_label == "llm_response_invalid":
+                self.state.metrics.llm_validation_error_total += 1
             fallback = self._resolve_llm_fallback()
             effective_verdict = "veto" if fallback == "veto" else "approve"
             response_json = {
@@ -485,6 +531,8 @@ class TradingPipeline:
                 "fallback": fallback,
                 "effective_verdict": effective_verdict,
             }
+            if guardrails.reasons:
+                response_json["mrm_guardrails"] = list(guardrails.reasons)
             if not request_json:
                 request_json = {"decision": decision.model_dump(mode="json")}
             self._persist_llm_review(
@@ -499,10 +547,15 @@ class TradingPipeline:
                 adjusted_qty=None,
                 adjusted_order_type=None,
                 rationale=f"llm_error_{fallback}",
-                risk_flags=[type(exc).__name__],
+                risk_flags=[type(exc).__name__] + list(guardrails.reasons),
                 tokens_prompt=None,
                 tokens_completion=None,
             )
+            if guardrails.shadow_mode:
+                self.state.metrics.llm_shadow_total += 1
+                if not settings.llm_shadow_mode:
+                    self.state.metrics.llm_guardrail_shadow_total += 1
+                return decision, None
             if fallback == "veto":
                 logger.warning("LLM review failed; vetoing decision_id=%s error=%s", decision_row.id, exc)
                 return decision, "llm_error"
@@ -517,6 +570,8 @@ class TradingPipeline:
         account: dict[str, str],
         positions: list[dict[str, Any]],
         reason: str,
+        shadow_mode: bool,
+        risk_flags: Optional[list[str]] = None,
     ) -> tuple[StrategyDecision, Optional[str]]:
         fallback = self._resolve_llm_fallback()
         effective_verdict = "veto" if fallback == "veto" else "approve"
@@ -527,13 +582,15 @@ class TradingPipeline:
             decision.strategy_id,
             decision.symbol,
         )
-        request_payload = {
-            "decision": decision.model_dump(mode="json"),
-            "portfolio": portfolio_snapshot.model_dump(mode="json"),
-            "market": market_snapshot.model_dump(mode="json") if market_snapshot else None,
-            "recent_decisions": [item.model_dump(mode="json") for item in recent_decisions],
-            "reason": reason,
-        }
+        engine = self.llm_review_engine or LLMReviewEngine()
+        request_payload = engine.build_request(
+            decision=decision,
+            account=account,
+            positions=positions,
+            portfolio=portfolio_snapshot,
+            market=market_snapshot,
+            recent_decisions=recent_decisions,
+        ).model_dump(mode="json")
         self._persist_llm_review(
             session=session,
             decision_row=decision_row,
@@ -546,12 +603,14 @@ class TradingPipeline:
             adjusted_qty=None,
             adjusted_order_type=None,
             rationale=reason,
-            risk_flags=[reason],
+            risk_flags=[reason] + (risk_flags or []),
             tokens_prompt=None,
             tokens_completion=None,
         )
-        if settings.llm_shadow_mode:
+        if shadow_mode:
             self.state.metrics.llm_shadow_total += 1
+            if not settings.llm_shadow_mode:
+                self.state.metrics.llm_guardrail_shadow_total += 1
             return decision, None
         if fallback == "veto":
             return decision, "llm_error"
@@ -700,6 +759,15 @@ def _coerce_json(value: Any) -> dict[str, Any]:
         raw = cast(Mapping[str, Any], value)
         return {str(key): val for key, val in raw.items()}
     return {}
+
+
+def _classify_llm_error(error: Exception) -> Optional[str]:
+    message = str(error)
+    if message == "llm_response_not_json":
+        return "llm_response_not_json"
+    if message == "llm_response_invalid":
+        return "llm_response_invalid"
+    return None
 
 
 def _price_snapshot_payload(snapshot: MarketSnapshot) -> dict[str, Any]:

--- a/services/torghut/tests/test_llm_policy.py
+++ b/services/torghut/tests/test_llm_policy.py
@@ -44,3 +44,44 @@ class TestLLMPolicy(TestCase):
         finally:
             config.settings.llm_adjustment_allowed = original["llm_adjustment_allowed"]
             config.settings.llm_min_confidence = original["llm_min_confidence"]
+
+    def test_adjustment_clamped_to_bounds(self) -> None:
+        original = {
+            "llm_adjustment_allowed": config.settings.llm_adjustment_allowed,
+            "llm_min_confidence": config.settings.llm_min_confidence,
+            "llm_min_qty_multiplier": config.settings.llm_min_qty_multiplier,
+            "llm_max_qty_multiplier": config.settings.llm_max_qty_multiplier,
+        }
+        config.settings.llm_adjustment_allowed = True
+        config.settings.llm_min_confidence = 0.0
+        config.settings.llm_min_qty_multiplier = 0.5
+        config.settings.llm_max_qty_multiplier = 1.25
+
+        try:
+            decision = StrategyDecision(
+                strategy_id="strategy",
+                symbol="AAPL",
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("10"),
+                order_type="market",
+                time_in_force="day",
+            )
+            review = LLMReviewResponse(
+                verdict="adjust",
+                confidence=1.0,
+                adjusted_qty=Decimal("25"),
+                adjusted_order_type="market",
+                rationale="clamp_requested",
+                risk_flags=[],
+            )
+            outcome = apply_policy(decision, review)
+            self.assertEqual(outcome.verdict, "adjust")
+            self.assertEqual(outcome.decision.qty, Decimal("12.5"))
+            self.assertEqual(outcome.reason, "llm_adjustment_clamped_max")
+        finally:
+            config.settings.llm_adjustment_allowed = original["llm_adjustment_allowed"]
+            config.settings.llm_min_confidence = original["llm_min_confidence"]
+            config.settings.llm_min_qty_multiplier = original["llm_min_qty_multiplier"]
+            config.settings.llm_max_qty_multiplier = original["llm_max_qty_multiplier"]

--- a/services/torghut/tests/test_llm_review_engine.py
+++ b/services/torghut/tests/test_llm_review_engine.py
@@ -59,3 +59,55 @@ class TestLLMReviewEngine(TestCase):
         self.assertEqual(outcome.response.confidence, 0.5)
         self.assertEqual(outcome.response.risk_flags, [])
 
+    def test_build_request_sanitizes_inputs(self) -> None:
+        engine = LLMReviewEngine(client=FakeLLMClient('{"verdict":"approve","confidence":1,"rationale":"ok","risk_flags":[]}'))
+
+        account = {"equity": "10000", "cash": "5000", "buying_power": "15000", "account_id": "secret"}
+        positions = [
+            {
+                "symbol": "AAPL",
+                "qty": "10",
+                "market_value": "1000",
+                "avg_entry_price": "95",
+                "account_id": "nope",
+            },
+            {"symbol": "MSFT", "qty": "5", "extra": "nope"},
+            {"qty": "1"},
+        ]
+        portfolio = PortfolioSnapshot(
+            equity=Decimal("10000"),
+            cash=Decimal("5000"),
+            buying_power=Decimal("15000"),
+            total_exposure=Decimal("0"),
+            exposure_by_symbol={},
+            positions=positions,
+        )
+        decision = StrategyDecision(
+            strategy_id="demo",
+            symbol="AAPL",
+            action="buy",
+            qty=Decimal("1"),
+            order_type="market",
+            time_in_force="day",
+            event_ts=datetime.now(timezone.utc),
+            timeframe="1Min",
+            rationale="demo",
+            params={
+                "macd": Decimal("1.0"),
+                "rsi": Decimal("30"),
+                "price": Decimal("100"),
+                "news": "should_drop",
+                "sizing": {"method": "default_qty", "notional_budget": "100", "extra": "drop"},
+            },
+        )
+
+        request = engine.build_request(decision, account, positions, portfolio, None, [])
+
+        self.assertNotIn("account_id", request.account)
+        self.assertEqual(request.account, {"equity": "10000", "cash": "5000", "buying_power": "15000"})
+        self.assertEqual([pos["symbol"] for pos in request.positions], ["AAPL", "MSFT"])
+        self.assertNotIn("account_id", request.positions[0])
+        self.assertNotIn("extra", request.positions[1])
+        self.assertNotIn("news", request.decision.params)
+        self.assertIn("sizing", request.decision.params)
+        self.assertEqual(request.decision.params["sizing"], {"method": "default_qty", "notional_budget": "100"})


### PR DESCRIPTION
## Summary
- add a /trading/llm-evaluation endpoint backed by Postgres with daily LLM review aggregates
- extend torghut trading API tests to cover the new evaluation payload
- add Graf Mimir alert rules for LLM error rate, token spikes, and missing telemetry

## Related Issues
None

## Testing
- `pytest services/torghut/tests/test_trading_api.py` (fails: ModuleNotFoundError: No module named 'fastapi')

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
