### PR TITLE
fix(saigak): make VM bootstrap reproducible

### DIFF
--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -17,11 +17,11 @@ stringData:
         layout: true
         overwrite: false
     fs_setup:
-      - device: /dev/vdb
+      - device: /dev/vdb1
         filesystem: ext4
         overwrite: false
     mounts:
-      - ["/dev/vdb", "/var/lib/ollama", "ext4", "defaults,nofail", "0", "2"]
+      - ["/dev/vdb1", "/var/lib/ollama", "ext4", "defaults,nofail", "0", "2"]
     packages:
       - openssh-server
       - ca-certificates
@@ -29,6 +29,7 @@ stringData:
       - git
       - jq
       - gnupg
+      - cuda-drivers
     write_files:
       - path: /etc/systemd/system/ollama.service.d/99-saigak.conf
         owner: root:root
@@ -66,11 +67,13 @@ stringData:
     disable_root: true
     runcmd:
       - [ bash, -lc, 'systemctl enable --now ssh' ]
+      - [ bash, -lc, 'for i in $(seq 1 30); do if nvidia-smi -L; then exit 0; fi; sleep 2; done; echo \"nvidia-smi did not become ready\" >&2; exit 1' ]
       - [ bash, -lc, 'curl -fsSL https://ollama.com/install.sh | sh' ]
+      - [ bash, -lc, 'systemctl stop ollama || true' ]
       - [ bash, -lc, 'mkdir -p /etc/systemd/system/ollama.service.d' ]
+      - [ bash, -lc, 'id ollama >/dev/null 2>&1 && chown -R ollama:ollama /var/lib/ollama || true' ]
       - [ bash, -lc, 'systemctl daemon-reload' ]
       - [ bash, -lc, 'systemctl enable --now ollama' ]
-      - [ bash, -lc, 'systemctl restart ollama' ]
       - [ bash, -lc, 'sleep 2' ]
       - [ bash, -lc, 'curl -fsS http://127.0.0.1:11434/api/version' ]
       - [ bash, -lc, 'ollama pull qwen3-embedding:0.6b' ]


### PR DESCRIPTION
## Summary

- Make `saigak` VM cloud-init reproducible: install guest `cuda-drivers`, validate `nvidia-smi`, mount `/var/lib/ollama` from `/dev/vdb1`, and ensure the mountpoint is writable by the `ollama` user.
- Update the runbook to match the actual VM bootstrap path and document the `/var/lib/ollama` permission failure mode and `virtctl ssh` debug workflow.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None
