### PR TITLE
fix(rook-ceph): use fuse mounter for cephfs on talos

### DIFF
--- a/argocd/applications/rook-ceph/storageclasses.yaml
+++ b/argocd/applications/rook-ceph/storageclasses.yaml
@@ -61,6 +61,8 @@ volumeBindingMode: Immediate
 parameters:
   clusterID: rook-ceph
   fsName: cephfs
+  # Talos nodes do not ship the kernel ceph module; force userspace mounts.
+  mounter: fuse
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
   csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner


### PR DESCRIPTION
## Summary

- Force CephFS mounts to use the CSI `fuse` mounter so RWX volumes work on Talos (no kernel `ceph` module).

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd`

## Screenshots (if applicable)

Removed (not applicable).

## Breaking Changes

- Existing CephFS PVs provisioned with the kernel mounter may still fail to mount; recreate affected PVCs so new PVs inherit `mounter: fuse`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
