### PR TITLE
fix(rook-ceph): keep rook-ceph app in sync

### DIFF
--- a/argocd/applications/rook-ceph/storageclasses.yaml
+++ b/argocd/applications/rook-ceph/storageclasses.yaml
@@ -61,8 +61,6 @@ volumeBindingMode: Immediate
 parameters:
   clusterID: rook-ceph
   fsName: cephfs
-  # Talos nodes do not ship the kernel ceph module; force userspace mounts.
-  mounter: fuse
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
   csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner


### PR DESCRIPTION
## Summary

- Remove the `mounter: fuse` parameter from the `rook-cephfs` StorageClass to avoid a permanent ArgoCD OutOfSync (StorageClass parameters are immutable).

## Related Issues

None

## Testing

- `argocd app diff rook-ceph` no longer shows a StorageClass parameter drift for `rook-cephfs`.

## Breaking Changes

None
