### PR TITLE
chore(devices): ephemeral 300gb + local-path rest

### DIFF
--- a/devices/altra/README.md
+++ b/devices/altra/README.md
@@ -10,6 +10,7 @@ Inventory:
 
 Docs:
 - `devices/altra/docs/cluster-bootstrap.md` (install + join existing cluster)
+- `devices/altra/docs/relayout-volumes.md` (EPHEMERAL=300GB, local-path=rest)
 
 Related:
 - NUC load balancer config: `devices/nuc/k8s-api-lb/README.md`

--- a/devices/altra/docs/relayout-volumes.md
+++ b/devices/altra/docs/relayout-volumes.md
@@ -1,0 +1,107 @@
+# Cordon Altra (192.168.1.85) and Re-layout Volumes (EPHEMERAL=300GB, local-path=rest)
+
+Goal: on Talos control-plane node `talos-192-168-1-85` (LAN `192.168.1.85`) change the
+storage layout to:
+
+- `EPHEMERAL` (system `/var`) = **300GB**
+- `local-path-provisioner` user volume = **all remaining available space** (mounted at `/var/mnt/local-path-provisioner`)
+- no additional scratch/runtime user volumes on this node
+
+This procedure preserves cluster state by having the node leave etcd before wiping `/var`.
+
+## Preconditions / Safety
+
+- Maintenance window: wiping `/var` restarts workloads on the node. Single-replica workloads will have downtime.
+- Keep quorum: do **not** reboot the other control planes (`192.168.1.194`, `192.168.1.203`) during the window.
+- Ensure nothing important is stored on local-path before re-laying out volumes:
+
+```bash
+kubectl get pv | rg local-path
+```
+
+No `Bound` PVs is the safe starting point.
+
+## Step 0: Snapshot and health checks
+
+```bash
+# etcd snapshot (store it somewhere safe)
+talosctl etcd snapshot -n 192.168.1.85 -e 192.168.1.85 /tmp/altra-etcd-snap.db
+
+talosctl etcd status -n 192.168.1.85 -e 192.168.1.85
+talosctl etcd members -n 192.168.1.85 -e 192.168.1.85
+kubectl get nodes -o wide
+```
+
+## Step 1: Confirm the current layout (baseline)
+
+On `altra`, `EPHEMERAL` is currently consuming essentially the whole install NVMe (no space left for `u-local-path-provisioner`):
+
+```bash
+talosctl get discoveredvolumes -n 192.168.1.85 -e 192.168.1.85 -o yaml | rg -n 'nvme0n1p4|EPHEMERAL|u-local-path'
+talosctl -n 192.168.1.85 -e 192.168.1.85 get mounts -o yaml
+```
+
+## Step 2: Cordon the node
+
+```bash
+kubectl cordon talos-192-168-1-85
+kubectl get pods -A -o wide --field-selector spec.nodeName=talos-192-168-1-85
+```
+
+## Step 3: Stage the new Talos volume config (no reboot)
+
+Repo patches (apply before wiping so the next boot reprovisions correctly):
+
+- `devices/altra/manifests/ephemeral-volume.patch.yaml` (`EPHEMERAL` fixed at 300GB)
+- `devices/altra/manifests/local-path.patch.yaml` (user volume grows to consume remaining space)
+
+```bash
+talosctl patch machineconfig -n 192.168.1.85 -e 192.168.1.85 --mode=no-reboot \
+  --patch @devices/altra/manifests/ephemeral-volume.patch.yaml
+
+talosctl patch machineconfig -n 192.168.1.85 -e 192.168.1.85 --mode=no-reboot \
+  --patch @devices/altra/manifests/local-path.patch.yaml
+```
+
+## Step 4: Wipe EPHEMERAL and reboot (reprovision `/var` to 300GB)
+
+Because this is the etcd endpoint node, rely on `talosctl reset --graceful` to cordon/drain and leave etcd.
+
+```bash
+talosctl reset -n 192.168.1.85 -e 192.168.1.85 \
+  --wipe-mode system-disk \
+  --system-labels-to-wipe EPHEMERAL \
+  --reboot
+```
+
+Wait for Talos API to come back:
+
+```bash
+talosctl version -n 192.168.1.85 -e 192.168.1.85
+```
+
+## Step 5: Verify volumes and mounts
+
+```bash
+talosctl get discoveredvolumes -n 192.168.1.85 -e 192.168.1.85 | rg -n 'EPHEMERAL|u-local-path'
+talosctl mounts -n 192.168.1.85 -e 192.168.1.85 | rg -n ' /var$|/var/mnt/local-path-provisioner'
+kubectl get nodes -o wide
+```
+
+Expected:
+- `EPHEMERAL` is ~300GB.
+- `u-local-path-provisioner` exists and consumes the remaining free space.
+- `/var/mnt/local-path-provisioner` is mounted.
+
+If `EPHEMERAL` stays full-disk sized after the reboot, the partition table did not get reprovisioned. At that point:
+1. put the node into Talos maintenance mode, and
+2. `talosctl wipe disk --insecure --drop-partition nvme0n1p4` to drop the EPHEMERAL partition, then reboot.
+
+## Acceptance Criteria
+
+- `kubectl get nodes` shows `talos-192-168-1-85` is `Ready`.
+- `talosctl etcd members` shows 3 healthy members.
+- `talosctl mounts` shows:
+  - `/var` on a ~300GB EPHEMERAL partition
+  - `/var/mnt/local-path-provisioner` mounted
+- No extra user volumes are present on the node besides `local-path-provisioner`.

