### PR TITLE
chore(jangar): promote image 92a1ac37

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-20T00:28:22.000Z"
+    deploy.knative.dev/rollout: "2026-02-20T05:50:02Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-19T19:10:00.000Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-20T05:50:02Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -56,5 +56,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "da51a300"
-    digest: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e
+    newTag: "92a1ac37"
+    digest: sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `92a1ac378d805abf399b2ce50b955f1ea463e682`
- Image tag: `92a1ac37`
- Image digest: `sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe`
- Updated API and worker rollout annotations