### PR TITLE
feat(altra): add dual local-path volumes for node 85

### DIFF
--- a/argocd/applications/local-path/patches/local-path-config.patch.yaml
+++ b/argocd/applications/local-path/patches/local-path-config.patch.yaml
@@ -9,7 +9,10 @@ data:
       "nodePathMap":[
         {
           "node":"talos-192-168-1-85",
-          "paths":["/var/mnt/local-path-provisioner"]
+          "paths":[
+            "/var/mnt/local-path-provisioner",
+            "/var/mnt/local-path-provisioner-extra"
+          ]
         },
         {
           "node":"talos-192-168-1-194",

--- a/devices/altra/manifests/README.md
+++ b/devices/altra/manifests/README.md
@@ -9,4 +9,5 @@ Files:
 - `devices/altra/manifests/controlplane-endpoint-nuc.patch.yaml`
 - `devices/altra/manifests/ephemeral-volume.patch.yaml`
 - `devices/altra/manifests/local-path.patch.yaml`
+- `devices/altra/manifests/local-path-extra.patch.yaml`
 - `devices/altra/manifests/vfio-modules.patch.yaml`

--- a/devices/altra/manifests/local-path-extra.patch.yaml
+++ b/devices/altra/manifests/local-path-extra.patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: local-path-provisioner-extra
+provisioning:
+  # Extra 4TB NVMe on `altra` (CT4000P3PSSD8).
+  diskSelector:
+    match: disk.wwid == 'eui.6479a7899000003d'
+  minSize: 100GB
+  # Omit maxSize to consume the remaining free space on the selected disk.
+  grow: true

--- a/devices/altra/manifests/local-path.patch.yaml
+++ b/devices/altra/manifests/local-path.patch.yaml
@@ -3,6 +3,7 @@ kind: UserVolumeConfig
 name: local-path-provisioner
 provisioning:
   # `altra` installs to `/dev/nvme0n1` (see `devices/altra/manifests/install-nvme0n1.patch.yaml`).
+  # This consumes the remaining space on the OS NVMe after EPHEMERAL is set to 300GB.
   diskSelector:
     match: disk.dev_path == '/dev/nvme0n1'
   minSize: 100GB


### PR DESCRIPTION
## Summary

- Add `devices/altra/manifests/local-path-extra.patch.yaml` with a second Talos `UserVolumeConfig` for node `talos-192-168-1-85`, pinned to the extra NVMe by WWID.
- Keep `devices/altra/manifests/local-path.patch.yaml` as the OS-disk user volume and clarify it consumes remaining space after `EPHEMERAL=300GB`.
- Update local-path `nodePathMap` for node `talos-192-168-1-85` to include both `/var/mnt/local-path-provisioner` and `/var/mnt/local-path-provisioner-extra`.
- Update `devices/altra/manifests/README.md` to include the new patch file.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/local-path >/tmp/local-path-rendered.yaml`
- `rg -n "talos-192-168-1-85|local-path-provisioner-extra" /tmp/local-path-rendered.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
