### PR TITLE
fix(ci): build jangar prebuild dependencies

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -45,7 +45,10 @@ jobs:
       - name: Prebuild jangar output
         env:
           JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
-        run: bun run --cwd services/jangar start:build
+        run: |
+          bun run --filter @proompteng/otel build
+          bun run --filter @proompteng/temporal-bun-sdk build
+          bun run --cwd services/jangar start:build
 
       - name: Build and push jangar image
         env:


### PR DESCRIPTION
## Summary

- Fix `jangar-build-push` prebuild stage by building required workspace dependencies first.
- Run `@proompteng/otel` and `@proompteng/temporal-bun-sdk` builds before `services/jangar` `start:build`.
- Keep the prebuilt-output Docker path introduced in #3237 so image build avoids the long in-container Nitro phase.

## Related Issues

None

## Testing

- N/A (workflow-only follow-up; validated by executing the workflow after merge)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
