### PR TITLE
fix(ci): build jangar image without prebuild phase

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -42,20 +42,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      - name: Prebuild jangar output
-        env:
-          NODE_OPTIONS: --max-old-space-size=4096
-        run: |
-          bun run --filter @proompteng/otel build
-          bun run --filter @proompteng/temporal-bun-sdk build
-          bun run --cwd services/jangar start:build
-
       - name: Build and push jangar image
         env:
           JANGAR_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
           JANGAR_IMAGE_PLATFORMS: linux/arm64
           JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
-          JANGAR_USE_PREBUILT_OUTPUT: 'true'
         run: bun run packages/scripts/src/jangar/build-image.ts
 
       - name: Update latest tag


### PR DESCRIPTION
## Summary

- Remove the `Prebuild jangar output` step from `jangar-build-push`.
- Stop relying on `JANGAR_USE_PREBUILT_OUTPUT=true` in CI image builds.
- Keep Docker build-time memory tuning via `JANGAR_BUILD_NODE_OPTIONS`.

## Related Issues

None

## Testing

- `gh workflow run jangar-build-push.yaml --ref main` (validated new workflow dispatch path starts and executes setup/build stages).

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
