### PR TITLE
fix(jangar): stabilize prometheus metrics rendering

### DIFF
--- a/services/jangar/server.ts
+++ b/services/jangar/server.ts
@@ -1,12 +1,7 @@
 import serverEntry from 'virtual:tanstack-start-server-entry'
 import { defineEventHandler } from 'h3'
 
-import {
-  getPrometheusMetricsPath,
-  handlePrometheusMetricsRequest,
-  isPrometheusMetricsEnabled,
-  renderPrometheusMetrics,
-} from './src/server/metrics'
+import { getPrometheusMetricsPath, isPrometheusMetricsEnabled, renderPrometheusMetrics } from './src/server/metrics'
 
 type UnknownRecord = Record<string, unknown>
 
@@ -78,10 +73,6 @@ export default defineEventHandler(async (event) => {
     const metricsPath = getPrometheusMetricsPath()
     const url = new URL(request.url)
     if (url.pathname === metricsPath) {
-      if (event?.node?.req && event?.node?.res) {
-        handlePrometheusMetricsRequest(event.node.req, event.node.res)
-        return
-      }
       const rendered = await renderPrometheusMetrics()
       if (!rendered.ok) {
         return new Response(JSON.stringify({ ok: false, message: rendered.message }), {

--- a/services/jangar/src/server/__tests__/metrics.test.ts
+++ b/services/jangar/src/server/__tests__/metrics.test.ts
@@ -1,0 +1,103 @@
+import { AggregationTemporality, type ResourceMetrics } from '@proompteng/otel/sdk-metrics'
+import { describe, expect, it } from 'vitest'
+
+import { __private } from '../metrics'
+
+describe('metrics Prometheus rendering', () => {
+  it('serializes counter and histogram metrics', () => {
+    const resourceMetrics: ResourceMetrics = {
+      resource: { attributes: [] },
+      scopeMetrics: [
+        {
+          scope: { name: 'jangar' },
+          metrics: [
+            {
+              name: 'jangar_sse_connections_total',
+              description: 'Count of SSE connections opened/closed.',
+              sum: {
+                aggregationTemporality: AggregationTemporality.CUMULATIVE,
+                isMonotonic: true,
+                dataPoints: [
+                  {
+                    attributes: [
+                      { key: 'stream', value: { stringValue: 'chat' } },
+                      { key: 'state', value: { stringValue: 'opened' } },
+                    ],
+                    startTimeUnixNano: '1',
+                    timeUnixNano: '2',
+                    asDouble: 3,
+                  },
+                ],
+              },
+            },
+            {
+              name: 'jangar_agents_queue_depth',
+              description: 'Observed queue depth for AgentRun admission control.',
+              histogram: {
+                aggregationTemporality: AggregationTemporality.CUMULATIVE,
+                dataPoints: [
+                  {
+                    attributes: [{ key: 'queue', value: { stringValue: 'default' } }],
+                    startTimeUnixNano: '1',
+                    timeUnixNano: '2',
+                    count: '2',
+                    sum: 7,
+                    min: 3,
+                    max: 4,
+                    bucketCounts: ['2'],
+                    explicitBounds: [],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    const rendered = __private.serializeResourceMetricsToPrometheus(resourceMetrics)
+
+    expect(rendered).toContain('# TYPE jangar_sse_connections_total counter')
+    expect(rendered).toContain('jangar_sse_connections_total{state="opened",stream="chat"} 3')
+    expect(rendered).toContain('# TYPE jangar_agents_queue_depth histogram')
+    expect(rendered).toContain('jangar_agents_queue_depth_bucket{le="+Inf",queue="default"} 2')
+    expect(rendered).toContain('jangar_agents_queue_depth_sum{queue="default"} 7')
+    expect(rendered).toContain('jangar_agents_queue_depth_count{queue="default"} 2')
+  })
+
+  it('sanitizes metric names and label keys', () => {
+    const resourceMetrics: ResourceMetrics = {
+      resource: { attributes: [] },
+      scopeMetrics: [
+        {
+          scope: { name: 'jangar' },
+          metrics: [
+            {
+              name: 'jangar.metric-name',
+              sum: {
+                aggregationTemporality: AggregationTemporality.CUMULATIVE,
+                isMonotonic: true,
+                dataPoints: [
+                  {
+                    attributes: [{ key: 'team-name', value: { stringValue: 'agents' } }],
+                    startTimeUnixNano: '1',
+                    timeUnixNano: '2',
+                    asDouble: 1,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    const rendered = __private.serializeResourceMetricsToPrometheus(resourceMetrics)
+    expect(rendered).toContain('# TYPE jangar_metric_name counter')
+    expect(rendered).toContain('jangar_metric_name{team_name="agents"} 1')
+  })
+
+  it('returns a comment when no metrics are collected', () => {
+    expect(__private.serializeResourceMetricsToPrometheus(null)).toBe('# no metrics collected\n')
+  })
+})


### PR DESCRIPTION
## Summary

- Replaced the Jangar Prometheus metrics rendering path with native serialization from `@proompteng/otel` `MeterProvider.collect()` output.
- Removed the Node `req/res` Prometheus handler branch so `/metrics` consistently uses `renderPrometheusMetrics()`.
- Added regression tests for counter/histogram exposition formatting, metric/label sanitization, and empty-collection behavior.

## Related Issues

None

## Testing

- `bunx biome check --config-path biome.json services/jangar/server.ts services/jangar/src/server/metrics.ts services/jangar/src/server/__tests__/metrics.test.ts`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/metrics.test.ts` (cwd: `services/jangar`)
- `bun run tsc` (cwd: `services/jangar`)

## Screenshots (if applicable)

N/A (backend metrics endpoint fix)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
