### PR TITLE
fix(arc): use rook-ceph-block for runner work volume

### DIFF
--- a/argocd/applications/arc/README.md
+++ b/argocd/applications/arc/README.md
@@ -5,6 +5,7 @@ These runners are not pinned to any specific node by default.
 - Chart version pinned in `application.yaml` is `0.12.1` for both the controller and the runner scale set.
 - Upgrading from ≤0.9.x requires deleting the legacy `actions.github.com` CRDs and reinstalling the controller/runner charts before letting Argo CD reconcile.
 - Keep the custom template (init container + privileged `docker:dind` sidecar with `DOCKER_HOST=unix:///var/run/docker.sock`) when reapplying so Docker builds continue to work under Kubernetes mode.
+- Runner workspace storage uses dynamic PVCs (60Gi) and must target an existing RWO StorageClass (currently `rook-ceph-block`).
 - Tailscale connectivity now comes from the node-level installation managed by OpenTofu (`tofu/harvester/main.tf`) and Ansible (`ansible/playbooks/install_tailscale.yml`); no sidecar or additional secret is required in the runner pods.
 - Generate the `github-token` SealedSecret with `scripts/generate-arc-github-token-secret.sh`. The script reads the token from 1Password via `${ARC_GITHUB_TOKEN_OP_PATH}` (defaults to `op://infra/github personal token/token`) and writes the sealed manifest to `argocd/applications/arc/github-token.yaml`.
 

--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -31,7 +31,7 @@ spec:
             type: "kubernetes"
             kubernetesModeWorkVolumeClaim:
               accessModes: ["ReadWriteOnce"]
-              storageClassName: "local-path"
+              storageClassName: "rook-ceph-block"
               resources:
                 requests:
                   storage: 60Gi
@@ -120,7 +120,7 @@ spec:
                     volumeClaimTemplate:
                       spec:
                         accessModes: ["ReadWriteOnce"]
-                        storageClassName: "local-path"
+                        storageClassName: "rook-ceph-block"
                         resources:
                           requests:
                             storage: 60Gi


### PR DESCRIPTION
## Summary

- Switch ARC runner workspace PVCs from nonexistent `local-path` StorageClass to `rook-ceph-block`.
- Document the StorageClass requirement for runner work volumes.


## Related Issues

None


## Testing

- Observed runner pods Pending with events `storageclass ... "local-path" not found`; after merge runners should start and register.

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

None


## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
