### PR TITLE
chore(build): bump bun runtime pins to 1.3.9

### DIFF
--- a/.github/workflows/agentctl-ci.yml
+++ b/.github/workflows/agentctl-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/agentctl-release.yml
+++ b/.github/workflows/agentctl-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -164,7 +164,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         if: ${{ steps.npm_token.outputs.skip != 'true' }}
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Install dependencies
         if: ${{ steps.npm_token.outputs.skip != 'true' }}

--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Install kubectl
         run: |

--- a/.github/workflows/bumba-ci.yml
+++ b/.github/workflows/bumba-ci.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/common-monorepo.yml
     with:
-      bun-version: 1.3.5
+      bun-version: 1.3.9
       node-version: 24.11.1
       install-command: bun install --frozen-lockfile --ignore-scripts && bun run --filter @proompteng/temporal-bun-sdk build
       lint-command: bunx biome check services/bumba packages/scripts/src/bumba argocd/applications/bumba
@@ -53,5 +53,5 @@ jobs:
       new_tag: ${{ github.sha }}
       turbo_scope: '@proompteng/bumba'
       turbo_copy: 'tsconfig.base.json'
-      bun_version: 1.3.5
+      bun_version: 1.3.9
     secrets: inherit

--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -19,7 +19,7 @@ jobs:
   test-and-build:
     uses: ./.github/workflows/common-monorepo.yml
     with:
-      bun-version: 1.3.5
+      bun-version: 1.3.9
       node-version: 24.11.1
       install-command: bun install --frozen-lockfile --ignore-scripts
       lint-command: bunx biome check packages/codex

--- a/.github/workflows/common-monorepo.yml
+++ b/.github/workflows/common-monorepo.yml
@@ -10,7 +10,7 @@ on:
       bun-version:
         required: false
         type: string
-        default: '1.3.5'
+        default: '1.3.9'
       install-command:
         required: true
         type: string

--- a/.github/workflows/docker-build-common.yaml
+++ b/.github/workflows/docker-build-common.yaml
@@ -34,7 +34,7 @@ on:
       bun_version:
         required: false
         type: string
-        default: '1.3.5'
+        default: '1.3.9'
 
 jobs:
   build:

--- a/.github/workflows/jangar-ci.yml
+++ b/.github/workflows/jangar-ci.yml
@@ -18,7 +18,7 @@ jobs:
   lint-and-typecheck:
     uses: ./.github/workflows/common-monorepo.yml
     with:
-      bun-version: 1.3.5
+      bun-version: 1.3.9
       node-version: 24.11.1
       install-command: ELECTRON_SKIP_BINARY_DOWNLOAD=1 bun install --frozen-lockfile --ignore-scripts && bun run --filter @proompteng/temporal-bun-sdk build && cd services/jangar && bun install --frozen-lockfile --ignore-scripts
       lint-command: bunx biome check services/jangar packages/scripts/src/jangar argocd/applications/jangar

--- a/.github/workflows/oirat-ci.yml
+++ b/.github/workflows/oirat-ci.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/common-monorepo.yml
     with:
-      bun-version: 1.3.5
+      bun-version: 1.3.9
       node-version: 24.11.1
       install-command: bun install --frozen-lockfile --ignore-scripts && bun run --filter @proompteng/discord build
       lint-command: bunx biome check services/oirat packages/scripts/src/oirat
@@ -51,5 +51,5 @@ jobs:
       new_tag: ${{ github.sha }}
       turbo_scope: '@proompteng/oirat'
       turbo_copy: 'tsconfig.base.json'
-      bun_version: 1.3.5
+      bun_version: 1.3.9
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -72,7 +72,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Install build tools
         run: |
@@ -82,9 +82,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -127,14 +127,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -176,14 +176,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -215,14 +215,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -249,14 +249,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -285,14 +285,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -317,7 +317,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Install build tools
         run: |
@@ -367,14 +367,14 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - run: bun install --frozen-lockfile --ignore-scripts
         working-directory: apps/reviseur

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -16,7 +16,7 @@ jobs:
   lint-and-test:
     uses: ./.github/workflows/common-monorepo.yml
     with:
-      bun-version: 1.3.5
+      bun-version: 1.3.9
       node-version: 24.11.1
       install-command: bun install --frozen-lockfile --ignore-scripts
       lint-command: bun run --filter @proompteng/scripts lint

