### PR TITLE
fix(argocd): drop application info metadata from appset templates

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -87,10 +87,6 @@ spec:
                 - name: traefik
                   path: argocd/applications/traefik
                   namespace: traefik
-                  dependsOnApps:
-                    - metallb-system
-                  requiresCrds:
-                    - traefik.io
                   annotations:
                     argocd.argoproj.io/sync-wave: "1"
                   automation: auto
@@ -144,17 +140,7 @@ spec:
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
     {{- $auto := eq .automation "auto" -}}
     {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-    {{- $deps := list -}}
-    {{- $crds := list -}}
-    {{- if hasKey . "dependsOnApps" -}}
-    {{- $deps = .dependsOnApps -}}
-    {{- end -}}
-    {{- if hasKey . "requiresCrds" -}}
-    {{- $crds = .requiresCrds -}}
-    {{- end -}}
-
-    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS (hasKey . "ignoreDifferences") -}}
     {{- if $needsSpec }}
     spec:
     {{- if or $hasDestServer $hasDestName }}
@@ -165,17 +151,6 @@ spec:
       {{- end }}
       {{- if $hasDestName }}
         name: '{{ .destinationName }}'
-      {{- end }}
-    {{- end }}
-    {{- if $hasInfo }}
-      info:
-      {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
-      {{- end }}
-      {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
       {{- end }}
     {{- end }}
     {{- if $useLovely }}

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -66,17 +66,7 @@ spec:
     {{- $hasDestServer := hasKey . "destinationServer" -}}
     {{- $hasDestName := hasKey . "destinationName" -}}
     {{- $auto := eq .automation "auto" -}}
-    {{- $deps := list -}}
-    {{- $crds := list -}}
-    {{- if hasKey . "dependsOnApps" -}}
-    {{- $deps = .dependsOnApps -}}
-    {{- end -}}
-    {{- if hasKey . "requiresCrds" -}}
-    {{- $crds = .requiresCrds -}}
-    {{- end -}}
-
-    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-    {{- $needsSpec := or $hasDestServer $hasDestName $auto $hasInfo -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $auto -}}
         {{- if $needsSpec }}
         spec:
           {{- if or $hasDestServer $hasDestName }}
@@ -87,17 +77,6 @@ spec:
             {{- end }}
             {{- if $hasDestName }}
             name: '{{ .destinationName }}'
-        {{- end }}
-      {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
-        {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
         {{- end }}
       {{- end }}
       {{- if $auto }}

--- a/argocd/applicationsets/helm-apps.yaml
+++ b/argocd/applicationsets/helm-apps.yaml
@@ -48,17 +48,7 @@ spec:
     {{- $hasDestServer := hasKey . "destinationServer" -}}
     {{- $hasDestName := hasKey . "destinationName" -}}
     {{- $hasValuesObject := hasKey . "valuesObject" -}}
-    {{- $deps := list -}}
-    {{- $crds := list -}}
-    {{- if hasKey . "dependsOnApps" -}}
-    {{- $deps = .dependsOnApps -}}
-    {{- end -}}
-    {{- if hasKey . "requiresCrds" -}}
-    {{- $crds = .requiresCrds -}}
-    {{- end -}}
-
-    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-    {{- $needsSpec := or $hasDestServer $hasDestName $hasValuesObject $hasInfo -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $hasValuesObject -}}
         {{- if $needsSpec }}
         spec:
           {{- if or $hasDestServer $hasDestName }}
@@ -69,17 +59,6 @@ spec:
             {{- end }}
             {{- if $hasDestName }}
             name: '{{ .destinationName }}'
-        {{- end }}
-      {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
-        {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
         {{- end }}
       {{- end }}
       {{- if $hasValuesObject }}

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -94,8 +94,6 @@ spec:
               - name: istio-ingress
                 path: argocd/applications/istio-ingress
                 namespace: istio-ingress
-                dependsOnApps:
-                  - istio-system
                 annotations:
                   argocd.argoproj.io/sync-wave: "1"
                 automation: auto
@@ -110,8 +108,6 @@ spec:
               - name: knative-serving
                 path: argocd/applications/knative-serving
                 namespace: knative-serving
-                dependsOnApps:
-                  - knative
                 annotations:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
@@ -119,8 +115,6 @@ spec:
               - name: knative-eventing
                 path: argocd/applications/knative-eventing
                 namespace: knative-eventing
-                dependsOnApps:
-                  - knative
                 annotations:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
@@ -465,17 +459,7 @@ spec:
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
     {{- $auto := eq .automation "auto" -}}
     {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-    {{- $deps := list -}}
-    {{- $crds := list -}}
-    {{- if hasKey . "dependsOnApps" -}}
-    {{- $deps = .dependsOnApps -}}
-    {{- end -}}
-    {{- if hasKey . "requiresCrds" -}}
-    {{- $crds = .requiresCrds -}}
-    {{- end -}}
-
-    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS $hasInfo (hasKey . "ignoreDifferences") -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS (hasKey . "ignoreDifferences") -}}
         {{- if $needsSpec }}
         spec:
           {{- if or $hasDestServer $hasDestName }}
@@ -486,17 +470,6 @@ spec:
             {{- end }}
             {{- if $hasDestName }}
             name: '{{ .destinationName }}'
-        {{- end }}
-      {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
-        {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
         {{- end }}
       {{- end }}
       {{- if $useLovely }}

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -272,17 +272,7 @@ spec:
     {{- $hasDestName := hasKey . "destinationName" -}}
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
     {{- $auto := eq .automation "auto" -}}
-    {{- $deps := list -}}
-    {{- $crds := list -}}
-    {{- if hasKey . "dependsOnApps" -}}
-    {{- $deps = .dependsOnApps -}}
-    {{- end -}}
-    {{- if hasKey . "requiresCrds" -}}
-    {{- $crds = .requiresCrds -}}
-    {{- end -}}
-
-    {{- $hasInfo := or (gt (len $deps) 0) (gt (len $crds) 0) -}}
-    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasInfo (hasKey . "ignoreDifferences") -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto (hasKey . "ignoreDifferences") -}}
         {{- if $needsSpec }}
         spec:
           {{- if or $hasDestServer $hasDestName }}
@@ -293,17 +283,6 @@ spec:
             {{- end }}
             {{- if $hasDestName }}
             name: '{{ .destinationName }}'
-        {{- end }}
-      {{- end }}
-      {{- if $hasInfo }}
-      info:
-        {{- if gt (len $deps) 0 }}
-        - name: Depends On (Argo apps)
-          value: '{{ join ", " $deps }}'
-        {{- end }}
-        {{- if gt (len $crds) 0 }}
-        - name: Requires CRDs
-          value: '{{ join ", " $crds }}'
         {{- end }}
       {{- end }}
       {{- if $useLovely }}


### PR DESCRIPTION
## Summary
- Removed `spec.info` rendering for dependency metadata from all ApplicationSet template patches.
- Removed now-unused dependency metadata keys from application element lists (`dependsOnApps` / `requiresCrds`) in bootstrap/platform entries.
- Kept sync ordering/dependency comments purely via existing sync-wave annotations and app-of-apps configuration.

## Related Issues
- None.

## Testing
- `rg -n "Depends On \(Argo apps\)|Requires CRDs|dependsOnApps:|requiresCrds:" argocd/applicationsets/*.yaml` (verifies no `info`-style dependency payload remains).
- `rg -n "templatePatch|needsSpec|useLovely|destinationServer" argocd/applicationsets/*.yaml` (basic sanity pass on updated template sections).
