### PR TITLE
chore(argocd): bump app/docs/proompteng images to 0.552.1

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    newTag: 0.550.1
+    newTag: 0.552.1
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - ingressroute.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    newTag: 0.550.1
+    newTag: 0.552.1
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  newTag: 0.550.1
+  newTag: 0.552.1
   newName: registry.ide-newton.ts.net/lab/proompteng


### PR DESCRIPTION
## Summary

- Bump Argo CD kustomization image tags for `app`, `docs`, and `proompteng` to `0.552.1`.

## Related Issues

None

## Testing

- Verified the images exist in `registry.ide-newton.ts.net`:
  - `registry.ide-newton.ts.net/lab/app:0.552.1`
  - `registry.ide-newton.ts.net/lab/docs:0.552.1`
  - `registry.ide-newton.ts.net/lab/proompteng:0.552.1`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
