### PR TITLE
chore(pgadmin): bump to 9.12 and include app-db secret

### DIFF
--- a/argocd/applications/pgadmin/values.yaml
+++ b/argocd/applications/pgadmin/values.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: pgadmin
 
 image:
-  tag: "9.11"
+  tag: "9.12"
 
 service:
   type: ClusterIP
@@ -84,6 +84,14 @@ extraVolumes:
               - key: password
                 path: cms-db-app/password
         - secret:
+            name: app-db-app
+            optional: true
+            items:
+              - key: uri
+                path: app-db-app/uri
+              - key: password
+                path: app-db-app/password
+        - secret:
             name: jangar-db-app
             optional: true
             items:
@@ -160,6 +168,7 @@ extraInitContainers: |
             {'secret': 'coder-cluster-app', 'name': 'coder-cluster'},
             {'secret': 'convex-db-app', 'name': 'convex-db'},
             {'secret': 'cms-db-app', 'name': 'cms-db'},
+            {'secret': 'app-db-app', 'name': 'app-db'},
             {'secret': 'jangar-db-app', 'name': 'jangar-db'},
             {'secret': 'golink-db-app', 'name': 'golink-db'},
             {'secret': 'facteur-vector-cluster-app', 'name': 'facteur-vector-cluster'},


### PR DESCRIPTION
## Summary

- Bump pgAdmin image to 9.12.
- Mount the reflected CNPG Secret `app-db-app` (uri/password) in the pgAdmin pod.
- Provision the `app-db` server entry in pgAdmin's generated `servers.json` and `pgpass`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/pgadmin`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
