### PR TITLE
feat(openclaw): add kubevirt ubuntu desktop argocd app

### DIFF
--- a/argocd/applications/openclaw/cloud-init-secret.yaml
+++ b/argocd/applications/openclaw/cloud-init-secret.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-cloud-init
+type: Opaque
+stringData:
+  userdata: |-
+    #cloud-config
+    preserve_hostname: false
+    hostname: openclaw
+    manage_etc_hosts: true
+    package_update: true
+    package_upgrade: false
+    package_reboot_if_required: true
+    packages:
+      - qemu-guest-agent
+      - openssh-server
+      - xrdp
+      - ubuntu-desktop
+    write_files:
+      - path: /etc/netplan/99-openclaw.yaml
+        owner: root:root
+        permissions: '0600'
+        content: |-
+          network:
+            version: 2
+            renderer: NetworkManager
+            ethernets:
+              default:
+                match:
+                  name: "e*"
+                dhcp4: true
+                dhcp6: false
+      - path: /etc/gdm3/custom.conf
+        owner: root:root
+        permissions: '0644'
+        content: |-
+          [daemon]
+          WaylandEnable=false
+          AutomaticLoginEnable=true
+          AutomaticLogin=ubuntu
+      - path: /var/lib/cloud/scripts/per-boot/10-netplan-apply
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          netplan generate || true
+          netplan apply || true
+    users:
+      - name: ubuntu
+        groups: [sudo]
+        shell: /bin/bash
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        ssh_authorized_keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOE//lpGZI2015yMUjHwhWJjgarTLIsqQBIFXlAanPvS
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVYPSSdt6tjSWRooRm7nUDS73CebsP92G6GjFa9X+zy
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAzVze3nx4QPa6t9Wvp5FLrcAlM7BDLUmxf049N4HC6d
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDW2gOD2bqZxDwKEsfZM+ggSBV+DlTrUxMQY8JxDMVgG
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAlmf/vteEu7gLBfxyEUjVtQiZ2LCqU6zo+6+G5gmaaa
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEht47QYSXM1n78ww4Aw9jHS50FR9IpQlQGU8emLg1ed
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB9gANXCk/KnE27qvzZk9pGSc1wIzSUewHhqZQXwFJs+
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINXAA7B1vTdTvaMTUcDJTD96v1oiNZx6XI+amVwPXPzy
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOco184B4eZEOoLP5ehTK9cgsJgbelKWUxXuO3+S38U/
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII0/89LwFLAM6tu2gtbwVDrQwFhPiW55RciZo0RUVMrF
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH77X+Ekaz8sSLPImUYO8VYhgDDcb+DXkqU26UZ2PaAP
+          - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMqGcgm6U9z2d9kH5SNjm4wZumlbMxndFi40iNEhI2OKvfSoE4OQJQ8j5KCiu6GrcE2biJcqP1dkMCaJ8xcaYA8= sshid.io/gregkonush
+    ssh_pwauth: false
+    disable_root: true
+    runcmd:
+      - [ bash, -lc, 'systemctl enable --now qemu-guest-agent' ]
+      - [ bash, -lc, 'systemctl enable --now ssh' ]
+      - [ bash, -lc, 'systemctl enable --now NetworkManager' ]
+      - [ bash, -lc, 'netplan generate && netplan apply || true' ]
+      - [ bash, -lc, 'adduser xrdp ssl-cert || true' ]
+      - [ bash, -lc, 'systemctl set-default graphical.target' ]
+      - [ bash, -lc, 'systemctl enable --now xrdp' ]
+      - [ bash, -lc, 'mkdir -p /var/lib/openclaw' ]
+      - [ bash, -lc, 'dpkg-query -W ubuntu-desktop > /var/lib/openclaw/desktop-package.txt' ]
+      - [ bash, -lc, 'date -u +"%Y-%m-%dT%H:%M:%SZ" > /var/lib/openclaw/desktop-ready' ]

--- a/argocd/applications/openclaw/kustomization.yaml
+++ b/argocd/applications/openclaw/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openclaw
+resources:
+  - cloud-init-secret.yaml
+  - virtualmachine.yaml
+  - service-rdp.yaml
+  - service-ssh.yaml

