### PR TITLE
fix(argocd): correct bootstrap applicationset template rendering

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -155,58 +155,58 @@ spec:
 
     {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
-        {{- if $needsSpec }}
-        spec:
-          {{- if or $hasDestServer $hasDestName }}
-          destination:
-            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-            {{- if $hasDestServer }}
-            server: '{{ .destinationServer }}'
-            {{- end }}
-            {{- if $hasDestName }}
-            name: '{{ .destinationName }}'
-        {{- end }}
+    {{- if $needsSpec }}
+    spec:
+    {{- if or $hasDestServer $hasDestName }}
+      destination:
+        namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+      {{- if $hasDestServer }}
+        server: '{{ .destinationServer }}'
       {{- end }}
-      {{- if $hasInfo }}
+      {{- if $hasDestName }}
+        name: '{{ .destinationName }}'
+      {{- end }}
+    {{- end }}
+    {{- if $hasInfo }}
       info:
-        {{- if gt (len $deps) 0 }}
+      {{- if gt (len $deps) 0 }}
         - name: Depends On (Argo apps)
           value: '{{ join ", " $deps }}'
-        {{- end }}
-        {{- if gt (len $crds) 0 }}
+      {{- end }}
+      {{- if gt (len $crds) 0 }}
         - name: Requires CRDs
           value: '{{ join ", " $crds }}'
-        {{- end }}
       {{- end }}
-      {{- if $useLovely }}
+    {{- end }}
+    {{- if $useLovely }}
       source:
         plugin:
           name: lovely
-      {{- end }}
-      {{- if or $auto $hasManagedNS }}
+    {{- end }}
+    {{- if or $auto $hasManagedNS }}
       syncPolicy:
-        {{- if $auto }}
+      {{- if $auto }}
         automated:
           prune: true
           selfHeal: true
-        {{- end }}
-        {{- if $hasManagedNS }}
+      {{- end }}
+      {{- if $hasManagedNS }}
         managedNamespaceMetadata:
-          {{- if hasKey .managedNamespaceMetadata "labels" }}
+        {{- if hasKey .managedNamespaceMetadata "labels" }}
           labels:
-            {{- range $key, $value := .managedNamespaceMetadata.labels }}
+          {{- range $key, $value := .managedNamespaceMetadata.labels }}
             {{ $key }}: {{ $value | quote }}
-            {{- end }}
           {{- end }}
-          {{- if hasKey .managedNamespaceMetadata "annotations" }}
+        {{- end }}
+        {{- if hasKey .managedNamespaceMetadata "annotations" }}
           annotations:
-            {{- range $key, $value := .managedNamespaceMetadata.annotations }}
+          {{- range $key, $value := .managedNamespaceMetadata.annotations }}
             {{ $key }}: {{ $value | quote }}
-            {{- end }}
           {{- end }}
         {{- end }}
       {{- end }}
-      {{- if hasKey . "ignoreDifferences" }}
+    {{- end }}
+    {{- if hasKey . "ignoreDifferences" }}
       ignoreDifferences: {{ toJson .ignoreDifferences }}
-      {{- end }}
+    {{- end }}
     {{- end }}


### PR DESCRIPTION
## Summary
- Fixed malformed `templatePatch` indentation in `argocd/applicationsets/bootstrap.yaml` that could emit invalid Application YAML.
- Preserved existing template behavior while keeping the generated structure valid under all branches of the goTemplate conditionals.
- Restores bootstrap `ApplicationSet` generation so dependent app resources (including `rook-ceph`) can be materialized again.

## Testing
- `kubectl -n argocd get applicationset bootstrap -o json | jq -r '.status.conditions[] | "\(.type)=\(.status) \(.reason) \(.message)"'` (verified `ApplicationSet` renders successfully)
- `kubectl -n argocd get applications | awk '{print $1}'` (verified `rook-ceph` application appears)

## Related
- Follow-up PR (separate): remove `info` metadata fields (`Depends On` / `Requires CRDs`) from applicationset-generated Application specs.

## Checklist
- [x] Validation step included.
- [x] No unrelated files modified.
