### PR TITLE
fix(jangar): prevent discord transcript reset loops

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -1,0 +1,59 @@
+name: jangar-build-push
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/jangar/**'
+      - 'packages/scripts/src/jangar/**'
+      - 'packages/scripts/src/shared/**'
+      - 'packages/codex/**'
+      - 'packages/otel/**'
+      - 'packages/temporal-bun-sdk/**'
+      - 'skills/**'
+      - 'package.json'
+      - 'bun.lock'
+      - '.github/workflows/jangar-build-push.yaml'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: arc-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Build and push jangar image
+        env:
+          JANGAR_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          JANGAR_IMAGE_PLATFORMS: linux/arm64
+          JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
+        run: bun run packages/scripts/src/jangar/build-image.ts
+
+      - name: Update latest tag
+        run: |
+          set -euo pipefail
+          IMAGE="registry.ide-newton.ts.net/lab/jangar"
+          TAG="${{ steps.meta.outputs.tag }}"
+          docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${TAG}"
+          docker buildx imagetools inspect "${IMAGE}:${TAG}"
+          docker buildx imagetools inspect "${IMAGE}:latest"

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -195,6 +195,8 @@ spec:
               value: "1"
             - name: JANGAR_REDIS_URL
               value: redis://jangar-openwebui-redis:6379/1
+            - name: JANGAR_AGENT_COMMS_SUBSCRIBER_DISABLED
+              value: "true"
             - name: NATS_URL
               value: nats://nats.nats.svc.cluster.local:4222
             - name: NATS_USER

--- a/packages/scripts/src/jangar/build-image.ts
+++ b/packages/scripts/src/jangar/build-image.ts
@@ -116,6 +116,14 @@ export const buildImage = async (options: BuildImageOptions = {}) => {
       JANGAR_VERSION: version,
       JANGAR_COMMIT: commit,
     }
+    const buildNodeOptions = process.env.JANGAR_BUILD_NODE_OPTIONS?.trim()
+    if (buildNodeOptions) {
+      buildArgs.JANGAR_BUILD_NODE_OPTIONS = buildNodeOptions
+    }
+    const buildMinify = process.env.JANGAR_BUILD_MINIFY?.trim()
+    if (buildMinify) {
+      buildArgs.JANGAR_BUILD_MINIFY = buildMinify
+    }
     if (process.env.BUILDX_VERSION) {
       buildArgs.BUILDX_VERSION = process.env.BUILDX_VERSION
     }

--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -556,8 +556,13 @@ COPY --from=jangar-pty /tmp/node-pty/build /app/services/jangar/.output/server/n
 COPY --from=jangar-pty /tmp/node-pty/prebuilds /app/services/jangar/.output/server/node_modules/node-pty/prebuilds
 
 RUN mkdir -p /root/.codex
-RUN --mount=type=secret,id=codexauth,target=/tmp/codex_auth.json \
-  install -m 600 /tmp/codex_auth.json /root/.codex/auth.json
+RUN --mount=type=secret,id=codexauth,target=/tmp/codex_auth.json,required=false \
+  if [ -f /tmp/codex_auth.json ]; then \
+    install -m 600 /tmp/codex_auth.json /root/.codex/auth.json; \
+  else \
+    printf '{}' > /root/.codex/auth.json; \
+    chmod 600 /root/.codex/auth.json; \
+  fi
 COPY --from=jangar-build /app/services/jangar/scripts/codex-config-container.toml /root/.codex/config.toml
 COPY --from=jangar-build /app/services/jangar/scripts/agent-runner.ts /usr/local/bin/agent-runner
 COPY --from=jangar-build /app/services/jangar/scripts/codex-implement.ts /usr/local/bin/codex-implement

--- a/services/jangar/src/server/chat-transcript.ts
+++ b/services/jangar/src/server/chat-transcript.ts
@@ -77,6 +77,8 @@ export type TranscriptComparison = {
   prefixMatch: boolean
   prefixLength: number
   resetRequired: boolean
+  resetReason: 'none' | 'stored_longer_than_incoming' | 'prefix_mismatch'
+  resetMismatchIndex: number | null
   deltaMessages: ChatMessage[]
   signature: TranscriptEntry[]
 }
@@ -94,6 +96,8 @@ export const compareTranscript = (
       prefixMatch: true,
       prefixLength: 0,
       resetRequired: false,
+      resetReason: 'none',
+      resetMismatchIndex: null,
       deltaMessages: [...messages],
       signature,
     }
@@ -104,6 +108,8 @@ export const compareTranscript = (
       prefixMatch: false,
       prefixLength: 0,
       resetRequired: true,
+      resetReason: 'stored_longer_than_incoming',
+      resetMismatchIndex: null,
       deltaMessages: [...messages],
       signature,
     }
@@ -115,6 +121,8 @@ export const compareTranscript = (
         prefixMatch: false,
         prefixLength: 0,
         resetRequired: true,
+        resetReason: 'prefix_mismatch',
+        resetMismatchIndex: i,
         deltaMessages: [...messages],
         signature,
       }
@@ -125,6 +133,8 @@ export const compareTranscript = (
     prefixMatch: true,
     prefixLength: stored.length,
     resetRequired: false,
+    resetReason: 'none',
+    resetMismatchIndex: null,
     deltaMessages: messages.slice(stored.length),
     signature,
   }

--- a/services/oirat/src/index.ts
+++ b/services/oirat/src/index.ts
@@ -45,6 +45,7 @@ type BotState = {
 
 const STOP_COMMANDS = new Set(['stop', '!stop'])
 const STOP_CUSTOM_ID_PREFIX = 'oirat-stop'
+const JANGAR_CLIENT_KIND_HEADER = 'x-jangar-client-kind'
 
 const logContext = (message: GuildMessage) => ({
   messageId: message.id,
@@ -198,6 +199,7 @@ const fetchJangarCompletion = async (
   }
   if (options.chatId) {
     headers['x-openwebui-chat-id'] = options.chatId
+    headers[JANGAR_CLIENT_KIND_HEADER] = 'discord'
   }
 
   const response = await fetch(`${state.config.jangarBaseUrl}/openai/v1/chat/completions`, {


### PR DESCRIPTION
## Summary

- Gate stateful transcript reconciliation to OpenWebUI clients only; Discord calls now run in stateless transcript mode while preserving Redis thread/worktree state.
- Add explicit client-kind header support in `oirat` (`x-jangar-client-kind: discord`) and add transcript reset diagnostics (`resetReason`, `resetMismatchIndex`) in `jangar`.
- Add a regression test proving Discord requests do not clear thread state on transcript mismatch.
- Keep `JANGAR_STATEFUL_CHAT_MODE` enabled and disable noisy agent comms subscriber by default in `jangar` deployment.
- Add `jangar-build-push` GitHub Actions workflow to build/push `registry.ide-newton.ts.net/lab/jangar:<short-sha>` on `main` and retag `latest`.
- Make `services/jangar/Dockerfile` codex auth secret mount optional so CI image builds can run without a local codex auth file.
- Allow `packages/scripts/src/jangar/build-image.ts` to pass through `JANGAR_BUILD_NODE_OPTIONS` / `JANGAR_BUILD_MINIFY` as Docker build args.

## Related Issues

None

## Testing

- `bunx biome check services/jangar/src/server/chat.ts services/jangar/src/server/chat-transcript.ts services/jangar/src/server/__tests__/chat-completions.test.ts services/oirat/src/index.ts packages/scripts/src/jangar/build-image.ts`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/chat-completions.test.ts -t "keeps thread state for discord clients even when transcript differs"`
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/chat-completions.test.ts -t "keeps thread state for discord clients even when transcript differs"` (target test passed; command exits non-zero due unrelated `@proompteng/temporal-bun-sdk` pretest TypeScript target error in this environment)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