--- a/argocd/applications/openclaw/service-rdp.yaml
+++ b/argocd/applications/openclaw/service-rdp.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-rdp
+  labels:
+    app.kubernetes.io/name: openclaw
+spec:
+  type: ClusterIP
+  selector:
+    kubevirt.io/domain: openclaw
+  ports:
+    - name: rdp
+      port: 3389
+      protocol: TCP
+      targetPort: 3389

--- a/argocd/applications/openclaw/service-ssh.yaml
+++ b/argocd/applications/openclaw/service-ssh.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-ssh
+  labels:
+    app.kubernetes.io/name: openclaw
+spec:
+  type: ClusterIP
+  selector:
+    kubevirt.io/domain: openclaw
+  ports:
+    - name: ssh
+      port: 22
+      protocol: TCP
+      targetPort: 22

--- a/argocd/applications/openclaw/virtualmachine.yaml
+++ b/argocd/applications/openclaw/virtualmachine.yaml
@@ -1,0 +1,72 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/name: openclaw
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  running: true
+  dataVolumeTemplates:
+    - metadata:
+        name: openclaw-rootdisk
+        creationTimestamp: null
+      spec:
+        source:
+          http:
+            url: https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img
+        pvc:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 80Gi
+          storageClassName: local-path
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: openclaw
+        app.kubernetes.io/name: openclaw
+      creationTimestamp: null
+    spec:
+      architecture: amd64
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      domain:
+        cpu:
+          cores: 4
+        firmware:
+          uuid: 09d47915-c293-4bf4-b5f1-c6f1cd8f22d2
+          serial: d9f74e8c-09f4-4e7d-a31d-26bf243d5fd5
+        machine:
+          type: q35
+        resources:
+          requests:
+            memory: 12Gi
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+              bootOrder: 1
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 22
+                - port: 3389
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: rootdisk
+          dataVolume:
+            name: openclaw-rootdisk
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: openclaw-cloud-init

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -91,6 +91,18 @@ spec:
                     pod-security.kubernetes.io/enforce: privileged
                     pod-security.kubernetes.io/audit: privileged
                     pod-security.kubernetes.io/warn: privileged
+              - name: openclaw
+                path: argocd/applications/openclaw
+                namespace: openclaw
+                annotations:
+                  argocd.argoproj.io/sync-wave: "2"
+                automation: manual
+                enabled: "true"
+                managedNamespaceMetadata:
+                  labels:
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
               - name: workers
                 path: argocd/applications/workers
                 namespace: workers
@@ -494,6 +506,18 @@ spec:
           group: kubevirt.io
           namespace: workers
           name: workers
+          jqPathExpressions:
+            - .metadata.annotations
+            - .metadata.finalizers
+            - .spec.dataVolumeTemplates[].metadata.creationTimestamp
+            - .spec.template.metadata.creationTimestamp
+            - .spec.template.spec.architecture
+            - .spec.template.spec.domain.firmware
+            - .spec.template.spec.domain.machine
+        - kind: VirtualMachine
+          group: kubevirt.io
+          namespace: openclaw
+          name: openclaw
           jqPathExpressions:
             - .metadata.annotations
             - .metadata.finalizers


### PR DESCRIPTION
## Summary

- Adds new Argo CD application manifests under `argocd/applications/openclaw` for a KubeVirt Ubuntu VM named `openclaw`.
- Configures cloud-init to install a full Ubuntu desktop (`ubuntu-desktop`) plus `xrdp`, `openssh-server`, and `qemu-guest-agent`.
- Exposes in-cluster access services for SSH (`22`) and RDP (`3389`).
- Registers `openclaw` in `argocd/applicationsets/platform.yaml` with privileged namespace metadata and VM ignore-diff rules.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/openclaw`
- `kubectl kustomize argocd/applications/openclaw | kubectl apply --dry-run=client -f -`
- `kubectl apply --dry-run=client -f argocd/applicationsets/platform.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
