### PR TITLE
fix(argocd): give argo-workflows alloy a writable data dir

### DIFF
--- a/argocd/applications/argo-workflows/alloy-deployment.yaml
+++ b/argocd/applications/argo-workflows/alloy-deployment.yaml
@@ -25,6 +25,7 @@ spec:
           args:
             - run
             - /etc/alloy/config.river
+          workingDir: /var/lib/alloy
           ports:
             - name: http-metrics
               containerPort: 12345
@@ -48,6 +49,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/alloy
+            - name: data
+              mountPath: /var/lib/alloy
       volumes:
         - name: config
           configMap:
@@ -55,3 +58,5 @@ spec:
             items:
               - key: config.river
                 path: config.river
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
## Summary

- Mount a writable `emptyDir` at `/var/lib/alloy` for `argo-workflows-alloy`.
- Set `workingDir: /var/lib/alloy` so Alloy can create its `data-alloy` directory under PodSecurity constraints.

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd`

## Screenshots (if applicable)

Removed (not applicable).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
