### PR TITLE
fix(agents): mount codex auth secret for runner pods

### DIFF
--- a/argocd/applications/agents/codex-research-secretbinding.yaml
+++ b/argocd/applications/agents/codex-research-secretbinding.yaml
@@ -8,3 +8,4 @@ spec:
       name: codex-research-agent
   allowedSecrets:
     - github-token
+    - codex-auth

--- a/argocd/applications/agents/codex-secretbinding.yaml
+++ b/argocd/applications/agents/codex-secretbinding.yaml
@@ -8,3 +8,4 @@ spec:
       name: codex-agent
   allowedSecrets:
     - github-token
+    - codex-auth

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -34,6 +34,10 @@ resources:
 controller:
   namespaces:
     - agents
+  authSecret:
+    name: codex-auth
+    key: auth.json
+    mountPath: /root/.codex
 rbac:
   clusterScoped: false
 database:


### PR DESCRIPTION
## Summary

- Configures agents controllers to mount `codex-auth/auth.json` into runner pods via `controller.authSecret`.
- Allowlists `codex-auth` in Codex agent secret bindings so AgentRuns can pass policy validation.
- Keeps existing GitHub token allowlist while adding runtime Codex auth for agent execution.

## Related Issues

None

## Testing

- `git -C /home/coder/github.com/lab/.worktrees/codex/fix-agents-runner-runtime-image-20260218 diff -- argocd/applications/agents/values.yaml argocd/applications/agents/codex-secretbinding.yaml argocd/applications/agents/codex-research-secretbinding.yaml`
- `kubectl -n agents create secret generic codex-auth --from-file=auth.json=$HOME/.codex/auth.json --dry-run=client -o yaml | kubectl apply -f -`
- `kubectl -n agents get secret codex-auth -o json | jq -r '.metadata.name + " keys=" + ((.data|keys)|join(","))'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
