### PR TITLE
feat(torghut): implement AgentRun orchestration playbook v3

### DIFF
--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -152,6 +152,37 @@ Troubleshooting:
   `*_NAMESPACE` variables if needed).
 - Ensure the referenced Orchestration exists and watch OrchestrationRun status for progress.
 
+## Torghut v3 orchestration guard checks
+- Source templates:
+  - `docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml`
+  - `docs/torghut/design-system/v3/full-loop/templates/orchestration-policy.yaml`
+  - `docs/torghut/design-system/v3/full-loop/templates/orchestration-observability.yaml`
+- Validate stage transition guard decisions before advancing a candidate:
+```bash
+cd services/torghut
+uv run python scripts/orchestration_guard.py check-transition \
+  --state artifacts/orchestration/candidate-state.json \
+  --candidate-id cand-abc123 \
+  --run-id run-abc123 \
+  --from-stage gate-evaluation \
+  --to-stage shadow-paper \
+  --previous-artifact artifacts/gates/cand-abc123/report.json \
+  --previous-gate-passed \
+  --risk-controls-passed \
+  --execution-controls-passed \
+  --mode gitops
+```
+- Evaluate retry/pause behavior after a stage failure:
+```bash
+cd services/torghut
+uv run python scripts/orchestration_guard.py evaluate-failure \
+  --state artifacts/orchestration/candidate-state.json \
+  --stage candidate-build \
+  --failure-class transient \
+  --attempt 2
+```
+- Use emergency mode only for ticketed incidents. Mutable actions remain GitOps-first by default.
+
 ## Jangar /health 500 (router init error)
 - Symptom: `/health` returns 500 with `ReferenceError: Cannot access 'aE' before initialization`.
 - Root cause: Jangar builds picked up an incompatible Nitro `latest` bundle output.

--- a/docs/torghut/design-system/v3/full-loop/02-gate-policy-matrix.md
+++ b/docs/torghut/design-system/v3/full-loop/02-gate-policy-matrix.md
@@ -119,12 +119,10 @@ Minimum deliverables:
 - CI checks and failure alert hooks.
 
 ## AgentRun Handoff Bundle
-- `ImplementationSpec`: `torghut-v3-gate-matrix-impl-v1`.
+- `ImplementationSpec`: `torghut-v3-gate-evaluation-v1`.
 - Required keys:
-  - `repository`
-  - `base`
-  - `head`
   - `gateConfigPath`
+  - `metricsBundlePath`
   - `artifactPath`
 - Expected artifacts:
   - gate evaluator scripts,

--- a/docs/torghut/design-system/v3/full-loop/03-implementationspec-catalog.md
+++ b/docs/torghut/design-system/v3/full-loop/03-implementationspec-catalog.md
@@ -92,6 +92,23 @@ Required keys:
 - `complianceProfile`
 - `outputPath`
 
+## Canonical Template Mapping
+
+| ImplementationSpec | AgentRun template |
+| --- | --- |
+| `torghut-v3-research-intake-v1` | `torghut-v3-research-intake-sample` |
+| `torghut-v3-candidate-build-v1` | `torghut-v3-candidate-build-sample` |
+| `torghut-v3-backtest-robustness-v1` | `torghut-v3-backtest-robustness-sample` |
+| `torghut-v3-gate-evaluation-v1` | `torghut-v3-gate-eval-sample` |
+| `torghut-v3-shadow-paper-run-v1` | `torghut-v3-shadow-paper-sample` |
+| `torghut-v3-live-ramp-v1` | `torghut-v3-live-ramp-sample` |
+| `torghut-v3-incident-recovery-v1` | `torghut-v3-incident-recovery-sample` |
+| `torghut-v3-audit-pack-v1` | `torghut-v3-audit-pack-sample` |
+
+Compatibility note:
+- `torghut-v3-audit-evidence-impl-v1` is retained as a temporary alias for one release cycle, while
+  `torghut-v3-audit-pack-v1` is canonical for new runs.
+
 ## Naming and Versioning Rules
 - use `torghut-v3-<lane>-v<major>` naming,
 - breaking contract change requires major version bump,

--- a/docs/torghut/design-system/v3/full-loop/06-backtest-realism-standard.md
+++ b/docs/torghut/design-system/v3/full-loop/06-backtest-realism-standard.md
@@ -68,10 +68,11 @@ Minimum deliverables:
 - regression tests.
 
 ## AgentRun Handoff Bundle
-- `ImplementationSpec`: `torghut-v3-backtest-realism-impl-v1`.
+- `ImplementationSpec`: `torghut-v3-backtest-robustness-v1`.
 - Required keys:
-  - `strategyId`
   - `datasetSnapshotId`
+  - `strategyId`
+  - `strategyVersion`
   - `costModelVersion`
   - `artifactPath`
 - Exit criteria:

--- a/docs/torghut/design-system/v3/full-loop/07-shadow-paper-evaluation-spec.md
+++ b/docs/torghut/design-system/v3/full-loop/07-shadow-paper-evaluation-spec.md
@@ -58,12 +58,12 @@ Minimum deliverables:
 - promotion-ready report schema.
 
 ## AgentRun Handoff Bundle
-- `ImplementationSpec`: `torghut-v3-shadow-paper-eval-impl-v1`.
+- `ImplementationSpec`: `torghut-v3-shadow-paper-run-v1`.
 - Required keys:
-  - `candidateId`
-  - `championId`
+  - `torghutNamespace`
+  - `gitopsPath`
+  - `strategyConfigPatchPath`
   - `evaluationWindow`
-  - `artifactPath`
 - Exit criteria:
   - shadow and paper workflows produce comparable reports,
   - gate evaluator consumes report outputs,

--- a/docs/torghut/design-system/v3/full-loop/08-live-rollout-capital-ramp-plan.md
+++ b/docs/torghut/design-system/v3/full-loop/08-live-rollout-capital-ramp-plan.md
@@ -58,13 +58,12 @@ Minimum deliverables:
 - live stage audit logs.
 
 ## AgentRun Handoff Bundle
-- `ImplementationSpec`: `torghut-v3-live-ramp-impl-v1`.
+- `ImplementationSpec`: `torghut-v3-live-ramp-v1`.
 - Required keys:
   - `torghutNamespace`
   - `gitopsPath`
   - `rampStage`
   - `confirm`
-  - `artifactPath`
 - Exit criteria:
   - stage transition dry run succeeds,
   - rollback trigger simulation succeeds,

--- a/docs/torghut/design-system/v3/full-loop/09-incident-kill-switch-recovery-runbook.md
+++ b/docs/torghut/design-system/v3/full-loop/09-incident-kill-switch-recovery-runbook.md
@@ -63,13 +63,12 @@ Minimum deliverables:
 - postmortem template.
 
 ## AgentRun Handoff Bundle
-- `ImplementationSpec`: `torghut-v3-incident-recovery-impl-v1`.
+- `ImplementationSpec`: `torghut-v3-incident-recovery-v1`.
 - Required keys:
-  - `incidentId`
   - `torghutNamespace`
+  - `incidentId`
   - `rollbackTarget`
   - `confirm`
-  - `artifactPath`
 - Exit criteria:
   - incident drill passes,
   - kill switch dry-run passes,

--- a/docs/torghut/design-system/v3/full-loop/10-audit-compliance-evidence-spec.md
+++ b/docs/torghut/design-system/v3/full-loop/10-audit-compliance-evidence-spec.md
@@ -63,7 +63,8 @@ Minimum deliverables:
 - audit report templates.
 
 ## AgentRun Handoff Bundle
-- `ImplementationSpec`: `torghut-v3-audit-evidence-impl-v1`.
+- `ImplementationSpec`: `torghut-v3-audit-pack-v1`.
+- Compatibility alias (deprecated): `torghut-v3-audit-evidence-impl-v1`.
 - Required keys:
   - `runId`
   - `artifactRefs`

--- a/docs/torghut/design-system/v3/full-loop/index.md
+++ b/docs/torghut/design-system/v3/full-loop/index.md
@@ -62,6 +62,8 @@ Definition of "significant scope" for this pack:
 ## Templates
 - `templates/implementationspecs.yaml`
 - `templates/agentruns.yaml`
+- `templates/orchestration-policy.yaml`
+- `templates/orchestration-observability.yaml`
 
 ## Cross-References
 - Core v3 architecture: `docs/torghut/design-system/v3/flexible-strategy-engine-architecture.md`

--- a/docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml
@@ -1,10 +1,13 @@
+# Reusable AgentRun templates for Torghut v3 orchestration lanes and stages.
+# Replace ${...} placeholders before applying.
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-research-intake-sample
+  name: torghut-v3-lane-a-research-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: research
+    torghut.proompteng.ai/lane: lane-a
+    torghut.proompteng.ai/stage: research-intake
 spec:
   agentRef:
     name: codex-research-agent
