### PR TITLE
fix(rook-ceph): use ceph-fuse for CephFS on Talos

### DIFF
--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -37,6 +37,8 @@ csi:
   enableRBDSnapshotter: true
   enableCephfsSnapshotter: true
   enableCSIHostNetwork: true
+  # Render `CSI_FORCE_CEPHFS_KERNEL_CLIENT: "false"` (Helm `with` blocks skip boolean false).
+  forceCephFSKernelClient: "false"
   provisionerReplicas: 2
   pluginPriorityClassName: system-node-critical
   provisionerPriorityClassName: system-cluster-critical


### PR DESCRIPTION
## Summary

- Configure Rook Ceph CSI to stop forcing the CephFS kernel client and use ceph-fuse on Talos nodes.

## Related Issues

None

## Testing

- Rendered manifests locally: `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph` (via a temp dir excluding vendored charts) and verified `CSI_FORCE_CEPHFS_KERNEL_CLIENT: "false"` is present.

## Breaking Changes

None
