### PR TITLE
chore(devices): pin talos hostnames

### DIFF
--- a/devices/altra/manifests/hostname.patch.yaml
+++ b/devices/altra/manifests/hostname.patch.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1alpha1
 kind: HostnameConfig
 auto: off
-hostname: altra
-
+# Keep node hostname stable: multiple components (e.g. Rook-Ceph) pin workloads to
+# `kubernetes.io/hostname`.
+hostname: talos-192-168-1-85

--- a/devices/ampone/manifests/ampone-tailscale-schematic.yaml
+++ b/devices/ampone/manifests/ampone-tailscale-schematic.yaml
@@ -1,0 +1,4 @@
+customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/tailscale

--- a/devices/ampone/manifests/hostname.patch.yaml
+++ b/devices/ampone/manifests/hostname.patch.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1alpha1
 kind: HostnameConfig
 auto: off
-hostname: ampone
+# NOTE: Rook Ceph OSD deployments are pinned to `kubernetes.io/hostname`.
+# Changing this after OSDs are created strands them in Pending.
+hostname: talos-192-168-1-203

--- a/devices/ryzen/manifests/hostname.patch.yaml
+++ b/devices/ryzen/manifests/hostname.patch.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1alpha1
 kind: HostnameConfig
-hostname: ryzen
 auto: off
+# Keep node hostname stable: multiple components (e.g. Rook-Ceph) pin workloads to
+# `kubernetes.io/hostname`.
+hostname: talos-192-168-1-194


### PR DESCRIPTION
## Summary

- Pin Talos hostnames for `altra`/`ryzen`/`ampone` to stable `talos-192-168-1-XX` names (avoids `kubernetes.io/hostname` drift that strands node-pinned workloads like Rook-Ceph OSDs).
- Add an Image Factory schematic for the `tailscale` system extension on `ampone`.

## Related Issues

None

## Testing

- `kubectl get nodes -o name`
- `kubectl -n rook-ceph get pods -o wide`

## Breaking Changes

- Applying the hostname patch to an existing node requires a reboot to take effect.
- Changing hostnames after node-pinned workloads (e.g. Rook-Ceph OSD Deployments pinned to `kubernetes.io/hostname`) exist can strand them in `Pending`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots section removed (not applicable).
- [x] Breaking Changes section filled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
