### PR TITLE
fix(saigak): harden arm64 gpu and model bootstrap

### DIFF
--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -29,7 +29,6 @@ stringData:
       - git
       - jq
       - gnupg
-      - cuda-drivers
     write_files:
       - path: /etc/systemd/system/ollama.service.d/99-saigak.conf
         owner: root:root
@@ -47,7 +46,7 @@ stringData:
           PARAMETER num_ctx 4096
       - path: /etc/netplan/99-saigak.yaml
         owner: root:root
-        permissions: '0644'
+        permissions: '0600'
         content: |-
           network:
             version: 2
@@ -89,7 +88,11 @@ stringData:
     runcmd:
       - [ bash, -lc, 'systemctl enable --now ssh' ]
       - [ bash, -lc, 'netplan generate && netplan apply || true' ]
-      - [ bash, -lc, 'for i in $(seq 1 60); do if nvidia-smi -L; then break; fi; sleep 2; done; nvidia-smi -L || echo \"warning: nvidia-smi not ready yet\" >&2' ]
+      - [ bash, -lc, 'apt-get update' ]
+      - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-drivers-common' ]
+      - [ bash, -lc, 'installed=0; for pkg in nvidia-driver-590 nvidia-driver-580 nvidia-driver-570 nvidia-driver-550 nvidia-driver-535; do if apt-cache show $pkg >/dev/null 2>&1; then if DEBIAN_FRONTEND=noninteractive apt-get install -y $pkg; then installed=1; break; fi; fi; done; if [ $installed -ne 1 ]; then echo "failed to install any nvidia-driver package" >&2; exit 1; fi' ]
+      - [ bash, -lc, 'modprobe nvidia || true; modprobe nvidia_uvm || true' ]
+      - [ bash, -lc, 'for i in $(seq 1 90); do if nvidia-smi -L; then break; fi; sleep 2; done; nvidia-smi -L' ]
       - [ bash, -lc, 'curl -fsSL https://ollama.com/install.sh | sh' ]
       - [ bash, -lc, 'systemctl stop ollama || true' ]
       - [ bash, -lc, 'mkdir -p /etc/systemd/system/ollama.service.d' ]
@@ -98,6 +101,6 @@ stringData:
       - [ bash, -lc, 'systemctl enable --now ollama' ]
       - [ bash, -lc, 'sleep 2' ]
       - [ bash, -lc, 'curl -fsS http://127.0.0.1:11434/api/version' ]
-      - [ bash, -lc, 'ollama pull qwen3-embedding:0.6b' ]
-      - [ bash, -lc, 'ollama create qwen3-embedding-saigak:0.6b -f /etc/saigak/qwen3-embedding-0-6b.modelfile' ]
-      - [ bash, -lc, 'ollama list | awk \"{print \\$1}\" | grep -Fxq \"qwen3-embedding-saigak:0.6b\"' ]
+      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama pull qwen3-embedding:0.6b' ]
+      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama create qwen3-embedding-saigak:0.6b -f /etc/saigak/qwen3-embedding-0-6b.modelfile' ]
+      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama show qwen3-embedding-saigak:0.6b >/dev/null' ]


### PR DESCRIPTION
## Summary

- Fix `saigak` cloud-init GPU bootstrap on Ubuntu arm64 by replacing invalid `cuda-drivers` package usage.
- Add resilient NVIDIA driver installation logic (`nvidia-driver-*` fallback list), explicit module load, and stronger GPU readiness checks.
- Fix Ollama bootstrap reliability by exporting `HOME`/`OLLAMA_HOST` for CLI calls and replacing brittle model verification with `ollama show`.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl get vm,vmi -n saigak -o wide`
- `kubectl run -n saigak netcheck-post --image=curlimages/curl:8.12.1 --restart=Never --rm -i -- curl -sS --max-time 5 http://saigak:11434/api/version`
- `kubectl run -n saigak netcheck-proof --image=curlimages/curl:8.12.1 --restart=Never --rm -i -- sh -lc 'curl -sS http://saigak:11434/api/version; echo; curl -sS http://saigak:11434/api/embed -d "{\"model\":\"qwen3-embedding-saigak:0.6b\",\"input\":\"gpu proof\"}" | head -c 120'`
- `ssh -i ~/.ssh/id_ed25519 -p 2222 ubuntu@127.0.0.1 'nvidia-smi -L; export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama ps'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
