### PR TITLE
chore(torghut): refresh live lean image digest

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4d5607ec723137b171101ab8deb1ca6a342f5b12be2dcf56b881816260c5fbd8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cb6828a896a7af4d9041b3cb46640cd06378633c76a3e13e0daed6d11795a860
           ports:
             - name: http1
               containerPort: 8181
@@ -156,9 +156,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.546.1
+              value: v0.546.1-7-g3c0a0c40
             - name: TORGHUT_COMMIT
-              value: 665a2ab351cb393f1a60cb1b123dae3eadcce6ff
+              value: 3c0a0c409afd68134c91724cd90ae8e0e7dbc398
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: lean-runner
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4d5607ec723137b171101ab8deb1ca6a342f5b12be2dcf56b881816260c5fbd8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cb6828a896a7af4d9041b3cb46640cd06378633c76a3e13e0daed6d11795a860
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary

- Rebuilt Torghut image from merged live-LEAN commit `3c0a0c409afd68134c91724cd90ae8e0e7dbc398`.
- Updated `torghut` Knative service and `torghut-lean-runner` deployment to use digest `sha256:cb6828a896a7af4d9041b3cb46640cd06378633c76a3e13e0daed6d11795a860`.
- Updated `TORGHUT_VERSION` and `TORGHUT_COMMIT` env metadata in Knative manifest.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut >/tmp/torghut-kustomize.out`
- `bun run build:torghut`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