--- a/.github/workflows/temporal-bun-sdk-protos.yml
+++ b/.github/workflows/temporal-bun-sdk-protos.yml
@@ -22,15 +22,15 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Cache Bun install
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - name: Install Buf CLI
         uses: bufbuild/buf-setup-action@v1

--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -61,15 +61,15 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Cache Bun install
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential
@@ -149,15 +149,15 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Cache Bun install
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential
@@ -224,15 +224,15 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.9
 
       - name: Cache Bun install
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.5-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-bun-1.3.9-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-1.3.5-
+            ${{ runner.os }}-bun-1.3.9-
 
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - `skills/`: agent skills; each skill includes a `SKILL.md`.
 
 ## Prereqs
-- Node 24.11.1 + Bun 1.3.5 (root `package.json`).
+- Node 24.11.1 + Bun 1.3.9 (root `package.json`).
 - Go 1.24+ for `services/`.
 - Ruby 3.4.7 + Bundler 2.7+ for `services/dernier`.
 - Python 3.9–3.12 for `apps/alchimie`; 3.11–3.12 for `services/torghut`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ kubectl --kubeconfig ~/.kube/altra.yaml apply -f ./tofu/harvester/templates
 - **Backend**: Go 1.24, Node.js 22.20, Python 3.9-3.13
 - **Data**: Dagster, Temporal, PostgreSQL, Kafka, Milvus
 - **Infrastructure**: Kubernetes (K3s), ArgoCD, Harvester, Ansible
-- **Tooling**: Bun 1.3.5, Biome, Turbo, Docker, UV
+- **Tooling**: Bun 1.3.9, Biome, Turbo, Docker, UV
 
 ### Application Patterns
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A multi-language monorepo for experimenting with conversational tooling, data pi
 ## Quick Start
 
 1. **Prerequisites**
-   - Node.js 24.11.x and Bun 1.3.5
+   - Node.js 24.11.x and Bun 1.3.9
    - Go 1.24+
    - Docker / Kubernetes tooling if you plan to run services or apply manifests locally
 2. **Install workspace dependencies**

--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION

--- a/apps/froussard/Dockerfile
+++ b/apps/froussard/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG NODE_VERSION=24.11.1
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM node:${NODE_VERSION}-bookworm AS base
 ARG BUN_VERSION

--- a/apps/kitty-krew/Dockerfile
+++ b/apps/kitty-krew/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM oven/bun:${BUN_VERSION}-alpine AS builder
 

--- a/apps/landing/Dockerfile
+++ b/apps/landing/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION

--- a/apps/reestr/Dockerfile
+++ b/apps/reestr/Dockerfile
@@ -2,7 +2,7 @@
 # Built from a Turbo-pruned context produced by:
 #   bunx turbo prune --scope=reestr --docker --out-dir <dir>
 
-FROM oven/bun:1.3.5 AS deps
+FROM oven/bun:1.3.9 AS deps
 WORKDIR /app
 COPY json/ ./
 COPY tsconfig.base.json ./tsconfig.base.json
@@ -17,7 +17,7 @@ COPY full/ ./
 WORKDIR /app/apps/reestr
 RUN bun run build
 
-FROM oven/bun:1.3.5 AS runner
+FROM oven/bun:1.3.9 AS runner
 WORKDIR /app/apps/reestr
 ENV NODE_ENV=production
 ENV PORT=4173

--- a/apps/reviseur/Dockerfile
+++ b/apps/reviseur/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM node:lts-alpine AS deps
 ARG BUN_VERSION

--- a/docs/agents/agentctl-release.md
+++ b/docs/agents/agentctl-release.md
@@ -8,7 +8,7 @@ For install/usage guidance, see `docs/agents/agentctl.md`.
 
 ## Prereqs
 
-- Bun 1.3.5
+- Bun 1.3.9
 - npm (for publishing)
 - Access to `proompteng` npm org and the Homebrew tap repo
 

--- a/package.json
+++ b/package.json
@@ -102,5 +102,5 @@
     "@types/bun": "^1.3.5",
     "xstate": "^5.25.0"
   },
-  "packageManager": "bun@1.3.5"
+  "packageManager": "bun@1.3.9"
 }

