### PR TITLE
feat(torghut): add execution policy hardening and impact assumptions

### DIFF
--- a/services/torghut/tests/test_evaluation_report.py
+++ b/services/torghut/tests/test_evaluation_report.py
@@ -63,6 +63,9 @@ class TestEvaluationReport(TestCase):
         self.assertEqual(report.metrics.max_drawdown, Decimal("0"))
         self.assertEqual(report.gates.recommended_mode, "shadow")
         self.assertFalse(report.gates.promotion_allowed)
+        self.assertEqual(report.impact_assumptions.default_execution_seconds, 60)
+        self.assertEqual(report.impact_assumptions.decisions_with_adv, 0)
+        self.assertIn("impact_bps_at_full_participation", report.impact_assumptions.assumptions)
 
         turnover_ratio = report.metrics.turnover_ratio.quantize(Decimal("0.1"))
         self.assertEqual(turnover_ratio, Decimal("4.0"))

--- a/services/torghut/tests/test_execution_policy.py
+++ b/services/torghut/tests/test_execution_policy.py
@@ -73,6 +73,22 @@ class TestExecutionPolicy(TestCase):
         self.assertFalse(outcome.approved)
         self.assertIn("max_notional_exceeded", outcome.reasons)
 
+    def test_approved_orders_stay_within_caps(self) -> None:
+        policy = ExecutionPolicy(
+            config=_config(
+                max_notional=Decimal("300"),
+                max_participation_rate=Decimal("0.25"),
+            )
+        )
+        decision = _decision(qty=Decimal("2"), price=Decimal("100"))
+        decision = decision.model_copy(update={"params": {"price": Decimal("100"), "adv": Decimal("2000")}})
+        outcome = policy.evaluate(decision, strategy=None, positions=[], market_snapshot=None)
+        self.assertTrue(outcome.approved)
+        self.assertIsNotNone(outcome.notional)
+        self.assertIsNotNone(outcome.participation_rate)
+        self.assertLessEqual(outcome.notional or Decimal("0"), Decimal("300"))
+        self.assertLessEqual(outcome.participation_rate or Decimal("0"), Decimal("0.25"))
+
     def test_participation_cap_enforced(self) -> None:
         policy = ExecutionPolicy(config=_config(max_participation_rate=Decimal("0.1")))
         decision = _decision(qty=Decimal("200"), price=Decimal("10"))
@@ -80,6 +96,29 @@ class TestExecutionPolicy(TestCase):
         outcome = policy.evaluate(decision, strategy=None, positions=[], market_snapshot=None)
         self.assertFalse(outcome.approved)
         self.assertIn("participation_exceeds_max", outcome.reasons)
+
+    def test_sell_to_reduce_long_position_allowed_with_no_shorts(self) -> None:
+        policy = ExecutionPolicy(config=_config(allow_shorts=False))
+        outcome = policy.evaluate(
+            _decision(action="sell", qty=Decimal("2")),
+            strategy=None,
+            positions=[{"symbol": "AAPL", "qty": "5", "side": "long"}],
+            market_snapshot=None,
+        )
+        self.assertTrue(outcome.approved)
+        self.assertNotIn("shorts_not_allowed", outcome.reasons)
+
+    def test_retry_backoff_schedule_sanitized_and_capped(self) -> None:
+        policy = ExecutionPolicy(
+            config=_config(
+                max_retries=4,
+                backoff_base_seconds=-1.0,
+                backoff_multiplier=0.5,
+                backoff_max_seconds=0.25,
+            )
+        )
+        outcome = policy.evaluate(_decision(), strategy=None, positions=[], market_snapshot=None)
+        self.assertEqual(outcome.retry_delays, [0.1, 0.1, 0.1, 0.1])
 
     def test_impact_assumptions_recorded(self) -> None:
         policy = ExecutionPolicy(config=_config(prefer_limit=True))
@@ -91,5 +130,6 @@ class TestExecutionPolicy(TestCase):
         )
         assumptions = outcome.impact_assumptions
         self.assertIn("model", assumptions)
+        self.assertIn("inputs", assumptions)
         self.assertIn("estimate", assumptions)
         self.assertEqual(outcome.decision.order_type, "limit")


### PR DESCRIPTION
## Summary

- Centralized additional execution safety normalization in `ExecutionPolicy` by sanitizing participation and retry/backoff config before order placement decisions are evaluated.
- Expanded execution-policy invariant tests to cover approved-cap bounds, no-shorts behavior for long reductions, and retry/backoff sanitization/capping.
- Surfaced market-impact realism in evaluation outputs via a new `impact_assumptions` section containing coverage of impact inputs (`spread`, `volatility`, `adv`) and core cost-model assumptions.
- Kept paper-by-default/live guardrails unchanged (`TRADING_MODE=paper`, `TRADING_LIVE_ENABLED=false`) while improving execution reproducibility and observability.

## Related Issues

- Relates to #0

## Testing

- `cd services/torghut && uv run python -m unittest tests.test_execution_policy tests.test_evaluation_report`
- `cd services/torghut && uv run python -m unittest discover -s tests`
- `cd services/torghut && uv run pyright`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
