### PR TITLE
docs(talos): add keycloak oidc apiserver patch

### DIFF
--- a/devices/altra/manifests/oidc-keycloak.patch.yaml
+++ b/devices/altra/manifests/oidc-keycloak.patch.yaml
@@ -1,0 +1,9 @@
+cluster:
+  apiServer:
+    extraArgs:
+      oidc-issuer-url: https://auth.proompteng.ai/realms/master
+      oidc-client-id: kubernetes
+      oidc-username-claim: preferred_username
+      oidc-username-prefix: 'oidc:'
+      oidc-groups-claim: groups
+      oidc-groups-prefix: 'oidc:'

--- a/devices/ampone/manifests/oidc-keycloak.patch.yaml
+++ b/devices/ampone/manifests/oidc-keycloak.patch.yaml
@@ -1,0 +1,9 @@
+cluster:
+  apiServer:
+    extraArgs:
+      oidc-issuer-url: https://auth.proompteng.ai/realms/master
+      oidc-client-id: kubernetes
+      oidc-username-claim: preferred_username
+      oidc-username-prefix: 'oidc:'
+      oidc-groups-claim: groups
+      oidc-groups-prefix: 'oidc:'

--- a/devices/ryzen/manifests/oidc-keycloak.patch.yaml
+++ b/devices/ryzen/manifests/oidc-keycloak.patch.yaml
@@ -1,0 +1,9 @@
+cluster:
+  apiServer:
+    extraArgs:
+      oidc-issuer-url: https://auth.proompteng.ai/realms/master
+      oidc-client-id: kubernetes
+      oidc-username-claim: preferred_username
+      oidc-username-prefix: 'oidc:'
+      oidc-groups-claim: groups
+      oidc-groups-prefix: 'oidc:'


### PR DESCRIPTION
## Summary

- Add Talos machineconfig patch files to configure kube-apiserver OIDC auth against Keycloak (client `kubernetes`).
- Update Headlamp runbook to document Talos-based control-plane OIDC configuration (replaces stale k3s instructions).

## Related Issues

None

## Testing

- Applied patches with `talosctl patch machineconfig --mode=no-reboot` on control planes.
- Verified kube-apiserver static pod includes `--oidc-*` flags.

## Breaking Changes

None
