### PR TITLE
fix(tailscale): label namespace privileged for proxy pods

### DIFF
--- a/argocd/applications/tailscale/kustomization.yaml
+++ b/argocd/applications/tailscale/kustomization.yaml
@@ -13,6 +13,17 @@ images:
 
 patches:
   - target:
+      version: v1
+      kind: Namespace
+      name: tailscale
+    patch: |-
+      - op: add
+        path: /metadata/labels
+        value:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/warn: privileged
+  - target:
       group: rbac.authorization.k8s.io
       version: v1
       kind: ClusterRole


### PR DESCRIPTION
## Summary

- Patch the upstream Tailscale k8s-operator `Namespace/tailscale` to include PodSecurityAdmission labels (`privileged`).
- Unblocks creation of `ts-*` proxy pods (e.g. `ts-jangar-*`) which currently fail with `violates PodSecurity baseline:latest: privileged`.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Verified pre-fix failure: `kubectl -n tailscale describe sts ts-jangar-tailscale-7fhzf` shows `FailedCreate ... violates PodSecurity baseline:latest: privileged`.

## Screenshots (if applicable)

Removed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
