### PR TITLE
feat(torghut): emit deterministic regime labels in walk-forward output

### DIFF
--- a/services/torghut/tests/test_regime_classifier.py
+++ b/services/torghut/tests/test_regime_classifier.py
@@ -45,6 +45,8 @@ class TestRegimeClassifier(TestCase):
 
         label_one = classify_regime(decisions)
         label_two = classify_regime(decisions)
+        reversed_label = classify_regime(list(reversed(decisions)))
 
         self.assertEqual(label_one, label_two)
+        self.assertEqual(label_one, reversed_label)
         self.assertEqual(label_one.label(), 'vol=high|trend=up|liq=liquid')

--- a/services/torghut/tests/test_walkforward.py
+++ b/services/torghut/tests/test_walkforward.py
@@ -53,6 +53,9 @@ class TestWalkForwardHarness(TestCase):
         self.assertEqual(fold_result.signals_count, 2)
         self.assertEqual(len(fold_result.decisions), 2)
         self.assertEqual(results.feature_spec, "app.trading.features.extract_signal_features")
+        self.assertEqual(fold_result.fold_metrics()["decision_count"], 2)
+        self.assertEqual(fold_result.fold_metrics()["buy_count"], 1)
+        self.assertEqual(fold_result.fold_metrics()["sell_count"], 1)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "walkforward-results.json"
@@ -60,3 +63,7 @@ class TestWalkForwardHarness(TestCase):
             payload = json.loads(output_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["feature_spec"], "app.trading.features.extract_signal_features")
             self.assertEqual(len(payload["folds"]), 1)
+            fold_payload = payload["folds"][0]
+            self.assertEqual(fold_payload["regime_label"], "vol=high|trend=up|liq=liquid")
+            self.assertEqual(fold_payload["metrics"]["signals_count"], 2)
+            self.assertEqual(fold_payload["metrics"]["decision_count"], 2)


### PR DESCRIPTION
## Summary

- add fold-level walk-forward metrics emission (`decision_count`, action counts, and `signals_count`) in `FoldResult.to_payload()`
- emit deterministic regime metadata (`regime_label` and structured `regime`) alongside each fold payload
- strengthen regime stability coverage by asserting classifier output is invariant to decision ordering
- extend walk-forward tests to validate new metrics and regime fields in serialized output

## Related Issues

None

## Testing

- `uv run python -m unittest tests.test_walkforward tests.test_regime_classifier tests.test_robustness_report tests.test_evaluation_report` (from `services/torghut`)
- `uv run python -m unittest` (from `services/torghut`)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
