### PR TITLE
fix(saigak): fix NoCloud networkdata

### DIFF
--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -80,7 +80,9 @@ stringData:
       - [ bash, -lc, 'ollama create qwen3-embedding-saigak:0.6b -f /etc/saigak/qwen3-embedding-0-6b.modelfile' ]
       - [ bash, -lc, 'ollama list | awk \"{print \\$1}\" | grep -Fxq \"qwen3-embedding-saigak:0.6b\"' ]
   networkdata: |-
-    version: 2
-    ethernets:
-      enp1s0:
-        dhcp4: true
+    network:
+      version: 2
+      renderer: networkd
+      ethernets:
+        enp1s0:
+          dhcp4: true


### PR DESCRIPTION
## Summary

- Fix `saigak` NoCloud `networkdata` format so cloud-init actually brings up `enp1s0` via DHCP.
- Required for the VM to get its guest IP (masquerade) so Ollama on `:11434` is reachable.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
