### PR TITLE
fix(argocd): keep templatePatch directives inside block

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -155,58 +155,58 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
-    {{- if $needsSpec }}
-    spec:
-  {{- if or $hasDestServer $hasDestName }}
-  destination:
-    namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-    {{- if $hasDestServer }}
-    server: '{{ .destinationServer }}'
-    {{- end }}
-    {{- if $hasDestName }}
-    name: '{{ .destinationName }}'
-    {{- end }}
-  {{- end }}
-  {{- if $hasInfo }}
-  info:
-    {{- if gt (len $deps) 0 }}
-    - name: Depends On (Argo apps)
-      value: '{{ join ", " $deps }}'
-    {{- end }}
-    {{- if gt (len $crds) 0 }}
-    - name: Requires CRDs
-      value: '{{ join ", " $crds }}'
-    {{- end }}
-  {{- end }}
-  {{- if $useLovely }}
-  source:
-    plugin:
-      name: lovely
-  {{- end }}
-  {{- if or $auto $hasManagedNS }}
-  syncPolicy:
-    {{- if $auto }}
-    automated:
-      prune: true
-      selfHeal: true
-    {{- end }}
-    {{- if $hasManagedNS }}
-    managedNamespaceMetadata:
-      {{- if hasKey .managedNamespaceMetadata "labels" }}
-      labels:
-        {{- range $key, $value := .managedNamespaceMetadata.labels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- if $needsSpec }}
+        spec:
+          {{- if or $hasDestServer $hasDestName }}
+          destination:
+            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+            {{- if $hasDestServer }}
+            server: '{{ .destinationServer }}'
+            {{- end }}
+            {{- if $hasDestName }}
+            name: '{{ .destinationName }}'
         {{- end }}
       {{- end }}
-      {{- if hasKey .managedNamespaceMetadata "annotations" }}
-      annotations:
-        {{- range $key, $value := .managedNamespaceMetadata.annotations }}
-        {{ $key }}: {{ $value | quote }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
+        {{- end }}
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
         {{- end }}
       {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- if hasKey . "ignoreDifferences" }}
