### PR TITLE
fix(ci): restore landing image publish by skipping arm64 qemu

### DIFF
--- a/.github/workflows/docker-build-common.yaml
+++ b/.github/workflows/docker-build-common.yaml
@@ -86,7 +86,26 @@ jobs:
             type=semver,pattern={{version}},value=${{ inputs.new_tag }}
             type=sha
 
+      - name: Detect QEMU requirement
+        id: qemu
+        run: |
+          set -euo pipefail
+          platforms='${{ inputs.platforms }}'
+          needs_qemu='false'
+
+          IFS=',' read -r -a targets <<< "$platforms"
+          for target in "${targets[@]}"; do
+            target="$(echo "$target" | xargs)"
+            if [ "$target" != 'linux/arm64' ]; then
+              needs_qemu='true'
+              break
+            fi
+          done
+
+          echo "needs_qemu=$needs_qemu" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
+        if: steps.qemu.outputs.needs_qemu == 'true'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -11,6 +11,13 @@ on:
       - "apps/**"
       - "packages/**"
       - "services/**"
+  workflow_dispatch:
+    inputs:
+      build_proompteng:
+        description: "Build and publish apps/landing image"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   changes:
@@ -18,7 +25,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      proompteng: ${{ steps.filter.outputs.proompteng }}
+      proompteng: ${{ github.event_name == 'workflow_dispatch' && steps.manual.outputs.proompteng || steps.filter.outputs.proompteng }}
       app: ${{ steps.filter.outputs.app }}
       cms: ${{ steps.filter.outputs.cms }}
       docs: ${{ steps.filter.outputs.docs }}
@@ -32,6 +39,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Check for file changes
+        if: github.event_name == 'push'
         uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -56,11 +64,22 @@ jobs:
             bonjour:
               - 'services/bonjour/**'
 
+      - name: Manual build selection
+        id: manual
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.event.inputs.build_proompteng }}" = "true" ]; then
+            echo "proompteng=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proompteng=false" >> "$GITHUB_OUTPUT"
+          fi
+
   version:
     runs-on: arc-arm64
     permissions:
       contents: write
     needs: changes
+    if: ${{ needs.changes.outputs.proompteng == 'true' || needs.changes.outputs.app == 'true' || needs.changes.outputs.cms == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.kitty-krew == 'true' || needs.changes.outputs.reviseur == 'true' || needs.changes.outputs.alchimie == 'true' || needs.changes.outputs.bonjour == 'true' }}
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
       changelog: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
## Summary

- Skip QEMU setup in the shared Docker build workflow when the requested platform list is arm64-only.
- Add a manual dispatch path for `Docker Build and Push` that can explicitly rebuild and publish the landing (`proompteng`) image.
- Gate the version/tag job on selected image builds so manual runs without selected targets do not bump releases.

## Related Issues

None

## Testing

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-build-common.yaml'); YAML.load_file('.github/workflows/docker-build-push.yaml'); puts 'ok'"`
- `gh workflow run docker-build-push.yaml -R proompteng/lab --ref codex/fix-landing-image-publish -f build_proompteng=true`
- `gh run view 22129763862 -R proompteng/lab --json status,conclusion,jobs`
- `curl -fsS https://registry.ide-newton.ts.net/v2/lab/proompteng/tags/list`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
