### PR TITLE
feat(torghut): enforce v3 feature contract quality and parity

### DIFF
--- a/docs/torghut/schemas/ta-signals.avsc
+++ b/docs/torghut/schemas/ta-signals.avsc
@@ -7,7 +7,9 @@
     {"name": "event_ts", "type": "string"},
     {"name": "symbol", "type": "string"},
     {"name": "seq", "type": "long"},
+    {"name": "feature_schema_version", "type": ["null", "string"], "default": null},
     {"name": "is_final", "type": ["null", "boolean"], "default": null},
+    {"name": "signal_quality_flag", "type": ["null", "string"], "default": null},
     {"name": "source", "type": ["null", "string"], "default": null},
     {"name": "window", "type": ["null", {
       "type": "record",

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -142,6 +142,26 @@ class Settings(BaseSettings):
         alias="TRADING_FEATURE_NORMALIZATION_VERSION",
         description="Feature normalization implementation version.",
     )
+    trading_feature_quality_enabled: bool = Field(
+        default=True,
+        alias="TRADING_FEATURE_QUALITY_ENABLED",
+        description="Fail closed on feature schema/freshness/data-quality violations.",
+    )
+    trading_feature_max_required_null_rate: float = Field(
+        default=0.01,
+        alias="TRADING_FEATURE_MAX_REQUIRED_NULL_RATE",
+        description="Maximum allowed null-rate for required canonical v3 feature fields.",
+    )
+    trading_feature_max_staleness_ms: int = Field(
+        default=120000,
+        alias="TRADING_FEATURE_MAX_STALENESS_MS",
+        description="Maximum allowed p95 feature staleness in milliseconds per batch.",
+    )
+    trading_feature_max_duplicate_ratio: float = Field(
+        default=0.02,
+        alias="TRADING_FEATURE_MAX_DUPLICATE_RATIO",
+        description="Maximum duplicate event ratio per ingest batch.",
+    )
     trading_autonomy_enabled: bool = Field(default=False, alias="TRADING_AUTONOMY_ENABLED")
     trading_autonomy_allow_live_promotion: bool = Field(
         default=False,

--- a/services/torghut/app/metrics.py
+++ b/services/torghut/app/metrics.py
@@ -204,6 +204,26 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
                             )
                         )
                     continue
+                if key == "feature_null_rate":
+                    metric_name = "torghut_trading_feature_null_rate"
+                    lines.append(f"# HELP {metric_name} Required feature null-rate by field.")
+                    lines.append(f"# TYPE {metric_name} gauge")
+                    sorted_items = sorted(
+                        [
+                            (str(field), float(null_rate))
+                            for field, null_rate in cast(dict[str, object], value).items()
+                            if isinstance(null_rate, (int, float, Decimal))
+                        ]
+                    )
+                    for field, null_rate in sorted_items:
+                        lines.extend(
+                            _render_labeled_metric(
+                                metric_name=metric_name,
+                                labels={"field": field},
+                                value=null_rate,
+                            )
+                        )
+                    continue
                 if key == "tca_summary":
                     summary = cast(dict[str, object], value)
                     scalar_metrics: list[tuple[str, str]] = [
@@ -251,6 +271,18 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
                     metric_name=metric_name, labels={"service": "torghut"}, value=value
                 )
             )
+            continue
+        if key == "feature_staleness_ms_p95":
+            metric_name = "torghut_trading_feature_staleness_ms_p95"
+            lines.append(f"# HELP {metric_name} Feature staleness p95 for the latest ingest batch.")
+            lines.append(f"# TYPE {metric_name} gauge")
+            lines.append(f"{metric_name} {value}")
+            continue
+        if key == "feature_duplicate_ratio":
+            metric_name = "torghut_trading_feature_duplicate_ratio"
+            lines.append(f"# HELP {metric_name} Duplicate event ratio in the latest ingest batch.")
+            lines.append(f"# TYPE {metric_name} gauge")
+            lines.append(f"{metric_name} {value}")
             continue
         metric_name = f"torghut_trading_{key}"
         help_text = f"Torghut trading metric {key.replace('_', ' ')}."

