### PR TITLE
feat(openclaw): add tailscale rdp access and codify install

### DIFF
--- a/argocd/applications/openclaw/cloud-init-secret.yaml
+++ b/argocd/applications/openclaw/cloud-init-secret.yaml
@@ -15,6 +15,7 @@ stringData:
     packages:
       - qemu-guest-agent
       - openssh-server
+      - curl
       - xrdp
       - ubuntu-desktop
     write_files:
@@ -52,12 +53,15 @@ stringData:
         content: |-
           #!/usr/bin/env bash
           set -euo pipefail
+          OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.2.17}"
           mkdir -p /var/lib/openclaw
           runuser -u ubuntu -- env HOME=/home/ubuntu OPENCLAW_NO_ONBOARD=1 OPENCLAW_NO_PROMPT=1 \
-            OPENCLAW_USE_GUM=0 DEBIAN_FRONTEND=noninteractive bash -lc \
-            'curl -fsSL --proto "=https" --tlsv1.2 https://openclaw.ai/install.sh | bash -s -- --no-onboard' \
+            OPENCLAW_USE_GUM=0 DEBIAN_FRONTEND=noninteractive OPENCLAW_VERSION="${OPENCLAW_VERSION}" \
+            bash -lc \
+            'curl -fsSL --proto "=https" --tlsv1.2 https://openclaw.ai/install.sh | bash -s -- --no-onboard --version "${OPENCLAW_VERSION}"' \
             > /var/lib/openclaw/openclaw-install.log 2>&1
           ln -sf /home/ubuntu/.npm-global/bin/openclaw /usr/local/bin/openclaw
+          echo "${OPENCLAW_VERSION}" > /var/lib/openclaw/openclaw-version-requested.txt
           /home/ubuntu/.npm-global/bin/openclaw --version > /var/lib/openclaw/openclaw-version.txt
           date -u +"%Y-%m-%dT%H:%M:%SZ" > /var/lib/openclaw/openclaw-installed-at
     users:
@@ -86,6 +90,7 @@ stringData:
       - [ bash, -lc, 'systemctl enable --now NetworkManager' ]
       - [ bash, -lc, 'netplan generate && netplan apply || true' ]
       - [ bash, -lc, 'adduser xrdp ssl-cert || true' ]
+      - [ bash, -lc, 'grep -q "unset DBUS_SESSION_BUS_ADDRESS" /etc/xrdp/startwm.sh || sed -i "/^if test -r \\/etc\\/profile;/i unset DBUS_SESSION_BUS_ADDRESS\\nunset XDG_RUNTIME_DIR\\n" /etc/xrdp/startwm.sh' ]
       - [ bash, -lc, 'systemctl set-default graphical.target' ]
       - [ bash, -lc, 'systemctl enable --now xrdp' ]
       - [ bash, -lc, 'mkdir -p /var/lib/openclaw' ]

--- a/argocd/applications/openclaw/kustomization.yaml
+++ b/argocd/applications/openclaw/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - cloud-init-secret.yaml
   - virtualmachine.yaml
   - service-rdp.yaml
+  - service-rdp-tailscale.yaml
   - service-ssh.yaml

--- a/argocd/applications/openclaw/service-rdp-tailscale.yaml
+++ b/argocd/applications/openclaw/service-rdp-tailscale.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-rdp-tailscale
+  annotations:
+    tailscale.com/hostname: openclaw-rdp
+    # Tailscale LB readiness is managed by the operator; do not block Argo health on it.
+    argocd.argoproj.io/ignore-healthcheck: 'true'
+  labels:
+    app.kubernetes.io/name: openclaw
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    kubevirt.io/domain: openclaw
+  ports:
+    - name: rdp
+      port: 3389
+      protocol: TCP
+      targetPort: 3389


### PR DESCRIPTION
## Summary

- Add a dedicated Tailscale LoadBalancer Service for OpenClaw RDP so clients can connect over tailnet without `kubectl port-forward`.
- Keep the internal ClusterIP RDP/SSH services unchanged for in-cluster use.
- Harden OpenClaw cloud-init provisioning by pinning installer version (`2026.2.17`) and recording requested vs installed versions under `/var/lib/openclaw`.
- Persist XRDP startup compatibility by patching `/etc/xrdp/startwm.sh` to unset conflicting DBus/runtime vars before starting X session.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Live VM validation in `openclaw` namespace:
  - Verified XRDP, XRDP sesman, and GDM services are active.
  - Applied the same `startwm.sh` DBus/runtime env fix live and restarted XRDP services.
  - Confirmed OpenClaw CLI is installed (`/home/ubuntu/.npm-global/bin/openclaw --version` -> `2026.2.17`).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
