### PR TITLE
feat(torghut): add deterministic regime labels to walk-forward evaluation

### DIFF
--- a/services/torghut/app/trading/evaluation.py
+++ b/services/torghut/app/trading/evaluation.py
@@ -46,8 +46,8 @@ class FoldResult:
     signals_count: int = 0
 
     def to_payload(self) -> dict[str, object]:
-        metrics = self.fold_metrics()
         regime = _fold_regime_payload(self.decisions)
+        metrics = self.fold_metrics(regime=regime)
         return {
             "fold": _fold_payload(self.fold),
             "signals_count": self.signals_count,
@@ -57,7 +57,8 @@ class FoldResult:
             "decisions": [self._decision_payload(item) for item in self.decisions],
         }
 
-    def fold_metrics(self) -> dict[str, int]:
+    def fold_metrics(self, regime: dict[str, str] | None = None) -> dict[str, object]:
+        resolved_regime = regime or _fold_regime_payload(self.decisions)
         action_counts = {"buy": 0, "sell": 0, "hold": 0}
         for item in self.decisions:
             action = item.decision.action
@@ -70,6 +71,8 @@ class FoldResult:
             "buy_count": action_counts["buy"],
             "sell_count": action_counts["sell"],
             "hold_count": action_counts["hold"],
+            "regime_label": resolved_regime["label"],
+            "regime": resolved_regime,
         }
 
     @staticmethod

--- a/services/torghut/tests/test_regime_classifier.py
+++ b/services/torghut/tests/test_regime_classifier.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from pathlib import Path
 from unittest import TestCase
+from uuid import uuid4
 
 from app.models import Strategy
 from app.trading.decisions import DecisionEngine
-from app.trading.evaluation import FixtureSignalSource, generate_walk_forward_folds, run_walk_forward
+from app.trading.evaluation import (
+    FixtureSignalSource,
+    WalkForwardDecision,
+    generate_walk_forward_folds,
+    run_walk_forward,
+)
+from app.trading.features import SignalFeatures
+from app.trading.models import StrategyDecision
 from app.trading.regime import classify_regime
 
 
@@ -50,3 +59,135 @@ class TestRegimeClassifier(TestCase):
         self.assertEqual(label_one, label_two)
         self.assertEqual(label_one, reversed_label)
         self.assertEqual(label_one.label(), 'vol=high|trend=up|liq=liquid')