--- a/services/torghut/app/trading/feature_quality.py
+++ b/services/torghut/app/trading/feature_quality.py
@@ -1,0 +1,153 @@
+"""Runtime feature data-quality gates for fail-closed strategy evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from statistics import quantiles
+
+from .features import (
+    FEATURE_VECTOR_V3_REQUIRED_FIELDS,
+    map_feature_values_v3,
+    signal_declares_compatible_schema,
+)
+from .models import SignalEnvelope
+
+QUALITY_GATED_REQUIRED_FIELDS = tuple([field for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS if field != 'price'])
+
+
+@dataclass(frozen=True)
+class FeatureQualityThresholds:
+    max_required_null_rate: float = 0.01
+    max_staleness_ms: int = 120_000
+    max_duplicate_ratio: float = 0.02
+
+
+@dataclass(frozen=True)
+class FeatureQualityReport:
+    accepted: bool
+    rows_total: int
+    null_rate_by_field: dict[str, float]
+    staleness_ms_p95: int
+    duplicate_ratio: float
+    schema_mismatch_total: int
+    reasons: list[str]
+
+
+class FeatureQualityError(RuntimeError):
+    """Raised when a quality report fails hard thresholds."""
+
+
+def evaluate_feature_batch_quality(
+    signals: list[SignalEnvelope],
+    *,
+    thresholds: FeatureQualityThresholds | None = None,
+) -> FeatureQualityReport:
+    policy = thresholds or FeatureQualityThresholds()
+    rows_total = len(signals)
+    if rows_total == 0:
+        return FeatureQualityReport(
+            accepted=True,
+            rows_total=0,
+            null_rate_by_field={field: 0.0 for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS},
+            staleness_ms_p95=0,
+            duplicate_ratio=0.0,
+            schema_mismatch_total=0,
+            reasons=[],
+        )
+
+    null_counts = {field: 0 for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS}
+    seen_keys: set[tuple[datetime, str, int]] = set()
+    duplicate_total = 0
+    schema_mismatch_total = 0
+    staleness_values: list[int] = []
+    reasons: list[str] = []
+
+    previous: tuple[datetime, str, int] | None = None
+    for signal in signals:
+        if not signal_declares_compatible_schema(signal):
+            schema_mismatch_total += 1
+
+        values = map_feature_values_v3(signal)
+        for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS:
+            if values.get(field) is None:
+                null_counts[field] += 1
+
+        staleness_raw = values.get('staleness_ms')
+        staleness = int(staleness_raw) if isinstance(staleness_raw, (int, float)) else 0
+        staleness_values.append(staleness)
+
+        key = (signal.event_ts, signal.symbol, signal.seq or 0)
+        if key in seen_keys:
+            duplicate_total += 1
+        else:
+            seen_keys.add(key)
+
+        if previous is not None and key < previous:
+            reasons.append('non_monotonic_progression')
+        previous = key
+
+    null_rate_by_field = {field: null_counts[field] / rows_total for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS}
+    duplicate_ratio = duplicate_total / rows_total
+    staleness_ms_p95 = _p95(staleness_values)
+
+    if schema_mismatch_total > 0:
+        reasons.append('schema_mismatch')
+    # Price can be enriched downstream by price fetchers, so null-rate gating is applied
+    # only to indicator fields that must be present at signal ingest time.
+    if any(null_rate_by_field[field] > policy.max_required_null_rate for field in QUALITY_GATED_REQUIRED_FIELDS):
+        reasons.append('required_feature_null_rate_exceeds_threshold')
+    if staleness_ms_p95 > policy.max_staleness_ms:
+        reasons.append('feature_staleness_exceeds_budget')
+    if duplicate_ratio > policy.max_duplicate_ratio:
+        reasons.append('duplicate_ratio_exceeds_threshold')
+
+    unique_reasons = sorted(set(reasons))
+    return FeatureQualityReport(
+        accepted=len(unique_reasons) == 0,
+        rows_total=rows_total,
+        null_rate_by_field=null_rate_by_field,
+        staleness_ms_p95=staleness_ms_p95,
+        duplicate_ratio=duplicate_ratio,
+        schema_mismatch_total=schema_mismatch_total,
+        reasons=unique_reasons,
+    )
+
+
+def enforce_feature_batch_quality(
+    signals: list[SignalEnvelope],
+    *,
+    thresholds: FeatureQualityThresholds | None = None,
+) -> FeatureQualityReport:
+    report = evaluate_feature_batch_quality(signals, thresholds=thresholds)
+    if report.accepted:
+        return report
+
+    parts: list[str] = []
+    if report.reasons:
+        parts.append(f"reasons={','.join(report.reasons)}")
+    parts.append(f'rows={report.rows_total}')
+    parts.append(f'schema_mismatch_total={report.schema_mismatch_total}')
+    parts.append(f'staleness_ms_p95={report.staleness_ms_p95}')
+    parts.append(f'duplicate_ratio={report.duplicate_ratio:.6f}')
+    raise FeatureQualityError('feature_quality_gate_failed ' + ' '.join(parts))
+
+
+def _p95(values: list[int]) -> int:
+    if not values:
+        return 0
+    if len(values) == 1:
+        return values[0]
+    quantized = quantiles(values, n=100, method='inclusive')
+    if not quantized:
+        return max(values)
+    return int(quantized[94])
+
+
+__all__ = [
+    'FeatureQualityError',
+    'FeatureQualityReport',
+    'FeatureQualityThresholds',
+    'enforce_feature_batch_quality',
+    'evaluate_feature_batch_quality',
+]

--- a/services/torghut/app/trading/parity.py
+++ b/services/torghut/app/trading/parity.py
@@ -1,0 +1,170 @@
+"""Online/offline feature parity checks for FeatureVectorV3."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from .features import FEATURE_VECTOR_V3_VALUE_FIELDS, FeatureNormalizationError, normalize_feature_vector_v3
+from .models import SignalEnvelope
+
+
+@dataclass(frozen=True)
+class FeatureParityThresholds:
+    max_hash_mismatch_ratio: float = 0.0
+    max_numeric_drift: float = 1e-9
+
+
+@dataclass(frozen=True)
+class FeatureParityReport:
+    checked_rows: int
+    missing_online_rows: int
+    missing_offline_rows: int
+    hash_mismatches: int
+    drift_by_field: dict[str, float]
+    top_drift_fields: list[dict[str, Any]]
+    failing_windows: list[dict[str, Any]]
+    accepted: bool
+    reasons: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'checked_rows': self.checked_rows,
+            'missing_online_rows': self.missing_online_rows,
+            'missing_offline_rows': self.missing_offline_rows,
+            'hash_mismatches': self.hash_mismatches,
+            'drift_by_field': self.drift_by_field,
+            'top_drift_fields': self.top_drift_fields,
+            'failing_windows': self.failing_windows,
+            'accepted': self.accepted,
+            'reasons': self.reasons,
+        }
+
+
+def run_feature_parity(
+    online_signals: list[SignalEnvelope],
+    offline_signals: list[SignalEnvelope],
+    *,
+    thresholds: FeatureParityThresholds | None = None,
+) -> FeatureParityReport:
+    policy = thresholds or FeatureParityThresholds()
+
+    online_vectors = _normalize_indexed(online_signals)
+    offline_vectors = _normalize_indexed(offline_signals)
+
+    online_keys = set(online_vectors)
+    offline_keys = set(offline_vectors)
+    shared_keys = sorted(online_keys & offline_keys)
+
+    missing_online_rows = len(offline_keys - online_keys)
+    missing_offline_rows = len(online_keys - offline_keys)
+
+    drift_by_field: dict[str, float] = {field: 0.0 for field in FEATURE_VECTOR_V3_VALUE_FIELDS}
+    hash_mismatches = 0
+    failing_windows: list[dict[str, Any]] = []
+
+    for key in shared_keys:
+        online = online_vectors[key]
+        offline = offline_vectors[key]
+
+        if online.normalization_hash != offline.normalization_hash:
+            hash_mismatches += 1
+
+        drift_record: dict[str, float] = {}
+        for field in FEATURE_VECTOR_V3_VALUE_FIELDS:
+            drift = _value_drift(online.values.get(field), offline.values.get(field))
+            if drift > drift_by_field[field]:
+                drift_by_field[field] = drift
+            if drift > policy.max_numeric_drift:
+                drift_record[field] = drift
+
+        if drift_record:
+            failing_windows.append(
+                {
+                    'event_ts': online.event_ts.isoformat(),
+                    'symbol': online.symbol,
+                    'timeframe': online.timeframe,
+                    'seq': online.seq,
+                    'source': online.source,
+                    'drift': drift_record,
+                }
+            )
+
+    top_drift_fields = [
+        {'field': field, 'max_abs_drift': drift}
+        for field, drift in sorted(drift_by_field.items(), key=lambda item: item[1], reverse=True)
+        if drift > 0
+    ][:5]
+
+    checked_rows = len(shared_keys)
+    reasons: list[str] = []
+    hash_mismatch_ratio = (hash_mismatches / checked_rows) if checked_rows else 0.0
+    if hash_mismatch_ratio > policy.max_hash_mismatch_ratio:
+        reasons.append('hash_mismatch_ratio_exceeds_threshold')
+    if failing_windows:
+        reasons.append('numeric_drift_exceeds_threshold')
+    if missing_online_rows > 0 or missing_offline_rows > 0:
+        reasons.append('coverage_mismatch')
+
+    return FeatureParityReport(
+        checked_rows=checked_rows,
+        missing_online_rows=missing_online_rows,
+        missing_offline_rows=missing_offline_rows,
+        hash_mismatches=hash_mismatches,
+        drift_by_field=drift_by_field,
+        top_drift_fields=top_drift_fields,
+        failing_windows=failing_windows,
+        accepted=len(reasons) == 0,
+        reasons=reasons,
+    )
+
+
+def write_feature_parity_report(report: FeatureParityReport, output_path: Path) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report.to_dict(), indent=2, sort_keys=True), encoding='utf-8')
+    return output_path
+
+
+def _normalize_indexed(signals: list[SignalEnvelope]) -> dict[tuple[datetime, str, str, int, str], Any]:
+    indexed: dict[tuple[datetime, str, str, int, str], Any] = {}
+    for signal in signals:
+        try:
+            fv = normalize_feature_vector_v3(signal)
+        except FeatureNormalizationError:
+            continue
+        key = (fv.event_ts, fv.symbol, fv.timeframe, fv.seq, fv.source)
+        indexed[key] = fv
+    return indexed
+
+
+def _value_drift(lhs: Any, rhs: Any) -> float:
+    left = _to_decimal(lhs)
+    right = _to_decimal(rhs)
+    if left is None or right is None:
+        return 0.0 if lhs == rhs else 1.0
+    return float(abs(left - right))
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float, str)):
+        try:
+            return Decimal(str(value))
+        except Exception:
+            return None
+    return None
+
+
+__all__ = [
+    'FeatureParityReport',
+    'FeatureParityThresholds',
+    'run_feature_parity',
+    'write_feature_parity_report',
+]

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -12,7 +12,7 @@ from decimal import Decimal
 from typing import Any, Literal, Protocol
 
 from ..models import Strategy
