### PR TITLE
feat(jangar): automate end-to-end build and deployment

### DIFF
--- a/.github/workflows/jangar-deploy-automerge.yml
+++ b/.github/workflows/jangar-deploy-automerge.yml
@@ -1,0 +1,38 @@
+name: jangar-deploy-automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  enable:
+    if: >-
+      ${{
+        startsWith(github.event.pull_request.head.ref, 'codex/jangar-release-') &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.draft == false
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable squash auto-merge
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          AUTO_MERGE_ENABLED="$(gh pr view "${PR_NUMBER}" -R "${REPO}" --json autoMergeRequest --jq '.autoMergeRequest != null')"
+          if [ "${AUTO_MERGE_ENABLED}" = "true" ]; then
+            echo "Auto-merge already enabled for PR #${PR_NUMBER}"
+            exit 0
+          fi
+
+          gh pr merge "${PR_NUMBER}" -R "${REPO}" --auto --squash

--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -1,0 +1,87 @@
+name: jangar-post-deploy-verify
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'argocd/applications/jangar/**'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: arc-arm64
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.31.2
+
+      - name: Validate kubectl context
+        shell: bash
+        run: |
+          set -euo pipefail
+          kubectl config current-context
+
+      - name: Wait for Argo application to be Synced and Healthy
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 60); do
+            STATUS="$(kubectl -n argocd get application jangar -o jsonpath='{.status.sync.status} {.status.health.status}' || true)"
+            SYNC_STATUS="$(echo "${STATUS}" | awk '{print $1}')"
+            HEALTH_STATUS="$(echo "${STATUS}" | awk '{print $2}')"
+            echo "Attempt ${attempt}: sync=${SYNC_STATUS:-unknown} health=${HEALTH_STATUS:-unknown}"
+
+            if [ "${SYNC_STATUS}" = "Synced" ] && [ "${HEALTH_STATUS}" = "Healthy" ]; then
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "Jangar Argo application did not reach Synced/Healthy within timeout"
+          exit 1
+
+      - name: Wait for deployment rollouts
+        shell: bash
+        run: |
+          set -euo pipefail
+          kubectl rollout status deployment/jangar -n jangar --timeout=10m
+          kubectl rollout status deployment/jangar-worker -n jangar --timeout=10m
+
+      - name: Verify deployed image digest matches manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXPECTED_DIGEST="$(
+            awk '
+              $0 ~ /name: registry\\.ide-newton\\.ts\\.net\\/lab\\/jangar/ { found=1; next }
+              found && $0 ~ /digest:/ { print $2; exit }
+            ' argocd/applications/jangar/kustomization.yaml
+          )"
+          if [ -z "${EXPECTED_DIGEST}" ]; then
+            echo "Unable to parse expected digest from argocd/applications/jangar/kustomization.yaml"
+            exit 1
+          fi
+
+          API_IMAGES="$(kubectl -n jangar get deployment jangar -o jsonpath='{..image}')"
+          WORKER_IMAGES="$(kubectl -n jangar get deployment jangar-worker -o jsonpath='{..image}')"
+
+          echo "Expected digest: ${EXPECTED_DIGEST}"
+          echo "API images: ${API_IMAGES}"
+          echo "Worker images: ${WORKER_IMAGES}"
+
+          if [[ "${API_IMAGES}" != *"${EXPECTED_DIGEST}"* ]]; then
+            echo "API deployment image digest does not match expected digest"
+            exit 1
+          fi
+          if [[ "${WORKER_IMAGES}" != *"${EXPECTED_DIGEST}"* ]]; then
+            echo "Worker deployment image digest does not match expected digest"
+            exit 1
+          fi

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -1,0 +1,149 @@
+name: jangar-release
+
+on:
+  workflow_run:
+    workflows:
+      - jangar-build-push
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to promote (defaults to current HEAD)
+        required: false
+        type: string
+      image_tag:
+        description: Image tag to promote (defaults to short SHA)
+        required: false
+        type: string
+      image_digest:
+        description: Image digest override (sha256:...)
+        required: false
+        type: string
+
+jobs:
+  promote:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+      }}
+    runs-on: arc-arm64
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            SOURCE_SHA="${{ github.event.workflow_run.head_sha }}"
+          elif [ -n "${{ inputs.commit_sha }}" ]; then
+            SOURCE_SHA="${{ inputs.commit_sha }}"
+          else
+            SOURCE_SHA="$(git rev-parse HEAD)"
+          fi
+
+          TAG_INPUT='${{ inputs.image_tag }}'
+          if [ -n "$TAG_INPUT" ]; then
+            TAG="$TAG_INPUT"
+          else
+            TAG="${SOURCE_SHA:0:8}"
+          fi
+
+          git checkout --force "$SOURCE_SHA"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve image digest
+        id: digest
+        shell: bash
+        env:
+          IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          DIGEST_INPUT: ${{ inputs.image_digest }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DIGEST_INPUT}" ]; then
+            DIGEST="${DIGEST_INPUT}"
+          else
+            DIGEST="$(
+              bun --eval "
+                import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
+                const image = \`registry.ide-newton.ts.net/lab/jangar:${process.env.IMAGE_TAG}\`
+                const repoDigest = inspectImageDigest(image)
+                const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
+                console.log(digest)
+              "
+            )"
+          fi
+
+          DIGEST="${DIGEST#*@}"
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Update Jangar manifests
+        env:
+          JANGAR_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          JANGAR_IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
+          JANGAR_ROLLOUT_TIMESTAMP: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          bun run packages/scripts/src/jangar/update-manifests.ts \
+            --tag "${JANGAR_IMAGE_TAG}" \
+            --digest "${JANGAR_IMAGE_DIGEST}" \
+            --rollout-timestamp "${TIMESTAMP}"
+
+      - name: Check for manifest changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- \
+            argocd/applications/jangar/kustomization.yaml \
+            argocd/applications/jangar/deployment.yaml \
+            argocd/applications/jangar/jangar-worker-deployment.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create deploy pull request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: codex/jangar-release-${{ steps.meta.outputs.tag }}
+          base: main
+          title: chore(jangar): promote image ${{ steps.meta.outputs.tag }}
+          commit-message: chore(jangar): promote image ${{ steps.meta.outputs.tag }}
+          delete-branch: true
+          add-paths: |
+            argocd/applications/jangar/kustomization.yaml
+            argocd/applications/jangar/deployment.yaml
+            argocd/applications/jangar/jangar-worker-deployment.yaml
+          body: |
+            ## Summary
+            Promote Jangar image into GitOps manifests.
+
+            - Source commit: `${{ steps.meta.outputs.source_sha }}`
+            - Image tag: `${{ steps.meta.outputs.tag }}`
+            - Image digest: `${{ steps.digest.outputs.digest }}`
+            - Updated API and worker rollout annotations
+
+      - name: No manifest changes detected
+        if: steps.changes.outputs.changed != 'true'
+        run: echo 'No Jangar manifest changes detected.'

--- a/packages/scripts/src/jangar/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/jangar/__tests__/update-manifests.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+import { updateJangarManifests } from '../update-manifests'
+
+const imageName = 'registry.ide-newton.ts.net/lab/jangar'
+
+const createFixture = () => {
+  const dir = mkdtempSync(join(tmpdir(), 'jangar-manifests-test-'))
+  const kustomizationPath = join(dir, 'kustomization.yaml')
+  const serviceManifestPath = join(dir, 'deployment.yaml')
+  const workerManifestPath = join(dir, 'worker-deployment.yaml')
+
+  writeFileSync(
+    kustomizationPath,
+    `images:
+  - name: registry.ide-newton.ts.net/lab/jangar
+    newTag: "old-tag"
+    digest: sha256:old
+`,
+    'utf8',
+  )
+  writeFileSync(
+    serviceManifestPath,
+    `metadata:
+  annotations:
+    deploy.knative.dev/rollout: "2025-01-01T00:00:00.000Z"
+`,
+    'utf8',
+  )
+  writeFileSync(
+    workerManifestPath,
+    `metadata:
+  annotations:
+    kubectl.kubernetes.io/restartedAt: "2025-01-01T00:00:00.000Z"
+`,
+    'utf8',
+  )
+
+  return { dir, kustomizationPath, serviceManifestPath, workerManifestPath }
+}
+
+describe('updateJangarManifests', () => {
+  it('updates tag, digest, and rollout annotations', () => {
+    const fixture = createFixture()
+    const rolloutTimestamp = '2026-02-20T06:30:00.000Z'
+
+    const result = updateJangarManifests({
+      imageName,
+      tag: 'new-tag',
+      digest: 'sha256:newdigest',
+      rolloutTimestamp,
+      kustomizationPath: relative(repoRoot, fixture.kustomizationPath),
+      serviceManifestPath: relative(repoRoot, fixture.serviceManifestPath),
+      workerManifestPath: relative(repoRoot, fixture.workerManifestPath),
+    })
+
+    const kustomization = readFileSync(fixture.kustomizationPath, 'utf8')
+    const serviceManifest = readFileSync(fixture.serviceManifestPath, 'utf8')
+    const workerManifest = readFileSync(fixture.workerManifestPath, 'utf8')
+
+    expect(kustomization).toContain('newTag: "new-tag"')
+    expect(kustomization).toContain('digest: sha256:newdigest')
+    expect(serviceManifest).toContain(`deploy.knative.dev/rollout: "${rolloutTimestamp}"`)
+    expect(workerManifest).toContain(`kubectl.kubernetes.io/restartedAt: "${rolloutTimestamp}"`)
+    expect(result.changed).toEqual({
+      kustomization: true,
+      service: true,
+      worker: true,
+    })
+
+    rmSync(fixture.dir, { recursive: true, force: true })
+  })
+
+  it('inserts digest when digest field is missing and normalizes repo digests', () => {
+    const fixture = createFixture()
+    const kustomizationWithoutDigest = `images:
+  - name: registry.ide-newton.ts.net/lab/jangar
+    newTag: "old-tag"
+`
+    writeFileSync(fixture.kustomizationPath, kustomizationWithoutDigest, 'utf8')
+
+    updateJangarManifests({
+      imageName,
+      tag: 'digest-add',
+      digest: 'registry.ide-newton.ts.net/lab/jangar@sha256:abc123',
+      rolloutTimestamp: '2026-02-20T07:00:00.000Z',
+      kustomizationPath: relative(repoRoot, fixture.kustomizationPath),
+      serviceManifestPath: relative(repoRoot, fixture.serviceManifestPath),
+      workerManifestPath: relative(repoRoot, fixture.workerManifestPath),
+    })
+
+    const kustomization = readFileSync(fixture.kustomizationPath, 'utf8')
+    expect(kustomization).toContain('newTag: "digest-add"')
+    expect(kustomization).toContain('digest: sha256:abc123')
+
+    rmSync(fixture.dir, { recursive: true, force: true })
+  })
+})

--- a/packages/scripts/src/jangar/update-manifests.ts
+++ b/packages/scripts/src/jangar/update-manifests.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+import { fatal, repoRoot } from '../shared/cli'
+import { inspectImageDigest } from '../shared/docker'
+import { execGit } from '../shared/git'
+
+const defaultRegistry = 'registry.ide-newton.ts.net'
+const defaultRepository = 'lab/jangar'
+const defaultKustomizationPath = 'argocd/applications/jangar/kustomization.yaml'
+const defaultServiceManifestPath = 'argocd/applications/jangar/deployment.yaml'
+const defaultWorkerManifestPath = 'argocd/applications/jangar/jangar-worker-deployment.yaml'
+
+export type UpdateManifestsOptions = {
+  imageName: string
+  tag: string
+  digest?: string
+  rolloutTimestamp: string
+  kustomizationPath?: string
+  serviceManifestPath?: string
+  workerManifestPath?: string
+}
+
+type CliOptions = {
+  registry?: string
+  repository?: string
+  tag?: string
+  digest?: string
+  rolloutTimestamp?: string
+  kustomizationPath?: string
+  serviceManifestPath?: string
+  workerManifestPath?: string
+}
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const resolvePath = (path: string) => resolve(repoRoot, path)
+
+const normalizeDigest = (digest: string): string => {
+  const trimmed = digest.trim()
+  if (!trimmed) return trimmed
+  const atIndex = trimmed.lastIndexOf('@')
+  return atIndex >= 0 ? trimmed.slice(atIndex + 1) : trimmed
+}
+
+const updateKustomizationManifest = (
+  kustomizationPath: string,
+  imageName: string,
+  tag: string,
+  digest: string,
+): boolean => {
+  const source = readFileSync(kustomizationPath, 'utf8')
+  const imagePattern = new RegExp(`(name:\\s+${escapeRegExp(imageName)}\\s*\\n\\s*newTag:\\s*)(.+)`, 'm')
+  const quotedTag = JSON.stringify(tag)
+  let updated = source.replace(imagePattern, (_, prefix) => `${prefix}${quotedTag}`)
+
+  const digestPattern = new RegExp(
+    `(name:\\s+${escapeRegExp(imageName)}\\s*\\n\\s*newTag:\\s*[^\\n]+\\n\\s*digest:\\s*)(.+)`,
+    'm',
+  )
+  if (digestPattern.test(updated)) {
+    updated = updated.replace(digestPattern, (_, prefix) => `${prefix}${digest}`)
+  } else {
+    updated = updated.replace(
+      new RegExp(`(name:\\s+${escapeRegExp(imageName)}\\s*\\n\\s*newTag:\\s*[^\\n]+)`),
+      `$1\n    digest: ${digest}`,
+    )
+  }
+
+  if (source === updated) {
+    console.warn('Warning: jangar kustomization was not updated; pattern may have changed.')
+    return false
+  }
+
+  writeFileSync(kustomizationPath, updated)
+  console.log(`Updated ${kustomizationPath} with tag ${tag} and digest ${digest}`)
+  return true
+}
+
+const updateRolloutAnnotation = (
+  manifestPath: string,
+  annotationKey: string,
+  rolloutTimestamp: string,
+  warningLabel: string,
+): boolean => {
+  const source = readFileSync(manifestPath, 'utf8')
+  const pattern = new RegExp(`(${escapeRegExp(annotationKey)}:\\s*)(["']?)([^"'\n]*)(["']?)`)
+  const updated = source.replace(pattern, `$1"${rolloutTimestamp}"`)
+
+  if (source === updated) {
+    console.warn(`Warning: jangar ${warningLabel} annotation was not updated; pattern may have changed.`)
+    return false
+  }
+
+  writeFileSync(manifestPath, updated)
+  console.log(`Updated ${manifestPath} annotation ${annotationKey} to ${rolloutTimestamp}`)
+  return true
+}
+
+export const updateJangarManifests = (options: UpdateManifestsOptions) => {
+  const kustomizationPath = resolvePath(options.kustomizationPath ?? defaultKustomizationPath)
+  const serviceManifestPath = resolvePath(options.serviceManifestPath ?? defaultServiceManifestPath)
+  const workerManifestPath = resolvePath(options.workerManifestPath ?? defaultWorkerManifestPath)
+  const digest = normalizeDigest(options.digest ?? inspectImageDigest(`${options.imageName}:${options.tag}`))
+
+  const kustomizationChanged = updateKustomizationManifest(kustomizationPath, options.imageName, options.tag, digest)
+  const serviceChanged = updateRolloutAnnotation(
+    serviceManifestPath,
+    'deploy.knative.dev/rollout',
+    options.rolloutTimestamp,
+    'service rollout',
+  )
+  const workerChanged = updateRolloutAnnotation(
+    workerManifestPath,
+    'kubectl.kubernetes.io/restartedAt',
+    options.rolloutTimestamp,
+    'worker rollout',
+  )
+
+  return {
+    tag: options.tag,
+    digest,
+    rolloutTimestamp: options.rolloutTimestamp,
+    changed: {
+      kustomization: kustomizationChanged,
+      service: serviceChanged,
+      worker: workerChanged,
+    },
+  }
+}
+
+const parseArgs = (argv: string[]): CliOptions => {
+  const options: CliOptions = {}
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: bun run packages/scripts/src/jangar/update-manifests.ts [options]
+
+Options:
+  --registry <value>
+  --repository <value>
+  --tag <value>
+  --digest <value>
+  --rollout-timestamp <ISO8601>
+  --kustomization-path <path>
+  --service-manifest-path <path>
+  --worker-manifest-path <path>`)
+      process.exit(0)
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+
+    const [flag, inlineValue] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    const value = inlineValue ?? argv[i + 1]
+    if (inlineValue === undefined) {
+      i += 1
+    }
+    if (value === undefined) {
+      throw new Error(`Missing value for ${flag}`)
+    }
+
+    switch (flag) {
+      case '--registry':
+        options.registry = value
+        break
+      case '--repository':
+        options.repository = value
+        break
+      case '--tag':
+        options.tag = value
+        break
+      case '--digest':
+        options.digest = value
+        break
+      case '--rollout-timestamp':
+        options.rolloutTimestamp = value
+        break
+      case '--kustomization-path':
+        options.kustomizationPath = value
+        break
+      case '--service-manifest-path':
+        options.serviceManifestPath = value
+        break
+      case '--worker-manifest-path':
+        options.workerManifestPath = value
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
+  }
+
+  return options
+}
+
+export const main = (cliOptions?: CliOptions) => {
+  const parsed = cliOptions ?? parseArgs(process.argv.slice(2))
+  const registry = parsed.registry ?? process.env.JANGAR_IMAGE_REGISTRY ?? defaultRegistry
+  const repository = parsed.repository ?? process.env.JANGAR_IMAGE_REPOSITORY ?? defaultRepository
+  const defaultTag = execGit(['rev-parse', '--short', 'HEAD'])
+  const tag = parsed.tag ?? process.env.JANGAR_IMAGE_TAG ?? defaultTag
+  const digest = parsed.digest ?? process.env.JANGAR_IMAGE_DIGEST
+  const rolloutTimestamp = parsed.rolloutTimestamp ?? process.env.JANGAR_ROLLOUT_TIMESTAMP ?? new Date().toISOString()
+
+  const result = updateJangarManifests({
+    imageName: `${registry}/${repository}`,
+    tag,
+    digest,
+    rolloutTimestamp,
+    kustomizationPath: parsed.kustomizationPath ?? process.env.JANGAR_KUSTOMIZATION_PATH,
+    serviceManifestPath: parsed.serviceManifestPath ?? process.env.JANGAR_SERVICE_MANIFEST,
+    workerManifestPath: parsed.workerManifestPath ?? process.env.JANGAR_WORKER_MANIFEST,
+  })
+
+  console.log(
+    `Jangar manifest update complete (tag=${result.tag}, digest=${result.digest}, rollout=${result.rolloutTimestamp})`,
+  )
+}
+
+if (import.meta.main) {
+  try {
+    main()
+  } catch (error) {
+    fatal('Failed to update jangar manifests', error)
+  }
+}
+
+export const __private = {
+  parseArgs,
+  normalizeDigest,
+  updateKustomizationManifest,
+  updateRolloutAnnotation,
+}


