### PR TITLE
chore(torghut): tune profit strategy risk budgets

### DIFF
--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -22,5 +22,5 @@ data:
         enabled: true
         base_timeframe: "1Sec"
         universe_type: intraday_tsmom_v1
-        max_notional_per_trade: 600
-        max_position_pct_equity: 0.035
+        max_notional_per_trade: 1000
+        max_position_pct_equity: 0.08


### PR DESCRIPTION
## Summary

- Tuned `intraday-tsmom-profit-v2` risk budgets in strategy catalog to reduce live rejection rate.
- Increased `max_notional_per_trade` from `600` to `1000`.
- Increased `max_position_pct_equity` from `0.035` to `0.08`.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut >/tmp/torghut-kustomize.out`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
