### PR TITLE
fix(headlamp): disable pvc to avoid multi-attach

### DIFF
--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -3,20 +3,9 @@ service:
 image:
   tag: v0.40.1
 persistentVolumeClaim:
-  enabled: true
-  accessModes:
-    - ReadWriteOnce
-  size: 1Gi
-  storageClassName: rook-ceph-block
+  enabled: false
 podSecurityContext:
   fsGroup: 101
-volumeMounts:
-  - name: headlamp-data
-    mountPath: /home/headlamp
-volumes:
-  - name: headlamp-data
-    persistentVolumeClaim:
-      claimName: headlamp
 config:
   oidc:
     secret:


### PR DESCRIPTION
## Summary

- Disable Headlamp PVC mounting so rollouts aren’t blocked by RWO multi-attach when a control-plane node is NotReady.

## Related Issues

None.

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp > /tmp/headlamp-rendered-no-pvc.yaml`

## Breaking Changes

- Headlamp state under `/home/headlamp` is no longer persisted (pod is now stateless).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
