### PR TITLE
fix(ci): make jangar verify digest parse awk-portable

### DIFF
--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -113,8 +113,8 @@ jobs:
           set -euo pipefail
           EXPECTED_DIGEST="$(
             awk '
-              $0 ~ /name: registry\\.ide-newton\\.ts\\.net\\/lab\\/jangar/ { found=1; next }
-              found && $0 ~ /digest:/ { print $2; exit }
+              index($0, "name: registry.ide-newton.ts.net/lab/jangar") { found=1; next }
+              found && $1 == "digest:" { print $2; exit }
             ' argocd/applications/jangar/kustomization.yaml
           )"
           if [ -z "${EXPECTED_DIGEST}" ]; then


### PR DESCRIPTION
## Summary

- replace regex-heavy `awk` pattern in `jangar-post-deploy-verify` with portable `index(...)` matching for image name lookup
- switch digest line detection to `$1 == "digest:"` to avoid backslash parsing issues on runner `awk`
- keep rollout and digest verification behavior unchanged while making the check reliable on ARC runners

## Related Issues

None

## Testing

- `awk 'index($0, "name: registry.ide-newton.ts.net/lab/jangar") { found=1; next } found && $1 == "digest:" { print $2; exit }' argocd/applications/jangar/kustomization.yaml`
- `actionlint .github/workflows/jangar-post-deploy-verify.yml` (workflow syntax checked; custom self-hosted label warning expected)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
