### PR TITLE
fix(ampone): set ephemeral to 300gb and local-path to remainder

### DIFF
--- a/argocd/applications/local-path/patches/local-path-config.patch.yaml
+++ b/argocd/applications/local-path/patches/local-path-config.patch.yaml
@@ -12,6 +12,10 @@ data:
           "paths":["/var/mnt/local-path-provisioner"]
         },
         {
+          "node":"talos-192-168-1-203",
+          "paths":["/var/mnt/local-path-provisioner"]
+        },
+        {
           "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
           "paths":["/var/local-path-provisioner"]
         }

--- a/devices/ampone/README.md
+++ b/devices/ampone/README.md
@@ -14,5 +14,5 @@ Manifests:
 - `devices/ampone/manifests/hostname.patch.yaml` (Talos hostname patch)
 - `devices/ampone/manifests/install-nvme0n1.patch.yaml` (install to `/dev/nvme0n1`, wipe)
 - `devices/ampone/manifests/allow-scheduling-controlplane.patch.yaml` (single-node: run workloads on the controlplane)
-- `devices/ampone/manifests/ephemeral-volume.patch.yaml` (cap system `/var` to 200GB)
+- `devices/ampone/manifests/ephemeral-volume.patch.yaml` (cap system `/var` to 300GB)
 - `devices/ampone/manifests/local-path.patch.yaml` (allocate remainder to local-path user volume)

--- a/devices/ampone/docs/cluster-bootstrap.md
+++ b/devices/ampone/docs/cluster-bootstrap.md
@@ -56,7 +56,7 @@ Apply these patches:
 - `devices/ampone/manifests/allow-scheduling-controlplane.patch.yaml`
 - `devices/ampone/manifests/controlplane-endpoint-nuc.patch.yaml` (endpoint + apiserver cert SANs)
 - `devices/ampone/manifests/hostname.patch.yaml`
-- `devices/ampone/manifests/ephemeral-volume.patch.yaml` (cap system `/var` to 200GB)
+- `devices/ampone/manifests/ephemeral-volume.patch.yaml` (cap system `/var` to 300GB)
 - `devices/ampone/manifests/local-path.patch.yaml` (allocate remainder to local-path user volume)
 
 ```bash

--- a/devices/ampone/manifests/ephemeral-volume.patch.yaml
+++ b/devices/ampone/manifests/ephemeral-volume.patch.yaml
@@ -4,6 +4,6 @@ name: EPHEMERAL
 provisioning:
   diskSelector:
     match: disk.dev_path == '/dev/nvme0n1'
-  minSize: 200GB
-  maxSize: 200GB
+  minSize: 300GB
+  maxSize: 300GB
   grow: false

--- a/devices/ampone/manifests/local-path.patch.yaml
+++ b/devices/ampone/manifests/local-path.patch.yaml
@@ -3,9 +3,9 @@ kind: UserVolumeConfig
 name: local-path-provisioner
 provisioning:
   # `ampone` installs to `/dev/nvme0n1` (see `devices/ampone/manifests/install-nvme0n1.patch.yaml`).
-  # Size is computed as: disk - EFI - META - STATE - EPHEMERAL(200GB) - ~5GB headroom.
+  # Allocate the remainder of the disk after Talos system partitions and EPHEMERAL.
+  # Keep `grow: false` so the partition size remains stable (no auto-resize if the disk size changes).
   diskSelector:
     match: disk.dev_path == '/dev/nvme0n1'
-  minSize: 3889GB
-  maxSize: 3889GB
+  minSize: 100GB
   grow: false


### PR DESCRIPTION
## Summary

- Set ampone Talos `EPHEMERAL` volume (`/var`) target to 300GB.
- Change ampone Talos `local-path-provisioner` user volume to take the remainder of `/dev/nvme0n1` with `grow: false` (prevents auto-resize if disk size changes).
- Update local-path provisioner config to use `/var/mnt/local-path-provisioner` on `talos-192-168-1-203`.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None (takes effect when ampone is reprovisioned/repartitioned per the Talos relayout procedure).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
