### PR TITLE
fix(argocd): add writable data dir for alloy

### DIFF
--- a/argocd/applications/argocd/alloy-deployment.yaml
+++ b/argocd/applications/argocd/alloy-deployment.yaml
@@ -25,6 +25,7 @@ spec:
           args:
             - run
             - /etc/alloy/config.river
+          workingDir: /var/lib/alloy
           ports:
             - name: http-metrics
               containerPort: 12345
@@ -48,6 +49,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/alloy
+            - name: data
+              mountPath: /var/lib/alloy
       volumes:
         - name: config
           configMap:
@@ -55,3 +58,5 @@ spec:
             items:
               - key: config.river
                 path: config.river
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
## Summary

- Give `argocd-alloy` a writable working directory so Alloy can create its default `data-alloy` directory when running as non-root.
- Avoid `/tmp` and keep the data directory explicitly mounted via `emptyDir`.

## Related Issues

None

## Testing

- `kubectl -n argocd logs deploy/argocd-alloy --tail=200` (confirmed failure mode: `mkdir data-alloy: permission denied`)
- `argocd app get argocd --refresh` (verify app health after sync)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots section not applicable.
- [x] Breaking Changes handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
