### PR TITLE
fix(argocd): redeploy jangar with image tag 20f20b8

### DIFF
--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -55,5 +55,4 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a803a452"
-    digest: sha256:f27a3e1b10dbe0e49ca1cabc9182ed7790abacf425540b57d5fe91df2cf8dea4
+    newTag: "20f20b8"


### PR DESCRIPTION
## Summary

- Update `argocd/applications/jangar/kustomization.yaml` image tag to `registry.ide-newton.ts.net/lab/jangar:20f20b8`.
- Remove the stale digest pin so Argo CD resolves the newly published tag on rollout.
- Keep the rest of the jangar manifest set unchanged.

## Related Issues

None

## Testing

- `rg -n "newTag" argocd/applications/jangar/kustomization.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.