### PR TITLE
fix(argocd): keep namespaces owned by applicationsets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,8 @@ Output:
 - Do not edit generated directories (`dist/`, `build/`, `_generated`) or lockfiles (`bun.lock`, `bun.lockb`); regenerate via the owning tool.
 - Default to GitOps (edit `argocd/` manifests and let Argo CD sync). Only apply directly to the cluster when explicitly asked or in an emergency, and document the deviation.
 - Argo CD apps under `argocd/applications/**` should not include `Namespace` manifests; namespaces are created via ApplicationSet `CreateNamespace=true` and `managedNamespaceMetadata` (Pod Security labels, etc).
+  - Upstream remote bases/releases often include `Namespace` objects; drop them from the rendered output (Kustomize `patches` with `$patch: delete`) so Argo applies namespace metadata from the ApplicationSet instead of owning the Namespace resource.
+  - `$patch: delete` removes the object from Kustomize output; it does not delete the live Namespace (the only risk is Argo prune, so avoid pruning Namespaces or set `argocd.argoproj.io/sync-options: Prune=false` on the Namespace via `managedNamespaceMetadata.annotations`).
 - Avoid introducing deprecated Kubernetes/KubeVirt features in new manifests; if a component warns a field/feature gate is deprecated, remove it unless there is a documented requirement.
 - Talos machine configs: do not define multiple `machine.files` entries with the same `path`. Talos will fail `writeUserFiles` with `resource ... already exists`, which prevents CRI/Kubelet from coming up (often surfacing as `/etc/kubernetes/bootstrap-kubeconfig: read-only file system`). Multi-document machine configs are hard to surgically edit via patches; prefer generating/applying a corrected full config via `talosctl apply-config` if you need to remove a duplicate entry.
 

--- a/argocd/applications/cdi/kustomization.yaml
+++ b/argocd/applications/cdi/kustomization.yaml
@@ -5,3 +5,14 @@ namespace: cdi
 resources:
   - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.64.0/cdi-operator.yaml
   - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.64.0/cdi-cr.yaml
+
+patches:
+  - target:
+      kind: Namespace
+      name: cdi
+    patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: cdi
+      $patch: delete

--- a/argocd/applications/kubevirt/kustomization.yaml
+++ b/argocd/applications/kubevirt/kustomization.yaml
@@ -7,6 +7,15 @@ resources:
   - https://github.com/kubevirt/kubevirt/releases/download/v1.7.0/kubevirt-cr.yaml
 patches:
   - target:
+      kind: Namespace
+      name: kubevirt
+    patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: kubevirt
+      $patch: delete
+  - target:
       kind: KubeVirt
       name: kubevirt
     patch: |-

--- a/argocd/applications/local-path/kustomization.yaml
+++ b/argocd/applications/local-path/kustomization.yaml
@@ -5,6 +5,15 @@ resources:
   - github.com/rancher/local-path-provisioner/deploy?ref=v0.0.34
 patches:
   - target:
+      kind: Namespace
+      name: local-path-storage
+    patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: local-path-storage
+      $patch: delete
+  - target:
       kind: ConfigMap
       name: local-path-config
       namespace: local-path-storage

--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -77,6 +77,9 @@ spec:
                       pod-security.kubernetes.io/enforce: privileged
                       pod-security.kubernetes.io/audit: privileged
                       pod-security.kubernetes.io/warn: privileged
+                    annotations:
+                      # Prevent accidental namespace deletion when an app stops managing the Namespace object.
+                      argocd.argoproj.io/sync-options: Prune=false
                 - name: metallb-system
                   path: argocd/applications/metallb-system
                   namespace: metallb-system

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -49,6 +49,9 @@ spec:
                     pod-security.kubernetes.io/enforce: privileged
                     pod-security.kubernetes.io/audit: privileged
                     pod-security.kubernetes.io/warn: privileged
+                  annotations:
+                    # Prevent accidental namespace deletion when an app stops managing the Namespace object.
+                    argocd.argoproj.io/sync-options: Prune=false
               - name: cdi
                 path: argocd/applications/cdi
                 namespace: cdi
@@ -61,6 +64,9 @@ spec:
                     pod-security.kubernetes.io/enforce: privileged
                     pod-security.kubernetes.io/audit: privileged
                     pod-security.kubernetes.io/warn: privileged
+                  annotations:
+                    # Prevent accidental namespace deletion when an app stops managing the Namespace object.
+                    argocd.argoproj.io/sync-options: Prune=false
               - name: nvidia-gpu-operator
                 path: argocd/applications/nvidia-gpu-operator
                 namespace: gpu-operator


### PR DESCRIPTION
## Summary

- Remove upstream `Namespace` objects from the rendered manifests for `local-path`, `kubevirt`, and `cdi` so ApplicationSets own namespace creation/labels.
- Add `Prune=false` on those namespaces via `managedNamespaceMetadata.annotations` to prevent accidental namespace deletion.
- Clarify the namespace ownership rule in `AGENTS.md` (upstream namespaces should be dropped from Kustomize output).

## Related Issues

None

## Testing

- `kustomize build argocd/applications/local-path | rg '^kind: Namespace$'` (expects no output)
- `kustomize build argocd/applications/kubevirt | rg '^kind: Namespace$'` (expects no output)
- `kustomize build argocd/applications/cdi | rg '^kind: Namespace$'` (expects no output)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
