### PR TITLE
fix(torghut-ws): enable trade_updates feed

### DIFF
--- a/argocd/applications/kafka/torghut-topics.yaml
+++ b/argocd/applications/kafka/torghut-topics.yaml
@@ -61,6 +61,21 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
+  name: torghut.trade_updates.v1
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  partitions: 3
+  replicas: 3
+  config:
+    compression.type: lz4
+    retention.ms: 604800000
+    cleanup.policy: delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
   name: torghut.ta.bars.1s.v1
   namespace: kafka
   labels:

--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   ALPACA_FEED: "iex"
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
+  ALPACA_TRADE_STREAM_URL: "wss://paper-api.alpaca.markets/stream"
   ALPACA_BASE_URL: "https://data.alpaca.markets"
   JANGAR_SYMBOLS_URL: "http://jangar.jangar.svc.cluster.local/api/torghut/symbols"
   # Fallback so the ws forwarder can become ready if Jangar has no ready endpoints.
@@ -14,7 +15,7 @@ data:
   SUBSCRIBE_BATCH_SIZE: "200"
   SHARD_COUNT: "1"
   SHARD_INDEX: "0"
-  ENABLE_TRADE_UPDATES: "false"
+  ENABLE_TRADE_UPDATES: "true"
   RECONNECT_BASE_MS: "500"
   RECONNECT_MAX_MS: "30000"
   DEDUP_TTL_SEC: "5"
@@ -28,4 +29,5 @@ data:
   TOPIC_TRADES: "torghut.trades.v1"
   TOPIC_QUOTES: "torghut.quotes.v1"
   TOPIC_BARS_1M: "torghut.bars.1m.v1"
+  TOPIC_TRADE_UPDATES: "torghut.trade_updates.v1"
   TOPIC_STATUS: "torghut.status.v1"


### PR DESCRIPTION
## Summary

- Enable `trade_updates` ingestion in `torghut-ws` by setting `ENABLE_TRADE_UPDATES=true`.
- Configure `ALPACA_TRADE_STREAM_URL` to the paper trading WebSocket endpoint used by current torghut credentials.
- Add `TOPIC_TRADE_UPDATES=torghut.trade_updates.v1` to ws config.
- Add Strimzi `KafkaTopic` resource for `torghut.trade_updates.v1` so rollout has topic provisioning via GitOps.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut/ws >/tmp/torghut-ws.rendered.yaml`
- `kubectl apply --dry-run=client -f argocd/applications/torghut/ws/configmap.yaml`
- `kubectl apply --dry-run=client -f argocd/applications/kafka/torghut-topics.yaml`
- `kubectl get secret torghut-alpaca -n torghut -o jsonpath='{.data.APCA_API_BASE_URL}' | base64 -d` (validated endpoint alignment for `ALPACA_TRADE_STREAM_URL`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