--- a/devices/altra/manifests/ephemeral-volume.patch.yaml
+++ b/devices/altra/manifests/ephemeral-volume.patch.yaml
@@ -4,6 +4,6 @@ name: EPHEMERAL
 provisioning:
   diskSelector:
     match: disk.dev_path == '/dev/nvme0n1'
-  minSize: 200GB
-  maxSize: 200GB
+  minSize: 300GB
+  maxSize: 300GB
   grow: false

--- a/devices/altra/manifests/local-path.patch.yaml
+++ b/devices/altra/manifests/local-path.patch.yaml
@@ -3,10 +3,8 @@ kind: UserVolumeConfig
 name: local-path-provisioner
 provisioning:
   # `altra` installs to `/dev/nvme0n1` (see `devices/altra/manifests/install-nvme0n1.patch.yaml`).
-  # Talos local storage guide: user volumes are carved from the system disk and mounted under `/var/mnt/<name>`.
-  # Size is computed as: disk - EFI - META - STATE - EPHEMERAL(200GB) - ~5GB headroom.
   diskSelector:
     match: disk.dev_path == '/dev/nvme0n1'
-  minSize: 3793GB
-  maxSize: 3793GB
-  grow: false
+  minSize: 100GB
+  # Omit maxSize to consume the remaining free space on the selected disk.
+  grow: true

--- a/devices/ampone/README.md
+++ b/devices/ampone/README.md
@@ -9,6 +9,7 @@ Docs:
 - `devices/ampone/docs/cluster-bootstrap.md` (Talos install/bootstrap template)
 - `devices/ampone/docs/ipmi.md` (IPMI/BMC command cookbook)
 - `devices/ampone/docs/memory-troubleshooting.md` (DDR training + DIMM isolation notes)
+- `devices/ampone/docs/relayout-volumes.md` (EPHEMERAL=300GB, local-path=rest)
 
 Manifests:
 - `devices/ampone/manifests/hostname.patch.yaml` (Talos hostname patch)

