### PR TITLE
chore(argocd): enable app/docs/proompteng

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -3,6 +3,8 @@
 This is a Next.js application generated with
 [Create Fumadocs](https://github.com/fuma-nama/fumadocs).
 
+Deployment: changes under `apps/docs/**` (or `packages/design/**`) merged to `main` trigger a Docker build and an Argo CD Image Updater PR that bumps `argocd/applications/docs/kustomization.yaml`.
+
 Run development server:
 
 ```bash

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -2,6 +2,8 @@
 
 This app now expects the shared Convex backend in `packages/backend`.
 
+Deployment: changes under `apps/landing/**` (or `packages/design/**`) merged to `main` trigger a Docker build and an Argo CD Image Updater PR that bumps `argocd/applications/proompteng/kustomization.yaml`.
+
 ## Local setup
 
 1. Configure Convex once:

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -23,7 +23,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "5"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: app
                 path: argocd/applications/app
                 namespace: app
@@ -31,7 +31,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "5"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: cms
                 path: argocd/applications/cms
                 namespace: cms
@@ -47,7 +47,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "5"
                 automation: auto
-                enabled: "false"
+                enabled: "true"
               - name: homepage
                 path: argocd/applications/homepage
                 namespace: homepage


### PR DESCRIPTION
## Summary

- Enable Argo CD product apps: `proompteng` (landing), `docs`, and `app`.
- Add a tiny docs/landing README note to ensure the Docker build + Argo CD Image Updater flow is triggered on merge.

## Related Issues

None

## Testing

- N/A (config-only enablement; runtime verification happens via Argo CD sync/health after merge)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
