### PR TITLE
chore(jangar): roll out image 5552afe7

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-11T07:49:26.229Z"
+    deploy.knative.dev/rollout: "2026-02-11T08:00:23.493Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -54,5 +54,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "faea147f"
-    digest: sha256:20356546c0932d83561ddac12e6e3e682fd611a62ad13bc69ed9e19596e1dea0
+    newTag: "5552afe7"
+    digest: sha256:39a39c019c2d3a10867dcff0a0df858782bcd0c3aaebe49e8eedf6081b7296cc


### PR DESCRIPTION
## Summary

- Roll Jangar Argo image tag/digest to `5552afe7` built from the latest merged `main` revision.
- Update Jangar deployment rollout annotation to trigger a controlled rollout.
- Keep GitOps source aligned with the already successful in-cluster rollout.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/jangar/deploy-service.ts`
- `kubectl -n jangar rollout status deployment/jangar --timeout=300s`
- `kubectl -n jangar exec <pod> -c app -- curl -i http://127.0.0.1:8080/health`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
