### PR TITLE
feat(argocd): enable automatic sync for jangar app

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -111,7 +111,7 @@ spec:
                 namespace: jangar
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
-                automation: manual
+                automation: auto
                 enabled: "true"
               - name: agents
                 path: argocd/applications/agents


### PR DESCRIPTION
## Summary

- switch Jangar entry in `argocd/applicationsets/product.yaml` from `automation: manual` to `automation: auto`
- ensure Argo CD auto-sync/self-heal is enabled for the generated `Application/jangar`
- unblock fully automated manifest promotion so release PR merges propagate to cluster without manual sync actions

## Related Issues

None

## Testing

- `rg -n "- name: jangar|automation:" argocd/applicationsets/product.yaml`
- Manual validation plan after merge: confirm `Application/jangar` has `spec.syncPolicy.automated` and rerun `jangar-post-deploy-verify` on `main`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
