### PR TITLE
feat(landing): polish macOS desktop and AgentRun terminal experience

### DIFF
--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -17,7 +17,7 @@
     --terminal-window-bg-top: 36 40 59;
     --terminal-window-bg-bottom: 31 35 53;
     --terminal-shell-border: 84 92 126;
-    --terminal-shell-border-alpha: 0.5;
+    --terminal-shell-border-alpha: 0.42;
     --terminal-text-primary: 192 202 245;
     --terminal-text-secondary: 169 177 214;
     --terminal-text-faint: 115 122 162;
@@ -46,16 +46,16 @@
     border: 1px solid rgb(var(--terminal-shell-border) / var(--terminal-shell-border-alpha));
     background: linear-gradient(
       180deg,
-      rgb(var(--terminal-window-bg-top) / 0.86) 0%,
-      rgb(var(--terminal-window-bg-bottom) / 0.76) 100%
+      rgb(var(--terminal-window-bg-top) / 0.72) 0%,
+      rgb(var(--terminal-window-bg-bottom) / 0.58) 100%
     );
     color: rgb(var(--terminal-titlebar-text));
     box-shadow:
       inset 0 1px 0 rgb(169 177 214 / 0.22),
       inset 0 -1px 0 rgb(27 30 45 / 0.5),
-      0 0 0 1px rgb(59 66 97 / 0.4),
-      0 38px 90px -46px rgb(0 0 0 / 0.88);
-    backdrop-filter: blur(16px) saturate(1.08);
+      0 0 0 1px rgb(59 66 97 / 0.35),
+      0 38px 90px -46px rgb(0 0 0 / 0.78);
+    backdrop-filter: blur(20px) saturate(1.12);
   }
 
   .font-display {

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -12,18 +12,18 @@
 
 @layer utilities {
   .terminal-squircle-shell {
-    --terminal-titlebar-bg: 30 35 52;
+    --terminal-titlebar-bg: 41 46 66;
     --terminal-titlebar-text: 192 202 245;
-    --terminal-window-bg-top: 20 23 33;
-    --terminal-window-bg-bottom: 12 14 22;
-    --terminal-shell-border: 88 97 123;
-    --terminal-shell-border-alpha: 0.4;
+    --terminal-window-bg-top: 36 40 59;
+    --terminal-window-bg-bottom: 31 35 53;
+    --terminal-shell-border: 84 92 126;
+    --terminal-shell-border-alpha: 0.5;
     --terminal-text-primary: 192 202 245;
-    --terminal-text-secondary: 154 165 206;
-    --terminal-text-faint: 86 95 137;
+    --terminal-text-secondary: 169 177 214;
+    --terminal-text-faint: 115 122 162;
     --terminal-text-dim: 86 95 137;
     --terminal-text-green: 158 206 106;
-    --terminal-text-cyan: 115 218 203;
+    --terminal-text-cyan: 125 207 255;
     --terminal-text-blue: 122 162 247;
     --terminal-text-purple: 187 154 247;
     --terminal-text-magenta: 187 154 247;
@@ -31,27 +31,31 @@
     --terminal-text-orange: 255 158 100;
     --terminal-text-yellow: 224 175 104;
     --terminal-accent-ripple-a: 122 162 247;
-    --terminal-accent-ripple-b: 73 176 238;
-    --terminal-accent-ripple-c: 115 218 203;
-    --terminal-top-left-radius: clamp(0.7rem, 1.5vw, 1.1rem);
-    --terminal-top-right-radius: clamp(0.62rem, 1.25vw, 1rem);
-    --terminal-bottom-right-radius: clamp(0.56rem, 1.12vw, 0.86rem);
-    --terminal-bottom-left-radius: clamp(0.58rem, 1.18vw, 0.95rem);
-    --terminal-squircle-h-radius: 1.1rem;
-    --terminal-squircle-v-radius: 1rem;
+    --terminal-accent-ripple-b: 187 154 247;
+    --terminal-accent-ripple-c: 125 207 255;
+    --terminal-top-left-radius: clamp(0.9rem, 1.55vw, 1.25rem);
+    --terminal-top-right-radius: clamp(0.82rem, 1.32vw, 1.12rem);
+    --terminal-bottom-right-radius: clamp(0.78rem, 1.18vw, 1rem);
+    --terminal-bottom-left-radius: clamp(0.8rem, 1.22vw, 1.06rem);
+    --terminal-squircle-h-radius: 1.28rem;
+    --terminal-squircle-v-radius: 1.18rem;
     border-radius:
       var(--terminal-top-left-radius) var(--terminal-top-right-radius) var(--terminal-bottom-right-radius)
       var(--terminal-bottom-left-radius) / var(--terminal-squircle-h-radius) var(--terminal-squircle-h-radius)
       var(--terminal-squircle-v-radius) var(--terminal-squircle-v-radius);
     border: 1px solid rgb(var(--terminal-shell-border) / var(--terminal-shell-border-alpha));
-    background: linear-gradient(180deg, rgb(var(--terminal-window-bg-top)), rgb(var(--terminal-window-bg-bottom)));
+    background: linear-gradient(
+      180deg,
+      rgb(var(--terminal-window-bg-top) / 0.86) 0%,
+      rgb(var(--terminal-window-bg-bottom) / 0.76) 100%
+    );
     color: rgb(var(--terminal-titlebar-text));
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.22),
-      inset 0 -1px 0 rgb(255 255 255 / 0.06),
-      0 0 0 1px rgb(255 255 255 / 0.04),
-      0 32px 100px -50px rgb(0 0 0 / 0.85);
-    backdrop-filter: blur(6px);
+      inset 0 1px 0 rgb(169 177 214 / 0.22),
+      inset 0 -1px 0 rgb(27 30 45 / 0.5),
+      0 0 0 1px rgb(59 66 97 / 0.4),
+      0 38px 90px -46px rgb(0 0 0 / 0.88);
+    backdrop-filter: blur(16px) saturate(1.08);
   }
 
   .font-display {

--- a/apps/landing/src/components/desktop-hero.tsx
+++ b/apps/landing/src/components/desktop-hero.tsx
@@ -606,7 +606,7 @@ function DockButton({
           'transform-gpu will-change-transform',
           showTooltip ? 'z-50' : 'z-10',
         )}
-        style={{ width: iconSize, height: iconSize, y: lift }}
+        style={{ width: DOCK_BASE_SIZE_PX, height: DOCK_BASE_SIZE_PX, y: lift }}
         aria-label={dockItem.label}
       >
         <motion.span
@@ -645,7 +645,7 @@ function DockButton({
         'transform-gpu will-change-transform',
         showTooltip ? 'z-50' : 'z-10',
       )}
-      style={{ width: iconSize, height: iconSize, y: lift }}
+      style={{ width: DOCK_BASE_SIZE_PX, height: DOCK_BASE_SIZE_PX, y: lift }}
       aria-label={dockItem.label}
     >
       <motion.span

--- a/apps/landing/src/components/desktop-hero.tsx
+++ b/apps/landing/src/components/desktop-hero.tsx
@@ -325,7 +325,8 @@ type DockItem = {
 const DOCK_BASE_SIZE_PX = 48
 const DOCK_MAX_SCALE = 1.82
 const DOCK_EFFECT_RADIUS_PX = 152
-const DOCK_MAX_NUDGE_PX = 16
+const DOCK_MAX_NUDGE_PX = 8
+const DOCK_NUDGE_EXPONENT = 3
 const DOCK_LIFT_MULTIPLIER = 12
 const DOCK_HOVER_DELAY_MS = 140
 const DOCK_TOOLTIP_TEXT_SIZE_PX = 13
@@ -588,7 +589,7 @@ function DockButton({
     if (!Number.isFinite(pointer)) return 0
     const { influence, direction } = getDockInfluence(pointer, buttonRef.current)
     if (influence <= 0 || direction === 0) return 0
-    return direction * influence * influence * DOCK_MAX_NUDGE_PX
+    return direction * influence ** DOCK_NUDGE_EXPONENT * DOCK_MAX_NUDGE_PX
   })
 
   const scale = useSpring(scaleTarget, {
@@ -597,8 +598,8 @@ function DockButton({
     mass: 0.24,
   })
   const nudgeX = useSpring(nudgeTarget, {
-    stiffness: 430,
-    damping: 36,
+    stiffness: 380,
+    damping: 40,
     mass: 0.26,
   })
   const iconSize = useTransform(scale, (value) => value * DOCK_BASE_SIZE_PX)

--- a/apps/landing/src/components/desktop-hero.tsx
+++ b/apps/landing/src/components/desktop-hero.tsx
@@ -1,15 +1,15 @@
 'use client'
 
 import { Wifi } from 'lucide-react'
-import { AnimatePresence, motion, useAnimationControls, useAnimationFrame } from 'motion/react'
+import { AnimatePresence, motion, useMotionValue, useReducedMotion, useSpring, useTransform } from 'motion/react'
 import Image from 'next/image'
 import {
-  type MutableRefObject,
   memo,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react'
@@ -21,6 +21,9 @@ type TopMenuItem = {
   id: string
   label: string
   action?: 'minimize' | 'restore' | 'toggle-fullscreen'
+  shortcut?: string
+  separatorBefore?: boolean
+  destructive?: boolean
 }
 
 type TopMenuSection = {
@@ -38,10 +41,12 @@ const topMenus: TopMenuSection[] = [
       { id: 'about-window', label: 'About This Mac' },
       { id: 'preferences', label: 'Preferences…' },
       { id: 'services', label: 'Services' },
+      { id: 'sep-hide', label: '', separatorBefore: true },
       { id: 'hide', label: 'Hide proompteng' },
       { id: 'hide-others', label: 'Hide Others' },
       { id: 'show-all', label: 'Show All' },
-      { id: 'quit', label: 'Quit proompteng', action: 'minimize' },
+      { id: 'sep-quit', label: '', separatorBefore: true },
+      { id: 'quit', label: 'Quit proompteng', action: 'minimize', shortcut: '⌘Q', destructive: true },
     ],
   },
   {
@@ -50,7 +55,7 @@ const topMenus: TopMenuSection[] = [
     items: [
       { id: 'new', label: 'New Window' },
       { id: 'open', label: 'Open' },
-      { id: 'close', label: 'Close Window', action: 'minimize' },
+      { id: 'close', label: 'Close Window', action: 'minimize', shortcut: '⌘W' },
       { id: 'save', label: 'Save As…' },
     ],
   },
@@ -69,7 +74,7 @@ const topMenus: TopMenuSection[] = [
     id: 'view',
     label: 'View',
     items: [
-      { id: 'as', label: 'Enter Full Screen', action: 'toggle-fullscreen' },
+      { id: 'as', label: 'Enter Full Screen', action: 'toggle-fullscreen', shortcut: '⌃⌘F' },
       { id: 'zoom-in', label: 'Zoom In' },
       { id: 'zoom-out', label: 'Zoom Out' },
       { id: 'toggle', label: 'Toggle Toolbar' },
@@ -79,7 +84,7 @@ const topMenus: TopMenuSection[] = [
     id: 'window',
     label: 'Window',
     items: [
-      { id: 'minimize', label: 'Minimize', action: 'minimize' },
+      { id: 'minimize', label: 'Minimize', action: 'minimize', shortcut: '⌘M' },
       { id: 'zoom', label: 'Zoom', action: 'toggle-fullscreen' },
       { id: 'arrange', label: 'Bring All to Front' },
     ],
@@ -95,12 +100,6 @@ const topMenus: TopMenuSection[] = [
   },
 ]
 
-const DESKTOP_ITEMS = [
-  { id: 'docs', label: 'Docs', emoji: '📘' },
-  { id: 'app', label: 'Apps', emoji: '⚙️' },
-  { id: 'root', label: 'System', emoji: '💻' },
-] as const
-
 const DOCK_ITEMS = [
   { id: 'docs', label: 'Docs', emoji: '📘', terminal: false },
   { id: 'terminal', label: 'proompteng', terminal: true },
@@ -115,6 +114,7 @@ export default function DesktopHero() {
   const desktopStageRef = useRef<HTMLDivElement>(null)
   const [currentTime, setCurrentTime] = useState('--:--')
   const [activeMenu, setActiveMenu] = useState<string | null>(null)
+  const [isTerminalClosed, setIsTerminalClosed] = useState(false)
 
   const restoreWindow = useCallback(() => {
     terminalWindowRef.current?.restore()
@@ -164,7 +164,10 @@ export default function DesktopHero() {
   useEffect(() => {
     const updateTime = () => {
       const formatter = new Intl.DateTimeFormat(undefined, {
-        hour: '2-digit',
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
         minute: '2-digit',
       })
       setCurrentTime(formatter.format(new Date()))
@@ -202,12 +205,19 @@ export default function DesktopHero() {
   }, [closeTopMenu])
 
   return (
-    <main className="relative min-h-[100svh] overflow-hidden bg-[radial-gradient(circle_at_18%_0%,rgba(122,162,247,0.24)_0%,rgba(26,27,38,0)_42%),radial-gradient(circle_at_84%_72%,rgba(187,154,247,0.18)_0%,rgba(26,27,38,0)_58%),radial-gradient(circle_at_45%_30%,rgba(125,207,255,0.12)_0%,rgba(26,27,38,0)_56%),linear-gradient(180deg,#2b2f46_0%,#23263a_54%,#1b2342_100%)]">
+    <main className="relative min-h-[100svh] overflow-hidden bg-[radial-gradient(circle_at_18%_0%,rgba(122,162,247,0.26)_0%,rgba(36,40,59,0)_42%),radial-gradient(circle_at_82%_74%,rgba(187,154,247,0.18)_0%,rgba(36,40,59,0)_58%),radial-gradient(circle_at_48%_34%,rgba(125,207,255,0.13)_0%,rgba(36,40,59,0)_56%),linear-gradient(180deg,#24283b_0%,#1f2335_56%,#1b1e2d_100%)]">
       <div className="relative flex min-h-[100svh] flex-col">
-        <header className="font-inter sticky top-0 z-20 h-11 border-b border-zinc-700/35 bg-black/35 px-3 py-1.5 text-[15px] font-normal text-zinc-100/90 backdrop-blur">
+        <header className="font-inter sticky top-0 z-20 h-11 border-b border-[rgb(84_92_126/0.45)] bg-[linear-gradient(180deg,rgba(61,89,161,0.64)_0%,rgba(41,46,66,0.86)_100%)] px-3 py-1 text-[13px] font-medium text-[rgb(192_202_245/0.95)] backdrop-blur-xl">
           <div className="mx-auto flex h-full max-w-[1200px] items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div ref={topMenuRef} className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="rounded-full px-2 py-1 text-[13px] leading-none text-[rgb(192_202_245/0.95)] transition-colors hover:bg-[rgb(122_162_247/0.24)]"
+                aria-label="Apple menu"
+              >
+                
+              </button>
+              <div ref={topMenuRef} className="flex items-center gap-1">
                 {topMenus.map((menu) => {
                   const isMenuActive = activeMenu === menu.id
                   return (
@@ -217,9 +227,13 @@ export default function DesktopHero() {
                         onClick={() => {
                           toggleTopMenuAtButton(menu.id)
                         }}
-                        className={`relative z-30 rounded-full px-3 py-1.5 text-[15px] font-normal transition-colors ${
+                        className={`relative z-30 rounded-full px-2.5 py-1.5 text-[13px] leading-none font-medium transition-colors ${
                           menu.id === 'terminal' ? 'font-bold' : ''
-                        } ${isMenuActive ? 'bg-white/15 text-zinc-50' : 'opacity-80'} hover:bg-white/10 hover:text-zinc-50`}
+                        } ${
+                          isMenuActive
+                            ? 'bg-[linear-gradient(180deg,rgba(122,162,247,0.52)_0%,rgba(61,89,161,0.66)_100%)] text-[rgb(192_202_245)] shadow-[inset_0_1px_0_rgba(192,202,245,0.24)]'
+                            : 'text-[rgb(192_202_245/0.92)]'
+                        } hover:bg-[linear-gradient(180deg,rgba(122,162,247,0.36)_0%,rgba(61,89,161,0.44)_100%)] hover:text-[rgb(192_202_245)]`}
                         onMouseEnter={() => {
                           openTopMenuAtButton(menu.id)
                         }}
@@ -235,20 +249,35 @@ export default function DesktopHero() {
                             animate={{ opacity: 1, y: 0 }}
                             exit={{ opacity: 0, y: -4 }}
                             transition={{ duration: 0.13, ease: 'easeOut' }}
-                            className="absolute top-full left-0 z-30 mt-0.5 w-52 rounded-lg border border-zinc-600/35 bg-zinc-900/85 p-1.5 shadow-[0_16px_42px_-20px_rgba(0,0,0,0.75)] backdrop-blur-md"
+                            className="absolute top-full left-0 z-30 mt-1.5 w-60 rounded-xl border border-[rgb(84_92_126/0.45)] bg-[rgba(31,35,53,0.9)] p-1.5 shadow-[0_22px_44px_-20px_rgba(0,0,0,0.9)] backdrop-blur-xl"
                           >
-                            {(topMenus.find((menu) => menu.id === activeMenu)?.items ?? []).map((item) => (
-                              <button
-                                key={item.id}
-                                type="button"
-                                className="flex w-full rounded-md px-2.5 py-2 text-left text-[13px] text-zinc-100 hover:bg-white/10"
-                                onClick={() => {
-                                  runTopMenuAction(item)
-                                }}
-                              >
-                                {item.label}
-                              </button>
-                            ))}
+                            {(topMenus.find((menu) => menu.id === activeMenu)?.items ?? []).map((item) => {
+                              if (item.separatorBefore) {
+                                return (
+                                  <div key={item.id} className="my-1 h-px bg-[rgb(84_92_126/0.38)]" role="separator" />
+                                )
+                              }
+
+                              return (
+                                <button
+                                  key={item.id}
+                                  type="button"
+                                  className={cn(
+                                    'flex w-full items-center justify-between rounded-md px-2.5 py-2 text-left text-[13px] text-[rgb(192_202_245)]',
+                                    'hover:bg-[rgb(61_89_161/0.52)]',
+                                    item.destructive ? 'text-red-200' : '',
+                                  )}
+                                  onClick={() => {
+                                    runTopMenuAction(item)
+                                  }}
+                                >
+                                  <span>{item.label}</span>
+                                  <span className="font-medium text-[11px] tracking-wide text-[rgb(115_122_162/0.9)]">
+                                    {item.shortcut ?? ''}
+                                  </span>
+                                </button>
+                              )
+                            })}
                           </motion.div>
                         ) : null}
                       </AnimatePresence>
@@ -257,38 +286,28 @@ export default function DesktopHero() {
                 })}
               </div>
             </div>
-            <div className="flex cursor-default select-none items-center gap-3 opacity-80">
-              <Wifi className="h-5 w-5 shrink-0" aria-hidden="true" />
-              <span className="cursor-default font-semibold">{currentTime}</span>
+            <div className="flex cursor-default select-none items-center gap-2 text-[12px] text-[rgb(169_177_214/0.95)]">
+              <Wifi className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              <span className="cursor-default font-medium tracking-[0.01em]">{currentTime}</span>
             </div>
           </div>
         </header>
 
         <div ref={desktopStageRef} className="relative z-10 flex-1 overflow-hidden">
-          <div className="relative z-10 px-4 pb-32 pt-8 sm:px-8">
-            <div className="mx-auto grid h-full max-w-[1200px] grid-cols-2 gap-5 px-2 sm:grid-cols-3 md:grid-cols-4">
-              {DESKTOP_ITEMS.map((item) => (
-                <button
-                  key={item.id}
-                  type="button"
-                  className="flex w-full flex-col items-center justify-end gap-1 text-3xl text-zinc-100/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/40"
-                  aria-label={item.label}
-                >
-                  {item.emoji}
-                  <span className="text-[11px] leading-none">{item.label}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-
           <TerminalWindow
             ref={terminalWindowRef}
             desktopBoundsRef={desktopStageRef}
             menuBarButtonRef={menuBarButtonRef}
+            onClosedStateChange={setIsTerminalClosed}
           />
 
           <footer className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex justify-center px-3 pb-4">
-            <Dock items={DOCK_ITEMS} menuBarButtonRef={menuBarButtonRef} onTerminalClick={handleDockClick} />
+            <Dock
+              items={DOCK_ITEMS}
+              menuBarButtonRef={menuBarButtonRef}
+              onTerminalClick={handleDockClick}
+              isTerminalClosed={isTerminalClosed}
+            />
           </footer>
         </div>
       </div>
@@ -303,195 +322,116 @@ type DockItem = {
   terminal: boolean
 }
 
-type DockIconTransform = {
-  scale: number
-  y: number
-  x: number
+const DOCK_BASE_SIZE_PX = 48
+const DOCK_MAX_SCALE = 1.82
+const DOCK_EFFECT_RADIUS_PX = 152
+const DOCK_HOVER_DELAY_MS = 140
+const DOCK_TOOLTIP_TEXT_SIZE_PX = 13
+const DOCK_TOOLTIP_LINE_HEIGHT_PX = 18
+const DOCK_TOOLTIP_PADDING_X_PX = 16
+const DOCK_TOOLTIP_PADDING_Y_PX = 6
+const DOCK_TOOLTIP_MIN_WIDTH_PX = 88
+const DOCK_TOOLTIP_MIN_BODY_HEIGHT_PX = 30
+const DOCK_TOOLTIP_TAIL_HEIGHT_PX = 8
+const DOCK_TOOLTIP_RADIUS_PX = 15
+
+function clampValue(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function createDockTooltipPath(
+  width: number,
+  bodyHeight: number,
+  radius: number,
+  tailWidth: number,
+  tailHeight: number,
+) {
+  const safeRadius = clampValue(radius, 4, Math.min(width / 2 - 1, bodyHeight / 2 - 1))
+  const centerX = width / 2
+  const halfTail = tailWidth / 2
+  const tailLeft = clampValue(centerX - halfTail, safeRadius + 6, width - safeRadius - 6)
+  const tailRight = clampValue(centerX + halfTail, safeRadius + 6, width - safeRadius - 6)
+  const tailCurvePull = Math.max(3, halfTail * 0.72)
+  const tipY = bodyHeight + tailHeight
+
+  return [
+    `M ${safeRadius} 0`,
+    `H ${width - safeRadius}`,
+    `Q ${width} 0 ${width} ${safeRadius}`,
+    `V ${bodyHeight - safeRadius}`,
+    `Q ${width} ${bodyHeight} ${width - safeRadius} ${bodyHeight}`,
+    `H ${tailRight}`,
+    `Q ${centerX + tailCurvePull} ${bodyHeight} ${centerX} ${tipY}`,
+    `Q ${centerX - tailCurvePull} ${bodyHeight} ${tailLeft} ${bodyHeight}`,
+    `H ${safeRadius}`,
+    `Q 0 ${bodyHeight} 0 ${bodyHeight - safeRadius}`,
+    `V ${safeRadius}`,
+    `Q 0 0 ${safeRadius} 0`,
+    'Z',
+  ].join(' ')
 }
 
 const Dock = memo(function Dock({
   items,
   menuBarButtonRef,
   onTerminalClick,
+  isTerminalClosed,
 }: {
   items: readonly DockItem[]
   menuBarButtonRef: RefObject<HTMLButtonElement | null>
   onTerminalClick: () => void
+  isTerminalClosed: boolean
 }) {
-  const dockRefs = useRef<Array<HTMLButtonElement | null>>([])
-  const dockCentersRef = useRef<number[]>([])
-  const dockLeftRef = useRef(0)
   const hoverIntentRef = useRef<number | null>(null)
-  const dockPointerXRef = useRef<number | null>(null)
-  const dockPointerXSmoothedRef = useRef<number | null>(null)
-  const dockPosControlsRef = useRef<Array<ReturnType<typeof useAnimationControls> | null>>([])
-  const dockScaleControlsRef = useRef<Array<ReturnType<typeof useAnimationControls> | null>>([])
-  const dockCurrentRef = useRef<DockIconTransform[]>([])
-  const shouldAnimateRef = useRef(false)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+  const pointerX = useMotionValue(Number.POSITIVE_INFINITY)
 
-  const measureDockCenters = useCallback(() => {
-    const dockNode = dockRefs.current[0]?.parentElement
-    if (dockNode instanceof HTMLElement) {
-      // Avoid layout reads inside animation frames: capture dock left edge during measurement.
-      dockLeftRef.current = dockNode.getBoundingClientRect().left
+  const clearHoverIntent = useCallback(() => {
+    if (hoverIntentRef.current !== null) {
+      window.clearTimeout(hoverIntentRef.current)
+      hoverIntentRef.current = null
     }
-
-    dockCentersRef.current = dockRefs.current.map((node) => {
-      if (!node) return 0
-      const rect = node.getBoundingClientRect()
-      return rect.left + rect.width / 2
-    })
   }, [])
 
-  useEffect(() => {
-    measureDockCenters()
-    const onResize = () => measureDockCenters()
-    window.addEventListener('resize', onResize)
-    return () => window.removeEventListener('resize', onResize)
-  }, [measureDockCenters])
-
-  const handleDockPointerMove = useCallback((event: ReactPointerEvent<HTMLElement>) => {
-    dockPointerXRef.current = event.clientX
-    shouldAnimateRef.current = true
-  }, [])
-
-  const handleDockPointerLeave = useCallback(() => {
-    dockPointerXRef.current = null
-    if (hoverIntentRef.current !== null) window.clearTimeout(hoverIntentRef.current)
-    hoverIntentRef.current = null
-    setHoveredIndex(null)
-    shouldAnimateRef.current = true
-  }, [])
-
-  useAnimationFrame(() => {
-    if (!shouldAnimateRef.current) return
-
-    const pointerXTarget = dockPointerXRef.current
-    if (pointerXTarget === null) {
-      dockPointerXSmoothedRef.current = null
-    } else {
-      const current = dockPointerXSmoothedRef.current ?? pointerXTarget
-      dockPointerXSmoothedRef.current = current + (pointerXTarget - current) * 0.28
-    }
-
-    const pointerX = dockPointerXSmoothedRef.current
-    const centers = dockCentersRef.current
-    const posControls = dockPosControlsRef.current
-    const scaleControls = dockScaleControlsRef.current
-
-    const settleEpsilonScale = 0.0025
-    const settleEpsilonY = 0.14
-    const settleEpsilonX = 0.35
-
-    if (!dockCurrentRef.current.length) {
-      dockCurrentRef.current = Array.from({ length: items.length }, () => ({ scale: 1, y: 0, x: 0 }))
-    }
-
-    const dockLeft = dockLeftRef.current
-    const baseCentersLocal = centers.map((c) => c - dockLeft)
-    const groupCenterLocal =
-      (baseCentersLocal[0] ?? 0) + ((baseCentersLocal.at(-1) ?? 0) - (baseCentersLocal[0] ?? 0)) / 2
-
-    const targetScales = Array.from({ length: items.length }, () => 1)
-    const targetLift = Array.from({ length: items.length }, () => 0)
-
-    if (pointerX !== null) {
-      const pointerLocal = pointerX - dockLeft
-      const range = 140
-      const magnification = 0.8
-      for (let i = 0; i < items.length; i += 1) {
-        const center = baseCentersLocal[i] ?? 0
-        const dist = Math.abs(pointerLocal - center)
-        if (dist >= range) continue
-        const t = dist / range
-        const falloff = Math.cos((t * Math.PI) / 2)
-        const scale = 1 + magnification * falloff * falloff
-        targetScales[i] = scale
-        targetLift[i] = -(scale - 1) * 18
-      }
-    }
-
-    // Re-layout by scaled widths, centered around the original dock center.
-    const widths = targetScales.map((s) => 48 * s)
-    const totalWidth = widths.reduce((sum, w) => sum + w, 0) + 18 * Math.max(0, widths.length - 1)
-    let cursor = groupCenterLocal - totalWidth / 2
-    const targetX: number[] = []
-    for (let i = 0; i < widths.length; i += 1) {
-      const w = widths[i] ?? 48
-      const center = cursor + w / 2
-      cursor += w + 18
-      targetX[i] = center - (baseCentersLocal[i] ?? 0)
-    }
-
-    let stillAnimating = false
-    for (let i = 0; i < items.length; i += 1) {
-      const posControl = posControls[i]
-      const scaleControl = scaleControls[i]
-      if (!posControl || !scaleControl) continue
-
-      const targetScale = targetScales[i] ?? 1
-      const targetY = targetLift[i] ?? 0
-      const targetTranslateX = pointerX === null ? 0 : (targetX[i] ?? 0)
-
-      const cur = dockCurrentRef.current[i] ?? { scale: 1, y: 0, x: 0 }
-      const scale = cur.scale + (targetScale - cur.scale) * 0.2
-      const y = cur.y + (targetY - cur.y) * 0.26
-      const x = cur.x + (targetTranslateX - cur.x) * 0.22
-      dockCurrentRef.current[i] = { scale, y, x }
-
-      // Keep tooltip unaffected by magnification: translate the button, scale only the icon.
-      posControl.set({ x, y })
-      scaleControl.set({ scale })
-
-      if (
-        Math.abs(targetScale - scale) > settleEpsilonScale ||
-        Math.abs(targetY - y) > settleEpsilonY ||
-        Math.abs(targetTranslateX - x) > settleEpsilonX
-      ) {
-        stillAnimating = true
-      }
-    }
-
-    if (pointerXTarget === null && !stillAnimating) {
-      shouldAnimateRef.current = false
-    }
-  })
+  useEffect(
+    () => () => {
+      clearHoverIntent()
+    },
+    [clearHoverIntent],
+  )
 
   return (
     <motion.nav
       className={cn(
         'pointer-events-auto relative flex items-end gap-[18px] overflow-visible rounded-[22px] px-6 py-3',
-        'bg-[rgba(18,20,33,0.44)] shadow-[0_26px_70px_-44px_rgba(0,0,0,0.95)] backdrop-blur-2xl backdrop-saturate-150',
-        'ring-1 ring-white/10',
+        'bg-[rgba(31,35,53,0.56)] shadow-[0_26px_70px_-44px_rgba(0,0,0,0.95)] backdrop-blur-2xl backdrop-saturate-150',
+        'ring-1 ring-[rgb(84_92_126/0.5)]',
       )}
-      onPointerEnter={() => {
-        measureDockCenters()
-        shouldAnimateRef.current = true
+      onPointerMove={(event: ReactPointerEvent<HTMLElement>) => {
+        pointerX.set(event.clientX)
       }}
-      onPointerMove={handleDockPointerMove}
-      onPointerLeave={handleDockPointerLeave}
+      onPointerLeave={() => {
+        pointerX.set(Number.POSITIVE_INFINITY)
+        clearHoverIntent()
+        setHoveredIndex(null)
+      }}
     >
       {items.map((dockItem, index) => {
         return (
           <DockButton
             key={dockItem.id}
             dockItem={dockItem}
-            index={index}
             menuBarButtonRef={menuBarButtonRef}
+            pointerX={pointerX}
             onTerminalClick={onTerminalClick}
-            dockRefs={dockRefs}
-            dockPosControlsRef={dockPosControlsRef}
-            dockScaleControlsRef={dockScaleControlsRef}
             showTooltip={hoveredIndex === index}
-            showRunningDot={dockItem.terminal}
+            showRunningDot={dockItem.terminal && isTerminalClosed}
             onHoverStart={() => {
-              if (hoverIntentRef.current !== null) window.clearTimeout(hoverIntentRef.current)
-              hoverIntentRef.current = window.setTimeout(() => setHoveredIndex(index), 180)
+              clearHoverIntent()
+              hoverIntentRef.current = window.setTimeout(() => setHoveredIndex(index), DOCK_HOVER_DELAY_MS)
             }}
             onHoverEnd={() => {
-              if (hoverIntentRef.current !== null) window.clearTimeout(hoverIntentRef.current)
-              hoverIntentRef.current = null
+              clearHoverIntent()
               setHoveredIndex((prev) => (prev === index ? null : prev))
             }}
           />
@@ -502,6 +442,44 @@ const Dock = memo(function Dock({
 })
 
 function DockTooltip({ label }: { label: string }) {
+  const labelRef = useRef<HTMLSpanElement | null>(null)
+  const [labelWidth, setLabelWidth] = useState(0)
+
+  useLayoutEffect(() => {
+    const node = labelRef.current
+    if (!node) return
+
+    const measure = () => {
+      const nextWidth = Math.ceil(node.getBoundingClientRect().width)
+      setLabelWidth((prev) => (prev === nextWidth ? prev : nextWidth))
+    }
+
+    measure()
+
+    const resizeObserver = new ResizeObserver(() => {
+      measure()
+    })
+    resizeObserver.observe(node)
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [label])
+
+  const bodyWidth = Math.max(DOCK_TOOLTIP_MIN_WIDTH_PX, labelWidth + DOCK_TOOLTIP_PADDING_X_PX * 2)
+  const bodyHeight = Math.max(
+    DOCK_TOOLTIP_MIN_BODY_HEIGHT_PX,
+    DOCK_TOOLTIP_LINE_HEIGHT_PX + DOCK_TOOLTIP_PADDING_Y_PX * 2,
+  )
+  const totalHeight = bodyHeight + DOCK_TOOLTIP_TAIL_HEIGHT_PX
+  const tailWidth = clampValue(bodyWidth * 0.22, 12, 24)
+  const tooltipPath = createDockTooltipPath(
+    bodyWidth,
+    bodyHeight,
+    DOCK_TOOLTIP_RADIUS_PX,
+    tailWidth,
+    DOCK_TOOLTIP_TAIL_HEIGHT_PX,
+  )
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 10, scale: 0.98 }}
@@ -510,65 +488,111 @@ function DockTooltip({ label }: { label: string }) {
       transition={{ duration: 0.14, ease: 'easeOut' }}
       className={cn(
         'pointer-events-none absolute left-1/2 bottom-full z-[70] -translate-x-1/2',
-        'mb-3 whitespace-nowrap rounded-full px-4 py-1.5',
-        'bg-[rgba(20,22,31,0.66)] text-[13px] font-medium leading-none text-white/92',
-        'shadow-[0_12px_32px_-24px_rgba(0,0,0,0.95)] backdrop-blur-xl ring-1 ring-white/12',
-        // Tail: a rounded rotated square, overlapped into the pill to avoid jagged seams.
-        'after:absolute after:left-1/2 after:top-full after:-translate-x-1/2 after:-translate-y-[7px] after:size-2.5 after:rotate-45 after:rounded-[3px]',
-        'after:bg-[rgba(20,22,31,0.66)] after:ring-1 after:ring-white/12 after:content-[""]',
+        'mb-3 whitespace-nowrap',
+        'text-[13px] font-medium leading-none text-[rgb(192_202_245/0.96)]',
       )}
+      style={{ width: bodyWidth, height: totalHeight }}
       aria-hidden="true"
     >
-      {label}
+      <svg
+        className="absolute inset-0"
+        width={bodyWidth}
+        height={totalHeight}
+        viewBox={`0 0 ${bodyWidth} ${totalHeight}`}
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <path
+          d={tooltipPath}
+          fill="rgb(31 35 53 / 0.88)"
+          stroke="rgb(84 92 126 / 0.62)"
+          strokeWidth="1"
+          vectorEffect="non-scaling-stroke"
+          style={{
+            filter: 'drop-shadow(0 12px 20px rgba(0,0,0,0.42))',
+          }}
+        />
+      </svg>
+      <span
+        className="absolute inset-x-0 top-0 flex items-center justify-center font-semibold tracking-[0.01em]"
+        style={{
+          height: bodyHeight,
+          fontSize: DOCK_TOOLTIP_TEXT_SIZE_PX,
+          lineHeight: `${DOCK_TOOLTIP_LINE_HEIGHT_PX}px`,
+          paddingLeft: DOCK_TOOLTIP_PADDING_X_PX,
+          paddingRight: DOCK_TOOLTIP_PADDING_X_PX,
+          paddingTop: DOCK_TOOLTIP_PADDING_Y_PX,
+          paddingBottom: DOCK_TOOLTIP_PADDING_Y_PX,
+        }}
+      >
+        <span ref={labelRef} className="inline-block">
+          {label}
+        </span>
+      </span>
     </motion.div>
   )
 }
 
 function DockButton({
   dockItem,
-  index,
   menuBarButtonRef,
+  pointerX,
   onTerminalClick,
-  dockRefs,
-  dockPosControlsRef,
-  dockScaleControlsRef,
   showTooltip,
   showRunningDot,
   onHoverStart,
   onHoverEnd,
 }: {
   dockItem: DockItem
-  index: number
   menuBarButtonRef: RefObject<HTMLButtonElement | null>
+  pointerX: ReturnType<typeof useMotionValue<number>>
   onTerminalClick: () => void
-  dockRefs: MutableRefObject<Array<HTMLButtonElement | null>>
-  dockPosControlsRef: MutableRefObject<Array<ReturnType<typeof useAnimationControls> | null>>
-  dockScaleControlsRef: MutableRefObject<Array<ReturnType<typeof useAnimationControls> | null>>
   showTooltip: boolean
   showRunningDot: boolean
   onHoverStart: () => void
   onHoverEnd: () => void
 }) {
-  const posControls = useAnimationControls()
-  const scaleControls = useAnimationControls()
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const reducedMotion = useReducedMotion()
 
-  useEffect(() => {
-    dockPosControlsRef.current[index] = posControls
-    dockScaleControlsRef.current[index] = scaleControls
-    return () => {
-      if (dockPosControlsRef.current[index] === posControls) dockPosControlsRef.current[index] = null
-      if (dockScaleControlsRef.current[index] === scaleControls) dockScaleControlsRef.current[index] = null
-    }
-  }, [dockPosControlsRef, dockScaleControlsRef, index, posControls, scaleControls])
+  const scaleTarget = useTransform(() => {
+    if (reducedMotion) return 1
+    const pointer = pointerX.get()
+    if (!Number.isFinite(pointer)) return 1
+    const rect = buttonRef.current?.getBoundingClientRect()
+    if (!rect) return 1
+
+    const center = rect.left + rect.width / 2
+    const distance = Math.abs(pointer - center)
+    if (distance >= DOCK_EFFECT_RADIUS_PX) return 1
+
+    const t = distance / DOCK_EFFECT_RADIUS_PX
+    const influence = Math.cos((t * Math.PI) / 2)
+    return 1 + influence * influence * (DOCK_MAX_SCALE - 1)
+  })
+
+  const scale = useSpring(scaleTarget, {
+    stiffness: 430,
+    damping: 34,
+    mass: 0.24,
+  })
+  const iconSize = useTransform(scale, (value) => value * DOCK_BASE_SIZE_PX)
+  const lift = useTransform(scale, (value) => -(value - 1) * 18)
+  const emojiFontSize = useTransform(iconSize, (value) => Math.max(30, value * 0.66))
+
+  const assignButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      buttonRef.current = node
+      if (dockItem.terminal) menuBarButtonRef.current = node
+    },
+    [dockItem.terminal, menuBarButtonRef],
+  )
 
   if (dockItem.terminal) {
     return (
       <motion.button
         type="button"
-        ref={(node) => {
-          dockRefs.current[index] = node
-          menuBarButtonRef.current = node
-        }}
+        ref={assignButtonRef}
         onClick={onTerminalClick}
         onKeyDown={(event) => {
           if (event.key !== ' ' && event.key !== 'Enter') return
@@ -577,28 +601,32 @@ function DockButton({
         }}
         onPointerEnter={onHoverStart}
         onPointerLeave={onHoverEnd}
-        animate={posControls}
         className={cn(
-          'relative isolate inline-flex h-12 w-12 items-center justify-center overflow-visible p-0 leading-none text-zinc-100',
+          'relative isolate inline-flex shrink-0 items-center justify-center overflow-visible p-0 leading-none text-zinc-100',
           'transform-gpu will-change-transform',
           showTooltip ? 'z-50' : 'z-10',
         )}
+        style={{ width: iconSize, height: iconSize, y: lift }}
         aria-label={dockItem.label}
       >
-        <motion.div animate={scaleControls} className="relative z-10 transform-gpu will-change-transform">
+        <motion.span
+          className="relative z-10 block shrink-0 transform-gpu will-change-transform"
+          style={{ width: iconSize, height: iconSize }}
+        >
           <Image
             src="/macos-terminal-icon.png"
             alt="proompteng"
             width={48}
             height={48}
-            className="size-12 object-contain"
+            className="block h-full w-full object-contain"
+            draggable={false}
             priority
           />
-        </motion.div>
+        </motion.span>
         {showRunningDot ? (
           <span
             aria-hidden="true"
-            className="absolute left-1/2 top-full mt-1 size-[6px] -translate-x-1/2 rounded-full bg-white/85 shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+            className="absolute left-1/2 top-full mt-1 size-[6px] -translate-x-1/2 rounded-full bg-[rgb(192_202_245/0.9)] shadow-[0_0_0_1px_rgba(31,35,53,0.85)]"
           />
         ) : null}
         <AnimatePresence>{showTooltip ? <DockTooltip label={dockItem.label} /> : null}</AnimatePresence>
@@ -609,22 +637,20 @@ function DockButton({
   return (
     <motion.button
       type="button"
-      ref={(node) => {
-        dockRefs.current[index] = node
-      }}
+      ref={assignButtonRef}
       onPointerEnter={onHoverStart}
       onPointerLeave={onHoverEnd}
-      animate={posControls}
       className={cn(
-        'relative isolate inline-flex h-12 w-12 items-center justify-center overflow-visible p-0 leading-none text-zinc-100',
+        'relative isolate inline-flex shrink-0 items-center justify-center overflow-visible p-0 leading-none text-zinc-100',
         'transform-gpu will-change-transform',
         showTooltip ? 'z-50' : 'z-10',
       )}
+      style={{ width: iconSize, height: iconSize, y: lift }}
       aria-label={dockItem.label}
     >
       <motion.span
-        animate={scaleControls}
-        className="relative z-10 transform-gpu will-change-transform text-[34px] leading-none"
+        className="relative z-10 transform-gpu leading-none will-change-transform"
+        style={{ fontSize: emojiFontSize }}
       >
         {dockItem.emoji}
       </motion.span>

--- a/apps/landing/src/components/desktop-hero.tsx
+++ b/apps/landing/src/components/desktop-hero.tsx
@@ -301,7 +301,7 @@ export default function DesktopHero() {
             onClosedStateChange={setIsTerminalClosed}
           />
 
-          <footer className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex justify-center px-3 pb-4">
+          <footer className="pointer-events-none absolute inset-x-0 bottom-0 z-[90] flex justify-center px-3 pb-4">
             <Dock
               items={DOCK_ITEMS}
               menuBarButtonRef={menuBarButtonRef}
@@ -403,7 +403,7 @@ const Dock = memo(function Dock({
   return (
     <motion.nav
       className={cn(
-        'pointer-events-auto relative flex items-end gap-[18px] overflow-visible rounded-[22px] px-6 py-3',
+        'pointer-events-auto relative z-[95] flex items-end gap-[18px] overflow-visible rounded-[22px] px-6 py-3',
         'bg-[rgba(31,35,53,0.56)] shadow-[0_26px_70px_-44px_rgba(0,0,0,0.95)] backdrop-blur-2xl backdrop-saturate-150',
         'ring-1 ring-[rgb(84_92_126/0.5)]',
       )}
@@ -487,7 +487,7 @@ function DockTooltip({ label }: { label: string }) {
       exit={{ opacity: 0, y: 10, scale: 0.98 }}
       transition={{ duration: 0.14, ease: 'easeOut' }}
       className={cn(
-        'pointer-events-none absolute left-1/2 bottom-full z-[70] -translate-x-1/2',
+        'pointer-events-none absolute left-1/2 bottom-full z-[120] -translate-x-1/2',
         'mb-3 whitespace-nowrap',
         'text-[13px] font-medium leading-none text-[rgb(192_202_245/0.96)]',
       )}

--- a/apps/landing/src/components/terminal-window.tsx
+++ b/apps/landing/src/components/terminal-window.tsx
@@ -278,6 +278,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
     const [windowMode, setWindowMode] = useState<WindowMode>('normal')
     const [fullscreenMode, setFullscreenMode] = useState<FullscreenMode>('normal')
     const [minimizeOffset, setMinimizeOffset] = useState({ x: 0, y: 0 })
+    const [isWindowActive, setIsWindowActive] = useState(true)
     const isClosedRef = useRef(false)
 
     useEffect(() => {
@@ -294,6 +295,19 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
         window.removeEventListener('resize', handleResize)
       }
     }, [desktopBoundsRef])
+
+    useEffect(() => {
+      const handlePointerDown = (event: PointerEvent) => {
+        const target = event.target
+        if (!(target instanceof Node)) return
+        setIsWindowActive(Boolean(windowRef.current?.contains(target)))
+      }
+
+      window.addEventListener('pointerdown', handlePointerDown, true)
+      return () => {
+        window.removeEventListener('pointerdown', handlePointerDown, true)
+      }
+    }, [])
 
     const beginDrag = useCallback(
       (pointerId: number, startX: number, startY: number) => {
@@ -379,6 +393,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
       if (windowMode === 'closed') {
         isClosedRef.current = false
         onClosedStateChange?.(false)
+        setIsWindowActive(true)
         setWindowMode('normal')
         setMinimizeOffset({ x: 0, y: 0 })
         onMinimizedStateChange?.(false)
@@ -401,6 +416,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
       // and keep the dock "running" indicator handled by the parent.
       isClosedRef.current = true
       onClosedStateChange?.(true)
+      setIsWindowActive(false)
       restoreToFullscreenRef.current = false
       setFullscreenMode('normal')
       setWindowMode('closed')
@@ -829,10 +845,11 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
         <div
           className={cn(
             'absolute inset-x-0 top-0 z-20 flex h-10 cursor-default items-center justify-between gap-3.5 px-3 py-1',
-            'touch-none bg-[rgb(var(--terminal-titlebar-bg)/0.88)] border-[color:rgb(var(--terminal-shell-border)/0.45)]',
+            'touch-none bg-[rgb(var(--terminal-titlebar-bg)/0.72)] border-[color:rgb(var(--terminal-shell-border)/0.38)]',
             'select-none text-left outline-none',
           )}
           onPointerDown={(event) => {
+            setIsWindowActive(true)
             beginDrag(event.pointerId, event.clientX, event.clientY)
             try {
               ;(event.currentTarget as HTMLDivElement).setPointerCapture(event.pointerId)
@@ -843,12 +860,14 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
           }}
           onMouseDown={(event) => {
             if (event.button !== 0) return
+            setIsWindowActive(true)
             beginDrag(-1, event.clientX, event.clientY)
             event.preventDefault()
           }}
           onTouchStart={(event) => {
             const touch = event.touches[0]
             if (!touch) return
+            setIsWindowActive(true)
             beginDrag(-2, touch.clientX, touch.clientY)
             event.preventDefault()
           }}
@@ -872,7 +891,10 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             >
               <svg
                 viewBox="0 0 85.4 85.4"
-                className="absolute inset-0 size-[14px] opacity-100 transition-opacity duration-150 group-hover/stoplights:opacity-0"
+                className={cn(
+                  'absolute inset-0 size-[14px] transition-opacity duration-150',
+                  isWindowActive ? 'opacity-100 group-hover/stoplights:opacity-0' : 'opacity-100',
+                )}
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -888,7 +910,10 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
               </svg>
               <svg
                 viewBox="0 0 85.4 85.4"
-                className="absolute inset-0 size-[14px] opacity-0 transition-opacity duration-150 group-hover/stoplights:opacity-100"
+                className={cn(
+                  'absolute inset-0 size-[14px] transition-opacity duration-150',
+                  isWindowActive ? 'opacity-0 group-hover/stoplights:opacity-100' : 'opacity-0',
+                )}
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -934,7 +959,10 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             >
               <svg
                 viewBox="0 0 85.4 85.4"
-                className="absolute inset-0 size-[14px] opacity-100 transition-opacity duration-150 group-hover/stoplights:opacity-0"
+                className={cn(
+                  'absolute inset-0 size-[14px] transition-opacity duration-150',
+                  isWindowActive ? 'opacity-100 group-hover/stoplights:opacity-0' : 'opacity-100',
+                )}
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -950,7 +978,10 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
               </svg>
               <svg
                 viewBox="0 0 85.4 85.4"
-                className="absolute inset-0 size-[14px] opacity-0 transition-opacity duration-150 group-hover/stoplights:opacity-100"
+                className={cn(
+                  'absolute inset-0 size-[14px] transition-opacity duration-150',
+                  isWindowActive ? 'opacity-0 group-hover/stoplights:opacity-100' : 'opacity-0',
+                )}
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -994,7 +1025,10 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             >
               <svg
                 viewBox="0 0 85.4 85.4"
-                className="absolute inset-0 size-[14px] opacity-100 transition-opacity duration-150 group-hover/stoplights:opacity-0"
+                className={cn(
+                  'absolute inset-0 size-[14px] transition-opacity duration-150',
+                  isWindowActive ? 'opacity-100 group-hover/stoplights:opacity-0' : 'opacity-100',
+                )}
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -1010,7 +1044,10 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
               </svg>
               <svg
                 viewBox="0 0 85.4 85.4"
-                className="absolute inset-0 size-[14px] opacity-0 transition-opacity duration-150 group-hover/stoplights:opacity-100"
+                className={cn(
+                  'absolute inset-0 size-[14px] transition-opacity duration-150',
+                  isWindowActive ? 'opacity-0 group-hover/stoplights:opacity-100' : 'opacity-0',
+                )}
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -1043,7 +1080,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             className={cn(
               'relative h-full overflow-auto px-5 py-4 text-[12.5px] leading-relaxed sm:text-[13.5px]',
               'cursor-text select-text',
-              'bg-[linear-gradient(180deg,rgb(var(--terminal-window-bg-top)/0.82),rgb(var(--terminal-window-bg-bottom)/0.68))]',
+              'bg-[linear-gradient(180deg,rgb(var(--terminal-window-bg-top)/0.72),rgb(var(--terminal-window-bg-bottom)/0.54))]',
             )}
           >
             <div className="space-y-1 whitespace-pre">

--- a/apps/landing/src/components/terminal-window.tsx
+++ b/apps/landing/src/components/terminal-window.tsx
@@ -4,44 +4,18 @@ import { motion } from 'motion/react'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 
-const COMMAND = 'kubectl get agentruns'
+const COMMAND = 'kubectl -n agents get agentrun -w'
 const MIN_VISIBLE_PX = 64
-const MINIMIZE_SCALE = 0.13
+const MINIMIZE_SCALE = 0.16
 const MAX_WINDOW_WIDTH_PX = 74 * 16
-const MAX_WINDOW_HEIGHT_PX = 760
+const MAX_WINDOW_HEIGHT_PX = 900
 const FALLBACK_VIEWPORT = { width: 1280, height: 720, left: 0, top: 0 }
 const TOP_MENU_BAR_HEIGHT_PX = 44
 const DOCK_SAFE_AREA_PX = 96
-const MACOS_MINIMIZE_DURATION = 0.78
-const MACOS_RESTORE_DURATION = 0.62
-const MACOS_FULLSCREEN_DURATION = 0.38
-const MACOS_FULLSCREEN_EASE = [0.21, 1, 0.35, 1] as const
-const MACOS_RESTORE_EASE = [0.16, 1, 0.3, 1] as const
-const MACOS_MINIMIZE_PATH = [0, 0.12, 0.28, 0.4, 0.52, 0.68, 0.86, 1] as const
-const MACOS_RESTORE_PATH = [0, 0.16, 0.33, 0.5, 0.66, 0.82, 0.92, 1] as const
-const MACOS_MINIMIZE_CURVE_EASE = [0.15, 0.98, 0.34, 0.98] as const
-const MACOS_MINIMIZE_SLIDE_EASE = [0.22, 1, 0.34, 1] as const
-const MACOS_MINIMIZE_CLIP_PATH = [
-  'inset(0% 0% 0% 0%)',
-  'inset(0% 0% 0% 0%)',
-  'inset(0% 2% 0% 2%)',
-  'inset(0% 8% 4% 8%)',
-  'inset(2% 16% 24% 16%)',
-  'inset(6% 22% 42% 22%)',
-  'inset(12% 28% 70% 28%)',
-  'inset(28% 36% 92% 36%)',
-] as const
-const MACOS_RESTORE_CLIP_PATH = [
-  'inset(28% 36% 92% 36%)',
-  'inset(12% 28% 70% 28%)',
-  'inset(6% 22% 42% 22%)',
-  'inset(2% 16% 24% 16%)',
-  'inset(0% 8% 4% 8%)',
-  'inset(0% 2% 0% 2%)',
-  'inset(0% 0% 0% 0%)',
-  'inset(0% 0% 0% 0%)',
-] as const
-const MINIMIZED_CLIP_PATH = MACOS_MINIMIZE_CLIP_PATH[MACOS_MINIMIZE_CLIP_PATH.length - 1]
+const MINIMIZE_DURATION = 0.3
+const MINIMIZE_EASE = [0.32, 0, 0.67, 0] as const
+const RESTORE_SPRING = { type: 'spring', stiffness: 380, damping: 32, mass: 0.75 } as const
+const FULLSCREEN_SPRING = { type: 'spring', stiffness: 320, damping: 34, mass: 0.88 } as const
 
 type WindowMode = 'normal' | 'minimizing' | 'minimized' | 'restoring' | 'closed'
 type FullscreenMode = 'normal' | 'fullscreen' | 'fullscreen-entering' | 'fullscreen-exiting'
@@ -55,6 +29,50 @@ type Row = {
   id: string
   segments: Segment[]
 }
+
+type SessionEvent = {
+  event: string
+  message: string
+  level?: 'INFO' | 'WARN' | 'ERROR'
+}
+
+type TranscriptRow = {
+  time: string
+  event: string
+  message: string
+}
+
+const INITIAL_TRANSCRIPT: readonly TranscriptRow[] = [
+  {
+    time: '01:18:22',
+    event: 'response_item.function_call',
+    message: 'exec_command(cmd="kubectl -n agents apply -f charts/agents/examples/agentrun-workflow-smoke.yaml")',
+  },
+  {
+    time: '01:18:23',
+    event: 'response_item.function_call_output',
+    message: 'agentrun.agents.proompteng.ai/agents-workflow-smoke configured',
+  },
+  {
+    time: '01:18:23',
+    event: 'response_item.function_call',
+    message:
+      'exec_command(cmd="kubectl -n agents get agentrun agents-workflow-smoke -o jsonpath=\'{.status.phase} {.status.conditions[?(@.type=="Accepted")].reason}\'")',
+  },
+  {
+    time: '01:18:24',
+    event: 'response_item.function_call_output',
+    message: 'Running Submitted',
+  },
+]
+
+const OBFUSCATED_NAMESPACES = ['agents', 'agents-stg', 'agents-dev', 'agents-canary'] as const
+const OBFUSCATED_RUN_STEMS = ['policy', 'replay', 'audit', 'ledger', 'router', 'dispatch'] as const
+const OBFUSCATED_AGENT_NAMES = ['codex-agent', 'smoke-agent', 'native-workflow-agent', 'ops-agent'] as const
+const OBFUSCATED_IMPLEMENTATIONS = ['smoke-impl', 'codex-impl-sample', 'codex-native-workflow-impl'] as const
+const OBFUSCATED_REPOSITORIES = ['proompteng/lab', 'proompteng/platform', 'proompteng/ops'] as const
+const OBFUSCATED_HEAD_BRANCHES = ['codex/agents/2614', 'codex/agents/3241', 'codex/workflow/1182'] as const
+const OBFUSCATED_TTLS = [600, 900, 1800] as const
 
 function usePrefersReducedMotion() {
   const [reduced, setReduced] = useState(false)
@@ -74,6 +92,10 @@ function formatTime(now: Date) {
   return now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
+function formatIso(now: Date) {
+  return now.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
 function mkRow(id: string, segments: Segment[]): Row {
   return { id, segments }
 }
@@ -83,18 +105,7 @@ function randomFrom<T>(items: readonly T[]) {
 }
 
 function generateAgentRunName() {
-  const nouns = [
-    'jangar',
-    'torghut',
-    'codex',
-    'policy',
-    'replay',
-    'audit',
-    'ledger',
-    'router',
-    'queue',
-    'deploy',
-  ] as const
+  const nouns = OBFUSCATED_RUN_STEMS
   const tails = ['a3f2', '9c1b', '77de', '0b42', 'c8aa', '3f1d', 'e204', '6a9e'] as const
   const noun = randomFrom(nouns)
   const tail = randomFrom(tails)
@@ -102,45 +113,74 @@ function generateAgentRunName() {
 }
 
 function generateLogRow(index: number) {
-  const level = index % 19 === 0 ? 'ERROR' : index % 7 === 0 ? 'WARN' : 'INFO'
   const run = `${generateAgentRunName()}-${String(index).padStart(2, '0')}`
-  const phase = randomFrom(['Pending', 'Running', 'Succeeded', 'Failed', 'Cancelled'] as const)
-  const runtime = randomFrom(['workflow', 'direct'] as const)
-  const reasons = [
-    'Completed',
-    'InvalidSpec',
-    'AdmissionDenied',
-    'QueueLimit',
-    'CancelledByUser',
-    'RuntimeError',
-  ] as const
-  const reason = phase === 'Succeeded' ? 'Completed' : phase === 'Pending' ? 'QueueLimit' : randomFrom(reasons)
-
-  const messages = {
-    INFO: [
-      `reconciled AgentRun ${run} status.phase=${phase} runtime=${runtime}`,
-      `wrote controller ConfigMap label agents.proompteng.ai/agent-run=${run}`,
-      `computed additionalPrinterColumns: Phase Agent Succeeded Reason StartTime CompletionTime Runtime`,
-      `policy checks completed AgentRun=${run} result=allow`,
-      `streaming status events AgentRun=${run} phase=${phase}`,
-    ],
-    WARN: [
-      `backpressure: AgentRun=${run} phase=Pending reason=QueueLimit`,
-      `admission policy latency elevated (p95=412ms) AgentRun=${run}`,
-      `retrying provider update AgentRun=${run} conditions.Succeeded.reason=${reason}`,
-    ],
-    ERROR: [
-      `admission denied AgentRun=${run} reason=InvalidSpec`,
-      `controller error AgentRun=${run} phase=Failed reason=RuntimeError`,
-      `actuation blocked AgentRun=${run} phase=Failed reason=AdmissionDenied`,
-    ],
-  } as const
+  const namespace = randomFrom(OBFUSCATED_NAMESPACES)
+  const agentName = randomFrom(OBFUSCATED_AGENT_NAMES)
+  const implementation = randomFrom(OBFUSCATED_IMPLEMENTATIONS)
+  const repository = randomFrom(OBFUSCATED_REPOSITORIES)
+  const headBranch = randomFrom(OBFUSCATED_HEAD_BRANCHES)
+  const ttlSeconds = randomFrom(OBFUSCATED_TTLS)
+  const nowIso = formatIso(new Date())
+  const sessionEvents: readonly SessionEvent[] = [
+    {
+      event: 'event_msg.agent_message',
+      message: `Reconciling AgentRun/${run} (apiVersion=agents.proompteng.ai/v1alpha1, kind=AgentRun).`,
+    },
+    {
+      event: 'response_item.function_call',
+      message: `exec_command(cmd="kubectl -n ${namespace} get agentrun ${run} -o jsonpath='{.spec.agentRef.name} {.spec.runtime.type} {.spec.implementationSpecRef.name}'")`,
+    },
+    {
+      event: 'response_item.function_call_output',
+      message: `spec.agentRef.name=${agentName} spec.runtime.type=workflow spec.implementationSpecRef.name=${implementation}`,
+    },
+    {
+      event: 'response_item.function_call',
+      message: `exec_command(cmd="kubectl -n ${namespace} get agentrun ${run} -o jsonpath='{.status.phase} {.status.conditions[?(@.type=="Accepted")].reason}'")`,
+    },
+    {
+      event: 'response_item.function_call_output',
+      message: 'status.phase=Running status.conditions[Accepted]=True(Submitted)',
+    },
+    {
+      event: 'response_item.function_call_output',
+      message: `status.runtimeRef={type:workflow,name:${run}-plan-a1,namespace:${namespace}}`,
+    },
+    {
+      event: 'response_item.function_call_output',
+      message:
+        'status.workflow.steps[0]={name:plan,attempt:1,phase:Succeeded} status.workflow.steps[1]={name:implement,attempt:1,phase:Running}',
+    },
+    {
+      event: 'response_item.function_call_output',
+      message: `status.contract.requiredKeys=[repository,base,head] status.contract.missingKeys=[] spec.ttlSecondsAfterFinished=${ttlSeconds}`,
+    },
+    {
+      event: 'response_item.function_call_output',
+      message: `status.vcs={provider:github,mode:read-write,repository:${repository},headBranch:${headBranch}}`,
+    },
+    {
+      event: 'event_msg.agent_message',
+      message: `status.phase=Succeeded status.conditions[Succeeded]=True(Completed) status.finishedAt=${nowIso}`,
+    },
+    {
+      event: 'response_item.message.assistant',
+      message: `tracked label agents.proompteng.ai/agent-run=${run}; workflow.phase=Succeeded`,
+    },
+    {
+      event: 'event_msg.agent_reasoning',
+      message: `retention: applying ttlSecondsAfterFinished=${ttlSeconds} to completed workflow jobs`,
+      level: 'WARN',
+    },
+  ]
+  const item = sessionEvents[index % sessionEvents.length] ?? sessionEvents[0]
+  const level = item?.level ?? 'INFO'
 
   return mkRow(`log-${Date.now()}-${index}`, [
     { text: formatTime(new Date()), className: 'text-[rgb(var(--terminal-text-faint)/0.45)]' },
     { text: '  ' },
     {
-      text: level.padEnd(5),
+      text: pad(level, 5),
       className:
         level === 'ERROR'
           ? 'text-[rgb(var(--terminal-text-red))]'
@@ -149,7 +189,9 @@ function generateLogRow(index: number) {
             : 'text-[rgb(var(--terminal-text-green))]',
     },
     { text: '  ' },
-    { text: randomFrom(messages[level]), className: 'text-[rgb(var(--terminal-text-primary)/0.82)]' },
+    { text: pad(item.event, 36), className: 'text-[rgb(var(--terminal-text-blue))]' },
+    { text: '  ' },
+    { text: item.message, className: 'text-[rgb(var(--terminal-text-primary)/0.82)]' },
   ])
 }
 
@@ -174,42 +216,30 @@ function getViewport(bounds?: HTMLElement | null) {
   return { width: window.innerWidth, height: window.innerHeight, left: 0, top: 0 }
 }
 
-function formatKubectlHeader() {
-  // Mirrors charts/agents/crds/agents.proompteng.ai_agentruns.yaml additionalPrinterColumns
-  const cols = [
-    pad('NAME', 38),
-    pad('PHASE', 10),
-    pad('AGENT', 16),
-    pad('SUCCEEDED', 10),
-    pad('REASON', 16),
-    pad('STARTTIME', 20),
-    pad('COMPLETIONTIME', 20),
-    pad('RUNTIME', 10),
-  ]
-  return cols.join(' ')
+function formatSessionHeader() {
+  const cols = [pad('TIME', 10), pad('EVENT', 36), 'MESSAGE']
+  return cols.join('  ')
 }
 
-function formatKubectlRow(input: {
-  name: string
-  phase: string
-  agent: string
-  succeeded: string
-  reason: string
-  startTime: string
-  completionTime: string
-  runtime: string
-}) {
-  const cols = [
-    pad(input.name, 38),
-    pad(input.phase, 10),
-    pad(input.agent, 16),
-    pad(input.succeeded, 10),
-    pad(input.reason, 16),
-    pad(input.startTime, 20),
-    pad(input.completionTime, 20),
-    pad(input.runtime, 10),
+function formatSessionRow(input: { time: string; event: string; message: string }) {
+  const cols = [pad(input.time, 10), pad(input.event, 36), input.message]
+  return cols.join('  ')
+}
+
+function createInitialOutputRows(prefix: string): Row[] {
+  return [
+    mkRow(`${prefix}-header`, [
+      { text: formatSessionHeader(), className: 'text-[rgb(var(--terminal-text-faint)/0.65)]' },
+    ]),
+    ...INITIAL_TRANSCRIPT.map((item, index) =>
+      mkRow(`${prefix}-${index}`, [
+        {
+          text: formatSessionRow(item),
+          className: 'text-[rgb(var(--terminal-text-primary)/0.82)]',
+        },
+      ]),
+    ),
   ]
-  return cols.join(' ')
 }
 
 export type TerminalWindowHandle = {
@@ -288,7 +318,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
     const getMinimizeTarget = useCallback(() => {
       if (!menuBarButtonRef?.current) return null
       const menuBarRect = menuBarButtonRef.current.getBoundingClientRect()
-      const topInsetPx = desktopBoundsRef ? 0 : TOP_MENU_BAR_HEIGHT_PX
+      const topInsetPx = desktopBoundsRef?.current ? viewport.top : TOP_MENU_BAR_HEIGHT_PX
       const isFullscreenLike = fullscreenMode === 'fullscreen'
       const windowCenterX = viewport.left + viewport.width / 2 + (isFullscreenLike ? 0 : offset.x)
       const windowCenterY = viewport.top + viewport.height / 2 + (isFullscreenLike ? topInsetPx / 2 : offset.y)
@@ -311,7 +341,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
     const getMinimizeTargetFallback = useCallback(() => {
       // If we can't measure the dock icon, still minimize to the dock area (bottom-center).
       // This avoids "minimize does nothing" when refs aren't available yet (SSR/fast interactions).
-      const topInsetPx = desktopBoundsRef ? 0 : TOP_MENU_BAR_HEIGHT_PX
+      const topInsetPx = desktopBoundsRef?.current ? viewport.top : TOP_MENU_BAR_HEIGHT_PX
       const isFullscreenLike = fullscreenMode === 'fullscreen'
       const windowCenterX = viewport.left + viewport.width / 2 + (isFullscreenLike ? 0 : offset.x)
       const windowCenterY = viewport.top + viewport.height / 2 + (isFullscreenLike ? topInsetPx / 2 : offset.y)
@@ -404,21 +434,30 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
       () => [
         mkRow('boot-0', [
           { text: 'proompteng ', className: 'text-[rgb(var(--terminal-text-green))]' },
-          { text: 'agent control plane', className: 'text-[rgb(var(--terminal-text-primary)/0.82)]' },
+          { text: 'AgentRun status stream', className: 'text-[rgb(var(--terminal-text-primary)/0.82)]' },
         ]),
         mkRow('boot-1', [
-          { text: 'connecting ', className: 'text-[rgb(var(--terminal-text-secondary)/0.72)]' },
-          { text: 'cluster=agents-prod ', className: 'text-[rgb(var(--terminal-text-blue))]' },
+          { text: 'loading ', className: 'text-[rgb(var(--terminal-text-secondary)/0.72)]' },
+          {
+            text: 'charts/agents/crds/agents.proompteng.ai_agentruns.yaml ',
+            className: 'text-[rgb(var(--terminal-text-blue))]',
+          },
           { text: '... ok', className: 'text-[rgb(var(--terminal-text-green))]' },
         ]),
         mkRow('boot-2', [
-          { text: 'auth ', className: 'text-[rgb(var(--terminal-text-secondary)/0.72)]' },
-          { text: 'serviceaccount=landing-ro ', className: 'text-[rgb(var(--terminal-text-primary)/0.82)]' },
+          { text: 'schema ', className: 'text-[rgb(var(--terminal-text-secondary)/0.72)]' },
+          {
+            text: 'spec.agentRef + spec.runtime + status.phase/conditions ',
+            className: 'text-[rgb(var(--terminal-text-primary)/0.82)]',
+          },
           { text: '... ok', className: 'text-[rgb(var(--terminal-text-green))]' },
         ]),
         mkRow('boot-3', [
-          { text: 'tailing ', className: 'text-[rgb(var(--terminal-text-secondary)/0.72)]' },
-          { text: 'agents-controller logs', className: 'text-[rgb(var(--terminal-text-primary)/0.82)]' },
+          { text: 'streaming ', className: 'text-[rgb(var(--terminal-text-secondary)/0.72)]' },
+          {
+            text: 'workflow steps + runtimeRef + contract/vcs status',
+            className: 'text-[rgb(var(--terminal-text-primary)/0.82)]',
+          },
           { text: ' (live)', className: 'text-[rgb(var(--terminal-text-faint)/0.45)]' },
         ]),
       ],
@@ -441,11 +480,15 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
         if (!dragRef.current) return
         if (!windowRef.current) return
 
-        const container = windowRef.current.offsetParent
-        const containerRect =
-          container instanceof HTMLElement
-            ? container.getBoundingClientRect()
-            : { width: window.innerWidth, height: window.innerHeight }
+        const viewportRect = {
+          left: 0,
+          top: 0,
+          right: window.innerWidth,
+          bottom: window.innerHeight,
+          width: window.innerWidth,
+          height: window.innerHeight,
+        }
+        const dragAreaRect = desktopBoundsRef?.current?.getBoundingClientRect() ?? viewportRect
         const windowRect = windowRef.current.getBoundingClientRect()
 
         const deltaX = clientX - dragRef.current.startX
@@ -453,16 +496,20 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
         const nextX = dragRef.current.startOffsetX + deltaX
         const nextY = dragRef.current.startOffsetY + deltaY
 
-        const maxX = containerRect.width / 2 + windowRect.width / 2 - MIN_VISIBLE_PX
-        const minX = MIN_VISIBLE_PX - containerRect.width / 2 - windowRect.width / 2
-        // Keep the window fully within the desktop: flush under the menu bar, and above the dock.
-        const topInsetPx = desktopBoundsRef ? 0 : TOP_MENU_BAR_HEIGHT_PX
-        const topBoundY = topInsetPx + windowRect.height / 2 - containerRect.height / 2
-        const bottomBoundY = containerRect.height / 2 - DOCK_SAFE_AREA_PX - windowRect.height / 2
-        const minY = Math.min(topBoundY, bottomBoundY)
-        const maxY = Math.max(topBoundY, bottomBoundY)
+        const minX = dragAreaRect.left + MIN_VISIBLE_PX - viewportRect.width / 2 - windowRect.width / 2
+        const maxX = dragAreaRect.right - MIN_VISIBLE_PX - viewportRect.width / 2 + windowRect.width / 2
 
-        setOffset({ x: clamp(nextX, minX, maxX), y: clamp(nextY, minY, maxY) })
+        // Keep the window below the menu bar and above the dock region.
+        const topBoundAbsY = desktopBoundsRef
+          ? Math.max(dragAreaRect.top, TOP_MENU_BAR_HEIGHT_PX)
+          : TOP_MENU_BAR_HEIGHT_PX
+        const bottomBoundAbsY = dragAreaRect.bottom - DOCK_SAFE_AREA_PX
+        const minY = topBoundAbsY + windowRect.height / 2 - viewportRect.height / 2
+        const maxY = bottomBoundAbsY - windowRect.height / 2 - viewportRect.height / 2
+        const clampedMinY = Math.min(minY, maxY)
+        const clampedMaxY = Math.max(minY, maxY)
+
+        setOffset({ x: clamp(nextX, minX, maxX), y: clamp(nextY, clampedMinY, clampedMaxY) })
       }
 
       const onPointerMove = (event: PointerEvent) => {
@@ -531,44 +578,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
       if (reducedMotion) {
         setPhase('output')
         setCommandText(COMMAND)
-        setRows((prev) => {
-          const initial = [
-            mkRow('out-header', [
-              { text: formatKubectlHeader(), className: 'text-[rgb(var(--terminal-text-faint)/0.65)]' },
-            ]),
-            mkRow('out-0', [
-              {
-                text: formatKubectlRow({
-                  name: 'leader-election-implementation-20260207-run',
-                  phase: 'Running',
-                  agent: 'codex-agent',
-                  succeeded: 'False',
-                  reason: 'Running',
-                  startTime: '2026-02-17T01:18:22Z',
-                  completionTime: '-',
-                  runtime: 'workflow',
-                }),
-                className: 'text-[rgb(var(--terminal-text-primary)/0.82)]',
-              },
-            ]),
-            mkRow('out-1', [
-              {
-                text: formatKubectlRow({
-                  name: 'torghut-audit-evidence-20260217-run',
-                  phase: 'Succeeded',
-                  agent: 'codex-agent',
-                  succeeded: 'True',
-                  reason: 'Completed',
-                  startTime: '2026-02-17T01:06:02Z',
-                  completionTime: '2026-02-17T01:10:44Z',
-                  runtime: 'workflow',
-                }),
-                className: 'text-[rgb(var(--terminal-text-primary)/0.82)]',
-              },
-            ]),
-          ]
-          return [...initial, ...prev]
-        })
+        setRows((prev) => [...createInitialOutputRows('out'), ...prev])
         return
       }
 
@@ -592,56 +602,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             timeouts.push(
               window.setTimeout(() => {
                 setPhase('output')
-                setRows([
-                  mkRow('out-header', [
-                    { text: formatKubectlHeader(), className: 'text-[rgb(var(--terminal-text-faint)/0.65)]' },
-                  ]),
-                  mkRow('out-0', [
-                    {
-                      text: formatKubectlRow({
-                        name: 'leader-election-implementation-20260207-run',
-                        phase: 'Running',
-                        agent: 'codex-agent',
-                        succeeded: 'False',
-                        reason: 'Running',
-                        startTime: '2026-02-17T01:18:22Z',
-                        completionTime: '-',
-                        runtime: 'workflow',
-                      }),
-                      className: 'text-[rgb(var(--terminal-text-primary)/0.82)]',
-                    },
-                  ]),
-                  mkRow('out-1', [
-                    {
-                      text: formatKubectlRow({
-                        name: 'control-plane-filters-20260130-run',
-                        phase: 'Pending',
-                        agent: 'codex-agent',
-                        succeeded: 'False',
-                        reason: 'QueueLimit',
-                        startTime: '2026-02-17T01:19:07Z',
-                        completionTime: '-',
-                        runtime: 'workflow',
-                      }),
-                      className: 'text-[rgb(var(--terminal-text-primary)/0.82)]',
-                    },
-                  ]),
-                  mkRow('out-2', [
-                    {
-                      text: formatKubectlRow({
-                        name: 'torghut-audit-evidence-20260217-run',
-                        phase: 'Succeeded',
-                        agent: 'codex-agent',
-                        succeeded: 'True',
-                        reason: 'Completed',
-                        startTime: '2026-02-17T01:06:02Z',
-                        completionTime: '2026-02-17T01:10:44Z',
-                        runtime: 'workflow',
-                      }),
-                      className: 'text-[rgb(var(--terminal-text-primary)/0.82)]',
-                    },
-                  ]),
-                ])
+                setRows(createInitialOutputRows('out'))
               }, 260),
             )
           }, 48)
@@ -681,12 +642,19 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
     const isHidden = windowMode === 'minimized' || windowMode === 'closed'
     const isControlLocked =
       windowMode !== 'normal' || fullscreenMode === 'fullscreen-entering' || fullscreenMode === 'fullscreen-exiting'
-    const topInsetPx = desktopBoundsRef ? 0 : TOP_MENU_BAR_HEIGHT_PX
+    const hasDesktopBounds = Boolean(desktopBoundsRef?.current)
+    const topInsetPx = hasDesktopBounds ? viewport.top : TOP_MENU_BAR_HEIGHT_PX
     const normalWidth = clamp(viewport.width * 0.95, MAX_WINDOW_WIDTH_PX / 4, MAX_WINDOW_WIDTH_PX)
-    const normalHeight = clamp(viewport.height * 0.72, 280, MAX_WINDOW_HEIGHT_PX)
+    const normalHeight = clamp(viewport.height * 0.82, 320, MAX_WINDOW_HEIGHT_PX)
     const isFullscreenTarget = fullscreenMode === 'fullscreen' || fullscreenMode === 'fullscreen-entering'
-    const fullscreenHeight = Math.max(260, viewport.height - topInsetPx)
-    const fullscreenY = isFullscreenTarget ? topInsetPx / 2 : 0
+    const fullscreenBottomInsetPx = DOCK_SAFE_AREA_PX
+    const fullscreenHeight = Math.max(
+      260,
+      hasDesktopBounds
+        ? viewport.height - fullscreenBottomInsetPx
+        : viewport.height - TOP_MENU_BAR_HEIGHT_PX - fullscreenBottomInsetPx,
+    )
+    const fullscreenY = isFullscreenTarget ? topInsetPx / 2 - fullscreenBottomInsetPx / 2 : 0
     const currentBaseX = isFullscreenTarget ? 0 : offset.x
     const currentBaseY = isFullscreenTarget ? fullscreenY : offset.y
     const targetWindowX = isFullscreenTarget ? 0 : offset.x
@@ -695,145 +663,41 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
     const targetWindowHeight = isFullscreenTarget ? fullscreenHeight : normalHeight
     const targetBaseX = isMenuTargeting ? currentBaseX + minimizeOffset.x : currentBaseX
     const targetBaseY = isMenuTargeting ? currentBaseY + minimizeOffset.y : currentBaseY
-    const minimizedX = isMenuTargeting ? minimizeOffset.x : 0
-    const minimizedY = isMenuTargeting ? minimizeOffset.y : 0
 
     const windowAnimate = useMemo(() => {
       if (windowMode === 'minimizing') {
         return {
-          x: [
-            currentBaseX,
-            currentBaseX,
-            currentBaseX + minimizedX * 0.04,
-            currentBaseX + minimizedX * 0.18,
-            currentBaseX + minimizedX * 0.42,
-            currentBaseX + minimizedX * 0.68,
-            currentBaseX + minimizedX * 0.86,
-            targetBaseX,
-          ],
-          y: [
-            currentBaseY,
-            currentBaseY,
-            currentBaseY + minimizedY * 0.08,
-            currentBaseY + minimizedY * 0.22,
-            currentBaseY + minimizedY * 0.5,
-            currentBaseY + minimizedY * 0.72,
-            currentBaseY + minimizedY * 0.86,
-            targetBaseY,
-          ],
-          width: [
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-          ],
-          height: [
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-          ],
-          scaleX: [1, 1, 0.95, 0.68, 0.42, 0.24, 0.16, MINIMIZE_SCALE],
-          scaleY: [1, 1, 1, 0.88, 0.64, 0.36, 0.2, MINIMIZE_SCALE],
-          opacity: [1, 1, 0.97, 0.82, 0.5, 0.26, 0.12, 0],
-          skewX: ['0deg', '-4deg', '-12deg', '-24deg', '-30deg', '-24deg', '-14deg', '-8deg'],
-          rotateZ: ['0deg', '0.2deg', '0.6deg', '-0.6deg', '-0.45deg', '-0.25deg', '0deg', '0deg'],
-          clipPath: [...MACOS_MINIMIZE_CLIP_PATH],
-          filter: [
-            'blur(0px)',
-            'blur(0px)',
-            'blur(0.12px)',
-            'blur(0.24px)',
-            'blur(0.16px)',
-            'blur(0.08px)',
-            'blur(0.04px)',
-            'blur(0px)',
-          ],
+          x: targetBaseX,
+          y: targetBaseY + 4,
+          width: targetWindowWidth,
+          height: targetWindowHeight,
+          scaleX: MINIMIZE_SCALE,
+          scaleY: MINIMIZE_SCALE * 0.96,
+          opacity: 0,
         }
       }
 
       if (windowMode === 'minimized') {
         return {
           x: targetBaseX,
-          y: targetBaseY,
+          y: targetBaseY + 4,
           width: targetWindowWidth,
           height: targetWindowHeight,
           scaleX: MINIMIZE_SCALE,
-          scaleY: MINIMIZE_SCALE,
+          scaleY: MINIMIZE_SCALE * 0.96,
           opacity: 0,
-          skewX: '-8deg',
-          rotateZ: '0deg',
-          clipPath: MINIMIZED_CLIP_PATH,
-          filter: 'blur(0px)',
         }
       }
 
       if (windowMode === 'restoring') {
         return {
-          x: [
-            targetBaseX,
-            targetBaseX - minimizedX * 0.08,
-            targetBaseX - minimizedX * 0.32,
-            targetBaseX - minimizedX * 0.58,
-            targetBaseX - minimizedX * 0.32,
-            targetBaseX - minimizedX * 0.08,
-            targetBaseX - minimizedX * 0.02,
-            currentBaseX,
-          ],
-          y: [
-            targetBaseY,
-            targetBaseY - minimizedY * 0.06,
-            targetBaseY - minimizedY * 0.2,
-            targetBaseY - minimizedY * 0.48,
-            targetBaseY - minimizedY * 0.22,
-            targetBaseY - minimizedY * 0.06,
-            targetBaseY - minimizedY * 0.02,
-            currentBaseY,
-          ],
-          width: [
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-            targetWindowWidth,
-          ],
-          height: [
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-            targetWindowHeight,
-          ],
-          scaleX: [MINIMIZE_SCALE, 0.18, 0.35, 0.6, 0.84, 0.96, 0.99, 1],
-          scaleY: [MINIMIZE_SCALE, 0.22, 0.48, 0.72, 0.84, 0.97, 0.99, 1],
-          opacity: [0, 0.2, 0.56, 0.84, 0.94, 0.98, 1, 1],
-          skewX: ['-8deg', '-6deg', '-3deg', '-2deg', '-1deg', '-0.5deg', '-0.2deg', '0deg'],
-          rotateZ: ['0deg', '0.1deg', '-0.2deg', '-0.08deg', '-0.05deg', '0deg', '0deg', '0deg'],
-          clipPath: [...MACOS_RESTORE_CLIP_PATH],
-          filter: [
-            'blur(0px)',
-            'blur(0.06px)',
-            'blur(0.06px)',
-            'blur(0.04px)',
-            'blur(0.02px)',
-            'blur(0.01px)',
-            'blur(0px)',
-            'blur(0px)',
-          ],
+          x: currentBaseX,
+          y: currentBaseY,
+          width: targetWindowWidth,
+          height: targetWindowHeight,
+          scaleX: 1,
+          scaleY: 1,
+          opacity: 1,
         }
       }
 
@@ -846,7 +710,6 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
           scaleX: 1,
           scaleY: 1,
           opacity: 0,
-          filter: 'blur(0px)',
         }
       }
 
@@ -858,11 +721,8 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
         scaleX: 1,
         scaleY: 1,
         opacity: 1,
-        filter: 'blur(0px)',
       }
     }, [
-      minimizedX,
-      minimizedY,
       currentBaseX,
       currentBaseY,
       targetWindowHeight,
@@ -883,146 +743,37 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
 
       if (windowMode === 'minimizing') {
         return {
-          x: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.15, 0.98, 0.34, 0.98] as const,
-          },
-          y: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: MACOS_MINIMIZE_SLIDE_EASE,
-          },
-          width: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.22, 1, 0.35, 1] as const,
-          },
-          height: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.22, 1, 0.35, 1] as const,
-          },
-          scaleX: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: MACOS_MINIMIZE_CURVE_EASE,
-          },
-          scaleY: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.1, 0.95, 0.25, 1] as const,
-          },
-          skewX: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.25, 1, 0.35, 1] as const,
-          },
-          rotateZ: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.14, 0.98, 0.32, 1] as const,
-          },
-          opacity: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.26, 1, 0.35, 1] as const,
-          },
-          clipPath: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.18, 1, 0.28, 1] as const,
-          },
-          filter: {
-            type: 'tween',
-            duration: MACOS_MINIMIZE_DURATION,
-            times: MACOS_MINIMIZE_PATH,
-            ease: [0.2, 1, 0.28, 1] as const,
-          },
+          x: { type: 'tween', duration: MINIMIZE_DURATION, ease: MINIMIZE_EASE },
+          y: { type: 'tween', duration: MINIMIZE_DURATION, ease: MINIMIZE_EASE },
+          scaleX: { type: 'tween', duration: MINIMIZE_DURATION, ease: MINIMIZE_EASE },
+          scaleY: { type: 'tween', duration: MINIMIZE_DURATION, ease: MINIMIZE_EASE },
+          opacity: { type: 'tween', duration: MINIMIZE_DURATION * 0.82, ease: MINIMIZE_EASE },
+          width: { type: 'tween', duration: 0.0001 },
+          height: { type: 'tween', duration: 0.0001 },
         }
       }
 
       if (windowMode === 'restoring') {
         return {
-          x: { type: 'tween', duration: MACOS_RESTORE_DURATION, times: MACOS_RESTORE_PATH, ease: MACOS_RESTORE_EASE },
-          y: { type: 'tween', duration: MACOS_RESTORE_DURATION, times: MACOS_RESTORE_PATH, ease: MACOS_RESTORE_EASE },
-          width: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: MACOS_RESTORE_EASE,
-          },
-          height: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: MACOS_RESTORE_EASE,
-          },
-          scaleX: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: [0.2, 0.98, 0.36, 1] as const,
-          },
-          scaleY: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: [0.22, 0.98, 0.42, 1] as const,
-          },
-          skewX: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: MACOS_RESTORE_EASE,
-          },
-          rotateZ: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: MACOS_RESTORE_EASE,
-          },
-          opacity: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: MACOS_RESTORE_EASE,
-          },
-          clipPath: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: [0.25, 1, 0.4, 1] as const,
-          },
-          filter: {
-            type: 'tween',
-            duration: MACOS_RESTORE_DURATION,
-            times: MACOS_RESTORE_PATH,
-            ease: MACOS_RESTORE_EASE,
-          },
+          x: RESTORE_SPRING,
+          y: RESTORE_SPRING,
+          width: RESTORE_SPRING,
+          height: RESTORE_SPRING,
+          scaleX: RESTORE_SPRING,
+          scaleY: RESTORE_SPRING,
+          opacity: { type: 'tween', duration: 0.18, ease: [0.12, 0.88, 0.2, 1] as const },
         }
       }
 
       if (fullscreenMode === 'fullscreen-entering' || fullscreenMode === 'fullscreen-exiting') {
         return {
-          x: { duration: MACOS_FULLSCREEN_DURATION, ease: MACOS_FULLSCREEN_EASE },
-          y: { duration: MACOS_FULLSCREEN_DURATION, ease: MACOS_FULLSCREEN_EASE },
-          width: { duration: MACOS_FULLSCREEN_DURATION, ease: MACOS_FULLSCREEN_EASE },
-          height: { duration: MACOS_FULLSCREEN_DURATION, ease: MACOS_FULLSCREEN_EASE },
-          scaleX: { duration: MACOS_FULLSCREEN_DURATION },
-          scaleY: { duration: MACOS_FULLSCREEN_DURATION },
-          opacity: { duration: MACOS_FULLSCREEN_DURATION },
-          filter: { duration: MACOS_FULLSCREEN_DURATION },
+          x: FULLSCREEN_SPRING,
+          y: FULLSCREEN_SPRING,
+          width: FULLSCREEN_SPRING,
+          height: FULLSCREEN_SPRING,
+          scaleX: FULLSCREEN_SPRING,
+          scaleY: FULLSCREEN_SPRING,
+          opacity: { type: 'tween', duration: 0.16, ease: [0.2, 0.8, 0.2, 1] as const },
         }
       }
 
@@ -1078,7 +829,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
         <div
           className={cn(
             'absolute inset-x-0 top-0 z-20 flex h-10 cursor-default items-center justify-between gap-3.5 px-3 py-1',
-            'touch-none bg-[rgb(var(--terminal-titlebar-bg))] border-[color:rgb(var(--terminal-shell-border)/0.45)]',
+            'touch-none bg-[rgb(var(--terminal-titlebar-bg)/0.88)] border-[color:rgb(var(--terminal-shell-border)/0.45)]',
             'select-none text-left outline-none',
           )}
           onPointerDown={(event) => {
@@ -1100,6 +851,11 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             if (!touch) return
             beginDrag(-2, touch.clientX, touch.clientY)
             event.preventDefault()
+          }}
+          onDoubleClick={(event) => {
+            event.preventDefault()
+            if (isControlLocked) return
+            toggleFullscreen()
           }}
         >
           <div className="group/stoplights flex items-center gap-[7px] px-0.5 py-0.5">
@@ -1275,8 +1031,8 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             </button>
           </div>
           <div className="min-w-0">
-            <p className="font-display truncate text-center text-base font-medium text-[rgb(var(--terminal-titlebar-text))]">
-              control plane
+            <p className="font-display truncate text-center text-sm font-medium tracking-[0.01em] text-[rgb(var(--terminal-titlebar-text))]">
+              landing
             </p>
           </div>
           <div className="w-10" />
@@ -1287,7 +1043,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             className={cn(
               'relative h-full overflow-auto px-5 py-4 text-[12.5px] leading-relaxed sm:text-[13.5px]',
               'cursor-text select-text',
-              'bg-[linear-gradient(180deg,rgb(var(--terminal-window-bg-top)),rgb(var(--terminal-window-bg-bottom)))]',
+              'bg-[linear-gradient(180deg,rgb(var(--terminal-window-bg-top)/0.82),rgb(var(--terminal-window-bg-bottom)/0.68))]',
             )}
           >
             <div className="space-y-1 whitespace-pre">
@@ -1304,7 +1060,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
               <div>
                 <span className="text-[rgb(var(--terminal-text-green))]">➜</span>
                 <span className="text-[rgb(var(--terminal-text-faint)/0.45)]"> </span>
-                <span className="text-[rgb(var(--terminal-text-blue))]">agents</span>
+                <span className="text-[rgb(var(--terminal-text-blue))]">agents-controller</span>
                 <span className="text-[rgb(var(--terminal-text-faint)/0.45)]"> </span>
                 <span className="text-[rgb(var(--terminal-text-primary)/0.82)]">
                   {phase === 'boot' ? '' : commandText}

--- a/apps/landing/src/components/terminal-window.tsx
+++ b/apps/landing/src/components/terminal-window.tsx
@@ -278,7 +278,6 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
     const [windowMode, setWindowMode] = useState<WindowMode>('normal')
     const [fullscreenMode, setFullscreenMode] = useState<FullscreenMode>('normal')
     const [minimizeOffset, setMinimizeOffset] = useState({ x: 0, y: 0 })
-    const [isWindowActive, setIsWindowActive] = useState(true)
     const isClosedRef = useRef(false)
 
     useEffect(() => {
@@ -295,19 +294,6 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
         window.removeEventListener('resize', handleResize)
       }
     }, [desktopBoundsRef])
-
-    useEffect(() => {
-      const handlePointerDown = (event: PointerEvent) => {
-        const target = event.target
-        if (!(target instanceof Node)) return
-        setIsWindowActive(Boolean(windowRef.current?.contains(target)))
-      }
-
-      window.addEventListener('pointerdown', handlePointerDown, true)
-      return () => {
-        window.removeEventListener('pointerdown', handlePointerDown, true)
-      }
-    }, [])
 
     const beginDrag = useCallback(
       (pointerId: number, startX: number, startY: number) => {
@@ -393,7 +379,6 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
       if (windowMode === 'closed') {
         isClosedRef.current = false
         onClosedStateChange?.(false)
-        setIsWindowActive(true)
         setWindowMode('normal')
         setMinimizeOffset({ x: 0, y: 0 })
         onMinimizedStateChange?.(false)
@@ -416,7 +401,6 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
       // and keep the dock "running" indicator handled by the parent.
       isClosedRef.current = true
       onClosedStateChange?.(true)
-      setIsWindowActive(false)
       restoreToFullscreenRef.current = false
       setFullscreenMode('normal')
       setWindowMode('closed')
@@ -849,7 +833,6 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             'select-none text-left outline-none',
           )}
           onPointerDown={(event) => {
-            setIsWindowActive(true)
             beginDrag(event.pointerId, event.clientX, event.clientY)
             try {
               ;(event.currentTarget as HTMLDivElement).setPointerCapture(event.pointerId)
@@ -860,14 +843,12 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
           }}
           onMouseDown={(event) => {
             if (event.button !== 0) return
-            setIsWindowActive(true)
             beginDrag(-1, event.clientX, event.clientY)
             event.preventDefault()
           }}
           onTouchStart={(event) => {
             const touch = event.touches[0]
             if (!touch) return
-            setIsWindowActive(true)
             beginDrag(-2, touch.clientX, touch.clientY)
             event.preventDefault()
           }}
@@ -891,10 +872,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             >
               <svg
                 viewBox="0 0 85.4 85.4"
-                className={cn(
-                  'absolute inset-0 size-[14px] transition-opacity duration-150',
-                  isWindowActive ? 'opacity-100 group-hover/stoplights:opacity-0' : 'opacity-100',
-                )}
+                className="absolute inset-0 size-[14px] opacity-100 transition-opacity duration-150 group-hover/stoplights:opacity-0"
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -910,10 +888,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
               </svg>
               <svg
                 viewBox="0 0 85.4 85.4"
-                className={cn(
-                  'absolute inset-0 size-[14px] transition-opacity duration-150',
-                  isWindowActive ? 'opacity-0 group-hover/stoplights:opacity-100' : 'opacity-0',
-                )}
+                className="absolute inset-0 size-[14px] opacity-0 transition-opacity duration-150 group-hover/stoplights:opacity-100"
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -959,10 +934,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             >
               <svg
                 viewBox="0 0 85.4 85.4"
-                className={cn(
-                  'absolute inset-0 size-[14px] transition-opacity duration-150',
-                  isWindowActive ? 'opacity-100 group-hover/stoplights:opacity-0' : 'opacity-100',
-                )}
+                className="absolute inset-0 size-[14px] opacity-100 transition-opacity duration-150 group-hover/stoplights:opacity-0"
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -978,10 +950,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
               </svg>
               <svg
                 viewBox="0 0 85.4 85.4"
-                className={cn(
-                  'absolute inset-0 size-[14px] transition-opacity duration-150',
-                  isWindowActive ? 'opacity-0 group-hover/stoplights:opacity-100' : 'opacity-0',
-                )}
+                className="absolute inset-0 size-[14px] opacity-0 transition-opacity duration-150 group-hover/stoplights:opacity-100"
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -1025,10 +994,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             >
               <svg
                 viewBox="0 0 85.4 85.4"
-                className={cn(
-                  'absolute inset-0 size-[14px] transition-opacity duration-150',
-                  isWindowActive ? 'opacity-100 group-hover/stoplights:opacity-0' : 'opacity-100',
-                )}
+                className="absolute inset-0 size-[14px] opacity-100 transition-opacity duration-150 group-hover/stoplights:opacity-0"
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -1044,10 +1010,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
               </svg>
               <svg
                 viewBox="0 0 85.4 85.4"
-                className={cn(
-                  'absolute inset-0 size-[14px] transition-opacity duration-150',
-                  isWindowActive ? 'opacity-0 group-hover/stoplights:opacity-100' : 'opacity-0',
-                )}
+                className="absolute inset-0 size-[14px] opacity-0 transition-opacity duration-150 group-hover/stoplights:opacity-100"
                 aria-hidden="true"
               >
                 <g clipRule="evenodd" fillRule="evenodd">
@@ -1062,6 +1025,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
                   <path
                     d="m31.2 20.8h26.7c3.6 0 6.5 2.9 6.5 6.5v26.7zm23.2 43.7h-26.8c-3.6 0-6.5-2.9-6.5-6.5v-26.8z"
                     fill="#2a6218"
+                    transform="translate(85.4 0) scale(-1 1)"
                   />
                 </g>
               </svg>

--- a/apps/landing/src/components/terminal-window.tsx
+++ b/apps/landing/src/components/terminal-window.tsx
@@ -1049,7 +1049,7 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
           </div>
           <div className="min-w-0">
             <p className="font-display truncate text-center text-sm font-medium tracking-[0.01em] text-[rgb(var(--terminal-titlebar-text))]">
-              landing
+              control plane
             </p>
           </div>
           <div className="w-10" />


### PR DESCRIPTION
## Summary

- Reworked the landing desktop shell to better match macOS behavior, including top menu interaction polish, drag bounds, and fullscreen layout behavior.
- Replaced dock interaction logic with motion-based magnification and hover behavior, fixed disappearing icon issues, and rewrote tooltip rendering as a single continuous bubble+nub shape.
- Updated terminal window controls and transitions (minimize/restore/fullscreen/double-click title bar) and tuned window layering so fullscreen content sits below the menu bar and above the dock.
- Replaced terminal transcript content with AgentRun-oriented output that mirrors `charts/agents/crds/agents.proompteng.ai_agentruns.yaml` fields and controller lifecycle semantics (`phase`, `conditions`, `workflow.steps`, `runtimeRef`, `contract`, `vcs`) while keeping logs obfuscated.

## Related Issues

None

## Testing

- `bun run --cwd apps/landing lint:oxlint`
- `bun run --cwd apps/landing lint:oxlint:type`
- Manual validation at `http://localhost:3000` using Chrome MCP:
  - Dock hover magnification and tooltip shape/spacing
  - Terminal icon visibility and closed-window indicator behavior
  - Terminal fullscreen/minimize/restore layering and motion behavior
  - AgentRun-style terminal transcript rendering

## Screenshots (if applicable)

N/A (visual changes were validated via Chrome MCP during implementation)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
