### PR TITLE
fix(tailscale): label namespace privileged for proxy pods

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -96,6 +96,11 @@ spec:
                   namespace: tailscale
                   annotations:
                     argocd.argoproj.io/sync-wave: "0"
+                  managedNamespaceMetadata:
+                    labels:
+                      pod-security.kubernetes.io/enforce: privileged
+                      pod-security.kubernetes.io/audit: privileged
+                      pod-security.kubernetes.io/warn: privileged
                   automation: auto
                   enabled: "true"
                 - name: registry


### PR DESCRIPTION
## Summary

- Label `tailscale` namespace with PodSecurityAdmission `privileged` via ApplicationSet managed namespace metadata.
- Unblocks Tailscale k8s-operator proxy StatefulSets (e.g. `ts-jangar-*`) which require privileged containers.
- Fixes Tailscale device/hostname not appearing (and DNS not resolving) when exposing Services via `tailscale.com/hostname`.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Verified current failure mode pre-fix: `kubectl -n tailscale describe sts ts-jangar-tailscale-7fhzf` showed `FailedCreate ... violates PodSecurity baseline:latest: privileged`.

## Screenshots (if applicable)

Removed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
