### PR TITLE
fix(argocd): enable agents application

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -114,8 +114,8 @@ spec:
                 namespace: agents
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
-                automation: manual
-                enabled: "false"
+                automation: auto
+                enabled: "true"
               - name: agents-ci
                 path: argocd/applications/agents-ci
                 namespace: agents-ci


### PR DESCRIPTION
## Summary

- Enable the `agents` Argo CD application in the `product` ApplicationSet.
- Switch the `agents` app to automated sync to keep it reconciled.
- No functional changes outside Argo CD app enablement.

## Related Issues

None

## Testing

- N/A (GitOps-only change; validated post-merge via Argo CD health)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
