### PR TITLE
chore(headlamp): bump to v0.40.1

### DIFF
--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp
-    version: 0.39.0
+    version: 0.40.0
     releaseName: headlamp
     namespace: headlamp
     valuesFile: values.yaml

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -1,5 +1,7 @@
 service:
   type: ClusterIP
+image:
+  tag: v0.40.1
 persistentVolumeClaim:
   enabled: true
   accessModes:


### PR DESCRIPTION
## Summary

- Bump Headlamp Helm chart to `0.40.0`.
- Pin Headlamp image tag to `v0.40.1`.

## Related Issues

None.

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp > /tmp/headlamp-rendered.yaml`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
