### PR TITLE
feat(torghut): add promotion governance policy automation

### DIFF
--- a/argocd/applications/agents/torghut-agentruns.yaml
+++ b/argocd/applications/agents/torghut-agentruns.yaml
@@ -55,6 +55,85 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec
 metadata:
+  name: torghut-v3-promotion-policy-check-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - candidateId
+      - runId
+      - promotionTarget
+      - policyPath
+      - candidateStatePath
+      - gateReportPath
+      - artifactRoot
+      - artifactPath
+  text: |
+    Objective: Enforce promotion prerequisite and rollback-readiness checks before stage promotion.
+
+    Guardrails:
+    - Read-only policy evaluation; no cluster mutation.
+    - Promotion progression is denied when either prerequisite or rollback checks fail.
+
+    Inputs:
+    - candidateId, runId, promotionTarget
+    - policyPath, candidateStatePath, gateReportPath
+    - artifactRoot, artifactPath
+
+    Steps:
+    1) Run:
+       - python services/torghut/scripts/validate_promotion_policy.py \
+         --policy ${policyPath} \
+         --state ${candidateStatePath} \
+         --gate-report ${gateReportPath} \
+         --artifact-root ${artifactRoot} \
+         --promotion-target ${promotionTarget} \
+         --output ${artifactPath}/promotion-policy-check.json
+    2) Fail fast if `promotion_progression_allowed` is false.
+    3) Publish the decision artifact path and reasons.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: torghut-v3-promotion-policy-dry-run-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - promotionTarget
+      - policyPath
+      - gateReportPath
+      - artifactPath
+      - simulateMissingArtifact
+      - simulateStaleRollback
+  text: |
+    Objective: Execute dry-run harness proving policy enforcement behavior for promotion and rollback workflows.
+
+    Constraints:
+    - Must remain dry-run only.
+    - Must emit structured JSON artifact to `${artifactPath}`.
+
+    Inputs:
+    - promotionTarget, policyPath, gateReportPath, artifactPath
+    - simulateMissingArtifact, simulateStaleRollback
+
+    Steps:
+    1) Build optional simulation flags:
+       - SIM_MISSING = `--simulate-missing-artifact` when simulateMissingArtifact is true.
+       - SIM_STALE = `--simulate-stale-rollback` when simulateStaleRollback is true.
+    2) Run:
+       - python services/torghut/scripts/run_governance_policy_dry_run.py \
+         --policy ${policyPath} \
+         --gate-report ${gateReportPath} \
+         --promotion-target ${promotionTarget} \
+         ${SIM_MISSING} \
+         ${SIM_STALE} \
+         --output ${artifactPath}/governance-policy-dry-run.json
+    3) Include `promotion_progression_allowed` and failure reasons in output summary.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
   name: torghut-gated-actuation-runner-v1
   namespace: agents
 spec:

--- a/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
+++ b/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
@@ -25,5 +25,21 @@ data:
       "gate2_max_cost_bps": "35",
       "gate3_max_llm_error_ratio": "0.10",
       "gate5_live_enabled": false,
-      "gate5_require_approval_token": true
+      "gate5_require_approval_token": true,
+      "promotion_required_artifacts": [
+        "research/candidate-spec.json",
+        "backtest/evaluation-report.json",
+        "gates/gate-evaluation.json"
+      ],
+      "promotion_require_patch_targets": [
+        "paper",
+        "live"
+      ],
+      "rollback_required_checks": [
+        "killSwitchDryRunPassed",
+        "gitopsRevertDryRunPassed",
+        "strategyDisableDryRunPassed"
+      ],
+      "rollback_dry_run_max_age_hours": 72,
+      "rollback_require_human_approval": true
     }

