### PR TITLE
fix(rook-ceph): replace cephfs storageclass to apply fuse mounter

### DIFF
--- a/argocd/applications/rook-ceph/storageclasses.yaml
+++ b/argocd/applications/rook-ceph/storageclasses.yaml
@@ -54,6 +54,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: rook-cephfs
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 provisioner: rook-ceph.cephfs.csi.ceph.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete


### PR DESCRIPTION
## Summary

- Add `argocd.argoproj.io/sync-options: Replace=true` to the `rook-cephfs` StorageClass so Argo CD can apply immutable `parameters` updates (Talos requires `mounter: fuse`).

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd`

## Screenshots (if applicable)

Removed (not applicable).

## Breaking Changes

- Existing CephFS PVs may still be using the kernel mounter; recreate affected PVCs to pick up the updated StorageClass parameters.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
