### PR TITLE
fix(jangar): resolve digest step shell interpolation bug

### DIFF
--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -85,7 +85,7 @@ jobs:
             DIGEST="$(
               bun --eval "
                 import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
-                const image = \`registry.ide-newton.ts.net/lab/jangar:${process.env.IMAGE_TAG}\`
+                const image = 'registry.ide-newton.ts.net/lab/jangar:' + process.env.IMAGE_TAG
                 const repoDigest = inspectImageDigest(image)
                 const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
                 console.log(digest)


### PR DESCRIPTION
## Summary

- fix `jangar-release.yml` digest resolution to avoid bash interpolating JS template expressions
- switch image string construction in the `bun --eval` block from template-literal syntax to string concatenation
- preserve existing digest lookup behavior while removing the `bad substitution` runtime failure

## Related Issues

None

## Testing

- `$(go env GOPATH)/bin/actionlint .github/workflows/jangar-release.yml`
- `gh run view --job 64250182425 -R proompteng/lab --log` (verified prior failure cause and corrected command path)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
