### PR TITLE
fix(argocd): rollback app image tags to 0.552.1

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    newTag: 0.554.1
+    newTag: 0.552.1
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - ingressroute.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    newTag: 0.554.1
+    newTag: 0.552.1
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  newTag: 0.554.1
+  newTag: 0.552.1
   newName: registry.ide-newton.ts.net/lab/proompteng


### PR DESCRIPTION
## Summary
- Roll back `proompteng`, `docs`, and `app` Argo CD image tags to `0.552.1`.
- Restores service availability while the `Docker Build and Push` workflow for `0.554.1` is still queued (images not yet in the registry).

## Related Issues
None

## Testing
- `bun run lint:argocd`
- Verified cluster pods were failing with `ErrImagePull` / `ImagePullBackOff` due to missing `:0.554.1` tags.

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
