### PR TITLE
fix(gpu): enable vfio passthrough on arm64

### DIFF
--- a/argocd/applications/kubevirt/kustomization.yaml
+++ b/argocd/applications/kubevirt/kustomization.yaml
@@ -19,8 +19,13 @@ patches:
           argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       spec:
         configuration:
+          developerConfiguration:
+            featureGates:
+              - GPU
           permittedHostDevices:
             pciHostDevices:
               - pciVendorSelector: "10DE:2204"
                 resourceName: "nvidia.com/GA102_GEFORCE_RTX_3090"
-                externalResourceProvider: true
+                # On ARM Talos nodes, NVIDIA's KubeVirt sandbox device plugin isn't available.
+                # KubeVirt's built-in device-plugin exposes this resource instead.
+                externalResourceProvider: false

--- a/argocd/applications/nvidia-gpu-operator/values.yaml
+++ b/argocd/applications/nvidia-gpu-operator/values.yaml
@@ -1,5 +1,29 @@
-# KubeVirt VM passthrough mode: installs VFIO manager + sandbox device plugin.
-# Node selection happens via `nvidia.com/gpu.workload.config=vm-passthrough` label.
+# KubeVirt VM passthrough mode:
+# - Talos does not support GPU Operator installing host drivers/toolkit.
+# - NVIDIA's KubeVirt sandbox device plugin image is amd64-only, but our GPU node (`altra`) is arm64.
+# We still use the GPU Operator for VFIO binding, and rely on KubeVirt's built-in device-plugin
+# (externalResourceProvider=false in the KubeVirt CR) to advertise the passthrough resource.
 sandboxWorkloads:
   enabled: true
 
+operator:
+  # Talos uses containerd.
+  defaultRuntime: containerd
+
+# Do not attempt to install host NVIDIA drivers/toolkit on Talos.
+driver:
+  enabled: false
+
+toolkit:
+  enabled: false
+
+# No container workloads use the GPU on the host.
+devicePlugin:
+  enabled: false
+
+# This image is amd64-only; disable it on arm64 nodes.
+sandboxDevicePlugin:
+  enabled: false
+
+vfioManager:
+  enabled: true

--- a/devices/altra/docs/cluster-bootstrap.md
+++ b/devices/altra/docs/cluster-bootstrap.md
@@ -71,6 +71,7 @@ talosctl apply-config --insecure -n "$ALTRA_IP" -e "$ALTRA_IP" \
   --config-patch @devices/altra/manifests/install-nvme0n1.patch.yaml \
   --config-patch @devices/altra/manifests/ephemeral-volume.patch.yaml \
   --config-patch @devices/altra/manifests/local-path.patch.yaml \
+  --config-patch @devices/altra/manifests/vfio-modules.patch.yaml \
   --config-patch @devices/altra/manifests/allow-scheduling-controlplane.patch.yaml \
   --config-patch @devices/altra/manifests/controlplane-endpoint-nuc.patch.yaml \
   --mode=reboot
@@ -79,6 +80,9 @@ talosctl apply-config --insecure -n "$ALTRA_IP" -e "$ALTRA_IP" \
 Note:
 - The IP can change after reboot/install (DHCP). Use console/KVM to confirm the
   post-install IP if `talosctl` can’t connect.
+ - `devices/altra/manifests/vfio-modules.patch.yaml` is required for KubeVirt GPU
+   passthrough on Talos (it preloads `vfio_pci` so the GPU Operator VFIO manager
+   can bind the GPU without `modprobe` privileges).
 
 ## 3) Update local Talos config to include all 3 nodes
 

--- a/devices/altra/manifests/README.md
+++ b/devices/altra/manifests/README.md
@@ -9,3 +9,4 @@ Files:
 - `devices/altra/manifests/controlplane-endpoint-nuc.patch.yaml`
 - `devices/altra/manifests/ephemeral-volume.patch.yaml`
 - `devices/altra/manifests/local-path.patch.yaml`
+- `devices/altra/manifests/vfio-modules.patch.yaml`

