### PR TITLE
fix(jangar): wire torghut trading DSN and shadcn day picker

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -189,6 +189,12 @@ spec:
                 secretKeyRef:
                   name: jangar-db-app
                   key: uri
+            - name: TORGHUT_DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: uri
+                  optional: true
             - name: PGSSLMODE
               value: require
             - name: JANGAR_DB_CA_CERT

--- a/argocd/applications/torghut/postgres-cluster.yaml
+++ b/argocd/applications/torghut/postgres-cluster.yaml
@@ -18,9 +18,9 @@ spec:
   inheritedMetadata:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "pgadmin"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "pgadmin,jangar"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "pgadmin"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "pgadmin,jangar"
   monitoring:
     enablePodMonitor: true
 # CNPG will emit application credentials in `torghut-db-app` (uri, user, password, host, port, dbname)


### PR DESCRIPTION
## Summary

- Enable Torghut trading history in Jangar by wiring `TORGHUT_DB_DSN` from `torghut-db-app` secret.
- Update Torghut CNPG reflector annotations to mirror `torghut-db-app` into `jangar` namespace.
- Replace native `type=date` control on `/torghut/trading` with shadcn `Calendar` + `Popover` picker and bounded day range.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applications/torghut/postgres-cluster.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/jangar/deployment.yaml`
- Manual verification in Chrome MCP: `http://jangar/torghut/trading` and network response for `/api/torghut/trading/strategies` (confirmed root cause pre-fix).
- `bun run --filter @proompteng/jangar tsc` (fails in this environment: `Cannot find type definition file for 'bun-types'`).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
