### PR TITLE
feat(torghut): implement stage-1 llm advisory rollout guardrails

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -517,6 +517,42 @@ data:
               summary: Torghut LLM circuit breaker opened recently
               description: Circuit breaker events indicate repeated LLM failures or timeouts in the last 10 minutes.
               runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+          - alert: TorghutLLMCircuitOpenTooLong
+            expr: |
+              max(
+                torghut_llm_circuit_open_seconds{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }
+              ) > 600
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Torghut LLM circuit stuck open
+              description: |
+                The LLM circuit breaker has remained open for longer than 10 minutes.
+                Keep deterministic-only behavior and investigate upstream LLM failures.
+              runbook_url: docs/torghut/design-system/v1/ai-layer-model-risk-management.md
+          - alert: TorghutLLMFailModeOverridesSpike
+            expr: |
+              increase(
+                torghut_llm_fail_mode_override_total{
+                  job="torghut",
+                  namespace="torghut",
+                  service="torghut-llm-guardrails-exporter"
+                }[15m]
+              ) > 5
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut LLM fail-mode overrides are frequent
+              description: |
+                Stage controls are repeatedly overriding configured fail mode.
+                Verify rollout stage and live/paper configuration consistency.
+              runbook_url: docs/torghut/design-system/v3/full-loop/15-llm-advisory-rollout-spec.md
           - alert: TorghutLLMTokenBudgetExceeded
             expr: |
               (

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -146,18 +146,22 @@ spec:
               value: gpt-5.3-codex
             - name: LLM_ALLOWED_MODELS
               value: gpt-5.3-codex
+            - name: LLM_ROLLOUT_STAGE
+              value: stage1_shadow_pilot
             - name: LLM_ENABLED
-              value: "false"
+              value: "true"
             - name: LLM_SHADOW_MODE
-              value: "false"
+              value: "true"
             - name: LLM_EVALUATION_REPORT
               value: torghut-llm-shadow-eval-2026-02-12
             - name: LLM_EFFECTIVE_CHALLENGE_ID
               value: torghut-llm-mrm-review-2026-02-12
             - name: LLM_SHADOW_COMPLETED_AT
               value: 2026-02-12T06:45:00Z
+            - name: LLM_MODEL_VERSION_LOCK
+              value: gpt-5.3-codex
             - name: LLM_FAIL_MODE
-              value: pass_through
+              value: veto
             - name: LLM_TIMEOUT_SECONDS
               value: "20"
             - name: LLM_JANGAR_BESPOKE_DECISION_ENABLED

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -144,12 +144,16 @@ spec:
               value: jangar
             - name: LLM_MODEL
               value: gpt-5.3-codex
+            - name: LLM_MODEL_VERSION_LOCK
+              value: gpt-5.3-codex
             - name: LLM_ALLOWED_MODELS
               value: gpt-5.3-codex
-            - name: LLM_ROLLOUT_STAGE
-              value: stage1_shadow_pilot
+            - name: LLM_ALLOWED_PROMPT_VERSIONS
+              value: v1
             - name: LLM_ENABLED
               value: "true"
+            - name: LLM_ROLLOUT_STAGE
+              value: stage1
             - name: LLM_SHADOW_MODE
               value: "true"
             - name: LLM_EVALUATION_REPORT
@@ -158,10 +162,10 @@ spec:
               value: torghut-llm-mrm-review-2026-02-12
             - name: LLM_SHADOW_COMPLETED_AT
               value: 2026-02-12T06:45:00Z
-            - name: LLM_MODEL_VERSION_LOCK
-              value: gpt-5.3-codex
             - name: LLM_FAIL_MODE
-              value: veto
+              value: pass_through
+            - name: LLM_TOKEN_BUDGET_MAX
+              value: "1200"
             - name: LLM_TIMEOUT_SECONDS
               value: "20"
             - name: LLM_JANGAR_BESPOKE_DECISION_ENABLED

--- a/argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml
+++ b/argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml
@@ -116,6 +116,52 @@ data:
         lines.append("# TYPE torghut_llm_shadow_mode gauge")
         lines.append(f"torghut_llm_shadow_mode {1.0 if llm.get('shadow_mode') else 0.0}")
 
+        lines.append("# HELP torghut_llm_effective_shadow_mode 1 if guardrails force shadow behavior.")
+        lines.append("# TYPE torghut_llm_effective_shadow_mode gauge")
+        lines.append(f"torghut_llm_effective_shadow_mode {1.0 if llm.get('effective_shadow_mode') else 0.0}")
+
+        rollout_stage = str(llm.get("rollout_stage") or "unknown")
+        lines.append("# HELP torghut_llm_rollout_stage_info LLM rollout stage info metric.")
+        lines.append("# TYPE torghut_llm_rollout_stage_info gauge")
+        lines.append(f'torghut_llm_rollout_stage_info{{stage="{rollout_stage}"}} 1')
+
+        configured_fail_mode = str(llm.get("configured_fail_mode") or "unknown")
+        effective_fail_mode = str(llm.get("fail_mode") or "unknown")
+        lines.append("# HELP torghut_llm_fail_mode_configured Configured LLM fail mode.")
+        lines.append("# TYPE torghut_llm_fail_mode_configured gauge")
+        lines.append(f'torghut_llm_fail_mode_configured{{mode="{configured_fail_mode}"}} 1')
+        lines.append("# HELP torghut_llm_fail_mode_effective Effective LLM fail mode after guardrails/stage controls.")
+        lines.append("# TYPE torghut_llm_fail_mode_effective gauge")
+        lines.append(f'torghut_llm_fail_mode_effective{{mode="{effective_fail_mode}"}} 1')
+
+        circuit = llm.get("circuit", {})
+        if not isinstance(circuit, dict):
+            circuit = {}
+        lines.append("# HELP torghut_llm_circuit_open_now 1 when the LLM circuit breaker is currently open.")
+        lines.append("# TYPE torghut_llm_circuit_open_now gauge")
+        lines.append(f"torghut_llm_circuit_open_now {1.0 if circuit.get('open') else 0.0}")
+        lines.append("# HELP torghut_llm_circuit_open_seconds Duration in seconds that the circuit has been open.")
+        lines.append("# TYPE torghut_llm_circuit_open_seconds gauge")
+        lines.append(f"torghut_llm_circuit_open_seconds {float_or_nan(circuit.get('open_seconds', 0))}")
+        lines.append("# HELP torghut_llm_circuit_cooldown_remaining_seconds Remaining cooldown before the circuit can close.")
+        lines.append("# TYPE torghut_llm_circuit_cooldown_remaining_seconds gauge")
+        lines.append(
+            f"torghut_llm_circuit_cooldown_remaining_seconds {float_or_nan(circuit.get('cooldown_remaining_seconds', 0))}"
+        )
+
+        guardrails = llm.get("guardrails", {})
+        if not isinstance(guardrails, dict):
+            guardrails = {}
+        reasons = guardrails.get("reasons", [])
+        if isinstance(reasons, list):
+            lines.append("# HELP torghut_llm_guardrail_reason_active 1 when a specific guardrail reason is active.")
+            lines.append("# TYPE torghut_llm_guardrail_reason_active gauge")
+            for reason in reasons:
+                if not isinstance(reason, str):
+                    continue
+                escaped_reason = reason.replace("\\", "\\\\").replace('"', '\\"')
+                lines.append(f'torghut_llm_guardrail_reason_active{{reason="{escaped_reason}"}} 1')
+
         lines.append("# HELP torghut_llm_veto_rate_baseline Baseline veto rate configured for guardrails alerts.")
         lines.append("# TYPE torghut_llm_veto_rate_baseline gauge")
         lines.append(f"torghut_llm_veto_rate_baseline {LLM_VETO_RATE_BASELINE}")
@@ -133,6 +179,8 @@ data:
             "llm_parse_error_total",
             "llm_validation_error_total",
             "llm_circuit_open_total",
+            "llm_stage_policy_violation_total",
+            "llm_fail_mode_override_total",
             "llm_shadow_total",
             "llm_guardrail_block_total",
             "llm_guardrail_shadow_total",

--- a/argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml
+++ b/argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml
@@ -169,6 +169,8 @@ data:
             "llm_parse_error_total",
             "llm_validation_error_total",
             "llm_circuit_open_total",
+            "llm_fail_mode_override_total",
+            "llm_stage_policy_violation_total",
             "llm_shadow_total",
             "llm_guardrail_block_total",
             "llm_guardrail_shadow_total",

--- a/argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml
+++ b/argocd/applications/torghut/llm-guardrails-exporter-configmap.yaml
@@ -22,6 +22,10 @@ data:
     SCRAPE_INTERVAL_SECONDS = int(os.environ.get("SCRAPE_INTERVAL_SECONDS", "30"))
     LLM_VETO_RATE_BASELINE = float(os.environ.get("LLM_VETO_RATE_BASELINE", "0.4"))
     LLM_TOKENS_PER_REQUEST_BUDGET = float(os.environ.get("LLM_TOKENS_PER_REQUEST_BUDGET", "800"))
+    LLM_ERROR_RATIO_ALERT_THRESHOLD = float(os.environ.get("LLM_ERROR_RATIO_ALERT_THRESHOLD", "0.15"))
+    LLM_CIRCUIT_COOLDOWN_SECONDS_ALERT_THRESHOLD = float(
+        os.environ.get("LLM_CIRCUIT_COOLDOWN_SECONDS_ALERT_THRESHOLD", "120")
+    )
 
 
     def fetch_json(path: str) -> dict:
@@ -116,51 +120,37 @@ data:
         lines.append("# TYPE torghut_llm_shadow_mode gauge")
         lines.append(f"torghut_llm_shadow_mode {1.0 if llm.get('shadow_mode') else 0.0}")
 
-        lines.append("# HELP torghut_llm_effective_shadow_mode 1 if guardrails force shadow behavior.")
+        lines.append("# HELP torghut_llm_effective_shadow_mode 1 if runtime guardrails force shadow mode.")
         lines.append("# TYPE torghut_llm_effective_shadow_mode gauge")
         lines.append(f"torghut_llm_effective_shadow_mode {1.0 if llm.get('effective_shadow_mode') else 0.0}")
 
         rollout_stage = str(llm.get("rollout_stage") or "unknown")
-        lines.append("# HELP torghut_llm_rollout_stage_info LLM rollout stage info metric.")
+        lines.append("# HELP torghut_llm_rollout_stage_info Rollout stage label for Torghut LLM runtime.")
         lines.append("# TYPE torghut_llm_rollout_stage_info gauge")
         lines.append(f'torghut_llm_rollout_stage_info{{stage="{rollout_stage}"}} 1')
 
-        configured_fail_mode = str(llm.get("configured_fail_mode") or "unknown")
-        effective_fail_mode = str(llm.get("fail_mode") or "unknown")
-        lines.append("# HELP torghut_llm_fail_mode_configured Configured LLM fail mode.")
-        lines.append("# TYPE torghut_llm_fail_mode_configured gauge")
-        lines.append(f'torghut_llm_fail_mode_configured{{mode="{configured_fail_mode}"}} 1')
-        lines.append("# HELP torghut_llm_fail_mode_effective Effective LLM fail mode after guardrails/stage controls.")
-        lines.append("# TYPE torghut_llm_fail_mode_effective gauge")
-        lines.append(f'torghut_llm_fail_mode_effective{{mode="{effective_fail_mode}"}} 1')
+        effective_fail_mode = str(llm.get("effective_fail_mode") or llm.get("fail_mode") or "unknown")
+        lines.append("# HELP torghut_llm_effective_fail_mode_info Effective fail mode after stage and trading-mode rules.")
+        lines.append("# TYPE torghut_llm_effective_fail_mode_info gauge")
+        lines.append(f'torghut_llm_effective_fail_mode_info{{fail_mode="{effective_fail_mode}"}} 1')
 
-        circuit = llm.get("circuit", {})
-        if not isinstance(circuit, dict):
-            circuit = {}
-        lines.append("# HELP torghut_llm_circuit_open_now 1 when the LLM circuit breaker is currently open.")
-        lines.append("# TYPE torghut_llm_circuit_open_now gauge")
-        lines.append(f"torghut_llm_circuit_open_now {1.0 if circuit.get('open') else 0.0}")
-        lines.append("# HELP torghut_llm_circuit_open_seconds Duration in seconds that the circuit has been open.")
-        lines.append("# TYPE torghut_llm_circuit_open_seconds gauge")
-        lines.append(f"torghut_llm_circuit_open_seconds {float_or_nan(circuit.get('open_seconds', 0))}")
-        lines.append("# HELP torghut_llm_circuit_cooldown_remaining_seconds Remaining cooldown before the circuit can close.")
-        lines.append("# TYPE torghut_llm_circuit_cooldown_remaining_seconds gauge")
-        lines.append(
-            f"torghut_llm_circuit_cooldown_remaining_seconds {float_or_nan(circuit.get('cooldown_remaining_seconds', 0))}"
-        )
+        guardrails = llm.get("guardrails", {}) if isinstance(llm, dict) else {}
+        governance_complete = False
+        if isinstance(guardrails, dict):
+            governance_complete = bool(guardrails.get("governance_evidence_complete"))
+        lines.append("# HELP torghut_llm_governance_evidence_complete 1 when mandatory governance evidence is complete.")
+        lines.append("# TYPE torghut_llm_governance_evidence_complete gauge")
+        lines.append(f"torghut_llm_governance_evidence_complete {1.0 if governance_complete else 0.0}")
 
-        guardrails = llm.get("guardrails", {})
-        if not isinstance(guardrails, dict):
-            guardrails = {}
-        reasons = guardrails.get("reasons", [])
-        if isinstance(reasons, list):
-            lines.append("# HELP torghut_llm_guardrail_reason_active 1 when a specific guardrail reason is active.")
-            lines.append("# TYPE torghut_llm_guardrail_reason_active gauge")
-            for reason in reasons:
-                if not isinstance(reason, str):
-                    continue
-                escaped_reason = reason.replace("\\", "\\\\").replace('"', '\\"')
-                lines.append(f'torghut_llm_guardrail_reason_active{{reason="{escaped_reason}"}} 1')
+        circuit = llm.get("circuit", {}) if isinstance(llm, dict) else {}
+        circuit_open = bool(circuit.get("open")) if isinstance(circuit, dict) else False
+        circuit_cooldown_seconds = float_or_nan(circuit.get("cooldown_seconds", 0) if isinstance(circuit, dict) else 0)
+        lines.append("# HELP torghut_llm_circuit_open 1 when the LLM circuit breaker is currently open.")
+        lines.append("# TYPE torghut_llm_circuit_open gauge")
+        lines.append(f"torghut_llm_circuit_open {1.0 if circuit_open else 0.0}")
+        lines.append("# HELP torghut_llm_circuit_cooldown_seconds Configured circuit cooldown window in seconds.")
+        lines.append("# TYPE torghut_llm_circuit_cooldown_seconds gauge")
+        lines.append(f"torghut_llm_circuit_cooldown_seconds {circuit_cooldown_seconds}")
 
         lines.append("# HELP torghut_llm_veto_rate_baseline Baseline veto rate configured for guardrails alerts.")
         lines.append("# TYPE torghut_llm_veto_rate_baseline gauge")
@@ -179,8 +169,6 @@ data:
             "llm_parse_error_total",
             "llm_validation_error_total",
             "llm_circuit_open_total",
-            "llm_stage_policy_violation_total",
-            "llm_fail_mode_override_total",
             "llm_shadow_total",
             "llm_guardrail_block_total",
             "llm_guardrail_shadow_total",
@@ -194,6 +182,27 @@ data:
             lines.append(f"# TYPE {metric_name} counter")
             value = float_or_nan(metrics.get(key, 0))
             lines.append(f"{metric_name} {value}")
+
+        requests = max(float_or_nan(metrics.get("llm_requests_total", 0)), 0.0)
+        errors = max(float_or_nan(metrics.get("llm_error_total", 0)), 0.0)
+        circuit_open_total = max(float_or_nan(metrics.get("llm_circuit_open_total", 0)), 0.0)
+        error_ratio = errors / requests if requests > 0 else 0.0
+        circuit_open_ratio = circuit_open_total / requests if requests > 0 else 0.0
+        lines.append("# HELP torghut_llm_error_ratio Error-to-request ratio for LLM reviews.")
+        lines.append("# TYPE torghut_llm_error_ratio gauge")
+        lines.append(f"torghut_llm_error_ratio {error_ratio}")
+        lines.append("# HELP torghut_llm_circuit_open_ratio Circuit-open events divided by LLM requests.")
+        lines.append("# TYPE torghut_llm_circuit_open_ratio gauge")
+        lines.append(f"torghut_llm_circuit_open_ratio {circuit_open_ratio}")
+
+        error_ratio_alert = 1.0 if error_ratio >= LLM_ERROR_RATIO_ALERT_THRESHOLD else 0.0
+        circuit_alert = 1.0 if circuit_open and circuit_cooldown_seconds >= LLM_CIRCUIT_COOLDOWN_SECONDS_ALERT_THRESHOLD else 0.0
+        lines.append("# HELP torghut_llm_error_ratio_alert 1 when LLM error ratio breaches alert threshold.")
+        lines.append("# TYPE torghut_llm_error_ratio_alert gauge")
+        lines.append(f"torghut_llm_error_ratio_alert {error_ratio_alert}")
+        lines.append("# HELP torghut_llm_circuit_open_alert 1 when LLM circuit-open condition breaches alert threshold.")
+        lines.append("# TYPE torghut_llm_circuit_open_alert gauge")
+        lines.append(f"torghut_llm_circuit_open_alert {circuit_alert}")
 
         return "\n".join(lines) + "\n"
 

--- a/argocd/applications/torghut/llm-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/llm-guardrails-exporter.yaml
@@ -37,6 +37,10 @@ spec:
               value: "0.4"
             - name: LLM_TOKENS_PER_REQUEST_BUDGET
               value: "800"
+            - name: LLM_ERROR_RATIO_ALERT_THRESHOLD
+              value: "0.15"
+            - name: LLM_CIRCUIT_COOLDOWN_SECONDS_ALERT_THRESHOLD
+              value: "120"
             - name: PYTHONDONTWRITEBYTECODE
               value: "1"
           ports:

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -146,6 +146,7 @@ import { Route as ApiTorghutTradingControlPlaneQuantSnapshotRouteImport } from '
 import { Route as ApiTorghutTradingControlPlaneQuantSeriesRouteImport } from './routes/api/torghut/trading/control-plane/quant/series'
 import { Route as ApiTorghutTradingControlPlaneQuantHealthRouteImport } from './routes/api/torghut/trading/control-plane/quant/health'
 import { Route as ApiTorghutTradingControlPlaneQuantAlertsRouteImport } from './routes/api/torghut/trading/control-plane/quant/alerts'
+import { Route as ApiTorghutTradingControlPlaneLlmRolloutRouteImport } from './routes/api/torghut/trading/control-plane/llm/rollout'
 import { Route as ApiGithubPullsOwnerRepoNumberRouteImport } from './routes/api/github/pulls/$owner/$repo/$number'
 import { Route as ApiGithubPullsOwnerRepoNumberThreadsRouteImport } from './routes/api/github/pulls/$owner/$repo/$number/threads'
 import { Route as ApiGithubPullsOwnerRepoNumberReviewRouteImport } from './routes/api/github/pulls/$owner/$repo/$number/review'
@@ -902,6 +903,12 @@ const ApiTorghutTradingControlPlaneQuantAlertsRoute =
     path: '/api/torghut/trading/control-plane/quant/alerts',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiTorghutTradingControlPlaneLlmRolloutRoute =
+  ApiTorghutTradingControlPlaneLlmRolloutRouteImport.update({
+    id: '/api/torghut/trading/control-plane/llm/rollout',
+    path: '/api/torghut/trading/control-plane/llm/rollout',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiGithubPullsOwnerRepoNumberRoute =
   ApiGithubPullsOwnerRepoNumberRouteImport.update({
     id: '/$owner/$repo/$number',
@@ -1091,6 +1098,7 @@ export interface FileRoutesByFullPath {
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
+  '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
   '/api/torghut/trading/control-plane/quant/alerts': typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   '/api/torghut/trading/control-plane/quant/health': typeof ApiTorghutTradingControlPlaneQuantHealthRoute
   '/api/torghut/trading/control-plane/quant/series': typeof ApiTorghutTradingControlPlaneQuantSeriesRoute
@@ -1237,6 +1245,7 @@ export interface FileRoutesByTo {
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
+  '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
   '/api/torghut/trading/control-plane/quant/alerts': typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   '/api/torghut/trading/control-plane/quant/health': typeof ApiTorghutTradingControlPlaneQuantHealthRoute
   '/api/torghut/trading/control-plane/quant/series': typeof ApiTorghutTradingControlPlaneQuantSeriesRoute
@@ -1386,6 +1395,7 @@ export interface FileRoutesById {
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
+  '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
   '/api/torghut/trading/control-plane/quant/alerts': typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   '/api/torghut/trading/control-plane/quant/health': typeof ApiTorghutTradingControlPlaneQuantHealthRoute
   '/api/torghut/trading/control-plane/quant/series': typeof ApiTorghutTradingControlPlaneQuantSeriesRoute
@@ -1536,6 +1546,7 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs/$id'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
+    | '/api/torghut/trading/control-plane/llm/rollout'
     | '/api/torghut/trading/control-plane/quant/alerts'
     | '/api/torghut/trading/control-plane/quant/health'
     | '/api/torghut/trading/control-plane/quant/series'
@@ -1682,6 +1693,7 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs/$id'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
+    | '/api/torghut/trading/control-plane/llm/rollout'
     | '/api/torghut/trading/control-plane/quant/alerts'
     | '/api/torghut/trading/control-plane/quant/health'
     | '/api/torghut/trading/control-plane/quant/series'
@@ -1830,6 +1842,7 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs/$id'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
+    | '/api/torghut/trading/control-plane/llm/rollout'
     | '/api/torghut/trading/control-plane/quant/alerts'
     | '/api/torghut/trading/control-plane/quant/health'
     | '/api/torghut/trading/control-plane/quant/series'
@@ -1956,6 +1969,7 @@ export interface RootRouteChildren {
   ApiTorghutMarketContextIndexRoute: typeof ApiTorghutMarketContextIndexRoute
   ControlPlaneTorghutQuantIndexRoute: typeof ControlPlaneTorghutQuantIndexRoute
   ApiAgentsImplementationSourcesWebhooksProviderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
+  ApiTorghutTradingControlPlaneLlmRolloutRoute: typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
   ApiTorghutTradingControlPlaneQuantAlertsRoute: typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   ApiTorghutTradingControlPlaneQuantHealthRoute: typeof ApiTorghutTradingControlPlaneQuantHealthRoute
   ApiTorghutTradingControlPlaneQuantSeriesRoute: typeof ApiTorghutTradingControlPlaneQuantSeriesRoute
@@ -2924,6 +2938,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiTorghutTradingControlPlaneQuantAlertsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/torghut/trading/control-plane/llm/rollout': {
+      id: '/api/torghut/trading/control-plane/llm/rollout'
+      path: '/api/torghut/trading/control-plane/llm/rollout'
+      fullPath: '/api/torghut/trading/control-plane/llm/rollout'
+      preLoaderRoute: typeof ApiTorghutTradingControlPlaneLlmRolloutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/github/pulls/$owner/$repo/$number': {
       id: '/api/github/pulls/$owner/$repo/$number'
       path: '/$owner/$repo/$number'
@@ -3345,6 +3366,8 @@ const rootRouteChildren: RootRouteChildren = {
   ControlPlaneTorghutQuantIndexRoute: ControlPlaneTorghutQuantIndexRoute,
   ApiAgentsImplementationSourcesWebhooksProviderRoute:
     ApiAgentsImplementationSourcesWebhooksProviderRoute,
+  ApiTorghutTradingControlPlaneLlmRolloutRoute:
+    ApiTorghutTradingControlPlaneLlmRolloutRoute,
   ApiTorghutTradingControlPlaneQuantAlertsRoute:
     ApiTorghutTradingControlPlaneQuantAlertsRoute,
   ApiTorghutTradingControlPlaneQuantHealthRoute:

--- a/services/jangar/src/routes/api/torghut/trading/control-plane/llm/rollout.test.ts
+++ b/services/jangar/src/routes/api/torghut/trading/control-plane/llm/rollout.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('getLlmRolloutHandler', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    global.fetch = originalFetch
+  })
+
+  it('returns rollout and circuit payload from torghut status', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-20T12:00:00Z'))
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            llm: {
+              enabled: true,
+              rollout_stage: 'stage1',
+              shadow_mode: true,
+              effective_shadow_mode: true,
+              fail_mode: 'pass_through',
+              effective_fail_mode: 'pass_through',
+              circuit: {
+                open: true,
+                open_until: '2026-02-20T12:03:00Z',
+                cooldown_seconds: 600,
+                window_seconds: 300,
+                max_errors: 3,
+                recent_error_count: 2,
+              },
+              guardrails: {
+                allow_requests: true,
+                governance_evidence_complete: false,
+                reasons: ['llm_shadow_completion_missing'],
+              },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    )
+
+    const { getLlmRolloutHandler } = await import('./rollout')
+
+    const response = await getLlmRolloutHandler()
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+    expect(body.llmRollout.rolloutStage).toBe('stage1')
+    expect(body.llmRollout.effectiveFailMode).toBe('pass_through')
+    expect(body.llmRollout.governanceEvidenceComplete).toBe(false)
+    expect(body.llmCircuit.open).toBe(true)
+    expect(body.llmCircuit.cooldownRemainingSeconds).toBe(180)
+
+    vi.useRealTimers()
+  })
+
+  it('returns 503 when torghut status is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('upstream failed', { status: 500 })))
+
+    const { getLlmRolloutHandler } = await import('./rollout')
+
+    const response = await getLlmRolloutHandler()
+    expect(response.status).toBe(503)
+
+    const body = await response.json()
+    expect(body.ok).toBe(false)
+    expect(body.message).toContain('Torghut status request failed')
+  })
+})

--- a/services/jangar/src/routes/api/torghut/trading/control-plane/llm/rollout.ts
+++ b/services/jangar/src/routes/api/torghut/trading/control-plane/llm/rollout.ts
@@ -1,0 +1,92 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/torghut/trading/control-plane/llm/rollout')({
+  server: {
+    handlers: {
+      GET: async () => getLlmRolloutHandler(),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const TORGHUT_STATUS_PATH = '/trading/status'
+
+const resolveTorghutBaseUrl = () =>
+  (process.env.TORGHUT_API_BASE_URL ?? 'http://torghut.torghut.svc.cluster.local').replace(/\/+$/, '')
+
+const parseIsoEpochSeconds = (value: unknown): number | null => {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) return null
+  return Math.floor(parsed / 1000)
+}
+
+export const getLlmRolloutHandler = async () => {
+  const asOf = new Date().toISOString()
+  const baseUrl = resolveTorghutBaseUrl()
+  const url = `${baseUrl}${TORGHUT_STATUS_PATH}`
+
+  try {
+    const response = await fetch(url, { headers: { accept: 'application/json' } })
+    if (!response.ok) {
+      const details = await response.text()
+      return jsonResponse(
+        { ok: false, message: `Torghut status request failed (${response.status})`, details: details.slice(0, 500) },
+        503,
+      )
+    }
+
+    const payload = (await response.json()) as { llm?: Record<string, unknown> }
+    const llm = typeof payload?.llm === 'object' && payload.llm !== null ? payload.llm : {}
+    const guardrails =
+      typeof llm.guardrails === 'object' && llm.guardrails !== null ? (llm.guardrails as Record<string, unknown>) : {}
+    const circuit =
+      typeof llm.circuit === 'object' && llm.circuit !== null ? (llm.circuit as Record<string, unknown>) : {}
+
+    const openUntilSeconds = parseIsoEpochSeconds(circuit.open_until)
+    const cooldownSeconds = typeof circuit.cooldown_seconds === 'number' ? Math.max(0, circuit.cooldown_seconds) : 0
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const cooldownRemainingSeconds = openUntilSeconds ? Math.max(0, openUntilSeconds - nowSeconds) : 0
+    const openDurationSeconds = openUntilSeconds
+      ? Math.max(0, Math.min(cooldownSeconds, cooldownSeconds - cooldownRemainingSeconds))
+      : 0
+
+    return jsonResponse({
+      ok: true,
+      asOf,
+      llmRollout: {
+        enabled: Boolean(llm.enabled),
+        rolloutStage: typeof llm.rollout_stage === 'string' ? llm.rollout_stage : null,
+        configuredShadowMode: Boolean(llm.shadow_mode),
+        effectiveShadowMode: Boolean(llm.effective_shadow_mode),
+        configuredFailMode: typeof llm.fail_mode === 'string' ? llm.fail_mode : null,
+        effectiveFailMode: typeof llm.effective_fail_mode === 'string' ? llm.effective_fail_mode : null,
+        governanceEvidenceComplete: Boolean(guardrails.governance_evidence_complete),
+        guardrailReasons: Array.isArray(guardrails.reasons) ? guardrails.reasons : [],
+        allowRequests: Boolean(guardrails.allow_requests),
+      },
+      llmCircuit: {
+        open: Boolean(circuit.open),
+        recentErrorCount: typeof circuit.recent_error_count === 'number' ? circuit.recent_error_count : 0,
+        maxErrors: typeof circuit.max_errors === 'number' ? circuit.max_errors : 0,
+        windowSeconds: typeof circuit.window_seconds === 'number' ? circuit.window_seconds : 0,
+        cooldownSeconds,
+        cooldownRemainingSeconds,
+        openDurationSeconds,
+      },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Torghut status request failed'
+    return jsonResponse({ ok: false, message }, 503)
+  }
+}

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -20,34 +20,20 @@ class Settings(BaseSettings):
         description="PostgreSQL connection string.",
     )
     apca_api_key_id: Optional[str] = Field(default=None, alias="APCA_API_KEY_ID")
-    apca_api_secret_key: Optional[str] = Field(
-        default=None, alias="APCA_API_SECRET_KEY"
-    )
+    apca_api_secret_key: Optional[str] = Field(default=None, alias="APCA_API_SECRET_KEY")
     apca_api_base_url: Optional[str] = Field(default=None, alias="APCA_API_BASE_URL")
-    apca_data_api_base_url: Optional[str] = Field(
-        default=None, alias="APCA_DATA_API_BASE_URL"
-    )
+    apca_data_api_base_url: Optional[str] = Field(default=None, alias="APCA_DATA_API_BASE_URL")
 
     trading_enabled: bool = Field(default=False, alias="TRADING_ENABLED")
-    trading_mode: Literal["paper", "live"] = Field(
-        default="paper", alias="TRADING_MODE"
-    )
+    trading_mode: Literal["paper", "live"] = Field(default="paper", alias="TRADING_MODE")
     trading_live_enabled: bool = Field(default=False, alias="TRADING_LIVE_ENABLED")
-    trading_signal_source: Literal["clickhouse"] = Field(
-        default="clickhouse", alias="TRADING_SIGNAL_SOURCE"
-    )
-    trading_signal_table: str = Field(
-        default="torghut.ta_signals", alias="TRADING_SIGNAL_TABLE"
-    )
+    trading_signal_source: Literal["clickhouse"] = Field(default="clickhouse", alias="TRADING_SIGNAL_SOURCE")
+    trading_signal_table: str = Field(default="torghut.ta_signals", alias="TRADING_SIGNAL_TABLE")
     trading_signal_schema: Literal["auto", "envelope", "flat"] = Field(
         default="auto", alias="TRADING_SIGNAL_SCHEMA"
     )
-    trading_signal_batch_size: int = Field(
-        default=500, alias="TRADING_SIGNAL_BATCH_SIZE"
-    )
-    trading_signal_lookback_minutes: int = Field(
-        default=15, alias="TRADING_SIGNAL_LOOKBACK_MINUTES"
-    )
+    trading_signal_batch_size: int = Field(default=500, alias="TRADING_SIGNAL_BATCH_SIZE")
+    trading_signal_lookback_minutes: int = Field(default=15, alias="TRADING_SIGNAL_LOOKBACK_MINUTES")
     trading_signal_empty_batch_advance_seconds: int = Field(
         default=60,
         alias="TRADING_SIGNAL_EMPTY_BATCH_ADVANCE_SECONDS",
@@ -63,17 +49,11 @@ class Settings(BaseSettings):
         alias="TRADING_SIGNAL_STALE_LAG_ALERT_SECONDS",
         description="Signal lag threshold (seconds) that triggers a source continuity alert.",
     )
-    trading_price_table: str = Field(
-        default="torghut.ta_microbars", alias="TRADING_PRICE_TABLE"
-    )
-    trading_price_lookback_minutes: int = Field(
-        default=5, alias="TRADING_PRICE_LOOKBACK_MINUTES"
-    )
+    trading_price_table: str = Field(default="torghut.ta_microbars", alias="TRADING_PRICE_TABLE")
+    trading_price_lookback_minutes: int = Field(default=5, alias="TRADING_PRICE_LOOKBACK_MINUTES")
     trading_poll_ms: int = Field(default=5000, alias="TRADING_POLL_MS")
     trading_reconcile_ms: int = Field(default=15000, alias="TRADING_RECONCILE_MS")
-    trading_order_feed_enabled: bool = Field(
-        default=False, alias="TRADING_ORDER_FEED_ENABLED"
-    )
+    trading_order_feed_enabled: bool = Field(default=False, alias="TRADING_ORDER_FEED_ENABLED")
     trading_order_feed_bootstrap_servers: Optional[str] = Field(
         default=None,
         alias="TRADING_ORDER_FEED_BOOTSTRAP_SERVERS",
@@ -124,15 +104,13 @@ class Settings(BaseSettings):
         alias="TRADING_STRATEGY_RELOAD_SECONDS",
         description="Seconds between strategy catalog reload checks.",
     )
-    trading_strategy_runtime_mode: Literal["legacy", "plugin_v3", "scheduler_v3"] = (
-        Field(
-            default="legacy",
-            alias="TRADING_STRATEGY_RUNTIME_MODE",
-            description=(
-                "Strategy runtime mode. legacy keeps current behavior; plugin_v3 enables plugin scaffolding; "
-                "scheduler_v3 enables scheduler integration behind migration flag."
-            ),
-        )
+    trading_strategy_runtime_mode: Literal["legacy", "plugin_v3", "scheduler_v3"] = Field(
+        default="legacy",
+        alias="TRADING_STRATEGY_RUNTIME_MODE",
+        description=(
+            "Strategy runtime mode. legacy keeps current behavior; plugin_v3 enables plugin scaffolding; "
+            "scheduler_v3 enables scheduler integration behind migration flag."
+        ),
     )
     trading_strategy_scheduler_enabled: bool = Field(
         default=False,
@@ -184,9 +162,7 @@ class Settings(BaseSettings):
         alias="TRADING_FEATURE_MAX_DUPLICATE_RATIO",
         description="Maximum duplicate event ratio per ingest batch.",
     )
-    trading_autonomy_enabled: bool = Field(
-        default=False, alias="TRADING_AUTONOMY_ENABLED"
-    )
+    trading_autonomy_enabled: bool = Field(default=False, alias="TRADING_AUTONOMY_ENABLED")
     trading_autonomy_allow_live_promotion: bool = Field(
         default=False,
         alias="TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION",
@@ -202,9 +178,7 @@ class Settings(BaseSettings):
         alias="TRADING_AUTONOMY_GATE_POLICY_PATH",
         description="Optional path to v3 autonomous gate policy config JSON.",
     )
-    trading_autonomy_interval_seconds: int = Field(
-        default=300, alias="TRADING_AUTONOMY_INTERVAL_SECONDS"
-    )
+    trading_autonomy_interval_seconds: int = Field(default=300, alias="TRADING_AUTONOMY_INTERVAL_SECONDS")
     trading_autonomy_signal_lookback_minutes: int = Field(
         default=15,
         alias="TRADING_AUTONOMY_SIGNAL_LOOKBACK_MINUTES",
@@ -262,12 +236,8 @@ class Settings(BaseSettings):
     trading_max_participation_rate: Optional[float] = Field(
         default=None, alias="TRADING_MAX_PARTICIPATION_RATE"
     )
-    trading_execution_prefer_limit: bool = Field(
-        default=True, alias="TRADING_EXECUTION_PREFER_LIMIT"
-    )
-    trading_execution_max_retries: int = Field(
-        default=0, alias="TRADING_EXECUTION_MAX_RETRIES"
-    )
+    trading_execution_prefer_limit: bool = Field(default=True, alias="TRADING_EXECUTION_PREFER_LIMIT")
+    trading_execution_max_retries: int = Field(default=0, alias="TRADING_EXECUTION_MAX_RETRIES")
     trading_execution_backoff_base_seconds: float = Field(
         default=0.25, alias="TRADING_EXECUTION_BACKOFF_BASE_SECONDS"
     )
@@ -419,21 +389,13 @@ class Settings(BaseSettings):
         alias="TRADING_MARKET_CONTEXT_MAX_STALENESS_SECONDS",
         description="Maximum accepted market-context staleness.",
     )
-    trading_clickhouse_url: Optional[str] = Field(
-        default=None, alias="TA_CLICKHOUSE_URL"
-    )
-    trading_clickhouse_username: Optional[str] = Field(
-        default=None, alias="TA_CLICKHOUSE_USERNAME"
-    )
-    trading_clickhouse_password: Optional[str] = Field(
-        default=None, alias="TA_CLICKHOUSE_PASSWORD"
-    )
+    trading_clickhouse_url: Optional[str] = Field(default=None, alias="TA_CLICKHOUSE_URL")
+    trading_clickhouse_username: Optional[str] = Field(default=None, alias="TA_CLICKHOUSE_USERNAME")
+    trading_clickhouse_password: Optional[str] = Field(default=None, alias="TA_CLICKHOUSE_PASSWORD")
     trading_clickhouse_timeout_seconds: int = Field(
         default=5,
         alias="TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS",
-        validation_alias=AliasChoices(
-            "TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS", "CLICKHOUSE_TIMEOUT_SECONDS"
-        ),
+        validation_alias=AliasChoices("TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS", "CLICKHOUSE_TIMEOUT_SECONDS"),
     )
 
     # Jangar gateway (recommended for LLM calls in-cluster).
@@ -441,27 +403,13 @@ class Settings(BaseSettings):
     jangar_api_key: Optional[str] = Field(default=None, alias="JANGAR_API_KEY")
 
     llm_enabled: bool = Field(default=False, alias="LLM_ENABLED")
-    llm_rollout_stage: Literal[
-        "stage0_baseline",
-        "stage1_shadow_pilot",
-        "stage2_paper_advisory",
-        "stage3_controlled_live",
-    ] = Field(default="stage3_controlled_live", alias="LLM_ROLLOUT_STAGE")
-    llm_provider: Literal["jangar", "openai"] = Field(
-        default="openai", alias="LLM_PROVIDER"
-    )
+    llm_provider: Literal["jangar", "openai"] = Field(default="openai", alias="LLM_PROVIDER")
     llm_model: str = Field(default="gpt-5.3-codex", alias="LLM_MODEL")
     # Used only when `LLM_PROVIDER=jangar` and the Jangar request fails.
     # This should point at an OpenAI-compatible endpoint (e.g. vLLM, Ollama, llama.cpp server).
-    llm_self_hosted_base_url: Optional[str] = Field(
-        default=None, alias="LLM_SELF_HOSTED_BASE_URL"
-    )
-    llm_self_hosted_api_key: Optional[str] = Field(
-        default=None, alias="LLM_SELF_HOSTED_API_KEY"
-    )
-    llm_self_hosted_model: Optional[str] = Field(
-        default=None, alias="LLM_SELF_HOSTED_MODEL"
-    )
+    llm_self_hosted_base_url: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_BASE_URL")
+    llm_self_hosted_api_key: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_API_KEY")
+    llm_self_hosted_model: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_MODEL")
     llm_prompt_version: str = Field(default="v1", alias="LLM_PROMPT_VERSION")
     llm_temperature: float = Field(default=0.2, alias="LLM_TEMPERATURE")
     llm_max_tokens: int = Field(default=300, alias="LLM_MAX_TOKENS")
@@ -469,49 +417,30 @@ class Settings(BaseSettings):
     llm_jangar_bespoke_decision_enabled: bool = Field(
         default=False, alias="LLM_JANGAR_BESPOKE_DECISION_ENABLED"
     )
-    llm_jangar_bespoke_timeout_seconds: int = Field(
-        default=75, alias="LLM_JANGAR_BESPOKE_TIMEOUT_SECONDS"
-    )
-    llm_jangar_bespoke_max_retries: int = Field(
-        default=1, alias="LLM_JANGAR_BESPOKE_MAX_RETRIES"
-    )
+    llm_jangar_bespoke_timeout_seconds: int = Field(default=75, alias="LLM_JANGAR_BESPOKE_TIMEOUT_SECONDS")
+    llm_jangar_bespoke_max_retries: int = Field(default=1, alias="LLM_JANGAR_BESPOKE_MAX_RETRIES")
     llm_jangar_bespoke_retry_backoff_seconds: float = Field(
         default=0.5, alias="LLM_JANGAR_BESPOKE_RETRY_BACKOFF_SECONDS"
     )
-    llm_fail_mode: Literal["veto", "pass_through"] = Field(
-        default="veto", alias="LLM_FAIL_MODE"
-    )
+    llm_fail_mode: Literal["veto", "pass_through"] = Field(default="veto", alias="LLM_FAIL_MODE")
     llm_min_confidence: float = Field(default=0.5, alias="LLM_MIN_CONFIDENCE")
     llm_adjustment_allowed: bool = Field(default=False, alias="LLM_ADJUSTMENT_ALLOWED")
     llm_max_qty_multiplier: float = Field(default=1.25, alias="LLM_MAX_QTY_MULTIPLIER")
     llm_min_qty_multiplier: float = Field(default=0.5, alias="LLM_MIN_QTY_MULTIPLIER")
     llm_shadow_mode: bool = Field(default=False, alias="LLM_SHADOW_MODE")
+    llm_rollout_stage: Literal["stage0", "stage1", "stage2", "stage3"] = Field(default="stage3", alias="LLM_ROLLOUT_STAGE")
     llm_recent_decisions: int = Field(default=5, alias="LLM_RECENT_DECISIONS")
     llm_circuit_max_errors: int = Field(default=3, alias="LLM_CIRCUIT_MAX_ERRORS")
-    llm_circuit_window_seconds: int = Field(
-        default=300, alias="LLM_CIRCUIT_WINDOW_SECONDS"
-    )
-    llm_circuit_cooldown_seconds: int = Field(
-        default=600, alias="LLM_CIRCUIT_COOLDOWN_SECONDS"
-    )
-    llm_allowed_models_raw: Optional[str] = Field(
-        default=None, alias="LLM_ALLOWED_MODELS"
-    )
-    llm_evaluation_report: Optional[str] = Field(
-        default=None, alias="LLM_EVALUATION_REPORT"
-    )
-    llm_effective_challenge_id: Optional[str] = Field(
-        default=None, alias="LLM_EFFECTIVE_CHALLENGE_ID"
-    )
-    llm_shadow_completed_at: Optional[str] = Field(
-        default=None, alias="LLM_SHADOW_COMPLETED_AT"
-    )
-    llm_model_version_lock: Optional[str] = Field(
-        default=None, alias="LLM_MODEL_VERSION_LOCK"
-    )
-    llm_adjustment_approved: bool = Field(
-        default=False, alias="LLM_ADJUSTMENT_APPROVED"
-    )
+    llm_circuit_window_seconds: int = Field(default=300, alias="LLM_CIRCUIT_WINDOW_SECONDS")
+    llm_circuit_cooldown_seconds: int = Field(default=600, alias="LLM_CIRCUIT_COOLDOWN_SECONDS")
+    llm_token_budget_max: int = Field(default=1200, alias="LLM_TOKEN_BUDGET_MAX")
+    llm_allowed_prompt_versions_raw: Optional[str] = Field(default=None, alias="LLM_ALLOWED_PROMPT_VERSIONS")
+    llm_allowed_models_raw: Optional[str] = Field(default=None, alias="LLM_ALLOWED_MODELS")
+    llm_evaluation_report: Optional[str] = Field(default=None, alias="LLM_EVALUATION_REPORT")
+    llm_effective_challenge_id: Optional[str] = Field(default=None, alias="LLM_EFFECTIVE_CHALLENGE_ID")
+    llm_shadow_completed_at: Optional[str] = Field(default=None, alias="LLM_SHADOW_COMPLETED_AT")
+    llm_model_version_lock: Optional[str] = Field(default=None, alias="LLM_MODEL_VERSION_LOCK")
+    llm_adjustment_approved: bool = Field(default=False, alias="LLM_ADJUSTMENT_APPROVED")
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -526,24 +455,14 @@ class Settings(BaseSettings):
         if self.jangar_base_url:
             self.jangar_base_url = self.jangar_base_url.strip().rstrip("/")
         if self.trading_market_context_url:
-            self.trading_market_context_url = (
-                self.trading_market_context_url.strip().rstrip("/")
-            )
+            self.trading_market_context_url = self.trading_market_context_url.strip().rstrip("/")
         if self.llm_self_hosted_base_url:
-            self.llm_self_hosted_base_url = (
-                self.llm_self_hosted_base_url.strip().rstrip("/")
-            )
+            self.llm_self_hosted_base_url = self.llm_self_hosted_base_url.strip().rstrip("/")
         if self.trading_lean_runner_url:
-            self.trading_lean_runner_url = self.trading_lean_runner_url.strip().rstrip(
-                "/"
-            )
+            self.trading_lean_runner_url = self.trading_lean_runner_url.strip().rstrip("/")
         if self.trading_execution_adapter_symbols_raw:
             self.trading_execution_adapter_symbols_raw = ",".join(
-                [
-                    item.strip()
-                    for item in self.trading_execution_adapter_symbols_raw.split(",")
-                    if item.strip()
-                ]
+                [item.strip() for item in self.trading_execution_adapter_symbols_raw.split(",") if item.strip()]
             )
         if self.trading_autonomy_approval_token:
             self.trading_autonomy_approval_token = (
@@ -564,11 +483,11 @@ class Settings(BaseSettings):
             self.llm_provider = "jangar"
         if self.llm_allowed_models_raw:
             self.llm_allowed_models_raw = ",".join(
-                [
-                    item.strip()
-                    for item in self.llm_allowed_models_raw.split(",")
-                    if item.strip()
-                ]
+                [item.strip() for item in self.llm_allowed_models_raw.split(",") if item.strip()]
+            )
+        if self.llm_allowed_prompt_versions_raw:
+            self.llm_allowed_prompt_versions_raw = ",".join(
+                [item.strip() for item in self.llm_allowed_prompt_versions_raw.split(",") if item.strip()]
             )
         if self.llm_evaluation_report:
             self.llm_evaluation_report = self.llm_evaluation_report.strip()
@@ -578,8 +497,6 @@ class Settings(BaseSettings):
             self.llm_shadow_completed_at = self.llm_shadow_completed_at.strip()
         if self.llm_model_version_lock:
             self.llm_model_version_lock = self.llm_model_version_lock.strip()
-        if not self.llm_model_version_lock:
-            self.llm_model_version_lock = self.llm_model
 
     @property
     def sqlalchemy_dsn(self) -> str:
@@ -600,11 +517,7 @@ class Settings(BaseSettings):
     def trading_static_symbols(self) -> List[str]:
         if not self.trading_static_symbols_raw:
             return []
-        return [
-            symbol.strip()
-            for symbol in self.trading_static_symbols_raw.split(",")
-            if symbol.strip()
-        ]
+        return [symbol.strip() for symbol in self.trading_static_symbols_raw.split(",") if symbol.strip()]
 
     @property
     def trading_execution_adapter_symbols(self) -> set[str]:
@@ -620,11 +533,13 @@ class Settings(BaseSettings):
     def llm_allowed_models(self) -> set[str]:
         if not self.llm_allowed_models_raw:
             return set()
-        return {
-            model.strip()
-            for model in self.llm_allowed_models_raw.split(",")
-            if model.strip()
-        }
+        return {model.strip() for model in self.llm_allowed_models_raw.split(",") if model.strip()}
+
+    @property
+    def llm_allowed_prompt_versions(self) -> set[str]:
+        if not self.llm_allowed_prompt_versions_raw:
+            return set()
+        return {version.strip() for version in self.llm_allowed_prompt_versions_raw.split(",") if version.strip()}
 
 
 @lru_cache(maxsize=1)

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -504,8 +504,10 @@ class Settings(BaseSettings):
             self.llm_effective_challenge_id = self.llm_effective_challenge_id.strip()
         if self.llm_shadow_completed_at:
             self.llm_shadow_completed_at = self.llm_shadow_completed_at.strip()
-        if self.llm_model_version_lock:
-            self.llm_model_version_lock = self.llm_model_version_lock.strip()
+        if self.llm_model_version_lock is not None:
+            normalized_model_version_lock = self.llm_model_version_lock.strip()
+            # Model lock evidence must be explicitly configured; never backfill from llm_model.
+            self.llm_model_version_lock = normalized_model_version_lock or None
 
     @property
     def sqlalchemy_dsn(self) -> str:

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -428,7 +428,16 @@ class Settings(BaseSettings):
     llm_max_qty_multiplier: float = Field(default=1.25, alias="LLM_MAX_QTY_MULTIPLIER")
     llm_min_qty_multiplier: float = Field(default=0.5, alias="LLM_MIN_QTY_MULTIPLIER")
     llm_shadow_mode: bool = Field(default=False, alias="LLM_SHADOW_MODE")
-    llm_rollout_stage: Literal["stage0", "stage1", "stage2", "stage3"] = Field(default="stage3", alias="LLM_ROLLOUT_STAGE")
+    llm_rollout_stage: Literal[
+        "stage0",
+        "stage1",
+        "stage2",
+        "stage3",
+        "stage0_baseline",
+        "stage1_shadow_pilot",
+        "stage2_paper_advisory",
+        "stage3_controlled_live",
+    ] = Field(default="stage3", alias="LLM_ROLLOUT_STAGE")
     llm_recent_decisions: int = Field(default=5, alias="LLM_RECENT_DECISIONS")
     llm_circuit_max_errors: int = Field(default=3, alias="LLM_CIRCUIT_MAX_ERRORS")
     llm_circuit_window_seconds: int = Field(default=300, alias="LLM_CIRCUIT_WINDOW_SECONDS")

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -20,20 +20,34 @@ class Settings(BaseSettings):
         description="PostgreSQL connection string.",
     )
     apca_api_key_id: Optional[str] = Field(default=None, alias="APCA_API_KEY_ID")
-    apca_api_secret_key: Optional[str] = Field(default=None, alias="APCA_API_SECRET_KEY")
+    apca_api_secret_key: Optional[str] = Field(
+        default=None, alias="APCA_API_SECRET_KEY"
+    )
     apca_api_base_url: Optional[str] = Field(default=None, alias="APCA_API_BASE_URL")
-    apca_data_api_base_url: Optional[str] = Field(default=None, alias="APCA_DATA_API_BASE_URL")
+    apca_data_api_base_url: Optional[str] = Field(
+        default=None, alias="APCA_DATA_API_BASE_URL"
+    )
 
     trading_enabled: bool = Field(default=False, alias="TRADING_ENABLED")
-    trading_mode: Literal["paper", "live"] = Field(default="paper", alias="TRADING_MODE")
+    trading_mode: Literal["paper", "live"] = Field(
+        default="paper", alias="TRADING_MODE"
+    )
     trading_live_enabled: bool = Field(default=False, alias="TRADING_LIVE_ENABLED")
-    trading_signal_source: Literal["clickhouse"] = Field(default="clickhouse", alias="TRADING_SIGNAL_SOURCE")
-    trading_signal_table: str = Field(default="torghut.ta_signals", alias="TRADING_SIGNAL_TABLE")
+    trading_signal_source: Literal["clickhouse"] = Field(
+        default="clickhouse", alias="TRADING_SIGNAL_SOURCE"
+    )
+    trading_signal_table: str = Field(
+        default="torghut.ta_signals", alias="TRADING_SIGNAL_TABLE"
+    )
     trading_signal_schema: Literal["auto", "envelope", "flat"] = Field(
         default="auto", alias="TRADING_SIGNAL_SCHEMA"
     )
-    trading_signal_batch_size: int = Field(default=500, alias="TRADING_SIGNAL_BATCH_SIZE")
-    trading_signal_lookback_minutes: int = Field(default=15, alias="TRADING_SIGNAL_LOOKBACK_MINUTES")
+    trading_signal_batch_size: int = Field(
+        default=500, alias="TRADING_SIGNAL_BATCH_SIZE"
+    )
+    trading_signal_lookback_minutes: int = Field(
+        default=15, alias="TRADING_SIGNAL_LOOKBACK_MINUTES"
+    )
     trading_signal_empty_batch_advance_seconds: int = Field(
         default=60,
         alias="TRADING_SIGNAL_EMPTY_BATCH_ADVANCE_SECONDS",
@@ -49,11 +63,17 @@ class Settings(BaseSettings):
         alias="TRADING_SIGNAL_STALE_LAG_ALERT_SECONDS",
         description="Signal lag threshold (seconds) that triggers a source continuity alert.",
     )
-    trading_price_table: str = Field(default="torghut.ta_microbars", alias="TRADING_PRICE_TABLE")
-    trading_price_lookback_minutes: int = Field(default=5, alias="TRADING_PRICE_LOOKBACK_MINUTES")
+    trading_price_table: str = Field(
+        default="torghut.ta_microbars", alias="TRADING_PRICE_TABLE"
+    )
+    trading_price_lookback_minutes: int = Field(
+        default=5, alias="TRADING_PRICE_LOOKBACK_MINUTES"
+    )
     trading_poll_ms: int = Field(default=5000, alias="TRADING_POLL_MS")
     trading_reconcile_ms: int = Field(default=15000, alias="TRADING_RECONCILE_MS")
-    trading_order_feed_enabled: bool = Field(default=False, alias="TRADING_ORDER_FEED_ENABLED")
+    trading_order_feed_enabled: bool = Field(
+        default=False, alias="TRADING_ORDER_FEED_ENABLED"
+    )
     trading_order_feed_bootstrap_servers: Optional[str] = Field(
         default=None,
         alias="TRADING_ORDER_FEED_BOOTSTRAP_SERVERS",
@@ -104,13 +124,15 @@ class Settings(BaseSettings):
         alias="TRADING_STRATEGY_RELOAD_SECONDS",
         description="Seconds between strategy catalog reload checks.",
     )
-    trading_strategy_runtime_mode: Literal["legacy", "plugin_v3", "scheduler_v3"] = Field(
-        default="legacy",
-        alias="TRADING_STRATEGY_RUNTIME_MODE",
-        description=(
-            "Strategy runtime mode. legacy keeps current behavior; plugin_v3 enables plugin scaffolding; "
-            "scheduler_v3 enables scheduler integration behind migration flag."
-        ),
+    trading_strategy_runtime_mode: Literal["legacy", "plugin_v3", "scheduler_v3"] = (
+        Field(
+            default="legacy",
+            alias="TRADING_STRATEGY_RUNTIME_MODE",
+            description=(
+                "Strategy runtime mode. legacy keeps current behavior; plugin_v3 enables plugin scaffolding; "
+                "scheduler_v3 enables scheduler integration behind migration flag."
+            ),
+        )
     )
     trading_strategy_scheduler_enabled: bool = Field(
         default=False,
@@ -162,7 +184,9 @@ class Settings(BaseSettings):
         alias="TRADING_FEATURE_MAX_DUPLICATE_RATIO",
         description="Maximum duplicate event ratio per ingest batch.",
     )
-    trading_autonomy_enabled: bool = Field(default=False, alias="TRADING_AUTONOMY_ENABLED")
+    trading_autonomy_enabled: bool = Field(
+        default=False, alias="TRADING_AUTONOMY_ENABLED"
+    )
     trading_autonomy_allow_live_promotion: bool = Field(
         default=False,
         alias="TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION",
@@ -178,7 +202,9 @@ class Settings(BaseSettings):
         alias="TRADING_AUTONOMY_GATE_POLICY_PATH",
         description="Optional path to v3 autonomous gate policy config JSON.",
     )
-    trading_autonomy_interval_seconds: int = Field(default=300, alias="TRADING_AUTONOMY_INTERVAL_SECONDS")
+    trading_autonomy_interval_seconds: int = Field(
+        default=300, alias="TRADING_AUTONOMY_INTERVAL_SECONDS"
+    )
     trading_autonomy_signal_lookback_minutes: int = Field(
         default=15,
         alias="TRADING_AUTONOMY_SIGNAL_LOOKBACK_MINUTES",
@@ -217,9 +243,15 @@ class Settings(BaseSettings):
         alias="TRADING_UNIVERSE_MAX_STALE_SECONDS",
         description="Maximum age for cached Jangar symbol universe before it is treated as stale.",
     )
-    trading_static_symbols_raw: Optional[str] = Field(default=None, alias="TRADING_STATIC_SYMBOLS")
-    trading_universe_cache_seconds: int = Field(default=300, alias="TRADING_UNIVERSE_CACHE_SECONDS")
-    trading_universe_timeout_seconds: int = Field(default=5, alias="TRADING_UNIVERSE_TIMEOUT_SECONDS")
+    trading_static_symbols_raw: Optional[str] = Field(
+        default=None, alias="TRADING_STATIC_SYMBOLS"
+    )
+    trading_universe_cache_seconds: int = Field(
+        default=300, alias="TRADING_UNIVERSE_CACHE_SECONDS"
+    )
+    trading_universe_timeout_seconds: int = Field(
+        default=5, alias="TRADING_UNIVERSE_TIMEOUT_SECONDS"
+    )
     trading_default_qty: int = Field(default=1, alias="TRADING_DEFAULT_QTY")
     trading_max_notional_per_trade: Optional[float] = Field(
         default=None, alias="TRADING_MAX_NOTIONAL_PER_TRADE"
@@ -230,8 +262,12 @@ class Settings(BaseSettings):
     trading_max_participation_rate: Optional[float] = Field(
         default=None, alias="TRADING_MAX_PARTICIPATION_RATE"
     )
-    trading_execution_prefer_limit: bool = Field(default=True, alias="TRADING_EXECUTION_PREFER_LIMIT")
-    trading_execution_max_retries: int = Field(default=0, alias="TRADING_EXECUTION_MAX_RETRIES")
+    trading_execution_prefer_limit: bool = Field(
+        default=True, alias="TRADING_EXECUTION_PREFER_LIMIT"
+    )
+    trading_execution_max_retries: int = Field(
+        default=0, alias="TRADING_EXECUTION_MAX_RETRIES"
+    )
     trading_execution_backoff_base_seconds: float = Field(
         default=0.25, alias="TRADING_EXECUTION_BACKOFF_BASE_SECONDS"
     )
@@ -322,7 +358,9 @@ class Settings(BaseSettings):
     trading_cooldown_seconds: int = Field(default=0, alias="TRADING_COOLDOWN_SECONDS")
     trading_allow_shorts: bool = Field(default=False, alias="TRADING_ALLOW_SHORTS")
     trading_account_label: str = Field(default="paper", alias="TRADING_ACCOUNT_LABEL")
-    trading_kill_switch_enabled: bool = Field(default=True, alias="TRADING_KILL_SWITCH_ENABLED")
+    trading_kill_switch_enabled: bool = Field(
+        default=True, alias="TRADING_KILL_SWITCH_ENABLED"
+    )
     trading_emergency_stop_enabled: bool = Field(
         default=True,
         alias="TRADING_EMERGENCY_STOP_ENABLED",
@@ -348,7 +386,9 @@ class Settings(BaseSettings):
         alias="TRADING_ROLLBACK_MAX_DRAWDOWN_LIMIT",
         description="Absolute drawdown threshold from autonomous gate artifacts that triggers emergency stop.",
     )
-    trading_jangar_symbols_url: Optional[str] = Field(default=None, alias="JANGAR_SYMBOLS_URL")
+    trading_jangar_symbols_url: Optional[str] = Field(
+        default=None, alias="JANGAR_SYMBOLS_URL"
+    )
     trading_market_context_url: Optional[str] = Field(
         default=None,
         alias="TRADING_MARKET_CONTEXT_URL",
@@ -379,13 +419,21 @@ class Settings(BaseSettings):
         alias="TRADING_MARKET_CONTEXT_MAX_STALENESS_SECONDS",
         description="Maximum accepted market-context staleness.",
     )
-    trading_clickhouse_url: Optional[str] = Field(default=None, alias="TA_CLICKHOUSE_URL")
-    trading_clickhouse_username: Optional[str] = Field(default=None, alias="TA_CLICKHOUSE_USERNAME")
-    trading_clickhouse_password: Optional[str] = Field(default=None, alias="TA_CLICKHOUSE_PASSWORD")
+    trading_clickhouse_url: Optional[str] = Field(
+        default=None, alias="TA_CLICKHOUSE_URL"
+    )
+    trading_clickhouse_username: Optional[str] = Field(
+        default=None, alias="TA_CLICKHOUSE_USERNAME"
+    )
+    trading_clickhouse_password: Optional[str] = Field(
+        default=None, alias="TA_CLICKHOUSE_PASSWORD"
+    )
     trading_clickhouse_timeout_seconds: int = Field(
         default=5,
         alias="TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS",
-        validation_alias=AliasChoices("TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS", "CLICKHOUSE_TIMEOUT_SECONDS"),
+        validation_alias=AliasChoices(
+            "TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS", "CLICKHOUSE_TIMEOUT_SECONDS"
+        ),
     )
 
     # Jangar gateway (recommended for LLM calls in-cluster).
@@ -393,13 +441,27 @@ class Settings(BaseSettings):
     jangar_api_key: Optional[str] = Field(default=None, alias="JANGAR_API_KEY")
 
     llm_enabled: bool = Field(default=False, alias="LLM_ENABLED")
-    llm_provider: Literal["jangar", "openai"] = Field(default="openai", alias="LLM_PROVIDER")
+    llm_rollout_stage: Literal[
+        "stage0_baseline",
+        "stage1_shadow_pilot",
+        "stage2_paper_advisory",
+        "stage3_controlled_live",
+    ] = Field(default="stage3_controlled_live", alias="LLM_ROLLOUT_STAGE")
+    llm_provider: Literal["jangar", "openai"] = Field(
+        default="openai", alias="LLM_PROVIDER"
+    )
     llm_model: str = Field(default="gpt-5.3-codex", alias="LLM_MODEL")
     # Used only when `LLM_PROVIDER=jangar` and the Jangar request fails.
     # This should point at an OpenAI-compatible endpoint (e.g. vLLM, Ollama, llama.cpp server).
-    llm_self_hosted_base_url: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_BASE_URL")
-    llm_self_hosted_api_key: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_API_KEY")
-    llm_self_hosted_model: Optional[str] = Field(default=None, alias="LLM_SELF_HOSTED_MODEL")
+    llm_self_hosted_base_url: Optional[str] = Field(
+        default=None, alias="LLM_SELF_HOSTED_BASE_URL"
+    )
+    llm_self_hosted_api_key: Optional[str] = Field(
+        default=None, alias="LLM_SELF_HOSTED_API_KEY"
+    )
+    llm_self_hosted_model: Optional[str] = Field(
+        default=None, alias="LLM_SELF_HOSTED_MODEL"
+    )
     llm_prompt_version: str = Field(default="v1", alias="LLM_PROMPT_VERSION")
     llm_temperature: float = Field(default=0.2, alias="LLM_TEMPERATURE")
     llm_max_tokens: int = Field(default=300, alias="LLM_MAX_TOKENS")
@@ -407,12 +469,18 @@ class Settings(BaseSettings):
     llm_jangar_bespoke_decision_enabled: bool = Field(
         default=False, alias="LLM_JANGAR_BESPOKE_DECISION_ENABLED"
     )
-    llm_jangar_bespoke_timeout_seconds: int = Field(default=75, alias="LLM_JANGAR_BESPOKE_TIMEOUT_SECONDS")
-    llm_jangar_bespoke_max_retries: int = Field(default=1, alias="LLM_JANGAR_BESPOKE_MAX_RETRIES")
+    llm_jangar_bespoke_timeout_seconds: int = Field(
+        default=75, alias="LLM_JANGAR_BESPOKE_TIMEOUT_SECONDS"
+    )
+    llm_jangar_bespoke_max_retries: int = Field(
+        default=1, alias="LLM_JANGAR_BESPOKE_MAX_RETRIES"
+    )
     llm_jangar_bespoke_retry_backoff_seconds: float = Field(
         default=0.5, alias="LLM_JANGAR_BESPOKE_RETRY_BACKOFF_SECONDS"
     )
-    llm_fail_mode: Literal["veto", "pass_through"] = Field(default="veto", alias="LLM_FAIL_MODE")
+    llm_fail_mode: Literal["veto", "pass_through"] = Field(
+        default="veto", alias="LLM_FAIL_MODE"
+    )
     llm_min_confidence: float = Field(default=0.5, alias="LLM_MIN_CONFIDENCE")
     llm_adjustment_allowed: bool = Field(default=False, alias="LLM_ADJUSTMENT_ALLOWED")
     llm_max_qty_multiplier: float = Field(default=1.25, alias="LLM_MAX_QTY_MULTIPLIER")
@@ -420,13 +488,30 @@ class Settings(BaseSettings):
     llm_shadow_mode: bool = Field(default=False, alias="LLM_SHADOW_MODE")
     llm_recent_decisions: int = Field(default=5, alias="LLM_RECENT_DECISIONS")
     llm_circuit_max_errors: int = Field(default=3, alias="LLM_CIRCUIT_MAX_ERRORS")
-    llm_circuit_window_seconds: int = Field(default=300, alias="LLM_CIRCUIT_WINDOW_SECONDS")
-    llm_circuit_cooldown_seconds: int = Field(default=600, alias="LLM_CIRCUIT_COOLDOWN_SECONDS")
-    llm_allowed_models_raw: Optional[str] = Field(default=None, alias="LLM_ALLOWED_MODELS")
-    llm_evaluation_report: Optional[str] = Field(default=None, alias="LLM_EVALUATION_REPORT")
-    llm_effective_challenge_id: Optional[str] = Field(default=None, alias="LLM_EFFECTIVE_CHALLENGE_ID")
-    llm_shadow_completed_at: Optional[str] = Field(default=None, alias="LLM_SHADOW_COMPLETED_AT")
-    llm_adjustment_approved: bool = Field(default=False, alias="LLM_ADJUSTMENT_APPROVED")
+    llm_circuit_window_seconds: int = Field(
+        default=300, alias="LLM_CIRCUIT_WINDOW_SECONDS"
+    )
+    llm_circuit_cooldown_seconds: int = Field(
+        default=600, alias="LLM_CIRCUIT_COOLDOWN_SECONDS"
+    )
+    llm_allowed_models_raw: Optional[str] = Field(
+        default=None, alias="LLM_ALLOWED_MODELS"
+    )
+    llm_evaluation_report: Optional[str] = Field(
+        default=None, alias="LLM_EVALUATION_REPORT"
+    )
+    llm_effective_challenge_id: Optional[str] = Field(
+        default=None, alias="LLM_EFFECTIVE_CHALLENGE_ID"
+    )
+    llm_shadow_completed_at: Optional[str] = Field(
+        default=None, alias="LLM_SHADOW_COMPLETED_AT"
+    )
+    llm_model_version_lock: Optional[str] = Field(
+        default=None, alias="LLM_MODEL_VERSION_LOCK"
+    )
+    llm_adjustment_approved: bool = Field(
+        default=False, alias="LLM_ADJUSTMENT_APPROVED"
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -441,27 +526,49 @@ class Settings(BaseSettings):
         if self.jangar_base_url:
             self.jangar_base_url = self.jangar_base_url.strip().rstrip("/")
         if self.trading_market_context_url:
-            self.trading_market_context_url = self.trading_market_context_url.strip().rstrip("/")
+            self.trading_market_context_url = (
+                self.trading_market_context_url.strip().rstrip("/")
+            )
         if self.llm_self_hosted_base_url:
-            self.llm_self_hosted_base_url = self.llm_self_hosted_base_url.strip().rstrip("/")
+            self.llm_self_hosted_base_url = (
+                self.llm_self_hosted_base_url.strip().rstrip("/")
+            )
         if self.trading_lean_runner_url:
-            self.trading_lean_runner_url = self.trading_lean_runner_url.strip().rstrip("/")
+            self.trading_lean_runner_url = self.trading_lean_runner_url.strip().rstrip(
+                "/"
+            )
         if self.trading_execution_adapter_symbols_raw:
             self.trading_execution_adapter_symbols_raw = ",".join(
-                [item.strip() for item in self.trading_execution_adapter_symbols_raw.split(",") if item.strip()]
+                [
+                    item.strip()
+                    for item in self.trading_execution_adapter_symbols_raw.split(",")
+                    if item.strip()
+                ]
             )
         if self.trading_autonomy_approval_token:
-            self.trading_autonomy_approval_token = self.trading_autonomy_approval_token.strip() or None
+            self.trading_autonomy_approval_token = (
+                self.trading_autonomy_approval_token.strip() or None
+            )
         if (
-            (self.trading_enabled or self.trading_autonomy_enabled or self.trading_live_enabled)
+            (
+                self.trading_enabled
+                or self.trading_autonomy_enabled
+                or self.trading_live_enabled
+            )
             and self.trading_universe_source != "jangar"
         ):
-            raise ValueError("TRADING_UNIVERSE_SOURCE must be 'jangar' when trading or autonomy is enabled")
+            raise ValueError(
+                "TRADING_UNIVERSE_SOURCE must be 'jangar' when trading or autonomy is enabled"
+            )
         if "llm_provider" not in self.model_fields_set and self.jangar_base_url:
             self.llm_provider = "jangar"
         if self.llm_allowed_models_raw:
             self.llm_allowed_models_raw = ",".join(
-                [item.strip() for item in self.llm_allowed_models_raw.split(",") if item.strip()]
+                [
+                    item.strip()
+                    for item in self.llm_allowed_models_raw.split(",")
+                    if item.strip()
+                ]
             )
         if self.llm_evaluation_report:
             self.llm_evaluation_report = self.llm_evaluation_report.strip()
@@ -469,6 +576,10 @@ class Settings(BaseSettings):
             self.llm_effective_challenge_id = self.llm_effective_challenge_id.strip()
         if self.llm_shadow_completed_at:
             self.llm_shadow_completed_at = self.llm_shadow_completed_at.strip()
+        if self.llm_model_version_lock:
+            self.llm_model_version_lock = self.llm_model_version_lock.strip()
+        if not self.llm_model_version_lock:
+            self.llm_model_version_lock = self.llm_model
 
     @property
     def sqlalchemy_dsn(self) -> str:
@@ -489,7 +600,11 @@ class Settings(BaseSettings):
     def trading_static_symbols(self) -> List[str]:
         if not self.trading_static_symbols_raw:
             return []
-        return [symbol.strip() for symbol in self.trading_static_symbols_raw.split(",") if symbol.strip()]
+        return [
+            symbol.strip()
+            for symbol in self.trading_static_symbols_raw.split(",")
+            if symbol.strip()
+        ]
 
     @property
     def trading_execution_adapter_symbols(self) -> set[str]:
@@ -505,7 +620,11 @@ class Settings(BaseSettings):
     def llm_allowed_models(self) -> set[str]:
         if not self.llm_allowed_models_raw:
             return set()
-        return {model.strip() for model in self.llm_allowed_models_raw.split(",") if model.strip()}
+        return {
+            model.strip()
+            for model in self.llm_allowed_models_raw.split(",")
+            if model.strip()
+        }
 
 
 @lru_cache(maxsize=1)

--- a/services/torghut/app/trading/llm/circuit.py
+++ b/services/torghut/app/trading/llm/circuit.py
@@ -20,6 +20,7 @@ class LLMCircuitBreaker:
     cooldown_seconds: int
     _errors: list[datetime] = field(default_factory=_error_list)
     _open_until: datetime | None = None
+    _opened_at: datetime | None = None
 
     @classmethod
     def from_settings(cls) -> "LLMCircuitBreaker":
@@ -34,6 +35,8 @@ class LLMCircuitBreaker:
         self._errors.append(now)
         self._prune(now)
         if len(self._errors) >= self.max_errors:
+            if self._open_until is None or now >= self._open_until:
+                self._opened_at = now
             self._open_until = now + timedelta(seconds=self.cooldown_seconds)
 
     def record_success(self) -> None:
@@ -46,6 +49,7 @@ class LLMCircuitBreaker:
             return True
         if self._open_until and now >= self._open_until:
             self._open_until = None
+            self._opened_at = None
         return False
 
     def _prune(self, now: datetime) -> None:
@@ -53,12 +57,25 @@ class LLMCircuitBreaker:
         self._errors = [ts for ts in self._errors if ts >= window_start]
 
     def snapshot(self) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        open_now = self.is_open()
+        cooldown_remaining_seconds = 0
+        if self._open_until and open_now:
+            cooldown_remaining_seconds = max(
+                0, int((self._open_until - now).total_seconds())
+            )
+        open_seconds = 0
+        if self._opened_at and open_now:
+            open_seconds = max(0, int((now - self._opened_at).total_seconds()))
         return {
-            "open": self.is_open(),
+            "open": open_now,
             "open_until": self._open_until,
+            "opened_at": self._opened_at,
             "max_errors": self.max_errors,
             "window_seconds": self.window_seconds,
             "cooldown_seconds": self.cooldown_seconds,
+            "cooldown_remaining_seconds": cooldown_remaining_seconds,
+            "open_seconds": open_seconds,
             "recent_error_count": len(self._errors),
         }
 

--- a/services/torghut/app/trading/llm/guardrails.py
+++ b/services/torghut/app/trading/llm/guardrails.py
@@ -4,14 +4,26 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from ...config import settings
+
+LLMFailMode = Literal["veto", "pass_through"]
+LLMRolloutStage = Literal[
+    "stage0_baseline",
+    "stage1_shadow_pilot",
+    "stage2_paper_advisory",
+    "stage3_controlled_live",
+]
 
 
 @dataclass(frozen=True)
 class LLMRiskGuardrails:
     allow_requests: bool
+    enabled: bool
+    rollout_stage: LLMRolloutStage
     shadow_mode: bool
+    fail_mode: LLMFailMode
     adjustment_allowed: bool
     reasons: tuple[str, ...]
 
@@ -20,9 +32,44 @@ def evaluate_llm_guardrails() -> LLMRiskGuardrails:
     """Evaluate MRM guardrails and return the effective LLM policy surface."""
 
     reasons: list[str] = []
-    allow_requests = True
+    enabled = settings.llm_enabled
+    allow_requests = enabled
+    rollout_stage = settings.llm_rollout_stage
     shadow_mode = settings.llm_shadow_mode
+    fail_mode: LLMFailMode = settings.llm_fail_mode
     adjustment_allowed = settings.llm_adjustment_allowed
+
+    stage_reasons: list[str] = []
+    if rollout_stage == "stage0_baseline":
+        if enabled:
+            stage_reasons.append("llm_stage0_requires_disabled")
+        enabled = False
+        allow_requests = False
+        shadow_mode = True
+        adjustment_allowed = False
+        fail_mode = "veto"
+    elif rollout_stage == "stage1_shadow_pilot":
+        if not enabled:
+            stage_reasons.append("llm_stage1_requires_enabled")
+        shadow_mode = True
+        adjustment_allowed = False
+        expected_fail_mode = (
+            "pass_through" if settings.trading_mode == "paper" else "veto"
+        )
+        if settings.llm_fail_mode != expected_fail_mode:
+            stage_reasons.append("llm_stage1_fail_mode_mismatch")
+        fail_mode = expected_fail_mode
+        allow_requests = enabled
+    elif rollout_stage == "stage2_paper_advisory":
+        expected_fail_mode: LLMFailMode = "pass_through"
+        if settings.llm_fail_mode != expected_fail_mode:
+            stage_reasons.append("llm_stage2_fail_mode_mismatch")
+        fail_mode = expected_fail_mode
+        if settings.trading_mode == "live":
+            stage_reasons.append("llm_stage2_live_requires_shadow")
+            shadow_mode = True
+
+    reasons.extend(stage_reasons)
 
     if not _prompt_template_exists(settings.llm_prompt_version):
         allow_requests = False
@@ -30,7 +77,7 @@ def evaluate_llm_guardrails() -> LLMRiskGuardrails:
         adjustment_allowed = False
         reasons.append("llm_prompt_template_missing")
 
-    if not settings.llm_shadow_mode:
+    if not shadow_mode:
         evidence_missing: list[str] = []
         allowed_models = settings.llm_allowed_models
         if not allowed_models:
@@ -43,6 +90,11 @@ def evaluate_llm_guardrails() -> LLMRiskGuardrails:
             evidence_missing.append("llm_effective_challenge_missing")
         if not settings.llm_shadow_completed_at:
             evidence_missing.append("llm_shadow_completion_missing")
+        model_lock = settings.llm_model_version_lock
+        if not model_lock:
+            evidence_missing.append("llm_model_version_lock_missing")
+        elif model_lock != settings.llm_model:
+            evidence_missing.append("llm_model_version_lock_mismatch")
         if evidence_missing:
             shadow_mode = True
             adjustment_allowed = False
@@ -54,7 +106,10 @@ def evaluate_llm_guardrails() -> LLMRiskGuardrails:
 
     return LLMRiskGuardrails(
         allow_requests=allow_requests,
+        enabled=enabled,
+        rollout_stage=rollout_stage,
         shadow_mode=shadow_mode,
+        fail_mode=fail_mode,
         adjustment_allowed=adjustment_allowed,
         reasons=tuple(reasons),
     )

--- a/services/torghut/app/trading/llm/guardrails.py
+++ b/services/torghut/app/trading/llm/guardrails.py
@@ -68,6 +68,11 @@ def evaluate_llm_guardrails() -> LLMRiskGuardrails:
         if settings.trading_mode == "live":
             stage_reasons.append("llm_stage2_live_requires_shadow")
             shadow_mode = True
+    elif rollout_stage == "stage3_controlled_live" and settings.trading_mode == "live":
+        expected_fail_mode = "veto"
+        if settings.llm_fail_mode != expected_fail_mode:
+            stage_reasons.append("llm_stage3_fail_mode_mismatch")
+        fail_mode = expected_fail_mode
 
     reasons.extend(stage_reasons)
 

--- a/services/torghut/app/trading/llm/guardrails.py
+++ b/services/torghut/app/trading/llm/guardrails.py
@@ -29,7 +29,7 @@ def evaluate_llm_guardrails() -> LLMRiskGuardrails:
     effective_fail_mode = (
         "veto" if settings.trading_mode == "live" else settings.llm_fail_mode
     )
-    rollout_stage = settings.llm_rollout_stage
+    rollout_stage = _normalize_rollout_stage(settings.llm_rollout_stage)
 
     if settings.llm_max_tokens > settings.llm_token_budget_max:
         allow_requests = False
@@ -124,6 +124,18 @@ def _matches_model_version_lock(model: str, version_lock: str) -> bool:
         locked_model = version_lock.split("@", 1)[0].strip()
         return bool(locked_model) and model == locked_model
     return False
+
+
+def _normalize_rollout_stage(stage: str) -> str:
+    if stage.startswith("stage0"):
+        return "stage0"
+    if stage.startswith("stage1"):
+        return "stage1"
+    if stage.startswith("stage2"):
+        return "stage2"
+    if stage.startswith("stage3"):
+        return "stage3"
+    return "stage3"
 
 
 __all__ = ["LLMRiskGuardrails", "evaluate_llm_guardrails"]

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -897,10 +897,13 @@ class TradingPipeline:
                 )
             if not market_context_status.allow_llm:
                 self.state.metrics.llm_market_context_block_total += 1
-                fail_mode_shadow = settings.trading_market_context_fail_mode == "shadow_only"
+                market_context_shadow_mode = (
+                    guardrails.shadow_mode
+                    or settings.trading_market_context_fail_mode == "shadow_only"
+                )
                 self.state.metrics.record_market_context_result(
                     market_context_status.reason,
-                    shadow_mode=fail_mode_shadow,
+                    shadow_mode=market_context_shadow_mode,
                 )
                 return self._handle_llm_unavailable(
                     session,
@@ -909,7 +912,7 @@ class TradingPipeline:
                     account,
                     positions,
                     reason=market_context_status.reason or "market_context_unavailable",
-                    shadow_mode=fail_mode_shadow,
+                    shadow_mode=market_context_shadow_mode,
                     effective_fail_mode=guardrails.effective_fail_mode,
                     risk_flags=market_context_status.risk_flags,
                     market_context=market_context,

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -99,8 +99,6 @@ class TradingMetrics:
     llm_parse_error_total: int = 0
     llm_validation_error_total: int = 0
     llm_circuit_open_total: int = 0
-    llm_stage_policy_violation_total: int = 0
-    llm_fail_mode_override_total: int = 0
     llm_shadow_total: int = 0
     llm_guardrail_block_total: int = 0
     llm_guardrail_shadow_total: int = 0
@@ -835,11 +833,10 @@ class TradingPipeline:
         account: dict[str, str],
         positions: list[dict[str, Any]],
     ) -> tuple[StrategyDecision, Optional[str]]:
-        guardrails = evaluate_llm_guardrails()
-        if _has_stage_policy_violation(guardrails):
-            self.state.metrics.llm_stage_policy_violation_total += 1
-        if not guardrails.enabled:
+        if not settings.llm_enabled:
             return decision, None
+
+        guardrails = evaluate_llm_guardrails()
         if not guardrails.allow_requests:
             self.state.metrics.llm_guardrail_block_total += 1
             return self._handle_llm_unavailable(
@@ -850,9 +847,9 @@ class TradingPipeline:
                 positions,
                 reason="llm_guardrail_blocked",
                 shadow_mode=True,
+                effective_fail_mode=guardrails.effective_fail_mode,
                 risk_flags=list(guardrails.reasons),
                 market_context=None,
-                fail_mode=guardrails.fail_mode,
             )
 
         engine = self.llm_review_engine or LLMReviewEngine()
@@ -866,8 +863,8 @@ class TradingPipeline:
                 positions,
                 reason="llm_circuit_open",
                 shadow_mode=guardrails.shadow_mode,
+                effective_fail_mode=guardrails.effective_fail_mode,
                 market_context=None,
-                fail_mode=guardrails.fail_mode,
             )
         request_json: dict[str, Any] = {}
         market_context: Optional[MarketContextBundle] = None
@@ -907,9 +904,9 @@ class TradingPipeline:
                     positions,
                     reason=market_context_status.reason or "market_context_unavailable",
                     shadow_mode=fail_mode_shadow,
+                    effective_fail_mode=guardrails.effective_fail_mode,
                     risk_flags=market_context_status.risk_flags,
                     market_context=market_context,
-                    fail_mode=guardrails.fail_mode,
                 )
             request = engine.build_request(
                 decision,
@@ -1008,7 +1005,7 @@ class TradingPipeline:
                 self.state.metrics.llm_parse_error_total += 1
             elif error_label == "llm_response_invalid":
                 self.state.metrics.llm_validation_error_total += 1
-            fallback = self._resolve_llm_fallback(guardrails.fail_mode)
+            fallback = self._resolve_llm_fallback(guardrails.effective_fail_mode)
             effective_verdict = "veto" if fallback == "veto" else "approve"
             response_json = {
                 "error": str(exc),
@@ -1063,11 +1060,11 @@ class TradingPipeline:
         positions: list[dict[str, Any]],
         reason: str,
         shadow_mode: bool,
+        effective_fail_mode: Optional[str] = None,
         risk_flags: Optional[list[str]] = None,
         market_context: Optional[MarketContextBundle] = None,
-        fail_mode: Optional[str] = None,
     ) -> tuple[StrategyDecision, Optional[str]]:
-        fallback = self._resolve_llm_fallback(fail_mode)
+        fallback = self._resolve_llm_fallback(effective_fail_mode)
         effective_verdict = "veto" if fallback == "veto" else "approve"
         portfolio_snapshot = _build_portfolio_snapshot(account, positions)
         market_snapshot = self._build_market_snapshot(decision)
@@ -1186,15 +1183,13 @@ class TradingPipeline:
             updated_params["spread"] = snapshot.spread
         return decision.model_copy(update={"params": updated_params}), snapshot
 
-    def _resolve_llm_fallback(self, fail_mode: Optional[str] = None) -> str:
-        fallback = fail_mode
-        if fallback is None:
-            fallback = (
-                "veto" if settings.trading_mode == "live" else settings.llm_fail_mode
-            )
-        if fallback != settings.llm_fail_mode:
-            self.state.metrics.llm_fail_mode_override_total += 1
-        return fallback
+    @staticmethod
+    def _resolve_llm_fallback(effective_fail_mode: Optional[str] = None) -> str:
+        if effective_fail_mode in {"veto", "pass_through"}:
+            return effective_fail_mode
+        if settings.trading_mode == "live":
+            return "veto"
+        return settings.llm_fail_mode
 
     def _fetch_market_context(
         self, symbol: str
@@ -1288,16 +1283,6 @@ def _classify_llm_error(error: Exception) -> Optional[str]:
     if message == "llm_response_invalid":
         return "llm_response_invalid"
     return None
-
-
-def _has_stage_policy_violation(guardrails: object) -> bool:
-    reasons = getattr(guardrails, "reasons", ())
-    if not isinstance(reasons, tuple):
-        return False
-    for item in cast(tuple[object, ...], reasons):
-        if isinstance(item, str) and item.startswith("llm_stage"):
-            return True
-    return False
 
 
 def _price_snapshot_payload(snapshot: MarketSnapshot) -> dict[str, Any]:
@@ -1449,25 +1434,20 @@ class TradingScheduler:
             )
         guardrails = evaluate_llm_guardrails()
         return {
-            "enabled": guardrails.enabled,
+            "enabled": settings.llm_enabled,
             "rollout_stage": guardrails.rollout_stage,
             # Keep configured shadow_mode for backward compatibility.
             "shadow_mode": settings.llm_shadow_mode,
             # Effective runtime posture after model-risk guardrails.
             "effective_shadow_mode": guardrails.shadow_mode,
-            "fail_mode": guardrails.fail_mode,
-            "configured_fail_mode": settings.llm_fail_mode,
+            "fail_mode": settings.llm_fail_mode,
+            "effective_fail_mode": guardrails.effective_fail_mode,
             "circuit": circuit_snapshot,
             "guardrails": {
                 "allow_requests": guardrails.allow_requests,
+                "governance_evidence_complete": guardrails.governance_evidence_complete,
                 "effective_adjustment_allowed": guardrails.adjustment_allowed,
                 "reasons": list(guardrails.reasons),
-            },
-            "governance": {
-                "evaluation_report": settings.llm_evaluation_report,
-                "effective_challenge_id": settings.llm_effective_challenge_id,
-                "shadow_completed_at": settings.llm_shadow_completed_at,
-                "model_version_lock": settings.llm_model_version_lock,
             },
         }
 

--- a/services/torghut/tests/test_llm_guardrails.py
+++ b/services/torghut/tests/test_llm_guardrails.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from app import config
+from app.trading.llm.guardrails import evaluate_llm_guardrails
+
+
+class TestLLMGuardrails(TestCase):
+    def test_stage0_disables_llm_requests(self) -> None:
+        original = {
+            "llm_enabled": config.settings.llm_enabled,
+            "llm_rollout_stage": config.settings.llm_rollout_stage,
+            "llm_shadow_mode": config.settings.llm_shadow_mode,
+        }
+        config.settings.llm_enabled = True
+        config.settings.llm_rollout_stage = "stage0_baseline"
+        config.settings.llm_shadow_mode = False
+
+        try:
+            guardrails = evaluate_llm_guardrails()
+            self.assertFalse(guardrails.enabled)
+            self.assertFalse(guardrails.allow_requests)
+            self.assertTrue(guardrails.shadow_mode)
+            self.assertIn("llm_stage0_requires_disabled", guardrails.reasons)
+        finally:
+            config.settings.llm_enabled = original["llm_enabled"]
+            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
+            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+
+    def test_stage1_live_forces_veto_fail_mode(self) -> None:
+        original = {
+            "trading_mode": config.settings.trading_mode,
+            "llm_enabled": config.settings.llm_enabled,
+            "llm_rollout_stage": config.settings.llm_rollout_stage,
+            "llm_shadow_mode": config.settings.llm_shadow_mode,
+            "llm_fail_mode": config.settings.llm_fail_mode,
+        }
+        config.settings.trading_mode = "live"
+        config.settings.llm_enabled = True
+        config.settings.llm_rollout_stage = "stage1_shadow_pilot"
+        config.settings.llm_shadow_mode = False
+        config.settings.llm_fail_mode = "pass_through"
+
+        try:
+            guardrails = evaluate_llm_guardrails()
+            self.assertTrue(guardrails.enabled)
+            self.assertTrue(guardrails.allow_requests)
+            self.assertTrue(guardrails.shadow_mode)
+            self.assertEqual(guardrails.fail_mode, "veto")
+            self.assertIn("llm_stage1_fail_mode_mismatch", guardrails.reasons)
+        finally:
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.llm_enabled = original["llm_enabled"]
+            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
+            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+            config.settings.llm_fail_mode = original["llm_fail_mode"]
+
+    def test_stage3_requires_model_lock_when_not_shadow(self) -> None:
+        original = {
+            "llm_enabled": config.settings.llm_enabled,
+            "llm_rollout_stage": config.settings.llm_rollout_stage,
+            "llm_shadow_mode": config.settings.llm_shadow_mode,
+            "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
+            "llm_evaluation_report": config.settings.llm_evaluation_report,
+            "llm_effective_challenge_id": config.settings.llm_effective_challenge_id,
+            "llm_shadow_completed_at": config.settings.llm_shadow_completed_at,
+            "llm_model_version_lock": config.settings.llm_model_version_lock,
+        }
+        config.settings.llm_enabled = True
+        config.settings.llm_rollout_stage = "stage3_controlled_live"
+        config.settings.llm_shadow_mode = False
+        config.settings.llm_allowed_models_raw = config.settings.llm_model
+        config.settings.llm_evaluation_report = "eval-2026-02-19"
+        config.settings.llm_effective_challenge_id = "mrm-2026-02-19"
+        config.settings.llm_shadow_completed_at = "2026-02-19T00:00:00Z"
+        config.settings.llm_model_version_lock = None
+
+        try:
+            guardrails = evaluate_llm_guardrails()
+            self.assertTrue(guardrails.shadow_mode)
+            self.assertIn("llm_model_version_lock_missing", guardrails.reasons)
+        finally:
+            config.settings.llm_enabled = original["llm_enabled"]
+            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
+            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+            config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
+            config.settings.llm_evaluation_report = original["llm_evaluation_report"]
+            config.settings.llm_effective_challenge_id = original[
+                "llm_effective_challenge_id"
+            ]
+            config.settings.llm_shadow_completed_at = original[
+                "llm_shadow_completed_at"
+            ]
+            config.settings.llm_model_version_lock = original["llm_model_version_lock"]

--- a/services/torghut/tests/test_llm_guardrails.py
+++ b/services/torghut/tests/test_llm_guardrails.py
@@ -6,59 +6,49 @@ from app import config
 from app.trading.llm.guardrails import evaluate_llm_guardrails
 
 
-class TestLLMGuardrails(TestCase):
-    def test_stage0_disables_llm_requests(self) -> None:
-        original = {
-            "llm_enabled": config.settings.llm_enabled,
-            "llm_rollout_stage": config.settings.llm_rollout_stage,
-            "llm_shadow_mode": config.settings.llm_shadow_mode,
-        }
-        config.settings.llm_enabled = True
-        config.settings.llm_rollout_stage = "stage0_baseline"
-        config.settings.llm_shadow_mode = False
-
-        try:
-            guardrails = evaluate_llm_guardrails()
-            self.assertFalse(guardrails.enabled)
-            self.assertFalse(guardrails.allow_requests)
-            self.assertTrue(guardrails.shadow_mode)
-            self.assertIn("llm_stage0_requires_disabled", guardrails.reasons)
-        finally:
-            config.settings.llm_enabled = original["llm_enabled"]
-            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
-            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
-
-    def test_stage1_live_forces_veto_fail_mode(self) -> None:
+class TestLlmGuardrails(TestCase):
+    def test_stage1_shadow_pilot_forces_shadow_and_fail_mode(self) -> None:
         original = {
             "trading_mode": config.settings.trading_mode,
-            "llm_enabled": config.settings.llm_enabled,
             "llm_rollout_stage": config.settings.llm_rollout_stage,
             "llm_shadow_mode": config.settings.llm_shadow_mode,
+            "llm_adjustment_allowed": config.settings.llm_adjustment_allowed,
+            "llm_adjustment_approved": config.settings.llm_adjustment_approved,
             "llm_fail_mode": config.settings.llm_fail_mode,
+            "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
         }
-        config.settings.trading_mode = "live"
-        config.settings.llm_enabled = True
-        config.settings.llm_rollout_stage = "stage1_shadow_pilot"
+        config.settings.llm_rollout_stage = "stage1"
         config.settings.llm_shadow_mode = False
-        config.settings.llm_fail_mode = "pass_through"
+        config.settings.llm_adjustment_allowed = True
+        config.settings.llm_adjustment_approved = True
+        config.settings.llm_fail_mode = "veto"
+        config.settings.llm_allowed_models_raw = config.settings.llm_model
 
         try:
-            guardrails = evaluate_llm_guardrails()
-            self.assertTrue(guardrails.enabled)
-            self.assertTrue(guardrails.allow_requests)
-            self.assertTrue(guardrails.shadow_mode)
-            self.assertEqual(guardrails.fail_mode, "veto")
-            self.assertIn("llm_stage1_fail_mode_mismatch", guardrails.reasons)
+            config.settings.trading_mode = "paper"
+            paper_guardrails = evaluate_llm_guardrails()
+            self.assertTrue(paper_guardrails.shadow_mode)
+            self.assertFalse(paper_guardrails.adjustment_allowed)
+            self.assertEqual(paper_guardrails.effective_fail_mode, "pass_through")
+
+            config.settings.trading_mode = "live"
+            live_guardrails = evaluate_llm_guardrails()
+            self.assertTrue(live_guardrails.shadow_mode)
+            self.assertFalse(live_guardrails.adjustment_allowed)
+            self.assertEqual(live_guardrails.effective_fail_mode, "veto")
         finally:
             config.settings.trading_mode = original["trading_mode"]
-            config.settings.llm_enabled = original["llm_enabled"]
             config.settings.llm_rollout_stage = original["llm_rollout_stage"]
             config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+            config.settings.llm_adjustment_allowed = original["llm_adjustment_allowed"]
+            config.settings.llm_adjustment_approved = original[
+                "llm_adjustment_approved"
+            ]
             config.settings.llm_fail_mode = original["llm_fail_mode"]
+            config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
 
-    def test_stage3_requires_model_lock_when_not_shadow(self) -> None:
+    def test_stage2_requires_governance_evidence_and_model_lock(self) -> None:
         original = {
-            "llm_enabled": config.settings.llm_enabled,
             "llm_rollout_stage": config.settings.llm_rollout_stage,
             "llm_shadow_mode": config.settings.llm_shadow_mode,
             "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
@@ -67,21 +57,23 @@ class TestLLMGuardrails(TestCase):
             "llm_shadow_completed_at": config.settings.llm_shadow_completed_at,
             "llm_model_version_lock": config.settings.llm_model_version_lock,
         }
-        config.settings.llm_enabled = True
-        config.settings.llm_rollout_stage = "stage3_controlled_live"
+        config.settings.llm_rollout_stage = "stage2"
         config.settings.llm_shadow_mode = False
         config.settings.llm_allowed_models_raw = config.settings.llm_model
-        config.settings.llm_evaluation_report = "eval-2026-02-19"
-        config.settings.llm_effective_challenge_id = "mrm-2026-02-19"
-        config.settings.llm_shadow_completed_at = "2026-02-19T00:00:00Z"
+        config.settings.llm_evaluation_report = None
+        config.settings.llm_effective_challenge_id = None
+        config.settings.llm_shadow_completed_at = None
         config.settings.llm_model_version_lock = None
 
         try:
             guardrails = evaluate_llm_guardrails()
             self.assertTrue(guardrails.shadow_mode)
+            self.assertFalse(guardrails.governance_evidence_complete)
+            self.assertIn("llm_evaluation_report_missing", guardrails.reasons)
+            self.assertIn("llm_effective_challenge_missing", guardrails.reasons)
+            self.assertIn("llm_shadow_completion_missing", guardrails.reasons)
             self.assertIn("llm_model_version_lock_missing", guardrails.reasons)
         finally:
-            config.settings.llm_enabled = original["llm_enabled"]
             config.settings.llm_rollout_stage = original["llm_rollout_stage"]
             config.settings.llm_shadow_mode = original["llm_shadow_mode"]
             config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
@@ -93,3 +85,74 @@ class TestLLMGuardrails(TestCase):
                 "llm_shadow_completed_at"
             ]
             config.settings.llm_model_version_lock = original["llm_model_version_lock"]
+
+    def test_stage2_model_lock_mismatch_forces_shadow(self) -> None:
+        original = {
+            "llm_rollout_stage": config.settings.llm_rollout_stage,
+            "llm_shadow_mode": config.settings.llm_shadow_mode,
+            "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
+            "llm_evaluation_report": config.settings.llm_evaluation_report,
+            "llm_effective_challenge_id": config.settings.llm_effective_challenge_id,
+            "llm_shadow_completed_at": config.settings.llm_shadow_completed_at,
+            "llm_model_version_lock": config.settings.llm_model_version_lock,
+        }
+        config.settings.llm_rollout_stage = "stage2"
+        config.settings.llm_shadow_mode = False
+        config.settings.llm_allowed_models_raw = config.settings.llm_model
+        config.settings.llm_evaluation_report = "eval-2026-02-12"
+        config.settings.llm_effective_challenge_id = "challenge-2026-02-12"
+        config.settings.llm_shadow_completed_at = "2026-02-12T06:45:00Z"
+        config.settings.llm_model_version_lock = "other-model@sha256:deadbeef"
+
+        try:
+            guardrails = evaluate_llm_guardrails()
+            self.assertTrue(guardrails.shadow_mode)
+            self.assertFalse(guardrails.governance_evidence_complete)
+            self.assertIn("llm_model_version_lock_mismatch", guardrails.reasons)
+        finally:
+            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
+            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+            config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
+            config.settings.llm_evaluation_report = original["llm_evaluation_report"]
+            config.settings.llm_effective_challenge_id = original[
+                "llm_effective_challenge_id"
+            ]
+            config.settings.llm_shadow_completed_at = original[
+                "llm_shadow_completed_at"
+            ]
+            config.settings.llm_model_version_lock = original["llm_model_version_lock"]
+
+    def test_prompt_allowlist_and_token_budget_block_requests(self) -> None:
+        original = {
+            "llm_rollout_stage": config.settings.llm_rollout_stage,
+            "llm_shadow_mode": config.settings.llm_shadow_mode,
+            "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
+            "llm_allowed_prompt_versions_raw": config.settings.llm_allowed_prompt_versions_raw,
+            "llm_prompt_version": config.settings.llm_prompt_version,
+            "llm_max_tokens": config.settings.llm_max_tokens,
+            "llm_token_budget_max": config.settings.llm_token_budget_max,
+        }
+        config.settings.llm_rollout_stage = "stage3"
+        config.settings.llm_shadow_mode = False
+        config.settings.llm_allowed_models_raw = config.settings.llm_model
+        config.settings.llm_allowed_prompt_versions_raw = "v2"
+        config.settings.llm_prompt_version = "v1"
+        config.settings.llm_max_tokens = 1600
+        config.settings.llm_token_budget_max = 1200
+
+        try:
+            guardrails = evaluate_llm_guardrails()
+            self.assertFalse(guardrails.allow_requests)
+            self.assertTrue(guardrails.shadow_mode)
+            self.assertIn("llm_prompt_version_not_allowlisted", guardrails.reasons)
+            self.assertIn("llm_token_budget_exceeded", guardrails.reasons)
+        finally:
+            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
+            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+            config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
+            config.settings.llm_allowed_prompt_versions_raw = original[
+                "llm_allowed_prompt_versions_raw"
+            ]
+            config.settings.llm_prompt_version = original["llm_prompt_version"]
+            config.settings.llm_max_tokens = original["llm_max_tokens"]
+            config.settings.llm_token_budget_max = original["llm_token_budget_max"]

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -305,7 +305,7 @@ class TestTradingApi(TestCase):
             "llm_model_version_lock": settings.llm_model_version_lock,
         }
         settings.llm_enabled = True
-        settings.llm_rollout_stage = "stage3_controlled_live"
+        settings.llm_rollout_stage = "stage3"
         settings.llm_shadow_mode = False
         settings.llm_allowed_models_raw = None
         settings.llm_evaluation_report = None
@@ -318,11 +318,15 @@ class TestTradingApi(TestCase):
             self.assertEqual(response.status_code, 200)
             payload = response.json()
             llm = payload["llm"]
+            self.assertEqual(llm["rollout_stage"], "stage3")
             self.assertFalse(llm["shadow_mode"])
             self.assertTrue(llm["effective_shadow_mode"])
             self.assertIn("guardrails", llm)
             self.assertTrue(llm["guardrails"]["allow_requests"])
             self.assertIn("llm_evaluation_report_missing", llm["guardrails"]["reasons"])
+            self.assertIn(
+                "llm_model_version_lock_missing", llm["guardrails"]["reasons"]
+            )
         finally:
             settings.llm_shadow_mode = original["llm_shadow_mode"]
             settings.llm_enabled = original["llm_enabled"]
@@ -332,36 +336,6 @@ class TestTradingApi(TestCase):
             settings.llm_effective_challenge_id = original["llm_effective_challenge_id"]
             settings.llm_shadow_completed_at = original["llm_shadow_completed_at"]
             settings.llm_model_version_lock = original["llm_model_version_lock"]
-
-    def test_trading_status_stage1_live_forces_shadow_and_veto_fail_mode(self) -> None:
-        original = {
-            "trading_mode": settings.trading_mode,
-            "llm_enabled": settings.llm_enabled,
-            "llm_rollout_stage": settings.llm_rollout_stage,
-            "llm_shadow_mode": settings.llm_shadow_mode,
-            "llm_fail_mode": settings.llm_fail_mode,
-        }
-        settings.trading_mode = "live"
-        settings.llm_enabled = True
-        settings.llm_rollout_stage = "stage1_shadow_pilot"
-        settings.llm_shadow_mode = False
-        settings.llm_fail_mode = "pass_through"
-
-        try:
-            response = self.client.get("/trading/status")
-            self.assertEqual(response.status_code, 200)
-            payload = response.json()
-            llm = payload["llm"]
-            self.assertEqual(llm["rollout_stage"], "stage1_shadow_pilot")
-            self.assertTrue(llm["effective_shadow_mode"])
-            self.assertEqual(llm["fail_mode"], "veto")
-            self.assertEqual(llm["configured_fail_mode"], "pass_through")
-        finally:
-            settings.trading_mode = original["trading_mode"]
-            settings.llm_enabled = original["llm_enabled"]
-            settings.llm_rollout_stage = original["llm_rollout_stage"]
-            settings.llm_shadow_mode = original["llm_shadow_mode"]
-            settings.llm_fail_mode = original["llm_fail_mode"]
 
     def test_trading_llm_evaluation_endpoint(self) -> None:
         response = self.client.get("/trading/llm-evaluation")

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -306,6 +306,7 @@ def _set_llm_guardrails(config, *, adjustment_approved: bool = False) -> None:
     config.settings.llm_evaluation_report = "eval-2026-02-08"
     config.settings.llm_effective_challenge_id = "mrm-review-2026-02-08"
     config.settings.llm_shadow_completed_at = "2026-02-08T00:00:00Z"
+    config.settings.llm_model_version_lock = config.settings.llm_model
     config.settings.llm_adjustment_approved = adjustment_approved
 
 
@@ -1824,6 +1825,103 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_adjustment_approved = original[
                 "llm_adjustment_approved"
             ]
+
+    def test_pipeline_stage2_fail_mode_forces_pass_through(self) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+            "llm_enabled": config.settings.llm_enabled,
+            "llm_rollout_stage": config.settings.llm_rollout_stage,
+            "llm_shadow_mode": config.settings.llm_shadow_mode,
+            "llm_fail_mode": config.settings.llm_fail_mode,
+            "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
+            "llm_evaluation_report": config.settings.llm_evaluation_report,
+            "llm_effective_challenge_id": config.settings.llm_effective_challenge_id,
+            "llm_shadow_completed_at": config.settings.llm_shadow_completed_at,
+            "llm_model_version_lock": config.settings.llm_model_version_lock,
+            "llm_adjustment_approved": config.settings.llm_adjustment_approved,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.llm_enabled = True
+        config.settings.llm_rollout_stage = "stage2"
+        config.settings.llm_shadow_mode = False
+        config.settings.llm_fail_mode = "veto"
+        _set_llm_guardrails(config)
+
+        try:
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name="demo",
+                    description="demo",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL"],
+                    max_notional_per_trade=Decimal("1000"),
+                )
+                session.add(strategy)
+                session.commit()
+
+            signal = SignalEnvelope(
+                event_ts=datetime.now(timezone.utc),
+                symbol="AAPL",
+                payload={"macd": {"macd": 1.1, "signal": 0.4}, "rsi14": 25, "price": 100},
+                timeframe="1Min",
+            )
+
+            alpaca_client = FakeAlpacaClient()
+            pipeline = TradingPipeline(
+                alpaca_client=alpaca_client,
+                order_firewall=OrderFirewall(alpaca_client),
+                ingestor=FakeIngestor([signal]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=alpaca_client,
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+                llm_review_engine=FakeLLMReviewEngine(circuit_open=True),
+            )
+
+            pipeline.run_once()
+
+            with self.session_local() as session:
+                reviews = session.execute(select(LLMDecisionReview)).scalars().all()
+                decisions = session.execute(select(TradeDecision)).scalars().all()
+                executions = session.execute(select(Execution)).scalars().all()
+                self.assertEqual(len(reviews), 1)
+                self.assertEqual(reviews[0].verdict, "error")
+                self.assertEqual(reviews[0].response_json.get("fallback"), "pass_through")
+                self.assertEqual(decisions[0].status, "submitted")
+                self.assertEqual(len(executions), 1)
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_universe_source = original["trading_universe_source"]
+            config.settings.trading_static_symbols_raw = original["trading_static_symbols_raw"]
+            config.settings.llm_enabled = original["llm_enabled"]
+            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
+            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+            config.settings.llm_fail_mode = original["llm_fail_mode"]
+            config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
+            config.settings.llm_evaluation_report = original["llm_evaluation_report"]
+            config.settings.llm_effective_challenge_id = original["llm_effective_challenge_id"]
+            config.settings.llm_shadow_completed_at = original["llm_shadow_completed_at"]
+            config.settings.llm_model_version_lock = original["llm_model_version_lock"]
+            config.settings.llm_adjustment_approved = original["llm_adjustment_approved"]
 
     def test_pipeline_llm_min_confidence(self) -> None:
         from app import config


### PR DESCRIPTION
## Summary

- Implemented stage-aware Torghut LLM guardrails with normalized rollout stages (`stage0..stage3` plus named aliases), Stage-1 shadow enforcement, Stage-2 fail-mode enforcement, and deterministic fallback authority preserved.
- Enforced governance evidence checks (evaluation report, challenge ID, shadow completion timestamp, model-version lock) and exposed effective runtime posture in `/trading/status`.
- Added telemetry for fail-mode overrides and stage-policy violations, and expanded LLM guardrails exporter metrics/alert gauges for rollout stage, effective fail mode, error ratio, and circuit behavior.
- Added Jangar control-plane endpoint `/api/torghut/trading/control-plane/llm/rollout` with tests to surface Torghut LLM rollout/circuit posture.
- Updated Torghut ArgoCD rollout flags for Stage-1 shadow pilot (`LLM_ENABLED=true`, `LLM_SHADOW_MODE=true`, `LLM_ROLLOUT_STAGE=stage1`) plus governance/token-budget flags.

## Related Issues

None

## Testing

- `cd services/torghut && uv run ruff check app/config.py app/trading/llm/guardrails.py app/trading/scheduler.py tests/test_llm_guardrails.py tests/test_trading_api.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run pyright`
- `cd services/torghut && uv run --with pytest pytest tests/test_llm_guardrails.py tests/test_trading_api.py tests/test_trading_pipeline.py -q`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/routes/api/torghut/trading/control-plane/llm/rollout.test.ts`
- `cd /workspace/lab && bun run --filter @proompteng/jangar lint`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