-from .features import FeatureVectorV3
+from .features import FeatureVectorV3, validate_declared_features
 
 
 @dataclass(frozen=True)
@@ -445,6 +445,9 @@ class StrategyRuntime:
         definition = self.definition_from_strategy(strategy)
         plugin = self.registry.resolve(definition)
         if plugin is None:
+            return None
+        declared_valid, _ = validate_declared_features(plugin.required_features)
+        if not declared_valid:
             return None
         context = StrategyContext(
             strategy_id=definition.strategy_id,

--- a/services/torghut/tests/test_autonomy_runtime_declared_features.py
+++ b/services/torghut/tests/test_autonomy_runtime_declared_features.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.autonomy.runtime import (
+    StrategyContext,
+    StrategyIntent,
+    StrategyPluginRegistry,
+    StrategyRuntime,
+    StrategyRuntimeConfig,
+)
+from app.trading.models import SignalEnvelope
+
+
+class _InvalidDeclaredFeaturePlugin:
+    strategy_type = 'invalid_declared_feature'
+    version = '1.0.0'
+
+    def validate_params(self, params: dict[str, object]) -> None:
+        _ = params
+
+    def required_features(self) -> set[str]:
+        return {'price', 'this_is_not_in_featurevector_v3'}
+
+    def warmup_bars(self) -> int:
+        return 0
+
+    def on_event(self, fv, ctx: StrategyContext):
+        _ = fv
+        _ = ctx
+        return StrategyIntent(
+            strategy_id='invalid-strategy',
+            symbol='AAPL',
+            direction='long',
+            confidence=Decimal('0.50'),
+            target_qty=Decimal('1'),
+            horizon='intraday',
+            rationale=['should_not_emit'],
+        )
+
+
+class TestAutonomyRuntimeDeclaredFeatures(TestCase):
+    def test_runtime_fails_closed_when_plugin_declares_unknown_feature(self) -> None:
+        registry = StrategyPluginRegistry()
+        registry.register(_InvalidDeclaredFeaturePlugin())
+        runtime = StrategyRuntime(registry=registry)
+
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Min',
+            seq=1,
+            source='fixture',
+            payload={
+                'feature_schema_version': '3.0.0',
+                'macd': {'macd': '1', 'signal': '0.5'},
+                'rsi14': '45',
+                'price': '101',
+            },
+        )
+
+        result = runtime.evaluate(
+            signal,
+            [
+                StrategyRuntimeConfig(
+                    strategy_id='invalid-strategy',
+                    strategy_type='invalid_declared_feature',
+                    version='1.0.0',
+                    params={},
+                    base_timeframe='1Min',
+                )
+            ],
+        )
+
+        self.assertEqual(result.decisions, [])
+        self.assertIn('declared_features_not_in_schema:invalid-strategy:this_is_not_in_featurevector_v3', result.errors)

