### PR TITLE
fix(local-path): per-node storage paths

### DIFF
--- a/argocd/applications/local-path/patches/local-path-config.patch.yaml
+++ b/argocd/applications/local-path/patches/local-path-config.patch.yaml
@@ -8,8 +8,12 @@ data:
     {
       "nodePathMap":[
         {
-          "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+          "node":"talos-192-168-1-194",
           "paths":["/var/mnt/local-path-provisioner"]
+        },
+        {
+          "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+          "paths":["/var/local-path-provisioner"]
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Configure local-path provisioner to use per-node base paths.
- Keep Ryzen (`talos-192-168-1-194`) on the dedicated Talos user volume mount (`/var/mnt/local-path-provisioner`).
- Use `/var/local-path-provisioner` for nodes without that user volume mount (prevents provisioning failures on those nodes).

## Related Issues

None

## Testing

- `kustomize build argocd/applications/local-path | rg 'nodePathMap' -A12`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
