### PR TITLE
fix(saigak): provide cloud-init networkData

### DIFF
--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -9,17 +9,6 @@ stringData:
     preserve_hostname: false
     hostname: saigak
     manage_etc_hosts: true
-    # KubeVirt masquerade requires the guest NIC to be up and DHCP enabled.
-    # Keeping this inside user-data (instead of a separate `networkData` key)
-    # avoids subtle Secret-key naming mismatches and ensures cloud-init applies it.
-    network:
-      version: 2
-      ethernets:
-        primary:
-          match:
-            name: 'en*'
-          dhcp4: true
-          dhcp6: false
     package_update: true
     package_upgrade: false
     disk_setup:
@@ -90,3 +79,13 @@ stringData:
       - [ bash, -lc, 'ollama pull qwen3-embedding:0.6b' ]
       - [ bash, -lc, 'ollama create qwen3-embedding-saigak:0.6b -f /etc/saigak/qwen3-embedding-0-6b.modelfile' ]
       - [ bash, -lc, 'ollama list | awk \"{print \\$1}\" | grep -Fxq \"qwen3-embedding-saigak:0.6b\"' ]
+  # cloud-init (NoCloud) expects a separate `network-config` file on the seed ISO.
+  # KubeVirt generates that from this secret key.
+  networkData: |-
+    version: 2
+    ethernets:
+      primary:
+        match:
+          name: 'en*'
+        dhcp4: true
+        dhcp6: false


### PR DESCRIPTION
## Summary

- Provide `networkData` in the `saigak-cloud-init` Secret so KubeVirt generates a NoCloud `network-config` file.
- Remove the invalid `network:` block from cloud-init user-data that failed schema validation.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/saigak > /tmp/saigak-kustomize.yaml`
- `python -c 'import yaml; list(yaml.safe_load_all(open("/tmp/saigak-kustomize.yaml")))'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
