### PR TITLE
feat(argocd): enable froussard

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -238,7 +238,7 @@ spec:
                       - /spec/template/spec/containers/0/ports/0/protocol
                       - /spec/template/spec/containers/0/resources
                 automation: manual
-                enabled: "false"
+                enabled: "true"
               - name: reestr
                 path: argocd/applications/reestr
                 namespace: registry


### PR DESCRIPTION
## Summary

- Enabled the `froussard` Argo CD application in the Product ApplicationSet.
- Keeps existing sync wave and manual automation defaults.
- Validated Argo CD manifests with `scripts/kubeconform.sh argocd`.

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd`

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
