### PR TITLE
fix(ci): remove qemu setup from arc-arm64 docker workflows

### DIFF
--- a/.github/workflows/dernier-build-push.yaml
+++ b/.github/workflows/dernier-build-push.yaml
@@ -19,9 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/docker-build-common.yaml
+++ b/.github/workflows/docker-build-common.yaml
@@ -86,27 +86,20 @@ jobs:
             type=semver,pattern={{version}},value=${{ inputs.new_tag }}
             type=sha
 
-      - name: Detect QEMU requirement
-        id: qemu
+      - name: Validate platform targets on arc-arm64
         run: |
           set -euo pipefail
           platforms='${{ inputs.platforms }}'
-          needs_qemu='false'
 
           IFS=',' read -r -a targets <<< "$platforms"
           for target in "${targets[@]}"; do
             target="$(echo "$target" | xargs)"
             if [ "$target" != 'linux/arm64' ]; then
-              needs_qemu='true'
-              break
+              echo "Unsupported platform on arc-arm64 runner: $target"
+              echo "This workflow supports linux/arm64 only."
+              exit 1
             fi
           done
-
-          echo "needs_qemu=$needs_qemu" >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        if: steps.qemu.outputs.needs_qemu == 'true'
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/facteur-build-push.yaml
+++ b/.github/workflows/facteur-build-push.yaml
@@ -19,9 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/graf-build-push.yaml
+++ b/.github/workflows/graf-build-push.yaml
@@ -34,9 +34,6 @@ jobs:
             type=sha
             type=raw,value=latest
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/tigresse-build-push.yaml
+++ b/.github/workflows/tigresse-build-push.yaml
@@ -19,9 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/torghut-ws-build-push.yaml
+++ b/.github/workflows/torghut-ws-build-push.yaml
@@ -28,9 +28,6 @@ jobs:
             type=sha
             type=raw,value=latest
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,4 +42,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut-ws:latest
           cache-to: type=inline
-

--- a/.github/workflows/vecteur-manual-build-push.yaml
+++ b/.github/workflows/vecteur-manual-build-push.yaml
@@ -22,8 +22,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Validate platform targets on arc-arm64
+        run: |
+          set -euo pipefail
+          platforms='${{ inputs.platforms }}'
+          IFS=',' read -r -a targets <<< "$platforms"
+          for target in "${targets[@]}"; do
+            target="$(echo "$target" | xargs)"
+            if [ "$target" != 'linux/arm64' ]; then
+              echo "Unsupported platform on arc-arm64 runner: $target"
+              echo "This workflow supports linux/arm64 only."
+              exit 1
+            fi
+          done
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

- Remove `docker/setup-qemu-action` from all Docker build/push workflows that run on `arc-arm64` to eliminate `binfmt_misc` mount failures (`cannot mount binfmt_misc filesystem`).
- Keep arm64-only Docker build workflows on native `arc-arm64` + Buildx without QEMU.
- Add explicit platform validation in reusable/manual workflows (`docker-build-common`, `vecteur-manual-build-push`) so unsupported non-`linux/arm64` targets fail early with a clear message instead of the QEMU/binfmt crash.

## Related Issues

None

## Testing

- `rg -l "docker/setup-qemu-action@v3" .github/workflows` (confirmed no remaining QEMU setup steps in workflow definitions)
- `gh run view 22154352072 -R proompteng/lab --log-failed` (confirmed prior failure signature was QEMU/binfmt mount error)
- `gh run list -R proompteng/lab --workflow "Torghut Docker Build and Push" --branch main --limit 8` (checked historical failure pattern and post-fix successful run baseline)

## Screenshots (if applicable)

N/A

## Breaking Changes

- `docker-build-common` now enforces `linux/arm64` targets on `arc-arm64` runners.
- `vecteur-manual-build-push` now enforces `linux/arm64` targets on `arc-arm64` runners.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
