### PR TITLE
feat(bootstrap): enable registry

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -103,8 +103,8 @@ spec:
                   namespace: registry
                   annotations:
                     argocd.argoproj.io/sync-wave: "1"
-                  automation: manual
-                  enabled: "false"
+                  automation: auto
+                  enabled: "true"
             selector:
               matchExpressions:
                 - key: enabled


### PR DESCRIPTION
## Summary

- Enable the `registry` ArgoCD application in the bootstrap ApplicationSet.
- Set registry to `automation: auto` so ArgoCD will self-heal/prune and keep it running.
- Registry persistence remains backed by Ceph via `storageClassName: rook-ceph-block` in `argocd/applications/registry/pvc.yaml`.

## Related Issues

None

## Testing

- Not run (GitOps toggle only). Expected: ArgoCD creates/syncs `Application/registry` and `pvc/registry-data` binds with StorageClass `rook-ceph-block`.

## Breaking Changes

None
