### PR TITLE
feat(argocd): add dependency info to applicationsets

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -133,88 +133,88 @@ spec:
       annotations:
     {{- range $key, $value := .annotations }}
         {{ $key }}: {{ $value | quote }}
-	    {{- end }}
-	    {{- end }}
-	    {{- $hasDestServer := hasKey . "destinationServer" -}}
-	    {{- $hasDestName := hasKey . "destinationName" -}}
-	    {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-	    {{- $auto := eq .automation "auto" -}}
-	    {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-	    {{- $hasAppName := hasKey . "name" -}}
-	    {{- $deps := list -}}
-	    {{- $crds := list -}}
-	    {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-	    {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-	    {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-	    {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-	    {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-	    {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-	    {{- $appsKubevirt := list "kubevirt" "workers" -}}
-	    {{- $appsCdi := list -}}
+      {{- end }}
+      {{- end }}
+      {{- $hasDestServer := hasKey . "destinationServer" -}}
+      {{- $hasDestName := hasKey . "destinationName" -}}
+      {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+      {{- $auto := eq .automation "auto" -}}
+      {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
+      {{- $hasAppName := hasKey . "name" -}}
+      {{- $deps := list -}}
+      {{- $crds := list -}}
+      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
+      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
+      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
+      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
+      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
+      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
+      {{- $appsKubevirt := list "kubevirt" "workers" -}}
+      {{- $appsCdi := list -}}
 
-	    {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-	    {{- $deps = append $deps "sealed-secrets" -}}
-	    {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-	    {{- $deps = append $deps "traefik" -}}
-	    {{- $crds = append $crds "traefik.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-	    {{- $deps = append $deps "metallb-system" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCnpg) -}}
-	    {{- $deps = append $deps "cloudnative-pg" -}}
-	    {{- $crds = append $crds "postgresql.cnpg.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIstio) -}}
-	    {{- $crds = append $crds "networking.istio.io" -}}
-	    {{- $crds = append $crds "security.istio.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKnative) -}}
-	    {{- $deps = append $deps "knative-serving" -}}
-	    {{- $crds = append $crds "serving.knative.dev" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKubevirt) -}}
-	    {{- $deps = append $deps "kubevirt" -}}
-	    {{- $crds = append $crds "kubevirt.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCdi) -}}
-	    {{- $deps = append $deps "cdi" -}}
-	    {{- $crds = append $crds "cdi.kubevirt.io" -}}
-	    {{- end -}}
+      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
+      {{- $deps = append $deps "sealed-secrets" -}}
+      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
+      {{- $deps = append $deps "traefik" -}}
+      {{- $crds = append $crds "traefik.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
+      {{- $deps = append $deps "metallb-system" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCnpg) -}}
+      {{- $deps = append $deps "cloudnative-pg" -}}
+      {{- $crds = append $crds "postgresql.cnpg.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIstio) -}}
+      {{- $crds = append $crds "networking.istio.io" -}}
+      {{- $crds = append $crds "security.istio.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKnative) -}}
+      {{- $deps = append $deps "knative-serving" -}}
+      {{- $crds = append $crds "serving.knative.dev" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKubevirt) -}}
+      {{- $deps = append $deps "kubevirt" -}}
+      {{- $crds = append $crds "kubevirt.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCdi) -}}
+      {{- $deps = append $deps "cdi" -}}
+      {{- $crds = append $crds "cdi.kubevirt.io" -}}
+      {{- end -}}
 
-	    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-	    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
-	    {{- if $needsSpec }}
-	    spec:
-	      {{- if or $hasDestServer $hasDestName }}
-	      destination:
-	        {{- if $hasDestServer }}
-	        server: '{{ .destinationServer }}'
-	        {{- end }}
-	        {{- if $hasDestName }}
-	        name: '{{ .destinationName }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $hasInfo }}
-	      info:
-	        {{- if gt (len $deps) 0 }}
-	        - name: Depends On (Argo apps)
-	          value: '{{ join ", " $deps }}'
-	        {{- end }}
-	        {{- if gt (len $crds) 0 }}
-	        - name: Requires CRDs
-	          value: '{{ join ", " $crds }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $useLovely }}
-	      source:
-	        plugin:
-	          name: lovely
-	      {{- end }}
-	      {{- if or $auto $hasManagedNS }}
-	      syncPolicy:
+      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+      {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
+      {{- if $needsSpec }}
+      spec:
+        {{- if or $hasDestServer $hasDestName }}
+        destination:
+          {{- if $hasDestServer }}
+          server: '{{ .destinationServer }}'
+          {{- end }}
+          {{- if $hasDestName }}
+          name: '{{ .destinationName }}'
+          {{- end }}
+        {{- end }}
+        {{- if $hasInfo }}
+        info:
+          {{- if gt (len $deps) 0 }}
+          - name: Depends On (Argo apps)
+            value: '{{ join ", " $deps }}'
+          {{- end }}
+          {{- if gt (len $crds) 0 }}
+          - name: Requires CRDs
+            value: '{{ join ", " $crds }}'
+          {{- end }}
+        {{- end }}
+        {{- if $useLovely }}
+        source:
+          plugin:
+            name: lovely
+        {{- end }}
+        {{- if or $auto $hasManagedNS }}
+        syncPolicy:
         {{- if $auto }}
         automated:
           prune: true
@@ -236,7 +236,7 @@ spec:
           {{- end }}
         {{- end }}
       {{- end }}
-	      {{- if hasKey . "ignoreDifferences" }}
-	      ignoreDifferences: {{ toJson .ignoreDifferences }}
-	      {{- end }}
-	    {{- end }}
+        {{- if hasKey . "ignoreDifferences" }}
+        ignoreDifferences: {{ toJson .ignoreDifferences }}
+        {{- end }}
+      {{- end }}

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -59,85 +59,85 @@ spec:
     {{- if .annotations }}
     metadata:
       annotations:
-	    {{- range $key, $value := .annotations }}
-	        {{ $key }}: {{ $value | quote }}
-	    {{- end }}
-	    {{- end }}
-	    {{- $hasDestServer := hasKey . "destinationServer" -}}
-	    {{- $hasDestName := hasKey . "destinationName" -}}
-	    {{- $auto := eq .automation "auto" -}}
-	    {{- $hasAppName := hasKey . "name" -}}
-	    {{- $deps := list -}}
-	    {{- $crds := list -}}
-	    {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-	    {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-	    {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-	    {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-	    {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-	    {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-	    {{- $appsKubevirt := list "kubevirt" "workers" -}}
-	    {{- $appsCdi := list -}}
+      {{- range $key, $value := .annotations }}
+          {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+      {{- $hasDestServer := hasKey . "destinationServer" -}}
+      {{- $hasDestName := hasKey . "destinationName" -}}
+      {{- $auto := eq .automation "auto" -}}
+      {{- $hasAppName := hasKey . "name" -}}
+      {{- $deps := list -}}
+      {{- $crds := list -}}
+      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
+      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
+      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
+      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
+      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
+      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
+      {{- $appsKubevirt := list "kubevirt" "workers" -}}
+      {{- $appsCdi := list -}}
 
-	    {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-	    {{- $deps = append $deps "sealed-secrets" -}}
-	    {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-	    {{- $deps = append $deps "traefik" -}}
-	    {{- $crds = append $crds "traefik.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-	    {{- $deps = append $deps "metallb-system" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCnpg) -}}
-	    {{- $deps = append $deps "cloudnative-pg" -}}
-	    {{- $crds = append $crds "postgresql.cnpg.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIstio) -}}
-	    {{- $crds = append $crds "networking.istio.io" -}}
-	    {{- $crds = append $crds "security.istio.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKnative) -}}
-	    {{- $deps = append $deps "knative-serving" -}}
-	    {{- $crds = append $crds "serving.knative.dev" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKubevirt) -}}
-	    {{- $deps = append $deps "kubevirt" -}}
-	    {{- $crds = append $crds "kubevirt.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCdi) -}}
-	    {{- $deps = append $deps "cdi" -}}
-	    {{- $crds = append $crds "cdi.kubevirt.io" -}}
-	    {{- end -}}
+      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
+      {{- $deps = append $deps "sealed-secrets" -}}
+      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
+      {{- $deps = append $deps "traefik" -}}
+      {{- $crds = append $crds "traefik.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
+      {{- $deps = append $deps "metallb-system" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCnpg) -}}
+      {{- $deps = append $deps "cloudnative-pg" -}}
+      {{- $crds = append $crds "postgresql.cnpg.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIstio) -}}
+      {{- $crds = append $crds "networking.istio.io" -}}
+      {{- $crds = append $crds "security.istio.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKnative) -}}
+      {{- $deps = append $deps "knative-serving" -}}
+      {{- $crds = append $crds "serving.knative.dev" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKubevirt) -}}
+      {{- $deps = append $deps "kubevirt" -}}
+      {{- $crds = append $crds "kubevirt.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCdi) -}}
+      {{- $deps = append $deps "cdi" -}}
+      {{- $crds = append $crds "cdi.kubevirt.io" -}}
+      {{- end -}}
 
-	    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-	    {{- $needsSpec := or $hasDestServer $hasDestName $auto $hasInfo -}}
-	    {{- if $needsSpec }}
-	    spec:
-	      {{- if or $hasDestServer $hasDestName }}
-	      destination:
-	        {{- if $hasDestServer }}
-	        server: '{{ .destinationServer }}'
-	        {{- end }}
-	        {{- if $hasDestName }}
-	        name: '{{ .destinationName }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $hasInfo }}
-	      info:
-	        {{- if gt (len $deps) 0 }}
-	        - name: Depends On (Argo apps)
-	          value: '{{ join ", " $deps }}'
-	        {{- end }}
-	        {{- if gt (len $crds) 0 }}
-	        - name: Requires CRDs
-	          value: '{{ join ", " $crds }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $auto }}
-	      syncPolicy:
-	        automated:
-	          prune: true
+      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+      {{- $needsSpec := or $hasDestServer $hasDestName $auto $hasInfo -}}
+      {{- if $needsSpec }}
+      spec:
+        {{- if or $hasDestServer $hasDestName }}
+        destination:
+          {{- if $hasDestServer }}
+          server: '{{ .destinationServer }}'
+          {{- end }}
+          {{- if $hasDestName }}
+          name: '{{ .destinationName }}'
+          {{- end }}
+        {{- end }}
+        {{- if $hasInfo }}
+        info:
+          {{- if gt (len $deps) 0 }}
+          - name: Depends On (Argo apps)
+            value: '{{ join ", " $deps }}'
+          {{- end }}
+          {{- if gt (len $crds) 0 }}
+          - name: Requires CRDs
+            value: '{{ join ", " $crds }}'
+          {{- end }}
+        {{- end }}
+        {{- if $auto }}
+        syncPolicy:
+          automated:
+            prune: true
           selfHeal: true
-	      {{- end }}
-	    {{- end }}
+        {{- end }}
+      {{- end }}

--- a/argocd/applicationsets/helm-apps.yaml
+++ b/argocd/applicationsets/helm-apps.yaml
@@ -44,81 +44,81 @@ spec:
         helm:
           releaseName: "{{.releaseName}}"
           skipCrds: false
-	  templatePatch: |
-	    {{- $hasDestServer := hasKey . "destinationServer" -}}
-	    {{- $hasDestName := hasKey . "destinationName" -}}
-	    {{- $hasValuesObject := hasKey . "valuesObject" -}}
-	    {{- $hasAppName := hasKey . "name" -}}
-	    {{- $deps := list -}}
-	    {{- $crds := list -}}
-	    {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-	    {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-	    {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-	    {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-	    {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-	    {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-	    {{- $appsKubevirt := list "kubevirt" "workers" -}}
-	    {{- $appsCdi := list -}}
+    templatePatch: |
+      {{- $hasDestServer := hasKey . "destinationServer" -}}
+      {{- $hasDestName := hasKey . "destinationName" -}}
+      {{- $hasValuesObject := hasKey . "valuesObject" -}}
+      {{- $hasAppName := hasKey . "name" -}}
+      {{- $deps := list -}}
+      {{- $crds := list -}}
+      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
+      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
+      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
+      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
+      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
+      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
+      {{- $appsKubevirt := list "kubevirt" "workers" -}}
+      {{- $appsCdi := list -}}
 
-	    {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-	    {{- $deps = append $deps "sealed-secrets" -}}
-	    {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-	    {{- $deps = append $deps "traefik" -}}
-	    {{- $crds = append $crds "traefik.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-	    {{- $deps = append $deps "metallb-system" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCnpg) -}}
-	    {{- $deps = append $deps "cloudnative-pg" -}}
-	    {{- $crds = append $crds "postgresql.cnpg.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIstio) -}}
-	    {{- $crds = append $crds "networking.istio.io" -}}
-	    {{- $crds = append $crds "security.istio.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKnative) -}}
-	    {{- $deps = append $deps "knative-serving" -}}
-	    {{- $crds = append $crds "serving.knative.dev" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKubevirt) -}}
-	    {{- $deps = append $deps "kubevirt" -}}
-	    {{- $crds = append $crds "kubevirt.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCdi) -}}
-	    {{- $deps = append $deps "cdi" -}}
-	    {{- $crds = append $crds "cdi.kubevirt.io" -}}
-	    {{- end -}}
+      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
+      {{- $deps = append $deps "sealed-secrets" -}}
+      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
+      {{- $deps = append $deps "traefik" -}}
+      {{- $crds = append $crds "traefik.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
+      {{- $deps = append $deps "metallb-system" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCnpg) -}}
+      {{- $deps = append $deps "cloudnative-pg" -}}
+      {{- $crds = append $crds "postgresql.cnpg.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIstio) -}}
+      {{- $crds = append $crds "networking.istio.io" -}}
+      {{- $crds = append $crds "security.istio.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKnative) -}}
+      {{- $deps = append $deps "knative-serving" -}}
+      {{- $crds = append $crds "serving.knative.dev" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKubevirt) -}}
+      {{- $deps = append $deps "kubevirt" -}}
+      {{- $crds = append $crds "kubevirt.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCdi) -}}
+      {{- $deps = append $deps "cdi" -}}
+      {{- $crds = append $crds "cdi.kubevirt.io" -}}
+      {{- end -}}
 
-	    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-	    {{- $needsSpec := or $hasDestServer $hasDestName $hasValuesObject $hasInfo -}}
-	    {{- if $needsSpec }}
-	    spec:
-	      {{- if or $hasDestServer $hasDestName }}
-	      destination:
-	        {{- if $hasDestServer }}
-	        server: '{{ .destinationServer }}'
-	        {{- end }}
-	        {{- if $hasDestName }}
-	        name: '{{ .destinationName }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $hasInfo }}
-	      info:
-	        {{- if gt (len $deps) 0 }}
-	        - name: Depends On (Argo apps)
-	          value: '{{ join ", " $deps }}'
-	        {{- end }}
-	        {{- if gt (len $crds) 0 }}
-	        - name: Requires CRDs
-	          value: '{{ join ", " $crds }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $hasValuesObject }}
-	      source:
-	        helm:
-	          valuesObject: {{- .valuesObject | toYaml | nindent 12 }}
-	      {{- end }}
-	    {{- end }}
+      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+      {{- $needsSpec := or $hasDestServer $hasDestName $hasValuesObject $hasInfo -}}
+      {{- if $needsSpec }}
+      spec:
+        {{- if or $hasDestServer $hasDestName }}
+        destination:
+          {{- if $hasDestServer }}
+          server: '{{ .destinationServer }}'
+          {{- end }}
+          {{- if $hasDestName }}
+          name: '{{ .destinationName }}'
+          {{- end }}
+        {{- end }}
+        {{- if $hasInfo }}
+        info:
+          {{- if gt (len $deps) 0 }}
+          - name: Depends On (Argo apps)
+            value: '{{ join ", " $deps }}'
+          {{- end }}
+          {{- if gt (len $crds) 0 }}
+          - name: Requires CRDs
+            value: '{{ join ", " $crds }}'
+          {{- end }}
+        {{- end }}
+        {{- if $hasValuesObject }}
+        source:
+          helm:
+            valuesObject: {{- .valuesObject | toYaml | nindent 12 }}
+        {{- end }}
+      {{- end }}

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -457,90 +457,90 @@ spec:
     {{- if .annotations }}
     metadata:
       annotations:
-	    {{- range $key, $value := .annotations }}
-	        {{ $key }}: {{ $value | quote }}
-	    {{- end }}
-	    {{ end }}
-	    {{- $hasDestServer := hasKey . "destinationServer" -}}
-	    {{- $hasDestName := hasKey . "destinationName" -}}
-	    {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-	    {{- $auto := eq .automation "auto" -}}
-	    {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-	    {{- $hasAppName := hasKey . "name" -}}
-	    {{- $deps := list -}}
-	    {{- $crds := list -}}
-	    {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-	    {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-	    {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-	    {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-	    {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-	    {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-	    {{- $appsKubevirt := list "kubevirt" "workers" -}}
-	    {{- $appsCdi := list -}}
+      {{- range $key, $value := .annotations }}
+          {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{ end }}
+      {{- $hasDestServer := hasKey . "destinationServer" -}}
+      {{- $hasDestName := hasKey . "destinationName" -}}
+      {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+      {{- $auto := eq .automation "auto" -}}
+      {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
+      {{- $hasAppName := hasKey . "name" -}}
+      {{- $deps := list -}}
+      {{- $crds := list -}}
+      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
+      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
+      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
+      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
+      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
+      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
+      {{- $appsKubevirt := list "kubevirt" "workers" -}}
+      {{- $appsCdi := list -}}
 
-	    {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-	    {{- $deps = append $deps "sealed-secrets" -}}
-	    {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-	    {{- $deps = append $deps "traefik" -}}
-	    {{- $crds = append $crds "traefik.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-	    {{- $deps = append $deps "metallb-system" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCnpg) -}}
-	    {{- $deps = append $deps "cloudnative-pg" -}}
-	    {{- $crds = append $crds "postgresql.cnpg.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIstio) -}}
-	    {{- $crds = append $crds "networking.istio.io" -}}
-	    {{- $crds = append $crds "security.istio.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKnative) -}}
-	    {{- $deps = append $deps "knative-serving" -}}
-	    {{- $crds = append $crds "serving.knative.dev" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKubevirt) -}}
-	    {{- $deps = append $deps "kubevirt" -}}
-	    {{- $crds = append $crds "kubevirt.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCdi) -}}
-	    {{- $deps = append $deps "cdi" -}}
-	    {{- $crds = append $crds "cdi.kubevirt.io" -}}
-	    {{- end -}}
+      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
+      {{- $deps = append $deps "sealed-secrets" -}}
+      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
+      {{- $deps = append $deps "traefik" -}}
+      {{- $crds = append $crds "traefik.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
+      {{- $deps = append $deps "metallb-system" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCnpg) -}}
+      {{- $deps = append $deps "cloudnative-pg" -}}
+      {{- $crds = append $crds "postgresql.cnpg.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIstio) -}}
+      {{- $crds = append $crds "networking.istio.io" -}}
+      {{- $crds = append $crds "security.istio.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKnative) -}}
+      {{- $deps = append $deps "knative-serving" -}}
+      {{- $crds = append $crds "serving.knative.dev" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKubevirt) -}}
+      {{- $deps = append $deps "kubevirt" -}}
+      {{- $crds = append $crds "kubevirt.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCdi) -}}
+      {{- $deps = append $deps "cdi" -}}
+      {{- $crds = append $crds "cdi.kubevirt.io" -}}
+      {{- end -}}
 
-	    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-	    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo -}}
-	    {{- if $needsSpec }}
-	    spec:
-	      {{- if or $hasDestServer $hasDestName }}
-	      destination:
-	        {{- if $hasDestServer }}
-	        server: '{{ .destinationServer }}'
-	        {{- end }}
-	        {{- if $hasDestName }}
-	        name: '{{ .destinationName }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $hasInfo }}
-	      info:
-	        {{- if gt (len $deps) 0 }}
-	        - name: Depends On (Argo apps)
-	          value: '{{ join ", " $deps }}'
-	        {{- end }}
-	        {{- if gt (len $crds) 0 }}
-	        - name: Requires CRDs
-	          value: '{{ join ", " $crds }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $useLovely }}
-	      source:
-	        plugin:
-	          name: lovely
-	      {{- end }}
-	      {{- if or $auto $hasManagedNS }}
-	      syncPolicy:
+      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+      {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo -}}
+      {{- if $needsSpec }}
+      spec:
+        {{- if or $hasDestServer $hasDestName }}
+        destination:
+          {{- if $hasDestServer }}
+          server: '{{ .destinationServer }}'
+          {{- end }}
+          {{- if $hasDestName }}
+          name: '{{ .destinationName }}'
+          {{- end }}
+        {{- end }}
+        {{- if $hasInfo }}
+        info:
+          {{- if gt (len $deps) 0 }}
+          - name: Depends On (Argo apps)
+            value: '{{ join ", " $deps }}'
+          {{- end }}
+          {{- if gt (len $crds) 0 }}
+          - name: Requires CRDs
+            value: '{{ join ", " $crds }}'
+          {{- end }}
+        {{- end }}
+        {{- if $useLovely }}
+        source:
+          plugin:
+            name: lovely
+        {{- end }}
+        {{- if or $auto $hasManagedNS }}
+        syncPolicy:
         {{- if $auto }}
         automated:
           prune: true
@@ -558,8 +558,8 @@ spec:
           annotations:
             {{- range $key, $value := .managedNamespaceMetadata.annotations }}
             {{ $key }}: {{ $value | quote }}
-	            {{- end }}
-	          {{- end }}
-	        {{- end }}
-	      {{- end }}
-	    {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -266,92 +266,92 @@ spec:
       annotations:
     {{- range $key, $value := .annotations }}
         {{ $key }}: {{ $value | quote }}
-	    {{- end }}
-	    {{- end }}
-	    {{- $hasDestServer := hasKey . "destinationServer" -}}
-	    {{- $hasDestName := hasKey . "destinationName" -}}
-	    {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-	    {{- $auto := eq .automation "auto" -}}
-	    {{- $hasAppName := hasKey . "name" -}}
-	    {{- $deps := list -}}
-	    {{- $crds := list -}}
-	    {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-	    {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-	    {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-	    {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-	    {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-	    {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-	    {{- $appsKubevirt := list "kubevirt" "workers" -}}
-	    {{- $appsCdi := list -}}
+      {{- end }}
+      {{- end }}
+      {{- $hasDestServer := hasKey . "destinationServer" -}}
+      {{- $hasDestName := hasKey . "destinationName" -}}
+      {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+      {{- $auto := eq .automation "auto" -}}
+      {{- $hasAppName := hasKey . "name" -}}
+      {{- $deps := list -}}
+      {{- $crds := list -}}
+      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
+      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
+      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
+      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
+      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
+      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
+      {{- $appsKubevirt := list "kubevirt" "workers" -}}
+      {{- $appsCdi := list -}}
 
-	    {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-	    {{- $deps = append $deps "sealed-secrets" -}}
-	    {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-	    {{- $deps = append $deps "traefik" -}}
-	    {{- $crds = append $crds "traefik.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-	    {{- $deps = append $deps "metallb-system" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCnpg) -}}
-	    {{- $deps = append $deps "cloudnative-pg" -}}
-	    {{- $crds = append $crds "postgresql.cnpg.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsIstio) -}}
-	    {{- $crds = append $crds "networking.istio.io" -}}
-	    {{- $crds = append $crds "security.istio.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKnative) -}}
-	    {{- $deps = append $deps "knative-serving" -}}
-	    {{- $crds = append $crds "serving.knative.dev" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsKubevirt) -}}
-	    {{- $deps = append $deps "kubevirt" -}}
-	    {{- $crds = append $crds "kubevirt.io" -}}
-	    {{- end -}}
-	    {{- if and $hasAppName (has .name $appsCdi) -}}
-	    {{- $deps = append $deps "cdi" -}}
-	    {{- $crds = append $crds "cdi.kubevirt.io" -}}
-	    {{- end -}}
+      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
+      {{- $deps = append $deps "sealed-secrets" -}}
+      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
+      {{- $deps = append $deps "traefik" -}}
+      {{- $crds = append $crds "traefik.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
+      {{- $deps = append $deps "metallb-system" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCnpg) -}}
+      {{- $deps = append $deps "cloudnative-pg" -}}
+      {{- $crds = append $crds "postgresql.cnpg.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsIstio) -}}
+      {{- $crds = append $crds "networking.istio.io" -}}
+      {{- $crds = append $crds "security.istio.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKnative) -}}
+      {{- $deps = append $deps "knative-serving" -}}
+      {{- $crds = append $crds "serving.knative.dev" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsKubevirt) -}}
+      {{- $deps = append $deps "kubevirt" -}}
+      {{- $crds = append $crds "kubevirt.io" -}}
+      {{- end -}}
+      {{- if and $hasAppName (has .name $appsCdi) -}}
+      {{- $deps = append $deps "cdi" -}}
+      {{- $crds = append $crds "cdi.kubevirt.io" -}}
+      {{- end -}}
 
-	    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-	    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasInfo (hasKey . "ignoreDifferences") -}}
-	    {{- if $needsSpec }}
-	    spec:
-	      {{- if or $hasDestServer $hasDestName }}
-	      destination:
-	        {{- if $hasDestServer }}
-	        server: '{{ .destinationServer }}'
-	        {{- end }}
-	        {{- if $hasDestName }}
-	        name: '{{ .destinationName }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $hasInfo }}
-	      info:
-	        {{- if gt (len $deps) 0 }}
-	        - name: Depends On (Argo apps)
-	          value: '{{ join ", " $deps }}'
-	        {{- end }}
-	        {{- if gt (len $crds) 0 }}
-	        - name: Requires CRDs
-	          value: '{{ join ", " $crds }}'
-	        {{- end }}
-	      {{- end }}
-	      {{- if $useLovely }}
-	      source:
-	        plugin:
-	          name: lovely
-	      {{- end }}
-	      {{- if $auto }}
+      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+      {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasInfo (hasKey . "ignoreDifferences") -}}
+      {{- if $needsSpec }}
+      spec:
+        {{- if or $hasDestServer $hasDestName }}
+        destination:
+          {{- if $hasDestServer }}
+          server: '{{ .destinationServer }}'
+          {{- end }}
+          {{- if $hasDestName }}
+          name: '{{ .destinationName }}'
+          {{- end }}
+        {{- end }}
+        {{- if $hasInfo }}
+        info:
+          {{- if gt (len $deps) 0 }}
+          - name: Depends On (Argo apps)
+            value: '{{ join ", " $deps }}'
+          {{- end }}
+          {{- if gt (len $crds) 0 }}
+          - name: Requires CRDs
+            value: '{{ join ", " $crds }}'
+          {{- end }}
+        {{- end }}
+        {{- if $useLovely }}
+        source:
+          plugin:
+            name: lovely
+        {{- end }}
+        {{- if $auto }}
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
       {{- end }}
-	      {{- if hasKey . "ignoreDifferences" }}
-	      ignoreDifferences: {{ toJson .ignoreDifferences }}
-	      {{- end }}
-	    {{- end }}
+        {{- if hasKey . "ignoreDifferences" }}
+        ignoreDifferences: {{ toJson .ignoreDifferences }}
+        {{- end }}
+      {{- end }}


### PR DESCRIPTION
## Summary

- Add non-enforcing dependency metadata to generated Argo CD Applications via `spec.info`.
- Derive dependency signals from repo manifests (SealedSecrets, IngressRoute/Traefik, LoadBalancer/MetalLB, CNPG, Knative, Istio, KubeVirt).

## Related Issues

None

## Testing

- N/A (UI-only metadata)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
