### PR TITLE
feat(jangar): harden end-to-end release and deploy automation

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -20,6 +20,10 @@ on:
       - '.github/workflows/jangar-build-push.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: jangar-build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: arc-arm64
@@ -64,11 +68,22 @@ jobs:
           echo "${DIGEST}" > jangar-image-digest.txt
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload image digest artifact
+      - name: Write release contract artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun run packages/scripts/src/jangar/release-contract.ts write \
+            --path jangar-release-contract.json \
+            --source-sha "${GITHUB_SHA}" \
+            --tag "${{ steps.meta.outputs.tag }}" \
+            --digest "${{ steps.digest.outputs.digest }}" \
+            --image "registry.ide-newton.ts.net/lab/jangar"
+
+      - name: Upload release contract artifact
         uses: actions/upload-artifact@v4
         with:
-          name: jangar-image-${{ steps.meta.outputs.tag }}
-          path: jangar-image-digest.txt
+          name: jangar-release-contract
+          path: jangar-release-contract.json
           if-no-files-found: error
           retention-days: 3
 

--- a/.github/workflows/jangar-guardrails.yml
+++ b/.github/workflows/jangar-guardrails.yml
@@ -44,7 +44,13 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest
 
       - name: Run actionlint
-        run: ./actionlint -color -ignore 'label "arc-arm64" is unknown'
+        run: |
+          ./actionlint -color -ignore 'label "arc-arm64" is unknown' \
+            .github/workflows/jangar-build-push.yaml \
+            .github/workflows/jangar-release.yml \
+            .github/workflows/jangar-deploy-automerge.yml \
+            .github/workflows/jangar-post-deploy-verify.yml \
+            .github/workflows/jangar-guardrails.yml
 
   automation-policy:
     runs-on: ubuntu-latest

--- a/.github/workflows/jangar-guardrails.yml
+++ b/.github/workflows/jangar-guardrails.yml
@@ -1,0 +1,61 @@
+name: jangar-guardrails
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/jangar-build-push.yaml'
+      - '.github/workflows/jangar-release.yml'
+      - '.github/workflows/jangar-deploy-automerge.yml'
+      - '.github/workflows/jangar-post-deploy-verify.yml'
+      - '.github/workflows/jangar-guardrails.yml'
+      - 'argocd/applicationsets/product.yaml'
+      - 'packages/scripts/src/jangar/check-automation-policy.ts'
+  pull_request:
+    paths:
+      - '.github/workflows/jangar-build-push.yaml'
+      - '.github/workflows/jangar-release.yml'
+      - '.github/workflows/jangar-deploy-automerge.yml'
+      - '.github/workflows/jangar-post-deploy-verify.yml'
+      - '.github/workflows/jangar-guardrails.yml'
+      - 'argocd/applicationsets/product.yaml'
+      - 'packages/scripts/src/jangar/check-automation-policy.ts'
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install ShellCheck
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest
+
+      - name: Run actionlint
+        run: ./actionlint -color -ignore 'label "arc-arm64" is unknown'
+
+  automation-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Enforce Jangar automation mode
+        run: bun run packages/scripts/src/jangar/check-automation-policy.ts --require jangar=auto

--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -8,14 +8,24 @@ on:
       - 'argocd/applications/jangar/**'
   workflow_dispatch:
 
+concurrency:
+  group: jangar-post-deploy-verify-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: arc-arm64
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
 
       - name: Set up kubectl
         uses: azure/setup-kubectl@v4
@@ -72,68 +82,66 @@ jobs:
           set -euo pipefail
           kubectl config current-context
 
-      - name: Wait for Argo application health
+      - name: Verify deployment health and digest
         shell: bash
         run: |
           set -euo pipefail
-          for attempt in $(seq 1 60); do
-            if ! STATUS="$(kubectl -n argocd get application jangar -o jsonpath='{.status.sync.status} {.status.health.status}' 2>&1)"; then
-              echo "Unable to query Argo application status (${STATUS}); continuing with rollout/digest verification"
-              exit 0
-            fi
-            SYNC_STATUS="$(echo "${STATUS}" | awk '{print $1}')"
-            HEALTH_STATUS="$(echo "${STATUS}" | awk '{print $2}')"
-            echo "Attempt ${attempt}: sync=${SYNC_STATUS:-unknown} health=${HEALTH_STATUS:-unknown}"
+          bun run packages/scripts/src/jangar/verify-deployment.ts
 
-            # Health + rollout/digest checks are authoritative for deployed state.
-            # Sync can remain OutOfSync due unrelated drift, so do not block on it.
-            if [ "${HEALTH_STATUS}" = "Healthy" ]; then
-              if [ "${SYNC_STATUS}" != "Synced" ]; then
-                echo "Application is Healthy but sync=${SYNC_STATUS}; continuing with rollout/digest verification"
-              fi
-              exit 0
-            fi
-
-            sleep 10
-          done
-
-          echo "Jangar Argo application did not reach Healthy within timeout"
-          exit 1
-
-      - name: Wait for deployment rollouts
+      - name: Prepare rollback manifests
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: rollback
         shell: bash
         run: |
           set -euo pipefail
-          kubectl rollout status deployment/jangar -n jangar --timeout=10m
-          kubectl rollout status deployment/jangar-worker -n jangar --timeout=10m
 
