### PR TITLE
fix(argocd): re-enable temporal in platform appset

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -248,7 +248,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "4"
                 automation: manual
-                enabled: "false"
+                enabled: "true"
               - name: airbyte
                 path: argocd/applications/airbyte
                 namespace: airbyte


### PR DESCRIPTION
## Summary

- Re-enabled `temporal` in the `platform` ApplicationSet by changing its generator element from `enabled: "false"` to `enabled: "true"`.
- Aligns Git desired state with the live recovery so `root` sync no longer removes the Temporal application.
- Ensures Temporal rollout is managed by GitOps instead of manual in-cluster patching.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applicationsets/platform.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
