### PR TITLE
feat(torghut): enforce kill switch and order firewall boundary

### DIFF
--- a/services/torghut/tests/test_order_firewall.py
+++ b/services/torghut/tests/test_order_firewall.py
@@ -56,6 +56,7 @@ class TestOrderFirewall(TestCase):
 
         self.assertTrue(firewall.cancel_open_orders_if_kill_switch())
         self.assertEqual(client.cancel_all_calls, 1)
+        self.assertEqual(firewall.status().reason, "kill_switch_enabled")
 
         with self.assertRaises(OrderFirewallBlocked):
             firewall.submit_order(
@@ -81,3 +82,12 @@ class TestOrderFirewall(TestCase):
 
         self.assertEqual(response["symbol"], "AAPL")
         self.assertEqual(len(client.submissions), 1)
+
+    def test_kill_switch_noop_when_disabled(self) -> None:
+        settings.trading_kill_switch_enabled = False
+        client = FakeAlpacaClient()
+        firewall = OrderFirewall(client)
+
+        self.assertFalse(firewall.cancel_open_orders_if_kill_switch())
+        self.assertEqual(client.cancel_all_calls, 0)
+        self.assertEqual(firewall.status().reason, "ok")


### PR DESCRIPTION
## Summary

- Implemented a deterministic, config-driven kill-switch contract in the Torghut order path that is safe-by-default and agent-independent.
- Hardened the broker mutation boundary by enforcing that order submit/cancel methods can only be invoked through `app.trading.firewall`.
- Added/updated fast unit tests covering kill-switch behavior and firewall boundary protections, including trading pipeline coverage.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --python 3.12 --with pytest python -m pytest tests/test_alpaca_client.py tests/test_order_firewall.py tests/test_trading_pipeline.py -q`
- `cd services/torghut && uv run --python 3.12 --with pytest python -m pytest tests -q`
- `cd services/torghut && uv run --python 3.12 pyright`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