-      - name: Verify deployed image digest matches manifests
-        shell: bash
-        run: |
-          set -euo pipefail
-          EXPECTED_DIGEST="$(
-            awk '
-              index($0, "name: registry.ide-newton.ts.net/lab/jangar") { found=1; next }
-              found && $1 == "digest:" { print $2; exit }
-            ' argocd/applications/jangar/kustomization.yaml
-          )"
-          if [ -z "${EXPECTED_DIGEST}" ]; then
-            echo "Unable to parse expected digest from argocd/applications/jangar/kustomization.yaml"
-            exit 1
+          HEAD_MESSAGE="$(git log -1 --pretty=%s)"
+          if [[ "${HEAD_MESSAGE}" == rollback\(jangar\):* ]]; then
+            echo "Skipping rollback PR because current commit is already a rollback"
+            echo "should_rollback=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          API_IMAGES="$(kubectl -n jangar get deployment jangar -o jsonpath='{..image}')"
-          WORKER_IMAGES="$(kubectl -n jangar get deployment jangar-worker -o jsonpath='{..image}')"
-
-          echo "Expected digest: ${EXPECTED_DIGEST}"
-          echo "API images: ${API_IMAGES}"
-          echo "Worker images: ${WORKER_IMAGES}"
-
-          if [[ "${API_IMAGES}" != *"${EXPECTED_DIGEST}"* ]]; then
-            echo "API deployment image digest does not match expected digest"
-            exit 1
+          if ! git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            echo "No parent commit available for rollback"
+            echo "should_rollback=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          if [[ "${WORKER_IMAGES}" != *"${EXPECTED_DIGEST}"* ]]; then
-            echo "Worker deployment image digest does not match expected digest"
-            exit 1
+
+          git checkout --quiet HEAD^ -- \
+            argocd/applications/jangar/kustomization.yaml \
+            argocd/applications/jangar/deployment.yaml \
+            argocd/applications/jangar/jangar-worker-deployment.yaml
+
+          if git diff --quiet -- \
+            argocd/applications/jangar/kustomization.yaml \
+            argocd/applications/jangar/deployment.yaml \
+            argocd/applications/jangar/jangar-worker-deployment.yaml; then
+            echo "No rollback diff detected"
+            echo "should_rollback=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          echo "should_rollback=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open rollback pull request
+        if: failure() && steps.rollback.outputs.should_rollback == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: codex/jangar-rollback-${{ github.run_id }}-${{ github.run_attempt }}
+          base: main
+          title: "rollback(jangar): revert failed promotion ${{ github.sha }}"
+          commit-message: "rollback(jangar): revert failed promotion ${{ github.sha }}"
+          delete-branch: true
+          add-paths: |
+            argocd/applications/jangar/kustomization.yaml
+            argocd/applications/jangar/deployment.yaml
+            argocd/applications/jangar/jangar-worker-deployment.yaml
+          body: |
+            ## Summary
+            Automatic rollback created because `jangar-post-deploy-verify` failed on `main`.
+
+            - Failed commit: `${{ github.sha }}`
+            - Workflow run: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+            - Rollback source: `HEAD^` manifests from the failed run checkout

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: jangar-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   promote:
     if: >-
@@ -48,57 +52,115 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Resolve release metadata
-        id: meta
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            SOURCE_SHA="${{ github.event.workflow_run.head_sha }}"
-          elif [ -n "${{ inputs.commit_sha }}" ]; then
-            SOURCE_SHA="${{ inputs.commit_sha }}"
-          else
-            SOURCE_SHA="$(git rev-parse HEAD)"
-          fi
-
-          TAG_INPUT='${{ inputs.image_tag }}'
-          if [ -n "$TAG_INPUT" ]; then
-            TAG="$TAG_INPUT"
-          else
-            TAG="${SOURCE_SHA:0:8}"
-          fi
-
-          git checkout --force "$SOURCE_SHA"
-          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Download digest artifact from triggering build
+      - name: Download release contract artifact from triggering build
         if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@v4
         with:
