### PR TITLE
docs(torghut): add live snapshot and state assessment runbook

### DIFF
--- a/docs/torghut/design-system/v3/current-state-snapshot-2026-02-12.md
+++ b/docs/torghut/design-system/v3/current-state-snapshot-2026-02-12.md
@@ -1,0 +1,144 @@
+# Current System Snapshot (2026-02-12)
+
+## Objective
+Provide a factual, timestamped snapshot of the Torghut trading system for human review and operational decision-making.
+
+## Snapshot Scope
+- Snapshot window (UTC): `2026-02-12T19:07:00Z` to `2026-02-12T19:14:30Z`
+- Namespaces: `torghut`, `argocd`, `jangar`
+- Planes covered:
+  - Control plane (Kubernetes, Argo CD, Knative, Flink, CNPG, ClickHouse operator)
+  - Compute plane (running workloads and revisions)
+  - Data plane (Postgres + ClickHouse freshness and volume)
+  - Decision plane (trading loop state, rejection mix, universe resolution)
+
+## Executive Summary
+- Trading pipeline is running end-to-end: WS ingestion, TA/Flink processing, ClickHouse writes, and Torghut decision loop are all active.
+- Torghut is currently `live` mode with `TRADING_LIVE_ENABLED=true`, `kill_switch=false`, and `LLM_ENABLED=false`.
+- ClickHouse freshness is near-real-time (`lag_seconds <= 3` for both `ta_signals` and `ta_microbars`).
+- Recent rejections are dominated by `llm_veto` and `max_position_pct_exceeded`; `symbol_not_allowed` is `0` in the last 10 minutes.
+- Argo app `torghut` is `OutOfSync` while `Healthy`, and API server availability was intermittent during capture (`ServiceUnavailable` / `apiserver not ready` observed and recovered).
+
+## Runtime Snapshot
+
+### Control Plane
+Sample timestamp: `2026-02-12T19:14:01Z`
+
+| Component | Probe | Observed |
+| --- | --- | --- |
+| Knative service | `kubectl -n torghut get ksvc torghut ...` | `latestReadyRevision=torghut-00072`, `Ready=True` |
+| Argo CD app | `kubectl -n argocd get application torghut ...` | `OutOfSync`, `Healthy`, reconciled `2026-02-12T19:09:58Z` |
+| FlinkDeployment | `kubectl -n torghut get flinkdeployment torghut-ta ...` | `RUNNING`, `STABLE`, `jobManagerDeploymentStatus=READY` |
+| CNPG cluster | `kubectl -n torghut get clusters.postgresql.cnpg.io torghut-db ...` | `Cluster in healthy state`, primary `torghut-db-1` |
+| ClickHouseInstallation | `kubectl -n torghut get clickhouseinstallation torghut-clickhouse ...` | `Completed` |
+
+### Workload Health
+Sample timestamp: `2026-02-12T19:14:xxZ`
+
+| Workload | Observed |
+| --- | --- |
+| `torghut-00072-deployment-56b49c9f94-przzw` | `2/2 Running`, restarts `0/0` |
+| `torghut-ws-5ddb9bbd9d-8qj4v` | `1/1 Running`, restarts `7` (last restart ~74m prior) |
+| `torghut-ta` JobManager | `1/1 Running` |
+| `torghut-ta-taskmanager-1-{1..4}` | all `1/1 Running` |
+| `torghut-lean-runner` | `1/1 Running` |
+
+## Decision Plane Snapshot
+
+### Trading Status Endpoint
+Probe: `GET /trading/status` via in-pod localhost at `2026-02-12T19:14:03Z`
+
+Key fields:
+- `enabled=true`
+- `mode=live`
+- `kill_switch_enabled=false`
+- `running=true`
+- `last_error=null`
+- `llm.enabled=false`
+- `metrics.decisions_total=9`
+- `metrics.orders_submitted_total=0`
+- `metrics.orders_rejected_total=9`
+- `metrics.reconcile_updates_total=288`
+
+### Universe State
+- Jangar symbols endpoint response:
+  - `["ARM","ASML","CRWD","GOOG","LRCX","MSFT","MU","NVDA","SNDK","TSM"]`
+- WS config map:
+  - `SYMBOLS=CRWD,MU,NVDA` (fallback),
+  - `JANGAR_SYMBOLS_URL=http://jangar.jangar.svc.cluster.local/api/torghut/symbols`,
+  - `SYMBOLS_POLL_INTERVAL_MS=30000`
+- Strategies in Postgres (`strategies`):
+  - Enabled strategy: `intraday-tsmom-profit-v2`, `universe_symbols=null` (global universe driven),
+  - Disabled: `intraday-tsmom-v1`, `macd-rsi-default`.
+
+## Data Plane Snapshot
+
+### Postgres (`torghut-db`)
+Sample timestamp: `2026-02-12T19:14:01Z`
+
+Row counts:
+- `strategies=3`
+- `trade_decisions=3887`
+- `executions=567`
+- `llm_decision_reviews=11015`
+- `position_snapshots=4535`
+
+Recent 10-minute decision statuses:
+- `rejected=33`
+- `planned=1`
+
+Recent 10-minute rejection reasons:
+- `["llm_veto"] = 21`
+- `["max_position_pct_exceeded"] = 10`
+- `["qty_below_min"] = 2`
+
+Symbol allowlist check:
+- `symbol_not_allowed` in last 10 minutes: `0`
+
+Latest account snapshot (`position_snapshots`):
+- `as_of=2026-02-12 19:13:51.050276+00`
+- `equity=30100.21000000`
+- `cash=12521.56000000`
+- `buying_power=92595.00000000`
+- `positions_count=8`
+- `alpaca_account_label=live`
+
+### ClickHouse (`torghut`)
+Sample timestamp: `2026-02-12T19:14:04Z`
+
+Table volume + freshness:
+- `ta_signals`: `239343` rows, `max_event_ts=2026-02-12 19:14:04.000`, lag `3s`
+- `ta_microbars`: `224879` rows, `max_event_ts=2026-02-12 19:14:06.000`, lag `1s`
+
+Top symbols in `ta_signals` over last 10 minutes:
+- `MSFT=283`
+- `NVDA=251`
+- `MU=123`
+- `TSM=108`
+- `GOOG=102`
+- `SNDK=74`
+- `LRCX=68`
+- `ARM=38`
+- `CRWD=27`
+- `ASML=26`
+
+Replica state (`system.replicas`):
+- `ta_microbars`: `is_readonly=0`, `is_session_expired=0`, `queue_size=1`, `inserts_in_queue=1`
+- `ta_signals`: `is_readonly=0`, `is_session_expired=0`, `queue_size=0`, `inserts_in_queue=0`
+
+## Operational Findings
+1. System is actively processing market data and running the trading loop.
+2. Rejection mix indicates policy/risk and LLM-gate behavior, not data starvation.
+3. Symbol universe mismatch issue is not present in current 10-minute window.
+4. Argo drift remains unresolved (`OutOfSync`) and should be reconciled via PR + sync.
+5. Kubernetes API server intermittency occurred during this capture window and should be treated as platform reliability risk.
+
+## Evidence Commands
+Primary command set used:
+- `kubectl -n torghut get ksvc torghut ...`
+- `kubectl -n argocd get application torghut ...`
+- `kubectl -n torghut get flinkdeployment torghut-ta ...`
+- `kubectl -n torghut exec torghut-db-1 -- psql ...`
+- `kubectl -n torghut exec chi-torghut-clickhouse-default-0-0-0 -- clickhouse-client ...`
+- `kubectl -n torghut exec <torghut-pod> -c user-container -- python -c "<HTTP probe>"`
+

