### PR TITLE
fix(argocd): enable metallb and fix appset templatePatch

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -83,7 +83,7 @@ spec:
                   annotations:
                     argocd.argoproj.io/sync-wave: "0"
                   automation: auto
-                  enabled: "false"
+                  enabled: "true"
                 - name: traefik
                   path: argocd/applications/traefik
                   namespace: traefik
@@ -137,53 +137,53 @@ spec:
       annotations:
     {{- range $key, $value := .annotations }}
         {{ $key }}: {{ $value | quote }}
-      {{- end }}
-      {{- end }}
-        {{- $hasDestServer := hasKey . "destinationServer" -}}
-        {{- $hasDestName := hasKey . "destinationName" -}}
-        {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-        {{- $auto := eq .automation "auto" -}}
-        {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-        {{- $deps := list -}}
-        {{- $crds := list -}}
-        {{- if hasKey . "dependsOnApps" -}}
-        {{- $deps = .dependsOnApps -}}
-        {{- end -}}
-        {{- if hasKey . "requiresCrds" -}}
-        {{- $crds = .requiresCrds -}}
-        {{- end -}}
+    {{- end }}
+    {{- end }}
+    {{- $hasDestServer := hasKey . "destinationServer" -}}
+    {{- $hasDestName := hasKey . "destinationName" -}}
+    {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+    {{- $auto := eq .automation "auto" -}}
+    {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
+    {{- $deps := list -}}
+    {{- $crds := list -}}
+    {{- if hasKey . "dependsOnApps" -}}
+    {{- $deps = .dependsOnApps -}}
+    {{- end -}}
+    {{- if hasKey . "requiresCrds" -}}
+    {{- $crds = .requiresCrds -}}
+    {{- end -}}
 
-        {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-        {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
-        {{- if $needsSpec }}
-      spec:
-        {{- if or $hasDestServer $hasDestName }}
-        destination:
-          {{- if $hasDestServer }}
-          server: '{{ .destinationServer }}'
-          {{- end }}
-          {{- if $hasDestName }}
-          name: '{{ .destinationName }}'
-          {{- end }}
+    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
+    {{- if $needsSpec }}
+    spec:
+      {{- if or $hasDestServer $hasDestName }}
+      destination:
+        {{- if $hasDestServer }}
+        server: '{{ .destinationServer }}'
         {{- end }}
-        {{- if $hasInfo }}
-        info:
-          {{- if gt (len $deps) 0 }}
-          - name: Depends On (Argo apps)
-            value: '{{ join ", " $deps }}'
-          {{- end }}
-          {{- if gt (len $crds) 0 }}
-          - name: Requires CRDs
-            value: '{{ join ", " $crds }}'
-          {{- end }}
+        {{- if $hasDestName }}
+        name: '{{ .destinationName }}'
         {{- end }}
-        {{- if $useLovely }}
-        source:
-          plugin:
-            name: lovely
+      {{- end }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
         {{- end }}
-        {{- if or $auto $hasManagedNS }}
-        syncPolicy:
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
+        {{- end }}
+      {{- end }}
+      {{- if $useLovely }}
+      source:
+        plugin:
+          name: lovely
+      {{- end }}
+      {{- if or $auto $hasManagedNS }}
+      syncPolicy:
         {{- if $auto }}
         automated:
           prune: true
@@ -205,7 +205,7 @@ spec:
           {{- end }}
         {{- end }}
       {{- end }}
-        {{- if hasKey . "ignoreDifferences" }}
-        ignoreDifferences: {{ toJson .ignoreDifferences }}
-        {{- end }}
+      {{- if hasKey . "ignoreDifferences" }}
+      ignoreDifferences: {{ toJson .ignoreDifferences }}
       {{- end }}
+    {{- end }}

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -62,47 +62,47 @@ spec:
       {{- range $key, $value := .annotations }}
           {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- end }}
-      {{- $hasDestServer := hasKey . "destinationServer" -}}
-      {{- $hasDestName := hasKey . "destinationName" -}}
-      {{- $auto := eq .automation "auto" -}}
-      {{- $deps := list -}}
-      {{- $crds := list -}}
-      {{- if hasKey . "dependsOnApps" -}}
-      {{- $deps = .dependsOnApps -}}
-      {{- end -}}
-      {{- if hasKey . "requiresCrds" -}}
-      {{- $crds = .requiresCrds -}}
-      {{- end -}}
+    {{- end }}
+    {{- $hasDestServer := hasKey . "destinationServer" -}}
+    {{- $hasDestName := hasKey . "destinationName" -}}
+    {{- $auto := eq .automation "auto" -}}
+    {{- $deps := list -}}
+    {{- $crds := list -}}
+    {{- if hasKey . "dependsOnApps" -}}
+    {{- $deps = .dependsOnApps -}}
+    {{- end -}}
+    {{- if hasKey . "requiresCrds" -}}
+    {{- $crds = .requiresCrds -}}
+    {{- end -}}
 
-      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-      {{- $needsSpec := or $hasDestServer $hasDestName $auto $hasInfo -}}
-      {{- if $needsSpec }}
-      spec:
-        {{- if or $hasDestServer $hasDestName }}
-        destination:
-          {{- if $hasDestServer }}
-          server: '{{ .destinationServer }}'
-          {{- end }}
-          {{- if $hasDestName }}
-          name: '{{ .destinationName }}'
-          {{- end }}
+    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $auto $hasInfo -}}
+    {{- if $needsSpec }}
+    spec:
+      {{- if or $hasDestServer $hasDestName }}
+      destination:
+        {{- if $hasDestServer }}
+        server: '{{ .destinationServer }}'
         {{- end }}
-        {{- if $hasInfo }}
-        info:
-          {{- if gt (len $deps) 0 }}
-          - name: Depends On (Argo apps)
-            value: '{{ join ", " $deps }}'
-          {{- end }}
-          {{- if gt (len $crds) 0 }}
-          - name: Requires CRDs
-            value: '{{ join ", " $crds }}'
-          {{- end }}
+        {{- if $hasDestName }}
+        name: '{{ .destinationName }}'
         {{- end }}
-          {{- if $auto }}
-          syncPolicy:
-            automated:
-              prune: true
-              selfHeal: true
-          {{- end }}
       {{- end }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
+        {{- end }}
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
+        {{- end }}
+      {{- end }}
+      {{- if $auto }}
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+      {{- end }}
+    {{- end }}

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -466,52 +466,52 @@ spec:
       {{- range $key, $value := .annotations }}
           {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{ end }}
-      {{- $hasDestServer := hasKey . "destinationServer" -}}
-      {{- $hasDestName := hasKey . "destinationName" -}}
-        {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-        {{- $auto := eq .automation "auto" -}}
-        {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-        {{- $deps := list -}}
-        {{- $crds := list -}}
-        {{- if hasKey . "dependsOnApps" -}}
-        {{- $deps = .dependsOnApps -}}
-        {{- end -}}
-        {{- if hasKey . "requiresCrds" -}}
-        {{- $crds = .requiresCrds -}}
-        {{- end -}}
+    {{- end }}
+    {{- $hasDestServer := hasKey . "destinationServer" -}}
+    {{- $hasDestName := hasKey . "destinationName" -}}
+    {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+    {{- $auto := eq .automation "auto" -}}
+    {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
+    {{- $deps := list -}}
+    {{- $crds := list -}}
+    {{- if hasKey . "dependsOnApps" -}}
+    {{- $deps = .dependsOnApps -}}
+    {{- end -}}
+    {{- if hasKey . "requiresCrds" -}}
+    {{- $crds = .requiresCrds -}}
+    {{- end -}}
 
-      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-      {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo -}}
-      {{- if $needsSpec }}
-      spec:
-        {{- if or $hasDestServer $hasDestName }}
-        destination:
-          {{- if $hasDestServer }}
-          server: '{{ .destinationServer }}'
-          {{- end }}
-          {{- if $hasDestName }}
-          name: '{{ .destinationName }}'
-          {{- end }}
+    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
+    {{- if $needsSpec }}
+    spec:
+      {{- if or $hasDestServer $hasDestName }}
+      destination:
+        {{- if $hasDestServer }}
+        server: '{{ .destinationServer }}'
         {{- end }}
-        {{- if $hasInfo }}
-        info:
-          {{- if gt (len $deps) 0 }}
-          - name: Depends On (Argo apps)
-            value: '{{ join ", " $deps }}'
-          {{- end }}
-          {{- if gt (len $crds) 0 }}
-          - name: Requires CRDs
-            value: '{{ join ", " $crds }}'
-          {{- end }}
+        {{- if $hasDestName }}
+        name: '{{ .destinationName }}'
         {{- end }}
-        {{- if $useLovely }}
-        source:
-          plugin:
-            name: lovely
+      {{- end }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
         {{- end }}
-        {{- if or $auto $hasManagedNS }}
-        syncPolicy:
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
+        {{- end }}
+      {{- end }}
+      {{- if $useLovely }}
+      source:
+        plugin:
+          name: lovely
+      {{- end }}
+      {{- if or $auto $hasManagedNS }}
+      syncPolicy:
         {{- if $auto }}
         automated:
           prune: true
@@ -529,8 +529,11 @@ spec:
           annotations:
             {{- range $key, $value := .managedNamespaceMetadata.annotations }}
             {{ $key }}: {{ $value | quote }}
-              {{- end }}
             {{- end }}
           {{- end }}
         {{- end }}
       {{- end }}
+      {{- if hasKey . "ignoreDifferences" }}
+      ignoreDifferences: {{ toJson .ignoreDifferences }}
+      {{- end }}
+    {{- end }}

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -266,57 +266,57 @@ spec:
       annotations:
     {{- range $key, $value := .annotations }}
         {{ $key }}: {{ $value | quote }}
-      {{- end }}
-      {{- end }}
-        {{- $hasDestServer := hasKey . "destinationServer" -}}
-        {{- $hasDestName := hasKey . "destinationName" -}}
-        {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
-        {{- $auto := eq .automation "auto" -}}
-        {{- $deps := list -}}
-        {{- $crds := list -}}
-        {{- if hasKey . "dependsOnApps" -}}
-        {{- $deps = .dependsOnApps -}}
-        {{- end -}}
-        {{- if hasKey . "requiresCrds" -}}
-        {{- $crds = .requiresCrds -}}
-        {{- end -}}
+    {{- end }}
+    {{- end }}
+    {{- $hasDestServer := hasKey . "destinationServer" -}}
+    {{- $hasDestName := hasKey . "destinationName" -}}
+    {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+    {{- $auto := eq .automation "auto" -}}
+    {{- $deps := list -}}
+    {{- $crds := list -}}
+    {{- if hasKey . "dependsOnApps" -}}
+    {{- $deps = .dependsOnApps -}}
+    {{- end -}}
+    {{- if hasKey . "requiresCrds" -}}
+    {{- $crds = .requiresCrds -}}
+    {{- end -}}
 
-      {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-      {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasInfo (hasKey . "ignoreDifferences") -}}
-      {{- if $needsSpec }}
-      spec:
-        {{- if or $hasDestServer $hasDestName }}
-        destination:
-          {{- if $hasDestServer }}
-          server: '{{ .destinationServer }}'
-          {{- end }}
-          {{- if $hasDestName }}
-          name: '{{ .destinationName }}'
-          {{- end }}
+    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasInfo (hasKey . "ignoreDifferences") -}}
+    {{- if $needsSpec }}
+    spec:
+      {{- if or $hasDestServer $hasDestName }}
+      destination:
+        {{- if $hasDestServer }}
+        server: '{{ .destinationServer }}'
         {{- end }}
-        {{- if $hasInfo }}
-        info:
-          {{- if gt (len $deps) 0 }}
-          - name: Depends On (Argo apps)
-            value: '{{ join ", " $deps }}'
-          {{- end }}
-          {{- if gt (len $crds) 0 }}
-          - name: Requires CRDs
-            value: '{{ join ", " $crds }}'
-          {{- end }}
-        {{- end }}
-        {{- if $useLovely }}
-        source:
-          plugin:
-            name: lovely
-        {{- end }}
-          {{- if $auto }}
-          syncPolicy:
-            automated:
-              prune: true
-              selfHeal: true
-          {{- end }}
-        {{- if hasKey . "ignoreDifferences" }}
-        ignoreDifferences: {{ toJson .ignoreDifferences }}
+        {{- if $hasDestName }}
+        name: '{{ .destinationName }}'
         {{- end }}
       {{- end }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
+        {{- end }}
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
+        {{- end }}
+      {{- end }}
+      {{- if $useLovely }}
+      source:
+        plugin:
+          name: lovely
+      {{- end }}
+      {{- if $auto }}
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+      {{- end }}
+      {{- if hasKey . "ignoreDifferences" }}
+      ignoreDifferences: {{ toJson .ignoreDifferences }}
+      {{- end }}
+    {{- end }}


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- 
- 
- 

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- 

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.

## Changes
- Enable `metallb-system` in `argocd/applicationsets/bootstrap.yaml`.
- Fix `templatePatch` rendering in ApplicationSets so generated Applications always include a valid destination (`spec.destination.server` / `name`) when required.

## Why
- `applicationset/bootstrap` was degraded with: `application destination spec is invalid: Destination server missing from app spec`.
- That was caused by malformed `templatePatch` indentation/structure.

## Rollout
- Merge this PR.
- In Argo CD: `root` should become Healthy after syncing to the new `main` revision.
- MetalLB will install via the bootstrap ApplicationSet and then Traefik can depend on it.
