### PR TITLE
fix(ci): prebuild jangar output in image workflow

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -42,11 +42,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
+      - name: Prebuild jangar output
+        env:
+          JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
+        run: bun run --cwd services/jangar start:build
+
       - name: Build and push jangar image
         env:
           JANGAR_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
           JANGAR_IMAGE_PLATFORMS: linux/arm64
           JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
+          JANGAR_USE_PREBUILT_OUTPUT: 'true'
         run: bun run packages/scripts/src/jangar/build-image.ts
 
       - name: Update latest tag


### PR DESCRIPTION
## Summary

- Update `jangar-build-push` workflow to prebuild `services/jangar/.output` on the runner before Docker build.
- Enable `JANGAR_USE_PREBUILT_OUTPUT=true` during image build so Docker reuses the prebuilt output and skips the slow in-container Nitro build step.
- Keep high-memory Node build options for both prebuild and image build steps.

## Related Issues

None

## Testing

- N/A (workflow-only change; validated by reviewing generated workflow plan and then executing the workflow on merge in this follow-up rollout)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
