### PR TITLE
chore(torghut): update prod rollout manifests for v0.556.1

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-16T21:34:26.756Z"
+        client.knative.dev/updateTimestamp: "2026-02-19T22:59:18.000Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:073dcbf3ea4875f9201d57ecce97ffdc70e130bdac5ca7ea4880277b9b9a86fa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:23464c08edc2bead7a2840d3e26ccb214dfd5ec59840cd586c8d27150c651445
           ports:
             - name: http1
               containerPort: 8181
@@ -176,9 +176,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.551.0-93-g4c9a4b66
+              value: v0.556.1-32-g950a4eb9
             - name: TORGHUT_COMMIT
-              value: 4c9a4b66f6a613e8c3e0df784cc8aac055ba9027
+              value: 950a4eb9badc5abab25d45f3c3ec2262ff3f8899
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -155,9 +155,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: v0.551.0-93-g4c9a4b66
+              value: v0.556.1-32-g950a4eb9
             - name: TORGHUT_TA_COMMIT
-              value: 4c9a4b66f6a613e8c3e0df784cc8aac055ba9027
+              value: 950a4eb9badc5abab25d45f3c3ec2262ff3f8899
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2026-02-16T21:34:26.762Z
+        kubectl.kubernetes.io/restartedAt: 2026-02-19T22:59:18.000Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:
@@ -27,7 +27,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:fd9ecec2c844f0013035275da22716a4bdb83076461fa4a319bc5d96e190369e
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:af0d9b811ffb6ecff388351f5e6c970c53fe8bf1623fd30618cabb1a08001c35
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -51,9 +51,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: v0.551.0-93-g4c9a4b66
+              value: v0.556.1-32-g950a4eb9
             - name: TORGHUT_WS_COMMIT
-              value: 4c9a4b66f6a613e8c3e0df784cc8aac055ba9027
+              value: 950a4eb9badc5abab25d45f3c3ec2262ff3f8899
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary

- Update Torghut Knative service image digest to `registry.ide-newton.ts.net/lab/torghut@sha256:23464c08edc2bead7a2840d3e26ccb214dfd5ec59840cd586c8d27150c651445`.
- Update Torghut websocket deployment image digest to `registry.ide-newton.ts.net/lab/torghut-ws@sha256:af0d9b811ffb6ecff388351f5e6c970c53fe8bf1623fd30618cabb1a08001c35` and bump restart timestamp.
- Keep Torghut TA image digest at `registry.ide-newton.ts.net/lab/torghut-ta@sha256:0a8ba5ac62d42feec61e9a027d2b27ed064e9f67e9f2d12e411d5a8ccabedb69` while bumping `TORGHUT_*_VERSION`/`TORGHUT_*_COMMIT` env values to `v0.556.1-32-g950a4eb9` / `950a4eb9badc5abab25d45f3c3ec2262ff3f8899` across app, ws, and ta manifests.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl -n torghut get ksvc torghut -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}{.status.latestReadyRevisionName}{"\n"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}'`
- `kubectl -n torghut get deploy torghut-ws -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}{.status.updatedReplicas}{"/"}{.status.replicas}{" ready="}{.status.readyReplicas}{"\n"}'`
- `kubectl -n torghut get flinkdeployment torghut-ta -o jsonpath='{.spec.image}{"\n"}{.status.jobManagerDeploymentStatus}{"\n"}{.status.jobStatus.state}{"\n"}{.status.reconciliationStatus.state}{"\n"}'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked (`N/A` for this manifest-only rollout metadata update).
