### PR TITLE
fix(jangar): repair release workflow yaml

### DIFF
--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -128,8 +128,8 @@ jobs:
         with:
           branch: codex/jangar-release-${{ steps.meta.outputs.tag }}
           base: main
-          title: chore(jangar): promote image ${{ steps.meta.outputs.tag }}
-          commit-message: chore(jangar): promote image ${{ steps.meta.outputs.tag }}
+          title: "chore(jangar): promote image ${{ steps.meta.outputs.tag }}"
+          commit-message: "chore(jangar): promote image ${{ steps.meta.outputs.tag }}"
           delete-branch: true
           add-paths: |
             argocd/applications/jangar/kustomization.yaml


### PR DESCRIPTION
## Summary

- fix invalid YAML in `jangar-release.yml` by quoting `create-pull-request` `title` and `commit-message` values
- preserve the existing release workflow logic while making the workflow parseable/executable by GitHub Actions
- validate workflow syntax locally with `actionlint` (runner-label warning only for custom self-hosted label)

## Related Issues

None

## Testing

- `$(go env GOPATH)/bin/actionlint .github/workflows/jangar-release.yml`
- `gh workflow view jangar-release.yml -R proompteng/lab --yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
