### PR TITLE
fix(argocd): restore istio cni on talos and enable keycloak

### DIFF
--- a/argocd/applications/istio-system/kustomization.yaml
+++ b/argocd/applications/istio-system/kustomization.yaml
@@ -25,6 +25,3 @@ helmCharts:
     version: 1.28.0
     releaseName: istio-cni
     namespace: istio-system
-    valuesInline:
-      global:
-        platform: k3s

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -89,6 +89,11 @@ spec:
                 namespace: istio-system
                 annotations:
                   argocd.argoproj.io/sync-wave: "0"
+                managedNamespaceMetadata:
+                  labels:
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
                 automation: auto
                 enabled: "true"
               - name: istio-ingress
@@ -258,7 +263,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "4"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: headlamp
                 path: argocd/applications/headlamp
                 namespace: headlamp


### PR DESCRIPTION
## Summary

- remove Istio CNI `global.platform: k3s` override so the CNI chart renders Talos-compatible paths
- set `managedNamespaceMetadata` PodSecurity labels for `istio-system` to `privileged` in the platform ApplicationSet
- enable `keycloak` in `argocd/applicationsets/platform.yaml`

## Related Issues

None

## Testing

- `kubectl -n istio-system describe daemonset istio-cni-node`
- `kubectl -n istio-system logs daemonset/istio-cni-node -c install-cni --tail=200`
- `kubectl -n argocd get app istio-system -o jsonpath='{.status.sync.status}{"\\n"}{.status.health.status}{"\\n"}'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
