### PR TITLE
feat(argocd): enable jangar

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -108,7 +108,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
                 automation: manual
-                enabled: "false"
+                enabled: "true"
               - name: agents
                 path: argocd/applications/agents
                 namespace: agents


### PR DESCRIPTION
## Summary

- Enabled the `jangar` Argo CD application in the Product ApplicationSet (required by `froussard`).
- Validated Argo CD manifests with `scripts/kubeconform.sh argocd`.
- No other Product apps changed.

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd`

## Breaking Changes

None

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
