### PR TITLE
docs(talos): document node-level tailscale for image pulls

### DIFF
--- a/devices/galactic/docs/bootstrap-argocd.md
+++ b/devices/galactic/docs/bootstrap-argocd.md
@@ -101,3 +101,4 @@ argocd admin initial-password -n argocd
    - `argocd/applicationsets/README.md`
 1. Install stage-based ApplicationSets once the prerequisites (CRDs, MetalLB, etc.) are in place:
    - `argocd/applicationsets/bootstrap.yaml`
+1. If you reference Tailscale-only hostnames (for example `registry.ide-newton.ts.net`) in Kubernetes image references, install node-level Tailscale first: `devices/galactic/docs/tailscale.md`.

--- a/devices/galactic/docs/tailscale.md
+++ b/devices/galactic/docs/tailscale.md
@@ -9,6 +9,14 @@ Why both:
 - The `ExtensionServiceConfig` alone is not enough if the system extension is not present.
 - System extensions only become active during **install/upgrade**.
 
+## Why this is required for pulling images from `*.ts.net` registries
+
+Kubernetes image pulls are performed by `kubelet`/`containerd` on the node OS. If the node cannot resolve or reach a Tailscale-only registry hostname, workloads will fail with `ImagePullBackOff` even if the pod network is healthy.
+
+In this cluster:
+1. The in-cluster registry is exposed via a Tailscale ingress hostname (`registry.ide-newton.ts.net`).
+1. Nodes must run Tailscale so they can resolve and route to that hostname during image pulls.
+
 ## 0) Pick the extension image for your Talos version
 
 For Talos `v1.12.4`, we pin the digest from the Sidero Labs extensions catalog:
@@ -99,3 +107,9 @@ After upgrade/reboot, verify the extension is installed:
 talosctl get extensions -n 192.168.1.194 -e 192.168.1.194 | rg tailscale
 ```
 
+Then validate an actual node-level image pull from the Tailscale registry hostname (this exercises `containerd` on the node):
+
+```bash
+export REGISTRY_SMOKETEST_IMAGE='registry.ide-newton.ts.net/lab/registry-smoketest:<tag>'
+talosctl image pull -n 192.168.1.85 -e 192.168.1.85 "$REGISTRY_SMOKETEST_IMAGE"
+```

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,5 +1,15 @@
 # Kubernetes installation
 
+## Talos-based cluster (galactic)
+
+The current home lab Kubernetes cluster is Talos-based and documented under `devices/galactic`.
+
+Start here:
+1. `devices/galactic/README.md`
+1. `devices/galactic/docs/bootstrap-argocd.md`
+1. `devices/galactic/docs/tailscale.md` (required if you reference `*.ts.net` registries in image references)
+1. `docs/runbooks/rook-ceph-on-talos.md`
+
 ## Install k3sup
 
 ```bash


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- 
- 
- 

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- 

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.

## Summary
- Documented why Talos node-level Tailscale is required for pulling images from `*.ts.net` registries.
- Linked the canonical `devices/galactic` Talos runbooks from `kubernetes/README.md`.
- Added a concrete node-level image pull smoke test using `talosctl image pull`.

## Validation
- Docs-only change.
