### PR TITLE
fix(argocd): run alloy with explicit non-root uid

### DIFF
--- a/argocd/applications/argocd/alloy-deployment.yaml
+++ b/argocd/applications/argocd/alloy-deployment.yaml
@@ -34,6 +34,8 @@ spec:
               drop:
                 - ALL
             runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
             seccompProfile:
               type: RuntimeDefault
           resources:


### PR DESCRIPTION
## Summary

- Fix `argocd-alloy` failing to start due to `runAsNonRoot` with an image that defaults to root.
- Set an explicit non-root UID/GID for the Alloy container so the Deployment can roll forward.

## Related Issues

None

## Testing

- `kubectl -n argocd describe pod <argocd-alloy-pod>` (confirmed failure mode: runAsNonRoot + root image)
- `argocd app get argocd --refresh` (verify app health after sync)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots section not applicable.
- [x] Breaking Changes handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
