### PR TITLE
chore(local-path): add altra node path

### DIFF
--- a/argocd/applications/local-path/patches/local-path-config.patch.yaml
+++ b/argocd/applications/local-path/patches/local-path-config.patch.yaml
@@ -8,6 +8,10 @@ data:
     {
       "nodePathMap":[
         {
+          "node":"talos-192-168-1-85",
+          "paths":["/var/mnt/local-path-provisioner"]
+        },
+        {
           "node":"talos-192-168-1-194",
           "paths":["/var/mnt/local-path-provisioner"]
         },


### PR DESCRIPTION
## Summary

- Configure `local-path-provisioner` to use `/var/mnt/local-path-provisioner` on `talos-192-168-1-85` (altra).

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation/follow-ups updated or not required for this change.