@@ -17,22 +20,29 @@ spec:
     required: false
     mode: none
   parameters:
-    researchPrompt: momentum plus regime thesis on NVDA/MSFT/MU
-    universe: NVDA,MSFT,MU,TSM,SNDK
-    featureSchemaVersion: v3
-    outputPath: docs/torghut/artifacts/research/candidate-a
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: research-intake
+    artifactPath: ${artifactPath}
+    researchPrompt: ${researchPrompt}
+    universe: ${universe}
+    featureSchemaVersion: ${featureSchemaVersion}
+    outputPath: ${outputPath}
   workflow:
     steps:
       - name: implement
+        retries: 2
+        retryBackoffSeconds: 15
         timeoutSeconds: 3600
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-candidate-build-sample
+  name: torghut-v3-lane-b-build-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: build
+    torghut.proompteng.ai/lane: lane-b
+    torghut.proompteng.ai/stage: candidate-build
 spec:
   agentRef:
     name: codex-agent
@@ -47,23 +57,30 @@ spec:
     required: true
     mode: read-write
   parameters:
-    repository: proompteng/lab
-    base: main
-    head: codex/torghut-v3-candidate-build-sample
-    candidateSpecPath: docs/torghut/artifacts/research/candidate-a/spec.md
+    repository: ${repository}
+    base: ${base}
+    head: ${head}
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: candidate-build
+    artifactPath: ${artifactPath}
+    candidateSpecPath: ${candidateSpecPath}
     strategyCatalogPath: argocd/applications/torghut/strategy-configmap.yaml
   workflow:
     steps:
       - name: implement
+        retries: 4
+        retryBackoffSeconds: 15
         timeoutSeconds: 7200
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-backtest-robustness-sample
+  name: torghut-v3-lane-c-backtest-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: backtest
+    torghut.proompteng.ai/lane: lane-c
+    torghut.proompteng.ai/stage: backtest-robustness
 spec:
   agentRef:
     name: codex-research-agent
@@ -71,28 +88,34 @@ spec:
     name: torghut-v3-backtest-robustness-v1
   runtime:
     type: workflow
-  ttlSecondsAfterFinished: 3600
+  ttlSecondsAfterFinished: 7200
   vcsPolicy:
     required: false
     mode: none
   parameters:
-    datasetSnapshotId: ds-2026-02-11-us-largecap-v3
-    strategyId: candidate-a
-    strategyVersion: v1
-    costModelVersion: tca-v3
-    artifactPath: docs/torghut/artifacts/backtests/candidate-a
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: backtest-robustness
+    artifactPath: ${artifactPath}
+    datasetSnapshotId: ${datasetSnapshotId}
+    strategyId: ${strategyId}
+    strategyVersion: ${strategyVersion}
+    costModelVersion: ${costModelVersion}
   workflow:
     steps:
       - name: implement
-        timeoutSeconds: 3600
+        retries: 4
+        retryBackoffSeconds: 15
+        timeoutSeconds: 7200
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-gate-eval-sample
+  name: torghut-v3-lane-d-gate-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: gate-evaluation
+    torghut.proompteng.ai/lane: lane-d
+    torghut.proompteng.ai/stage: gate-evaluation
 spec:
   agentRef:
     name: codex-research-agent
@@ -105,21 +128,27 @@ spec:
     required: false
     mode: none
   parameters:
-    gateConfigPath: docs/torghut/design-system/v3/full-loop/gates/policy-v1.json
-    metricsBundlePath: docs/torghut/artifacts/backtests/candidate-a/metrics.json
-    artifactPath: docs/torghut/artifacts/gates/candidate-a
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: gate-evaluation
+    artifactPath: ${artifactPath}
+    gateConfigPath: ${gateConfigPath}
+    metricsBundlePath: ${metricsBundlePath}
   workflow:
     steps:
       - name: implement
+        retries: 2
+        retryBackoffSeconds: 15
         timeoutSeconds: 3600
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-shadow-paper-sample
+  name: torghut-v3-lane-e-shadow-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: paper-eval
+    torghut.proompteng.ai/lane: lane-e
+    torghut.proompteng.ai/stage: shadow-paper
 spec:
   agentRef:
     name: codex-agent
@@ -134,25 +163,32 @@ spec:
     required: true
     mode: read-write
   parameters:
-    repository: proompteng/lab
-    base: main
-    head: codex/torghut-v3-shadow-paper-sample
-    torghutNamespace: torghut
+    repository: ${repository}
+    base: ${base}
+    head: ${head}
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: shadow-paper
+    artifactPath: ${artifactPath}
+    torghutNamespace: ${torghutNamespace}
     gitopsPath: argocd/applications/torghut
-    strategyConfigPatchPath: docs/torghut/artifacts/gates/candidate-a/patch.yaml
-    evaluationWindow: P7D
+    strategyConfigPatchPath: ${strategyConfigPatchPath}
+    evaluationWindow: ${evaluationWindow}
   workflow:
     steps:
       - name: implement
+        retries: 3
+        retryBackoffSeconds: 30
         timeoutSeconds: 7200
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-live-ramp-sample
+  name: torghut-v3-lane-e-live-ramp-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: live-ramp
+    torghut.proompteng.ai/lane: lane-e
+    torghut.proompteng.ai/stage: live-ramp
     torghut.proompteng.ai/actuation: 'true'
 spec:
   agentRef:
@@ -168,25 +204,32 @@ spec:
     required: true
     mode: read-write
   parameters:
-    repository: proompteng/lab
-    base: main
-    head: codex/torghut-v3-live-ramp-sample
-    torghutNamespace: torghut
+    repository: ${repository}
+    base: ${base}
+    head: ${head}
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: live-ramp
+    artifactPath: ${artifactPath}
+    torghutNamespace: ${torghutNamespace}
     gitopsPath: argocd/applications/torghut
-    rampStage: L1
-    confirm: ACTUATE_TORGHUT
+    rampStage: ${rampStage}
+    confirm: ${confirm}
   workflow:
     steps:
       - name: implement
+        retries: 1
+        retryBackoffSeconds: 60
         timeoutSeconds: 7200
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-incident-recovery-sample
+  name: torghut-v3-lane-f-incident-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: incident
+    torghut.proompteng.ai/lane: lane-f
+    torghut.proompteng.ai/stage: incident-recovery
     torghut.proompteng.ai/actuation: 'true'
 spec:
   agentRef:
@@ -200,22 +243,28 @@ spec:
     required: false
     mode: none
   parameters:
-    torghutNamespace: torghut
-    incidentId: INC-2026-02-11-001
-    rollbackTarget: argocd/main@<commit>
-    confirm: ACTUATE_TORGHUT
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: incident-recovery
+    artifactPath: ${artifactPath}
+    incidentId: ${incidentId}
+    torghutNamespace: ${torghutNamespace}
+    rollbackTarget: ${rollbackTarget}
+    confirm: ${confirm}
   workflow:
     steps:
       - name: implement
+        retries: 0
         timeoutSeconds: 7200
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-audit-pack-sample
+  name: torghut-v3-lane-f-audit-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: audit
+    torghut.proompteng.ai/lane: lane-f
+    torghut.proompteng.ai/stage: audit-evidence
 spec:
   agentRef:
     name: codex-research-agent
@@ -228,13 +277,18 @@ spec:
     required: false
     mode: none
   parameters:
-    runId: run-candidate-a-2026-02-11
-    artifactRefs: docs/torghut/artifacts/gates/candidate-a/report.json,docs/torghut/artifacts/live-ramp/candidate-a
-    complianceProfile: torghut-us-equities-v1
-    outputPath: docs/torghut/artifacts/audit/candidate-a
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: audit-evidence
+    artifactPath: ${artifactPath}
+    complianceProfile: ${complianceProfile}
+    artifactRefs: ${artifactRefs}
+    outputPath: ${outputPath}
   workflow:
     steps:
       - name: implement
+        retries: 1
+        retryBackoffSeconds: 30
         timeoutSeconds: 3600
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
@@ -258,10 +312,10 @@ spec:
     required: true
     mode: read-write
   parameters:
-    repository: proompteng/lab
-    base: main
-    head: codex/torghut-v3-implspec-catalog-sample
-    catalogPath: docs/torghut/design-system/v3/full-loop/03-implementationspec-catalog.md
+    repository: ${repository}
+    base: ${base}
+    head: ${head}
+    catalogPath: ${catalogPath}
   workflow:
     steps:
       - name: implement

