### PR TITLE
chore(talos): set maxPods=200 for talos control-plane nodes

### DIFF
--- a/devices/altra/docs/cluster-bootstrap.md
+++ b/devices/altra/docs/cluster-bootstrap.md
@@ -74,6 +74,7 @@ talosctl apply-config --insecure -n "$ALTRA_IP" -e "$ALTRA_IP" \
   --config-patch @devices/altra/manifests/vfio-modules.patch.yaml \
   --config-patch @devices/altra/manifests/allow-scheduling-controlplane.patch.yaml \
   --config-patch @devices/altra/manifests/controlplane-endpoint-nuc.patch.yaml \
+  --config-patch @devices/altra/manifests/kubelet-maxpods.patch.yaml \
   --mode=reboot
 ```
 

--- a/devices/altra/manifests/README.md
+++ b/devices/altra/manifests/README.md
@@ -11,3 +11,4 @@ Files:
 - `devices/altra/manifests/local-path.patch.yaml`
 - `devices/altra/manifests/local-path-extra.patch.yaml`
 - `devices/altra/manifests/vfio-modules.patch.yaml`
+- `devices/altra/manifests/kubelet-maxpods.patch.yaml`

--- a/devices/altra/manifests/kubelet-maxpods.patch.yaml
+++ b/devices/altra/manifests/kubelet-maxpods.patch.yaml
@@ -1,0 +1,4 @@
+machine:
+  kubelet:
+    extraConfig:
+      maxPods: 200

--- a/devices/ampone/README.md
+++ b/devices/ampone/README.md
@@ -18,3 +18,4 @@ Manifests:
 - `devices/ampone/manifests/allow-scheduling-controlplane.patch.yaml` (single-node: run workloads on the controlplane)
 - `devices/ampone/manifests/ephemeral-volume.patch.yaml` (cap system `/var` to 300GB)
 - `devices/ampone/manifests/local-path.patch.yaml` (allocate remainder to local-path user volume)
+- `devices/ampone/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 200)

--- a/devices/ampone/docs/cluster-bootstrap.md
+++ b/devices/ampone/docs/cluster-bootstrap.md
@@ -60,6 +60,7 @@ Apply these patches:
 - `devices/ampone/manifests/hostname.patch.yaml`
 - `devices/ampone/manifests/ephemeral-volume.patch.yaml` (cap system `/var` to 300GB)
 - `devices/ampone/manifests/local-path.patch.yaml` (allocate remainder to local-path user volume)
+- `devices/ampone/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 200)
 
 ```bash
 talosctl apply-config --insecure -n <node_ip> -e <node_ip> \
@@ -70,6 +71,7 @@ talosctl apply-config --insecure -n <node_ip> -e <node_ip> \
   --config-patch @devices/ampone/manifests/hostname.patch.yaml \
   --config-patch @devices/ampone/manifests/ephemeral-volume.patch.yaml \
   --config-patch @devices/ampone/manifests/local-path.patch.yaml \
+  --config-patch @devices/ampone/manifests/kubelet-maxpods.patch.yaml \
   --mode=reboot
 ```
 

--- a/devices/ampone/manifests/kubelet-maxpods.patch.yaml
+++ b/devices/ampone/manifests/kubelet-maxpods.patch.yaml
@@ -1,0 +1,4 @@
+machine:
+  kubelet:
+    extraConfig:
+      maxPods: 200

--- a/devices/ryzen/docs/cluster-bootstrap.md
+++ b/devices/ryzen/docs/cluster-bootstrap.md
@@ -15,6 +15,7 @@ Node-level patches:
 - `devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml` (allow workloads on single-node controlplane)
 - `devices/ryzen/manifests/hostname.patch.yaml` (set Talos hostname to `ryzen`, optional if the generated config already sets it)
 - `devices/ryzen/manifests/node-labels.patch.yaml` (labels for KubeVirt scheduling)
+- `devices/ryzen/manifests/kubelet-maxpods.patch.yaml` (set kubelet `maxPods` to 200)
 - `devices/ryzen/manifests/tailscale-extension-service.template.yaml` (Tailscale extension service template)
 - `devices/ryzen/manifests/tailscale-extension-service.yaml` (generated from template; gitignored)
 - `devices/ryzen/manifests/tailscale-dns.patch.yaml` (prefer MagicDNS for tailnet hostnames)
@@ -83,6 +84,7 @@ If you need to re-layout these volumes on an already-installed node, follow:
 - `devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml` (single-node)
 - `devices/ryzen/manifests/hostname.patch.yaml`
 - `devices/ryzen/manifests/node-labels.patch.yaml`
+- `devices/ryzen/manifests/kubelet-maxpods.patch.yaml`
 - `devices/ryzen/manifests/tailscale-extension-service.yaml` (generate via `bun run packages/scripts/src/tailscale/generate-ryzen-extension-service.ts`)
 - `devices/ryzen/manifests/tailscale-dns.patch.yaml`
 
@@ -122,6 +124,7 @@ talosctl apply-config --insecure -n 192.168.1.194 -e 192.168.1.194 \
 #   --config-patch @devices/ryzen/manifests/allow-scheduling-controlplane.patch.yaml
 #   --config-patch @devices/ryzen/manifests/hostname.patch.yaml
 #   --config-patch @devices/ryzen/manifests/node-labels.patch.yaml
+#   --config-patch @devices/ryzen/manifests/kubelet-maxpods.patch.yaml
 #   --config-patch @devices/ryzen/manifests/tailscale-extension-service.yaml
 #   --config-patch @devices/ryzen/manifests/tailscale-dns.patch.yaml
 ```

--- a/devices/ryzen/manifests/kubelet-maxpods.patch.yaml
+++ b/devices/ryzen/manifests/kubelet-maxpods.patch.yaml
@@ -1,0 +1,4 @@
+machine:
+  kubelet:
+    extraConfig:
+      maxPods: 200


### PR DESCRIPTION
## Summary

- Added `kubelet-maxpods.patch.yaml` for `ryzen`, `ampone`, and `altra` with `machine.kubelet.extraConfig.maxPods: 200`.
- Updated node manifest inventories to include the new kubelet maxPods patch files.
- Updated Talos bootstrap/apply command examples for `ampone` and `altra` to include the new patch.
- Updated the `ryzen` bootstrap runbook optional patch list to include the new kubelet maxPods patch.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' devices/altra/manifests/kubelet-maxpods.patch.yaml devices/ampone/manifests/kubelet-maxpods.patch.yaml devices/ryzen/manifests/kubelet-maxpods.patch.yaml`
- `bunx biome check devices/altra/docs/cluster-bootstrap.md devices/altra/manifests/README.md devices/ampone/README.md devices/ampone/docs/cluster-bootstrap.md devices/ryzen/docs/cluster-bootstrap.md devices/altra/manifests/kubelet-maxpods.patch.yaml devices/ampone/manifests/kubelet-maxpods.patch.yaml devices/ryzen/manifests/kubelet-maxpods.patch.yaml` (fails locally because CLI is `2.2.4` while repo config requires `2.3.8`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
