### PR TITLE
feat(openclaw): install chrome and ghostty in VM cloud-init

### DIFF
--- a/argocd/applications/openclaw/cloud-init-secret.yaml
+++ b/argocd/applications/openclaw/cloud-init-secret.yaml
@@ -18,6 +18,7 @@ stringData:
       - curl
       - xrdp
       - ubuntu-desktop
+      - snapd
     write_files:
       - path: /etc/netplan/99-openclaw.yaml
         owner: root:root
@@ -64,6 +65,50 @@ stringData:
           echo "${OPENCLAW_VERSION}" > /var/lib/openclaw/openclaw-version-requested.txt
           /home/ubuntu/.npm-global/bin/openclaw --version > /var/lib/openclaw/openclaw-version.txt
           date -u +"%Y-%m-%dT%H:%M:%SZ" > /var/lib/openclaw/openclaw-installed-at
+      - path: /usr/local/bin/install-desktop-apps.sh
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          mkdir -p /var/lib/openclaw
+
+          retry() {
+            local attempts="$1"
+            shift
+            local attempt=1
+            until "$@"; do
+              if [ "${attempt}" -ge "${attempts}" ]; then
+                return 1
+              fi
+              attempt=$((attempt + 1))
+              sleep 3
+            done
+          }
+
+          install_chrome() {
+            local chrome_deb='/tmp/google-chrome-stable_current_amd64.deb'
+            retry 5 curl -fsSL --proto "=https" --tlsv1.2 \
+              -o "${chrome_deb}" \
+              https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            retry 5 apt-get install -y "${chrome_deb}"
+            google-chrome --version > /var/lib/openclaw/google-chrome-version.txt
+          }
+
+          install_ghostty() {
+            systemctl enable --now snapd.socket
+            ln -sfn /var/lib/snapd/snap /snap
+            retry 20 bash -lc 'snap version >/dev/null 2>&1'
+            if ! snap list ghostty >/dev/null 2>&1; then
+              retry 5 snap install ghostty --classic
+            fi
+            snap list ghostty > /var/lib/openclaw/ghostty-version.txt
+          }
+
+          install_chrome
+          install_ghostty
+          date -u +"%Y-%m-%dT%H:%M:%SZ" > /var/lib/openclaw/desktop-apps-installed-at
     users:
       - name: ubuntu
         groups: [sudo]
@@ -95,5 +140,6 @@ stringData:
       - [ bash, -lc, 'systemctl enable --now xrdp' ]
       - [ bash, -lc, 'mkdir -p /var/lib/openclaw' ]
       - [ bash, -lc, '/usr/local/bin/openclaw-install.sh' ]
+      - [ bash, -lc, '/usr/local/bin/install-desktop-apps.sh' ]
       - [ bash, -lc, 'dpkg-query -W ubuntu-desktop > /var/lib/openclaw/desktop-package.txt' ]
       - [ bash, -lc, 'date -u +"%Y-%m-%dT%H:%M:%SZ" > /var/lib/openclaw/desktop-ready' ]


### PR DESCRIPTION
## Summary

- Extend OpenClaw VM cloud-init to install `snapd` during base package provisioning.
- Add `/usr/local/bin/install-desktop-apps.sh` to install Google Chrome from Google's official `.deb` and install Ghostty via `snap`.
- Keep OpenClaw installation codified in cloud-init and run all three installers during `runcmd` with install markers in `/var/lib/openclaw`.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/openclaw >/tmp/openclaw-kustomize.yaml && echo "kustomize-ok" && wc -l /tmp/openclaw-kustomize.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
