### PR TITLE
fix(jangar): patch quant migration window keyword

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-12T18:12:41.412Z"
+    deploy.knative.dev/rollout: "2026-02-12T18:25:38.824Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -55,5 +55,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "0ab66ae1"
-    digest: sha256:f57423daac2bf96b70281e597b74bcc1666d304a0b4e6feaa0423650cea9f14e
+    newTag: "4f33f29f"
+    digest: sha256:f15708daa8e32192072ee857656df5314746226fb4b51b016502993eb789427e

--- a/services/jangar/src/server/migrations/20260212_torghut_quant_control_plane.ts
+++ b/services/jangar/src/server/migrations/20260212_torghut_quant_control_plane.ts
@@ -16,7 +16,7 @@ export const up = async (db: Kysely<Database>) => {
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       strategy_id UUID NOT NULL,
       account TEXT NOT NULL DEFAULT '',
-      window TEXT NOT NULL,
+      "window" TEXT NOT NULL,
       metric_name TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'ok',
       quality TEXT NOT NULL DEFAULT 'good',
@@ -33,12 +33,12 @@ export const up = async (db: Kysely<Database>) => {
 
   await sql`
     CREATE UNIQUE INDEX IF NOT EXISTS torghut_qm_latest_uniq
-    ON torghut_control_plane.quant_metrics_latest(strategy_id, account, window, metric_name);
+    ON torghut_control_plane.quant_metrics_latest(strategy_id, account, "window", metric_name);
   `.execute(db)
 
   await sql`
     CREATE INDEX IF NOT EXISTS torghut_qm_latest_strategy_window_idx
-    ON torghut_control_plane.quant_metrics_latest(strategy_id, window);
+    ON torghut_control_plane.quant_metrics_latest(strategy_id, "window");
   `.execute(db)
 
   await sql`
@@ -46,7 +46,7 @@ export const up = async (db: Kysely<Database>) => {
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       strategy_id UUID NOT NULL,
       account TEXT NOT NULL DEFAULT '',
-      window TEXT NOT NULL,
+      "window" TEXT NOT NULL,
       metric_name TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'ok',
       quality TEXT NOT NULL DEFAULT 'good',
@@ -63,7 +63,7 @@ export const up = async (db: Kysely<Database>) => {
 
   await sql`
     CREATE INDEX IF NOT EXISTS torghut_qm_series_lookup_idx
-    ON torghut_control_plane.quant_metrics_series(strategy_id, account, window, metric_name, as_of DESC);
+    ON torghut_control_plane.quant_metrics_series(strategy_id, account, "window", metric_name, as_of DESC);
   `.execute(db)
 
   await sql`
@@ -79,7 +79,7 @@ export const up = async (db: Kysely<Database>) => {
       account TEXT NOT NULL DEFAULT '',
       severity TEXT NOT NULL DEFAULT 'warning',
       metric_name TEXT NOT NULL,
-      window TEXT NOT NULL,
+      "window" TEXT NOT NULL,
       threshold_json JSONB NOT NULL DEFAULT '{}'::jsonb,
       observed_json JSONB NOT NULL DEFAULT '{}'::jsonb,
       opened_at TIMESTAMPTZ NOT NULL DEFAULT now(),


### PR DESCRIPTION
## Summary

- Fix Torghut quant control-plane migration by quoting the reserved PostgreSQL identifier `window` in DDL/index SQL.
- Roll Jangar image pin to commit `4f33f29f` with digest `sha256:f15708daa8e32192072ee857656df5314746226fb4b51b016502993eb789427e`.
- Update Jangar rollout annotation so the fixed image redeploys immediately via GitOps.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/jangar tsc`
- `bun run packages/scripts/src/jangar/deploy-service.ts`
- `kubectl rollout status deployment/jangar -n jangar --timeout=300s`
- `kubectl exec -n jangar <pod> -c app -- curl -sS -i http://127.0.0.1:8080/api/torghut/trading/control-plane/quant/health`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
