### PR TITLE
fix(agents): refresh codex runner image digest

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -15,8 +15,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/codex-universal
-    tag: 5436c9d2
-    digest: sha256:ff8e864d9ad6319fd46629f340c046370fd10cc9b2f31e7ddc100124a080e3f8
+    tag: latest
+    digest: sha256:5b8ea0386b7377ef9e910ca3a32fa392e5439a92f314aeac8885d4d2e35a1ea4
 controllers:
   enabled: true
   replicaCount: 2


### PR DESCRIPTION
## Summary

- Update Agents runner image pin in `argocd/applications/agents/values.yaml` from missing digest `sha256:ff8e...` to current available digest `sha256:5b8ea0...`.
- Keep the runner repository unchanged (`registry.ide-newton.ts.net/lab/codex-universal`) and move runner tag to `latest` to align with current registry state.
- Unblocks AgentRun workload pods that were failing with `ImagePullBackOff` due to `MANIFEST_UNKNOWN` on the old digest.

## Related Issues

None

## Testing

- `curl -sS 'https://registry.ide-newton.ts.net/v2/lab/codex-universal/tags/list?n=10000'`
- `curl -sSI -H 'Accept: application/vnd.oci.image.index.v1+json' 'https://registry.ide-newton.ts.net/v2/lab/codex-universal/manifests/latest'`
- `curl -sS -o /tmp/failing.out -w '%{http_code}' -H 'Accept: application/vnd.oci.image.index.v1+json' 'https://registry.ide-newton.ts.net/v2/lab/codex-universal/manifests/sha256:ff8e864d9ad6319fd46629f340c046370fd10cc9b2f31e7ddc100124a080e3f8'`
- `kubectl -n agents get deploy agents-controllers -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' | rg '^JANGAR_AGENT_RUNNER_IMAGE='`
- `kubectl -n agents describe pod torghut-v3-order-feed-2108-step-1-attempt-1-4q4r9` (confirmed prior pull failure reason for old digest)
- `kubectl kustomize --enable-helm argocd/applications/agents` (fails in local env because `helm` binary is unavailable)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
