### PR TITLE
fix(argocd): disable surge for single-replica rollouts

### DIFF
--- a/argocd/applications/app/deployment.yaml
+++ b/argocd/applications/app/deployment.yaml
@@ -4,6 +4,12 @@ metadata:
   name: app
   namespace: app
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Single-replica rollout in a resource-constrained cluster: avoid needing a surge pod.
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: app

--- a/argocd/applications/docs/deployment.yaml
+++ b/argocd/applications/docs/deployment.yaml
@@ -4,6 +4,12 @@ metadata:
   name: docs
   namespace: docs
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Single-replica rollout in a resource-constrained cluster: avoid needing a surge pod.
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: docs

--- a/argocd/applications/proompteng/deployment.yaml
+++ b/argocd/applications/proompteng/deployment.yaml
@@ -4,6 +4,12 @@ metadata:
   name: proompteng
   namespace: proompteng
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Single-replica rollout in a resource-constrained cluster: avoid needing a surge pod.
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: proompteng


### PR DESCRIPTION
## Summary
- Set `maxSurge: 0` / `maxUnavailable: 1` on `proompteng`, `docs`, and `app` Deployments.
- Prevents rollouts from getting stuck Pending when the cluster is at its pod capacity (single-replica apps).

## Related Issues
None

## Testing
- `bun run lint:argocd`
- Observed Pending pods due to `Too many pods`; strategy change enables non-surge rollout.

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
