### PR TITLE
fix(jangar): restore select visibility in dark mode

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-19T03:56:46.226Z"
+    deploy.knative.dev/rollout: "2026-02-19T22:22:03.938Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -56,5 +56,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "7a2f2212"
-    digest: sha256:aa031615d6454e186414da0c9d25b77c0a5a36d9b2e42f1f926fe5e1e7b03aa7
+    newTag: "da51a300"
+    digest: sha256:8a9229954d18959071c48a2596a83bfb9e95b5ae3910074937ff064515aadcbb

--- a/services/jangar/src/styles.css
+++ b/services/jangar/src/styles.css
@@ -26,6 +26,16 @@
     Consolas, monospace;
 }
 
+@layer base {
+  select {
+    color-scheme: light;
+  }
+
+  .dark select {
+    color-scheme: dark;
+  }
+}
+
 .xterm {
   width: 100%;
   height: 100%;

--- a/services/jangar/tests/ui-pages.e2e.ts
+++ b/services/jangar/tests/ui-pages.e2e.ts
@@ -38,5 +38,9 @@ test.describe('ui pages', () => {
   test('torghut visuals', async ({ page }) => {
     await page.goto('/torghut/visuals')
     await expect(page.getByRole('heading', { name: 'Visuals', level: 1 })).toBeVisible()
+    const symbolSelect = page.locator('#torghut-symbol')
+    await expect(symbolSelect).toBeVisible()
+    const colorScheme = await symbolSelect.evaluate((element) => getComputedStyle(element).colorScheme)
+    expect(colorScheme).toContain('dark')
   })
 })


### PR DESCRIPTION
## Summary

- Fixed native `<select>` dropdown visibility in dark mode by applying theme-aware `color-scheme` rules in Jangar base styles.
- Added a UI regression assertion for `/torghut/visuals` to verify the symbol select resolves to dark color scheme.
- Rolled out Jangar with updated image/tag and synced GitOps manifests (`kustomization.yaml` image tag/digest and deployment rollout annotation).

## Related Issues

None

## Testing

- `bunx @biomejs/biome@2.3.8 check services/jangar/src/styles.css services/jangar/tests/ui-pages.e2e.ts`
- `bun run packages/scripts/src/jangar/deploy-service.ts`
- `kubectl rollout status deployment/jangar -n jangar --timeout=300s`
- Playwright e2e execution is currently blocked in this environment (global `playwright` binary does not provide `test`, and local `@playwright/test` runtime is not installed).

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