--- a/services/torghut/tests/test_feature_contract_v3.py
+++ b/services/torghut/tests/test_feature_contract_v3.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from decimal import Decimal
 from unittest import TestCase
 
 from app.trading.features import FeatureNormalizationError, normalize_feature_vector_v3
@@ -55,3 +56,49 @@ class TestFeatureContractV3(TestCase):
 
         feature_vector = normalize_feature_vector_v3(signal)
         self.assertEqual(feature_vector.values.get('price'), 101)
+
+    def test_normalization_maps_nested_schema_fields(self) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 1, 1, 0, 0, 2, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Min',
+            payload={
+                'feature_schema_version': '3.1.0',
+                'macd': {'macd': '0.4', 'signal': '0.2', 'hist': '0.2'},
+                'ema': {'ema12': '101.1', 'ema26': '100.6'},
+                'rsi14': '55',
+                'vwap': {'session': '100.8', 'w5m': '100.9'},
+                'boll': {'mid': '100', 'upper': '101', 'lower': '99'},
+                'vol_realized': {'w60s': '0.009'},
+                'imbalance': {'spread': '0.03', 'bid_px': '100.7', 'ask_px': '100.9'},
+            },
+            seq=3,
+            source='fixture',
+        )
+
+        fv = normalize_feature_vector_v3(signal)
+        self.assertEqual(fv.values['ema12'], Decimal('101.1'))
+        self.assertEqual(fv.values['ema26'], Decimal('100.6'))
+        self.assertEqual(fv.values['vwap_session'], Decimal('100.8'))
+        self.assertEqual(fv.values['vwap_w5m'], Decimal('100.9'))
+        self.assertEqual(fv.values['boll_mid'], Decimal('100'))
+        self.assertEqual(fv.values['vol_realized_w60s'], Decimal('0.009'))
+        self.assertEqual(fv.values['imbalance_spread'], Decimal('0.03'))
+        self.assertEqual(fv.values['staleness_ms'], 2000)
+
+    def test_normalization_rejects_incompatible_schema_major(self) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Min',
+            payload={
+                'feature_schema_version': '4.0.0',
+                'macd': {'macd': '0.4', 'signal': '0.2'},
+                'rsi14': '50',
+                'price': '100',
+            },
+        )
+
+        with self.assertRaises(FeatureNormalizationError):
+            normalize_feature_vector_v3(signal)

