### PR TITLE
fix(jangar): align build and release tag width

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Resolve image tag
         id: meta
-        run: echo "tag=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## Summary

- change `jangar-build-push` tag generation to `git rev-parse --short=8 HEAD`
- align build tag length with `jangar-release` tag derivation from source SHA
- fix artifact handoff lookup (`jangar-image-<tag>`) between build and release workflows

## Related Issues

None

## Testing

- `$(go env GOPATH)/bin/actionlint .github/workflows/jangar-build-push.yaml .github/workflows/jangar-release.yml`
- `gh run view --job 64250941319 -R proompteng/lab --log` (verified artifact lookup failure due 7/8-char tag mismatch)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
