### PR TITLE
chore(jangar): deploy image a803a452

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-16T18:58:07.778Z"
+    deploy.knative.dev/rollout: "2026-02-18T09:46:51.937Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -55,5 +55,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "20260216-service-534aaf31"
-    digest: sha256:6d4f104ec2a91af329e9a81b96765d57dc22f74a6085a2622f4c2f074aa3602a
+    newTag: "a803a452"
+    digest: sha256:f27a3e1b10dbe0e49ca1cabc9182ed7790abacf425540b57d5fe91df2cf8dea4


### PR DESCRIPTION
## Summary

- Built and pushed `registry.ide-newton.ts.net/lab/jangar:a803a452` via the typed Jangar deploy script.
- Updated `argocd/applications/jangar/kustomization.yaml` to set `newTag: "a803a452"` and digest `sha256:f27a3e1b10dbe0e49ca1cabc9182ed7790abacf425540b57d5fe91df2cf8dea4`.
- Updated `argocd/applications/jangar/deployment.yaml` rollout annotation timestamp to trigger rollout.
- Applied the rendered manifests to the cluster through the deploy script’s `kubectl apply` step.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/jangar/deploy-service.ts`
- Verified deploy output reported the pushed digest and successful `kubectl apply` of Jangar manifests.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
