### PR TITLE
fix(rook-ceph): expose dashboard ingress + remove cleanup policy

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -24,9 +24,6 @@ cephClusterSpec:
 
   dataDirHostPath: /var/lib/rook
 
-  cleanupPolicy:
-    wipeDevicesFromOtherClusters: true
-
   mon:
     count: 3
     allowMultiplePerNode: false

--- a/argocd/applications/rook-ceph/ingressroute-dashboard.yaml
+++ b/argocd/applications/rook-ceph/ingressroute-dashboard.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: ceph-dashboard
+  namespace: rook-ceph
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: Host(`ceph.lan`)
+      services:
+        - name: rook-ceph-mgr-dashboard
+          port: 7000

--- a/argocd/applications/rook-ceph/kustomization.yaml
+++ b/argocd/applications/rook-ceph/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: rook-ceph
 
 resources:
   - storageclasses.yaml
+  - ingressroute-dashboard.yaml
 
 helmCharts:
   - name: rook-ceph


### PR DESCRIPTION
## Summary
- Expose the Rook Ceph dashboard via Traefik `IngressRoute` at `ceph.lan` (no TLS; local LAN route).
- Remove `cephClusterSpec.cleanupPolicy.wipeDevicesFromOtherClusters` to avoid destructive wipe behavior.

## Changes
- `argocd/applications/rook-ceph/ingressroute-dashboard.yaml`: new `IngressRoute` -> `rook-ceph-mgr-dashboard:7000`.
- `argocd/applications/rook-ceph/kustomization.yaml`: include the new resource.
- `argocd/applications/rook-ceph/cluster-values.yaml`: drop cleanup policy.

## Rollout / Notes
- After merge: sync `argocd` app `rook-ceph`.
- Dashboard should be reachable at `http://ceph.lan/`.
