### PR TITLE
fix(observability): use /tmp for mimir ruler local storage

### DIFF
--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -51,7 +51,7 @@ mimir:
     ruler_storage:
       backend: local
       local:
-        directory: /data/rules
+        directory: /tmp
     ruler:
       # Must not overlap ruler_storage.local.directory.
       # /etc/mimir/rules is used as the read-only rule store (local backend),


### PR DESCRIPTION
## Summary

- set Mimir ruler local rules directory to `/tmp` to ensure the path exists at startup
- keep ruler `rule_path` at `/data/ruler` and avoid failing on missing `/data/rules`

## Related Issues

None

## Testing

- `kubectl -n observability logs observability-mimir-ruler-<pod> --tail=120`
- observed startup failure caused by missing local rules directory path

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
