### PR TITLE
fix(rook-ceph): set pool defaults and document stale cephfs recovery

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -22,6 +22,13 @@ cephClusterSpec:
     image: quay.io/ceph/ceph:v19.2.3
     allowUnsupported: false
 
+  cephConfig:
+    global:
+      # This cluster currently runs OSDs on 2 hosts, so the default replicated pool size must be 2.
+      # Pools without an explicit size (e.g. `.mgr`) inherit these defaults.
+      osd_pool_default_size: "2"
+      osd_pool_default_min_size: "1"
+
   dataDirHostPath: /var/lib/rook
 
   mon:


### PR DESCRIPTION
## Summary

- Set Ceph default replicated pool settings for a 2-host OSD cluster (`osd_pool_default_size=2`, `osd_pool_default_min_size=1`).
- Document recovery steps for `HEALTH_ERR` caused by a stale CephFS (`ceph-filesystem`) and leftover `size=3` pools.
- Capture the exact commands used to prune stale CRs, remove the stale filesystem, and recover to `HEALTH_OK`.

## Related Issues

None

## Testing

- `kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail`
- `kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s`
- `argocd app get rook-ceph --refresh`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots section not applicable.
- [x] Breaking Changes handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
