### PR TITLE
fix(ci): restore jangar post-deploy verify RBAC

### DIFF
--- a/argocd/applications/agents-ci/runner-rbac-cluster.yaml
+++ b/argocd/applications/agents-ci/runner-rbac-cluster.yaml
@@ -38,10 +38,9 @@ roleRef:
   name: agents-ci-runner-crd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: agents-ci-runner-jangar-verify-read
-  namespace: argocd
 rules:
   - apiGroups:
       - argoproj.io
@@ -53,24 +52,22 @@ rules:
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: agents-ci-runner-jangar-verify-read
-  namespace: argocd
 subjects:
   - kind: ServiceAccount
     name: arc-arm64-gha-rs-kube-mode
     namespace: arc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: agents-ci-runner-jangar-verify-read
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: agents-ci-runner-jangar-rollout-read
-  namespace: jangar
 rules:
   - apiGroups:
       - apps
@@ -83,15 +80,14 @@ rules:
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: agents-ci-runner-jangar-rollout-read
-  namespace: jangar
 subjects:
   - kind: ServiceAccount
     name: arc-arm64-gha-rs-kube-mode
     namespace: arc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: agents-ci-runner-jangar-rollout-read


### PR DESCRIPTION
## Summary

- Fix `argocd/applications/agents-ci/runner-rbac-cluster.yaml` so Jangar post-deploy verify permissions are cluster-scoped RBAC objects.
- Replace `Role`/`RoleBinding` pairs with `ClusterRole`/`ClusterRoleBinding` pairs for `agents-ci-runner-jangar-verify-read` and `agents-ci-runner-jangar-rollout-read`.
- Prevent Kustomize `namespace: agents-ci` rewriting from relocating verify RBAC out of `argocd`/`jangar` access paths.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/agents-ci >/tmp/agents-ci-kustomize.yaml`
- `rg -n "kind: ClusterRoleBinding|kind: ClusterRole|agents-ci-runner-jangar" /tmp/agents-ci-kustomize.yaml`
- `bun run packages/scripts/src/jangar/verify-deployment.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
