### PR TITLE
fix(torghut): update lean-runner image digest

### DIFF
--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -22,7 +22,8 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: lean-runner
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cb6828a896a7af4d9041b3cb46640cd06378633c76a3e13e0daed6d11795a860
+          # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:073dcbf3ea4875f9201d57ecce97ffdc70e130bdac5ca7ea4880277b9b9a86fa
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary

<!-- 3-5 concise bullets describing what changed. -->
- 
- 
- 

## Related Issues

<!-- Reference issues with closes/fixes/resolves keywords. Write `None` if no issue. -->

## Testing

<!-- List each command or manual step used to verify the change. Use `N/A` only when nothing could be tested. -->
- 

## Screenshots (if applicable)

<!-- Describe or attach images/GIFs that demonstrate the change. Delete this section if not applicable. -->

## Breaking Changes

<!-- State `None` or explain required migrations, deprecations, or follow-up actions. -->

## Checklist

- [ ] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [ ] Documentation, release notes, and follow-ups are updated or tracked.

## Summary
- Fix `torghut-lean-runner` ImagePullBackOff by updating the torghut image digest.

## Validation
- Observed `torghut-lean-runner` failing with `...: not found` for the previous digest.
- This updates the digest to match the currently deployed torghut backend image.
