### PR TITLE
docs(ampone): document ipmi password file

### DIFF
--- a/devices/ampone/docs/ipmi.md
+++ b/devices/ampone/docs/ipmi.md
@@ -17,6 +17,22 @@ export IPMI_PASSWORD='...'
 ipmitool -I lanplus -H 192.168.1.224 -U admin -E chassis power status
 ```
 
+### Local password file (reproducible, gitignored)
+
+For repeatable runs without leaking credentials into shell history, store the BMC
+password in a local file (do not commit it):
+
+```bash
+mkdir -p ~/.secrets
+chmod 700 ~/.secrets
+cat > ~/.secrets/ampone-ipmi-password <<'EOF'
+<ampone BMC password>
+EOF
+chmod 600 ~/.secrets/ampone-ipmi-password
+
+export IPMI_PASSWORD="$(cat ~/.secrets/ampone-ipmi-password)"
+```
+
 ## Power control
 
 ```bash


### PR DESCRIPTION
## Summary

- Document a local, gitignored `~/.secrets/ampone-ipmi-password` flow for `ipmitool` so the Ampone BMC reboot steps are reproducible without leaking credentials into shell history.

## Related Issues

None

## Testing

- N/A (docs-only)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed (not applicable).
- [x] Documentation updated.