--- a/docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml
@@ -1,10 +1,13 @@
+# Reusable AgentRun templates for Torghut v3 orchestration lanes and stages.
+# Replace ${...} placeholders before applying.
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-research-intake-sample
+  name: torghut-v3-lane-a-research-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: research
+    torghut.proompteng.ai/lane: lane-a
+    torghut.proompteng.ai/stage: research-intake
 spec:
   agentRef:
     name: codex-research-agent
@@ -17,22 +20,29 @@ spec:
     required: false
     mode: none
   parameters:
-    researchPrompt: momentum plus regime thesis on NVDA/MSFT/MU
-    universe: NVDA,MSFT,MU,TSM,SNDK
-    featureSchemaVersion: v3
-    outputPath: docs/torghut/artifacts/research/candidate-a
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: research-intake
+    artifactPath: ${artifactPath}
+    researchPrompt: ${researchPrompt}
+    universe: ${universe}
+    featureSchemaVersion: ${featureSchemaVersion}
+    outputPath: ${outputPath}
   workflow:
     steps:
       - name: implement
+        retries: 2
+        retryBackoffSeconds: 15
         timeoutSeconds: 3600
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-candidate-build-sample
+  name: torghut-v3-lane-b-build-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: build
+    torghut.proompteng.ai/lane: lane-b
+    torghut.proompteng.ai/stage: candidate-build
 spec:
   agentRef:
     name: codex-agent
@@ -47,23 +57,65 @@ spec:
     required: true
     mode: read-write
   parameters:
-    repository: proompteng/lab
-    base: main
-    head: codex/torghut-v3-candidate-build-sample
-    candidateSpecPath: docs/torghut/artifacts/research/candidate-a/spec.md
+    repository: ${repository}
+    base: ${base}
+    head: ${head}
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: candidate-build
+    artifactPath: ${artifactPath}
+    candidateSpecPath: ${candidateSpecPath}
     strategyCatalogPath: argocd/applications/torghut/strategy-configmap.yaml
   workflow:
     steps:
       - name: implement
+        retries: 4
+        retryBackoffSeconds: 15
         timeoutSeconds: 7200
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-gate-eval-sample
+  name: torghut-v3-lane-c-backtest-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: gate-evaluation
+    torghut.proompteng.ai/lane: lane-c
+    torghut.proompteng.ai/stage: backtest-robustness
+spec:
+  agentRef:
+    name: codex-research-agent
+  implementationSpecRef:
+    name: torghut-v3-backtest-robustness-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 7200
+  vcsPolicy:
+    required: false
+    mode: none
+  parameters:
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: backtest-robustness
+    artifactPath: ${artifactPath}
+    datasetSnapshotId: ${datasetSnapshotId}
+    strategyId: ${strategyId}
+    strategyVersion: ${strategyVersion}
+    costModelVersion: ${costModelVersion}
+  workflow:
+    steps:
+      - name: implement
+        retries: 4
+        retryBackoffSeconds: 15
+        timeoutSeconds: 7200
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: torghut-v3-lane-d-gate-template
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/lane: lane-d
+    torghut.proompteng.ai/stage: gate-evaluation
 spec:
   agentRef:
     name: codex-research-agent
@@ -76,21 +128,27 @@ spec:
     required: false
     mode: none
   parameters:
-    gateConfigPath: docs/torghut/design-system/v3/full-loop/gates/policy-v1.json
-    metricsBundlePath: docs/torghut/artifacts/backtests/candidate-a/metrics.json
-    artifactPath: docs/torghut/artifacts/gates/candidate-a
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: gate-evaluation
+    artifactPath: ${artifactPath}
+    gateConfigPath: ${gateConfigPath}
+    metricsBundlePath: ${metricsBundlePath}
   workflow:
     steps:
       - name: implement
+        retries: 2
+        retryBackoffSeconds: 15
         timeoutSeconds: 3600
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-shadow-paper-sample
+  name: torghut-v3-lane-e-shadow-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: paper-eval
+    torghut.proompteng.ai/lane: lane-e
+    torghut.proompteng.ai/stage: shadow-paper
 spec:
   agentRef:
     name: codex-agent
@@ -105,26 +163,33 @@ spec:
     required: true
     mode: read-write
   parameters:
-    repository: proompteng/lab
-    base: main
-    head: codex/torghut-v3-shadow-paper-sample
-    torghutNamespace: torghut
+    repository: ${repository}
+    base: ${base}
+    head: ${head}
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: shadow-paper
+    artifactPath: ${artifactPath}
+    torghutNamespace: ${torghutNamespace}
     gitopsPath: argocd/applications/torghut
-    strategyConfigPatchPath: docs/torghut/artifacts/gates/candidate-a/patch.yaml
-    evaluationWindow: P7D
+    strategyConfigPatchPath: ${strategyConfigPatchPath}
+    evaluationWindow: ${evaluationWindow}
   workflow:
     steps:
       - name: implement
+        retries: 3
+        retryBackoffSeconds: 30
         timeoutSeconds: 7200
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-live-ramp-sample
+  name: torghut-v3-lane-e-live-ramp-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: live-ramp
-    torghut.proompteng.ai/actuation: "true"
+    torghut.proompteng.ai/lane: lane-e
+    torghut.proompteng.ai/stage: live-ramp
+    torghut.proompteng.ai/actuation: 'true'
 spec:
   agentRef:
     name: codex-agent
@@ -139,27 +204,33 @@ spec:
     required: true
     mode: read-write
   parameters:
-    repository: proompteng/lab
-    base: main
-    head: codex/torghut-v3-live-ramp-sample
-    torghutNamespace: torghut
+    repository: ${repository}
+    base: ${base}
+    head: ${head}
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: live-ramp
+    artifactPath: ${artifactPath}
+    torghutNamespace: ${torghutNamespace}
     gitopsPath: argocd/applications/torghut
-    rampStage: L1
-    confirm: ACTUATE_TORGHUT
-    artifactPath: docs/torghut/artifacts/live-ramp/candidate-a
+    rampStage: ${rampStage}
+    confirm: ${confirm}
   workflow:
     steps:
       - name: implement
+        retries: 1
+        retryBackoffSeconds: 60
         timeoutSeconds: 7200
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: torghut-v3-incident-recovery-sample
+  name: torghut-v3-lane-f-incident-template
   namespace: agents
   labels:
-    torghut.proompteng.ai/purpose: incident
-    torghut.proompteng.ai/actuation: "true"
+    torghut.proompteng.ai/lane: lane-f
+    torghut.proompteng.ai/stage: incident-recovery
+    torghut.proompteng.ai/actuation: 'true'
 spec:
   agentRef:
     name: codex-agent
@@ -172,12 +243,50 @@ spec:
     required: false
     mode: none
   parameters:
-    incidentId: INC-2026-02-11-001
-    torghutNamespace: torghut
-    rollbackTarget: argocd/main@<commit>
-    confirm: ACTUATE_TORGHUT
-    artifactPath: docs/torghut/artifacts/incidents/INC-2026-02-11-001
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: incident-recovery
+    artifactPath: ${artifactPath}
+    incidentId: ${incidentId}
+    torghutNamespace: ${torghutNamespace}
+    rollbackTarget: ${rollbackTarget}
+    confirm: ${confirm}
   workflow:
     steps:
       - name: implement
+        retries: 0
         timeoutSeconds: 7200
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: torghut-v3-lane-f-audit-template
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/lane: lane-f
+    torghut.proompteng.ai/stage: audit-evidence
+spec:
+  agentRef:
+    name: codex-research-agent
+  implementationSpecRef:
+    name: torghut-v3-audit-evidence-impl-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 3600
+  vcsPolicy:
+    required: false
+    mode: none
+  parameters:
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: audit-evidence
+    artifactPath: ${artifactPath}
+    complianceProfile: ${complianceProfile}
+    artifactRefs: ${artifactRefs}
+    outputPath: ${outputPath}
+  workflow:
+    steps:
+      - name: implement
+        retries: 1
+        retryBackoffSeconds: 30
+        timeoutSeconds: 3600

--- a/docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml
@@ -60,6 +60,35 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
+  name: torghut-v3-backtest-robustness-sample
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/purpose: backtest
+spec:
+  agentRef:
+    name: codex-research-agent
+  implementationSpecRef:
+    name: torghut-v3-backtest-robustness-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 3600
+  vcsPolicy:
+    required: false
+    mode: none
+  parameters:
+    datasetSnapshotId: ds-2026-02-11-us-largecap-v3
+    strategyId: candidate-a
+    strategyVersion: v1
+    costModelVersion: tca-v3
+    artifactPath: docs/torghut/artifacts/backtests/candidate-a
+  workflow:
+    steps:
+      - name: implement
+        timeoutSeconds: 3600
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
   name: torghut-v3-gate-eval-sample
   namespace: agents
   labels:
