### PR TITLE
docs(torghut): add v4 quant llm profitability design pack

### DIFF
--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -34,6 +34,12 @@ The v1 documents are written to stay consistent with:
 - `v2/` - research and profitability blueprint for a more autonomous system (not production-facing; may drift).
   - Entry point: `docs/torghut/design-system/v2/index.md`
 
+- `v3/` - production handoff for flexible quant strategy engine + full-loop autonomous operation.
+  - Entry point: `docs/torghut/design-system/v3/index.md`
+
+- `v4/` - fresh quant/LLM profitability expansion pack grounded in 2024-2025 papers and white papers.
+  - Entry point: `docs/torghut/design-system/v4/index.md`
+
 - `v1/` - first cohesive design-system pass aligned to production reality as of **2026-02-08**.
 
 ### v1 Index

--- a/docs/torghut/design-system/v4/01-time-series-foundation-model-routing-and-calibration.md
+++ b/docs/torghut/design-system/v4/01-time-series-foundation-model-routing-and-calibration.md
@@ -1,0 +1,64 @@
+# Time-Series Foundation Model Routing and Calibration
+
+## Objective
+Add a model-routing layer that chooses between deterministic alpha models and time-series foundation models, with hard
+calibration gates before any strategy can influence paper/live decisions.
+
+## Why This Matters
+Recent foundation-model papers show strong zero-shot and transfer behavior for time series, but they can be brittle
+under market regime shifts unless uncertainty calibration and fallback routing are enforced.
+
+## Proposed Torghut Design
+- Add `ForecastRouterV4` in Torghut to route symbol/horizon requests to:
+  - legacy deterministic forecaster,
+  - Chronos-family adapter,
+  - MOMENT/TiRex adapter.
+- Add per-model calibration profiles (coverage error, interval width, drift score).
+- Fail closed to deterministic baseline when calibration thresholds degrade.
+- Persist model-selection and calibration decisions for audit and replay.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/features.py`
+- `services/torghut/app/trading/evaluation.py`
+- `services/torghut/app/trading/autonomy.py`
+- `services/torghut/app/models/entities.py`
+- `argocd/applications/torghut/strategy-configmap.yaml`
+
+## Deliverables
+- `ForecastRouterV4` and adapters for at least two foundation model families.
+- Calibration gate module with configurable thresholds.
+- DB schema updates for per-model calibration and routing audit rows.
+- Backfill/replay tool to compare baseline vs routed model outcomes.
+
+## Verification
+- Offline replay on rolling windows with deterministic seeds.
+- Coverage and error metrics must exceed baseline by configured margin.
+- Calibration gate denial paths must be tested and observable.
+
+## Rollback
+- Single config switch to route all forecasts to deterministic baseline.
+- Keep model adapters loaded but non-authoritative for shadow diagnostics.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-forecast-routing-calibration-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `strategyConfigPath`
+  - `evaluationWindow`
+- Expected artifacts:
+  - router + calibration modules,
+  - migration + audit schema,
+  - replay and comparison report.
+- Exit criteria:
+  - calibration SLOs pass in paper/shadow,
+  - deterministic fallback verified,
+  - no risk-gate bypass paths.
+
+## Research References
+- Chronos: https://arxiv.org/abs/2403.07815
+- Chronos-2: https://arxiv.org/abs/2506.03109
+- MOMENT: https://arxiv.org/abs/2402.03885
+- TiRex: https://arxiv.org/abs/2508.19141

--- a/docs/torghut/design-system/v4/02-limit-order-book-intelligence-and-feature-stack.md
+++ b/docs/torghut/design-system/v4/02-limit-order-book-intelligence-and-feature-stack.md
@@ -1,0 +1,63 @@
+# Limit-Order-Book Intelligence and Feature Stack
+
+## Objective
+Upgrade Torghut microstructure intelligence from TA-heavy inputs to a hybrid feature stack that includes limit-order-book
+state features and order-flow imbalance signals.
+
+## Why This Matters
+New LOB modeling papers show that richer microstructure features can improve short-horizon prediction and execution
+quality, but only when feature freshness and quality gates are strict.
+
+## Proposed Torghut Design
+- Introduce `OrderBookFeatureVectorV4` with:
+  - top-k level imbalance,
+  - queue dynamics,
+  - spread and depth elasticity,
+  - short-horizon signed flow statistics.
+- Build a feature-quality gate for missing levels, stale timestamps, and malformed depth snapshots.
+- Keep existing TA features and add compatibility mappers for dual-mode strategies.
+
+## Owned Code and Config Areas
+- `services/dorvud/technical-analysis-flink/**`
+- `services/torghut/app/trading/features.py`
+- `services/torghut/app/trading/ingest.py`
+- `docs/torghut/schemas/ta-signals.avsc`
+- `argocd/applications/torghut/ta/configmap.yaml`
+
+## Deliverables
+- New LOB-derived feature schema and mappers.
+- Flink-side extraction path and ClickHouse persistence.
+- Torghut ingestion path with strict validation.
+- Regression tests and parity reports against legacy features.
+
+## Verification
+- Freshness/quality gate pass rates per symbol/session.
+- Backtest uplift in fill-adjusted PnL and slippage metrics.
+- Zero schema drift incidents during replay tests.
+
+## Rollback
+- Disable LOB feature consumption via feature flag.
+- Continue producing LOB features in shadow for diagnostics.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-lob-feature-stack-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `taSchemaPath`
+  - `flinkConfigPath`
+- Expected artifacts:
+  - schema changes,
+  - extraction/ingest implementation,
+  - parity and quality reports.
+- Exit criteria:
+  - gate stability achieved for paper sessions,
+  - deterministic fallback confirmed,
+  - no ingestion regressions.
+
+## Research References
+- HLOB paper page: https://www.sciencedirect.com/science/article/pii/S0957417425011210
+- Dilated Conv + Transformer + MTL for stocks: https://arxiv.org/abs/2509.00696
+- TCSMI model for financial prediction: https://arxiv.org/abs/2507.08093

--- a/docs/torghut/design-system/v4/03-event-driven-synthetic-market-and-offline-policy-lab.md
+++ b/docs/torghut/design-system/v4/03-event-driven-synthetic-market-and-offline-policy-lab.md
@@ -1,0 +1,60 @@
+# Event-Driven Synthetic Market and Offline Policy Lab
+
+## Objective
+Create a high-fidelity synthetic market lab for Torghut to pretrain and stress autonomous policies before paper/live
+exposure.
+
+## Why This Matters
+Recent event-driven simulation and diffusion-based financial data generation work enables broader stress coverage than
+historical replay alone, especially for rare-liquidity and volatility regimes.
+
+## Proposed Torghut Design
+- Add `MarketSimV4` module with two generators:
+  - event-driven Neural Hawkes simulation,
+  - diffusion-style path generation for stress scenarios.
+- Use generated scenarios to pretrain candidate policies offline.
+- Add simulation provenance hashing so every promotion decision can reference exact synthetic datasets.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/backtest.py`
+- `services/torghut/app/trading/evaluation.py`
+- `services/torghut/scripts/run_autonomous_lane.py`
+- `docs/torghut/design-system/v3/full-loop/06-backtest-realism-standard.md`
+
+## Deliverables
+- Synthetic market generator interfaces and dataset registry.
+- Scenario taxonomy (liquidity shock, spread blowout, volatility clustering).
+- Offline policy pretraining and evaluation pipeline.
+- Promotion reports including synthetic-stress metrics.
+
+## Verification
+- Generated scenario statistics match configured constraints.
+- Offline-trained policy must beat baseline in robustness metrics.
+- Reproducibility check: identical seed yields identical scenario bundles.
+
+## Rollback
+- Disable synthetic pretraining for promotion while keeping generators for diagnostics.
+- Fall back to historical replay-only gate set.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-synthetic-market-lab-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `artifactPath`
+  - `datasetRegistryPath`
+- Expected artifacts:
+  - generator modules,
+  - scenario catalog,
+  - offline policy evaluation report.
+- Exit criteria:
+  - reproducible synthetic bundles,
+  - improved robustness gates,
+  - no uncontrolled promotion path.
+
+## Research References
+- Event-based LOB simulation via Neural Hawkes: https://arxiv.org/abs/2502.17417
+- CoFinDiff (IJCAI 2025): https://www.ijcai.org/proceedings/2025/1040
+- Market Making without Regret: https://arxiv.org/abs/2411.13993

--- a/docs/torghut/design-system/v4/04-latency-and-inventory-aware-market-making-policy.md
+++ b/docs/torghut/design-system/v4/04-latency-and-inventory-aware-market-making-policy.md
@@ -1,0 +1,62 @@
+# Latency and Inventory-Aware Market-Making Policy
+
+## Objective
+Design a latency-aware, inventory-constrained market-making policy layer for Torghut that can operate safely in paper
+mode and later support bounded live canaries.
+
+## Why This Matters
+Recent RL market-making work explicitly models latency and inventory risk, showing better stability than naive quoting
+policies under realistic delays and adverse selection.
+
+## Proposed Torghut Design
+- Add `QuotingPolicyV4` with state inputs:
+  - inventory skew,
+  - latency estimates,
+  - spread/depth state,
+  - fill hazard estimates.
+- Policy outputs quote width/size under hard deterministic risk clamps.
+- Add a controlled exploration budget for paper-only learning.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/decisions.py`
+- `services/torghut/app/trading/execution.py`
+- `services/torghut/app/trading/autonomy.py`
+- `argocd/applications/torghut/knative-service.yaml`
+
+## Deliverables
+- Policy module with latency/inventory feature interfaces.
+- Deterministic clamp layer integrated with risk gates.
+- Paper-mode replay and shadow telemetry dashboards.
+- Canary rollout checklist and rollback automation.
+
+## Verification
+- Inventory excursions stay inside configured limits.
+- Adverse selection and realized spread metrics improve vs baseline.
+- Kill-switch and clamp precedence validated under stress.
+
+## Rollback
+- Disable policy output influence and route to baseline execution policy.
+- Preserve telemetry path for postmortem.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-latency-inventory-mm-policy-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `torghutNamespace`
+  - `riskPolicyPath`
+- Expected artifacts:
+  - policy module,
+  - clamp/risk integration,
+  - paper canary report.
+- Exit criteria:
+  - paper-mode stability achieved,
+  - risk clamp behavior proven,
+  - rollback path rehearsed.
+
+## Research References
+- Resolving latency + inventory risk with RL: https://arxiv.org/abs/2505.12465
+- Multi-agent RL market making: https://arxiv.org/abs/2510.25929
+- Market Making without Regret: https://arxiv.org/abs/2411.13993

--- a/docs/torghut/design-system/v4/05-conformal-uncertainty-and-regime-shift-gating.md
+++ b/docs/torghut/design-system/v4/05-conformal-uncertainty-and-regime-shift-gating.md
@@ -1,0 +1,59 @@
+# Conformal Uncertainty and Regime-Shift Gating
+
+## Objective
+Introduce conformal uncertainty envelopes and shift-aware recalibration gates so Torghut can reject low-confidence
+forecasts and degrade safely when market regimes shift.
+
+## Why This Matters
+Recent conformal forecasting papers for multivariate and shifted time-series show practical ways to maintain calibrated
+prediction intervals under non-stationarity.
+
+## Proposed Torghut Design
+- Add `ConformalGateV4` stage between feature generation and strategy execution.
+- Compute per-symbol predictive intervals and empirical coverage drift.
+- Add change-point aware recalibration trigger and abstain policy.
+- Use uncertainty scores as first-class gate signals in promotion decisions.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/evaluation.py`
+- `services/torghut/app/trading/autonomy.py`
+- `services/torghut/app/trading/features.py`
+- `docs/torghut/design-system/v3/full-loop/02-gate-policy-matrix.md`
+
+## Deliverables
+- Conformal interval engine and calibration monitor.
+- Shift-detection and automatic recalibration workflow.
+- Gate-policy extensions for abstain/degrade states.
+- Dashboards and alerts for coverage drift.
+
+## Verification
+- Coverage metrics hold near configured target ranges.
+- Regime-shift replay triggers recalibration and safe degradation.
+- No live/paper promotion when calibration SLO fails.
+
+## Rollback
+- Force deterministic abstain on symbols failing coverage checks.
+- Disable conformal-driven promotion while keeping diagnostics.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-conformal-regime-gates-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `gateConfigPath`
+  - `evaluationWindow`
+- Expected artifacts:
+  - conformal modules,
+  - gate config updates,
+  - drift/recalibration reports.
+- Exit criteria:
+  - stable coverage under replay,
+  - shift-aware degradation validated,
+  - promotion guardrails enforced.
+
+## Research References
+- Flow-based conformal prediction for MTS: https://arxiv.org/abs/2502.05709
+- Conformal prediction under change-point shifts: https://arxiv.org/abs/2509.02844
+- Temporal conformal prediction for uncertainty: https://arxiv.org/abs/2507.05470

--- a/docs/torghut/design-system/v4/06-robust-portfolio-optimization-and-regime-allocation.md
+++ b/docs/torghut/design-system/v4/06-robust-portfolio-optimization-and-regime-allocation.md
@@ -1,0 +1,57 @@
+# Robust Portfolio Optimization and Regime Allocation
+
+## Objective
+Add a robust portfolio allocation layer that remains stable under covariance uncertainty and regime changes, with
+explicit concentration and turnover controls.
+
+## Why This Matters
+Recent robust optimization and online change-point portfolio research enables scalable allocation with stronger
+worst-case guarantees than static mean-variance setups.
+
+## Proposed Torghut Design
+- Add `AllocatorV4` using distributionally robust optimization (DRO) constraints.
+- Integrate online regime segmentation to switch risk budgets and turnover constraints.
+- Track allocation confidence and uncertainty penalties in promotion reports.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/portfolio.py`
+- `services/torghut/app/trading/evaluation.py`
+- `services/torghut/app/models/entities.py`
+- `argocd/applications/torghut/strategy-configmap.yaml`
+
+## Deliverables
+- Robust allocator module with uncertainty budget controls.
+- Regime segmentation integration and config schema.
+- Allocation audit trail and explainability output.
+- Regression tests for concentration, turnover, and fallback behavior.
+
+## Verification
+- Out-of-sample drawdown and turnover metrics improve vs baseline.
+- Allocation remains inside concentration and liquidity caps.
+- Regime transitions do not trigger uncontrolled reallocations.
+
+## Rollback
+- Revert to baseline allocator with static risk budgets.
+- Keep regime diagnostics running for shadow analysis.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-robust-allocator-regime-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `strategyConfigPath`
+  - `artifactPath`
+- Expected artifacts:
+  - allocator implementation,
+  - regime policy config,
+  - robustness backtest report.
+- Exit criteria:
+  - risk metrics pass gates,
+  - fallback behavior verified,
+  - reproducible allocation evidence stored.
+
+## Research References
+- Accelerating large-scale robust portfolio optimization: https://arxiv.org/abs/2411.02938
+- Bayesian online change-point portfolio optimization: https://arxiv.org/abs/2405.04941

--- a/docs/torghut/design-system/v4/07-llm-multi-agent-trade-committee-and-critic.md
+++ b/docs/torghut/design-system/v4/07-llm-multi-agent-trade-committee-and-critic.md
@@ -1,0 +1,62 @@
+# LLM Multi-Agent Trade Committee and Critic
+
+## Objective
+Implement a bounded multi-agent LLM committee for trade proposals, with deterministic critic vetoes and hard policy
+contracts before any output can influence execution.
+
+## Why This Matters
+Recent financial multi-agent LLM papers indicate improved reasoning diversity, but they also increase coordination and
+hallucination risk unless strict verification and role separation are applied.
+
+## Proposed Torghut Design
+- Add committee roles:
+  - `researcher` (hypothesis generation),
+  - `risk_critic` (adversarial stress),
+  - `execution_reviewer` (microstructure feasibility),
+  - `policy_judge` (contract compliance).
+- Require machine-readable rationale schema and confidence fields.
+- Enforce deterministic veto when any mandatory critic gate fails.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/llm/**`
+- `services/jangar/src/server/**`
+- `docs/torghut/design-system/v3/full-loop/15-llm-advisory-rollout-spec.md`
+- `argocd/applications/torghut/knative-service.yaml`
+
+## Deliverables
+- Multi-agent orchestration contract and bounded runtime.
+- Critic/veto policy engine with structured refusal reasons.
+- Storage of rationale traces and policy decisions.
+- Evaluation suite for consistency, refusal quality, and drift.
+
+## Verification
+- Committee outputs improve paper-mode decision quality metrics.
+- Critic vetoes trigger deterministically under malformed proposals.
+- No path allows direct execution without deterministic policy approval.
+
+## Rollback
+- Disable committee influence and keep single-agent advisory baseline.
+- Preserve traces for postmortem tuning.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-llm-committee-critic-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `torghutNamespace`
+  - `policyConfigPath`
+- Expected artifacts:
+  - committee runtime,
+  - critic/veto policies,
+  - paper evaluation report.
+- Exit criteria:
+  - contract compliance > target threshold,
+  - deterministic veto coverage validated,
+  - advisory-only boundary preserved.
+
+## Research References
+- TradingAgents: https://arxiv.org/abs/2412.20138
+- QuantAgent: https://arxiv.org/abs/2509.09995
+- TradingGroup: https://arxiv.org/abs/2508.17565

--- a/docs/torghut/design-system/v4/08-financial-rag-and-time-series-memory-architecture.md
+++ b/docs/torghut/design-system/v4/08-financial-rag-and-time-series-memory-architecture.md
@@ -1,0 +1,61 @@
+# Financial RAG and Time-Series Memory Architecture
+
+## Objective
+Build a finance-specific RAG + time-series memory stack so Torghut LLM paths can ground reasoning in recent market
+context, historical similar regimes, and validated system telemetry.
+
+## Why This Matters
+Recent finance RAG and time-series memory work suggests that retrieval quality and temporal memory controls are more
+important than raw model size for decision reliability.
+
+## Proposed Torghut Design
+- Add `MarketMemoryStoreV4` with three lanes:
+  - structured fundamentals/events,
+  - recent high-frequency telemetry,
+  - historical analog windows.
+- Add retrieval quality metrics (hit relevance, staleness, contradiction score).
+- Require memory provenance in every LLM recommendation.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/llm/**`
+- `services/jangar/src/routes/api/torghut/**`
+- `schemas/embeddings/memories.sql`
+- `docs/torghut/design-system/v3/jangar-market-intelligence-and-lean-integration-plan.md`
+
+## Deliverables
+- Memory schema and retrieval API contracts.
+- Provenance-aware prompt assembly with conflict detection.
+- Evaluation harness for retrieval precision and staleness.
+- Runbook for memory invalidation and hotfix rollback.
+
+## Verification
+- Retrieval precision and recency SLOs pass on benchmark suites.
+- Recommendation quality improves over non-RAG baseline.
+- Contradictory context detection blocks unsafe recommendations.
+
+## Rollback
+- Disable RAG augmentation and use deterministic prompt baseline.
+- Keep memory ingestion active for offline diagnostics.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-financial-rag-memory-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `memorySchemaPath`
+  - `artifactPath`
+- Expected artifacts:
+  - memory schema/API updates,
+  - retrieval evaluation report,
+  - rollback runbook updates.
+- Exit criteria:
+  - retrieval SLOs pass,
+  - provenance attached to all recommendations,
+  - safety blocks validated.
+
+## Research References
+- FinSrag: https://arxiv.org/abs/2502.05878
+- TiMi: https://arxiv.org/abs/2505.16043
+- FinTMMBench: https://arxiv.org/abs/2503.05185

--- a/docs/torghut/design-system/v4/09-ai-market-fragility-and-stability-controls.md
+++ b/docs/torghut/design-system/v4/09-ai-market-fragility-and-stability-controls.md
@@ -1,0 +1,64 @@
+# AI Market Fragility and Stability Controls
+
+## Objective
+Design stability controls for Torghut autonomous behavior under AI-driven market fragility conditions, including dynamic
+liquidity stress responses and crowding-aware exposure limits.
+
+## Why This Matters
+Recent white papers show that AI can amplify market crowding and reduce resilience during stress. Torghut needs explicit
+stability controls before scaling autonomous behavior.
+
+## Proposed Torghut Design
+- Add `FragilityMonitorV4` with indicators:
+  - liquidity compression,
+  - spread acceleration,
+  - participation crowding proxies,
+  - correlated strategy exposure.
+- Add automatic stability mode:
+  - reduce notional,
+  - widen quote constraints,
+  - increase abstain probability,
+  - require stronger confidence for new entries.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/risk.py`
+- `services/torghut/app/trading/autonomy.py`
+- `services/torghut/app/trading/execution.py`
+- `argocd/applications/torghut/strategy-configmap.yaml`
+
+## Deliverables
+- Fragility indicator computation and monitoring dashboard.
+- Stability-mode policy and parameterization.
+- Automated alerts and circuit-breaker integration.
+- Stress-playbook update with operator actions.
+
+## Verification
+- Simulated fragility scenarios trigger stability mode deterministically.
+- Exposure and turnover reduce according to policy.
+- No execution path bypasses stability clamps.
+
+## Rollback
+- Revert to static risk limits while preserving fragility telemetry.
+- Keep alerts active for operator visibility.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-fragility-stability-controls-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `riskConfigPath`
+  - `artifactPath`
+- Expected artifacts:
+  - fragility monitor implementation,
+  - stability policy integration,
+  - stress validation report.
+- Exit criteria:
+  - stability triggers validated,
+  - risk constraints enforced,
+  - rollback rehearsal complete.
+
+## Research References
+- BIS WP 1229 (AI liquidity fragility): https://www.bis.org/publ/work1229.htm
+- NBER w33351 (AI asset pricing models): https://www.nber.org/papers/w33351

--- a/docs/torghut/design-system/v4/10-profitability-evidence-standard-and-benchmark-suite.md
+++ b/docs/torghut/design-system/v4/10-profitability-evidence-standard-and-benchmark-suite.md
@@ -1,0 +1,64 @@
+# Profitability Evidence Standard and Benchmark Suite
+
+## Objective
+Define a strict profitability evidence protocol for Torghut autonomous upgrades so no technique is promoted without
+comparable, reproducible, and risk-adjusted evidence.
+
+## Why This Matters
+New techniques can overfit quickly in finance. A standardized benchmark and evidence format is required to compare
+foundation models, LLM workflows, and execution policies fairly.
+
+## Proposed Torghut Design
+- Create `ProfitabilityEvidenceV4` contract that requires:
+  - risk-adjusted returns (Sharpe, Sortino, drawdown, tail risk),
+  - capacity and turnover metrics,
+  - cost-aware slippage and fill realism,
+  - confidence intervals and calibration stats,
+  - reproducibility hashes (data, code, config).
+- Add benchmark suites by horizon and regime bucket.
+- Require evidence package artifacts before gate progression.
+
+## Owned Code and Config Areas
+- `services/torghut/app/trading/evaluation.py`
+- `services/torghut/scripts/run_autonomous_lane.py`
+- `docs/torghut/design-system/v3/full-loop/10-audit-compliance-evidence-spec.md`
+- `docs/torghut/design-system/v3/full-loop/13-research-ledger-promotion-evidence-spec.md`
+
+## Deliverables
+- Evidence schema and validation CLI.
+- Benchmark runner for baseline vs candidate comparisons.
+- Promotion gate integration with machine-readable pass/fail reasons.
+- Operator-facing report templates for investment committee review.
+
+## Verification
+- Same run inputs produce bitwise-identical evidence bundles.
+- Promotion gate blocks when evidence is incomplete or under threshold.
+- Benchmark drift alerts fire when baseline quality degrades.
+
+## Rollback
+- Freeze promotions and revert to last known-good candidate.
+- Continue benchmark collection for diagnosis.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v4-profitability-evidence-benchmark-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `artifactPath`
+  - `gateConfigPath`
+- Expected artifacts:
+  - evidence contract + validator,
+  - benchmark suite outputs,
+  - gate integration patch.
+- Exit criteria:
+  - validator enforced in CI and AgentRuns,
+  - at least one candidate benchmarked end-to-end,
+  - promotion decisions fully auditable.
+
+## Research References
+- FinTMMBench: https://arxiv.org/abs/2503.05185
+- TradingAgents: https://arxiv.org/abs/2412.20138
+- QuantAgent: https://arxiv.org/abs/2509.09995
+- NBER w33351: https://www.nber.org/papers/w33351

--- a/docs/torghut/design-system/v4/index.md
+++ b/docs/torghut/design-system/v4/index.md
@@ -1,0 +1,54 @@
+# Torghut Design System v4: Quant LLM Profitability Expansion
+
+## Status
+- Version: `v4`
+- Date: `2026-02-19`
+- Maturity: `research-to-implementation pack`
+- Scope: 10 additional design docs focused on profitability, robustness, and autonomous controls.
+
+## Objective
+Translate fresh quant and LLM research (2024-2025) into implementation-ready Torghut designs that can be executed by
+engineers or AgentRuns with clear acceptance gates.
+
+## Non-Negotiable Invariants
+- Paper trading remains default.
+- Deterministic risk gates and kill-switch controls remain final authority.
+- LLM systems are bounded by policy and cannot directly bypass deterministic execution controls.
+- Every promotion decision must be backed by reproducible evidence.
+
+## New Design Pack (10 Documents)
+1. `01-time-series-foundation-model-routing-and-calibration.md`
+2. `02-limit-order-book-intelligence-and-feature-stack.md`
+3. `03-event-driven-synthetic-market-and-offline-policy-lab.md`
+4. `04-latency-and-inventory-aware-market-making-policy.md`
+5. `05-conformal-uncertainty-and-regime-shift-gating.md`
+6. `06-robust-portfolio-optimization-and-regime-allocation.md`
+7. `07-llm-multi-agent-trade-committee-and-critic.md`
+8. `08-financial-rag-and-time-series-memory-architecture.md`
+9. `09-ai-market-fragility-and-stability-controls.md`
+10. `10-profitability-evidence-standard-and-benchmark-suite.md`
+
+## Primary Research Inputs (Fresh)
+- Chronos / Chronos-2 / MOMENT / TiRex (time-series foundation models).
+- HLOB and recent limit-order-book prediction work.
+- Neural Hawkes event simulation and CoFinDiff synthetic data generation.
+- Market making RL papers for latency/inventory-aware quoting.
+- Conformal forecasting papers for shift-aware uncertainty calibration.
+- Robust portfolio optimization and online change-point portfolio methods.
+- TradingAgents / QuantAgent / TradingGroup multi-agent LLM trading research.
+- FinSrag / TiMi / FinTMMBench for finance RAG + memory + evaluation.
+- BIS and NBER white papers on AI market fragility and asset pricing.
+
+## Execution Expectations
+Every doc in this pack includes:
+- owned code/config paths,
+- concrete deliverables,
+- verification and rollback,
+- an AgentRun handoff bundle (`ImplementationSpec` name, required keys, artifacts, exit criteria).
+
+## Recommended Starting Order
+1. `05-conformal-uncertainty-and-regime-shift-gating.md`
+2. `10-profitability-evidence-standard-and-benchmark-suite.md`
+3. `01-time-series-foundation-model-routing-and-calibration.md`
+4. `04-latency-and-inventory-aware-market-making-policy.md`
+5. `07-llm-multi-agent-trade-committee-and-critic.md`


### PR DESCRIPTION
## Summary
- Added a new `v4` Torghut design-system pack with 10 implementation-oriented design docs focused on quant profitability and autonomous safety.
- Grounded the new docs in fresh 2024-2025 primary research (arXiv papers plus BIS/NBER white papers), with direct references in each document.
- Standardized each new doc with owned code/config areas, concrete deliverables, verification/rollback guidance, and AgentRun handoff bundles.
- Added a `v4` entry point to `docs/torghut/design-system/README.md`.

## Related Issues
None

## Testing
- `git status -sb`
- `find docs/torghut/design-system/v4 -maxdepth 1 -type f -name '*.md' | sort`
- `for f in docs/torghut/design-system/v4/*.md; do wc -l "$f"; done | sort -nr`
- Manual content review of `docs/torghut/design-system/v4/index.md` and all 10 new docs for structure, references, and handoff completeness.

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
