### PR TITLE
fix(saigak): enable DHCP in cloud-init

### DIFF
--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -79,3 +79,8 @@ stringData:
       - [ bash, -lc, 'ollama pull qwen3-embedding:0.6b' ]
       - [ bash, -lc, 'ollama create qwen3-embedding-saigak:0.6b -f /etc/saigak/qwen3-embedding-0-6b.modelfile' ]
       - [ bash, -lc, 'ollama list | awk \"{print \\$1}\" | grep -Fxq \"qwen3-embedding-saigak:0.6b\"' ]
+  networkdata: |-
+    version: 2
+    ethernets:
+      enp1s0:
+        dhcp4: true


### PR DESCRIPTION
## Summary

- Add `networkdata` to `saigak` cloud-init secret to enable DHCP on `enp1s0`.
- Fixes `saigak` VM coming up with the NIC down (no guest IP), which makes the Ollama endpoint unreachable after VM restarts.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
