### PR TITLE
fix(agents): wire github token secret

### DIFF
--- a/argocd/applications/agents/codex-research-secretbinding.yaml
+++ b/argocd/applications/agents/codex-research-secretbinding.yaml
@@ -7,4 +7,4 @@ spec:
     - kind: Agent
       name: codex-research-agent
   allowedSecrets:
-    - codex-github-token
+    - github-token

--- a/argocd/applications/agents/codex-secretbinding.yaml
+++ b/argocd/applications/agents/codex-secretbinding.yaml
@@ -7,4 +7,4 @@ spec:
     - kind: Agent
       name: codex-agent
   allowedSecrets:
-    - codex-github-token
+    - github-token

--- a/argocd/applications/agents/codex-versioncontrolprovider.yaml
+++ b/argocd/applications/agents/codex-versioncontrolprovider.yaml
@@ -11,7 +11,7 @@ spec:
     method: token
     token:
       secretRef:
-        name: codex-github-token
+        name: github-token
         key: token
   repositoryPolicy:
     allow:

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -54,5 +54,8 @@ env:
     JANGAR_GRPC_PORT: "50051"
     JANGAR_GITHUB_REPOS_ALLOWED: proompteng/lab
     JANGAR_AGENTS_CONTROLLER_REPO_CONCURRENCY_OVERRIDES: "{}"
-envFromSecretRefs:
-  - agents-github-token-env
+  secrets:
+    - name: GITHUB_TOKEN
+      secretName: github-token
+      key: token
+envFromSecretRefs: []

--- a/argocd/applications/jangar/github-token.yaml
+++ b/argocd/applications/jangar/github-token.yaml
@@ -15,6 +15,6 @@ spec:
       namespace: jangar
       annotations:
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "argo-workflows,froussard"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "agents,argo-workflows,froussard"
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "argo-workflows,froussard"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "agents,argo-workflows,froussard"


### PR DESCRIPTION
## Summary

- Reflect the existing SealedSecret `github-token` into the `agents` namespace.
- Wire `agents` deployments to read `GITHUB_TOKEN` from the reflected `github-token` Secret.
- Update the Agents `VersionControlProvider` + SecretBindings to reference `github-token`.

## Related Issues

None

## Testing

- N/A (GitOps-only change; validated post-merge via Argo CD app health + pod status)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
