### PR TITLE
fix(jangar): hand off image digest from build to release

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -49,6 +49,29 @@ jobs:
           JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
         run: bun run packages/scripts/src/jangar/build-image.ts
 
+      - name: Resolve pushed image digest
+        id: digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE="registry.ide-newton.ts.net/lab/jangar"
+          TAG="${{ steps.meta.outputs.tag }}"
+          DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" | awk '/^Digest:/ { print $2; exit }')"
+          if [ -z "${DIGEST}" ]; then
+            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
+            exit 1
+          fi
+          echo "${DIGEST}" > jangar-image-digest.txt
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload image digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jangar-image-${{ steps.meta.outputs.tag }}
+          path: jangar-image-digest.txt
+          if-no-files-found: error
+          retention-days: 3
+
       - name: Update latest tag
         run: |
           set -euo pipefail

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -30,6 +30,7 @@ jobs:
       }}
     runs-on: arc-arm64
     permissions:
+      actions: read
       contents: write
       pull-requests: write
     steps:
@@ -71,6 +72,15 @@ jobs:
           echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+      - name: Download digest artifact from triggering build
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: jangar-image-${{ steps.meta.outputs.tag }}
+          path: .artifacts/jangar
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Resolve image digest
         id: digest
         shell: bash
@@ -79,8 +89,11 @@ jobs:
           DIGEST_INPUT: ${{ inputs.image_digest }}
         run: |
           set -euo pipefail
+          ARTIFACT_DIGEST_FILE=".artifacts/jangar/jangar-image-digest.txt"
           if [ -n "${DIGEST_INPUT}" ]; then
             DIGEST="${DIGEST_INPUT}"
+          elif [ -f "${ARTIFACT_DIGEST_FILE}" ]; then
+            DIGEST="$(cat "${ARTIFACT_DIGEST_FILE}")"
           else
             DIGEST="$(
               bun --eval "
@@ -94,6 +107,10 @@ jobs:
           fi
 
           DIGEST="${DIGEST#*@}"
+          if [ -z "${DIGEST}" ]; then
+            echo "Resolved digest is empty"
+            exit 1
+          fi
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Update Jangar manifests


### PR DESCRIPTION
## Summary

- add digest capture to `.github/workflows/jangar-build-push.yaml` and upload it as an artifact keyed by image tag
- update `.github/workflows/jangar-release.yml` to download the digest artifact from the triggering `workflow_run`
- keep manual dispatch support via `image_digest` input and leave registry inspection as fallback only

## Related Issues

None

## Testing

- `$(go env GOPATH)/bin/actionlint .github/workflows/jangar-build-push.yaml .github/workflows/jangar-release.yml`
- `gh run view --job 64250346517 -R proompteng/lab --log` (verified prior digest-resolution failure path and validated this fix addresses that handoff)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