@@ -124,7 +153,7 @@ metadata:
   namespace: agents
   labels:
     torghut.proompteng.ai/purpose: live-ramp
-    torghut.proompteng.ai/actuation: "true"
+    torghut.proompteng.ai/actuation: 'true'
 spec:
   agentRef:
     name: codex-agent
@@ -146,7 +175,6 @@ spec:
     gitopsPath: argocd/applications/torghut
     rampStage: L1
     confirm: ACTUATE_TORGHUT
-    artifactPath: docs/torghut/artifacts/live-ramp/candidate-a
   workflow:
     steps:
       - name: implement
@@ -159,7 +187,7 @@ metadata:
   namespace: agents
   labels:
     torghut.proompteng.ai/purpose: incident
-    torghut.proompteng.ai/actuation: "true"
+    torghut.proompteng.ai/actuation: 'true'
 spec:
   agentRef:
     name: codex-agent
@@ -172,11 +200,68 @@ spec:
     required: false
     mode: none
   parameters:
-    incidentId: INC-2026-02-11-001
     torghutNamespace: torghut
+    incidentId: INC-2026-02-11-001
     rollbackTarget: argocd/main@<commit>
     confirm: ACTUATE_TORGHUT
-    artifactPath: docs/torghut/artifacts/incidents/INC-2026-02-11-001
+  workflow:
+    steps:
+      - name: implement
+        timeoutSeconds: 7200
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: torghut-v3-audit-pack-sample
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/purpose: audit
+spec:
+  agentRef:
+    name: codex-research-agent
+  implementationSpecRef:
+    name: torghut-v3-audit-pack-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 3600
+  vcsPolicy:
+    required: false
+    mode: none
+  parameters:
+    runId: run-candidate-a-2026-02-11
+    artifactRefs: docs/torghut/artifacts/gates/candidate-a/report.json,docs/torghut/artifacts/live-ramp/candidate-a
+    complianceProfile: torghut-us-equities-v1
+    outputPath: docs/torghut/artifacts/audit/candidate-a
+  workflow:
+    steps:
+      - name: implement
+        timeoutSeconds: 3600
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: torghut-v3-implspec-catalog-ops-sample
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/purpose: catalog-ops
+spec:
+  agentRef:
+    name: codex-agent
+  implementationSpecRef:
+    name: torghut-v3-implspec-catalog-ops-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 7200
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-write
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/torghut-v3-implspec-catalog-sample
+    catalogPath: docs/torghut/design-system/v3/full-loop/03-implementationspec-catalog.md
   workflow:
     steps:
       - name: implement

--- a/docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml
@@ -167,9 +167,11 @@ spec:
       - base
       - head
       - candidateId
+      - runId
       - stage
       - artifactPath
+      - policyPath
   text: |
     Objective: Implement AgentRun orchestration controls (retry, idempotency, lane ownership).
-    Inputs: repository, base, head, candidateId, stage, artifactPath.
-    Output: orchestration runbook + runnable templates.
+    Inputs: repository, base, head, candidateId, runId, stage, artifactPath, policyPath.
+    Output: orchestration runbook + runnable templates + observability contract.

--- a/docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml
@@ -199,9 +199,11 @@ spec:
       - base
       - head
       - candidateId
+      - runId
       - stage
       - artifactPath
+      - policyPath
   text: |
     Objective: Implement AgentRun orchestration controls (retry, idempotency, lane ownership).
-    Inputs: repository, base, head, candidateId, stage, artifactPath.
-    Output: orchestration runbook + runnable templates.
+    Inputs: repository, base, head, candidateId, runId, stage, artifactPath, policyPath.
+    Output: orchestration runbook + runnable templates + observability contract.

--- a/docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml
@@ -96,10 +96,9 @@ spec:
       - gitopsPath
       - rampStage
       - confirm
-      - artifactPath
   text: |
     Objective: Apply controlled live-ramp stage with policy checks.
-    Inputs: torghutNamespace, gitopsPath, rampStage, confirm, artifactPath.
+    Inputs: torghutNamespace, gitopsPath, rampStage, confirm.
     Output: rollout report and stage health summary.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
@@ -110,15 +109,31 @@ metadata:
 spec:
   contract:
     requiredKeys:
-      - incidentId
       - torghutNamespace
+      - incidentId
       - rollbackTarget
       - confirm
-      - artifactPath
   text: |
     Objective: Execute containment, rollback, and recovery verification.
-    Inputs: incidentId, torghutNamespace, rollbackTarget, confirm, artifactPath.
+    Inputs: torghutNamespace, incidentId, rollbackTarget, confirm.
     Output: incident recovery report with verification checklist.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: torghut-v3-audit-pack-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - runId
+      - artifactRefs
+      - complianceProfile
+      - outputPath
+  text: |
+    Objective: Build audit/compliance evidence package for run.
+    Inputs: runId, artifactRefs, complianceProfile, outputPath.
+    Output: immutable evidence bundle and validation report.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec
@@ -133,9 +148,26 @@ spec:
       - complianceProfile
       - outputPath
   text: |
-    Objective: Build audit/compliance evidence package for run.
+    Objective: Compatibility alias for the canonical torghut-v3-audit-pack-v1 evidence workflow.
     Inputs: runId, artifactRefs, complianceProfile, outputPath.
     Output: immutable evidence bundle and validation report.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: torghut-v3-implspec-catalog-ops-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - repository
+      - base
+      - head
+      - catalogPath
+  text: |
+    Objective: Keep full-loop ImplementationSpec catalog manifests and AgentRun templates synchronized.
+    Inputs: repository, base, head, catalogPath.
+    Output: updated manifests, required-key checks, and template/documentation alignment.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec

--- a/docs/torghut/design-system/v3/full-loop/templates/orchestration-observability.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/orchestration-observability.yaml
@@ -1,0 +1,104 @@
+version: torghut-v3-orchestration-observability-v1
+description: Dashboard and alert contract for AgentRun orchestration lanes/stages.
+
+labels:
+  required:
+    - candidate_id
+    - run_id
+    - stage
+    - lane
+    - failure_class
+    - mode
+
+metrics:
+  - name: torghut_orchestration_stage_duration_seconds
+    type: histogram
+    unit: seconds
+    description: Duration of each stage execution attempt.
+    labels:
+      - candidate_id
+      - run_id
+      - stage
+      - lane
+      - result
+  - name: torghut_orchestration_retry_total
+    type: counter
+    unit: attempts
+    description: Count of retry attempts by stage and failure class.
+    labels:
+      - candidate_id
+      - run_id
+      - stage
+      - failure_class
+  - name: torghut_orchestration_failure_total
+    type: counter
+    unit: failures
+    description: Failure classes emitted by the orchestration guard.
+    labels:
+      - candidate_id
+      - run_id
+      - stage
+      - failure_class
+  - name: torghut_orchestration_queue_depth
+    type: gauge
+    unit: runs
+    description: Number of candidate runs waiting per stage.
+    labels:
+      - stage
+      - lane
+  - name: torghut_orchestration_handoff_latency_seconds
+    type: histogram
+    unit: seconds
+    description: Time between stage complete and next stage start.
+    labels:
+      - candidate_id
+      - run_id
+      - from_stage
+      - to_stage
+
+alerts:
+  - name: TorghutOrchestrationRetryStorm
+    expr: sum(rate(torghut_orchestration_retry_total[15m])) by (stage) > 0.5
+    for: 20m
+    severity: warning
+    summary: Retry volume indicates persistent stage instability.
+  - name: TorghutOrchestrationFailureSpike
+    expr: sum(rate(torghut_orchestration_failure_total[10m])) by (failure_class) > 0.2
+    for: 10m
+    severity: critical
+    summary: Elevated deterministic/policy failures require immediate review.
+  - name: TorghutOrchestrationQueueBacklog
+    expr: max(torghut_orchestration_queue_depth) by (stage) > 10
+    for: 15m
+    severity: warning
+    summary: Stage queue depth exceeds operational threshold.
+
+dashboard:
+  title: Torghut v3 Orchestration
+  panels:
+    - title: Stage Duration p95
+      metric: torghut_orchestration_stage_duration_seconds
+      stat: p95
+      groupBy:
+        - stage
+    - title: Retry Count by Stage
+      metric: torghut_orchestration_retry_total
+      stat: rate
+      groupBy:
+        - stage
+    - title: Failure Classes
+      metric: torghut_orchestration_failure_total
+      stat: rate
+      groupBy:
+        - failure_class
+    - title: Queue Depth
+      metric: torghut_orchestration_queue_depth
+      stat: max
+      groupBy:
+        - stage
+    - title: Handoff Latency p95
+      metric: torghut_orchestration_handoff_latency_seconds
+      stat: p95
+      groupBy:
+        - from_stage
+        - to_stage

