### PR TITLE
fix(openclaw): enable gateway systemd service in cloud-init

### DIFF
--- a/argocd/applications/openclaw/cloud-init-secret.yaml
+++ b/argocd/applications/openclaw/cloud-init-secret.yaml
@@ -55,15 +55,46 @@ stringData:
           #!/usr/bin/env bash
           set -euo pipefail
           OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.2.17}"
+          OPENCLAW_BIN='/home/ubuntu/.npm-global/bin/openclaw'
           mkdir -p /var/lib/openclaw
           runuser -u ubuntu -- env HOME=/home/ubuntu OPENCLAW_NO_ONBOARD=1 OPENCLAW_NO_PROMPT=1 \
             OPENCLAW_USE_GUM=0 DEBIAN_FRONTEND=noninteractive OPENCLAW_VERSION="${OPENCLAW_VERSION}" \
             bash -lc \
             'curl -fsSL --proto "=https" --tlsv1.2 https://openclaw.ai/install.sh | bash -s -- --no-onboard --version "${OPENCLAW_VERSION}"' \
             > /var/lib/openclaw/openclaw-install.log 2>&1
-          ln -sf /home/ubuntu/.npm-global/bin/openclaw /usr/local/bin/openclaw
+          ln -sf "${OPENCLAW_BIN}" /usr/local/bin/openclaw
+          if ! grep -q 'npm-global/bin' /home/ubuntu/.profile 2>/dev/null; then
+            echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> /home/ubuntu/.profile
+          fi
+          if ! grep -q 'npm-global/bin' /home/ubuntu/.bashrc 2>/dev/null; then
+            echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> /home/ubuntu/.bashrc
+          fi
+
+          uid="$(id -u ubuntu)"
+          loginctl enable-linger ubuntu || true
+          systemctl start "user@${uid}.service" || true
+          for _ in $(seq 1 30); do
+            if [ -S "/run/user/${uid}/bus" ]; then
+              break
+            fi
+            sleep 1
+          done
+          runuser -u ubuntu -- env HOME=/home/ubuntu XDG_RUNTIME_DIR="/run/user/${uid}" \
+            DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${uid}/bus" OPENCLAW_BIN="${OPENCLAW_BIN}" \
+            bash -lc '$OPENCLAW_BIN gateway install'
+          runuser -u ubuntu -- env HOME=/home/ubuntu XDG_RUNTIME_DIR="/run/user/${uid}" \
+            DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${uid}/bus" \
+            bash -lc 'systemctl --user daemon-reload && systemctl --user enable --now openclaw-gateway.service'
+
           echo "${OPENCLAW_VERSION}" > /var/lib/openclaw/openclaw-version-requested.txt
-          /home/ubuntu/.npm-global/bin/openclaw --version > /var/lib/openclaw/openclaw-version.txt
+          "${OPENCLAW_BIN}" --version > /var/lib/openclaw/openclaw-version.txt
+          runuser -u ubuntu -- env HOME=/home/ubuntu XDG_RUNTIME_DIR="/run/user/${uid}" \
+            DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${uid}/bus" OPENCLAW_BIN="${OPENCLAW_BIN}" \
+            bash -lc '$OPENCLAW_BIN gateway status' > /var/lib/openclaw/openclaw-gateway-status.txt
+          runuser -u ubuntu -- env HOME=/home/ubuntu XDG_RUNTIME_DIR="/run/user/${uid}" \
+            DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${uid}/bus" \
+            bash -lc 'systemctl --user is-enabled openclaw-gateway.service && systemctl --user is-active openclaw-gateway.service' \
+            > /var/lib/openclaw/openclaw-gateway-systemd.txt
           date -u +"%Y-%m-%dT%H:%M:%SZ" > /var/lib/openclaw/openclaw-installed-at
       - path: /usr/local/bin/install-desktop-apps.sh
         owner: root:root


### PR DESCRIPTION
## Summary

- Update OpenClaw VM cloud-init installer to ensure `openclaw` is linked at `/usr/local/bin/openclaw` and user PATH includes `~/.npm-global/bin`.
- Enable user lingering and start the user manager during provisioning so the OpenClaw gateway can run as a user systemd service without an active login.
- Install and enable `openclaw-gateway.service` during provisioning and persist gateway/systemd verification artifacts in `/var/lib/openclaw`.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/openclaw >/tmp/openclaw-kustomize-systemd.yaml && echo "kustomize-ok" && wc -l /tmp/openclaw-kustomize-systemd.yaml`
- `bun run lint:argocd`
- Live VM verification:
- `systemctl --user is-enabled openclaw-gateway.service`
- `systemctl --user is-active openclaw-gateway.service`
- `openclaw gateway status`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