-          name: jangar-image-${{ steps.meta.outputs.tag }}
+          name: jangar-release-contract
           path: .artifacts/jangar
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_SHA_INPUT: ${{ inputs.commit_sha }}
+          IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+
+          MAIN_HEAD="$(git rev-parse origin/main)"
+          IMAGE="registry.ide-newton.ts.net/lab/jangar"
+          SOURCE_SHA=""
+          TAG=""
+          CONTRACT_DIGEST=""
+          PROMOTE="true"
+
+          if [ "${EVENT_NAME}" = "workflow_run" ]; then
+            CONTRACT_PATH=".artifacts/jangar/jangar-release-contract.json"
+            if [ ! -f "${CONTRACT_PATH}" ]; then
+              echo "Release contract artifact is missing at ${CONTRACT_PATH}"
+              exit 1
+            fi
+
+            SOURCE_SHA="$(bun run packages/scripts/src/jangar/release-contract.ts get --path "${CONTRACT_PATH}" --field sourceSha)"
+            TAG="$(bun run packages/scripts/src/jangar/release-contract.ts get --path "${CONTRACT_PATH}" --field tag)"
+            CONTRACT_DIGEST="$(bun run packages/scripts/src/jangar/release-contract.ts get --path "${CONTRACT_PATH}" --field digest)"
+            CONTRACT_IMAGE="$(bun run packages/scripts/src/jangar/release-contract.ts get --path "${CONTRACT_PATH}" --field image)"
+
+            if [ "${CONTRACT_IMAGE}" != "${IMAGE}" ]; then
+              echo "Release contract image mismatch: expected ${IMAGE}, got ${CONTRACT_IMAGE}"
+              exit 1
+            fi
+
+            if [ "${SOURCE_SHA}" != "${WORKFLOW_RUN_HEAD_SHA}" ]; then
+              echo "Release contract source SHA ${SOURCE_SHA} does not match workflow_run head ${WORKFLOW_RUN_HEAD_SHA}"
+              exit 1
+            fi
+
+            if [ "${SOURCE_SHA}" != "${MAIN_HEAD}" ]; then
+              echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; latest main is ${MAIN_HEAD}"
+              PROMOTE="false"
+            fi
+          else
+            if [ -n "${COMMIT_SHA_INPUT}" ]; then
+              SOURCE_SHA="${COMMIT_SHA_INPUT}"
+            else
+              SOURCE_SHA="${MAIN_HEAD}"
+            fi
+
+            if [ -n "${IMAGE_TAG_INPUT}" ]; then
+              TAG="${IMAGE_TAG_INPUT}"
+            else
+              TAG="${SOURCE_SHA:0:8}"
+            fi
+          fi
+
+          if [ "${PROMOTE}" = "true" ] && ! git cat-file -e "${SOURCE_SHA}^{commit}" >/dev/null 2>&1; then
+            echo "Source SHA ${SOURCE_SHA} is not present in local git history"
+            exit 1
+          fi
+
+          {
+            echo "main_head=${MAIN_HEAD}"
+            echo "source_sha=${SOURCE_SHA}"
+            echo "tag=${TAG}"
+            echo "contract_digest=${CONTRACT_DIGEST}"
+            echo "image=${IMAGE}"
+            echo "promote=${PROMOTE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout source revision
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout --force "${{ steps.meta.outputs.source_sha }}"
+
       - name: Resolve image digest
+        if: steps.meta.outputs.promote == 'true'
         id: digest
         shell: bash
         env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image }}
           IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          CONTRACT_DIGEST: ${{ steps.meta.outputs.contract_digest }}
           DIGEST_INPUT: ${{ inputs.image_digest }}
         run: |
           set -euo pipefail
-          ARTIFACT_DIGEST_FILE=".artifacts/jangar/jangar-image-digest.txt"
+
           if [ -n "${DIGEST_INPUT}" ]; then
             DIGEST="${DIGEST_INPUT}"
-          elif [ -f "${ARTIFACT_DIGEST_FILE}" ]; then
-            DIGEST="$(cat "${ARTIFACT_DIGEST_FILE}")"
+          elif [ -n "${CONTRACT_DIGEST}" ]; then
+            DIGEST="${CONTRACT_DIGEST}"
           else
             DIGEST="$(
               bun --eval "
                 import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
-                const image = 'registry.ide-newton.ts.net/lab/jangar:' + process.env.IMAGE_TAG
+                const image = process.env.IMAGE_NAME + ':' + process.env.IMAGE_TAG
                 const repoDigest = inspectImageDigest(image)
                 const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
                 console.log(digest)
@@ -111,13 +173,14 @@ jobs:
             echo "Resolved digest is empty"
             exit 1
           fi
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Update Jangar manifests
+        if: steps.meta.outputs.promote == 'true'
         env:
           JANGAR_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
           JANGAR_IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
-          JANGAR_ROLLOUT_TIMESTAMP: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           bun run packages/scripts/src/jangar/update-manifests.ts \
@@ -126,6 +189,7 @@ jobs:
             --rollout-timestamp "${TIMESTAMP}"
 
       - name: Check for manifest changes
+        if: steps.meta.outputs.promote == 'true'
         id: changes
         shell: bash
         run: |
@@ -140,7 +204,7 @@ jobs:
           fi
 
       - name: Create deploy pull request
-        if: steps.changes.outputs.changed == 'true'
+        if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
@@ -163,5 +227,9 @@ jobs:
             - Updated API and worker rollout annotations
 
       - name: No manifest changes detected
-        if: steps.changes.outputs.changed != 'true'
+        if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'
         run: echo 'No Jangar manifest changes detected.'
+
+      - name: Promotion skipped (stale workflow_run)
+        if: steps.meta.outputs.promote != 'true'
+        run: echo 'Skipping stale workflow_run promotion because source SHA is not current main.'

--- a/argocd/applications/agents-ci/runner-rbac-cluster.yaml
+++ b/argocd/applications/agents-ci/runner-rbac-cluster.yaml
@@ -38,9 +38,10 @@ roleRef:
   name: agents-ci-runner-crd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: agents-ci-runner-jangar-verify-read
+  namespace: argocd
 rules:
   - apiGroups:
       - argoproj.io
@@ -50,24 +51,47 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - get
-      - list
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: agents-ci-runner-jangar-verify-read
+  namespace: argocd
 subjects:
   - kind: ServiceAccount
     name: arc-arm64-gha-rs-kube-mode
     namespace: arc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: agents-ci-runner-jangar-verify-read
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agents-ci-runner-jangar-rollout-read
+  namespace: jangar
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agents-ci-runner-jangar-rollout-read
+  namespace: jangar
+subjects:
+  - kind: ServiceAccount
+    name: arc-arm64-gha-rs-kube-mode
+    namespace: arc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agents-ci-runner-jangar-rollout-read

