### PR TITLE
fix(argocd): repair product applicationset templatePatch

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -294,30 +294,30 @@ spec:
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
     {{- $auto := eq .automation "auto" -}}
     {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto (hasKey . "ignoreDifferences") -}}
-        {{- if $needsSpec }}
-        spec:
-          {{- if or $hasDestServer $hasDestName }}
-          destination:
-            namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
-            {{- if $hasDestServer }}
-            server: '{{ .destinationServer }}'
-            {{- end }}
-            {{- if $hasDestName }}
-            name: '{{ .destinationName }}'
-        {{- end }}
+    {{- if $needsSpec }}
+    spec:
+    {{- if or $hasDestServer $hasDestName }}
+      destination:
+        namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
+      {{- if $hasDestServer }}
+        server: '{{ .destinationServer }}'
       {{- end }}
-      {{- if $useLovely }}
+      {{- if $hasDestName }}
+        name: '{{ .destinationName }}'
+      {{- end }}
+    {{- end }}
+    {{- if $useLovely }}
       source:
         plugin:
           name: lovely
-      {{- end }}
-      {{- if $auto }}
+    {{- end }}
+    {{- if $auto }}
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
-      {{- end }}
-      {{- if hasKey . "ignoreDifferences" }}
+    {{- end }}
+    {{- if hasKey . "ignoreDifferences" }}
       ignoreDifferences: {{ toJson .ignoreDifferences }}
-      {{- end }}
+    {{- end }}
     {{- end }}


### PR DESCRIPTION
## Summary

- Fix product ApplicationSet templatePatch indentation so generated Application patches are valid.
- Unblock generation and sync of enabled product apps (e.g. agents-ci).


## Related Issues

None


## Testing

- N/A (template fix; validated by Argo CD controller conditions after merge)

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

None


## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
