### PR TITLE
feat(bootstrap): enable cert-manager

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -36,7 +36,7 @@ spec:
                   annotations:
                     argocd.argoproj.io/sync-wave: "-1"
                   automation: auto
-                  enabled: "false"
+                  enabled: "true"
                   ignoreDifferences:
                     - group: admissionregistration.k8s.io
                       kind: MutatingWebhookConfiguration


### PR DESCRIPTION
## Summary

- Enable the `cert-manager` ArgoCD Application via the bootstrap ApplicationSet.

## Related Issues

None

## Testing

- `argocd app sync root` (after merge)
- `argocd app get cert-manager --refresh`
- `kubectl -n cert-manager get pods`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots section not applicable.
- [x] Breaking Changes handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
