### PR TITLE
feat(argocd): enable argo-workflows

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -165,7 +165,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "3"
                 automation: manual
-                enabled: "false"
+                enabled: "true"
               - name: observability
                 path: argocd/applications/observability
                 namespace: observability


### PR DESCRIPTION
## Summary

- Enable the argo-workflows Argo CD application in the Platform ApplicationSet.
- This is required for Argo Events EventBus/Sensors used by froussard.

## Related Issues

Unblocks fro​​ussard Argo Events resources (EventBus default was stuck Progressing due to missing controllers).

## Testing

- scripts/kubeconform.sh argocd

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
