### PR TITLE
fix(observability): stabilize ceph buckets and mimir ruler startup

### DIFF
--- a/argocd/applications/observability/loki-values.yaml
+++ b/argocd/applications/observability/loki-values.yaml
@@ -12,7 +12,7 @@ loki:
     aws:
       s3: http://${OBS_S3_ENDPOINT}
       s3forcepathstyle: true
-      bucketnames: ${OBS_S3_BUCKET}
+      bucketnames: loki-data
       access_key_id: ${OBS_S3_ACCESS_KEY}
       secret_access_key: ${OBS_S3_SECRET_KEY}
       insecure: true
@@ -66,11 +66,6 @@ distributor:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket
 
 ingester:
   extraArgs:
@@ -91,11 +86,6 @@ ingester:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket
 
 querier:
   extraArgs:
@@ -116,11 +106,6 @@ querier:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket
 
 queryFrontend:
   extraArgs:
@@ -141,11 +126,6 @@ queryFrontend:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket
 
 gateway:
   extraArgs:
@@ -166,11 +146,6 @@ gateway:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket
 
 compactor:
   extraArgs:
@@ -191,11 +166,6 @@ compactor:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket
 
 ruler:
   extraArgs:
@@ -216,8 +186,3 @@ ruler:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket

--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -15,11 +15,6 @@ global:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket
     - name: OBS_S3_REGION
       valueFrom:
         secretKeyRef:
@@ -37,7 +32,7 @@ mimir:
         sync_dir: /data/tsdb-sync
       s3:
         endpoint: ${OBS_S3_ENDPOINT}
-        bucket_name: ${OBS_S3_BUCKET}
+        bucket_name: mimir-blocks
         access_key_id: ${OBS_S3_ACCESS_KEY}
         secret_access_key: ${OBS_S3_SECRET_KEY}
         region: ${OBS_S3_REGION}
@@ -47,7 +42,7 @@ mimir:
       backend: s3
       s3:
         endpoint: ${OBS_S3_ENDPOINT}
-        bucket_name: ${OBS_S3_BUCKET}
+        bucket_name: mimir-alertmanager
         access_key_id: ${OBS_S3_ACCESS_KEY}
         secret_access_key: ${OBS_S3_SECRET_KEY}
         region: ${OBS_S3_REGION}
@@ -104,37 +99,6 @@ query_scheduler:
 
 ruler:
   replicas: 1
-  # mimir-distributed chart uses `initContainers` (not `extraInitContainers`).
-  initContainers:
-    - name: copy-graf-rules
-      image: docker.io/library/busybox:1.36
-      imagePullPolicy: IfNotPresent
-      command:
-        - /bin/sh
-        - -c
-        - |
-          set -eu
-          rm -rf /etc/mimir/rules/*
-          mkdir -p /etc/mimir/rules/anonymous
-          # ConfigMap mounts use symlinks + timestamped dirs (..data/..2026_...).
-          # Copy dereferenced files into the tenant directory without trying to preserve ownership.
-          for f in /etc/mimir/rules-src/*.yml /etc/mimir/rules-src/*.yaml; do
-            if [ -f "$f" ]; then
-              cp -Lf "$f" /etc/mimir/rules/anonymous/
-            fi
-          done
-  extraVolumes:
-    - name: graf-mimir-rules
-      configMap:
-        name: graf-mimir-rules
-    - name: graf-mimir-rules-writable
-      emptyDir: {}
-  extraVolumeMounts:
-    - name: graf-mimir-rules
-      mountPath: /etc/mimir/rules-src
-      readOnly: true
-    - name: graf-mimir-rules-writable
-      mountPath: /etc/mimir/rules
 
 store_gateway:
   replicas: 1

--- a/argocd/applications/observability/tempo-values.yaml
+++ b/argocd/applications/observability/tempo-values.yaml
@@ -18,11 +18,6 @@ global:
         secretKeyRef:
           name: rook-ceph-rgw-loki
           key: endpoint
-    - name: OBS_S3_BUCKET
-      valueFrom:
-        secretKeyRef:
-          name: rook-ceph-rgw-loki
-          key: bucket
 
 traces:
   otlp:
@@ -67,7 +62,7 @@ storage:
     backend: s3
     s3:
       endpoint: ${OBS_S3_ENDPOINT}
-      bucket: ${OBS_S3_BUCKET}
+      bucket: tempo-traces
       access_key: ${OBS_S3_ACCESS_KEY}
       secret_key: ${OBS_S3_SECRET_KEY}
       insecure: true


### PR DESCRIPTION
## Summary

- switch Loki/Tempo to explicit Ceph bucket names (`loki-data`, `tempo-traces`) while keeping Ceph RGW credentials from `rook-ceph-rgw-loki`
- split Mimir storage buckets (`mimir-blocks`, `mimir-alertmanager`) to avoid invalid shared-bucket config
- remove custom Mimir ruler init-container/mount overrides that failed due filesystem permission issues

## Related Issues

None

## Testing

- `kubectl -n observability logs observability-mimir-alertmanager-0 --tail=120`
- `kubectl -n observability describe pod observability-mimir-ruler-<pod>`
- `kubectl -n argocd get app observability -o jsonpath='{.status.sync.status}{"\\n"}{.status.health.status}{"\\n"}'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