--- a/services/torghut/tests/test_feature_parity.py
+++ b/services/torghut/tests/test_feature_parity.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import TestCase
+
+from app.trading.models import SignalEnvelope
+from app.trading.parity import run_feature_parity, write_feature_parity_report
+
+
+class TestFeatureParity(TestCase):
+    def _signal(self, *, price: str, symbol: str = 'AAPL') -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            symbol=symbol,
+            timeframe='1Min',
+            seq=1,
+            source='fixture',
+            payload={
+                'feature_schema_version': '3.0.0',
+                'macd': {'macd': '1.2', 'signal': '0.8'},
+                'rsi14': '25',
+                'price': price,
+            },
+        )
+
+    def test_parity_report_detects_drift_and_is_machine_readable(self) -> None:
+        online = [self._signal(price='100.00')]
+        offline = [self._signal(price='101.00')]
+
+        report = run_feature_parity(online, offline)
+
+        self.assertFalse(report.accepted)
+        self.assertIn('numeric_drift_exceeds_threshold', report.reasons)
+        self.assertTrue(report.top_drift_fields)
+        self.assertEqual(report.top_drift_fields[0]['field'], 'price')
+        self.assertEqual(len(report.failing_windows), 1)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = write_feature_parity_report(report, Path(tmpdir) / 'parity.json')
+            payload = json.loads(output_path.read_text(encoding='utf-8'))
+            self.assertEqual(payload['accepted'], report.accepted)
+            self.assertEqual(payload['checked_rows'], 1)
+            self.assertEqual(payload['top_drift_fields'][0]['field'], 'price')

