### PR TITLE
fix(argocd): enable platform apps and normalize ceph storage classes

### DIFF
--- a/argocd/applications/pgadmin/values.yaml
+++ b/argocd/applications/pgadmin/values.yaml
@@ -17,6 +17,10 @@ existingSecret: pgadmin-auth
 strategy:
   type: Recreate
 
+persistentVolume:
+  enabled: true
+  storageClass: rook-ceph-block
+
 envVarsExtra:
   - name: PGADMIN_SERVER_JSON_FILE
     value: /var/lib/pgadmin/servers/servers.json

--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -95,6 +95,13 @@ cephClusterSpec:
       status:
         interval: 60s
 
+# Disable chart-managed default block/filesystem classes to avoid duplicates.
+# Canonical classes are managed in storageclasses.yaml as:
+# - rook-ceph-block (RWO)
+# - rook-cephfs (RWX)
+cephBlockPools: []
+cephFileSystems: []
+
 cephObjectStores:
   - name: objectstore
     spec:

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -22,21 +22,21 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "-1"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: clickhouse-operator
                 path: argocd/applications/clickhouse-operator
                 namespace: clickhouse-operator
                 annotations:
                   argocd.argoproj.io/sync-wave: "-1"
                 automation: manual
-                enabled: "false"
+                enabled: "true"
               - name: redis-operator
                 path: argocd/applications/redis-operator
                 namespace: redis-operator
                 annotations:
                   argocd.argoproj.io/sync-wave: "-1"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: kubevirt
                 path: argocd/applications/kubevirt
                 namespace: kubevirt
@@ -90,35 +90,35 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "0"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: istio-ingress
                 path: argocd/applications/istio-ingress
                 namespace: istio-ingress
                 annotations:
                   argocd.argoproj.io/sync-wave: "1"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: knative
                 path: argocd/applications/knative
                 namespace: knative
                 annotations:
                   argocd.argoproj.io/sync-wave: "1"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: knative-serving
                 path: argocd/applications/knative-serving
                 namespace: knative-serving
                 annotations:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: knative-eventing
                 path: argocd/applications/knative-eventing
                 namespace: knative-eventing
                 annotations:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: fission
                 path: argocd/applications/fission
                 namespace: fission
@@ -153,7 +153,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: argo-workflows
                 path: argocd/applications/argo-workflows
                 namespace: argo-workflows
@@ -181,7 +181,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "3"
                 automation: manual
-                enabled: "false"
+                enabled: "true"
               - name: milvus
                 path: argocd/applications/milvus
                 namespace: milvus
@@ -265,14 +265,14 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "4"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: pgadmin
                 path: argocd/applications/pgadmin
                 namespace: pgadmin
                 annotations:
                   argocd.argoproj.io/sync-wave: "4"
                 automation: manual
-                enabled: "false"
+                enabled: "true"
               - name: graf
                 path: argocd/applications/graf
                 namespace: graf