-  ignoreDifferences: {{ toJson .ignoreDifferences }}
-  {{- end }}
+      {{- if $useLovely }}
+      source:
+        plugin:
+          name: lovely
+      {{- end }}
+      {{- if or $auto $hasManagedNS }}
+      syncPolicy:
+        {{- if $auto }}
+        automated:
+          prune: true
+          selfHeal: true
+        {{- end }}
+        {{- if $hasManagedNS }}
+        managedNamespaceMetadata:
+          {{- if hasKey .managedNamespaceMetadata "labels" }}
+          labels:
+            {{- range $key, $value := .managedNamespaceMetadata.labels }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if hasKey .managedNamespaceMetadata "annotations" }}
+          annotations:
+            {{- range $key, $value := .managedNamespaceMetadata.annotations }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- if hasKey . "ignoreDifferences" }}
+      ignoreDifferences: {{ toJson .ignoreDifferences }}
+      {{- end }}
     {{- end }}

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -77,33 +77,33 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $auto $hasInfo -}}
-    {{- if $needsSpec }}
-    spec:
-  {{- if or $hasDestServer $hasDestName }}
-  destination:
-    namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-    {{- if $hasDestServer }}
-    server: '{{ .destinationServer }}'
-    {{- end }}
-    {{- if $hasDestName }}
-    name: '{{ .destinationName }}'
-    {{- end }}
-  {{- end }}
-  {{- if $hasInfo }}
-  info:
-    {{- if gt (len $deps) 0 }}
-    - name: Depends On (Argo apps)
-      value: '{{ join ", " $deps }}'
-    {{- end }}
-    {{- if gt (len $crds) 0 }}
-    - name: Requires CRDs
-      value: '{{ join ", " $crds }}'
-    {{- end }}
-  {{- end }}
-  {{- if $auto }}
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-  {{- end }}
+        {{- if $needsSpec }}
+        spec:
+          {{- if or $hasDestServer $hasDestName }}
+          destination:
+            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+            {{- if $hasDestServer }}
+            server: '{{ .destinationServer }}'
+            {{- end }}
+            {{- if $hasDestName }}
+            name: '{{ .destinationName }}'
+        {{- end }}
+      {{- end }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
+        {{- end }}
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
+        {{- end }}
+      {{- end }}
+      {{- if $auto }}
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+      {{- end }}
     {{- end }}

--- a/argocd/applicationsets/helm-apps.yaml
+++ b/argocd/applicationsets/helm-apps.yaml
@@ -59,32 +59,32 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $hasValuesObject $hasInfo -}}
-    {{- if $needsSpec }}
-    spec:
-  {{- if or $hasDestServer $hasDestName }}
-  destination:
-    namespace: "{{.namespace}}"
-    {{- if $hasDestServer }}
-    server: '{{ .destinationServer }}'
-    {{- end }}
-    {{- if $hasDestName }}
-    name: '{{ .destinationName }}'
-    {{- end }}
-  {{- end }}
-  {{- if $hasInfo }}
-  info:
-    {{- if gt (len $deps) 0 }}
-    - name: Depends On (Argo apps)
-      value: '{{ join ", " $deps }}'
-    {{- end }}
-    {{- if gt (len $crds) 0 }}
-    - name: Requires CRDs
-      value: '{{ join ", " $crds }}'
-    {{- end }}
-  {{- end }}
-  {{- if $hasValuesObject }}
-  source:
-    helm:
-      valuesObject: {{- .valuesObject | toYaml | nindent 12 }}
-  {{- end }}
+        {{- if $needsSpec }}
+        spec:
+          {{- if or $hasDestServer $hasDestName }}
+          destination:
+            namespace: "{{.namespace}}"
+            {{- if $hasDestServer }}
+            server: '{{ .destinationServer }}'
+            {{- end }}
+            {{- if $hasDestName }}
+            name: '{{ .destinationName }}'
+        {{- end }}
+      {{- end }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
+        {{- end }}
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
+        {{- end }}
+      {{- end }}
+      {{- if $hasValuesObject }}
+      source:
+        helm:
+          valuesObject: {{- .valuesObject | toYaml | nindent 12 }}
+      {{- end }}
     {{- end }}

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -476,58 +476,58 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
-    {{- if $needsSpec }}
-    spec:
-  {{- if or $hasDestServer $hasDestName }}
-  destination:
-    namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-    {{- if $hasDestServer }}
-    server: '{{ .destinationServer }}'
-    {{- end }}
-    {{- if $hasDestName }}
-    name: '{{ .destinationName }}'
-    {{- end }}
-  {{- end }}
-  {{- if $hasInfo }}
-  info:
-    {{- if gt (len $deps) 0 }}
-    - name: Depends On (Argo apps)
-      value: '{{ join ", " $deps }}'
-    {{- end }}
-    {{- if gt (len $crds) 0 }}
-    - name: Requires CRDs
-      value: '{{ join ", " $crds }}'
-    {{- end }}
-  {{- end }}
-  {{- if $useLovely }}
-  source:
-    plugin:
-      name: lovely
-  {{- end }}
-  {{- if or $auto $hasManagedNS }}
-  syncPolicy:
-    {{- if $auto }}
-    automated:
-      prune: true
-      selfHeal: true
-    {{- end }}
-    {{- if $hasManagedNS }}
-    managedNamespaceMetadata:
-      {{- if hasKey .managedNamespaceMetadata "labels" }}
-      labels:
-        {{- range $key, $value := .managedNamespaceMetadata.labels }}
-        {{ $key }}: {{ $value | quote }}
+        {{- if $needsSpec }}
+        spec:
+          {{- if or $hasDestServer $hasDestName }}
+          destination:
+            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+            {{- if $hasDestServer }}
+            server: '{{ .destinationServer }}'
+            {{- end }}
+            {{- if $hasDestName }}
+            name: '{{ .destinationName }}'
         {{- end }}
       {{- end }}
-      {{- if hasKey .managedNamespaceMetadata "annotations" }}
-      annotations:
-        {{- range $key, $value := .managedNamespaceMetadata.annotations }}
-        {{ $key }}: {{ $value | quote }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
+        {{- end }}
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
         {{- end }}
       {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- if hasKey . "ignoreDifferences" }}
-  ignoreDifferences: {{ toJson .ignoreDifferences }}
-  {{- end }}
+      {{- if $useLovely }}
+      source:
+        plugin:
+          name: lovely
+      {{- end }}
+      {{- if or $auto $hasManagedNS }}
+      syncPolicy:
+        {{- if $auto }}
+        automated:
+          prune: true
+          selfHeal: true
+        {{- end }}
+        {{- if $hasManagedNS }}
+        managedNamespaceMetadata:
+          {{- if hasKey .managedNamespaceMetadata "labels" }}
+          labels:
+            {{- range $key, $value := .managedNamespaceMetadata.labels }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if hasKey .managedNamespaceMetadata "annotations" }}
+          annotations:
+            {{- range $key, $value := .managedNamespaceMetadata.annotations }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- if hasKey . "ignoreDifferences" }}
+      ignoreDifferences: {{ toJson .ignoreDifferences }}
+      {{- end }}
     {{- end }}

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -283,41 +283,41 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasInfo (hasKey . "ignoreDifferences") -}}
-    {{- if $needsSpec }}
-    spec:
-  {{- if or $hasDestServer $hasDestName }}
-  destination:
-    namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-    {{- if $hasDestServer }}
-    server: '{{ .destinationServer }}'
-    {{- end }}
-    {{- if $hasDestName }}
-    name: '{{ .destinationName }}'
-    {{- end }}
-  {{- end }}
-  {{- if $hasInfo }}
-  info:
-    {{- if gt (len $deps) 0 }}
-    - name: Depends On (Argo apps)
-      value: '{{ join ", " $deps }}'
-    {{- end }}
-    {{- if gt (len $crds) 0 }}
-    - name: Requires CRDs
-      value: '{{ join ", " $crds }}'
-    {{- end }}
-  {{- end }}
-  {{- if $useLovely }}
-  source:
-    plugin:
-      name: lovely
-  {{- end }}
-  {{- if $auto }}
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-  {{- end }}
-  {{- if hasKey . "ignoreDifferences" }}
-  ignoreDifferences: {{ toJson .ignoreDifferences }}
-  {{- end }}
+        {{- if $needsSpec }}
+        spec:
+          {{- if or $hasDestServer $hasDestName }}
+          destination:
+            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+            {{- if $hasDestServer }}
+            server: '{{ .destinationServer }}'
+            {{- end }}
+            {{- if $hasDestName }}
+            name: '{{ .destinationName }}'
+        {{- end }}
+      {{- end }}
+      {{- if $hasInfo }}
+      info:
+        {{- if gt (len $deps) 0 }}
+        - name: Depends On (Argo apps)
+          value: '{{ join ", " $deps }}'
+        {{- end }}
+        {{- if gt (len $crds) 0 }}
+        - name: Requires CRDs
+          value: '{{ join ", " $crds }}'
+        {{- end }}
+      {{- end }}
+      {{- if $useLovely }}
+      source:
+        plugin:
+          name: lovely
+      {{- end }}
+      {{- if $auto }}
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+      {{- end }}
+      {{- if hasKey . "ignoreDifferences" }}
+      ignoreDifferences: {{ toJson .ignoreDifferences }}
+      {{- end }}
     {{- end }}


### PR DESCRIPTION
## Summary

- Fix malformed `templatePatch` indentation in all ApplicationSet templates (bootstrap, cdk8s, helm-apps, platform, product).
- Ensure `templatePatch` content remains a valid YAML block scalar by keeping `{{- if $needsSpec }}`, `spec:` and matching `{{- end }}` at block indentation.
- Prevents `failed to unmarshal manifest` errors during ArgoCD ApplicationSet generation.

## Related Issues

- This is a follow-up fix to PR #3089.

## Testing

- N/A (manifest-only static YAML + template syntax correction).

## Breaking Changes

- None.