--- a/docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/agentruns.yaml
@@ -144,6 +144,110 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
+  name: torghut-v3-lane-e-promotion-prereq-template
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/lane: lane-e
+    torghut.proompteng.ai/stage: promotion-prerequisites
+spec:
+  agentRef:
+    name: codex-research-agent
+  implementationSpecRef:
+    name: torghut-v3-promotion-prerequisites-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 3600
+  vcsPolicy:
+    required: false
+    mode: none
+  parameters:
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: promotion-prerequisites
+    artifactPath: ${artifactPath}
+    promotionTarget: ${promotionTarget}
+    gateReportPath: ${gateReportPath}
+    candidateStatePath: ${candidateStatePath}
+    policyPath: ${policyPath}
+    artifactRoot: ${artifactRoot}
+  workflow:
+    steps:
+      - name: implement
+        retries: 1
+        retryBackoffSeconds: 10
+        timeoutSeconds: 3600
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: torghut-v3-lane-f-rollback-readiness-template
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/lane: lane-f
+    torghut.proompteng.ai/stage: rollback-readiness
+spec:
+  agentRef:
+    name: codex-research-agent
+  implementationSpecRef:
+    name: torghut-v3-rollback-readiness-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 3600
+  vcsPolicy:
+    required: false
+    mode: none
+  parameters:
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: rollback-readiness
+    artifactPath: ${artifactPath}
+    candidateStatePath: ${candidateStatePath}
+    policyPath: ${policyPath}
+  workflow:
+    steps:
+      - name: implement
+        retries: 1
+        retryBackoffSeconds: 10
+        timeoutSeconds: 3600
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: torghut-v3-lane-f-policy-dry-run-template
+  namespace: agents
+  labels:
+    torghut.proompteng.ai/lane: lane-f
+    torghut.proompteng.ai/stage: policy-dry-run
+spec:
+  agentRef:
+    name: codex-research-agent
+  implementationSpecRef:
+    name: torghut-v3-policy-dry-run-v1
+  runtime:
+    type: workflow
+  ttlSecondsAfterFinished: 1800
+  vcsPolicy:
+    required: false
+    mode: none
+  parameters:
+    candidateId: ${candidateId}
+    runId: ${runId}
+    stage: policy-dry-run
+    artifactPath: ${artifactPath}
+    promotionTarget: ${promotionTarget}
+    policyPath: ${policyPath}
+    gateReportPath: ${gateReportPath}
+    simulateMissingArtifact: ${simulateMissingArtifact}
+    simulateStaleRollback: ${simulateStaleRollback}
+  workflow:
+    steps:
+      - name: implement
+        retries: 0
+        timeoutSeconds: 1800
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
   name: torghut-v3-lane-e-shadow-template
   namespace: agents
   labels:

--- a/docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/implementationspecs.yaml
@@ -87,6 +87,45 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec
 metadata:
+  name: torghut-v3-promotion-prerequisites-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - candidateId
+      - runId
+      - promotionTarget
+      - gateReportPath
+      - candidateStatePath
+      - policyPath
+      - artifactRoot
+      - artifactPath
+  text: |
+    Objective: Enforce promotion prerequisite policy checks prior to any progression into shadow/paper/live.
+    Inputs: candidateId, runId, promotionTarget, gateReportPath, candidateStatePath, policyPath, artifactRoot, artifactPath.
+    Output: deterministic prerequisite decision JSON and failure reasons for audit trail.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: torghut-v3-rollback-readiness-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - candidateId
+      - runId
+      - candidateStatePath
+      - policyPath
+      - artifactPath
+  text: |
+    Objective: Validate rollback readiness before or during promotion progression.
+    Inputs: candidateId, runId, candidateStatePath, policyPath, artifactPath.
+    Output: rollback readiness decision JSON with stale/missing control checks.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
   name: torghut-v3-live-ramp-v1
   namespace: agents
 spec:
@@ -100,6 +139,25 @@ spec:
     Objective: Apply controlled live-ramp stage with policy checks.
     Inputs: torghutNamespace, gitopsPath, rampStage, confirm.
     Output: rollout report and stage health summary.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: torghut-v3-policy-dry-run-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - promotionTarget
+      - policyPath
+      - gateReportPath
+      - artifactPath
+      - simulateMissingArtifact
+      - simulateStaleRollback
+  text: |
+    Objective: Prove policy enforcement with deterministic dry-run scenarios.
+    Inputs: promotionTarget, policyPath, gateReportPath, artifactPath, simulateMissingArtifact, simulateStaleRollback.
+    Output: dry-run policy evidence JSON for both promotion and rollback workflows.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec

--- a/docs/torghut/design-system/v3/full-loop/templates/orchestration-policy.yaml
+++ b/docs/torghut/design-system/v3/full-loop/templates/orchestration-policy.yaml
@@ -24,6 +24,21 @@ stages:
     mutableAction: false
     requirePreviousArtifact: true
     requirePreviousGatePass: true
