### PR TITLE
docs(torghut): standardize TA replay guardrails

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -30,6 +30,7 @@ Replay is constrained by **both** Kafka retention (inputs) and ClickHouse TTL (o
 
 If you replay data older than the ClickHouse TTL, it may be deleted during merges shortly after replay (see
 `docs/torghut/design-system/v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md`).
+Record the planned replay start/end timestamps in your ticket and confirm they fit within both windows.
 
 ### Safety gates (read first)
 - **Trading safety (prerequisite):** if there is any uncertainty about signal correctness (stale/corrupt/partial), pause
@@ -48,12 +49,14 @@ If you replay data older than the ClickHouse TTL, it may be deleted during merge
 Before touching the TA job or Kafka topics, record the following in your ticket/incident:
 - `REPLAY_ID` (unique id used in group id + any backups), example: `2026-02-09T0315Z-INC1234`
 - `PREV_TA_GROUP_ID` (current steady-state group id from `argocd/applications/torghut/ta/configmap.yaml`)
+- `PREV_TA_AUTO_OFFSET_RESET` (current steady-state offset reset policy)
 - Confirmation that trading is paused (or explicitly confirmed safe for paper-only replay)
 - Confirmation of replay window feasibility (Kafka retention vs ClickHouse TTL; see above)
 - If Mode 2 is required: explicit human approval + acknowledgement of destructive steps
 
 ### Inputs to capture (for rollback)
 - `PREV_TA_GROUP_ID` (current steady-state group id from `argocd/applications/torghut/ta/configmap.yaml`)
+- `PREV_TA_AUTO_OFFSET_RESET` (current steady-state offset reset policy)
 - `REPLAY_ID` (unique id used in group id + any backups), example: `2026-02-09T0315Z-INC1234`
 - Current TA job state: `running` vs `suspended`
 
@@ -72,6 +75,7 @@ Goal: recompute TA outputs from retained Kafka inputs without deleting topics or
    - Edit `argocd/applications/torghut/ta/configmap.yaml`:
      - `TA_GROUP_ID: "torghut-ta-replay-<REPLAY_ID>"`
      - `TA_AUTO_OFFSET_RESET: "earliest"`
+   - Confirm the new `TA_GROUP_ID` has never been used before; never reuse an old replay group id.
 4) Restart and resume TA (required to pick up ConfigMap env changes)
    - GitOps-first:
      - bump `spec.restartNonce` in `argocd/applications/torghut/ta/flinkdeployment.yaml`

--- a/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+++ b/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
@@ -55,14 +55,17 @@ flowchart LR
 5) Record the required confirmation points in your ticket/incident:
    - `REPLAY_ID` (unique id used in group id + backups), example `2026-02-09T0315Z-INC1234`
    - `PREV_TA_GROUP_ID` (current steady-state group id)
+   - `PREV_TA_AUTO_OFFSET_RESET` (current steady-state offset reset policy)
+   - Replay start/end window is within Kafka retention and ClickHouse TTL (see below)
    - Confirmation that replay window is feasible (Kafka retention vs ClickHouse TTL)
    - Explicit approval if destructive Mode 2 is required
 
 ## Replay window constraints (summary)
 Replay is limited by both Kafka retention (inputs) and ClickHouse TTL (outputs):
 - **Kafka retention is the hard limit** for replay/backfill. If events have aged out, TA cannot replay them.
+- v1 ingest retention is expected to be **7–30 days**; confirm broker settings for each topic before proceeding.
 - **ClickHouse TTL limits how long replayed results persist.** If replayed data is older than the TTL, merges may delete
-  it shortly after replay.
+  it shortly after replay (v1 defaults: `ta_microbars` 30 days, `ta_signals` 14 days).
 See:
 - `docs/torghut/design-system/v1/component-kafka-topics-and-retention.md`
 - `docs/torghut/design-system/v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md`
@@ -118,6 +121,7 @@ Required replay isolation inputs (do not skip):
 - `REPLAY_ID` (unique id); set `TA_GROUP_ID: "torghut-ta-replay-<REPLAY_ID>"`.
 - `TA_AUTO_OFFSET_RESET: "earliest"` for replay/backfill.
 - Preserve `PREV_TA_GROUP_ID` for rollback.
+- Preserve `PREV_TA_AUTO_OFFSET_RESET` for rollback.
 
 ## Automation (AgentRuns)
 AgentRuns should treat these procedures as two classes of automation:
@@ -126,7 +130,7 @@ AgentRuns should treat these procedures as two classes of automation:
 2) Actuation (gated): open a PR updating `argocd/applications/torghut/ta/**` (suspend/resume, new `TA_GROUP_ID`,
    restart nonce, image rollback), then trigger an Argo sync if your environment supports it.
 
-## Rollback
+## Rollback / recovery if replay fails
 - If a replay causes regressions or excessive lag, revert GitOps changes:
   - restore the previous `TA_GROUP_ID` in `argocd/applications/torghut/ta/configmap.yaml`,
   - restore previous `TA_AUTO_OFFSET_RESET` if it was changed,


### PR DESCRIPTION
## Summary
- documented replay window constraints alongside expected Kafka retention and ClickHouse TTL defaults
- added explicit replay confirmation inputs for offset reset and replay window planning
- clarified replay guardrails and rollback metadata in TA replay runbooks

## Related Issues
None

## Testing
- bun run lint:argocd

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