--- a/services/torghut/tests/test_feature_quality.py
+++ b/services/torghut/tests/test_feature_quality.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest import TestCase
+
+from app.trading.feature_quality import FeatureQualityThresholds, evaluate_feature_batch_quality
+from app.trading.models import SignalEnvelope
+
+
+def _signal(
+    *,
+    ts: datetime,
+    symbol: str = 'AAPL',
+    seq: int = 1,
+    ingest_lag_ms: int = 200,
+    schema: str | None = '3.0.0',
+    payload_overrides: dict[str, object] | None = None,
+) -> SignalEnvelope:
+    payload: dict[str, object] = {
+        'macd': {'macd': '1', 'signal': '0.4'},
+        'rsi14': '48',
+        'price': '100',
+    }
+    if schema is not None:
+        payload['feature_schema_version'] = schema
+    if payload_overrides:
+        payload.update(payload_overrides)
+    return SignalEnvelope(
+        event_ts=ts,
+        ingest_ts=ts + timedelta(milliseconds=ingest_lag_ms),
+        symbol=symbol,
+        timeframe='1Min',
+        seq=seq,
+        payload=payload,
+    )
+
+
+class TestFeatureQuality(TestCase):
+    def test_batch_fails_closed_on_schema_mismatch(self) -> None:
+        signals = [
+            _signal(ts=datetime(2026, 1, 1, tzinfo=timezone.utc), seq=1, schema='4.0.0'),
+            _signal(ts=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc), seq=2),
+        ]
+
+        report = evaluate_feature_batch_quality(signals)
+
+        self.assertFalse(report.accepted)
+        self.assertEqual(report.schema_mismatch_total, 1)
+        self.assertIn('schema_mismatch', report.reasons)
+
+    def test_batch_fails_closed_on_duplicates_and_staleness(self) -> None:
+        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        signals = [
+            _signal(ts=ts, seq=1, ingest_lag_ms=1_000),
+            _signal(ts=ts, seq=1, ingest_lag_ms=210_000),
+        ]
+
+        report = evaluate_feature_batch_quality(
+            signals,
+            thresholds=FeatureQualityThresholds(
+                max_required_null_rate=0.01,
+                max_duplicate_ratio=0.10,
+                max_staleness_ms=2_000,
+            ),
+        )
+
+        self.assertFalse(report.accepted)
+        self.assertGreater(report.duplicate_ratio, 0)
+        self.assertGreater(report.staleness_ms_p95, 2_000)
+        self.assertIn('duplicate_ratio_exceeds_threshold', report.reasons)
+        self.assertIn('feature_staleness_exceeds_budget', report.reasons)
+
+    def test_batch_fails_closed_on_required_field_null_rate(self) -> None:
+        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        signals = [
+            _signal(ts=ts, seq=1),
+            _signal(
+                ts=ts + timedelta(seconds=1),
+                seq=2,
+                payload_overrides={'macd': {'macd': None, 'signal': None}},
+            ),
+        ]
+
+        report = evaluate_feature_batch_quality(
+            signals,
+            thresholds=FeatureQualityThresholds(max_required_null_rate=0.0),
+        )
+
+        self.assertFalse(report.accepted)
+        self.assertGreater(report.null_rate_by_field['macd'], 0)
+        self.assertIn('required_feature_null_rate_exceeds_threshold', report.reasons)
+
+    def test_batch_fails_on_non_monotonic_progression(self) -> None:
+        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        signals = [
+            _signal(ts=ts + timedelta(seconds=1), symbol='MSFT', seq=2),
+            _signal(ts=ts, symbol='AAPL', seq=1),
+        ]
+
+        report = evaluate_feature_batch_quality(signals)
+
+        self.assertFalse(report.accepted)
+        self.assertIn('non_monotonic_progression', report.reasons)