--- a/docs/torghut/design-system/v3/full-loop/templates/orchestration-policy.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/orchestration-policy.yaml
@@ -1,0 +1,107 @@
+version: torghut-v3-orchestration-policy-v1
+description: >
+  Deterministic stage transition and failure governance policy for Torghut v3
+  autonomous orchestration.
+
+stages:
+  - stage: research-intake
+    lane: lane-a
+    mutableAction: false
+    requirePreviousArtifact: false
+    requirePreviousGatePass: false
+  - stage: candidate-build
+    lane: lane-b
+    mutableAction: true
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
+  - stage: backtest-robustness
+    lane: lane-c
+    mutableAction: false
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
+  - stage: gate-evaluation
+    lane: lane-d
+    mutableAction: false
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
+  - stage: shadow-paper
+    lane: lane-e
+    mutableAction: true
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
+  - stage: live-ramp
+    lane: lane-e
+    mutableAction: true
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
+  - stage: continuous-monitoring
+    lane: lane-f
+    mutableAction: false
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
+  - stage: incident-recovery
+    lane: lane-f
+    mutableAction: true
+    requirePreviousArtifact: true
+    requirePreviousGatePass: false
+  - stage: audit-evidence
+    lane: lane-f
+    mutableAction: false
+    requirePreviousArtifact: true
+    requirePreviousGatePass: false
+
+transitions:
+  research-intake:
+    - candidate-build
+  candidate-build:
+    - backtest-robustness
+  backtest-robustness:
+    - gate-evaluation
+  gate-evaluation:
+    - research-intake
+    - shadow-paper
+  shadow-paper:
+    - live-ramp
+    - incident-recovery
+  live-ramp:
+    - continuous-monitoring
+    - incident-recovery
+  continuous-monitoring:
+    - live-ramp
+    - incident-recovery
+  incident-recovery:
+    - research-intake
+    - audit-evidence
+  audit-evidence: []
+
+failurePolicies:
+  transient:
+    maxRetries: 4
+    initialBackoffSeconds: 15
+    backoffMultiplier: 2
+    maxBackoffSeconds: 300
+    autopauseAfterFailures: 5
+  deterministic:
+    maxRetries: 0
+    initialBackoffSeconds: 0
+    backoffMultiplier: 1
+    maxBackoffSeconds: 0
+    autopauseAfterFailures: 2
+  spec:
+    maxRetries: 0
+    initialBackoffSeconds: 0
+    backoffMultiplier: 1
+    maxBackoffSeconds: 0
+    autopauseAfterFailures: 2
+  policy:
+    maxRetries: 0
+    initialBackoffSeconds: 0
+    backoffMultiplier: 1
+    maxBackoffSeconds: 0
+    autopauseAfterFailures: 1
+
+controls:
+  riskControlsAuthority: final
+  executionControlsAuthority: final
+  mutableActionMode: gitops-first
+  emergencyOverrideRequiresTicket: true

