### PR TITLE
fix(saigak): stabilize VM uuid and MAC

### DIFF
--- a/argocd/applications/saigak/virtualmachine.yaml
+++ b/argocd/applications/saigak/virtualmachine.yaml
@@ -33,6 +33,10 @@ spec:
       domain:
         cpu:
           cores: 8
+        firmware:
+          # Keep these stable so cloud-init doesn't pin config to a transient MAC/instance-id.
+          # Changing uuid forces cloud-init to treat this as a new instance.
+          uuid: 2d3cf6e5-888f-4c35-8a3f-353f50e30f85
         resources:
           requests:
             memory: 32Gi
@@ -54,6 +58,7 @@ spec:
           interfaces:
             - name: default
               masquerade: {}
+              macAddress: "02:00:00:00:00:85"
               ports:
                 - port: 22
                 - port: 11434


### PR DESCRIPTION
## Summary

- Set a stable firmware UUID for `saigak` to ensure NoCloud `instance-id` is stable/controlled.
- Set a stable VM interface MAC so cloud-init/network config doesn't break across restarts.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/saigak > /tmp/saigak-kustomize.yaml`
- `python -c 'import yaml; list(yaml.safe_load_all(open("/tmp/saigak-kustomize.yaml")))'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
