### PR TITLE
fix(ci): apply node memory options to jangar prebuild

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Prebuild jangar output
         env:
-          JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=4096
         run: |
           bun run --filter @proompteng/otel build
           bun run --filter @proompteng/temporal-bun-sdk build


### PR DESCRIPTION
## Summary

- Fix `jangar-build-push` prebuild env to use `NODE_OPTIONS=--max-old-space-size=4096`.
- Keep dependency prebuild steps (`@proompteng/otel`, `@proompteng/temporal-bun-sdk`) before `services/jangar` build.
- Align prebuild memory behavior with image build memory settings.

## Related Issues

None

## Testing

- N/A (workflow-only follow-up; validated by executing workflow after merge)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