--- a/services/torghut/tests/test_metrics.py
+++ b/services/torghut/tests/test_metrics.py
@@ -135,3 +135,17 @@ class TestTradingMetrics(TestCase):
         self.assertEqual(metrics.strategy_latency_ms.get("s1"), 9)
         self.assertEqual(metrics.intent_conflict_total, 1)
         self.assertEqual(metrics.strategy_runtime_isolated_failures_total, 1)
+
+    def test_feature_quality_metrics_are_exported(self) -> None:
+        metrics = TradingMetrics()
+        metrics.feature_null_rate = {"price": 0.5}
+        metrics.feature_staleness_ms_p95 = 1234
+        metrics.feature_duplicate_ratio = 0.2
+        metrics.feature_schema_mismatch_total = 2
+
+        payload = render_trading_metrics(metrics.__dict__)
+
+        self.assertIn('torghut_trading_feature_null_rate{field="price"} 0.5', payload)
+        self.assertIn("torghut_trading_feature_staleness_ms_p95 1234", payload)
+        self.assertIn("torghut_trading_feature_duplicate_ratio 0.2", payload)
+        self.assertIn("torghut_trading_feature_schema_mismatch_total 2", payload)


### PR DESCRIPTION
## Summary

- implemented canonical `FeatureVectorV3` mapping boundaries with schema-compatible nested field extraction and declared-feature validation in `services/torghut/app/trading/features.py`.
- added fail-closed runtime data-quality gates (`schema_mismatch`, monotonic progression, required indicator null-rate, staleness p95, duplicate ratio) in `services/torghut/app/trading/feature_quality.py` and enforced them in `TradingPipeline.run_once`.
- added online/offline parity evaluation + machine-readable JSON report writer in `services/torghut/app/trading/parity.py`, including hash mismatch, numeric drift, top-drift fields, and failing time windows.
- added regression coverage for schema mismatch, mapping quality, declared-feature enforcement, parity report output, and scheduler fail-closed behavior across `services/torghut/tests/**`.
- updated `docs/torghut/schemas/ta-signals.avsc` with additive fields (`feature_schema_version`, `signal_quality_flag`) for schema evolution compatibility.

## Related Issues

None

## Testing

- `cd services/torghut && uv run ruff check app tests`
- `cd services/torghut && uv run pyright`
- `cd services/torghut && uv run python -m unittest tests.test_feature_contract_v3 tests.test_feature_quality tests.test_feature_parity tests.test_autonomy_runtime_declared_features tests.test_strategy_runtime tests.test_trading_pipeline tests.test_metrics`
- `cd services/torghut && uv run python - <<'PY' ... write_feature_parity_report(..., Path('/tmp/torghut-feature-parity-report.json')) ... PY`
- parity report path: `/tmp/torghut-feature-parity-report.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