--- a/docs/jangar/jangar-application-dependency-tree.md
+++ b/docs/jangar/jangar-application-dependency-tree.md
@@ -1,0 +1,87 @@
+# Jangar application dependency tree
+
+This document maps `argocd/applications/jangar` dependencies across Argo CD applications and runtime services.
+
+## 1. Argo CD application dependency tree
+
+```mermaid
+graph TD
+  ROOT[Argo Root App] --> PRODUCT[ApplicationSet: product]
+  PRODUCT --> JANGAR[Jangar App]
+
+  JANGAR --> BOOTSTRAP[Bootstrap prerequisites]
+  BOOTSTRAP --> SEALED[sealed-secrets]
+  BOOTSTRAP --> CEPH[rook-ceph]
+  BOOTSTRAP --> TAILSCALE[tailscale-operator]
+
+  JANGAR --> PLATFORM[Platform prerequisites]
+  PLATFORM --> CNPG[cloudnative-pg]
+  PLATFORM --> REDISOP[redis-operator]
+  PLATFORM --> KNATIVE[knative + knative-eventing]
+  PLATFORM --> KAFKA[kafka]
+  PLATFORM --> NATS[nats]
+  PLATFORM --> ARGO[argo-workflows]
+  PLATFORM --> OBS[observability]
+
+  JANGAR -. optional integration .-> TORGHUT[torghut]
+  JANGAR -. optional integration .-> FACTEUR[facteur]
+```
+
+## 2. Runtime dependency tree (inside `jangar` manifests)
+
+```mermaid
+graph TD
+  JDEPLOY[Deployment: jangar] --> JDB[Secret: jangar-db-app]
+  JDEPLOY --> JREDIS[Service: jangar-openwebui-redis]
+  JDEPLOY --> NATSSEC[Secret: nats-jangar-credentials]
+  JDEPLOY --> NATSSVC[nats.nats.svc.cluster.local:4222]
+  JDEPLOY --> KAFKASEC[Secrets: kafka-codex-username / kafka-codex-credentials]
+  JDEPLOY --> ARGOSVC[argo-workflows-server.argo-workflows.svc.cluster.local]
+  JDEPLOY --> MINIOSEC[Secret: observability-minio-creds]
+  JDEPLOY --> CHSEC[Secret: jangar-clickhouse-auth]
+  JDEPLOY --> CHSVC[torghut-clickhouse.torghut.svc]
+  JDEPLOY -. optional .-> TDB[Secret: torghut-db-app]
+  JDEPLOY -. optional .-> FINT[facteur-internal.facteur.svc.cluster.local]
+
+  OUI[OpenWebUI Helm release] --> JDB
+  OUI --> JREDIS
+
+  KSRC1[KafkaSource: jangar-codex-github-events] --> KAFKASVC[kafka-kafka-bootstrap.kafka:9092]
+  KSRC1 --> KAFKASEC
+  KSRC2[KafkaSource: jangar-codex-completions] --> KAFKASVC
+  KSRC2 --> KAFKASEC
+```
+
+## 3. Hard vs optional dependencies
+
+Hard dependencies:
+1. `sealed-secrets` (for decrypting all SealedSecret resources).
+1. `rook-ceph` (`rook-ceph-block` and `rook-cephfs` storage classes).
+1. `cloudnative-pg` (CNPG `Cluster` + generated DB secrets).
+1. `redis-operator` (for `Redis` custom resource).
+1. `knative` + `knative-eventing` + `kafka` (for `KafkaSource` resources).
+1. `nats` (NATS credentials + broker endpoint).
+1. `argo-workflows` (run-complete and workflow API integration).
+1. `observability` (MinIO creds/endpoint currently referenced by `jangar` and CNPG backup config).
+1. `tailscale-operator` (for `LoadBalancer` services using `loadBalancerClass: tailscale`).
+
+Optional or feature-gated integrations:
+1. `torghut` (`torghut-db-app` is optional; clickhouse integration depends on `torghut-clickhouse` service/creds).
+1. `facteur` (`facteur-internal` URL is configured; behavior depends on enabled feature paths).
+
+## 4. Recommended enable order
+
+1. `sealed-secrets`, `rook-ceph`, `tailscale-operator` (bootstrap layer).
+1. `cloudnative-pg`, `redis-operator`, `knative`, `knative-eventing`, `kafka`, `nats`, `argo-workflows`, `observability` (platform layer).
+1. `jangar` (product layer).
+1. Optional product integrations: `torghut`, `facteur`.
+
+## 5. Quick validation
+
+```bash
+kubectl get applications -n argocd | rg 'sealed-secrets|rook-ceph|tailscale|cloudnative-pg|redis-operator|knative|kafka|nats|argo-workflows|observability|jangar'
+kubectl -n jangar get secret jangar-db-app github-token jangar-clickhouse-auth
+kubectl -n jangar get kafkasources.sources.knative.dev
+kubectl -n jangar get redis.redis.opstreelabs.in
+kubectl -n jangar get cluster.postgresql.cnpg.io,scheduledbackup.postgresql.cnpg.io
+```


### PR DESCRIPTION
## Summary

- enable requested platform applications in `argocd/applicationsets/platform.yaml`
- pin `pgadmin` persistence to `rook-ceph-block`
- disable chart-generated default Ceph block/filesystem classes to avoid duplicate StorageClasses
- add Jangar dependency tree documentation for reproducible app dependency tracking

## Related Issues

None

## Testing

- `kubectl get storageclass -o wide`
- `kubectl get storageclass -o yaml`
- `kubectl -n argocd get applications`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
