### PR TITLE
chore(jangar): promote image 0c902a0c

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-20T05:50:02Z"
+    deploy.knative.dev/rollout: "2026-02-20T06:36:43Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-20T05:50:02Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-20T06:36:43Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -56,5 +56,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "92a1ac37"
-    digest: sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe
+    newTag: "0c902a0c"
+    digest: sha256:6e52596041b625c1341a26475133acded44ba1a0e7c8067e0a28791e712fbf93


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `0c902a0ccde095fbf45c733b11f4504c60723f19`
- Image tag: `0c902a0c`
- Image digest: `sha256:6e52596041b625c1341a26475133acded44ba1a0e7c8067e0a28791e712fbf93`
- Updated API and worker rollout annotations