### PR TITLE
fix(argocd): prevent repo-server rollout deadlock

### DIFF
--- a/argocd/applications/argocd/overlays/argocd-repo-server-deployment.yaml
+++ b/argocd/applications/argocd/overlays/argocd-repo-server-deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: argocd-repo-server
 spec:
   replicas: 3
+  strategy:
+    rollingUpdate:
+      # With required pod anti-affinity and a 3-node cluster, allowing surge pods can deadlock rollouts:
+      # the new pod can't schedule until an old one is removed.
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     spec:
       dnsConfig:


### PR DESCRIPTION
## Summary

- Prevent `argocd-repo-server` rollouts from deadlocking on a 3-node cluster with required pod anti-affinity by setting `maxSurge: 0` and `maxUnavailable: 1`.

## Related Issues

None

## Testing

- kubectl --context galactic -n argocd rollout status deploy/argocd-repo-server --timeout=180s

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
