### PR TITLE
chore(deploy): roll jangar manifests

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-18T09:46:51.937Z"
+    deploy.knative.dev/rollout: "2026-02-19T03:56:46.226Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -55,4 +55,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "20f20b8"
+    newTag: "7a2f2212"
+    digest: sha256:aa031615d6454e186414da0c9d25b77c0a5a36d9b2e42f1f926fe5e1e7b03aa7


### PR DESCRIPTION
## Summary

- Ran `bun run packages/scripts/src/jangar/deploy-service.ts` to build and push `registry.ide-newton.ts.net/lab/jangar:7a2f2212`.
- Updated `argocd/applications/jangar/kustomization.yaml` with `newTag: "7a2f2212"` and digest `sha256:aa031615d6454e186414da0c9d25b77c0a5a36d9b2e42f1f926fe5e1e7b03aa7`.
- Bumped `deploy.knative.dev/rollout` annotation in `argocd/applications/jangar/deployment.yaml` to trigger rollout.
- Applied rendered manifests and confirmed `deployment/jangar` rollout in `jangar` namespace.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/jangar/deploy-service.ts`
- `kubectl rollout status deployment/jangar -n jangar --timeout=180s`
- `kubectl get pods -n jangar -l app=jangar -o wide`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