--- a/docs/torghut/design-system/v3/index.md
+++ b/docs/torghut/design-system/v3/index.md
@@ -107,6 +107,11 @@ For end-to-end autonomous operation (research -> strategy -> backtest -> paper -
 - `docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml`
 - `docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml`
 
+## Operational Snapshot Package (Current-State Review)
+- `docs/torghut/design-system/v3/current-state-snapshot-2026-02-12.md`
+- `docs/torghut/design-system/v3/system-state-assessment-runbook.md`
+- `docs/torghut/design-system/v3/system-state-snapshot-design.md`
+
 Significant-scope standard for every design doc:
 - At least 2 owned code/config areas.
 - At least 3 concrete deliverables.

--- a/docs/torghut/design-system/v3/system-state-assessment-runbook.md
+++ b/docs/torghut/design-system/v3/system-state-assessment-runbook.md
@@ -1,0 +1,144 @@
+# Torghut System State Assessment Runbook
+
+## Objective
+Assess whether Torghut is healthy enough to trade, identify the failing layer when unhealthy, and provide a repeatable triage flow.
+
+## Scope
+- Namespace focus: `torghut`
+- Dependencies checked: `argocd`, `jangar`
+- Data stores: CNPG Postgres + ClickHouse
+- Pipeline: WS -> Kafka -> Flink TA -> ClickHouse -> Torghut decision loop -> executions
+
+## Preconditions
+- `kubectl` context points to production cluster.
+- Operator has read access to `torghut`, `argocd`, and `jangar` namespaces.
+- `kubectl cnpg` plugin available for CNPG SQL convenience (optional).
+
+## Severity Model
+- `GREEN`: trading safe to continue (no critical failures, data fresh, controls intact).
+- `YELLOW`: degraded but controlled (data flow present, but drift/rejections/latency issues).
+- `RED`: immediate intervention required (data stale, component down, or safety gate broken).
+
+## Step 0: Fast Connectivity Check (1 minute)
+```bash
+kubectl cluster-info
+kubectl -n torghut get pods
+```
+Interpretation:
+- If API server is unstable (`ServiceUnavailable`, `apiserver not ready`), classify platform as at least `YELLOW`.
+- If repeated failures persist > 3 minutes, escalate platform incident and classify `RED`.
+
+## Step 1: Control Plane Health (2 minutes)
+```bash
+kubectl -n argocd get application torghut -o jsonpath='{.status.sync.status} {.status.health.status} {.status.reconciledAt}'; echo
+kubectl -n torghut get ksvc torghut -o jsonpath='{.status.latestReadyRevisionName} {.status.conditions[?(@.type=="Ready")].status}'; echo
+kubectl -n torghut get flinkdeployment torghut-ta -o jsonpath='{.status.jobStatus.state} {.status.lifecycleState} {.status.jobManagerDeploymentStatus}'; echo
+kubectl -n torghut get clusters.postgresql.cnpg.io torghut-db -o wide
+kubectl -n torghut get clickhouseinstallation torghut-clickhouse -o wide
+```
+Pass criteria:
+- ksvc Ready = `True`
+- Flink = `RUNNING STABLE READY`
+- CNPG = healthy state
+- ClickHouseInstallation = `Completed`
+
+## Step 2: Workload Health (2 minutes)
+```bash
+kubectl -n torghut get pods -o wide
+kubectl -n torghut get deploy torghut-ws torghut-ta torghut-lean-runner -o wide
+kubectl -n torghut get pods -l app=torghut-ta,component=taskmanager
+```
+Pass criteria:
+- Torghut pod has all containers ready.
+- `torghut-ws`, `torghut-ta`, and `torghut-lean-runner` each have available replicas.
+- 4/4 TA taskmanagers ready.
+
+## Step 3: Trading Loop Runtime State (2 minutes)
+```bash
+TORGHUT_POD=$(kubectl -n torghut get pods -l serving.knative.dev/service=torghut -o jsonpath='{.items[0].metadata.name}')
+kubectl -n torghut exec "$TORGHUT_POD" -c user-container -- python -c "import urllib.request;print(urllib.request.urlopen('http://localhost:8181/trading/status',timeout=10).read().decode())"
+kubectl -n torghut exec "$TORGHUT_POD" -c user-container -- python -c "import urllib.request;print(urllib.request.urlopen('http://localhost:8181/trading/metrics',timeout=10).read().decode())"
+```
+Pass criteria:
+- `running=true`
+- `last_error=null`
+- `kill_switch_enabled=false` (unless intentionally enabled)
+- Metrics counters moving over time (decisions/reconcile at minimum)
+
+## Step 4: Universe Consistency Check (2 minutes)
+```bash
+kubectl -n torghut exec "$TORGHUT_POD" -c user-container -- python -c "import urllib.request;print(urllib.request.urlopen('http://jangar.jangar.svc.cluster.local/api/torghut/symbols',timeout=10).read().decode())"
+kubectl -n torghut get configmap torghut-ws-config -o jsonpath='{.data.SYMBOLS} {.data.JANGAR_SYMBOLS_URL} {.data.SYMBOLS_POLL_INTERVAL_MS}'; echo
+kubectl -n torghut exec torghut-db-1 -- psql -U postgres -d torghut -P pager=off -c "select name,enabled,coalesce(universe_symbols::text,'null') as universe_symbols from strategies order by enabled desc,name;"
+```
+Pass criteria:
+- Jangar symbols endpoint returns non-empty list.
+- Enabled strategy does not unintentionally restrict symbols.
+- If recent `symbol_not_allowed` spikes occur, classify `YELLOW` and inspect strategy `universe_symbols` immediately.
+
+## Step 5: Postgres Decision/Execution Health (4 minutes)
+```bash
+kubectl -n torghut exec torghut-db-1 -- psql -U postgres -d torghut -P pager=off -c "select 'strategies' as table, count(*) as rows from strategies union all select 'trade_decisions', count(*) from trade_decisions union all select 'executions', count(*) from executions union all select 'llm_decision_reviews', count(*) from llm_decision_reviews union all select 'position_snapshots', count(*) from position_snapshots;"
+kubectl -n torghut exec torghut-db-1 -- psql -U postgres -d torghut -P pager=off -c "select status,count(*) from trade_decisions where created_at >= now()-interval '10 minutes' group by status order by count(*) desc;"
+kubectl -n torghut exec torghut-db-1 -- psql -U postgres -d torghut -P pager=off -c "select decision_json->>'risk_reasons' as reason,count(*) from trade_decisions where created_at >= now()-interval '10 minutes' and status='rejected' group by 1 order by 2 desc;"
+kubectl -n torghut exec torghut-db-1 -- psql -U postgres -d torghut -Atc "select count(*) from trade_decisions where created_at >= now()-interval '10 minutes' and status='rejected' and decision_json->>'risk_reasons' like '%symbol_not_allowed%';"
+kubectl -n torghut exec torghut-db-1 -- psql -U postgres -d torghut -P pager=off -c "select as_of,equity,cash,buying_power,jsonb_array_length(positions) as positions_count,alpaca_account_label from position_snapshots order by as_of desc limit 3;"
+```
+Interpretation:
+- High rejection ratio is acceptable only if reasons are expected policy gates.
+- `symbol_not_allowed > 0` after a universe rollout is a direct misconfiguration signal.
+- Missing fresh position snapshots is `RED` for execution confidence.
+
+## Step 6: ClickHouse Freshness and Replica Health (4 minutes)
+```bash
+CH_PASS=$(kubectl -n torghut get secret torghut-clickhouse-auth -o jsonpath='{.data.torghut_password}' | base64 --decode)
+kubectl -n torghut exec chi-torghut-clickhouse-default-0-0-0 -- clickhouse-client --user torghut --password "$CH_PASS" -q "SELECT 'ta_signals' AS table, count() AS rows, max(event_ts) AS max_event_ts, dateDiff('second', max(event_ts), now()) AS lag_seconds FROM torghut.ta_signals UNION ALL SELECT 'ta_microbars', count(), max(event_ts), dateDiff('second', max(event_ts), now()) FROM torghut.ta_microbars;"
+kubectl -n torghut exec chi-torghut-clickhouse-default-0-0-0 -- clickhouse-client --user torghut --password "$CH_PASS" -q "SELECT symbol, count() AS rows FROM torghut.ta_signals WHERE event_ts >= now() - INTERVAL 10 MINUTE GROUP BY symbol ORDER BY rows DESC LIMIT 10;"
+kubectl -n torghut exec chi-torghut-clickhouse-default-0-0-0 -- clickhouse-client --user torghut --password "$CH_PASS" -q "SELECT database, table, is_readonly, is_session_expired, queue_size, inserts_in_queue FROM system.replicas WHERE database='torghut' ORDER BY table;"
+```
+Pass criteria:
+- `lag_seconds` near-real-time (typically single-digit seconds during market hours).
+- Replica flags remain `is_readonly=0`, `is_session_expired=0`.
+
+## Classification Rules
+- `GREEN`:
+  - All critical components healthy,
+  - ClickHouse fresh,
+  - Decision loop running with expected rejection profile.
+- `YELLOW`:
+  - Argo OutOfSync,
+  - elevated rejection concentration (policy/LLM),
+  - intermittent control plane/API instability.
+- `RED`:
+  - ksvc not ready,
+  - Flink not running,
+  - stale ClickHouse data,
+  - Postgres unavailable,
+  - unexpected safety bypass or kill-switch inconsistency.
+
+## Immediate Actions by Failure Mode
+- `symbol_not_allowed` spike:
+  - compare strategy `universe_symbols` vs Jangar symbols endpoint,
+  - remove unintended strategy-level symbol cap,
+  - verify 10-minute rejection mix.
+- Flink degraded:
+  - inspect `kubectl -n torghut logs deploy/torghut-ta --since=15m`,
+  - verify checkpoints advancing.
+- ClickHouse replica issues:
+  - inspect `system.replicas`,
+  - follow `docs/torghut/design-system/v1/operations-clickhouse-replica-and-keeper.md`.
+- WS ingestion issues:
+  - inspect `kubectl -n torghut logs deploy/torghut-ws --since=15m`,
+  - verify Kafka produce responses continue.
+
+## Human Review Output Template
+Use this format in incident/report updates:
+- Snapshot time (UTC):
+- Overall status (`GREEN`/`YELLOW`/`RED`):
+- ksvc/flink/cnpg/clickhouse states:
+- Data freshness (`ta_signals` lag / `ta_microbars` lag):
+- 10-minute decision status mix:
+- Top rejection reasons:
+- Symbol mismatch check result:
+- Required actions and owner:
+

--- a/docs/torghut/design-system/v3/system-state-snapshot-design.md
+++ b/docs/torghut/design-system/v3/system-state-snapshot-design.md
@@ -1,0 +1,150 @@
+# Torghut System Snapshot Design (Human Review)
+
+## Purpose
+Define what a "system snapshot" means for Torghut, how to interpret it, and how to use it for operational decisions.
+
+This document is the design contract behind:
+- `current-state-snapshot-2026-02-12.md`
+- `system-state-assessment-runbook.md`
+
+## Design Goals
+- Single-page operational truth for current state.
+- Clear separation between observed facts and interpretation.
+- Fast triage path from symptom to affected layer.
+- Human-review friendly structure with diagrams and explicit probes.
+
+## Snapshot Model
+The snapshot is a four-plane model:
+- Control plane: orchestration and rollout state.
+- Compute plane: workload readiness and revisions.
+- Data plane: storage health, freshness, and throughput.
+- Decision plane: trading loop behavior and rejection composition.
+
+```mermaid
+flowchart LR
+  subgraph "Control Plane"
+    A["Argo CD App"]
+    B["Knative Service (torghut)"]
+    C["FlinkDeployment (torghut-ta)"]
+    D["CNPG Cluster (torghut-db)"]
+    E["ClickHouseInstallation"]
+  end
+
+  subgraph "Compute Plane"
+    F["torghut Pod"]
+    G["torghut-ws Pod"]
+    H["torghut-ta JobManager + TaskManagers"]
+    I["torghut-lean-runner Pod"]
+  end
+
+  subgraph "Data Plane"
+    J["Postgres (trade_decisions, executions, snapshots)"]
+    K["ClickHouse (ta_signals, ta_microbars)"]
+    L["Jangar Symbols API"]
+  end
+
+  subgraph "Decision Plane"
+    M["/trading/status + /trading/metrics"]
+    N["Risk reasons distribution"]
+    O["Execution state distribution"]
+  end
+
+  A --> B
+  B --> F
+  C --> H
+  D --> J
+  E --> K
+  G --> H
+  H --> K
+  F --> J
+  F --> M
+  L --> F
+  L --> G
+  J --> N
+  J --> O
+```
+
+## Assessment Workflow Design
+The workflow is intentionally staged so failures are localized quickly.
+
+```mermaid
+sequenceDiagram
+  participant Op as Oncall
+  participant K8s as Kubernetes API
+  participant Tor as torghut service
+  participant WS as torghut-ws
+  participant TA as torghut-ta (Flink)
+  participant PG as Postgres
+  participant CH as ClickHouse
+  participant Jg as Jangar symbols API
+
+  Op->>K8s: Check control-plane objects\n(ksvc, flinkdeployment, cnpg, CHI, Argo app)
+  K8s-->>Op: Ready/degraded state
+  Op->>Tor: GET /trading/status + /trading/metrics
+  Tor-->>Op: Runtime mode, counters, last_error
+  Op->>Jg: Fetch symbols
+  Jg-->>Op: Current symbol universe
+  Op->>PG: Query decision/execution/snapshot tables
+  PG-->>Op: Status mix + risk reasons
+  Op->>CH: Query table freshness + replica status
+  CH-->>Op: lag + row volumes + replica queue
+  Op->>WS: Verify ingestion pod health and Kafka produce logs
+  WS-->>Op: Ingestion continuity evidence
+  Op->>TA: Verify checkpoint progression
+  TA-->>Op: Processing continuity evidence
+```
+
+## State Classification Logic
+
+```mermaid
+flowchart TD
+  S["Start Assessment"] --> C1{"Control plane healthy?"}
+  C1 -- "No" --> R["RED: platform incident"]
+  C1 -- "Yes" --> C2{"Data fresh\n(CH lag acceptable)?"}
+  C2 -- "No" --> R2["RED: data pipeline incident"]
+  C2 -- "Yes" --> C3{"Trading loop running\nand no fatal error?"}
+  C3 -- "No" --> R3["RED: service incident"]
+  C3 -- "Yes" --> C4{"Rejection profile expected?"}
+  C4 -- "No (unexpected spike,\nnew risk reason)" --> Y["YELLOW: policy/config investigation"]
+  C4 -- "Yes" --> G["GREEN: continue operations"]
+  Y --> C5{"Contains symbol_not_allowed spike?"}
+  C5 -- "Yes" --> A1["Check strategy universe_symbols\nvs Jangar symbols"]
+  C5 -- "No" --> A2["Investigate LLM/risk/execution policy changes"]
+```
+
+## Data Contract for a Snapshot Artifact
+Each snapshot should capture:
+- Metadata:
+  - capture window (UTC),
+  - operator identity,
+  - command bundle version.
+- Control plane facts:
+  - ksvc revision + readiness,
+  - Argo sync/health,
+  - Flink/CNPG/ClickHouse operator status.
+- Compute plane facts:
+  - pod/deployment readiness and restart counts.
+- Data plane facts:
+  - Postgres table counts and recent status distribution,
+  - ClickHouse row counts, freshness lag, and replica health.
+- Decision plane facts:
+  - `/trading/status` runtime posture,
+  - top rejection reasons,
+  - universe consistency verification.
+
+## Interpretation Rules
+- Snapshot facts are time-bound and must include exact UTC timestamps.
+- Any inferred conclusion must be explicitly labeled as interpretation.
+- If control plane availability is intermittent, confidence in all concurrent probes is reduced and must be noted.
+
+## Review Checklist
+- Are all four planes represented?
+- Are timestamps explicit and recent?
+- Are probe commands reproducible?
+- Is drift called out (`OutOfSync`, manual patch risk)?
+- Are next actions mapped to concrete owners?
+
+## Relationship to Existing v1/v3 Docs
+- v1 docs remain source of truth for component-level recovery runbooks.
+- This v3 design defines the operational "snapshot grammar" used to summarize current state quickly for human reviewers.
+


### PR DESCRIPTION
## Summary

- add a dated, evidence-backed live system snapshot for human review: `docs/torghut/design-system/v3/current-state-snapshot-2026-02-12.md`
- add an operator runbook to assess current state and classify incidents: `docs/torghut/design-system/v3/system-state-assessment-runbook.md`
- add a snapshot design document with Mermaid diagrams for architecture, assessment flow, and state classification: `docs/torghut/design-system/v3/system-state-snapshot-design.md`
- link the operational snapshot package from the v3 index

## Related Issues

None

## Testing

- `kubectl -n torghut get ksvc torghut -o jsonpath='{.status.latestReadyRevisionName} {.status.latestCreatedRevisionName} {.status.conditions[?(@.type=="Ready")].status}'`
- `kubectl -n argocd get application torghut -o jsonpath='{.status.sync.status} {.status.health.status} {.status.reconciledAt}'`
- `kubectl -n torghut get flinkdeployment torghut-ta -o jsonpath='{.status.jobStatus.state} {.status.lifecycleState} {.status.jobManagerDeploymentStatus}'`
- `kubectl -n torghut exec torghut-db-1 -- psql -U postgres -d torghut ...` (strategy state, decision/execution counts, rejection reason mix, latest position snapshots)
- `kubectl -n torghut exec chi-torghut-clickhouse-default-0-0-0 -- clickhouse-client ...` (ta table counts, freshness lag, replica state, recent symbol distribution)
- `kubectl -n torghut exec <torghut-pod> -c user-container -- python -c ...` (`/trading/status`, `/trading/metrics`, and Jangar symbols endpoint)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