--- a/services/jangar/scripts/codex/__tests__/torghut-v3-full-loop-catalog.test.ts
+++ b/services/jangar/scripts/codex/__tests__/torghut-v3-full-loop-catalog.test.ts
@@ -1,0 +1,108 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = resolve(fileURLToPath(new URL('../../../../../', import.meta.url)))
+const implementationSpecsPath = resolve(
+  repoRoot,
+  'docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml',
+)
+const agentRunsPath = resolve(repoRoot, 'docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml')
+
+const CATALOG_REQUIRED_KEYS: Record<string, string[]> = {
+  'torghut-v3-research-intake-v1': ['researchPrompt', 'universe', 'featureSchemaVersion', 'outputPath'],
+  'torghut-v3-candidate-build-v1': ['repository', 'base', 'head', 'candidateSpecPath', 'strategyCatalogPath'],
+  'torghut-v3-backtest-robustness-v1': [
+    'datasetSnapshotId',
+    'strategyId',
+    'strategyVersion',
+    'costModelVersion',
+    'artifactPath',
+  ],
+  'torghut-v3-gate-evaluation-v1': ['gateConfigPath', 'metricsBundlePath', 'artifactPath'],
+  'torghut-v3-shadow-paper-run-v1': ['torghutNamespace', 'gitopsPath', 'strategyConfigPatchPath', 'evaluationWindow'],
+  'torghut-v3-live-ramp-v1': ['torghutNamespace', 'gitopsPath', 'rampStage', 'confirm'],
+  'torghut-v3-incident-recovery-v1': ['torghutNamespace', 'incidentId', 'rollbackTarget', 'confirm'],
+  'torghut-v3-audit-pack-v1': ['runId', 'artifactRefs', 'complianceProfile', 'outputPath'],
+}
+
+const splitYamlDocuments = (raw: string): string[] =>
+  raw
+    .split(/^---\s*$/m)
+    .map((document) => document.trim())
+    .filter((document) => document.length > 0)
+
+const parseMetadataName = (document: string): string | null => {
+  const metadataBlock = document.match(/metadata:\n([\s\S]*?)\nspec:/)
+  if (!metadataBlock) return null
+  const nameMatch = metadataBlock[1]?.match(/^\s*name:\s*([^\s]+)\s*$/m)
+  return nameMatch?.[1] ?? null
+}
+
+const parseRequiredKeys = (document: string): string[] => {
+  const blockMatch = document.match(/requiredKeys:\n((?:\s*-\s[^\n]+\n?)+)/)
+  if (!blockMatch) return []
+  return [...blockMatch[1].matchAll(/-\s*([^\n#]+)/g)].map((match) => match[1]?.trim() ?? '').filter(Boolean)
+}
+
+const parseAgentRunImplementationSpecRef = (document: string): string | null => {
+  const specRefMatch = document.match(/implementationSpecRef:\n\s*name:\s*([^\s]+)/)
+  return specRefMatch?.[1] ?? null
+}
+
+const parseParameterKeys = (document: string): Set<string> => {
+  const parametersMatch = document.match(/parameters:\n([\s\S]*?)\n\s*workflow:/)
+  if (!parametersMatch) return new Set()
+  return new Set(
+    [...parametersMatch[1].matchAll(/^\s{4}([a-zA-Z][a-zA-Z0-9]*):/gm)]
+      .map((match) => match[1]?.trim() ?? '')
+      .filter(Boolean),
+  )
+}
+
+describe('Torghut v3 full-loop catalog templates', () => {
+  it('keeps canonical requiredKeys aligned in ImplementationSpec manifests', async () => {
+    const raw = await readFile(implementationSpecsPath, 'utf8')
+    const documents = splitYamlDocuments(raw).filter((document) => document.includes('kind: ImplementationSpec'))
+    const requiredKeysBySpec = new Map<string, string[]>()
+
+    for (const document of documents) {
+      const name = parseMetadataName(document)
+      if (!name) continue
+      requiredKeysBySpec.set(name, parseRequiredKeys(document))
+    }
+
+    for (const [specName, expectedRequiredKeys] of Object.entries(CATALOG_REQUIRED_KEYS)) {
+      expect(requiredKeysBySpec.get(specName)).toEqual(expectedRequiredKeys)
+    }
+  })
+
+  it('maps every canonical catalog spec to an AgentRun template with matching parameters', async () => {
+    const raw = await readFile(agentRunsPath, 'utf8')
+    const documents = splitYamlDocuments(raw).filter((document) => document.includes('kind: AgentRun'))
+    const specsWithRuns = new Set<string>()
+    const runNames = new Set<string>()
+
+    for (const document of documents) {
+      const runName = parseMetadataName(document)
+      const implementationSpecRef = parseAgentRunImplementationSpecRef(document)
+      if (!runName) {
+        continue
+      }
+      expect(runNames.has(runName), `duplicate AgentRun metadata.name ${runName}`).toBe(false)
+      runNames.add(runName)
+      if (!implementationSpecRef || !(implementationSpecRef in CATALOG_REQUIRED_KEYS)) {
+        continue
+      }
+
+      specsWithRuns.add(implementationSpecRef)
+      const parameterKeys = parseParameterKeys(document)
+      for (const requiredKey of CATALOG_REQUIRED_KEYS[implementationSpecRef]) {
+        expect(parameterKeys.has(requiredKey), `run ${runName} missing required key ${requiredKey}`).toBe(true)
+      }
+    }
+
+    expect(new Set(Object.keys(CATALOG_REQUIRED_KEYS))).toEqual(specsWithRuns)
+  })
+})

--- a/services/jangar/src/server/__tests__/torghut-v3-full-loop-catalog.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-v3-full-loop-catalog.test.ts
@@ -1,0 +1,227 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const IMPLEMENTATION_SPECS_PATH = fileURLToPath(
+  new URL('../../../../../docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml', import.meta.url),
+)
+const AGENT_RUNS_PATH = fileURLToPath(
+  new URL('../../../../../docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml', import.meta.url),
+)
+
+const REQUIRED_KEYS_BY_SPEC = new Map<string, string[]>([
+  ['torghut-v3-research-intake-v1', ['researchPrompt', 'universe', 'featureSchemaVersion', 'outputPath']],
+  ['torghut-v3-candidate-build-v1', ['repository', 'base', 'head', 'candidateSpecPath', 'strategyCatalogPath']],
+  [
+    'torghut-v3-backtest-robustness-v1',
+    ['datasetSnapshotId', 'strategyId', 'strategyVersion', 'costModelVersion', 'artifactPath'],
+  ],
+  ['torghut-v3-gate-evaluation-v1', ['gateConfigPath', 'metricsBundlePath', 'artifactPath']],
+  ['torghut-v3-shadow-paper-run-v1', ['torghutNamespace', 'gitopsPath', 'strategyConfigPatchPath', 'evaluationWindow']],
+  ['torghut-v3-live-ramp-v1', ['torghutNamespace', 'gitopsPath', 'rampStage', 'confirm']],
+  ['torghut-v3-incident-recovery-v1', ['torghutNamespace', 'incidentId', 'rollbackTarget', 'confirm']],
+  ['torghut-v3-audit-pack-v1', ['runId', 'artifactRefs', 'complianceProfile', 'outputPath']],
+])
+
+const CATALOG_OPS_SPEC = 'torghut-v3-implspec-catalog-ops-v1'
+const CATALOG_OPS_REQUIRED_KEYS = ['repository', 'base', 'head', 'catalogPath']
+
+const splitYamlDocs = (content: string) =>
+  content
+    .split(/^---\s*$/m)
+    .map((doc) => doc.trim())
+    .filter((doc) => doc.length > 0)
+
+const countIndent = (line: string): number => {
+  const match = line.match(/^ */)
+  return match ? match[0].length : 0
+}
+
+const getMappingValue = (lines: string[], path: string[]): string | null => {
+  let start = 0
+  let end = lines.length
+  let indent = 0
+
+  for (let index = 0; index < path.length; index += 1) {
+    const key = path[index]
+    let keyLineIndex = -1
+    for (let i = start; i < end; i += 1) {
+      const line = lines[i]
+      if (!line) continue
+      if (countIndent(line) !== indent) continue
+      if (line.trim() === `${key}:`) {
+        keyLineIndex = i
+        break
+      }
+      if (line.trim().startsWith(`${key}: `)) {
+        return line.trim().slice(`${key}: `.length).trim()
+      }
+    }
+    if (keyLineIndex === -1) return null
+
+    start = keyLineIndex + 1
+    end = lines.length
+    for (let i = start; i < lines.length; i += 1) {
+      const line = lines[i]
+      if (!line) continue
+      if (countIndent(line) <= indent) {
+        end = i
+        break
+      }
+    }
+    indent += 2
+  }
+
+  return null
+}
+
+const getListValues = (lines: string[], path: string[]): string[] => {
+  let start = 0
+  let end = lines.length
+  let indent = 0
+
+  for (const key of path) {
+    let keyLineIndex = -1
+    for (let i = start; i < end; i += 1) {
+      const line = lines[i]
+      if (!line) continue
+      if (countIndent(line) !== indent) continue
+      if (line.trim() === `${key}:`) {
+        keyLineIndex = i
+        break
+      }
+    }
+    if (keyLineIndex === -1) return []
+
+    start = keyLineIndex + 1
+    end = lines.length
+    for (let i = start; i < lines.length; i += 1) {
+      const line = lines[i]
+      if (!line) continue
+      if (countIndent(line) <= indent) {
+        end = i
+        break
+      }
+    }
+    indent += 2
+  }
+
+  const values: string[] = []
+  for (let i = start; i < end; i += 1) {
+    const line = lines[i]
+    if (!line) continue
+    if (countIndent(line) !== indent) continue
+    const trimmed = line.trim()
+    if (trimmed.startsWith('- ')) {
+      values.push(trimmed.slice(2).trim())
+    }
+  }
+  return values
+}
+
+const getMapKeys = (lines: string[], path: string[]): string[] => {
+  let start = 0
+  let end = lines.length
+  let indent = 0
+
+  for (const key of path) {
+    let keyLineIndex = -1
+    for (let i = start; i < end; i += 1) {
+      const line = lines[i]
+      if (!line) continue
+      if (countIndent(line) !== indent) continue
+      if (line.trim() === `${key}:`) {
+        keyLineIndex = i
+        break
+      }
+    }
+    if (keyLineIndex === -1) return []
+
+    start = keyLineIndex + 1
+    end = lines.length
+    for (let i = start; i < lines.length; i += 1) {
+      const line = lines[i]
+      if (!line) continue
+      if (countIndent(line) <= indent) {
+        end = i
+        break
+      }
+    }
+    indent += 2
+  }
+
+  const keys: string[] = []
+  for (let i = start; i < end; i += 1) {
+    const line = lines[i]
+    if (!line) continue
+    if (countIndent(line) !== indent) continue
+    const trimmed = line.trim()
+    if (trimmed.startsWith('- ')) continue
+    const colonIndex = trimmed.indexOf(':')
+    if (colonIndex <= 0) continue
+    keys.push(trimmed.slice(0, colonIndex))
+  }
+  return keys
+}
+
+describe('Torghut v3 full-loop catalog templates', () => {
+  it('keeps canonical ImplementationSpec names and required keys aligned', () => {
+    const docs = splitYamlDocs(readFileSync(IMPLEMENTATION_SPECS_PATH, 'utf8'))
+    const requiredKeysBySpec = new Map<string, string[]>()
+
+    for (const doc of docs) {
+      const lines = doc.split('\n')
+      const kind = getMappingValue(lines, ['kind'])
+      if (kind !== 'ImplementationSpec') continue
+      const name = getMappingValue(lines, ['metadata', 'name'])
+      if (!name) continue
+      const requiredKeys = getListValues(lines, ['spec', 'contract', 'requiredKeys'])
+      requiredKeysBySpec.set(name, requiredKeys)
+    }
+
+    for (const [name, requiredKeys] of REQUIRED_KEYS_BY_SPEC) {
+      expect(requiredKeysBySpec.has(name), `missing ImplementationSpec ${name}`).toBe(true)
+      expect(requiredKeysBySpec.get(name)).toEqual(requiredKeys)
+    }
+
+    expect(requiredKeysBySpec.get(CATALOG_OPS_SPEC)).toEqual(CATALOG_OPS_REQUIRED_KEYS)
+  })
+
+  it('provides AgentRun coverage and required-key parameters for each catalog spec', () => {
+    const docs = splitYamlDocs(readFileSync(AGENT_RUNS_PATH, 'utf8'))
+    const seenSpecs = new Set<string>()
+    const seenRunNames = new Set<string>()
+
+    for (const doc of docs) {
+      const lines = doc.split('\n')
+      const kind = getMappingValue(lines, ['kind'])
+      if (kind !== 'AgentRun') continue
+
+      const runName = getMappingValue(lines, ['metadata', 'name'])
+      if (runName) {
+        expect(seenRunNames.has(runName), `duplicate AgentRun metadata.name ${runName}`).toBe(false)
+        seenRunNames.add(runName)
+      }
+
+      const specName = getMappingValue(lines, ['spec', 'implementationSpecRef', 'name'])
+      if (!specName) continue
+      const parameterKeys = new Set(getMapKeys(lines, ['spec', 'parameters']))
+
+      const expectedKeys =
+        REQUIRED_KEYS_BY_SPEC.get(specName) ?? (specName === CATALOG_OPS_SPEC ? CATALOG_OPS_REQUIRED_KEYS : null)
+      if (!expectedKeys) continue
+
+      seenSpecs.add(specName)
+      expect(
+        expectedKeys.every((key) => parameterKeys.has(key)),
+        `AgentRun template for ${specName} is missing required parameters`,
+      ).toBe(true)
+    }
+
+    for (const name of REQUIRED_KEYS_BY_SPEC.keys()) {
+      expect(seenSpecs.has(name), `missing AgentRun template mapping for ${name}`).toBe(true)
+    }
+    expect(seenSpecs.has(CATALOG_OPS_SPEC), `missing AgentRun template mapping for ${CATALOG_OPS_SPEC}`).toBe(true)
+  })
+})

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -54,3 +54,30 @@ Outputs:
 Safety defaults:
 - live promotions are blocked unless gate policy explicitly enables them and approval token requirements are satisfied.
 - LLM remains bounded/advisory; deterministic risk/firewall controls remain final authority.
+
+## v3 orchestration guard CLI
+Validate stage transitions and retry/failure actions with policy-driven guardrails:
+
+```bash
+cd services/torghut
+uv run python scripts/orchestration_guard.py check-transition \
+  --state artifacts/orchestration/candidate-state.json \
+  --candidate-id cand-abc123 \
+  --run-id run-abc123 \
+  --from-stage gate-evaluation \
+  --to-stage shadow-paper \
+  --previous-artifact artifacts/gates/cand-abc123/report.json \
+  --previous-gate-passed \
+  --risk-controls-passed \
+  --execution-controls-passed \
+  --mode gitops
+```
+
+```bash
+cd services/torghut
+uv run python scripts/orchestration_guard.py evaluate-failure \
+  --state artifacts/orchestration/candidate-state.json \
+  --stage candidate-build \
+  --failure-class transient \
+  --attempt 2
+```

--- a/services/torghut/scripts/orchestration_guard.py
+++ b/services/torghut/scripts/orchestration_guard.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Torghut v3 orchestration guard and retry policy CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+DEFAULT_POLICY_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    .parent
+    / 'docs'
+    / 'torghut'
+    / 'design-system'
+    / 'v3'
+    / 'full-loop'
+    / 'templates'
+    / 'orchestration-policy.yaml'
+)
+
+ID_PATTERN = re.compile(r'^[a-z0-9][a-z0-9-]{5,62}$')
+JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_retries: int
+    initial_backoff_seconds: int
+    backoff_multiplier: float
+    max_backoff_seconds: int
+    autopause_after_failures: int
+
+
+@dataclass(frozen=True)
+class StageDefinition:
+    stage: str
+    lane: str
+    mutable_action: bool
+    require_previous_artifact: bool
+    require_previous_gate_pass: bool
+
+
+class GuardError(ValueError):
+    """Raised when stage transition or failure policy input is invalid."""
+
+
+def _parse_json_file(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict):
+        raise GuardError(f'Expected JSON object in {path}')
+    return cast(JsonDict, payload)
+
+
+def _validate_identifier(name: str, value: str) -> None:
+    if not ID_PATTERN.match(value):
+        raise GuardError(f'{name} must match {ID_PATTERN.pattern!r}: {value!r}')
+
+
+def load_policy(path: Path | None = None) -> JsonDict:
+    policy_path = path or DEFAULT_POLICY_PATH
+    payload = yaml.safe_load(policy_path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict):
+        raise GuardError(f'Invalid policy YAML at {policy_path}')
+    return cast(JsonDict, payload)
+
+
+def _stage_definitions(policy: JsonDict) -> dict[str, StageDefinition]:
+    stages_raw = policy.get('stages')
+    if not isinstance(stages_raw, list) or not stages_raw:
+        raise GuardError('Policy must include non-empty stages list')
+    stages = cast(list[object], stages_raw)
+
+    parsed: dict[str, StageDefinition] = {}
+    for raw_any in stages:
+        if not isinstance(raw_any, dict):
+            raise GuardError('Each stage policy must be an object')
+        raw = cast(JsonDict, raw_any)
+        stage = str(raw.get('stage', '')).strip()
+        lane = str(raw.get('lane', '')).strip()
+        if not stage or not lane:
+            raise GuardError('Each stage policy requires stage and lane')
+        parsed[stage] = StageDefinition(
+            stage=stage,
+            lane=lane,
+            mutable_action=bool(raw.get('mutableAction', False)),
+            require_previous_artifact=bool(raw.get('requirePreviousArtifact', True)),
+            require_previous_gate_pass=bool(raw.get('requirePreviousGatePass', True)),
+        )
+    return parsed
+
+
+def _retry_policies(policy: JsonDict) -> dict[str, RetryPolicy]:
+    raw_policies_input = policy.get('failurePolicies')
+    if not isinstance(raw_policies_input, dict) or not raw_policies_input:
+        raise GuardError('Policy must include failurePolicies map')
+    raw_policies = cast(dict[object, object], raw_policies_input)
+
+    parsed: dict[str, RetryPolicy] = {}
+    for failure_class_any, raw_any in raw_policies.items():
+        failure_class = str(failure_class_any)
+        if not isinstance(raw_any, dict):
+            raise GuardError(f'Failure policy for {failure_class} must be an object')
+        raw = cast(JsonDict, raw_any)
+        parsed[str(failure_class)] = RetryPolicy(
+            max_retries=int(raw.get('maxRetries', 0)),
+            initial_backoff_seconds=int(raw.get('initialBackoffSeconds', 0)),
+            backoff_multiplier=float(raw.get('backoffMultiplier', 1.0)),
+            max_backoff_seconds=int(raw.get('maxBackoffSeconds', 0)),
+            autopause_after_failures=int(raw.get('autopauseAfterFailures', 1)),
+        )
+    return parsed
+
+
+def evaluate_transition(
+    *,
+    policy: JsonDict,
+    state: JsonDict,
+    candidate_id: str,
+    run_id: str,
+    from_stage: str | None,
+    to_stage: str,
+    previous_artifact: Path | None,
+    previous_gate_passed: bool,
+    risk_controls_passed: bool,
+    execution_controls_passed: bool,
+    mode: str,
+    emergency_ticket: str | None,
+) -> JsonDict:
+    _validate_identifier('candidate_id', candidate_id)
+    _validate_identifier('run_id', run_id)
+
+    stage_definitions = _stage_definitions(policy)
+    if to_stage not in stage_definitions:
+        raise GuardError(f'Unknown destination stage: {to_stage}')
+    if from_stage and from_stage not in stage_definitions:
+        raise GuardError(f'Unknown source stage: {from_stage}')
+
+    transitions = policy.get('transitions')
+    if not isinstance(transitions, dict):
+        raise GuardError('Policy must include transitions map')
+    transitions_map = cast(dict[str, list[str]], transitions)
+
+    if from_stage:
+        allowed_targets = transitions_map.get(from_stage, [])
+        if to_stage not in allowed_targets:
+            return {
+                'allowed': False,
+                'reason': f'illegal_transition:{from_stage}->{to_stage}',
+                'nextAction': 'halt',
+            }
+
+    if str(state.get('candidateId', candidate_id)) != candidate_id:
+        return {'allowed': False, 'reason': 'candidate_mismatch', 'nextAction': 'halt'}
+
+    active_stage = state.get('activeStage')
+    if active_stage and from_stage and active_stage != from_stage:
+        return {'allowed': False, 'reason': f'active_stage_mismatch:{active_stage}', 'nextAction': 'halt'}
+
+    paused = bool(state.get('paused', False))
+    if paused:
+        return {'allowed': False, 'reason': 'candidate_paused_for_review', 'nextAction': 'human_review'}
+
+    stage_policy = stage_definitions[to_stage]
+    if stage_policy.require_previous_artifact:
+        if previous_artifact is None or not previous_artifact.exists():
+            return {'allowed': False, 'reason': 'missing_previous_artifact', 'nextAction': 'halt'}
+    if stage_policy.require_previous_gate_pass and not previous_gate_passed:
+        return {'allowed': False, 'reason': 'previous_gate_failed', 'nextAction': 'rollback'}
+
+    # Final authority: deterministic risk + execution controls.
+    if not risk_controls_passed:
+        return {'allowed': False, 'reason': 'risk_controls_not_passed', 'nextAction': 'rollback'}
+    if not execution_controls_passed:
+        return {'allowed': False, 'reason': 'execution_controls_not_passed', 'nextAction': 'rollback'}
+
+    if stage_policy.mutable_action:
+        if mode == 'gitops':
+            pass
+        elif mode == 'emergency' and emergency_ticket:
+            pass
+        else:
+            return {'allowed': False, 'reason': 'mutable_action_requires_gitops_or_ticketed_emergency', 'nextAction': 'halt'}
+
+    return {
+        'allowed': True,
+        'reason': 'transition_allowed',
+        'nextAction': 'proceed',
+        'lane': stage_policy.lane,
+        'toStage': to_stage,
+    }
+
+
+def evaluate_failure(
+    *,
+    policy: JsonDict,
+    state: JsonDict,
+    stage: str,
+    failure_class: str,
+    attempt: int,
+) -> JsonDict:
+    if attempt < 1:
+        raise GuardError('attempt must be >= 1')
+
+    retries = _retry_policies(policy)
+    if failure_class not in retries:
+        raise GuardError(f'Unknown failure class: {failure_class}')
+    retry_policy = retries[failure_class]
+
+    counts_raw = state.get('failureCounts', {})
+    counts: JsonDict
+    if isinstance(counts_raw, dict):
+        counts = cast(JsonDict, counts_raw)
+    else:
+        counts = {}
+    stage_failures = int(counts.get(stage, 0)) + 1
+
+    if failure_class == 'transient' and attempt <= retry_policy.max_retries:
+        backoff = retry_policy.initial_backoff_seconds * (retry_policy.backoff_multiplier ** (attempt - 1))
+        next_backoff_seconds = int(min(backoff, retry_policy.max_backoff_seconds))
+        return {
+            'action': 'retry',
+            'stage': stage,
+            'attempt': attempt,
+            'nextBackoffSeconds': next_backoff_seconds,
+            'stageFailures': stage_failures,
+        }
+
+    if stage_failures >= retry_policy.autopause_after_failures:
+        return {
+            'action': 'pause_for_review',
+            'stage': stage,
+            'attempt': attempt,
+            'stageFailures': stage_failures,
+            'reason': f'{failure_class}_failure_threshold_reached',
+        }
+
+    return {
+        'action': 'fail',
+        'stage': stage,
+        'attempt': attempt,
+        'stageFailures': stage_failures,
+        'reason': f'{failure_class}_non_retryable',
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Torghut v3 orchestration transition guard and retry evaluator.')
+    parser.add_argument('--policy', type=Path, default=DEFAULT_POLICY_PATH, help='Path to orchestration policy YAML.')
+
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    transition = subparsers.add_parser('check-transition', help='Validate a stage transition request.')
+    transition.add_argument('--state', type=Path, required=True, help='Path to candidate state JSON.')
+    transition.add_argument('--candidate-id', required=True)
+    transition.add_argument('--run-id', required=True)
+    transition.add_argument('--from-stage')
+    transition.add_argument('--to-stage', required=True)
+    transition.add_argument('--previous-artifact', type=Path)
+    transition.add_argument('--previous-gate-passed', action='store_true', default=False)
+    transition.add_argument('--risk-controls-passed', action='store_true', default=False)
+    transition.add_argument('--execution-controls-passed', action='store_true', default=False)
+    transition.add_argument('--mode', choices=('gitops', 'emergency'), default='gitops')
+    transition.add_argument('--emergency-ticket')
+
+    failure = subparsers.add_parser('evaluate-failure', help='Evaluate failure class retry/pause behavior.')
+    failure.add_argument('--state', type=Path, required=True, help='Path to candidate state JSON.')
+    failure.add_argument('--stage', required=True)
+    failure.add_argument('--failure-class', choices=('transient', 'deterministic', 'spec', 'policy'), required=True)
+    failure.add_argument('--attempt', type=int, required=True)
+
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    policy = load_policy(args.policy)
+    state = _parse_json_file(args.state)
+
+    if args.command == 'check-transition':
+        result = evaluate_transition(
+            policy=policy,
+            state=state,
+            candidate_id=args.candidate_id,
+            run_id=args.run_id,
+            from_stage=args.from_stage,
+            to_stage=args.to_stage,
+            previous_artifact=args.previous_artifact,
+            previous_gate_passed=bool(args.previous_gate_passed),
+            risk_controls_passed=bool(args.risk_controls_passed),
+            execution_controls_passed=bool(args.execution_controls_passed),
+            mode=args.mode,
+            emergency_ticket=args.emergency_ticket,
+        )
+    elif args.command == 'evaluate-failure':
+        result = evaluate_failure(
+            policy=policy,
+            state=state,
+            stage=args.stage,
+            failure_class=args.failure_class,
+            attempt=args.attempt,
+        )
+    else:
+        raise GuardError(f'Unsupported command: {args.command}')
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/tests/test_orchestration_guard.py
+++ b/services/torghut/tests/test_orchestration_guard.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest import TestCase
+
+from scripts.orchestration_guard import evaluate_failure, evaluate_transition, load_policy
+
+
+class TestOrchestrationGuard(TestCase):
+    def setUp(self) -> None:
+        self.policy = load_policy()
+        self.state: dict[str, Any] = {
+            'candidateId': 'cand-abc123',
+            'activeStage': 'gate-evaluation',
+            'paused': False,
+            'failureCounts': {},
+        }
+
+    def test_allows_valid_transition(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact = Path(tmpdir) / 'report.json'
+            artifact.write_text('{"ok":true}', encoding='utf-8')
+            result = evaluate_transition(
+                policy=self.policy,
+                state=self.state,
+                candidate_id='cand-abc123',
+                run_id='run-abc123',
+                from_stage='gate-evaluation',
+                to_stage='shadow-paper',
+                previous_artifact=artifact,
+                previous_gate_passed=True,
+                risk_controls_passed=True,
+                execution_controls_passed=True,
+                mode='gitops',
+                emergency_ticket=None,
+            )
+        self.assertTrue(result['allowed'])
+        self.assertEqual(result['nextAction'], 'proceed')
+
+    def test_blocks_mutable_stage_without_gitops_or_ticket(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact = Path(tmpdir) / 'report.json'
+            artifact.write_text('{"ok":true}', encoding='utf-8')
+            result = evaluate_transition(
+                policy=self.policy,
+                state=self.state,
+                candidate_id='cand-abc123',
+                run_id='run-abc123',
+                from_stage='gate-evaluation',
+                to_stage='shadow-paper',
+                previous_artifact=artifact,
+                previous_gate_passed=True,
+                risk_controls_passed=True,
+                execution_controls_passed=True,
+                mode='emergency',
+                emergency_ticket=None,
+            )
+        self.assertFalse(result['allowed'])
+        self.assertEqual(result['nextAction'], 'halt')
+
+    def test_allows_ticketed_emergency_transition(self) -> None:
+        state: dict[str, Any] = {
+            'candidateId': 'cand-abc123',
+            'activeStage': 'live-ramp',
+            'paused': False,
+            'failureCounts': {},
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact = Path(tmpdir) / 'monitor.json'
+            artifact.write_text('{"drift":"detected"}', encoding='utf-8')
+            result = evaluate_transition(
+                policy=self.policy,
+                state=state,
+                candidate_id='cand-abc123',
+                run_id='run-abc123',
+                from_stage='live-ramp',
+                to_stage='incident-recovery',
+                previous_artifact=artifact,
+                previous_gate_passed=True,
+                risk_controls_passed=True,
+                execution_controls_passed=True,
+                mode='emergency',
+                emergency_ticket='INC-2026-02-12-001',
+            )
+        self.assertTrue(result['allowed'])
+        self.assertEqual(result['lane'], 'lane-f')
+
+    def test_retries_transient_failure_with_backoff(self) -> None:
+        result = evaluate_failure(
+            policy=self.policy,
+            state=self.state,
+            stage='candidate-build',
+            failure_class='transient',
+            attempt=2,
+        )
+        self.assertEqual(result['action'], 'retry')
+        self.assertGreaterEqual(result['nextBackoffSeconds'], 30)
+
+    def test_autopauses_after_deterministic_failures(self) -> None:
+        state: dict[str, Any] = {
+            'candidateId': 'cand-abc123',
+            'activeStage': 'candidate-build',
+            'paused': False,
+            'failureCounts': {'candidate-build': 1},
+        }
+        result = evaluate_failure(
+            policy=self.policy,
+            state=state,
+            stage='candidate-build',
+            failure_class='deterministic',
+            attempt=1,
+        )
+        self.assertEqual(result['action'], 'pause_for_review')


### PR DESCRIPTION
## Summary

- add reusable Torghut v3 AgentRun orchestration templates across lanes/stages (`lane-a` through `lane-f`) with workflow retry/backoff settings and required orchestration parameters.
- add policy-driven orchestration artifacts: `orchestration-policy.yaml` (stage transitions + failure class policy) and `orchestration-observability.yaml` (metrics, alerts, dashboard contract).
- implement `services/torghut/scripts/orchestration_guard.py` CLI for stage transition guard checks and retry/failure decisions, preserving deterministic risk/execution controls as final authority and GitOps-first mutable actions.
- add `services/torghut/tests/test_orchestration_guard.py` and update docs in Torghut full-loop playbook/index, Torghut README, and Agents runbooks to align templates and operations.

## Related Issues

None (`ISSUE_NUMBER=0` in run environment; no linked issue provided).

## Testing

- `cd services/torghut && uv run python -m unittest tests.test_orchestration_guard tests.test_autonomous_lane`
- `cd services/torghut && uv run pyright scripts/orchestration_guard.py tests/test_orchestration_guard.py`
- `cd services/torghut && uv run python - <<'PY'`
  YAML parse validation for:
  - `docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml`
  - `docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml`
  - `docs/torghut/design-system/v3/full-loop/templates/orchestration-policy.yaml`
  - `docs/torghut/design-system/v3/full-loop/templates/orchestration-observability.yaml`
  `PY`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
