### PR TITLE
fix(gitops): sweep saigak endpoints and namespaces

### DIFF
--- a/argocd/applications/argo-workflows/jangar-embeddings-config.yaml
+++ b/argocd/applications/argo-workflows/jangar-embeddings-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jangar-embeddings-config
   namespace: argo-workflows
 data:
-  openaiApiBaseUrl: http://192.168.1.190:11434/v1
+  openaiApiBaseUrl: http://saigak.saigak.svc.cluster.local:11434/v1
   openaiEmbeddingModel: qwen3-embedding-saigak:0.6b
   openaiEmbeddingDimension: "1024"
   openaiEmbeddingTimeoutMs: "15000"

--- a/argocd/applications/argocd/base/namespace.yaml
+++ b/argocd/applications/argocd/base/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: argocd

--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -10,7 +10,6 @@ configMapGenerator:
       disableNameSuffixHash: true
 resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.0/manifests/ha/install.yaml
-  - base/namespace.yaml
   - base/ingressroute.yaml
   - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/v1.1.0/config/install.yaml
   - base/secrets.yaml

--- a/argocd/applications/argocd/overlays/argocd-image-updater-namespace-delete.yaml
+++ b/argocd/applications/argocd/overlays/argocd-image-updater-namespace-delete.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: argocd-image-updater-system
-$patch: delete

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -112,7 +112,7 @@ spec:
             - name: PGSSLMODE
               value: require
             - name: OPENAI_API_BASE_URL
-              value: http://192.168.1.190:11434/v1
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_COMPLETION_MODEL
               value: qwen3-coder-saigak:30b-a3b-q4_K_M
             - name: OPENAI_COMPLETION_MAX_ATTEMPTS
@@ -134,7 +134,7 @@ spec:
             - name: OPENAI_EMBEDDING_DIMENSION
               value: "1024"
             - name: OPENAI_EMBEDDING_API_BASE_URL
-              value: http://192.168.1.190:11434/api
+              value: http://saigak.saigak.svc.cluster.local:11434/api
             - name: OPENAI_EMBEDDING_BATCH_SIZE
               value: "32"
             - name: OPENAI_EMBEDDING_KEEP_ALIVE

--- a/argocd/applications/kitty-krew/overlays/dev/kustomization.yaml
+++ b/argocd/applications/kitty-krew/overlays/dev/kustomization.yaml
@@ -3,12 +3,11 @@ kind: Kustomization
 
 resources:
   - ../../base
-  - namespace.yaml
   - serviceaccount.yaml
   - clusterrole.yaml
   - clusterrolebinding.yaml
 
-namespace: kitty-krew-dev
+namespace: kitty-krew
 
 patches:
   - path: configmap.yaml

--- a/argocd/applications/kitty-krew/overlays/dev/namespace.yaml
+++ b/argocd/applications/kitty-krew/overlays/dev/namespace.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kitty-krew-dev
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-  labels:
-    app.kubernetes.io/part-of: kitty-krew
-    environment: development

--- a/argocd/applications/tailscale/kustomization.yaml
+++ b/argocd/applications/tailscale/kustomization.yaml
@@ -13,16 +13,14 @@ images:
 
 patches:
   - target:
-      version: v1
       kind: Namespace
       name: tailscale
     patch: |-
-      - op: add
-        path: /metadata/labels
-        value:
-          pod-security.kubernetes.io/enforce: privileged
-          pod-security.kubernetes.io/audit: privileged
-          pod-security.kubernetes.io/warn: privileged
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: tailscale
+      $patch: delete
   - target:
       group: rbac.authorization.k8s.io
       version: v1

--- a/argocd/applications/tigresse/kustomization.yaml
+++ b/argocd/applications/tigresse/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tigresse-system
 resources:
-  - namespace.yaml
   - serviceaccount.yaml
   - role.yaml
   - rolebinding.yaml

--- a/argocd/applications/tigresse/namespace.yaml
+++ b/argocd/applications/tigresse/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: tigresse-system
-  labels:
-    app.kubernetes.io/name: tigresse
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/managed-by: argocd

--- a/argocd/applications/traefik/kustomization.yaml
+++ b/argocd/applications/traefik/kustomization.yaml
@@ -3,8 +3,6 @@ kind: Kustomization
 namespace: traefik
 
 resources:
-  - namespace.yaml
-
 helmCharts:
   - name: traefik
     repo: https://traefik.github.io/charts
@@ -13,4 +11,3 @@ helmCharts:
     namespace: traefik
     includeCRDs: true
     valuesFile: values.yaml
-

--- a/argocd/applications/traefik/namespace.yaml
+++ b/argocd/applications/traefik/namespace.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: traefik
-

--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -23,6 +23,10 @@ spec:
                     argocd.argoproj.io/sync-wave: "-2"
                   automation: manual
                   enabled: "true"
