### PR TITLE
refactor(argocd): make applicationset info explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,11 @@ Output:
 
 ## Merge Guidelines
 - Use squash merges for pull requests.
+- Always create new work branches from a fresh `main`:
+  - `git fetch origin main`
+  - `git switch main`
+  - `git pull --ff-only`
+  - `git switch -c <branch>`
 - Use `gh pr merge 2202 --squash -R proompteng/lab` (no `--delete-branch`; avoids worktree checkout conflicts).
 
 ## CI/CD

--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -87,6 +87,10 @@ spec:
                 - name: traefik
                   path: argocd/applications/traefik
                   namespace: traefik
+                  dependsOnApps:
+                    - metallb-system
+                  requiresCrds:
+                    - traefik.io
                   annotations:
                     argocd.argoproj.io/sync-wave: "1"
                   automation: auto
@@ -135,58 +139,23 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}
-      {{- $hasDestServer := hasKey . "destinationServer" -}}
-      {{- $hasDestName := hasKey . "destinationName" -}}
-      {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-      {{- $auto := eq .automation "auto" -}}
-      {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-      {{- $hasAppName := hasKey . "name" -}}
-      {{- $deps := list -}}
-      {{- $crds := list -}}
-      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-      {{- $appsKubevirt := list "kubevirt" "workers" -}}
-      {{- $appsCdi := list -}}
+        {{- $hasDestServer := hasKey . "destinationServer" -}}
+        {{- $hasDestName := hasKey . "destinationName" -}}
+        {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+        {{- $auto := eq .automation "auto" -}}
+        {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
+        {{- $deps := list -}}
+        {{- $crds := list -}}
+        {{- if hasKey . "dependsOnApps" -}}
+        {{- $deps = .dependsOnApps -}}
+        {{- end -}}
+        {{- if hasKey . "requiresCrds" -}}
+        {{- $crds = .requiresCrds -}}
+        {{- end -}}
 
-      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-      {{- $deps = append $deps "sealed-secrets" -}}
-      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-      {{- $deps = append $deps "traefik" -}}
-      {{- $crds = append $crds "traefik.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-      {{- $deps = append $deps "metallb-system" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCnpg) -}}
-      {{- $deps = append $deps "cloudnative-pg" -}}
-      {{- $crds = append $crds "postgresql.cnpg.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIstio) -}}
-      {{- $crds = append $crds "networking.istio.io" -}}
-      {{- $crds = append $crds "security.istio.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKnative) -}}
-      {{- $deps = append $deps "knative-serving" -}}
-      {{- $crds = append $crds "serving.knative.dev" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKubevirt) -}}
-      {{- $deps = append $deps "kubevirt" -}}
-      {{- $crds = append $crds "kubevirt.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCdi) -}}
-      {{- $deps = append $deps "cdi" -}}
-      {{- $crds = append $crds "cdi.kubevirt.io" -}}
-      {{- end -}}
-
-      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-      {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
-      {{- if $needsSpec }}
+        {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+        {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
+        {{- if $needsSpec }}
       spec:
         {{- if or $hasDestServer $hasDestName }}
         destination:

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -66,48 +66,13 @@ spec:
       {{- $hasDestServer := hasKey . "destinationServer" -}}
       {{- $hasDestName := hasKey . "destinationName" -}}
       {{- $auto := eq .automation "auto" -}}
-      {{- $hasAppName := hasKey . "name" -}}
       {{- $deps := list -}}
       {{- $crds := list -}}
-      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-      {{- $appsKubevirt := list "kubevirt" "workers" -}}
-      {{- $appsCdi := list -}}
-
-      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-      {{- $deps = append $deps "sealed-secrets" -}}
-      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
+      {{- if hasKey . "dependsOnApps" -}}
+      {{- $deps = .dependsOnApps -}}
       {{- end -}}
-      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-      {{- $deps = append $deps "traefik" -}}
-      {{- $crds = append $crds "traefik.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-      {{- $deps = append $deps "metallb-system" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCnpg) -}}
-      {{- $deps = append $deps "cloudnative-pg" -}}
-      {{- $crds = append $crds "postgresql.cnpg.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIstio) -}}
-      {{- $crds = append $crds "networking.istio.io" -}}
-      {{- $crds = append $crds "security.istio.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKnative) -}}
-      {{- $deps = append $deps "knative-serving" -}}
-      {{- $crds = append $crds "serving.knative.dev" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKubevirt) -}}
-      {{- $deps = append $deps "kubevirt" -}}
-      {{- $crds = append $crds "kubevirt.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCdi) -}}
-      {{- $deps = append $deps "cdi" -}}
-      {{- $crds = append $crds "cdi.kubevirt.io" -}}
+      {{- if hasKey . "requiresCrds" -}}
+      {{- $crds = .requiresCrds -}}
       {{- end -}}
 
       {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
@@ -134,10 +99,10 @@ spec:
             value: '{{ join ", " $crds }}'
           {{- end }}
         {{- end }}
-        {{- if $auto }}
-        syncPolicy:
-          automated:
-            prune: true
-          selfHeal: true
-        {{- end }}
+          {{- if $auto }}
+          syncPolicy:
+            automated:
+              prune: true
+              selfHeal: true
+          {{- end }}
       {{- end }}

--- a/argocd/applicationsets/helm-apps.yaml
+++ b/argocd/applicationsets/helm-apps.yaml
@@ -44,81 +44,46 @@ spec:
         helm:
           releaseName: "{{.releaseName}}"
           skipCrds: false
-    templatePatch: |
-      {{- $hasDestServer := hasKey . "destinationServer" -}}
-      {{- $hasDestName := hasKey . "destinationName" -}}
-      {{- $hasValuesObject := hasKey . "valuesObject" -}}
-      {{- $hasAppName := hasKey . "name" -}}
-      {{- $deps := list -}}
-      {{- $crds := list -}}
-      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-      {{- $appsKubevirt := list "kubevirt" "workers" -}}
-      {{- $appsCdi := list -}}
+  templatePatch: |
+    {{- $hasDestServer := hasKey . "destinationServer" -}}
+    {{- $hasDestName := hasKey . "destinationName" -}}
+    {{- $hasValuesObject := hasKey . "valuesObject" -}}
+    {{- $deps := list -}}
+    {{- $crds := list -}}
+    {{- if hasKey . "dependsOnApps" -}}
+    {{- $deps = .dependsOnApps -}}
+    {{- end -}}
+    {{- if hasKey . "requiresCrds" -}}
+    {{- $crds = .requiresCrds -}}
+    {{- end -}}
 
-      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-      {{- $deps = append $deps "sealed-secrets" -}}
-      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-      {{- $deps = append $deps "traefik" -}}
-      {{- $crds = append $crds "traefik.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-      {{- $deps = append $deps "metallb-system" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCnpg) -}}
-      {{- $deps = append $deps "cloudnative-pg" -}}
-      {{- $crds = append $crds "postgresql.cnpg.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIstio) -}}
-      {{- $crds = append $crds "networking.istio.io" -}}
-      {{- $crds = append $crds "security.istio.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKnative) -}}
-      {{- $deps = append $deps "knative-serving" -}}
-      {{- $crds = append $crds "serving.knative.dev" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKubevirt) -}}
-      {{- $deps = append $deps "kubevirt" -}}
-      {{- $crds = append $crds "kubevirt.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCdi) -}}
-      {{- $deps = append $deps "cdi" -}}
-      {{- $crds = append $crds "cdi.kubevirt.io" -}}
-      {{- end -}}
-
-      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-      {{- $needsSpec := or $hasDestServer $hasDestName $hasValuesObject $hasInfo -}}
-      {{- if $needsSpec }}
-      spec:
-        {{- if or $hasDestServer $hasDestName }}
-        destination:
-          {{- if $hasDestServer }}
-          server: '{{ .destinationServer }}'
-          {{- end }}
-          {{- if $hasDestName }}
-          name: '{{ .destinationName }}'
-          {{- end }}
+    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $hasValuesObject $hasInfo -}}
+    {{- if $needsSpec }}
+    spec:
+      {{- if or $hasDestServer $hasDestName }}
+      destination:
+        {{- if $hasDestServer }}
+        server: '{{ .destinationServer }}'
         {{- end }}
-        {{- if $hasInfo }}
-        info:
-          {{- if gt (len $deps) 0 }}
-          - name: Depends On (Argo apps)
-            value: '{{ join ", " $deps }}'
-          {{- end }}
-          {{- if gt (len $crds) 0 }}
-          - name: Requires CRDs
-            value: '{{ join ", " $crds }}'
-          {{- end }}
-        {{- end }}
-        {{- if $hasValuesObject }}
-        source:
-          helm:
-            valuesObject: {{- .valuesObject | toYaml | nindent 12 }}
+        {{- if $hasDestName }}
+        name: '{{ .destinationName }}'
         {{- end }}
       {{- end }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
+        {{- end }}
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
+        {{- end }}
+      {{- end }}
+      {{- if $hasValuesObject }}
+      source:
+        helm:
+          valuesObject: {{- .valuesObject | toYaml | nindent 12 }}
+      {{- end }}
+    {{- end }}

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -101,6 +101,8 @@ spec:
               - name: istio-ingress
                 path: argocd/applications/istio-ingress
                 namespace: istio-ingress
+                dependsOnApps:
+                  - istio-system
                 annotations:
                   argocd.argoproj.io/sync-wave: "1"
                 automation: auto
@@ -115,6 +117,8 @@ spec:
               - name: knative-serving
                 path: argocd/applications/knative-serving
                 namespace: knative-serving
+                dependsOnApps:
+                  - knative
                 annotations:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
@@ -122,6 +126,8 @@ spec:
               - name: knative-eventing
                 path: argocd/applications/knative-eventing
                 namespace: knative-eventing
+                dependsOnApps:
+                  - knative
                 annotations:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
@@ -463,52 +469,17 @@ spec:
       {{ end }}
       {{- $hasDestServer := hasKey . "destinationServer" -}}
       {{- $hasDestName := hasKey . "destinationName" -}}
-      {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-      {{- $auto := eq .automation "auto" -}}
-      {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-      {{- $hasAppName := hasKey . "name" -}}
-      {{- $deps := list -}}
-      {{- $crds := list -}}
-      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-      {{- $appsKubevirt := list "kubevirt" "workers" -}}
-      {{- $appsCdi := list -}}
-
-      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-      {{- $deps = append $deps "sealed-secrets" -}}
-      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-      {{- $deps = append $deps "traefik" -}}
-      {{- $crds = append $crds "traefik.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-      {{- $deps = append $deps "metallb-system" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCnpg) -}}
-      {{- $deps = append $deps "cloudnative-pg" -}}
-      {{- $crds = append $crds "postgresql.cnpg.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIstio) -}}
-      {{- $crds = append $crds "networking.istio.io" -}}
-      {{- $crds = append $crds "security.istio.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKnative) -}}
-      {{- $deps = append $deps "knative-serving" -}}
-      {{- $crds = append $crds "serving.knative.dev" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKubevirt) -}}
-      {{- $deps = append $deps "kubevirt" -}}
-      {{- $crds = append $crds "kubevirt.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCdi) -}}
-      {{- $deps = append $deps "cdi" -}}
-      {{- $crds = append $crds "cdi.kubevirt.io" -}}
-      {{- end -}}
+        {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+        {{- $auto := eq .automation "auto" -}}
+        {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
+        {{- $deps := list -}}
+        {{- $crds := list -}}
+        {{- if hasKey . "dependsOnApps" -}}
+        {{- $deps = .dependsOnApps -}}
+        {{- end -}}
+        {{- if hasKey . "requiresCrds" -}}
+        {{- $crds = .requiresCrds -}}
+        {{- end -}}
 
       {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
       {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo -}}

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -268,53 +268,18 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}
-      {{- $hasDestServer := hasKey . "destinationServer" -}}
-      {{- $hasDestName := hasKey . "destinationName" -}}
-      {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-      {{- $auto := eq .automation "auto" -}}
-      {{- $hasAppName := hasKey . "name" -}}
-      {{- $deps := list -}}
-      {{- $crds := list -}}
-      {{- $appsSealedSecret := list "app" "arc" "argo-workflows" "argocd" "cloudflare" "cms" "coder" "convex" "dagster" "dernier" "discourse" "ecran" "facteur" "froussard" "graf" "headlamp" "jangar" "keycloak" "miel" "milvus" "minio" "nats" "observability" "oirat" "pgadmin" "reviseur" "rook-ceph" "tailscale" "torghut" -}}
-      {{- $appsIngressRoute := list "app" "argo-workflows" "argocd" "backstage" "cms" "convex" "discourse" "docs" "ecran" "graf" "keycloak" "proompteng" "reviseur" "traefik" -}}
-      {{- $appsLoadBalancer := list "agents" "convex" "dagster" "facteur" "golink" "graf" "homepage" "jangar" "kafka" "milvus" "minio" "observability" "pgadmin" "registry" "temporal" "torghut" "traefik" -}}
-      {{- $appsCnpg := list "app" "cms" "coder" "convex" "dernier" "discourse" "ecran" "facteur" "golink" "jangar" "keycloak" "torghut" -}}
-      {{- $appsIstio := list "istio-ingress" "istio-system" -}}
-      {{- $appsKnative := list "dernier" "facteur" "froussard" "galette" "golink" "graf" "jangar" "prt" "registry" "torghut" "traefik" -}}
-      {{- $appsKubevirt := list "kubevirt" "workers" -}}
-      {{- $appsCdi := list -}}
-
-      {{- if and $hasAppName (has .name $appsSealedSecret) -}}
-      {{- $deps = append $deps "sealed-secrets" -}}
-      {{- $crds = append $crds "sealedsecrets.bitnami.com" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIngressRoute) -}}
-      {{- $deps = append $deps "traefik" -}}
-      {{- $crds = append $crds "traefik.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsLoadBalancer) -}}
-      {{- $deps = append $deps "metallb-system" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCnpg) -}}
-      {{- $deps = append $deps "cloudnative-pg" -}}
-      {{- $crds = append $crds "postgresql.cnpg.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsIstio) -}}
-      {{- $crds = append $crds "networking.istio.io" -}}
-      {{- $crds = append $crds "security.istio.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKnative) -}}
-      {{- $deps = append $deps "knative-serving" -}}
-      {{- $crds = append $crds "serving.knative.dev" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsKubevirt) -}}
-      {{- $deps = append $deps "kubevirt" -}}
-      {{- $crds = append $crds "kubevirt.io" -}}
-      {{- end -}}
-      {{- if and $hasAppName (has .name $appsCdi) -}}
-      {{- $deps = append $deps "cdi" -}}
-      {{- $crds = append $crds "cdi.kubevirt.io" -}}
-      {{- end -}}
+        {{- $hasDestServer := hasKey . "destinationServer" -}}
+        {{- $hasDestName := hasKey . "destinationName" -}}
+        {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+        {{- $auto := eq .automation "auto" -}}
+        {{- $deps := list -}}
+        {{- $crds := list -}}
+        {{- if hasKey . "dependsOnApps" -}}
+        {{- $deps = .dependsOnApps -}}
+        {{- end -}}
+        {{- if hasKey . "requiresCrds" -}}
+        {{- $crds = .requiresCrds -}}
+        {{- end -}}
 
       {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
       {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasInfo (hasKey . "ignoreDifferences") -}}
@@ -345,12 +310,12 @@ spec:
           plugin:
             name: lovely
         {{- end }}
-        {{- if $auto }}
-      syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
-      {{- end }}
+          {{- if $auto }}
+          syncPolicy:
+            automated:
+              prune: true
+              selfHeal: true
+          {{- end }}
         {{- if hasKey . "ignoreDifferences" }}
         ignoreDifferences: {{ toJson .ignoreDifferences }}
         {{- end }}


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- 
- 
- 

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- 

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.

## Changes
- Refactor ApplicationSet `templatePatch` to stop inferring dependency info from hardcoded name lists.
- Add support for explicit per-app metadata via `dependsOnApps` and `requiresCrds`.
- Fix `appset-helm` manifest to use `spec.templatePatch` (was incorrectly nested under `spec.template`).
- Update `AGENTS.md` Merge Guidelines to require new branches from fresh `origin/main`.

## Why
- The name-list inference was brittle and noisy.
- `spec.info` should be declared where the app is configured, not embedded in controller-wide heuristics.

## Rollout / Notes
- This is metadata-only (no ordering enforcement). Existing Argo sync waves remain the source of execution ordering.
- After merge, Argo CD `root` should return to `Synced` once it re-syncs to `main`.