### PR DESCRIPTION
## Summary

- add `packages/scripts/src/jangar/update-manifests.ts` to update Jangar GitOps manifests (tag, digest, API rollout annotation, worker restart annotation)
- add unit coverage in `packages/scripts/src/jangar/__tests__/update-manifests.test.ts` for digest normalization/insertion and rollout annotation updates
- refactor `packages/scripts/src/jangar/deploy-service.ts` to reuse the shared manifest updater so manual and automated paths stay consistent
- add automated release workflows: `.github/workflows/jangar-release.yml`, `.github/workflows/jangar-deploy-automerge.yml`, and `.github/workflows/jangar-post-deploy-verify.yml`

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/update-manifests.test.ts`
- `bunx tsc --noEmit --project packages/scripts/tsconfig.jangar.json`
- `bunx biome check packages/scripts/src/jangar/update-manifests.ts packages/scripts/src/jangar/deploy-service.ts packages/scripts/src/jangar/__tests__/update-manifests.test.ts .github/workflows/jangar-release.yml .github/workflows/jangar-deploy-automerge.yml .github/workflows/jangar-post-deploy-verify.yml`
- `bun run packages/scripts/src/jangar/update-manifests.ts --tag e2e-test-tag --digest sha256:e2e1234567890 --rollout-timestamp 2026-02-20T12:00:00Z --kustomization-path <tmp>/kustomization.yaml --service-manifest-path <tmp>/deployment.yaml --worker-manifest-path <tmp>/jangar-worker-deployment.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
