### PR TITLE
feat(torghut): autonomy runtime route ledger

### DIFF
--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -22,5 +22,5 @@ data:
         enabled: true
         base_timeframe: "1Sec"
         universe_type: intraday_tsmom_v1
-        max_notional_per_trade: 600
-        max_position_pct_equity: 0.035
+        max_notional_per_trade: 1000
+        max_position_pct_equity: 0.08

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -74,10 +74,21 @@ class Settings(BaseSettings):
         alias="TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION",
         description="Safety gate for autonomous promotion actions; live stays disabled by default.",
     )
+    trading_autonomy_approval_token: Optional[str] = Field(
+        default=None,
+        alias="TRADING_AUTONOMY_APPROVAL_TOKEN",
+        description="Optional approval token for live promotion when required by policy.",
+    )
     trading_autonomy_gate_policy_path: Optional[str] = Field(
         default=None,
         alias="TRADING_AUTONOMY_GATE_POLICY_PATH",
         description="Optional path to v3 autonomous gate policy config JSON.",
+    )
+    trading_autonomy_interval_seconds: int = Field(default=300, alias="TRADING_AUTONOMY_INTERVAL_SECONDS")
+    trading_autonomy_signal_lookback_minutes: int = Field(
+        default=15,
+        alias="TRADING_AUTONOMY_SIGNAL_LOOKBACK_MINUTES",
+        description="Lookback window for signals passed to autonomous lane runs.",
     )
     trading_autonomy_artifact_dir: str = Field(
         default="/tmp/torghut-autonomy",
@@ -255,6 +266,8 @@ class Settings(BaseSettings):
             self.trading_execution_adapter_symbols_raw = ",".join(
                 [item.strip() for item in self.trading_execution_adapter_symbols_raw.split(",") if item.strip()]
             )
+        if self.trading_autonomy_approval_token:
+            self.trading_autonomy_approval_token = self.trading_autonomy_approval_token.strip() or None
         if "llm_provider" not in self.model_fields_set and self.jangar_base_url:
             self.llm_provider = "jangar"
         if self.llm_allowed_models_raw:

--- a/services/torghut/app/models/__init__.py
+++ b/services/torghut/app/models/__init__.py
@@ -3,6 +3,11 @@
 from .base import Base, GUID, JSONType, coerce_json_payload, metadata_obj
 from .entities import (
     CreatedAtMixin,
+    ResearchCandidate,
+    ResearchFoldMetrics,
+    ResearchPromotion,
+    ResearchRun,
+    ResearchStressMetrics,
     Execution,
     LLMDecisionReview,
     PositionSnapshot,
@@ -23,6 +28,11 @@ __all__ = [
     "Execution",
     "LLMDecisionReview",
     "PositionSnapshot",
+    "ResearchCandidate",
+    "ResearchFoldMetrics",
+    "ResearchPromotion",
+    "ResearchRun",
+    "ResearchStressMetrics",
     "Strategy",
     "TimestampMixin",
     "ToolRunLog",

--- a/services/torghut/app/trading/execution.py
+++ b/services/torghut/app/trading/execution.py
@@ -73,6 +73,7 @@ class OrderExecutor:
         decision_row: TradeDecision,
         account_label: str,
         *,
+        execution_expected_adapter: Optional[str] = None,
         retry_delays: Optional[list[float]] = None,
     ) -> Optional[Execution]:
         existing_execution = self._fetch_execution(session, decision_row)
@@ -82,7 +83,20 @@ class OrderExecutor:
 
         existing_order = self._fetch_existing_order(execution_client, decision_row.decision_hash)
         if existing_order is not None:
-            execution = sync_order_to_db(session, existing_order, trade_decision_id=str(decision_row.id))
+            route_expected, route_actual, fallback_reason, fallback_count = _route_metadata(
+                expected_adapter=execution_expected_adapter,
+                execution_client=execution_client,
+                order_response=existing_order,
+            )
+            execution = sync_order_to_db(
+                session,
+                existing_order,
+                trade_decision_id=str(decision_row.id),
+                execution_expected_adapter=route_expected,
+                execution_actual_adapter=route_actual,
+                execution_fallback_reason=fallback_reason,
+                execution_fallback_count=fallback_count,
+            )
             _apply_execution_status(decision_row, execution, account_label)
             session.add(decision_row)
             session.commit()
@@ -131,7 +145,20 @@ class OrderExecutor:
                 )
                 time.sleep(delay)
 
-        execution = sync_order_to_db(session, order_response, trade_decision_id=str(decision_row.id))
+        route_expected, route_actual, fallback_reason, fallback_count = _route_metadata(
+            expected_adapter=execution_expected_adapter,
+            execution_client=execution_client,
+            order_response=order_response,
+        )
+        execution = sync_order_to_db(
+            session,
+            order_response,
+            trade_decision_id=str(decision_row.id),
+            execution_expected_adapter=route_expected,
+            execution_actual_adapter=route_actual,
+            execution_fallback_reason=fallback_reason,
+            execution_fallback_count=fallback_count,
+        )
         _apply_execution_status(
             decision_row,
             execution,
@@ -200,6 +227,76 @@ def _coerce_json(value: Any) -> dict[str, Any]:
         raw = cast(Mapping[str, Any], value)
         return {str(key): val for key, val in raw.items()}
     return {}
+
+
+def _route_metadata(
+    *,
+    expected_adapter: Optional[str],
+    execution_client: Any,
+    order_response: Mapping[str, Any],
+) -> tuple[Optional[str], Optional[str], Optional[str], Optional[int]]:
+    expected = _coerce_route_text(expected_adapter)
+    if not expected:
+        expected = _coerce_route_text(getattr(execution_client, 'name', None))
+    if not expected and execution_client.__class__.__name__ == 'OrderFirewall':
+        expected = 'alpaca'
+
+    actual = _coerce_route_text(order_response.get('_execution_route_actual'))
+    if not actual:
+        actual = _coerce_route_text(order_response.get('_execution_adapter'))
+    if not actual:
+        actual = _coerce_route_text(order_response.get('execution_actual_adapter'))
+    if not actual:
+        raw_actual = _coerce_route_text(getattr(execution_client, 'last_route', None))
+        if raw_actual == 'alpaca_fallback':
+            actual = 'alpaca'
+        elif raw_actual:
+            actual = raw_actual
+    if not actual:
+        actual = expected
+
+    fallback_count = _coerce_route_int(order_response.get('_execution_fallback_count'))
+    fallback_reason = _coerce_route_text(order_response.get('_execution_fallback_reason')) or _coerce_route_text(
+        order_response.get('_fallback_reason')
+    )
+
+    if fallback_count is None and expected and actual and actual != expected:
+        fallback_count = 1
+        if fallback_reason is None:
+            fallback_reason = f'fallback_from_{expected}_to_{actual}'
+
+    if fallback_count is not None and fallback_count <= 0 and fallback_reason is not None:
+        fallback_count = 1
+
+    return expected, actual, fallback_reason, fallback_count
+
+
+def _coerce_route_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text == 'alpaca_fallback':
+            return 'alpaca'
+        return text
+    return None
+
+
+def _coerce_route_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
 
 
 def _apply_execution_status(

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -1,9 +1,18 @@
 {
-  "policy_version": "v3",
-  "allow_live_promotion": false,
-  "auto_freeze_failure_count": 3,
-  "gate_1_max_negative_fold_count": 0,
-  "gate_2_max_drawdown": 0.35,
-  "gate_2_max_turnover_ratio": 5.0,
-  "gate_5_required_paper_days": 14
+  "policy_version": "v3-gates-1",
+  "required_feature_schema_version": "3.0.0",
+  "gate0_max_null_rate": "0.01",
+  "gate0_max_staleness_ms": 120000,
+  "gate0_min_symbol_coverage": 1,
+  "gate1_min_decision_count": 1,
+  "gate1_min_trade_count": 1,
+  "gate1_min_net_pnl": "0",
+  "gate1_max_negative_fold_ratio": "0.50",
+  "gate1_max_net_pnl_cv": "2.0",
+  "gate2_max_drawdown": "250",
+  "gate2_max_turnover_ratio": "8.0",
+  "gate2_max_cost_bps": "35",
+  "gate3_max_llm_error_ratio": "0.10",
+  "gate5_live_enabled": false,
+  "gate5_require_approval_token": true
 }

--- a/services/torghut/migrations/versions/0006_autonomy_ledger_and_execution_route.py
+++ b/services/torghut/migrations/versions/0006_autonomy_ledger_and_execution_route.py
@@ -1,0 +1,216 @@
+"""Persist execution-route metadata and autonomous research ledger tables."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "0006_autonomy_ledger_and_execution_route"
+down_revision = "0005_trade_cursor_symbol"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    execution_columns = {column["name"] for column in inspector.get_columns("executions")}
+    if "execution_expected_adapter" not in execution_columns:
+        op.add_column(
+            "executions",
+            sa.Column("execution_expected_adapter", sa.String(length=32), nullable=True),
+        )
+    if "execution_actual_adapter" not in execution_columns:
+        op.add_column(
+            "executions",
+            sa.Column("execution_actual_adapter", sa.String(length=32), nullable=True),
+        )
+    if "execution_fallback_reason" not in execution_columns:
+        op.add_column(
+            "executions",
+            sa.Column("execution_fallback_reason", sa.String(length=128), nullable=True),
+        )
+    if "execution_fallback_count" not in execution_columns:
+        op.add_column(
+            "executions",
+            sa.Column(
+                "execution_fallback_count",
+                sa.BigInteger(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+
+    execution_indexes = {index["name"] for index in inspector.get_indexes("executions")}
+    if "ix_executions_expected_adapter" not in execution_indexes:
+        op.create_index("ix_executions_expected_adapter", "executions", ["execution_expected_adapter"])
+    if "ix_executions_actual_adapter" not in execution_indexes:
+        op.create_index("ix_executions_actual_adapter", "executions", ["execution_actual_adapter"])
+
+    if not inspector.has_table("research_runs"):
+        op.create_table(
+            "research_runs",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column("run_id", sa.String(length=64), nullable=False, unique=True),
+            sa.Column(
+                "status",
+                sa.String(length=32),
+                nullable=False,
+                server_default=sa.text("'running'"),
+            ),
+            sa.Column("strategy_id", sa.String(length=64), nullable=True),
+            sa.Column("strategy_name", sa.String(length=255), nullable=True),
+            sa.Column("strategy_type", sa.String(length=128), nullable=True),
+            sa.Column("strategy_version", sa.String(length=64), nullable=True),
+            sa.Column("code_commit", sa.String(length=128), nullable=True),
+            sa.Column("feature_version", sa.String(length=64), nullable=True),
+            sa.Column("feature_schema_version", sa.String(length=64), nullable=True),
+            sa.Column("feature_spec_hash", sa.String(length=128), nullable=True),
+            sa.Column("signal_source", sa.String(length=128), nullable=True),
+            sa.Column("dataset_version", sa.String(length=64), nullable=True),
+            sa.Column("dataset_from", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("dataset_to", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("dataset_snapshot_ref", sa.String(length=255), nullable=True),
+            sa.Column("runner_version", sa.String(length=64), nullable=True),
+            sa.Column("runner_binary_hash", sa.String(length=128), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+        )
+        op.create_index("ix_research_runs_status", "research_runs", ["status"])
+        op.create_index("ix_research_runs_created_at", "research_runs", ["created_at"])
+
+    if not inspector.has_table("research_candidates"):
+        op.create_table(
+            "research_candidates",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column("run_id", sa.String(length=64), nullable=False),
+            sa.Column("candidate_id", sa.String(length=64), nullable=False, unique=True),
+            sa.Column("candidate_hash", sa.String(length=128), nullable=True),
+            sa.Column("parameter_set", postgresql.JSONB(), nullable=True),
+            sa.Column("decision_count", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("trade_count", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("symbols_covered", postgresql.JSONB(), nullable=True),
+            sa.Column("universe_definition", postgresql.JSONB(), nullable=True),
+            sa.Column("promotion_target", sa.String(length=16), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+        op.create_index("ix_research_candidates_run_id", "research_candidates", ["run_id"])
+        op.create_index(
+            "ix_research_candidates_candidate_id",
+            "research_candidates",
+            ["candidate_id"],
+        )
+
+    if not inspector.has_table("research_fold_metrics"):
+        op.create_table(
+            "research_fold_metrics",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column("candidate_id", sa.String(length=64), nullable=False),
+            sa.Column("fold_name", sa.String(length=128), nullable=False),
+            sa.Column("fold_order", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("train_start", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("train_end", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("test_start", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("test_end", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("decision_count", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("trade_count", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("gross_pnl", sa.Numeric(20, 8), nullable=True),
+            sa.Column("net_pnl", sa.Numeric(20, 8), nullable=True),
+            sa.Column("max_drawdown", sa.Numeric(20, 8), nullable=True),
+            sa.Column("turnover_ratio", sa.Numeric(20, 8), nullable=True),
+            sa.Column("cost_bps", sa.Numeric(20, 8), nullable=True),
+            sa.Column("cost_assumptions", postgresql.JSONB(), nullable=True),
+            sa.Column("regime_label", sa.String(length=64), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+        op.create_index("ix_research_fold_metrics_candidate", "research_fold_metrics", ["candidate_id"])
+        op.create_index("ix_research_fold_metrics_fold_order", "research_fold_metrics", ["fold_order"])
+
+    if not inspector.has_table("research_stress_metrics"):
+        op.create_table(
+            "research_stress_metrics",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column("candidate_id", sa.String(length=64), nullable=False),
+            sa.Column("stress_case", sa.String(length=64), nullable=False),
+            sa.Column("metric_bundle", postgresql.JSONB(), nullable=True),
+            sa.Column("pessimistic_pnl_delta", sa.Numeric(20, 8), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+        op.create_index("ix_research_stress_metrics_candidate", "research_stress_metrics", ["candidate_id"])
+        op.create_index("ix_research_stress_metrics_case", "research_stress_metrics", ["stress_case"])
+
+    if not inspector.has_table("research_promotions"):
+        op.create_table(
+            "research_promotions",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column("candidate_id", sa.String(length=64), nullable=False),
+            sa.Column("requested_mode", sa.String(length=16), nullable=True),
+            sa.Column("approved_mode", sa.String(length=16), nullable=True),
+            sa.Column("approver", sa.String(length=128), nullable=True),
+            sa.Column("approver_role", sa.String(length=64), nullable=True),
+            sa.Column("approve_reason", sa.Text(), nullable=True),
+            sa.Column("deny_reason", sa.Text(), nullable=True),
+            sa.Column("paper_candidate_patch_ref", sa.String(length=255), nullable=True),
+            sa.Column("effective_time", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+        op.create_index("ix_research_promotions_candidate", "research_promotions", ["candidate_id"])
+        op.create_index("ix_research_promotions_requested_mode", "research_promotions", ["requested_mode"])
+        op.create_index("ix_research_promotions_approved_mode", "research_promotions", ["approved_mode"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if inspector.has_table("research_promotions"):
+        op.drop_index("ix_research_promotions_candidate", table_name="research_promotions")
+        op.drop_index("ix_research_promotions_requested_mode", table_name="research_promotions")
+        op.drop_index("ix_research_promotions_approved_mode", table_name="research_promotions")
+        op.drop_table("research_promotions")
+    if inspector.has_table("research_stress_metrics"):
+        op.drop_index("ix_research_stress_metrics_candidate", table_name="research_stress_metrics")
+        op.drop_index("ix_research_stress_metrics_case", table_name="research_stress_metrics")
+        op.drop_table("research_stress_metrics")
+    if inspector.has_table("research_fold_metrics"):
+        op.drop_index("ix_research_fold_metrics_candidate", table_name="research_fold_metrics")
+        op.drop_index("ix_research_fold_metrics_fold_order", table_name="research_fold_metrics")
+        op.drop_table("research_fold_metrics")
+    if inspector.has_table("research_candidates"):
+        op.drop_index("ix_research_candidates_run_id", table_name="research_candidates")
+        op.drop_index("ix_research_candidates_candidate_id", table_name="research_candidates")
+        op.drop_table("research_candidates")
+    if inspector.has_table("research_runs"):
+        op.drop_index("ix_research_runs_status", table_name="research_runs")
+        op.drop_index("ix_research_runs_created_at", table_name="research_runs")
+        op.drop_table("research_runs")
+
+    execution_indexes = {index["name"] for index in inspector.get_indexes("executions")}
+    if "ix_executions_expected_adapter" in execution_indexes:
+        op.drop_index("ix_executions_expected_adapter", table_name="executions")
+    if "ix_executions_actual_adapter" in execution_indexes:
+        op.drop_index("ix_executions_actual_adapter", table_name="executions")
+
+    execution_columns = {column["name"] for column in inspector.get_columns("executions")}
+    if "execution_fallback_count" in execution_columns:
+        op.drop_column("executions", "execution_fallback_count")
+    if "execution_fallback_reason" in execution_columns:
+        op.drop_column("executions", "execution_fallback_reason")
+    if "execution_actual_adapter" in execution_columns:
+        op.drop_column("executions", "execution_actual_adapter")
+    if "execution_expected_adapter" in execution_columns:
+        op.drop_column("executions", "execution_expected_adapter")
+

--- a/services/torghut/tests/test_autonomous_lane.py
+++ b/services/torghut/tests/test_autonomous_lane.py
@@ -6,8 +6,12 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest import TestCase
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from yaml import safe_load
 
 from app.trading.autonomy.lane import run_autonomous_lane
+from app.models import Base, ResearchCandidate, ResearchFoldMetrics, ResearchPromotion, ResearchRun, ResearchStressMetrics
 
 
 class TestAutonomousLane(TestCase):
@@ -79,8 +83,67 @@ class TestAutonomousLane(TestCase):
                 self.assertIsNotNone(result.paper_patch_path)
                 assert result.paper_patch_path is not None
                 self.assertTrue(result.paper_patch_path.exists())
+
+                patch_payload = safe_load(result.paper_patch_path.read_text(encoding='utf-8'))
+                self.assertIsNotNone(patch_payload)
+                strategies_payload = safe_load(patch_payload['data']['strategies.yaml'])
+                self.assertIsInstance(strategies_payload, dict)
+                strategies = strategies_payload.get('strategies', [])
+                self.assertTrue(strategies)
+                self.assertFalse(any('symbols' in strategy for strategy in strategies))
+                self.assertEqual(strategies[0]['universe_type'], 'static')
         finally:
             os.chdir(previous_cwd)
+
+    def test_lane_persists_research_ledger_when_enabled(self) -> None:
+        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
+        strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
+        gate_policy_path = Path(__file__).parent.parent / 'config' / 'autonomous-gate-policy.json'
+
+        engine = create_engine(
+            'sqlite+pysqlite:///:memory:',
+            future=True,
+            connect_args={"check_same_thread": False},
+        )
+        Base.metadata.create_all(engine)
+        session_factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / 'lane-ledger'
+            result = run_autonomous_lane(
+                signals_path=fixture_path,
+                strategy_config_path=strategy_config_path,
+                gate_policy_path=gate_policy_path,
+                output_dir=output_dir,
+                promotion_target='paper',
+                code_version='test-sha',
+                persist_results=True,
+                session_factory=session_factory,
+            )
+
+            self.assertIsNotNone(result.paper_patch_path)
+            with session_factory() as session:
+                run_row = session.execute(select(ResearchRun).where(ResearchRun.run_id == result.run_id)).scalar_one()
+                candidate = session.execute(
+                    select(ResearchCandidate).where(ResearchCandidate.candidate_id == result.candidate_id)
+                ).scalar_one()
+                fold_rows = session.execute(
+                    select(ResearchFoldMetrics).where(ResearchFoldMetrics.candidate_id == result.candidate_id)
+                ).scalars().all()
+                stress_rows = session.execute(
+                    select(ResearchStressMetrics).where(ResearchStressMetrics.candidate_id == result.candidate_id)
+                ).scalars().all()
+                promotion_row = session.execute(
+                    select(ResearchPromotion).where(ResearchPromotion.candidate_id == result.candidate_id)
+                ).scalar_one()
+
+            self.assertEqual(run_row.status, 'passed')
+            self.assertIsInstance(candidate.decision_count, int)
+            self.assertGreaterEqual(candidate.decision_count, 0)
+            self.assertTrue(fold_rows)
+            self.assertEqual(len(stress_rows), 4)
+            self.assertEqual(promotion_row.requested_mode, 'paper')
+            self.assertIn(promotion_row.approved_mode, {'paper', None})
 
     def test_lane_counts_rsi_alias_for_gate_null_rate(self) -> None:
         strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
@@ -143,3 +206,64 @@ class TestAutonomousLane(TestCase):
             gate_payload = json.loads(result.gate_report_path.read_text(encoding='utf-8'))
             gate0 = next(item for item in gate_payload['gates'] if item['gate_id'] == 'gate0_data_integrity')
             self.assertEqual(gate0['status'], 'pass')
+
+    def test_intraday_strategy_candidate_uses_intraday_universe_type(self) -> None:
+        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / 'configs'
+            config_dir.mkdir(parents=True, exist_ok=True)
+            strategy_config_path = config_dir / 'intraday_strategy_candidate.json'
+            gate_policy_path = config_dir / 'autonomous_gate_policy_short.json'
+
+            strategy_config_path.write_text(
+                json.dumps(
+                    {
+                        'strategies': [
+                            {
+                                'strategy_id': 'candidate-intraday',
+                                'strategy_type': 'intraday_tsmom_v1',
+                                'version': '1.1.0',
+                                'enabled': True,
+                            }
+                        ]
+                    },
+                    sort_keys=False,
+                ),
+                encoding='utf-8',
+            )
+            gate_policy_path.write_text(
+                json.dumps(
+                    {
+                        'policy_version': 'test-policy',
+                        'required_feature_schema_version': '3.0.0',
+                        'gate1_min_decision_count': 0,
+                        'gate1_min_trade_count': 0,
+                        'gate1_min_net_pnl': '-100000',
+                        'gate1_max_negative_fold_ratio': '1',
+                        'gate1_max_net_pnl_cv': '100',
+                        'gate2_max_drawdown': '100000',
+                        'gate2_max_turnover_ratio': '1000',
+                        'gate2_max_cost_bps': '1000',
+                        'gate3_max_llm_error_ratio': '1',
+                        'gate5_live_enabled': False,
+                    },
+                    sort_keys=True,
+                ),
+                encoding='utf-8',
+            )
+
+            output_dir = Path(tmpdir) / 'lane-tsmom'
+            result = run_autonomous_lane(
+                signals_path=fixture_path,
+                strategy_config_path=strategy_config_path,
+                gate_policy_path=gate_policy_path,
+                output_dir=output_dir,
+                promotion_target='paper',
+                code_version='test-sha',
+            )
+            self.assertIsNotNone(result.paper_patch_path)
+            assert result.paper_patch_path is not None
+            patch_payload = safe_load(result.paper_patch_path.read_text(encoding='utf-8'))
+            strategies_payload = safe_load(patch_payload['data']['strategies.yaml'])
+            strategies = strategies_payload['strategies']
+            self.assertEqual(strategies[0]['universe_type'], 'intraday_tsmom_v1')

--- a/services/torghut/tests/test_autonomy_artifact_root.py
+++ b/services/torghut/tests/test_autonomy_artifact_root.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from app.trading.scheduler import _resolve_autonomy_artifact_root
+
+
+class TestAutonomyArtifactRoot(TestCase):
+    def test_prefers_configured_root_when_writable(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            configured_root = Path(tmpdir) / "custom-artifacts"
+            resolved = _resolve_autonomy_artifact_root(configured_root)
+            self.assertEqual(resolved, configured_root)
+            self.assertTrue(resolved.is_dir())
+
+    def test_falls_back_when_configured_root_unwritable(self) -> None:
+        configured_root = Path("/dev/null")
+        resolved = _resolve_autonomy_artifact_root(configured_root)
+        self.assertNotEqual(resolved, configured_root)
+        self.assertEqual(resolved, Path("/tmp/torghut/autonomy"))

--- a/services/torghut/tests/test_snapshots.py
+++ b/services/torghut/tests/test_snapshots.py
@@ -133,3 +133,25 @@ class TestSnapshots(TestCase):
             )
 
             self.assertEqual(execution.raw_order["meta"]["strategy_run_id"], str(sample_id))
+
+    def test_sync_order_to_db_normalizes_fallback_route_marker(self) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-fallback",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "0",
+                    "status": "accepted",
+                    "execution_expected_adapter": "lean",
+                    "_execution_route_actual": "alpaca_fallback",
+                    "_execution_adapter": "alpaca_fallback",
+                },
+            )
+
+            self.assertEqual(execution.execution_expected_adapter, 'lean')
+            self.assertEqual(execution.execution_actual_adapter, 'alpaca')

--- a/services/torghut/tests/test_trading_scheduler_autonomy.py
+++ b/services/torghut/tests/test_trading_scheduler_autonomy.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.config import settings
+from app.trading.models import SignalEnvelope
+from app.trading.scheduler import TradingScheduler
+
+
+@dataclass
+class _PipelineStub:
+    signals: list[SignalEnvelope]
+    session_factory: object
+
+    def __post_init__(self) -> None:
+        self.ingestor = self
+
+    def fetch_signals_between(self, start: datetime, end: datetime) -> list[SignalEnvelope]:
+        return list(self.signals)
+
+
+class _SchedulerDependencies:
+    def __init__(self) -> None:
+        self.call_kwargs: dict[str, Any] = {}
+
+
+def _signal_batch() -> list[SignalEnvelope]:
+    return [
+        SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            payload={"macd": {"macd": "1", "signal": "0"}, "rsi14": "58", "price": "100"},
+        ),
+    ]
+
+
+class TestTradingSchedulerAutonomy(TestCase):
+    def setUp(self) -> None:
+        self._settings_snapshot = {
+            "trading_autonomy_allow_live_promotion": settings.trading_autonomy_allow_live_promotion,
+            "trading_autonomy_approval_token": settings.trading_autonomy_approval_token,
+            "trading_strategy_config_path": settings.trading_strategy_config_path,
+            "trading_autonomy_gate_policy_path": settings.trading_autonomy_gate_policy_path,
+            "trading_autonomy_artifact_dir": settings.trading_autonomy_artifact_dir,
+        }
+
+    def tearDown(self) -> None:
+        settings.trading_autonomy_allow_live_promotion = self._settings_snapshot["trading_autonomy_allow_live_promotion"]
+        settings.trading_autonomy_approval_token = self._settings_snapshot["trading_autonomy_approval_token"]
+        settings.trading_strategy_config_path = self._settings_snapshot["trading_strategy_config_path"]
+        settings.trading_autonomy_gate_policy_path = self._settings_snapshot["trading_autonomy_gate_policy_path"]
+        settings.trading_autonomy_artifact_dir = self._settings_snapshot["trading_autonomy_artifact_dir"]
+
+    def test_run_autonomous_cycle_uses_live_promotion_when_token_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scheduler, deps = self._build_scheduler_with_fixtures(
+                tmpdir,
+                allow_live=True,
+                approval_token="live-approve-token",
+            )
+            with patch("app.trading.scheduler.run_autonomous_lane", side_effect=self._fake_run_autonomous_lane(deps)):
+                scheduler._run_autonomous_cycle()
+
+            self.assertEqual(deps.call_kwargs["promotion_target"], "live")
+            self.assertEqual(deps.call_kwargs["approval_token"], "live-approve-token")
+
+    def test_run_autonomous_cycle_falls_back_to_paper_when_live_disabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scheduler, deps = self._build_scheduler_with_fixtures(
+                tmpdir,
+                allow_live=False,
+                approval_token=None,
+            )
+            with patch("app.trading.scheduler.run_autonomous_lane", side_effect=self._fake_run_autonomous_lane(deps)):
+                scheduler._run_autonomous_cycle()
+
+            self.assertEqual(deps.call_kwargs["promotion_target"], "paper")
+            self.assertIsNone(deps.call_kwargs["approval_token"])
+
+    def test_run_autonomous_cycle_falls_back_to_paper_when_live_token_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scheduler, deps = self._build_scheduler_with_fixtures(
+                tmpdir,
+                allow_live=True,
+                approval_token=None,
+            )
+            with patch("app.trading.scheduler.run_autonomous_lane", side_effect=self._fake_run_autonomous_lane(deps)):
+                scheduler._run_autonomous_cycle()
+
+            self.assertEqual(deps.call_kwargs["promotion_target"], "paper")
+            self.assertIsNone(deps.call_kwargs["approval_token"])
+
+    def test_run_autonomous_cycle_uses_strategy_paths_from_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scheduler, deps = self._build_scheduler_with_fixtures(
+                tmpdir,
+                allow_live=False,
+                approval_token=None,
+            )
+            with patch("app.trading.scheduler.run_autonomous_lane", side_effect=self._fake_run_autonomous_lane(deps)):
+                scheduler._run_autonomous_cycle()
+
+            self.assertEqual(deps.call_kwargs["strategy_config_path"], Path(settings.trading_strategy_config_path))
+            self.assertEqual(deps.call_kwargs["gate_policy_path"], Path(settings.trading_autonomy_gate_policy_path))
+
+    def test_run_autonomous_cycle_passes_persistence_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scheduler, deps = self._build_scheduler_with_fixtures(
+                tmpdir,
+                allow_live=False,
+                approval_token=None,
+            )
+            with patch("app.trading.scheduler.run_autonomous_lane", side_effect=self._fake_run_autonomous_lane(deps)):
+                scheduler._run_autonomous_cycle()
+
+            self.assertTrue(deps.call_kwargs["persist_results"])
+            self.assertIsNotNone(deps.call_kwargs["session_factory"])
+            self.assertIsNotNone(deps.call_kwargs["session_factory"])
+
+    def test_run_autonomous_cycle_records_gate_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scheduler, deps = self._build_scheduler_with_fixtures(
+                tmpdir,
+                allow_live=False,
+                approval_token=None,
+            )
+            with patch("app.trading.scheduler.run_autonomous_lane", side_effect=self._fake_run_autonomous_lane(deps)):
+                scheduler._run_autonomous_cycle()
+
+            self.assertEqual(scheduler.state.last_autonomy_gates, str(deps.gate_report_path))
+            self.assertEqual(scheduler.state.last_autonomy_run_id, "test-run-id")
+            self.assertEqual(scheduler.state.last_autonomy_recommendation, "paper")
+
+    def _build_scheduler_with_fixtures(
+        self,
+        tmpdir: str,
+        *,
+        allow_live: bool,
+        approval_token: str | None,
+    ) -> tuple[TradingScheduler, _SchedulerDependencies]:
+        strategy_config_path = Path(tmpdir) / "strategies.yaml"
+        strategy_config_path.write_text(
+            json.dumps(
+                {
+                    "strategies": [
+                        {
+                            "strategy_id": "intraday-tsmom-profit-v2",
+                            "strategy_type": "intraday_tsmom_v1",
+                            "version": "1.1.0",
+                            "enabled": True,
+                            "base_timeframe": "1Min",
+                        }
+                    ]
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        gate_policy_path = Path(tmpdir) / "autonomy-gates-v3.json"
+        gate_policy_path.write_text(
+            json.dumps(
+                {
+                    "policy_version": "v3-gates-1",
+                    "required_feature_schema_version": "3.0.0",
+                    "gate1_min_decision_count": 0,
+                    "gate1_min_trade_count": 0,
+                    "gate1_min_net_pnl": "-1",
+                    "gate1_max_negative_fold_ratio": "1",
+                    "gate1_max_net_pnl_cv": "100",
+                    "gate2_max_drawdown": "100000",
+                    "gate2_max_turnover_ratio": "1000",
+                    "gate2_max_cost_bps": "1000",
+                    "gate3_max_llm_error_ratio": "1",
+                    "gate5_live_enabled": True,
+                    "gate5_require_approval_token": True,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        settings.trading_autonomy_allow_live_promotion = allow_live
+        settings.trading_autonomy_approval_token = approval_token
+        settings.trading_strategy_config_path = str(strategy_config_path)
+        settings.trading_autonomy_gate_policy_path = str(gate_policy_path)
+        settings.trading_autonomy_artifact_dir = str(Path(tmpdir) / "autonomy-artifacts")
+
+        scheduler = TradingScheduler()
+        scheduler._pipeline = _PipelineStub(signals=_signal_batch(), session_factory=lambda: None)
+
+        return scheduler, _SchedulerDependencies()
+
+    @staticmethod
+    def _fake_run_autonomous_lane(deps: _SchedulerDependencies):
+        def _capture(*, signals_path: Path, strategy_config_path: Path, gate_policy_path: Path, output_dir: Path, **kwargs: Any) -> SimpleNamespace:
+            deps.call_kwargs = kwargs
+            deps.call_kwargs["strategy_config_path"] = strategy_config_path
+            deps.call_kwargs["gate_policy_path"] = gate_policy_path
+
+            deps.call_kwargs.update(
+                {
+                    "strategy_config_path": strategy_config_path,
+                    "gate_policy_path": gate_policy_path,
+                    "promotion_target": kwargs.get("promotion_target"),
+                    "approval_token": kwargs.get("approval_token"),
+                }
+            )
+
+            gate_report_path = output_dir / "gate-evaluation.json"
+            gate_report_path.write_text('{"recommended_mode": "paper", "gates": []}', encoding='utf-8')
+            deps.gate_report_path = gate_report_path
+
+            return SimpleNamespace(
+                run_id="test-run-id",
+                candidate_id="cand-test",
+                output_dir=output_dir,
+                gate_report_path=gate_report_path,
+                paper_patch_path=None,
+            )
+
+        return _capture


### PR DESCRIPTION
## Summary
- Add LEAN/autonomous execution metadata on execution and order lifecycle paths.
- Implement v3 autonomous strategy runtime scaffold (runtime plugins + lane orchestration), gate integration, and research ledger persistence.
- Extend trading APIs, models, migration, and unit tests to support autonomous execution visibility and route provenance.

## Testing
- uv run --with pytest --env-file /dev/null pytest -q test_autonomy_runtime.py test_autonomous_lane.py test_trading_scheduler_autonomy.py test_order_idempotency.py test_snapshots.py test_execution_policy.py test_autonomy_artifact_root.py (services/torghut) *(blocked: missing local Python deps in environment, collection error for pydantic/sqlalchemy/psycopg packages)
- Manual SQL checks against CNPG indicate migration `0006_autonomy_ledger_and_execution_route` is already present and column additions exist; route metadata currently all null on historical rows.

## Related Issues
None
