### PR TITLE
fix(argocd): correct applicationset templatePatch indentation

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -155,58 +155,58 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
-        {{- if $needsSpec }}
-        spec:
-          {{- if or $hasDestServer $hasDestName }}
-          destination:
-            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-            {{- if $hasDestServer }}
-            server: '{{ .destinationServer }}'
-            {{- end }}
-            {{- if $hasDestName }}
-            name: '{{ .destinationName }}'
+{{- if $needsSpec }}
+spec:
+  {{- if or $hasDestServer $hasDestName }}
+  destination:
+    namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+    {{- if $hasDestServer }}
+    server: '{{ .destinationServer }}'
+    {{- end }}
+    {{- if $hasDestName }}
+    name: '{{ .destinationName }}'
+    {{- end }}
+  {{- end }}
+  {{- if $hasInfo }}
+  info:
+    {{- if gt (len $deps) 0 }}
+    - name: Depends On (Argo apps)
+      value: '{{ join ", " $deps }}'
+    {{- end }}
+    {{- if gt (len $crds) 0 }}
+    - name: Requires CRDs
+      value: '{{ join ", " $crds }}'
+    {{- end }}
+  {{- end }}
+  {{- if $useLovely }}
+  source:
+    plugin:
+      name: lovely
+  {{- end }}
+  {{- if or $auto $hasManagedNS }}
+  syncPolicy:
+    {{- if $auto }}
+    automated:
+      prune: true
+      selfHeal: true
+    {{- end }}
+    {{- if $hasManagedNS }}
+    managedNamespaceMetadata:
+      {{- if hasKey .managedNamespaceMetadata "labels" }}
+      labels:
+        {{- range $key, $value := .managedNamespaceMetadata.labels }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
+      {{- if hasKey .managedNamespaceMetadata "annotations" }}
+      annotations:
+        {{- range $key, $value := .managedNamespaceMetadata.annotations }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
-        {{- end }}
-      {{- end }}
-      {{- if $useLovely }}
-      source:
-        plugin:
-          name: lovely
-      {{- end }}
-      {{- if or $auto $hasManagedNS }}
-      syncPolicy:
-        {{- if $auto }}
-        automated:
-          prune: true
-          selfHeal: true
-        {{- end }}
-        {{- if $hasManagedNS }}
-        managedNamespaceMetadata:
-          {{- if hasKey .managedNamespaceMetadata "labels" }}
-          labels:
-            {{- range $key, $value := .managedNamespaceMetadata.labels }}
-            {{ $key }}: {{ $value | quote }}
-            {{- end }}
-          {{- end }}
-          {{- if hasKey .managedNamespaceMetadata "annotations" }}
-          annotations:
-            {{- range $key, $value := .managedNamespaceMetadata.annotations }}
-            {{ $key }}: {{ $value | quote }}
-            {{- end }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
-      {{- if hasKey . "ignoreDifferences" }}
-      ignoreDifferences: {{ toJson .ignoreDifferences }}
       {{- end }}
     {{- end }}
+  {{- end }}
+  {{- if hasKey . "ignoreDifferences" }}
+  ignoreDifferences: {{ toJson .ignoreDifferences }}
+  {{- end }}
+{{- end }}

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -77,33 +77,33 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $auto $hasInfo -}}
-        {{- if $needsSpec }}
-        spec:
-          {{- if or $hasDestServer $hasDestName }}
-          destination:
-            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-            {{- if $hasDestServer }}
-            server: '{{ .destinationServer }}'
-            {{- end }}
-            {{- if $hasDestName }}
-            name: '{{ .destinationName }}'
-        {{- end }}
-      {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
-        {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
-        {{- end }}
-      {{- end }}
-      {{- if $auto }}
-      syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
-      {{- end }}
+{{- if $needsSpec }}
+spec:
+  {{- if or $hasDestServer $hasDestName }}
+  destination:
+    namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+    {{- if $hasDestServer }}
+    server: '{{ .destinationServer }}'
     {{- end }}
+    {{- if $hasDestName }}
+    name: '{{ .destinationName }}'
+    {{- end }}
+  {{- end }}
+  {{- if $hasInfo }}
+  info:
+    {{- if gt (len $deps) 0 }}
+    - name: Depends On (Argo apps)
+      value: '{{ join ", " $deps }}'
+    {{- end }}
+    {{- if gt (len $crds) 0 }}
+    - name: Requires CRDs
+      value: '{{ join ", " $crds }}'
+    {{- end }}
+  {{- end }}
+  {{- if $auto }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  {{- end }}
+{{- end }}

--- a/argocd/applicationsets/helm-apps.yaml
+++ b/argocd/applicationsets/helm-apps.yaml
@@ -59,32 +59,32 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $hasValuesObject $hasInfo -}}
-        {{- if $needsSpec }}
-        spec:
-          {{- if or $hasDestServer $hasDestName }}
-          destination:
-            namespace: "{{.namespace}}"
-            {{- if $hasDestServer }}
-            server: '{{ .destinationServer }}'
-            {{- end }}
-            {{- if $hasDestName }}
-            name: '{{ .destinationName }}'
-        {{- end }}
-      {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
-        {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
-        {{- end }}
-      {{- end }}
-      {{- if $hasValuesObject }}
-      source:
-        helm:
-          valuesObject: {{- .valuesObject | toYaml | nindent 12 }}
-      {{- end }}
+{{- if $needsSpec }}
+spec:
+  {{- if or $hasDestServer $hasDestName }}
+  destination:
+    namespace: "{{.namespace}}"
+    {{- if $hasDestServer }}
+    server: '{{ .destinationServer }}'
     {{- end }}
+    {{- if $hasDestName }}
+    name: '{{ .destinationName }}'
+    {{- end }}
+  {{- end }}
+  {{- if $hasInfo }}
+  info:
+    {{- if gt (len $deps) 0 }}
+    - name: Depends On (Argo apps)
+      value: '{{ join ", " $deps }}'
+    {{- end }}
+    {{- if gt (len $crds) 0 }}
+    - name: Requires CRDs
+      value: '{{ join ", " $crds }}'
+    {{- end }}
+  {{- end }}
+  {{- if $hasValuesObject }}
+  source:
+    helm:
+      valuesObject: {{- .valuesObject | toYaml | nindent 12 }}
+  {{- end }}
+{{- end }}

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -476,58 +476,58 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
-        {{- if $needsSpec }}
-        spec:
-          {{- if or $hasDestServer $hasDestName }}
-          destination:
-            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-            {{- if $hasDestServer }}
-            server: '{{ .destinationServer }}'
-            {{- end }}
-            {{- if $hasDestName }}
-            name: '{{ .destinationName }}'
+{{- if $needsSpec }}
+spec:
+  {{- if or $hasDestServer $hasDestName }}
+  destination:
+    namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+    {{- if $hasDestServer }}
+    server: '{{ .destinationServer }}'
+    {{- end }}
+    {{- if $hasDestName }}
+    name: '{{ .destinationName }}'
+    {{- end }}
+  {{- end }}
+  {{- if $hasInfo }}
+  info:
+    {{- if gt (len $deps) 0 }}
+    - name: Depends On (Argo apps)
+      value: '{{ join ", " $deps }}'
+    {{- end }}
+    {{- if gt (len $crds) 0 }}
+    - name: Requires CRDs
+      value: '{{ join ", " $crds }}'
+    {{- end }}
+  {{- end }}
+  {{- if $useLovely }}
+  source:
+    plugin:
+      name: lovely
+  {{- end }}
+  {{- if or $auto $hasManagedNS }}
+  syncPolicy:
+    {{- if $auto }}
+    automated:
+      prune: true
+      selfHeal: true
+    {{- end }}
+    {{- if $hasManagedNS }}
+    managedNamespaceMetadata:
+      {{- if hasKey .managedNamespaceMetadata "labels" }}
+      labels:
+        {{- range $key, $value := .managedNamespaceMetadata.labels }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
+      {{- if hasKey .managedNamespaceMetadata "annotations" }}
+      annotations:
+        {{- range $key, $value := .managedNamespaceMetadata.annotations }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
-        {{- end }}
-      {{- end }}
-      {{- if $useLovely }}
-      source:
-        plugin:
-          name: lovely
-      {{- end }}
-      {{- if or $auto $hasManagedNS }}
-      syncPolicy:
-        {{- if $auto }}
-        automated:
-          prune: true
-          selfHeal: true
-        {{- end }}
-        {{- if $hasManagedNS }}
-        managedNamespaceMetadata:
-          {{- if hasKey .managedNamespaceMetadata "labels" }}
-          labels:
-            {{- range $key, $value := .managedNamespaceMetadata.labels }}
-            {{ $key }}: {{ $value | quote }}
-            {{- end }}
-          {{- end }}
-          {{- if hasKey .managedNamespaceMetadata "annotations" }}
-          annotations:
-            {{- range $key, $value := .managedNamespaceMetadata.annotations }}
-            {{ $key }}: {{ $value | quote }}
-            {{- end }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
-      {{- if hasKey . "ignoreDifferences" }}
-      ignoreDifferences: {{ toJson .ignoreDifferences }}
       {{- end }}
     {{- end }}
+  {{- end }}
+  {{- if hasKey . "ignoreDifferences" }}
+  ignoreDifferences: {{ toJson .ignoreDifferences }}
+  {{- end }}
+{{- end }}

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -283,41 +283,41 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasInfo (hasKey . "ignoreDifferences") -}}
-        {{- if $needsSpec }}
-        spec:
-          {{- if or $hasDestServer $hasDestName }}
-          destination:
-            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-            {{- if $hasDestServer }}
-            server: '{{ .destinationServer }}'
-            {{- end }}
-            {{- if $hasDestName }}
-            name: '{{ .destinationName }}'
-        {{- end }}
-      {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
-        {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
-        {{- end }}
-      {{- end }}
-      {{- if $useLovely }}
-      source:
-        plugin:
-          name: lovely
-      {{- end }}
-      {{- if $auto }}
-      syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
-      {{- end }}
-      {{- if hasKey . "ignoreDifferences" }}
-      ignoreDifferences: {{ toJson .ignoreDifferences }}
-      {{- end }}
+{{- if $needsSpec }}
+spec:
+  {{- if or $hasDestServer $hasDestName }}
+  destination:
+    namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+    {{- if $hasDestServer }}
+    server: '{{ .destinationServer }}'
     {{- end }}
+    {{- if $hasDestName }}
+    name: '{{ .destinationName }}'
+    {{- end }}
+  {{- end }}
+  {{- if $hasInfo }}
+  info:
+    {{- if gt (len $deps) 0 }}
+    - name: Depends On (Argo apps)
+      value: '{{ join ", " $deps }}'
+    {{- end }}
+    {{- if gt (len $crds) 0 }}
+    - name: Requires CRDs
+      value: '{{ join ", " $crds }}'
+    {{- end }}
+  {{- end }}
+  {{- if $useLovely }}
+  source:
+    plugin:
+      name: lovely
+  {{- end }}
+  {{- if $auto }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  {{- end }}
+  {{- if hasKey . "ignoreDifferences" }}
+  ignoreDifferences: {{ toJson .ignoreDifferences }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Fix malformed ArgoCD ApplicationSet `templatePatch` annotations handling that was writing objects into metadata annotations.
- Ensure `spec` is only emitted when needed and correctly top-level indented in ApplicationSet templates.
- Apply the same fix across bootstrap, cdk8s, helm-apps, platform, and product ApplicationSets.

## Related Issues

- None.

## Testing

- N/A (manifest-only change; no cluster-side validation in this session).

## Breaking Changes

- None.

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