+                  managedNamespaceMetadata:
+                    annotations:
+                      # Prevent accidental namespace deletion when an app stops managing the Namespace object.
+                      argocd.argoproj.io/sync-options: Prune=false
                 - name: sealed-secrets
                   path: argocd/applications/sealed-secrets
                   namespace: sealed-secrets
@@ -94,6 +98,10 @@ spec:
                     argocd.argoproj.io/sync-wave: "1"
                   automation: auto
                   enabled: "true"
+                  managedNamespaceMetadata:
+                    annotations:
+                      # Prevent accidental namespace deletion when an app stops managing the Namespace object.
+                      argocd.argoproj.io/sync-options: Prune=false
                 - name: tailscale
                   path: argocd/applications/tailscale
                   namespace: tailscale
@@ -104,6 +112,9 @@ spec:
                       pod-security.kubernetes.io/enforce: privileged
                       pod-security.kubernetes.io/audit: privileged
                       pod-security.kubernetes.io/warn: privileged
+                    annotations:
+                      # Prevent accidental namespace deletion when an app stops managing the Namespace object.
+                      argocd.argoproj.io/sync-options: Prune=false
                   automation: auto
                   enabled: "true"
                 - name: registry

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -234,6 +234,14 @@ spec:
                   argocd.argoproj.io/sync-wave: "3"
                 automation: auto
                 enabled: "false"
+                managedNamespaceMetadata:
+                  labels:
+                    app.kubernetes.io/name: tigresse
+                    app.kubernetes.io/component: operator
+                    app.kubernetes.io/managed-by: argocd
+                  annotations:
+                    # Prevent accidental namespace deletion when an app stops managing the Namespace object.
+                    argocd.argoproj.io/sync-options: Prune=false
               - name: temporal
                 path: argocd/applications/temporal
                 namespace: temporal

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -72,6 +72,10 @@ spec:
                   argocd.argoproj.io/sync-wave: "5"
                 automation: auto
                 enabled: "false"
+                managedNamespaceMetadata:
+                  annotations:
+                    # Prevent accidental namespace deletion when an app stops managing the Namespace object.
+                    argocd.argoproj.io/sync-options: Prune=false
               - name: reviseur
                 path: argocd/applications/reviseur
                 namespace: reviseur

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -203,12 +203,12 @@ Jangar also exposes JSON endpoints that mirror the MCP memory inputs:
 - `OPENAI_EMBEDDING_TIMEOUT_MS` (optional; defaults to `15000`)
 - `OPENAI_EMBEDDING_MAX_INPUT_CHARS` (optional; defaults to `60000`)
 
-### Ollama embeddings (docker-host)
+### Ollama embeddings (saigak)
 
-To use the self-hosted embeddings model on `docker-host`:
+To use the self-hosted embeddings model on `saigak`:
 
 ```bash
-export OPENAI_API_BASE_URL='http://192.168.1.190:11434/v1'
+export OPENAI_API_BASE_URL='http://saigak.saigak.svc.cluster.local:11434/v1'
 export OPENAI_EMBEDDING_MODEL='qwen3-embedding-saigak:0.6b'
 export OPENAI_EMBEDDING_DIMENSION='1024'
 # OPENAI_API_KEY is optional for Ollama

--- a/skills/memories/references/memories-runbook.md
+++ b/skills/memories/references/memories-runbook.md
@@ -7,7 +7,7 @@ Memories are stored in Postgres using the schema in `schemas/embeddings/memories
 ## Default self-hosted settings
 
 ```bash
-export OPENAI_API_BASE_URL='http://192.168.1.190:11434/v1'
+export OPENAI_API_BASE_URL='http://saigak.saigak.svc.cluster.local:11434/v1'
 export OPENAI_EMBEDDING_MODEL='qwen3-embedding-saigak:0.6b'
 export OPENAI_EMBEDDING_DIMENSION='1024'
 ```


### PR DESCRIPTION
## Summary

- Point remaining in-cluster embeddings clients (Argo Workflows + bumba) at `saigak` instead of `192.168.1.190`.
- Update docs/runbooks to use the in-cluster `saigak` OpenAI-compatible base URL.
- Remove `Namespace` objects from Argo CD app kustomizations (ApplicationSets own namespace lifecycle/metadata).

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kustomize build argocd/applications/argocd >/tmp/kust-argocd.yaml`
- `kustomize build argocd/applications/tailscale >/tmp/kust-tailscale.yaml`
- `kustomize build argocd/applications/tigresse >/tmp/kust-tigresse.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/traefik >/tmp/kust-traefik.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None (apps will roll on sync due to env/config changes; namespaces are now created/managed via ApplicationSets `CreateNamespace=true` + `managedNamespaceMetadata`).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
