### PR TITLE
docs(torghut): standardize ta replay guardrails

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -36,6 +36,7 @@ If you replay data older than the ClickHouse TTL, it may be deleted during merge
   trading first and keep it paused until verification passes.
   - set `TRADING_ENABLED=false` in `argocd/applications/torghut/knative-service.yaml`
   - keep `TRADING_LIVE_ENABLED=false` (safety backstop)
+  - do not change `TRADING_MODE` defaults during replay/recovery
 - **Unique consumer group required (hard requirement):** every replay/backfill must use a **new** `TA_GROUP_ID`
   (consumer-group isolation). Never reuse an old replay group id.
 - **GitOps-first:** prefer changing manifests under `argocd/applications/torghut/**` and syncing via Argo CD.


### PR DESCRIPTION
## Summary
- add replay window constraints and confirmation points to TA replay/recovery ops doc
- document replay isolation inputs and rollback summary
- clarify trading safety gate to keep TRADING_MODE defaults during replay

## Related Issues
None

## Testing
- bun run lint:argocd

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
