### PR TITLE
fix(jangar): reflect db secrets to agents

### DIFF
--- a/argocd/applications/jangar/postgres-cluster.yaml
+++ b/argocd/applications/jangar/postgres-cluster.yaml
@@ -32,9 +32,9 @@ spec:
   inheritedMetadata:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "pgadmin"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "agents,pgadmin"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "pgadmin"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "agents,pgadmin"
   monitoring:
     enablePodMonitor: true
 # CNPG defaults generate application credentials in `jangar-db-app` (uri, user, password, host, port, dbname)


### PR DESCRIPTION
## Summary

- Allow CNPG-generated `jangar-db-*` secrets to be auto-reflected into the `agents` namespace.
- Unblock the `agents` Argo CD application from failing on missing `jangar-db-app`.
- Keep existing reflection behavior for `pgadmin`.

## Related Issues

None

## Testing

- N/A (GitOps-only change; validated post-merge via secret reflection + pod readiness)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
