### PR TITLE
fix(jangar): avoid workflow suppression in automation chain

### DIFF
--- a/.github/workflows/jangar-deploy-automerge.yml
+++ b/.github/workflows/jangar-deploy-automerge.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Enable squash auto-merge
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -143,6 +143,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/jangar-release-${{ steps.meta.outputs.tag }}
           base: main
           title: "chore(jangar): promote image ${{ steps.meta.outputs.tag }}"


### PR DESCRIPTION
## Summary

- switch `jangar-release` PR creation token to `AGENTS_SPLIT_TOKEN` (fallback `GITHUB_TOKEN`)
- switch `jangar-deploy-automerge` merge token to `AGENTS_SPLIT_TOKEN` (fallback `GITHUB_TOKEN`)
- ensure follow-on workflow triggers are not suppressed by default `GITHUB_TOKEN` behavior on automated PR/merge actions

## Related Issues

None

## Testing

- `$(go env GOPATH)/bin/actionlint .github/workflows/jangar-release.yml .github/workflows/jangar-deploy-automerge.yml`
- `gh run list -R proompteng/lab --workflow jangar-release.yml --limit 5` (validated previous failure/rerun flow and applied tokenization fix)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
