### PR TITLE
feat(argocd): enable coder app

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -282,8 +282,13 @@ spec:
                 namespace: coder
                 annotations:
                   argocd.argoproj.io/sync-wave: "3"
-                automation: manual
-                enabled: "false"
+                managedNamespaceMetadata:
+                  labels:
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
+                automation: auto
+                enabled: "true"
               - name: arc
                 path: argocd/applications/arc
                 namespace: arc


### PR DESCRIPTION
## Summary

- Enable the `coder` Argo CD application in the platform ApplicationSet.
- Add privileged Pod Security labels to the `coder` namespace via `managedNamespaceMetadata`.

## Related Issues

None

## Testing

- `kubectl -n argocd apply -f argocd/applicationsets/platform.yaml`
- `kubectl -n argocd get application coder -o jsonpath='{.status.sync.status} {.status.health.status}{"\n"}'`
- `curl -fsSL -o /dev/null -w "%{http_code}\n" https://coder.proompteng.ai/api/v2/buildinfo`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
