### PR TITLE
fix(torghut): use jangar enabled symbol universe

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -97,7 +97,7 @@ spec:
             - name: TRADING_STRATEGY_RELOAD_SECONDS
               value: "10"
             - name: TRADING_UNIVERSE_SOURCE
-              value: static
+              value: jangar
             - name: TRADING_STATIC_SYMBOLS
               value: CRWD,MU,NVDA
             - name: JANGAR_SYMBOLS_URL

--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -15,9 +15,6 @@ data:
         enabled: true
         base_timeframe: "1Sec"
         universe_type: static
-        symbols:
-          - CRWD
-          - MU
-          - NVDA
+        symbols: []
         max_notional_per_trade: 500
         max_position_pct_equity: 0.05


### PR DESCRIPTION
## Summary

- Switch Torghut trading universe source from `static` to `jangar` in Knative service env.
- Remove hardcoded `CRWD/MU/NVDA` strategy symbol list from `torghut-strategy-config`.
- Keep strategy enabled while allowing runtime symbol resolution from Jangar enabled symbols.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl get ksvc torghut -n torghut -o yaml | rg -n "TRADING_UNIVERSE_SOURCE|TRADING_STATIC_SYMBOLS|JANGAR_SYMBOLS_URL" -C 1`
- `kubectl get cm torghut-strategy-config -n torghut -o yaml | rg -n "macd-rsi-default|symbols|universe_type" -C 2`
- `kubectl cnpg psql -n torghut torghut-db -- -d torghut -c "SELECT name,enabled,universe_type,universe_symbols,updated_at FROM strategies WHERE name='macd-rsi-default';"`
- `kubectl exec -n torghut $(kubectl get pods -n torghut -l serving.knative.dev/revision=torghut-00060 -o jsonpath='{.items[0].metadata.name}') -c user-container -- python -c "from app.trading.universe import UniverseResolver; from app.config import settings; s=sorted(UniverseResolver().get_symbols()); print('source=',settings.trading_universe_source); print('count=',len(s)); print('symbols=',','.join(s))"`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