--- a/devices/ampone/docs/relayout-volumes.md
+++ b/devices/ampone/docs/relayout-volumes.md
@@ -1,0 +1,147 @@
+# Cordon Ampone (192.168.1.203) and Re-layout Volumes (EPHEMERAL=300GB, local-path=rest)
+
+Goal: on Talos control-plane node `talos-192-168-1-203` (LAN `192.168.1.203`) change the
+storage layout to:
+
+- `EPHEMERAL` (system `/var`) = **300GB**
+- `local-path-provisioner` user volume = **all remaining available space** (mounted at `/var/mnt/local-path-provisioner`)
+- no additional scratch/runtime user volumes on this node
+
+This procedure preserves cluster state by having the node leave etcd before wiping `/var`.
+
+## Preconditions / Safety
+
+- Maintenance window: wiping `/var` restarts workloads on the node. Single-replica workloads will have downtime.
+- Keep quorum: do **not** reboot the other control planes (`192.168.1.85`, `192.168.1.194`) during the window.
+- Ensure nothing important is stored on local-path before re-laying out volumes:
+
+```bash
+kubectl get pv | rg local-path
+```
+
+No `Bound` PVs is the safe starting point.
+
+## Step 0: Snapshot and health checks
+
+```bash
+# etcd snapshot (store it somewhere safe)
+talosctl etcd snapshot -n 192.168.1.85 -e 192.168.1.85 /tmp/ampone-etcd-snap.db
+
+talosctl etcd status -n 192.168.1.85 -e 192.168.1.85
+talosctl etcd members -n 192.168.1.85 -e 192.168.1.85
+kubectl get nodes -o wide
+```
+
+## Step 1: Confirm the current layout (baseline)
+
+On `ampone`, `EPHEMERAL` is currently consuming essentially the whole install NVMe (no space left for `u-local-path-provisioner`):
+
+```bash
+talosctl get discoveredvolumes -n 192.168.1.203 -e 192.168.1.85 -o yaml | rg -n 'nvme0n1p4|EPHEMERAL|u-local-path'
+talosctl -n 192.168.1.203 -e 192.168.1.85 get mounts -o yaml
+```
+
+## Step 2: Cordon the node
+
+```bash
+kubectl cordon talos-192-168-1-203
+kubectl get pods -A -o wide --field-selector spec.nodeName=talos-192-168-1-203
+```
+
+## Step 3: Stage the new Talos volume config (no reboot)
+
+Repo patches (apply before wiping so the next boot reprovisions correctly):
+
+- `devices/ampone/manifests/ephemeral-volume.patch.yaml` (`EPHEMERAL` fixed at 300GB)
+- `devices/ampone/manifests/local-path.patch.yaml` (user volume grows to consume remaining space)
+
+```bash
+talosctl patch machineconfig -n 192.168.1.203 -e 192.168.1.85 --mode=no-reboot \
+  --patch @devices/ampone/manifests/ephemeral-volume.patch.yaml
+
+talosctl patch machineconfig -n 192.168.1.203 -e 192.168.1.85 --mode=no-reboot \
+  --patch @devices/ampone/manifests/local-path.patch.yaml
+```
+
+## Step 4: Remove 203 from etcd
+
+```bash
+# If 203 is leader, forfeit leadership first:
+talosctl etcd forfeit-leadership -n 192.168.1.203 -e 192.168.1.85
+
+talosctl etcd leave -n 192.168.1.203 -e 192.168.1.85
+talosctl etcd members -n 192.168.1.85 -e 192.168.1.85
+```
+
+Confirm only `192.168.1.85` + `192.168.1.194` remain in etcd before wiping `/var`.
+
+## Step 5: Wipe EPHEMERAL and reboot (reprovision `/var` to 300GB)
+
+```bash
+talosctl reset -n 192.168.1.203 -e 192.168.1.85 \
+  --wipe-mode system-disk \
+  --system-labels-to-wipe EPHEMERAL \
+  --reboot --graceful=false
+```
+
+Wait for Talos API to come back:
+
+```bash
+talosctl version -n 192.168.1.203 -e 192.168.1.85
+```
+
+## Step 6: Verify volumes and mounts
+
+```bash
+talosctl get discoveredvolumes -n 192.168.1.203 -e 192.168.1.85 | rg -n 'EPHEMERAL|u-local-path'
+talosctl mounts -n 192.168.1.203 -e 192.168.1.85 | rg -n ' /var$|/var/mnt/local-path-provisioner'
+```
+
+Expected:
+- `EPHEMERAL` is ~300GB.
+- `u-local-path-provisioner` exists and consumes the remaining free space.
+- `/var/mnt/local-path-provisioner` is mounted.
+
+If `EPHEMERAL` stays full-disk sized after the reboot, the partition table did not get reprovisioned. At that point:
+1. put the node into Talos maintenance mode, and
+2. `talosctl wipe disk --insecure --drop-partition nvme0n1p4` to drop the EPHEMERAL partition, then reboot.
+
+## Step 7: Ensure 203 re-joins etcd, then uncordon
+
+```bash
+talosctl etcd members -n 192.168.1.85 -e 192.168.1.85
+kubectl get nodes -o wide
+
+kubectl uncordon talos-192-168-1-203
+```
+
+## Pitfall: Duplicate `machine.files` paths break kubelet/bootstrap
+
+Symptom:
+- Logs show:
+  - `writeUserFiles failed ... resource EtcFileSpecs... already exists`
+  - `error writing kubelet PKI ... /etc/kubernetes/bootstrap-kubeconfig: read-only file system`
+
+Cause:
+- Machine config contains multiple `machine.files` entries with the same `path`.
+
+Fix:
+1. Download the machine config and remove the duplicate file spec.
+2. Apply the corrected full config.
+
+```bash
+talosctl get machineconfig -n 192.168.1.203 -e 192.168.1.85 -o yaml > /tmp/ampone-machineconfig.yaml
+
+# Edit /tmp/ampone-machineconfig.yaml so each `machine.files[].path` appears only once.
+
+talosctl apply-config -n 192.168.1.203 -e 192.168.1.85 -f /tmp/ampone-machineconfig.yaml --mode=reboot
+```
+
+## Acceptance Criteria
+
+- `kubectl get nodes` shows `talos-192-168-1-203` is `Ready`.
+- `talosctl etcd members` shows 3 healthy members.
+- `talosctl mounts` shows:
+  - `/var` on a ~300GB EPHEMERAL partition
+  - `/var/mnt/local-path-provisioner` mounted
+- No extra user volumes are present on the node besides `local-path-provisioner`.

--- a/devices/ampone/manifests/local-path.patch.yaml
+++ b/devices/ampone/manifests/local-path.patch.yaml
@@ -2,10 +2,8 @@ apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-path-provisioner
 provisioning:
-  # `ampone` installs to `/dev/nvme0n1` (see `devices/ampone/manifests/install-nvme0n1.patch.yaml`).
-  # Allocate the remainder of the disk after Talos system partitions and EPHEMERAL.
-  # Keep `grow: false` so the partition size remains stable (no auto-resize if the disk size changes).
   diskSelector:
     match: disk.dev_path == '/dev/nvme0n1'
   minSize: 100GB
-  grow: false
+  # Omit maxSize to consume the remaining free space on the selected disk.
+  grow: true


### PR DESCRIPTION
## Summary

- Set `altra` volume patches to `EPHEMERAL=300GB` and `local-path-provisioner=rest-of-disk`.
- Fix `ampone` local-path patch to actually consume the remaining space (match `ryzen` behavior).
- Add reproducible runbooks for re-laying out volumes on `altra (192.168.1.85)` and `ampone (192.168.1.203)`.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation updated (device runbooks).
