### PR TITLE
fix(torghut): point self-hosted LLM fallback at saigak

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -141,7 +141,7 @@ spec:
             - name: LLM_ADJUSTMENT_APPROVED
               value: "false"
             - name: LLM_SELF_HOSTED_BASE_URL
-              value: http://192.168.1.190:11434/v1
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: LLM_SELF_HOSTED_MODEL
               value: qwen3-coder-saigak:30b-a3b-q4_K_M
             - name: TA_CLICKHOUSE_URL


### PR DESCRIPTION
## Summary

- Point Torghut `LLM_SELF_HOSTED_BASE_URL` at the in-cluster `saigak` service instead of the old `192.168.1.190` endpoint.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