+
+    def test_regime_classifier_bucket_boundaries(self) -> None:
+        low_regime = classify_regime(
+            [
+                self._decision(
+                    0,
+                    price=Decimal('100'),
+                    volatility=Decimal('0.009'),
+                    macd=Decimal('0.01'),
+                    macd_signal=Decimal('0.01'),
+                ),
+                self._decision(
+                    1,
+                    price=Decimal('100.1'),
+                    volatility=Decimal('0.009'),
+                    macd=Decimal('0.01'),
+                    macd_signal=Decimal('0.01'),
+                ),
+            ]
+        )
+        self.assertEqual(low_regime.label(), 'vol=low|trend=flat|liq=liquid')
+
+        mid_regime = classify_regime(
+            [
+                self._decision(
+                    0,
+                    price=Decimal('100'),
+                    volatility=Decimal('0.02'),
+                    macd=Decimal('0.1'),
+                    macd_signal=Decimal('0.01'),
+                ),
+                self._decision(
+                    1,
+                    price=Decimal('101'),
+                    volatility=Decimal('0.02'),
+                    macd=Decimal('0.1'),
+                    macd_signal=Decimal('0.01'),
+                ),
+            ]
+        )
+        self.assertEqual(mid_regime.label(), 'vol=mid|trend=up|liq=liquid')
+
+        high_illiquid_regime = classify_regime(
+            [
+                self._decision(
+                    0,
+                    price=Decimal('100'),
+                    volatility=Decimal('0.04'),
+                    macd=Decimal('-0.2'),
+                    macd_signal=Decimal('0.01'),
+                ),
+                self._decision(
+                    1,
+                    price=Decimal('89'),
+                    volatility=Decimal('0.04'),
+                    macd=Decimal('-0.2'),
+                    macd_signal=Decimal('0.01'),
+                ),
+            ]
+        )
+        self.assertEqual(high_illiquid_regime.label(), 'vol=high|trend=down|liq=illiquid')
+
+    def test_regime_classifier_deterministic_with_equal_sort_keys(self) -> None:
+        event_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        first = self._decision(
+            0,
+            event_ts=event_ts,
+            strategy_id='stable-order',
+            symbol='AAPL',
+            price=Decimal('100'),
+            volatility=Decimal('0.01'),
+            macd=Decimal('0.1'),
+            macd_signal=Decimal('0.02'),
+        )
+        second = self._decision(
+            1,
+            event_ts=event_ts,
+            strategy_id='stable-order',
+            symbol='AAPL',
+            price=Decimal('100'),
+            volatility=Decimal('0.01'),
+            macd=Decimal('0.1'),
+            macd_signal=Decimal('0.02'),
+        )
+        third = self._decision(
+            2,
+            event_ts=event_ts,
+            strategy_id='stable-order',
+            symbol='AAPL',
+            price=None,
+            volatility=Decimal('0.01'),
+            macd=Decimal('0.1'),
+            macd_signal=Decimal('0.02'),
+        )
+
+        one = classify_regime([first, second, third])
+        two = classify_regime([third, first, second])
+        three = classify_regime([second, third, first])
+
+        self.assertEqual(one.label(), 'vol=mid|trend=flat|liq=liquid')
+        self.assertEqual(one, two)
+        self.assertEqual(two, three)
+
+    @staticmethod
+    def _decision(
+        minute_offset: int,
+        *,
+        price: Decimal | None,
+        volatility: Decimal | None,
+        macd: Decimal | None,
+        macd_signal: Decimal | None,
+        strategy_id: str | None = None,
+        symbol: str = 'AAPL',
+        event_ts: datetime | None = None,
+    ) -> WalkForwardDecision:
+        resolved_ts = event_ts or datetime(2026, 1, 1, 0, minute_offset, tzinfo=timezone.utc)
+        decision = StrategyDecision(
+            strategy_id=strategy_id or str(uuid4()),
+            symbol=symbol,
+            event_ts=resolved_ts,
+            timeframe='1Min',
+            action='buy',
+            qty=Decimal('1'),
+        )
+        features = SignalFeatures(
+            macd=macd,
+            macd_signal=macd_signal,
+            rsi=Decimal('50'),
+            price=price,
+            volatility=volatility,
+        )
+        return WalkForwardDecision(decision=decision, features=features)

--- a/services/torghut/tests/test_walkforward.py
+++ b/services/torghut/tests/test_walkforward.py
@@ -67,3 +67,8 @@ class TestWalkForwardHarness(TestCase):
             self.assertEqual(fold_payload["regime_label"], "vol=high|trend=up|liq=liquid")
             self.assertEqual(fold_payload["metrics"]["signals_count"], 2)
             self.assertEqual(fold_payload["metrics"]["decision_count"], 2)
+            self.assertEqual(fold_payload["metrics"]["regime_label"], "vol=high|trend=up|liq=liquid")
+            self.assertEqual(
+                fold_payload["metrics"]["regime"]["label"],
+                "vol=high|trend=up|liq=liquid",
+            )


### PR DESCRIPTION
## Summary

- add deterministic regime metadata directly into each fold `metrics` payload (`regime_label` + structured `regime`) so labels are emitted alongside walk-forward metrics
- keep the classifier evaluation-only and deterministic, with no live auto-enable behavior changes
- expand regime classifier tests with explicit bucket boundary coverage (low/mid/high volatility, up/down/flat trend, liquidity flag behavior)
- add stability tests proving identical labels across repeated runs and reordered inputs, including equal-key ordering cases

## Related Issues

None

## Testing

- `cd services/torghut && uv sync`
- `cd services/torghut && uv pip install pytest pyright`
- `cd services/torghut && uv run python -m pytest -q tests/test_regime_classifier.py tests/test_walkforward.py tests/test_robustness_report.py tests/test_evaluation_report.py`
- `cd services/torghut && uv run python -m pytest -q tests`
- `cd services/torghut && uv run pyright`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
