### PR TITLE
feat(cert-manager): use cloudflare dns01 for letsencrypt-prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ node_modules/
 .DS_Store
 kubernetes/kubeconfig
 kubeconfig
+token
+tok
 
 devices/ryzen/controlplane.yaml
 devices/ryzen/worker.yaml

--- a/argocd/applications/cert-manager/cloudflare-api-token-sealedsecret.yaml
+++ b/argocd/applications/cert-manager/cloudflare-api-token-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cloudflare-api-token
+  namespace: cert-manager
+spec:
+  encryptedData:
+    api-token: AgCsZJVsu3LY8GlvCfd5EPYzpzCuFA/DK8QHjSP5LLGxqDfVRgRwaAE/hAeDAkooM3CBZg0m7PnPfb4CtesAifgKzofpPbvBYeFPuay7X1L18Dw7NmmgI78CGpf90Q7Zh2H88ISsecp3Q30x7rh4pJbUJqpdlLdaEK4SyCxffxfyMtER0930n7B7SujkkDHAnMlZ6JB34UGZQSrs31Bs8cauzgNY4mnPS9XwoT8Hj+3EZv/30DLg/P4u27jd3Lwg92V4RKoES83/ZJ1N5Bge0c8FDJejzikxUHamAL64N06YwKJkjJ2JAmmQ3b5TlYnzxfIaHmiNJo4+CDGev6mvP36LEphknYrWUCEY0o3HyVlmG6Tnda0nTQKKpfzD+yQt5H3gZdEYh2F+lhh6IchYbkoiQU27L55M/dMkO7nr0vs4prHfJ1vcX33ARodXMB6yYHxixFKtPktQhQVxYhN1Z/PDQheY+DVLUYWB2FinF+6LMiFCQNSQwKFbnrZjWE4fgl/7iOtYzWDbwgRpJ+B0VLgHGOOtdrlW59pFBwZVh3k0222PF7uQI3hjfAH+PMJu45vp7xT0/3eI/zH/a3PmQu+H1EkcgN8/3xNqNigkuaicYOJtGz5kPaiB4fNfUZiu9d5D3yTF2tpwr7Yj9exMj4FLP1VRLXWOvLBalVs5fyxWAfZpFd4MYeOvTHezIXkDE1rCSqIc+vc9a+EshWrWHdQiCj3qcJ5LlUbkzo8X93JnUxZJ4mXYPaGQGw==
+  template:
+    metadata:
+      name: cloudflare-api-token
+      namespace: cert-manager

--- a/argocd/applications/cert-manager/cluster-issuer.yaml
+++ b/argocd/applications/cert-manager/cluster-issuer.yaml
@@ -9,14 +9,14 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-prod-account-key
     solvers:
-      - http01:
-          ingress:
-            ingressClassName: istio
-            podTemplate:
-              metadata:
-                annotations:
-                  sidecar.istio.io/inject: "false"
-              spec: {}
+      - selector:
+          dnsZones:
+            - proompteng.ai
+        dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
 
 ---
 apiVersion: cert-manager.io/v1

--- a/argocd/applications/cert-manager/kustomization.yaml
+++ b/argocd/applications/cert-manager/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: cert-manager
 resources:
   - cluster-issuer.yaml
+  - cloudflare-api-token-sealedsecret.yaml
 helmCharts:
   - name: cert-manager
     repo: https://charts.jetstack.io

--- a/argocd/applications/knative-serving/README.md
+++ b/argocd/applications/knative-serving/README.md
@@ -13,7 +13,7 @@ The integration uses the Let's Encrypt production issuer with HTTP01 challenges 
 - External Domain TLS: `Enabled` - Automatically provisions certificates for external domains via cert-manager
 - HTTP-01 Challenges: `httpProtocol` stays `Enabled` so Let's Encrypt can complete callbacks before Knative enforces HTTPS
 - Ingress: `Istio` - net-istio is explicitly enabled via `spec.ingress.istio.enabled`
-- ClusterIssuer: `letsencrypt-prod` - Uses Let's Encrypt production with HTTP01 challenges through Istio
+- ClusterIssuer: `letsencrypt-prod` - Uses Let's Encrypt production with DNS01 challenges via Cloudflare
 - Domain Template: `{{.Name}}.{{.Domain}}` - Routes render as single-level subdomains (e.g., `froussard.proompteng.ai`)
 
 **Reference:** [Knative cert-manager integration](https://knative.dev/docs/serving/encryption/configure-certmanager-integration/)


### PR DESCRIPTION
## Summary

- Switch letsencrypt-prod ClusterIssuer from HTTP-01 (Istio) to Cloudflare DNS-01 for proompteng.ai.
- Add a SealedSecret for the Cloudflare API token in cert-manager.
- Update Knative Serving docs to reflect DNS-01.

## Related Issues

Fixes Knative Route TLS provisioning getting stuck behind Cloudflare/NPM (HTTP-01 challenge 404).

## Testing

- scripts/kubeconform.sh argocd

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
