### PR TITLE
fix(kafka): run alloy non-root and expose kafka-ui via tailscale ingress

### DIFF
--- a/argocd/applications/kafka/alloy-deployment.yaml
+++ b/argocd/applications/kafka/alloy-deployment.yaml
@@ -34,6 +34,7 @@ spec:
               drop:
                 - ALL
             runAsNonRoot: true
+            runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
           resources:

--- a/argocd/applications/kafka/load-balancer.yaml
+++ b/argocd/applications/kafka/load-balancer.yaml
@@ -1,18 +1,23 @@
-apiVersion: v1
-kind: Service
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: kafka-ui-lb
+  name: kafka-ui-tailscale
   namespace: kafka
   annotations:
-    tailscale.com/hostname: kafka-ui
+    tailscale.com/tags: tag:k8s
 spec:
-  type: LoadBalancer
-  loadBalancerClass: tailscale
-  selector:
-    app.kubernetes.io/instance: kafka-ui
-    app.kubernetes.io/name: kafka-ui
-  ports:
-    - port: 80
-      targetPort: 8080
-      protocol: TCP
-      name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - kafka-ui.ide-newton.ts.net
+  rules:
+    - host: kafka-ui.ide-newton.ts.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-ui
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary

- Fix `kafka-alloy` by explicitly running the Alloy container as a non-root UID.
- Replace the Tailscale `Service` LoadBalancer for Kafka UI with a Tailscale `Ingress` so it works under PodSecurity `baseline`.

## Related Issues

None

## Testing

- `argocd app get kafka --refresh` (confirmed app `Progressing`).
- `kubectl -n kafka describe pod kafka-alloy-...` (confirmed `runAsNonRoot` vs root image user error).
- `kubectl -n kafka get svc kafka-ui-lb -o wide` (confirmed `EXTERNAL-IP <pending>` from Tailscale LB).

## Breaking Changes

- Kafka UI is now exposed via `Ingress` host `kafka-ui.ide-newton.ts.net` instead of a Tailscale `Service` LoadBalancer.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Breaking Changes handled appropriately.
- [x] Documentation updated or N/A.
