### PR TITLE
fix(jangar): point OpenWebUI at saigak

### DIFF
--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -2,7 +2,7 @@ ollama:
   enabled: false
 
 ollamaUrls:
-  - http://192.168.1.190:11434
+  - http://saigak.saigak.svc.cluster.local:11434
 
 pipelines:
   enabled: false
@@ -47,7 +47,7 @@ extraEnvVars:
   - name: AIOHTTP_CLIENT_SESSION_SSL
     value: "false"
   - name: DEFAULT_MODELS
-    value: meta-orchestrator
+    value: gpt-5.3-codex
   - name: WEBUI_AUTH
     value: "false"
   - name: ENABLE_SIGNUP


### PR DESCRIPTION
## Summary

- Update OpenWebUI Helm values to use the in-cluster `saigak` service for Ollama-compatible calls (`ollamaUrls`).
- Align OpenWebUI default model to a model actually exposed by Jangar's OpenAI gateway (`gpt-5.3-codex`).

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