--- a/packages/schematic/src/docker/index.ts
+++ b/packages/schematic/src/docker/index.ts
@@ -1,5 +1,5 @@
 export const dockerfile = (name: string) => `# syntax=docker/dockerfile:1.7
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM oven/bun:${'$'}{BUN_VERSION} AS builder
 WORKDIR /workspace

--- a/services/bonjour/Dockerfile
+++ b/services/bonjour/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM oven/bun:${BUN_VERSION} AS builder
 WORKDIR /app

--- a/services/bumba/Dockerfile
+++ b/services/bumba/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 # This Dockerfile is intended to be built from a Turbo-pruned context:
 # `bunx turbo prune --scope=@proompteng/bumba --docker --out-dir <dir>`
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 ARG LAB_GIT_SHA=dev
 
 FROM oven/bun:${BUN_VERSION} AS deps

--- a/services/bumba/package.json
+++ b/services/bumba/package.json
@@ -42,5 +42,5 @@
     "@types/bun": "latest",
     "typescript": "^5.9.3"
   },
-  "packageManager": "bun@1.3.5"
+  "packageManager": "bun@1.3.9"
 }

--- a/services/golink/Dockerfile
+++ b/services/golink/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM oven/bun:${BUN_VERSION} AS builder
 WORKDIR /workspace

--- a/services/golink/README.md
+++ b/services/golink/README.md
@@ -4,7 +4,7 @@ Internal Knative service that powers `http://go/<slug>` redirects with a small a
 
 ## Prerequisites
 - `.env.local` in `services/golink` (copy `.env.example`) with `GOLINK_DATABASE_URL` set. Defaults point to the local compose Postgres on port 15433.
-- Bun 1.3.5 and Node 24.11.1 (workspace defaults).
+- Bun 1.3.9 and Node 24.11.1 (workspace defaults).
 
 ## Scripts
 All commands run from the repo root unless noted.

--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -9,7 +9,7 @@
 # - `full/` contains the full pruned source tree
 # - `tsconfig.base.json` is copied into the context root by the build script
 # - `skills/` is present at the context root for Codex CLI skills
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 ARG OPENVSCODE_VERSION=1.106.3
 ARG GH_VERSION=2.83.2
 ARG ZOXIDE_VERSION=0.9.8

--- a/services/jangar/Dockerfile.codex
+++ b/services/jangar/Dockerfile.codex
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 ENV CODEX_ENV_NODE_VERSION=24.11.1 \
     CODEX_ENV_GO_VERSION=1.25.4 \
     CODEX_ENV_JAVA_VERSION=21 \
-    BUN_VERSION=1.3.5
+    BUN_VERSION=1.3.9
 
 # Preinstall requested Node version to avoid nvm cache misses during setup.
 RUN bash -lc 'source /root/.nvm/nvm.sh && nvm install ${CODEX_ENV_NODE_VERSION}'

--- a/services/jangar/agentctl/package.json
+++ b/services/jangar/agentctl/package.json
@@ -64,5 +64,5 @@
     "@types/node": "^24.10.2",
     "bun-types": "latest"
   },
-  "packageManager": "bun@1.3.5"
+  "packageManager": "bun@1.3.9"
 }

--- a/services/jangar/package.json
+++ b/services/jangar/package.json
@@ -94,5 +94,5 @@
     "vitest": "^4.0.18",
     "web-vitals": "^5.1.0"
   },
-  "packageManager": "bun@1.3.5"
+  "packageManager": "bun@1.3.9"
 }

--- a/services/oirat/Dockerfile
+++ b/services/oirat/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 # This Dockerfile is intended to be built from a Turbo-pruned context:
 # `bunx turbo prune --scope=@proompteng/oirat --docker --out-dir <dir>`
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.9
 
 FROM oven/bun:${BUN_VERSION} AS deps
 WORKDIR /app

--- a/services/oirat/package.json
+++ b/services/oirat/package.json
@@ -21,5 +21,5 @@
     "bun-types": "latest",
     "typescript": "^5.9.3"
   },
-  "packageManager": "bun@1.3.5"
+  "packageManager": "bun@1.3.9"
 }

--- a/services/workers/Dockerfile
+++ b/services/workers/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.5
+FROM oven/bun:1.3.9
 
 ARG NODE_VERSION=24.11.1
 ARG NVM_VERSION=0.39.7


### PR DESCRIPTION
## Summary

- Bumps Bun runtime/tooling pins from 1.3.5 to 1.3.9 across the repo.
- Updates CI workflow Bun versions (`bun-version` inputs, workflow defaults, and Bun cache key suffixes).
- Updates build/runtime references (Docker ARGs/images), package manager declarations, and local docs/instructions to the same Bun version.

## Related Issues

None

## Testing

- N/A: string/baseline version alignment changes only; no runtime verification executed in this pass.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (`N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
