### PR TITLE
fix(arc): disable hostnetwork for runners

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -37,14 +37,10 @@ spec:
                   storage: 60Gi
           listenerTemplate:
             spec:
-              hostNetwork: true
-              dnsPolicy: ClusterFirstWithHostNet
               containers:
                 - name: listener
           template:
             spec:
-              hostNetwork: true
-              dnsPolicy: ClusterFirstWithHostNet
               securityContext:
                 runAsNonRoot: false
                 # ARC runners need a writable tool cache under /home/runner/_work/_tool.


### PR DESCRIPTION
## Summary

- Disable `hostNetwork` for ARC listener + runner pods to prevent Docker-in-Docker from creating host bridges (e.g. `docker0`) on Talos nodes.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None expected. ARC runners still use the Docker socket sidecar; only the pod network mode changes.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
