### PR TITLE
fix(saigak): correct NoCloud network-config schema

### DIFF
--- a/argocd/applications/saigak/cloud-init-network-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-network-secret.yaml
@@ -7,18 +7,16 @@ stringData:
   # KubeVirt expects NoCloud network config as a separate blob.
   # Provide both key casings to avoid subtle version/keying mismatches.
   networkData: |-
-    network:
-      version: 1
-      config:
-        - type: physical
-          name: enp1s0
-          subnets:
-            - type: dhcp
+    version: 1
+    config:
+      - type: physical
+        name: enp1s0
+        subnets:
+          - type: dhcp
   networkdata: |-
-    network:
-      version: 1
-      config:
-        - type: physical
-          name: enp1s0
-          subnets:
-            - type: dhcp
+    version: 1
+    config:
+      - type: physical
+        name: enp1s0
+        subnets:
+          - type: dhcp


### PR DESCRIPTION
## Summary

- Fix `saigak` NoCloud `network-config` content to follow cloud-init's documented schema (no top-level `network:` key).

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/saigak > /tmp/saigak-kustomize.yaml`
- `python -c 'import yaml; list(yaml.safe_load_all(open("/tmp/saigak-kustomize.yaml")))'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
