### PR TITLE
fix(jangar): recover memories schema bootstrap after transient failure

### DIFF
--- a/services/jangar/src/server/memories-store.ts
+++ b/services/jangar/src/server/memories-store.ts
@@ -248,7 +248,10 @@ export const createPostgresMemoriesStore = (options: PostgresMemoriesStoreOption
       schemaReady = (async () => {
         await ensureMigrations(db)
         await ensureEmbeddingDimensionMatches()
-      })()
+      })().catch((error) => {
+        schemaReady = null
+        throw error
+      })
     }
     await schemaReady
   }


### PR DESCRIPTION
## Summary

- Reset `schemaReady` in memories store when schema bootstrap fails so subsequent requests retry instead of reusing a rejected promise.
- Extend the fake DB test harness to simulate a one-time extension lookup failure.
- Add a regression test that proves memories retrieval succeeds on a second attempt after a transient bootstrap error.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/memories-store.test.ts` (from `services/jangar`)
- `bunx biome check services/jangar/src/server/memories-store.ts services/jangar/src/server/__tests__/memories-store.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
