### PR TITLE
feat(torghut): rollout via torghut deploy script and sync observability

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -657,6 +657,61 @@ data:
                 No Torghut trading decisions have been recorded for 15 minutes during market hours (UTC schedule).
                 This stalls quant control-plane snapshots and freshness.
               runbook_url: docs/runbooks/torghut-quant-control-plane.md
+          - alert: TorghutAutonomyNoSignalStreakDuringMarketHours
+            expr: |
+              (
+                increase(
+                  torghut_trading_no_signal_windows_total{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut"
+                  }[10m]
+                ) >= 2
+              )
+              * on() group_left()
+              (
+                (day_of_week(vector(time())) >= bool 1)
+                * (day_of_week(vector(time())) <= bool 5)
+                * (hour(vector(time())) >= bool 14)
+                * (hour(vector(time())) < bool 21)
+              )
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut autonomy no-signal streak (market hours)
+              description: |
+                Autonomy ingest returned empty windows for consecutive cycles for 10 minutes in market hours.
+                Check TA signal chain health, Jangar symbol feed, and autonomy cursor state.
+              runbook_url: docs/runbooks/torghut-quant-control-plane.md
+          - alert: TorghutAutonomyCursorAheadOfStreamDuringMarketHours
+            expr: |
+              (
+                increase(
+                  torghut_trading_no_signal_reason_total{
+                    job="torghut",
+                    namespace="torghut",
+                    service="torghut",
+                    reason="cursor_ahead_of_stream"
+                  }[10m]
+                ) >= 2
+              )
+              * on() group_left()
+              (
+                (day_of_week(vector(time())) >= bool 1)
+                * (day_of_week(vector(time())) <= bool 5)
+                * (hour(vector(time())) >= bool 14)
+                * (hour(vector(time())) < bool 21)
+              )
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut autonomy cursor is ahead of stream (market hours)
+              description: |
+                Autonomy ingest reports repeated cursor_ahead_of_stream for 10 minutes during market hours.
+                This indicates the TA pipeline is not advancing or ingestion is behind.
+              runbook_url: docs/runbooks/torghut-quant-control-plane.md
           - alert: TorghutQuantOrderRejectionRateHigh
             expr: |
               (

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -14,18 +14,19 @@ metadata:
 spec:
   template:
     metadata:
-        annotations:
-        autoscaling.knative.dev/minScale: "1"
-        autoscaling.knative.dev/maxScale: "1"
-        autoscaling.knative.dev/target: "80"
-        client.knative.dev/updateTimestamp: 2026-02-13T03:15:00.000Z
+      annotations:
+        client.knative.dev/updateTimestamp: 2026-02-13T04:23:10.458Z
+      autoscaling.knative.dev/minScale: "1"
+      autoscaling.knative.dev/maxScale: "1"
+      autoscaling.knative.dev/target: "80"
+      client.knative.dev/updateTimestamp: 2026-02-13T03:15:00.000Z
     spec:
       containerConcurrency: 0
       timeoutSeconds: 60
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut:latest
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b0c8f0ca9170248afbf9003f3cd3f7705c667e0dffadf4d6fa9f78845e3bbf08
           ports:
             - name: http1
               containerPort: 8181
@@ -127,7 +128,7 @@ spec:
             - name: LLM_EFFECTIVE_CHALLENGE_ID
               value: torghut-llm-mrm-review-2026-02-12
             - name: LLM_SHADOW_COMPLETED_AT
-              value: "2026-02-12T06:45:00Z"
+              value: 2026-02-12T06:45:00Z
             - name: LLM_FAIL_MODE
               value: pass_through
             - name: LLM_TIMEOUT_SECONDS
@@ -156,9 +157,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.548.0-5-g0b079fc3
+              value: v0.550.0
             - name: TORGHUT_COMMIT
-              value: 0b079fc304df7f7c59d39c87fc91bc43f16bde60
+              value: 9607c73b73f0b22f40e755758bfe80d945ecffc7
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:5c6a23dde129d6e041bde539dd5409941d0cee3d6fc04001b8f9e9d1692c96cd
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:90a35c6c9267835735b657065ef6e1b3797a5befd76eba5fd74876733230ad90
   imagePullPolicy: IfNotPresent
   restartNonce: 2
   flinkVersion: v2_0
@@ -155,9 +155,9 @@ spec:
                   name: observability-minio-creds
                   key: secretkey
             - name: TORGHUT_TA_VERSION
-              value: v0.523.3
+              value: v0.550.0
             - name: TORGHUT_TA_COMMIT
-              value: 14348305dfe4be8d192b1920eb72f093c73896ee
+              value: 9607c73b73f0b22f40e755758bfe80d945ecffc7
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2026-02-10T16:50:25Z
+        kubectl.kubernetes.io/restartedAt: 2026-02-13T04:23:10.464Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:
@@ -27,7 +27,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:54b60a70ca6d5e416a0a093d9b02d5767935497ba6371856021acf63835e3fef
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7187e76497e4b221dcce32483f33797f26d182ab9321201ca0f282ad21c587d4
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -51,9 +51,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: v0.533.0-5-g33e27f02
+              value: v0.550.0
             - name: TORGHUT_WS_COMMIT
-              value: 33e27f020b18b7693fee4799d66ddd193a6346be
+              value: 9607c73b73f0b22f40e755758bfe80d945ecffc7
           ports:
             - containerPort: 8080
               name: http

--- a/docs/runbooks/torghut-quant-control-plane.md
+++ b/docs/runbooks/torghut-quant-control-plane.md
@@ -12,6 +12,8 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
 `torghut-quant-control-plane.rules`.
 
 - **TorghutQuantDecisionsStalledDuringMarketHours**: No trading decisions for 15 minutes during market hours.
+- **TorghutAutonomyNoSignalStreakDuringMarketHours**: Autonomy has consecutive no-signal windows in market hours.
+- **TorghutAutonomyCursorAheadOfStreamDuringMarketHours**: Autonomy repeatedly reports cursor_ahead_of_stream in market hours.
 - **TorghutQuantOrderRejectionRateHigh**: Rejected orders >20% of submitted orders for 10 minutes.
 - **TorghutQuantLLMErrorRateHigh**: Trading LLM errors >10% of requests for 10 minutes.
 - **JangarQuantControlPlaneStreamErrors**: Control-plane SSE errors >0.05/sec for 10 minutes.

--- a/services/torghut/app/metrics.py
+++ b/services/torghut/app/metrics.py
@@ -10,11 +10,13 @@ def _escape_label_value(value: str | int | float) -> str:
     return text.replace("\\", "\\\\").replace('"', '\\"')
 
 
-def _render_labeled_counter(
+def _render_labeled_metric(
     metric_name: str,
     labels: Mapping[str, str],
     value: int | float,
 ) -> list[str]:
+    if not labels:
+        return [f"{metric_name} {value}"]
     label_text = ",".join([f'{key}="{_escape_label_value(val)}"' for key, val in labels.items()])
     return [f'{metric_name}{{{label_text}}} {value}']
 
@@ -27,14 +29,14 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
         if not isinstance(value, (int, float)):
             if isinstance(value, Mapping):
                 if key == "execution_requests_total":
+                    metric_name = "torghut_trading_execution_requests_total"
+                    lines.append(f"# HELP {metric_name} Count of execution requests by adapter.")
+                    lines.append(f"# TYPE {metric_name} counter")
                     for adapter, count in sorted(value.items()):
                         if not isinstance(adapter, str) or not isinstance(count, (int, float)):
                             continue
-                        metric_name = "torghut_trading_execution_requests_total"
-                        lines.append(f"# HELP {metric_name} Count of execution requests by adapter.")
-                        lines.append(f"# TYPE {metric_name} counter")
                         lines.extend(
-                            _render_labeled_counter(
+                            _render_labeled_metric(
                                 metric_name=metric_name,
                                 labels={"adapter": adapter},
                                 value=count,
@@ -42,6 +44,9 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
                         )
                     continue
                 if key == "execution_fallback_total":
+                    metric_name = "torghut_trading_execution_fallback_total"
+                    lines.append(f"# HELP {metric_name} Count of execution fallbacks by adapter transition.")
+                    lines.append(f"# TYPE {metric_name} counter")
                     for transition, count in sorted(value.items()):
                         if not isinstance(transition, str) or not isinstance(count, (int, float)):
                             continue
@@ -49,11 +54,8 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
                         actual_adapter = "unknown"
                         if "->" in transition:
                             expected_adapter, actual_adapter = transition.split("->", 1)
-                        metric_name = "torghut_trading_execution_fallback_total"
-                        lines.append(f"# HELP {metric_name} Count of execution fallbacks by adapter transition.")
-                        lines.append(f"# TYPE {metric_name} counter")
                         lines.extend(
-                            _render_labeled_counter(
+                            _render_labeled_metric(
                                 metric_name=metric_name,
                                 labels={"from": expected_adapter, "to": actual_adapter},
                                 value=count,
@@ -61,20 +63,41 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
                         )
                     continue
                 if key == "execution_fallback_reason_total":
+                    metric_name = "torghut_trading_execution_fallback_reason_total"
+                    lines.append(f"# HELP {metric_name} Count of execution fallbacks by reason.")
+                    lines.append(f"# TYPE {metric_name} counter")
                     for reason, count in sorted(value.items()):
                         if not isinstance(reason, str) or not isinstance(count, (int, float)):
                             continue
-                        metric_name = "torghut_trading_execution_fallback_reason_total"
-                        lines.append(f"# HELP {metric_name} Count of execution fallbacks by reason.")
-                        lines.append(f"# TYPE {metric_name} counter")
                         lines.extend(
-                            _render_labeled_counter(
+                            _render_labeled_metric(
                                 metric_name=metric_name,
                                 labels={"reason": reason},
                                 value=count,
                             )
                         )
                     continue
+                if key == "no_signal_reason_total":
+                    metric_name = "torghut_trading_no_signal_reason_total"
+                    lines.append(f"# HELP {metric_name} Count of autonomy cycles skipped by no-signal reason.")
+                    lines.append(f"# TYPE {metric_name} counter")
+                    for reason, count in sorted(value.items()):
+                        if not isinstance(reason, str) or not isinstance(count, (int, float)):
+                            continue
+                        lines.extend(
+                            _render_labeled_metric(
+                                metric_name=metric_name,
+                                labels={"reason": reason},
+                                value=count,
+                            )
+                        )
+                    continue
+            continue
+        if key == "no_signal_streak":
+            metric_name = "torghut_trading_no_signal_streak"
+            lines.append(f"# HELP {metric_name} Consecutive no-signal autonomy cycles.")
+            lines.append(f"# TYPE {metric_name} gauge")
+            lines.extend(_render_labeled_metric(metric_name=metric_name, labels={"service": "torghut"}, value=value))
             continue
         metric_name = f"torghut_trading_{key}"
         help_text = f"Torghut trading metric {key.replace('_', ' ')}."

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -97,6 +97,7 @@ class TradingMetrics:
     execution_fallback_reason_total: dict[str, int] = field(default_factory=dict)
     no_signal_windows_total: int = 0
     no_signal_reason_total: dict[str, int] = field(default_factory=dict)
+    no_signal_streak: int = 0
 
     def record_execution_request(self, adapter: str | None) -> None:
         adapter_name = coerce_route_text(adapter)
@@ -1149,6 +1150,7 @@ class TradingScheduler:
         if not signals:
             self.state.metrics.record_no_signal(autonomy_batch.no_signal_reason)
             self.state.autonomy_no_signal_streak += 1
+            self.state.metrics.no_signal_streak = self.state.autonomy_no_signal_streak
             run_output_dir = artifact_root / now.strftime("%Y%m%dT%H%M%S")
             run_output_dir.mkdir(parents=True, exist_ok=True)
             no_signal_path = run_output_dir / "no-signals.json"
@@ -1203,6 +1205,7 @@ class TradingScheduler:
         signals_path.write_text(json.dumps(signal_payloads, indent=2), encoding="utf-8")
 
         self.state.autonomy_no_signal_streak = 0
+        self.state.metrics.no_signal_streak = 0
 
         promotion_target: Literal["paper", "live"]
         approval_token: str | None

--- a/services/torghut/tests/test_metrics.py
+++ b/services/torghut/tests/test_metrics.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from app.metrics import render_trading_metrics
+from app.trading.scheduler import TradingMetrics
+
+
+class TestTradingMetrics(TestCase):
+    def test_no_signal_reason_and_streak_are_exported(self) -> None:
+        metrics = TradingMetrics()
+        metrics.record_no_signal("cursor_ahead_of_stream")
+        metrics.no_signal_streak = 2
+
+        payload = render_trading_metrics(metrics.__dict__)
+
+        self.assertIn(
+            'torghut_trading_no_signal_reason_total{reason="cursor_ahead_of_stream"} 1',
+            payload,
+        )
+        self.assertIn(
+            'torghut_trading_no_signal_streak{service="torghut"} 2',
+            payload,
+        )
+        self.assertIn('# TYPE torghut_trading_no_signal_streak gauge', payload)


### PR DESCRIPTION
## Summary

- Update Torghut deployment manifests with freshly built images (app, websocket forwarder, technical analysis).
- Run Torghut rollout script to push images and apply knative/ws/ta changes.
- Sync observability ArgoCD app so alerting/observability manifests reconcile with updated `graf-mimir-rules`.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/torghut/deploy-service.ts`
- `argocd app sync observability`
- `argocd app get observability`

## Screenshots

Not applicable.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed
- [x] Screenshots and Breaking Changes sections are handled appropriately
- [x] Documentation, release notes, and follow-ups are updated or tracked
