### PR TITLE
fix(saigak): inline DHCP network config

### DIFF
--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -9,6 +9,17 @@ stringData:
     preserve_hostname: false
     hostname: saigak
     manage_etc_hosts: true
+    # KubeVirt masquerade requires the guest NIC to be up and DHCP enabled.
+    # Keeping this inside user-data (instead of a separate `networkData` key)
+    # avoids subtle Secret-key naming mismatches and ensures cloud-init applies it.
+    network:
+      version: 2
+      ethernets:
+        primary:
+          match:
+            name: 'en*'
+          dhcp4: true
+          dhcp6: false
     package_update: true
     package_upgrade: false
     disk_setup:
@@ -67,7 +78,7 @@ stringData:
     disable_root: true
     runcmd:
       - [ bash, -lc, 'systemctl enable --now ssh' ]
-      - [ bash, -lc, 'for i in $(seq 1 30); do if nvidia-smi -L; then exit 0; fi; sleep 2; done; echo \"nvidia-smi did not become ready\" >&2; exit 1' ]
+      - [ bash, -lc, 'for i in $(seq 1 60); do if nvidia-smi -L; then break; fi; sleep 2; done; nvidia-smi -L || echo \"warning: nvidia-smi not ready yet\" >&2' ]
       - [ bash, -lc, 'curl -fsSL https://ollama.com/install.sh | sh' ]
       - [ bash, -lc, 'systemctl stop ollama || true' ]
       - [ bash, -lc, 'mkdir -p /etc/systemd/system/ollama.service.d' ]
@@ -79,10 +90,3 @@ stringData:
       - [ bash, -lc, 'ollama pull qwen3-embedding:0.6b' ]
       - [ bash, -lc, 'ollama create qwen3-embedding-saigak:0.6b -f /etc/saigak/qwen3-embedding-0-6b.modelfile' ]
       - [ bash, -lc, 'ollama list | awk \"{print \\$1}\" | grep -Fxq \"qwen3-embedding-saigak:0.6b\"' ]
-  networkdata: |-
-    version: 1
-    config:
-      - type: physical
-        name: enp1s0
-        subnets:
-          - type: dhcp4


### PR DESCRIPTION
## Summary

- Inline netplan DHCP config in `saigak` cloud-init user-data for KubeVirt masquerade.
- Remove the separate `networkdata` key to avoid Secret key naming mismatches.
- Make the `nvidia-smi` readiness check non-fatal so rest of bootstrap can proceed.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/saigak > /tmp/saigak-kustomize.yaml`
- `python -c 'import yaml; list(yaml.safe_load_all(open("/tmp/saigak-kustomize.yaml")))'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
