### PR TITLE
fix(argocd): allow arc pods in privileged namespace

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -248,6 +248,11 @@ spec:
                 namespace: arc
                 annotations:
                   argocd.argoproj.io/sync-wave: "4"
+                managedNamespaceMetadata:
+                  labels:
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
                 automation: auto
                 enabled: "true"
               - name: backstage


### PR DESCRIPTION
## Summary

- Label the `arc` namespace as PodSecurity `privileged` via Argo CD managedNamespaceMetadata.
- Unblock ARC listener/runner pods which require hostNetwork and privileged dind.


## Related Issues

None


## Testing

- Verified controller logs show listener pod creation previously blocked by PodSecurity; this change allows it.
- After merge: `kubectl -n arc get pods` should show listener/runner pods and GitHub UI should show runners Online.

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

None


## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
