### PR TITLE
fix(torghut-ws): use RFC1123-safe trade updates topic name

### DIFF
--- a/argocd/applications/kafka/torghut-topics.yaml
+++ b/argocd/applications/kafka/torghut-topics.yaml
@@ -61,7 +61,7 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: torghut.trade_updates.v1
+  name: torghut.trade-updates.v1
   namespace: kafka
   labels:
     strimzi.io/cluster: kafka

--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -29,5 +29,5 @@ data:
   TOPIC_TRADES: "torghut.trades.v1"
   TOPIC_QUOTES: "torghut.quotes.v1"
   TOPIC_BARS_1M: "torghut.bars.1m.v1"
-  TOPIC_TRADE_UPDATES: "torghut.trade_updates.v1"
+  TOPIC_TRADE_UPDATES: "torghut.trade-updates.v1"
   TOPIC_STATUS: "torghut.status.v1"


### PR DESCRIPTION
## Summary

- Fix the newly added `trade_updates` KafkaTopic resource name to satisfy Kubernetes RFC1123 naming constraints.
- Rename topic from `torghut.trade_updates.v1` to `torghut.trade-updates.v1` in KafkaTopic manifest.
- Update `TOPIC_TRADE_UPDATES` in torghut-ws config to match the corrected topic name.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applications/kafka/torghut-topics.yaml`
- `kubectl apply --dry-run=client -f argocd/applications/torghut/ws/configmap.yaml`
- `kubectl get app kafka -n argocd -o jsonpath='{.status.operationState.message}'` (validated previous sync failure cause)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
