### PR TITLE
fix(kafka): make alloy writable data dir

### DIFF
--- a/argocd/applications/kafka/alloy-deployment.yaml
+++ b/argocd/applications/kafka/alloy-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         - name: alloy
           image: grafana/alloy:v1.11.2
           imagePullPolicy: IfNotPresent
+          workingDir: /tmp
           args:
             - run
             - /etc/alloy/config.river


### PR DESCRIPTION
## Summary

- Make Grafana Alloy writable when running as a non-root UID by setting `workingDir: /tmp` (fixes `mkdir data-alloy: permission denied`).

## Related Issues

None

## Testing

- `kubectl -n kafka logs kafka-alloy-...` (confirmed `mkdir data-alloy: permission denied` before).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