--- a/packages/scripts/src/jangar/__tests__/check-automation-policy.test.ts
+++ b/packages/scripts/src/jangar/__tests__/check-automation-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test'
+
+import { __private } from '../check-automation-policy'
+
+describe('check-automation-policy', () => {
+  it('parses automation modes for app entries', () => {
+    const source = `elements:
+  - name: jangar
+    path: argocd/applications/jangar
+    automation: auto
+  - name: bumba
+    path: argocd/applications/bumba
+    automation: manual
+`
+
+    const parsed = __private.parseAutomationModes(source)
+    expect(parsed.get('jangar')).toBe('auto')
+    expect(parsed.get('bumba')).toBe('manual')
+  })
+
+  it('parses repeated require flags', () => {
+    const parsed = __private.parseArgs(['--require', 'jangar=auto', '--require', 'bumba=manual'])
+    expect(parsed.requirements).toEqual([
+      { app: 'jangar', mode: 'auto' },
+      { app: 'bumba', mode: 'manual' },
+    ])
+  })
+})

--- a/packages/scripts/src/jangar/__tests__/release-contract.test.ts
+++ b/packages/scripts/src/jangar/__tests__/release-contract.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+import { readReleaseContract, writeReleaseContract } from '../release-contract'
+
+describe('release-contract', () => {
+  it('writes and reads a valid contract', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jangar-release-contract-'))
+    const contractPath = join(dir, 'contract.json')
+
+    writeReleaseContract(relative(repoRoot, contractPath), {
+      sourceSha: '1234567890abcdef1234567890abcdef12345678',
+      tag: '12345678',
+      digest: 'sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe',
+      image: 'registry.ide-newton.ts.net/lab/jangar',
+      createdAt: '2026-02-20T06:30:00.000Z',
+    })
+
+    const parsed = readReleaseContract(relative(repoRoot, contractPath))
+    expect(parsed.sourceSha).toBe('1234567890abcdef1234567890abcdef12345678')
+    expect(parsed.tag).toBe('12345678')
+    expect(parsed.digest).toBe('sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe')
+    expect(parsed.image).toBe('registry.ide-newton.ts.net/lab/jangar')
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('normalizes digest values with repository prefix', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'jangar-release-contract-'))
+    const contractPath = join(dir, 'contract.json')
+
+    writeReleaseContract(relative(repoRoot, contractPath), {
+      sourceSha: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      tag: 'abcdefab',
+      digest:
+        'registry.ide-newton.ts.net/lab/jangar@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+      image: 'registry.ide-newton.ts.net/lab/jangar',
+      createdAt: '2026-02-20T06:31:00.000Z',
+    })
+
+    const parsed = readReleaseContract(relative(repoRoot, contractPath))
+    expect(parsed.digest).toBe('sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/packages/scripts/src/jangar/__tests__/verify-deployment.test.ts
+++ b/packages/scripts/src/jangar/__tests__/verify-deployment.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test'
+
+import { __private } from '../verify-deployment'
+
+describe('verify-deployment', () => {
+  it('extracts expected digest for configured image', () => {
+    const source = `images:
+  - name: registry.ide-newton.ts.net/lab/jangar
+    newTag: "abcd1234"
+    digest: sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe
+  - name: registry.ide-newton.ts.net/lab/other
+    newTag: latest
+    digest: sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+`
+
+    const digest = __private.extractExpectedDigest(source, 'registry.ide-newton.ts.net/lab/jangar')
+    expect(digest).toBe('sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe')
+  })
+
+  it('parses deployment and sync args', () => {
+    const parsed = __private.parseArgs([
+      '--namespace',
+      'jangar',
+      '--deployments',
+      'jangar,jangar-worker',
+      '--require-synced',
+      '--health-attempts',
+      '10',
+      '--health-interval-seconds',
+      '5',
+    ])
+
+    expect(parsed.namespace).toBe('jangar')
+    expect(parsed.deployments).toEqual(['jangar', 'jangar-worker'])
+    expect(parsed.requireSynced).toBe(true)
+    expect(parsed.healthAttempts).toBe(10)
+    expect(parsed.healthIntervalSeconds).toBe(5)
+  })
+})

--- a/packages/scripts/src/jangar/check-automation-policy.ts
+++ b/packages/scripts/src/jangar/check-automation-policy.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+import { fatal, repoRoot } from '../shared/cli'
+
+const defaultPolicyFile = 'argocd/applicationsets/product.yaml'
+const defaultRequirement = 'jangar=auto'
+
+type Requirement = {
+  app: string
+  mode: string
+}
+
+type CliOptions = {
+  filePath?: string
+  requirements: Requirement[]
+}
+
+const resolvePath = (path: string) => resolve(repoRoot, path)
+
+const normalizeValue = (value: string): string => value.trim().replace(/^['"]|['"]$/g, '')
+
+export const parseAutomationModes = (source: string): Map<string, string> => {
+  const lines = source.split(/\r?\n/)
+  const modes = new Map<string, string>()
+
+  let currentApp: string | undefined
+  let currentIndent = 0
+
+  for (const line of lines) {
+    const appMatch = line.match(/^(\s*)-\s+name:\s*([^\s#]+)/)
+    if (appMatch) {
+      currentApp = normalizeValue(appMatch[2])
+      currentIndent = appMatch[1].length
+      continue
+    }
+
+    if (!currentApp) {
+      continue
+    }
+
+    const trimmed = line.trim()
+    const leadingSpaces = line.match(/^(\s*)/)?.[1].length ?? 0
+    if (trimmed && !trimmed.startsWith('#') && leadingSpaces <= currentIndent) {
+      currentApp = undefined
+      continue
+    }
+
+    const automationMatch = line.match(/^\s*automation:\s*([^\s#]+)/)
+    if (automationMatch) {
+      modes.set(currentApp, normalizeValue(automationMatch[1]))
+    }
+  }
+
+  return modes
+}
+
+const parseRequirement = (raw: string): Requirement => {
+  const [appRaw, modeRaw] = raw.split('=', 2)
+  const app = appRaw?.trim()
+  const mode = modeRaw?.trim()
+  if (!app || !mode) {
+    throw new Error(`Invalid --require value '${raw}'. Expected format <app>=<mode>`)
+  }
+  return {
+    app,
+    mode,
+  }
+}
+
+const parseArgs = (argv: string[]): CliOptions => {
+  const options: CliOptions = {
+    requirements: [],
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: bun run packages/scripts/src/jangar/check-automation-policy.ts [options]
+
+Options:
+  --file <path>              Path to ApplicationSet file (default: argocd/applicationsets/product.yaml)
+  --require <app>=<mode>     Required automation mode. Can be passed multiple times.
+
+Example:
+  bun run packages/scripts/src/jangar/check-automation-policy.ts --require jangar=auto`)
+      process.exit(0)
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+
+    const [flag, inlineValue] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    const value = inlineValue ?? argv[i + 1]
+    if (inlineValue === undefined) {
+      i += 1
+    }
+    if (value === undefined) {
+      throw new Error(`Missing value for ${flag}`)
+    }
+
+    switch (flag) {
+      case '--file':
+        options.filePath = value
+        break
+      case '--require':
+        options.requirements.push(parseRequirement(value))
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
+  }
+
+  if (options.requirements.length === 0) {
+    options.requirements.push(parseRequirement(defaultRequirement))
+  }
+
+  return options
+}
+
+const main = (cliOptions?: CliOptions) => {
+  const parsed = cliOptions ?? parseArgs(process.argv.slice(2))
+  const filePath = resolvePath(parsed.filePath ?? defaultPolicyFile)
+  const source = readFileSync(filePath, 'utf8')
+  const modes = parseAutomationModes(source)
+
+  for (const requirement of parsed.requirements) {
+    const actual = modes.get(requirement.app)
+    if (!actual) {
+      throw new Error(`App '${requirement.app}' was not found in ${parsed.filePath ?? defaultPolicyFile}`)
+    }
+
+    if (actual !== requirement.mode) {
+      throw new Error(
+        `Automation mode mismatch for '${requirement.app}': expected '${requirement.mode}', found '${actual}'`,
+      )
+    }
+  }
+
+  for (const requirement of parsed.requirements) {
+    console.log(`Automation policy ok: ${requirement.app}=${requirement.mode}`)
+  }
+}
+
+if (import.meta.main) {
+  try {
+    main()
+  } catch (error) {
+    fatal('Automation policy check failed', error)
+  }
+}
+
+export const __private = {
+  parseArgs,
+  parseAutomationModes,
+  parseRequirement,
+}

--- a/packages/scripts/src/jangar/release-contract.ts
+++ b/packages/scripts/src/jangar/release-contract.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+import { fatal, repoRoot } from '../shared/cli'
+
+const defaultContractPath = 'jangar-release-contract.json'
+
+const sourceShaPattern = /^[0-9a-f]{40}$/i
+const tagPattern = /^[A-Za-z0-9._-]{1,128}$/
+const digestPattern = /^sha256:[0-9a-f]{64}$/i
+
+export type JangarReleaseContract = {
+  sourceSha: string
+  tag: string
+  digest: string
+  image: string
+  createdAt: string
+}
+
+type ContractField = keyof JangarReleaseContract
+
+type CliOptions = {
+  command?: 'write' | 'get' | 'emit-github-output'
+  path?: string
+  sourceSha?: string
+  tag?: string
+  digest?: string
+  image?: string
+  field?: ContractField
+}
+
+const normalizeDigest = (value: string): string => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return trimmed
+  }
+  const digestPart = trimmed.includes('@') ? trimmed.slice(trimmed.lastIndexOf('@') + 1) : trimmed
+  return digestPart
+}
+
+const resolveContractPath = (path: string) => resolve(repoRoot, path)
+
+const parseArgs = (argv: string[]): CliOptions => {
+  const options: CliOptions = {}
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: bun run packages/scripts/src/jangar/release-contract.ts <command> [options]
+
+Commands:
+  write
+    --path <path>
+    --source-sha <sha40>
+    --tag <tag>
+    --digest <sha256:...>
+    --image <registry/repo>
+  get
+    --path <path>
+    --field <sourceSha|tag|digest|image|createdAt>
+  emit-github-output
+    --path <path>`)
+      process.exit(0)
+    }
+
+    if (!options.command && (arg === 'write' || arg === 'get' || arg === 'emit-github-output')) {
+      options.command = arg
+      continue
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+
+    const [flag, inlineValue] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    const value = inlineValue ?? argv[i + 1]
+    if (inlineValue === undefined) {
+      i += 1
+    }
+    if (value === undefined) {
+      throw new Error(`Missing value for ${flag}`)
+    }
+
+    switch (flag) {
+      case '--path':
+        options.path = value
+        break
+      case '--source-sha':
+        options.sourceSha = value
+        break
+      case '--tag':
+        options.tag = value
+        break
+      case '--digest':
+        options.digest = value
+        break
+      case '--image':
+        options.image = value
+        break
+      case '--field':
+        if (!['sourceSha', 'tag', 'digest', 'image', 'createdAt'].includes(value)) {
+          throw new Error(`Unknown field: ${value}`)
+        }
+        options.field = value as ContractField
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
+  }
+
+  return options
+}
+
+const assertValidContract = (contract: JangarReleaseContract) => {
+  if (!sourceShaPattern.test(contract.sourceSha)) {
+    throw new Error(`Invalid sourceSha '${contract.sourceSha}'`)
+  }
+  if (!tagPattern.test(contract.tag)) {
+    throw new Error(`Invalid tag '${contract.tag}'`)
+  }
+  if (!digestPattern.test(contract.digest)) {
+    throw new Error(`Invalid digest '${contract.digest}'`)
+  }
+  if (!contract.image.trim()) {
+    throw new Error('image cannot be empty')
+  }
+  if (!contract.createdAt.trim()) {
+    throw new Error('createdAt cannot be empty')
+  }
+
+  const createdAtMs = Date.parse(contract.createdAt)
+  if (Number.isNaN(createdAtMs)) {
+    throw new Error(`Invalid createdAt '${contract.createdAt}'`)
+  }
+}
+
+export const writeReleaseContract = (path: string, contract: JangarReleaseContract) => {
+  const normalized: JangarReleaseContract = {
+    ...contract,
+    digest: normalizeDigest(contract.digest),
+  }
+  assertValidContract(normalized)
+  writeFileSync(resolveContractPath(path), `${JSON.stringify(normalized, null, 2)}\n`, 'utf8')
+}
+
+export const readReleaseContract = (path: string): JangarReleaseContract => {
+  const source = readFileSync(resolveContractPath(path), 'utf8')
+  const parsed = JSON.parse(source) as Partial<JangarReleaseContract>
+  const contract: JangarReleaseContract = {
+    sourceSha: parsed.sourceSha ?? '',
+    tag: parsed.tag ?? '',
+    digest: normalizeDigest(parsed.digest ?? ''),
+    image: parsed.image ?? '',
+    createdAt: parsed.createdAt ?? '',
+  }
+  assertValidContract(contract)
+  return contract
+}
+
+export const main = (cliOptions?: CliOptions) => {
+  const parsed = cliOptions ?? parseArgs(process.argv.slice(2))
+  const command = parsed.command
+  const path = parsed.path ?? defaultContractPath
+
+  if (!command) {
+    throw new Error('Missing command (write|get|emit-github-output)')
+  }
+
+  if (command === 'write') {
+    const sourceSha = parsed.sourceSha?.trim() ?? ''
+    const tag = parsed.tag?.trim() ?? ''
+    const digest = normalizeDigest(parsed.digest ?? '')
+    const image = parsed.image?.trim() ?? ''
+    const createdAt = new Date().toISOString()
+
+    const contract: JangarReleaseContract = {
+      sourceSha,
+      tag,
+      digest,
+      image,
+      createdAt,
+    }
+    writeReleaseContract(path, contract)
+    return
+  }
+
+  const contract = readReleaseContract(path)
+
+  if (command === 'get') {
+    if (!parsed.field) {
+      throw new Error('get requires --field')
+    }
+    console.log(contract[parsed.field])
+    return
+  }
+
+  console.log(`source_sha=${contract.sourceSha}`)
+  console.log(`tag=${contract.tag}`)
+  console.log(`digest=${contract.digest}`)
+  console.log(`image=${contract.image}`)
+  console.log(`created_at=${contract.createdAt}`)
+}
+
+if (import.meta.main) {
+  try {
+    main()
+  } catch (error) {
+    fatal('Failed to process jangar release contract', error)
+  }
+}
+
+export const __private = {
+  assertValidContract,
+  normalizeDigest,
+  parseArgs,
+}

--- a/packages/scripts/src/jangar/verify-deployment.ts
+++ b/packages/scripts/src/jangar/verify-deployment.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+import { ensureCli, fatal, repoRoot } from '../shared/cli'
+
+type CliOptions = {
+  namespace?: string
+  deployments?: string[]
+  kustomizationPath?: string
+  imageName?: string
+  argoNamespace?: string
+  argoApplication?: string
+  rolloutTimeout?: string
+  healthAttempts?: number
+  healthIntervalSeconds?: number
+  requireSynced?: boolean
+}
+
+type CommandResult = {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+const defaultImageName = 'registry.ide-newton.ts.net/lab/jangar'
+const defaultKustomizationPath = 'argocd/applications/jangar/kustomization.yaml'
+const defaultNamespace = 'jangar'
+const defaultDeployments = ['jangar', 'jangar-worker']
+const defaultArgoNamespace = 'argocd'
+const defaultArgoApplication = 'jangar'
+const defaultRolloutTimeout = '10m'
+const defaultHealthAttempts = 60
+const defaultHealthIntervalSeconds = 10
+
+const resolvePath = (path: string) => resolve(repoRoot, path)
+
+const stripYamlValueQuotes = (value: string): string => value.replace(/^['"]|['"]$/g, '')
+
+export const extractExpectedDigest = (kustomizationSource: string, imageName: string): string => {
+  const lines = kustomizationSource.split(/\r?\n/)
+  let inImageBlock = false
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    const nameMatch = trimmed.match(/^-?\s*name:\s*(.+)$/)
+    if (nameMatch) {
+      const candidate = stripYamlValueQuotes(nameMatch[1].trim())
+      inImageBlock = candidate === imageName
+      continue
+    }
+
+    if (!inImageBlock) {
+      continue
+    }
+
+    const digestMatch = trimmed.match(/^digest:\s*(.+)$/)
+    if (digestMatch) {
+      const digest = stripYamlValueQuotes(digestMatch[1].trim())
+      return digest.includes('@') ? digest.slice(digest.lastIndexOf('@') + 1) : digest
+    }
+  }
+
+  throw new Error(`Unable to find digest for image '${imageName}' in kustomization`)
+}
+
+const runCommand = async (command: string, args: string[], allowFailure = false): Promise<CommandResult> => {
+  const subprocess = Bun.spawn([command, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    subprocess.stdout ? new Response(subprocess.stdout).text() : Promise.resolve(''),
+    subprocess.stderr ? new Response(subprocess.stderr).text() : Promise.resolve(''),
+    subprocess.exited,
+  ])
+
+  if (exitCode !== 0 && !allowFailure) {
+    throw new Error(`Command failed (${exitCode}): ${command} ${args.join(' ')}\n${stderr || stdout}`.trim())
+  }
+
+  return { stdout, stderr, exitCode }
+}
+
+const parseArgs = (argv: string[]): CliOptions => {
+  const options: CliOptions = {}
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: bun run packages/scripts/src/jangar/verify-deployment.ts [options]
+
+Options:
+  --namespace <name>                 Kubernetes namespace (default: jangar)
+  --deployments <name1,name2>        Deployments to verify (default: jangar,jangar-worker)
+  --kustomization-path <path>        Kustomization path with expected digest
+  --image-name <registry/repository> Image name in kustomization
+  --argo-namespace <name>            Argo CD namespace (default: argocd)
+  --argo-application <name>          Argo CD Application name (default: jangar)
+  --rollout-timeout <duration>       kubectl rollout timeout (default: 10m)
+  --health-attempts <number>         Argo health polling attempts (default: 60)
+  --health-interval-seconds <number> Argo health polling interval seconds (default: 10)
+  --require-synced                   Require Argo application sync status to be Synced`)
+      process.exit(0)
+    }
+
+    if (arg === '--require-synced') {
+      options.requireSynced = true
+      continue
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+
+    const [flag, inlineValue] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    const value = inlineValue ?? argv[i + 1]
+    if (inlineValue === undefined) {
+      i += 1
+    }
+    if (value === undefined) {
+      throw new Error(`Missing value for ${flag}`)
+    }
+
+    switch (flag) {
+      case '--namespace':
+        options.namespace = value
+        break
+      case '--deployments':
+        options.deployments = value
+          .split(',')
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+        break
+      case '--kustomization-path':
+        options.kustomizationPath = value
+        break
+      case '--image-name':
+        options.imageName = value
+        break
+      case '--argo-namespace':
+        options.argoNamespace = value
+        break
+      case '--argo-application':
+        options.argoApplication = value
+        break
+      case '--rollout-timeout':
+        options.rolloutTimeout = value
+        break
+      case '--health-attempts':
+        options.healthAttempts = Number.parseInt(value, 10)
+        break
+      case '--health-interval-seconds':
+        options.healthIntervalSeconds = Number.parseInt(value, 10)
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
+  }
+
+  return options
+}
+
+const waitForArgoHealth = async (options: Required<CliOptions>) => {
+  for (let attempt = 1; attempt <= options.healthAttempts; attempt += 1) {
+    const status = await runCommand(
+      'kubectl',
+      [
+        '-n',
+        options.argoNamespace,
+        'get',
+        'application',
+        options.argoApplication,
+        '-o',
+        'jsonpath={.status.sync.status} {.status.health.status}',
+      ],
+      true,
+    )
+
+    if (status.exitCode !== 0) {
+      const message = (status.stderr || status.stdout || '').trim()
+      console.log(`Unable to query Argo application status (${message}); continuing with deployment verification`)
+      return
+    }
+
+    const [syncStatus = 'unknown', healthStatus = 'unknown'] = status.stdout.trim().split(/\s+/)
+    console.log(`Attempt ${attempt}: sync=${syncStatus} health=${healthStatus}`)
+
+    if (healthStatus !== 'Healthy') {
+      await Bun.sleep(options.healthIntervalSeconds * 1000)
+      continue
+    }
+
+    if (options.requireSynced && syncStatus !== 'Synced') {
+      throw new Error(
+        `Argo application ${options.argoApplication} is Healthy but sync=${syncStatus} (require-synced is enabled)`,
+      )
+    }
+
+    if (syncStatus !== 'Synced') {
+      console.log(`Application is Healthy but sync=${syncStatus}; continuing with rollout/digest verification`)
+    }
+    return
+  }
+
+  throw new Error(`Argo application ${options.argoApplication} did not become Healthy within timeout`)
+}
+
+const verifyRollouts = async (namespace: string, deployments: string[], rolloutTimeout: string) => {
+  for (const deployment of deployments) {
+    await runCommand('kubectl', [
+      'rollout',
+      'status',
+      `deployment/${deployment}`,
+      '-n',
+      namespace,
+      `--timeout=${rolloutTimeout}`,
+    ])
+  }
+}
+
+const verifyDeploymentDigests = async (namespace: string, deployments: string[], expectedDigest: string) => {
+  for (const deployment of deployments) {
+    const deploymentImages = await runCommand('kubectl', [
+      '-n',
+      namespace,
+      'get',
+      'deployment',
+      deployment,
+      '-o',
+      'jsonpath={..image}',
+    ])
+    const images = deploymentImages.stdout.trim()
+    console.log(`${deployment} images: ${images}`)
+
+    if (!images.includes(expectedDigest)) {
+      throw new Error(`Deployment ${deployment} image digest does not include expected digest ${expectedDigest}`)
+    }
+  }
+}
+
+export const main = async (cliOptions?: CliOptions) => {
+  ensureCli('kubectl')
+
+  const parsed = cliOptions ?? parseArgs(process.argv.slice(2))
+  const resolvedOptions: Required<CliOptions> = {
+    namespace: parsed.namespace ?? defaultNamespace,
+    deployments: parsed.deployments?.length ? parsed.deployments : [...defaultDeployments],
+    kustomizationPath: parsed.kustomizationPath ?? defaultKustomizationPath,
+    imageName: parsed.imageName ?? defaultImageName,
+    argoNamespace: parsed.argoNamespace ?? defaultArgoNamespace,
+    argoApplication: parsed.argoApplication ?? defaultArgoApplication,
+    rolloutTimeout: parsed.rolloutTimeout ?? defaultRolloutTimeout,
+    healthAttempts: parsed.healthAttempts ?? defaultHealthAttempts,
+    healthIntervalSeconds: parsed.healthIntervalSeconds ?? defaultHealthIntervalSeconds,
+    requireSynced: parsed.requireSynced ?? false,
+  }
+
+  if (!Number.isInteger(resolvedOptions.healthAttempts) || resolvedOptions.healthAttempts <= 0) {
+    throw new Error(`healthAttempts must be a positive integer, received ${resolvedOptions.healthAttempts}`)
+  }
+  if (!Number.isInteger(resolvedOptions.healthIntervalSeconds) || resolvedOptions.healthIntervalSeconds <= 0) {
+    throw new Error(
+      `healthIntervalSeconds must be a positive integer, received ${resolvedOptions.healthIntervalSeconds}`,
+    )
+  }
+
+  const kustomizationPath = resolvePath(resolvedOptions.kustomizationPath)
+  const kustomizationSource = readFileSync(kustomizationPath, 'utf8')
+  const expectedDigest = extractExpectedDigest(kustomizationSource, resolvedOptions.imageName)
+
+  console.log(`Expected digest: ${expectedDigest}`)
+  await waitForArgoHealth(resolvedOptions)
+  await verifyRollouts(resolvedOptions.namespace, resolvedOptions.deployments, resolvedOptions.rolloutTimeout)
+  await verifyDeploymentDigests(resolvedOptions.namespace, resolvedOptions.deployments, expectedDigest)
+}
+
+if (import.meta.main) {
+  main().catch((error) => fatal('Failed to verify jangar deployment rollout', error))
+}
+
+export const __private = {
+  extractExpectedDigest,
+  parseArgs,
+}


### PR DESCRIPTION
## Summary

- add a strict Jangar release contract artifact (`jangar-release-contract.json`) in build and consume it in release to keep source SHA/tag/digest hand-off explicit
- harden release workflow with concurrency and stale `workflow_run` gating so only the latest successful `main` build is promoted automatically
- replace inline shell deploy checks with typed script `packages/scripts/src/jangar/verify-deployment.ts`, and add auto-rollback PR creation when post-deploy verification fails on `main`
- add CI guardrails via new `jangar-guardrails` workflow (actionlint + shellcheck + automation policy check), and enforce `jangar=auto` policy with `check-automation-policy.ts`
- tighten verify RBAC from cluster-wide read to namespace-scoped Roles/RoleBindings in `argocd` and `jangar`

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/update-manifests.test.ts packages/scripts/src/jangar/__tests__/release-contract.test.ts packages/scripts/src/jangar/__tests__/verify-deployment.test.ts packages/scripts/src/jangar/__tests__/check-automation-policy.test.ts`
- `bunx tsc --noEmit --project packages/scripts/tsconfig.jangar.json`
- `bunx biome check packages/scripts/src/jangar/release-contract.ts packages/scripts/src/jangar/verify-deployment.ts packages/scripts/src/jangar/check-automation-policy.ts packages/scripts/src/jangar/__tests__/release-contract.test.ts packages/scripts/src/jangar/__tests__/verify-deployment.test.ts packages/scripts/src/jangar/__tests__/check-automation-policy.test.ts`
- `kustomize build argocd/applications/agents-ci >/tmp/agents-ci-rbac-render.yaml`
- `bun run packages/scripts/src/jangar/check-automation-policy.ts --require jangar=auto`
- `bun run packages/scripts/src/jangar/verify-deployment.ts`
- `actionlint .github/workflows/jangar-build-push.yaml .github/workflows/jangar-release.yml .github/workflows/jangar-post-deploy-verify.yml .github/workflows/jangar-guardrails.yml` (local custom runner label warning is expected for `arc-arm64`; guardrail workflow ignores that exact warning)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
