### PR TITLE
fix(galactic): add nuc tailscale FQDN to control-plane endpoint patch

### DIFF
--- a/devices/altra/manifests/controlplane-endpoint-nuc.patch.yaml
+++ b/devices/altra/manifests/controlplane-endpoint-nuc.patch.yaml
@@ -1,9 +1,10 @@
 cluster:
   controlPlane:
-    endpoint: https://192.168.1.130:6443
+    endpoint: https://nuc.ide-newton.ts.net:6443
   apiServer:
     certSANs:
       - nuc
+      - nuc.ide-newton.ts.net
       - 192.168.1.130
       - 192.168.1.194
       - 192.168.1.203

--- a/devices/ampone/manifests/controlplane-endpoint-nuc.patch.yaml
+++ b/devices/ampone/manifests/controlplane-endpoint-nuc.patch.yaml
@@ -1,9 +1,10 @@
 cluster:
   controlPlane:
-    endpoint: https://192.168.1.130:6443
+    endpoint: https://nuc.ide-newton.ts.net:6443
   apiServer:
     certSANs:
       - nuc
+      - nuc.ide-newton.ts.net
       - 192.168.1.130
       - 192.168.1.194
       - 192.168.1.203

--- a/devices/ryzen/manifests/controlplane-endpoint-nuc.patch.yaml
+++ b/devices/ryzen/manifests/controlplane-endpoint-nuc.patch.yaml
@@ -1,9 +1,10 @@
 cluster:
   controlPlane:
-    endpoint: https://192.168.1.130:6443
+    endpoint: https://nuc.ide-newton.ts.net:6443
   apiServer:
     certSANs:
       - nuc
+      - nuc.ide-newton.ts.net
       - 192.168.1.130
       - 192.168.1.194
       - 192.168.1.203


### PR DESCRIPTION
## Summary

- Update `devices/*/manifests/controlplane-endpoint-nuc.patch.yaml` to use `https://nuc.ide-newton.ts.net:6443` as the control-plane endpoint.
- Add `nuc.ide-newton.ts.net` to `cluster.apiServer.certSANs` while keeping `nuc` and the existing LB/control-plane IP SANs.
- Apply the patch to all control-plane nodes without reboot and validate access with a fresh Talos-generated kubeconfig.

## Related Issues

None

## Testing

- `talosctl --talosconfig ~/.talos/config --endpoints 192.168.1.194 --nodes 192.168.1.194 patch machineconfig --patch @/tmp/controlplane-endpoint-nuc.ryzen.patch.yaml --mode=no-reboot`
- `talosctl --talosconfig ~/.talos/config --endpoints 192.168.1.194 --nodes 192.168.1.203 patch machineconfig --patch @/tmp/controlplane-endpoint-nuc.ampone.patch.yaml --mode=no-reboot`
- `talosctl --talosconfig ~/.talos/config --endpoints 192.168.1.194 --nodes 192.168.1.85 patch machineconfig --patch @/tmp/controlplane-endpoint-nuc.altra.patch.yaml --mode=no-reboot`
- `ssh kalmyk@nuc "openssl s_client -connect 127.0.0.1:6443 -servername nuc.ide-newton.ts.net -showcerts </dev/null 2>/dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | openssl x509 -noout -ext subjectAltName"`
- `kubectl --request-timeout=12s get ns -o name`
- `ssh kalmyk@nuc 'kubectl --request-timeout=12s get ns -o name | sed -n "1,8p"'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
