### PR TITLE
fix(saigak): cloud-init DHCP network config

### DIFF
--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -80,9 +80,9 @@ stringData:
       - [ bash, -lc, 'ollama create qwen3-embedding-saigak:0.6b -f /etc/saigak/qwen3-embedding-0-6b.modelfile' ]
       - [ bash, -lc, 'ollama list | awk \"{print \\$1}\" | grep -Fxq \"qwen3-embedding-saigak:0.6b\"' ]
   networkdata: |-
-    network:
-      version: 2
-      renderer: networkd
-      ethernets:
-        enp1s0:
-          dhcp4: true
+    version: 1
+    config:
+      - type: physical
+        name: enp1s0
+        subnets:
+          - type: dhcp4


### PR DESCRIPTION
## Summary

- Switch `saigak` NoCloud `networkdata` to cloud-init v1 network config.
- Fixes Ubuntu cloud image booting with `enp1s0` down (no DHCP), which prevents reaching Ollama on `:11434`.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