--- a/devices/altra/manifests/vfio-modules.patch.yaml
+++ b/devices/altra/manifests/vfio-modules.patch.yaml
@@ -1,0 +1,7 @@
+machine:
+  kernel:
+    modules:
+      - name: vfio
+      - name: vfio_iommu_type1
+      - name: vfio_pci
+      - name: irqbypass

--- a/docs/jangar/self-hosted-model-kubevirt-talos.md
+++ b/docs/jangar/self-hosted-model-kubevirt-talos.md
@@ -27,8 +27,8 @@ Goal: run the embeddings model in a KubeVirt VM scheduled onto the Talos node `a
 
 1. Talos node `altra` provides the physical GPU.
 2. KubeVirt runs a VM (“model VM”) on Kubernetes.
-3. NVIDIA GPU Operator provisions the node for VM passthrough (VFIO manager binds GPUs to `vfio-pci`; sandbox device plugin advertises passthrough devices to kubelet; node label `nvidia.com/gpu.workload.config=vm-passthrough` selects the mode).
-4. KubeVirt is configured to permit the passthrough resource via `KubeVirt.spec.configuration.permittedHostDevices.pciHostDevices` with `externalResourceProvider: true`.
+3. NVIDIA GPU Operator provisions the node for VM passthrough (VFIO manager binds GPUs to `vfio-pci`; node label `nvidia.com/gpu.workload.config=vm-passthrough` selects the mode).
+4. KubeVirt advertises and permits the passthrough resource via `KubeVirt.spec.configuration.permittedHostDevices.pciHostDevices` (KubeVirt's built-in device-plugin; `externalResourceProvider: false`).
 5. The VM runs Ubuntu and exposes the Saigak proxy (`:11434`) on the pod network.
 6. A Kubernetes `Service` targets the VM launcher pod so cluster workloads can reach `http://<svc>:11434/v1`.
 7. Jangar uses that service as `OPENAI_API_BASE_URL`, with the embeddings model `qwen3-embedding-saigak:0.6b` (1024d).
@@ -64,8 +64,8 @@ Goal: run the embeddings model in a KubeVirt VM scheduled onto the Talos node `a
 
 1. Ensure Talos config enables IOMMU and required modules for VFIO (exact kernel args depend on platform).
 2. Label the node `altra` for GPU Operator mode: `nvidia.com/gpu.workload.config=vm-passthrough`.
-3. Deploy NVIDIA GPU Operator configured for KubeVirt passthrough (VFIO manager and sandbox device plugin enabled).
-4. Verify kubelet advertises the passthrough resource on `altra`.
+3. Deploy NVIDIA GPU Operator configured for KubeVirt passthrough (VFIO manager enabled).
+4. Verify kubelet advertises the passthrough resource on `altra` (via KubeVirt's built-in device-plugin).
 
 Notes:
 1. For VM passthrough, the host typically uses `vfio-pci`, not the NVIDIA datacenter driver.


### PR DESCRIPTION
## Summary

- Configure KubeVirt to use its built-in device-plugin for GPU passthrough on arm64 (`externalResourceProvider: false`) and enable the `GPU` feature gate.
- Adjust NVIDIA GPU Operator values for Talos VM passthrough: disable driver/toolkit/device plugin/sandbox device plugin; keep VFIO manager; set runtime to `containerd`.
- Add and document a Talos patch to preload VFIO kernel modules on `altra`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/nvidia-gpu-operator > /tmp/kustomize-nvidia.yaml`
- `kustomize build argocd/applications/kubevirt > /tmp/kustomize-kubevirt.yaml`
- Verified `vfio_pci` is loaded and GPU is bound to `vfio-pci` on `altra`:
  - `talosctl read -n 192.168.1.85 -e 192.168.1.85 /proc/modules | rg '^vfio_pci '` 
  - `talosctl read -n 192.168.1.85 -e 192.168.1.85 /sys/bus/pci/devices/000c:01:00.0/uevent | rg 'DRIVER=vfio-pci'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation and follow-ups are updated.
