### PR TITLE
fix(knative-eventing): bump eventing-kafka-broker manifests

### DIFF
--- a/argocd/applications/knative-eventing/kustomization.yaml
+++ b/argocd/applications/knative-eventing/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: knative-eventing
 resources:
   - knative-eventing.yaml
-  - https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.19.7/eventing-kafka-controller.yaml
-  - https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.19.7/eventing-kafka-source.yaml
+  - https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.20.0/eventing-kafka-controller.yaml
+  - https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.20.0/eventing-kafka-source.yaml
 patchesStrategicMerge:
   - mutating-webhook-namespace-selector-patch.yaml


### PR DESCRIPTION
## Summary

- Fix `knative-eventing` sync failure by bumping eventing-kafka-broker manifests to a release that includes the missing `contract-resources` volume for `kafka-source-dispatcher`.

## Related Issues

None

## Testing

- `argocd app get knative-eventing --refresh` (after merge + sync)
- `kubectl -n knative-eventing get statefulset kafka-source-dispatcher`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots section not applicable.
- [x] Breaking Changes handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
