### PR TITLE
fix(observability): set mimir ruler local rules directory

### DIFF
--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -51,7 +51,7 @@ mimir:
     ruler_storage:
       backend: local
       local:
-        directory: /etc/mimir/rules
+        directory: /data/rules
     ruler:
       # Must not overlap ruler_storage.local.directory.
       # /etc/mimir/rules is used as the read-only rule store (local backend),


### PR DESCRIPTION
## Summary

- set Mimir ruler local rules directory to `/data/rules` instead of `/etc/mimir/rules`
- keep `rule_path` on `/data/ruler` so startup can read local rules directory without failing on missing read-only path

## Related Issues

None

## Testing

- `kubectl -n observability logs observability-mimir-ruler-<pod> --tail=120`
- verified startup failure referenced missing `/etc/mimir/rules`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
