### PR TITLE
fix(agents): use multi-arch runner image for agentruns

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -14,9 +14,9 @@ controlPlane:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
-    repository: registry.ide-newton.ts.net/lab/codex-universal
-    tag: latest
-    digest: sha256:5b8ea0386b7377ef9e910ca3a32fa392e5439a92f314aeac8885d4d2e35a1ea4
+    repository: registry.ide-newton.ts.net/lab/jangar
+    tag: "95765432"
+    digest: sha256:44669d6e24474c9661977b3ad231caa532bc9548acd46ef5bca2905435394992
 controllers:
   enabled: true
   replicaCount: 2


### PR DESCRIPTION
## Summary

- Switches `argocd/applications/agents/values.yaml` runner image from `lab/codex-universal` to `lab/jangar`.
- Pins runner image to the same multi-arch tag+digest already used by agents controllers.
- Unblocks AgentRun pods on mixed-arch clusters by avoiding arm64-only runner image pulls.

## Related Issues

None

## Testing

- `git -C /home/coder/github.com/lab/.worktrees/codex/fix-agents-runner-runtime-image-20260218 diff -- argocd/applications/agents/values.yaml`
- `kubectl get nodes -o custom-columns=NAME:.metadata.name,ARCH:.status.nodeInfo.architecture`
- `kubectl -n agents get pods -o wide | rg 'torghut-v3-(order-feed|tca-pipeline|feature-parity)-2108'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
