### PR TITLE
fix(saigak): force netplan DHCP

### DIFF
--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -45,6 +45,27 @@ stringData:
           FROM qwen3-embedding:0.6b
           TEMPLATE {{ .Prompt }}
           PARAMETER num_ctx 4096
+      - path: /etc/netplan/99-saigak.yaml
+        owner: root:root
+        permissions: '0644'
+        content: |-
+          network:
+            version: 2
+            renderer: networkd
+            ethernets:
+              primary:
+                match:
+                  name: 'en*'
+                dhcp4: true
+                dhcp6: false
+      - path: /var/lib/cloud/scripts/per-boot/10-netplan-apply
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          netplan generate || true
+          netplan apply || true
     users:
       - name: ubuntu
         groups: [sudo]
@@ -67,6 +88,7 @@ stringData:
     disable_root: true
     runcmd:
       - [ bash, -lc, 'systemctl enable --now ssh' ]
+      - [ bash, -lc, 'netplan generate && netplan apply || true' ]
       - [ bash, -lc, 'for i in $(seq 1 60); do if nvidia-smi -L; then break; fi; sleep 2; done; nvidia-smi -L || echo \"warning: nvidia-smi not ready yet\" >&2' ]
       - [ bash, -lc, 'curl -fsSL https://ollama.com/install.sh | sh' ]
       - [ bash, -lc, 'systemctl stop ollama || true' ]


### PR DESCRIPTION
## Summary

- Write a netplan DHCP config for the guest NIC (`en*`) via cloud-init `write_files`.
- Apply netplan early in `runcmd` and also via a per-boot cloud-init script.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/saigak > /tmp/saigak-kustomize.yaml`
- `python -c 'import yaml; list(yaml.safe_load_all(open("/tmp/saigak-kustomize.yaml")))'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