+  - stage: promotion-prerequisites
+    lane: lane-e
+    mutableAction: false
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
+  - stage: rollback-readiness
+    lane: lane-f
+    mutableAction: false
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
+  - stage: policy-dry-run
+    lane: lane-f
+    mutableAction: false
+    requirePreviousArtifact: true
+    requirePreviousGatePass: true
   - stage: shadow-paper
     lane: lane-e
     mutableAction: true
@@ -59,7 +74,16 @@ transitions:
     - gate-evaluation
   gate-evaluation:
     - research-intake
+    - promotion-prerequisites
+  promotion-prerequisites:
+    - rollback-readiness
+    - research-intake
+  rollback-readiness:
+    - policy-dry-run
+    - incident-recovery
+  policy-dry-run:
     - shadow-paper
+    - incident-recovery
   shadow-paper:
     - live-ramp
     - incident-recovery

--- a/services/torghut/app/trading/autonomy/__init__.py
+++ b/services/torghut/app/trading/autonomy/__init__.py
@@ -7,6 +7,12 @@ from .lane import (
     run_autonomous_lane,
     upsert_autonomy_no_signal_run,
 )
+from .policy_checks import (
+    PromotionPrerequisiteResult,
+    RollbackReadinessResult,
+    evaluate_promotion_prerequisites,
+    evaluate_rollback_readiness,
+)
 from .runtime import (
     LegacyMacdRsiPlugin,
     RuntimeEvaluationResult,
@@ -26,7 +32,9 @@ __all__ = [
     'GatePolicyMatrix',
     'LegacyMacdRsiPlugin',
     'PromotionTarget',
+    'PromotionPrerequisiteResult',
     'RuntimeEvaluationResult',
+    'RollbackReadinessResult',
     'StrategyContext',
     'StrategyIntent',
     'StrategyPlugin',
@@ -36,6 +44,8 @@ __all__ = [
     'default_runtime_registry',
     'evaluate_gate_matrix',
     'load_runtime_strategy_config',
+    'evaluate_promotion_prerequisites',
+    'evaluate_rollback_readiness',
     'upsert_autonomy_no_signal_run',
     'run_autonomous_lane',
 ]

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -1,0 +1,192 @@
+"""Promotion progression and rollback readiness policy checks for Torghut autonomy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, cast
+
+
+@dataclass(frozen=True)
+class PromotionPrerequisiteResult:
+    allowed: bool
+    reasons: list[str]
+    required_artifacts: list[str]
+    missing_artifacts: list[str]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            'allowed': self.allowed,
+            'reasons': list(self.reasons),
+            'required_artifacts': list(self.required_artifacts),
+            'missing_artifacts': list(self.missing_artifacts),
+        }
+
+
+@dataclass(frozen=True)
+class RollbackReadinessResult:
+    ready: bool
+    reasons: list[str]
+    required_checks: list[str]
+    missing_checks: list[str]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            'ready': self.ready,
+            'reasons': list(self.reasons),
+            'required_checks': list(self.required_checks),
+            'missing_checks': list(self.missing_checks),
+        }
+
+
+def evaluate_promotion_prerequisites(
+    *,
+    policy_payload: dict[str, Any],
+    gate_report_payload: dict[str, Any],
+    candidate_state_payload: dict[str, Any],
+    promotion_target: str,
+    artifact_root: Path,
+) -> PromotionPrerequisiteResult:
+    reasons: list[str] = []
+    required_artifacts = _required_artifacts_for_target(policy_payload, promotion_target)
+    missing_artifacts = [item for item in required_artifacts if not (artifact_root / item).exists()]
+
+    if missing_artifacts:
+        reasons.append('required_artifacts_missing')
+
+    if candidate_state_payload.get('paused', False):
+        reasons.append('candidate_paused_for_review')
+
+    if not bool(gate_report_payload.get('promotion_allowed', False)):
+        reasons.append('gate_report_not_promotable')
+
+    requested_rank = _promotion_rank(promotion_target)
+    recommended_rank = _promotion_rank(str(gate_report_payload.get('recommended_mode', 'shadow')))
+    if recommended_rank < requested_rank:
+        reasons.append('gate_recommended_mode_below_target')
+
+    gate_index = {str(gate.get('gate_id', '')): gate for gate in _gates(gate_report_payload)}
+    for required_gate in ('gate0_data_integrity', 'gate1_statistical_robustness', 'gate2_risk_capacity'):
+        status = str(gate_index.get(required_gate, {}).get('status', 'fail'))
+        if status != 'pass':
+            reasons.append(f'{required_gate}_not_passed')
+
+    if str(candidate_state_payload.get('runId', '')).strip() != str(gate_report_payload.get('run_id', '')).strip():
+        # gate report payload may not always include run_id; only enforce when available.
+        run_id = str(gate_report_payload.get('run_id', '')).strip()
+        if run_id:
+            reasons.append('run_id_mismatch_between_state_and_gate_report')
+
+    return PromotionPrerequisiteResult(
+        allowed=not reasons,
+        reasons=sorted(set(reasons)),
+        required_artifacts=required_artifacts,
+        missing_artifacts=missing_artifacts,
+    )
+
+
+def evaluate_rollback_readiness(
+    *,
+    policy_payload: dict[str, Any],
+    candidate_state_payload: dict[str, Any],
+    now: datetime | None = None,
+) -> RollbackReadinessResult:
+    reasons: list[str] = []
+    required_checks = _required_rollback_checks(policy_payload)
+    rollback_raw = candidate_state_payload.get('rollbackReadiness')
+    rollback: dict[str, Any]
+    if isinstance(rollback_raw, dict):
+        rollback = cast(dict[str, Any], rollback_raw)
+    else:
+        rollback = {}
+
+    missing_checks = [name for name in required_checks if not bool(rollback.get(name, False))]
+    if missing_checks:
+        reasons.append('rollback_checks_missing_or_failed')
+
+    max_age_hours = int(policy_payload.get('rollback_dry_run_max_age_hours', 72))
+    dry_run_completed_at = _parse_datetime(str(rollback.get('dryRunCompletedAt', '')).strip())
+    current = now or datetime.now(timezone.utc)
+    if dry_run_completed_at is None:
+        reasons.append('rollback_dry_run_timestamp_missing')
+    else:
+        if current - dry_run_completed_at > timedelta(hours=max_age_hours):
+            reasons.append('rollback_dry_run_stale')
+
+    if policy_payload.get('rollback_require_human_approval', True) and not bool(rollback.get('humanApproved', False)):
+        reasons.append('rollback_human_approval_missing')
+
+    if not str(rollback.get('rollbackTarget', '')).strip():
+        reasons.append('rollback_target_missing')
+
+    return RollbackReadinessResult(
+        ready=not reasons,
+        reasons=sorted(set(reasons)),
+        required_checks=required_checks,
+        missing_checks=missing_checks,
+    )
+
+
+def _required_artifacts_for_target(policy_payload: dict[str, Any], promotion_target: str) -> list[str]:
+    base_raw = policy_payload.get(
+        'promotion_required_artifacts',
+        ['research/candidate-spec.json', 'backtest/evaluation-report.json', 'gates/gate-evaluation.json'],
+    )
+    base = _list_from_any(base_raw)
+    required = [str(item) for item in base if isinstance(item, str)]
+    patch_targets_raw = policy_payload.get('promotion_require_patch_targets', ['paper', 'live'])
+    patch_targets = _list_from_any(patch_targets_raw)
+    if promotion_target in patch_targets:
+        required.append('paper-candidate/strategy-configmap-patch.yaml')
+    return sorted(set(required))
+
+
+def _required_rollback_checks(policy_payload: dict[str, Any]) -> list[str]:
+    checks_raw = policy_payload.get(
+        'rollback_required_checks',
+        ['killSwitchDryRunPassed', 'gitopsRevertDryRunPassed', 'strategyDisableDryRunPassed'],
+    )
+    checks = _list_from_any(checks_raw)
+    return [str(item) for item in checks if isinstance(item, str)]
+
+
+def _gates(gate_report_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    gates_raw = gate_report_payload.get('gates')
+    gates_list = _list_from_any(gates_raw)
+    gates: list[dict[str, Any]] = []
+    for item in gates_list:
+        if isinstance(item, dict):
+            gates.append(cast(dict[str, Any], item))
+    return gates
+
+
+def _list_from_any(value: Any) -> list[object]:
+    if not isinstance(value, list):
+        return []
+    return cast(list[object], value)
+
+
+def _promotion_rank(target: str) -> int:
+    ranking = {'shadow': 1, 'paper': 2, 'live': 3}
+    return ranking.get(target, 0)
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+__all__ = [
+    'PromotionPrerequisiteResult',
+    'RollbackReadinessResult',
+    'evaluate_promotion_prerequisites',
+    'evaluate_rollback_readiness',
+]

--- a/services/torghut/config/autonomous-gate-policy.json
+++ b/services/torghut/config/autonomous-gate-policy.json
@@ -14,5 +14,21 @@
   "gate2_max_cost_bps": "35",
   "gate3_max_llm_error_ratio": "0.10",
   "gate5_live_enabled": false,
-  "gate5_require_approval_token": true
+  "gate5_require_approval_token": true,
+  "promotion_required_artifacts": [
+    "research/candidate-spec.json",
+    "backtest/evaluation-report.json",
+    "gates/gate-evaluation.json"
+  ],
+  "promotion_require_patch_targets": [
+    "paper",
+    "live"
+  ],
+  "rollback_required_checks": [
+    "killSwitchDryRunPassed",
+    "gitopsRevertDryRunPassed",
+    "strategyDisableDryRunPassed"
+  ],
+  "rollback_dry_run_max_age_hours": 72,
+  "rollback_require_human_approval": true
 }

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -14,5 +14,21 @@
   "gate2_max_cost_bps": "35",
   "gate3_max_llm_error_ratio": "0.10",
   "gate5_live_enabled": false,
-  "gate5_require_approval_token": true
+  "gate5_require_approval_token": true,
+  "promotion_required_artifacts": [
+    "research/candidate-spec.json",
+    "backtest/evaluation-report.json",
+    "gates/gate-evaluation.json"
+  ],
+  "promotion_require_patch_targets": [
+    "paper",
+    "live"
+  ],
+  "rollback_required_checks": [
+    "killSwitchDryRunPassed",
+    "gitopsRevertDryRunPassed",
+    "strategyDisableDryRunPassed"
+  ],
+  "rollback_dry_run_max_age_hours": 72,
+  "rollback_require_human_approval": true
 }

--- a/services/torghut/scripts/run_governance_policy_dry_run.py
+++ b/services/torghut/scripts/run_governance_policy_dry_run.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Execute local dry-run harness for Torghut promotion and rollback policy enforcement."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from app.trading.autonomy.policy_checks import evaluate_promotion_prerequisites, evaluate_rollback_readiness
+
+
+def _json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict):
+        raise ValueError(f'Expected JSON object at {path}')
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Run dry-run policy enforcement harness for Torghut governance checks.')
+    parser.add_argument('--policy', type=Path, required=True, help='Policy JSON (autonomy-gates-v3).')
+    parser.add_argument('--gate-report', type=Path, required=True, help='Gate evaluation JSON payload.')
+    parser.add_argument('--promotion-target', choices=('shadow', 'paper', 'live'), default='paper')
+    parser.add_argument('--output', type=Path, help='Optional output file path.')
+    parser.add_argument(
+        '--simulate-missing-artifact',
+        action='store_true',
+        default=False,
+        help='Delete paper patch artifact before checks to prove enforcement behavior.',
+    )
+    parser.add_argument(
+        '--simulate-stale-rollback',
+        action='store_true',
+        default=False,
+        help='Use stale rollback dry-run timestamp to trigger readiness failure.',
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    policy = _json(args.policy)
+    gate_report = _json(args.gate_report)
+
+    with TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        (root / 'research').mkdir(parents=True, exist_ok=True)
+        (root / 'backtest').mkdir(parents=True, exist_ok=True)
+        (root / 'gates').mkdir(parents=True, exist_ok=True)
+        (root / 'paper-candidate').mkdir(parents=True, exist_ok=True)
+
+        (root / 'research' / 'candidate-spec.json').write_text('{"candidate":"ok"}\n', encoding='utf-8')
+        (root / 'backtest' / 'evaluation-report.json').write_text('{"report":"ok"}\n', encoding='utf-8')
+        (root / 'gates' / 'gate-evaluation.json').write_text(json.dumps(gate_report, indent=2), encoding='utf-8')
+        (root / 'paper-candidate' / 'strategy-configmap-patch.yaml').write_text(
+            'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: dry-run\n',
+            encoding='utf-8',
+        )
+
+        if args.simulate_missing_artifact:
+            (root / 'paper-candidate' / 'strategy-configmap-patch.yaml').unlink()
+
+        stale_ts = '2025-01-01T00:00:00+00:00'
+        recent_ts = datetime.now(timezone.utc).isoformat()
+        state = {
+            'candidateId': 'cand-dry-run',
+            'runId': str(gate_report.get('run_id', 'run-dry-run')),
+            'activeStage': 'gate-evaluation',
+            'paused': False,
+            'rollbackReadiness': {
+                'killSwitchDryRunPassed': True,
+                'gitopsRevertDryRunPassed': True,
+                'strategyDisableDryRunPassed': True,
+                'dryRunCompletedAt': stale_ts if args.simulate_stale_rollback else recent_ts,
+                'humanApproved': True,
+                'rollbackTarget': 'main@abcdef0',
+            },
+        }
+        promotion = evaluate_promotion_prerequisites(
+            policy_payload=policy,
+            gate_report_payload=gate_report,
+            candidate_state_payload=state,
+            promotion_target=args.promotion_target,
+            artifact_root=root,
+        )
+        rollback = evaluate_rollback_readiness(policy_payload=policy, candidate_state_payload=state)
+
+        payload = {
+            'promotion_target': args.promotion_target,
+            'promotion_prerequisites': promotion.to_payload(),
+            'rollback_readiness': rollback.to_payload(),
+            'promotion_progression_allowed': promotion.allowed and rollback.ready,
+            'simulation': {
+                'missing_artifact': args.simulate_missing_artifact,
+                'stale_rollback': args.simulate_stale_rollback,
+            },
+        }
+
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + '\n', encoding='utf-8')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/scripts/validate_promotion_policy.py
+++ b/services/torghut/scripts/validate_promotion_policy.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Validate Torghut promotion prerequisites and rollback readiness policies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from app.trading.autonomy.policy_checks import evaluate_promotion_prerequisites, evaluate_rollback_readiness
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict):
+        raise ValueError(f'Expected JSON object at {path}')
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Validate Torghut v3 promotion and rollback policy checks.')
+    parser.add_argument('--policy', type=Path, required=True, help='Gate and operational policy JSON.')
+    parser.add_argument('--state', type=Path, required=True, help='Candidate state JSON.')
+    parser.add_argument('--gate-report', type=Path, required=True, help='Gate evaluation report JSON.')
+    parser.add_argument('--artifact-root', type=Path, required=True, help='Artifact root directory for prerequisite files.')
+    parser.add_argument('--promotion-target', choices=('shadow', 'paper', 'live'), default='paper')
+    parser.add_argument(
+        '--output',
+        type=Path,
+        help='Optional output JSON file for combined check results. Prints to stdout regardless.',
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    policy = _load_json(args.policy)
+    state = _load_json(args.state)
+    gate_report = _load_json(args.gate_report)
+
+    promotion = evaluate_promotion_prerequisites(
+        policy_payload=policy,
+        gate_report_payload=gate_report,
+        candidate_state_payload=state,
+        promotion_target=args.promotion_target,
+        artifact_root=args.artifact_root,
+    )
+    rollback = evaluate_rollback_readiness(
+        policy_payload=policy,
+        candidate_state_payload=state,
+    )
+
+    payload = {
+        'promotion_target': args.promotion_target,
+        'promotion_prerequisites': promotion.to_payload(),
+        'rollback_readiness': rollback.to_payload(),
+        'promotion_progression_allowed': promotion.allowed and rollback.ready,
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + '\n', encoding='utf-8')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/tests/test_governance_policy_dry_run.py
+++ b/services/torghut/tests/test_governance_policy_dry_run.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+
+class TestGovernancePolicyDryRun(TestCase):
+    def test_dry_run_blocks_progression_when_artifact_missing(self) -> None:
+        output = self._run_harness('--simulate-missing-artifact')
+        self.assertFalse(output['promotion_progression_allowed'])
+        reasons = output['promotion_prerequisites']['reasons']
+        self.assertIn('required_artifacts_missing', reasons)
+
+    def test_dry_run_blocks_progression_when_rollback_stale(self) -> None:
+        output = self._run_harness('--simulate-stale-rollback')
+        self.assertFalse(output['promotion_progression_allowed'])
+        reasons = output['rollback_readiness']['reasons']
+        self.assertIn('rollback_dry_run_stale', reasons)
+
+    def test_dry_run_allows_progression_when_checks_pass(self) -> None:
+        output = self._run_harness()
+        self.assertTrue(output['promotion_progression_allowed'])
+
+    def _run_harness(self, *extra_args: str) -> dict[str, object]:
+        repo_root = Path(__file__).resolve().parents[3]
+        service_root = repo_root / 'services' / 'torghut'
+        script = service_root / 'scripts' / 'run_governance_policy_dry_run.py'
+        policy = service_root / 'config' / 'autonomy-gates-v3.json'
+
+        gate_report = {
+            'run_id': 'run-dry-run',
+            'promotion_allowed': True,
+            'recommended_mode': 'paper',
+            'gates': [
+                {'gate_id': 'gate0_data_integrity', 'status': 'pass'},
+                {'gate_id': 'gate1_statistical_robustness', 'status': 'pass'},
+                {'gate_id': 'gate2_risk_capacity', 'status': 'pass'},
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gate_report_path = Path(tmpdir) / 'gate-report.json'
+            gate_report_path.write_text(json.dumps(gate_report, indent=2), encoding='utf-8')
+
+            cmd = [
+                'python',
+                str(script),
+                '--policy',
+                str(policy),
+                '--gate-report',
+                str(gate_report_path),
+                '--promotion-target',
+                'paper',
+                *extra_args,
+            ]
+            result = subprocess.run(
+                cmd,
+                cwd=service_root,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        return json.loads(result.stdout)

--- a/services/torghut/tests/test_orchestration_guard.py
+++ b/services/torghut/tests/test_orchestration_guard.py
@@ -29,7 +29,7 @@ class TestOrchestrationGuard(TestCase):
                 candidate_id='cand-abc123',
                 run_id='run-abc123',
                 from_stage='gate-evaluation',
-                to_stage='shadow-paper',
+                to_stage='promotion-prerequisites',
                 previous_artifact=artifact,
                 previous_gate_passed=True,
                 risk_controls_passed=True,
@@ -41,15 +41,22 @@ class TestOrchestrationGuard(TestCase):
         self.assertEqual(result['nextAction'], 'proceed')
 
     def test_blocks_mutable_stage_without_gitops_or_ticket(self) -> None:
+        state: dict[str, Any] = {
+            'candidateId': 'cand-abc123',
+            'runId': 'run-abc123',
+            'activeStage': 'rollback-readiness',
+            'paused': False,
+            'failureCounts': {},
+        }
         with tempfile.TemporaryDirectory() as tmpdir:
             artifact = Path(tmpdir) / 'report.json'
             artifact.write_text('{"ok":true}', encoding='utf-8')
             result = evaluate_transition(
                 policy=self.policy,
-                state=self.state,
+                state=state,
                 candidate_id='cand-abc123',
                 run_id='run-abc123',
-                from_stage='gate-evaluation',
+                from_stage='rollback-readiness',
                 to_stage='shadow-paper',
                 previous_artifact=artifact,
                 previous_gate_passed=True,
@@ -127,7 +134,7 @@ class TestOrchestrationGuard(TestCase):
                 candidate_id='cand-abc123',
                 run_id='run-abc123',
                 from_stage='gate-evaluation',
-                to_stage='shadow-paper',
+                to_stage='promotion-prerequisites',
                 previous_artifact=artifact,
                 previous_gate_passed=True,
                 risk_controls_passed=True,
@@ -156,7 +163,7 @@ class TestOrchestrationGuard(TestCase):
                 candidate_id='cand-abc123',
                 run_id='run-abc123',
                 from_stage='gate-evaluation',
-                to_stage='shadow-paper',
+                to_stage='promotion-prerequisites',
                 previous_artifact=artifact,
                 previous_gate_passed=True,
                 risk_controls_passed=True,

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import TestCase
+
+from app.trading.autonomy.policy_checks import evaluate_promotion_prerequisites, evaluate_rollback_readiness
+
+
+class TestPolicyChecks(TestCase):
+    def test_promotion_prerequisites_fail_when_patch_missing_for_paper(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / 'research').mkdir(parents=True, exist_ok=True)
+            (root / 'backtest').mkdir(parents=True, exist_ok=True)
+            (root / 'gates').mkdir(parents=True, exist_ok=True)
+            (root / 'research' / 'candidate-spec.json').write_text('{}', encoding='utf-8')
+            (root / 'backtest' / 'evaluation-report.json').write_text('{}', encoding='utf-8')
+            (root / 'gates' / 'gate-evaluation.json').write_text('{}', encoding='utf-8')
+
+            result = evaluate_promotion_prerequisites(
+                policy_payload={},
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target='paper',
+                artifact_root=root,
+            )
+
+        self.assertFalse(result.allowed)
+        self.assertIn('required_artifacts_missing', result.reasons)
+        self.assertIn('paper-candidate/strategy-configmap-patch.yaml', result.missing_artifacts)
+
+    def test_rollback_readiness_fails_when_dry_run_stale(self) -> None:
+        state = _candidate_state()
+        state['rollbackReadiness'] = {
+            'killSwitchDryRunPassed': True,
+            'gitopsRevertDryRunPassed': True,
+            'strategyDisableDryRunPassed': True,
+            'dryRunCompletedAt': '2025-01-01T00:00:00+00:00',
+            'humanApproved': True,
+            'rollbackTarget': 'main@deadbeef',
+        }
+        result = evaluate_rollback_readiness(
+            policy_payload={'rollback_dry_run_max_age_hours': 1},
+            candidate_state_payload=state,
+            now=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        )
+        self.assertFalse(result.ready)
+        self.assertIn('rollback_dry_run_stale', result.reasons)
+
+    def test_allows_progression_when_artifacts_and_rollback_are_ready(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / 'research').mkdir(parents=True, exist_ok=True)
+            (root / 'backtest').mkdir(parents=True, exist_ok=True)
+            (root / 'gates').mkdir(parents=True, exist_ok=True)
+            (root / 'paper-candidate').mkdir(parents=True, exist_ok=True)
+            (root / 'research' / 'candidate-spec.json').write_text('{}', encoding='utf-8')
+            (root / 'backtest' / 'evaluation-report.json').write_text('{}', encoding='utf-8')
+            (root / 'gates' / 'gate-evaluation.json').write_text('{}', encoding='utf-8')
+            (root / 'paper-candidate' / 'strategy-configmap-patch.yaml').write_text('kind: ConfigMap', encoding='utf-8')
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={},
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target='paper',
+                artifact_root=root,
+            )
+            rollback = evaluate_rollback_readiness(
+                policy_payload={},
+                candidate_state_payload=_candidate_state(),
+                now=datetime.now(timezone.utc),
+            )
+
+        self.assertTrue(promotion.allowed)
+        self.assertTrue(rollback.ready)
+
+
+def _candidate_state() -> dict[str, object]:
+    return {
+        'candidateId': 'cand-test',
+        'runId': 'run-test',
+        'activeStage': 'gate-evaluation',
+        'paused': False,
+        'rollbackReadiness': {
+            'killSwitchDryRunPassed': True,
+            'gitopsRevertDryRunPassed': True,
+            'strategyDisableDryRunPassed': True,
+            'dryRunCompletedAt': datetime.now(timezone.utc).isoformat(),
+            'humanApproved': True,
+            'rollbackTarget': 'main@a1b2c3d',
+        },
+    }
+
+
+def _gate_report() -> dict[str, object]:
+    return {
+        'run_id': 'run-test',
+        'promotion_allowed': True,
+        'recommended_mode': 'paper',
+        'gates': [
+            {'gate_id': 'gate0_data_integrity', 'status': 'pass'},
+            {'gate_id': 'gate1_statistical_robustness', 'status': 'pass'},
+            {'gate_id': 'gate2_risk_capacity', 'status': 'pass'},
+        ],
+    }


### PR DESCRIPTION
## Summary

- Added runtime-enforced governance checks for promotion progression and rollback readiness in the Torghut autonomy lane.
- Added policy validation CLIs (`validate_promotion_policy.py`) and a dry-run harness (`run_governance_policy_dry_run.py`) for promotion/rollback workflows.
- Expanded full-loop governance templates with new orchestration stages (`promotion-prerequisites`, `rollback-readiness`, `policy-dry-run`) plus matching ImplementationSpec/AgentRun artifacts.
- Wired operational policy parameters into Torghut gate policy JSON and ArgoCD ConfigMap for cluster/runtime parity.
- Added regression tests for policy checks, dry-run enforcement behavior, and updated orchestration transition expectations.

## Related Issues

None

## Testing

- `cd services/torghut && uv run ruff check app tests scripts`
- `cd services/torghut && uv run pyright`
- `cd services/torghut && uv run python -m unittest discover -s tests -p "test_*.py"`
- `cd services/torghut && uv run python -m unittest tests.test_policy_checks tests.test_governance_policy_dry_run tests.test_orchestration_guard`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
