### PR TITLE
fix(kafka): use writable volume for alloy data dir

### DIFF
--- a/argocd/applications/kafka/alloy-deployment.yaml
+++ b/argocd/applications/kafka/alloy-deployment.yaml
@@ -18,11 +18,13 @@ spec:
         app.kubernetes.io/component: observability
     spec:
       serviceAccountName: kafka-alloy
+      securityContext:
+        fsGroup: 65532
       containers:
         - name: alloy
           image: grafana/alloy:v1.11.2
           imagePullPolicy: IfNotPresent
-          workingDir: /tmp
+          workingDir: /var/lib/alloy
           args:
             - run
             - /etc/alloy/config.river
@@ -36,6 +38,7 @@ spec:
                 - ALL
             runAsNonRoot: true
             runAsUser: 65532
+            runAsGroup: 65532
             seccompProfile:
               type: RuntimeDefault
           resources:
@@ -48,6 +51,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/alloy
+            - name: data
+              mountPath: /var/lib/alloy
       volumes:
         - name: config
           configMap:
@@ -55,3 +60,5 @@ spec:
             items:
               - key: config.river
                 path: config.river
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
## Summary

- Replace the `/tmp` workaround for `kafka-alloy` with an explicit writable `emptyDir` volume mounted at `/var/lib/alloy`.
- Keep Alloy running as a non-root UID/GID (`65532`) while ensuring it can create its `data-alloy` directory.

## Related Issues

None

## Testing

- `kubectl -n kafka logs kafka-alloy-...` (confirmed `mkdir data-alloy: permission denied` previously).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
