### PR TITLE
fix(saigak): correct cloud-init network-config format

### DIFF
--- a/argocd/applications/saigak/cloud-init-network-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-network-secret.yaml
@@ -7,19 +7,18 @@ stringData:
   # KubeVirt expects NoCloud network config as a separate blob.
   # Provide both key casings to avoid subtle version/keying mismatches.
   networkData: |-
-    version: 2
-    ethernets:
-      primary:
-        match:
-          name: 'en*'
-        dhcp4: true
-        dhcp6: false
+    network:
+      version: 1
+      config:
+        - type: physical
+          name: enp1s0
+          subnets:
+            - type: dhcp
   networkdata: |-
-    version: 2
-    ethernets:
-      primary:
-        match:
-          name: 'en*'
-        dhcp4: true
-        dhcp6: false
-
+    network:
+      version: 1
+      config:
+        - type: physical
+          name: enp1s0
+          subnets:
+            - type: dhcp


### PR DESCRIPTION
## Summary

- Fix `saigak` NoCloud `network-config` to use cloud-init's expected schema (top-level `network:`).
- Switch to cloud-init v1 DHCP config for `enp1s0` (matches KubeVirt docs).

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/saigak > /tmp/saigak-kustomize.yaml`
- `python -c 'import yaml; list(yaml.safe_load_all(open("/tmp/saigak-kustomize.yaml")))'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
