### PR TITLE
fix(agents): harden chart publish and artifacthub metadata

### DIFF
--- a/.github/workflows/agents-sync.yml
+++ b/.github/workflows/agents-sync.yml
@@ -50,8 +50,42 @@ jobs:
 
           git remote add origin "https://x-access-token:${AGENTS_SPLIT_TOKEN}@github.com/proompteng/charts.git"
           git fetch origin main
+
+          cp charts/agents/README.md README.md
+          if ! git diff --quiet -- README.md; then
+            git add README.md
+            git commit -m "docs: mirror agents chart README at repository root"
+          fi
+
           git push --force-with-lease=main -u origin HEAD:main
 
-          helm package charts/agents --destination "${tmpdir}/chart-packages"
+          chart_version="$(awk '/^version:/ {print $2; exit}' charts/agents/Chart.yaml)"
+          package_dir="${tmpdir}/chart-packages"
+          existing_dir="${tmpdir}/existing-packages"
+          mkdir -p "${package_dir}" "${existing_dir}"
+
+          helm package charts/agents --destination "${package_dir}"
+          package_path="${package_dir}/agents-${chart_version}.tgz"
+          if [ ! -f "${package_path}" ]; then
+            echo "Expected packaged chart at ${package_path}" >&2
+            exit 1
+          fi
+
           echo "${AGENTS_SPLIT_TOKEN}" | helm registry login ghcr.io -u proompteng --password-stdin
-          helm push "${tmpdir}/chart-packages/"*.tgz oci://ghcr.io/proompteng/charts
+          if helm pull oci://ghcr.io/proompteng/charts/agents --version "${chart_version}" --destination "${existing_dir}" >/dev/null 2>&1; then
+            existing_path="${existing_dir}/agents-${chart_version}.tgz"
+            compare_new_dir="${tmpdir}/compare-new"
+            compare_existing_dir="${tmpdir}/compare-existing"
+            mkdir -p "${compare_new_dir}" "${compare_existing_dir}"
+            tar -xzf "${package_path}" -C "${compare_new_dir}"
+            tar -xzf "${existing_path}" -C "${compare_existing_dir}"
+
+            if diff -qr "${compare_new_dir}" "${compare_existing_dir}" >/dev/null; then
+              echo "Chart ${chart_version} already published and matches packaged contents; skipping helm push."
+            else
+              echo "Chart ${chart_version} already exists in OCI but differs from current contents. Bump charts/agents/Chart.yaml version." >&2
+              exit 1
+            fi
+          else
+            helm push "${package_path}" oci://ghcr.io/proompteng/charts
+          fi

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,4 @@
 repositoryID: proompteng-lab
 owners:
-  - name: ProomptEng
-    email: eng@proompt.com
+  - name: Greg Konush
+    email: greg@proompteng.ai

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -14,8 +14,8 @@ keywords:
   - control-plane
   - codex
 maintainers:
-  - name: ProomptEng
-    email: eng@proompt.com
+  - name: Greg Konush
+    email: greg@proompteng.ai
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -13,5 +13,5 @@ keywords:
   - control-plane
   - codex
 maintainers:
-  - name: ProomptEng
-    email: eng@proompt.com
+  - name: Greg Konush
+    email: greg@proompteng.ai

--- a/packages/scripts/src/agents/publish-chart.ts
+++ b/packages/scripts/src/agents/publish-chart.ts
@@ -1,16 +1,20 @@
 #!/usr/bin/env bun
 
-import { mkdir } from 'node:fs/promises'
+import { mkdir, mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 const rootDir = resolve(import.meta.dir, '..', '..', '..', '..')
 const outputDir = resolve(rootDir, '.chart-packages')
+const localPackageDir = resolve(outputDir, 'local')
+const existingPackageDir = resolve(outputDir, 'existing')
 const chartRepoUrl = 'https://github.com/proompteng/charts.git'
 
-const chartWorkDir = await Bun.makeTempDir({ dir: tmpdir() })
+const chartWorkDir = await mkdtemp(join(tmpdir(), 'agents-chart-'))
 const chartRepoDir = join(chartWorkDir, 'charts')
 const chartDir = join(chartRepoDir, 'charts', 'agents')
+const chartPackageRef = 'oci://ghcr.io/proompteng/charts/agents'
+const decode = (bytes: Uint8Array<ArrayBufferLike>) => new TextDecoder().decode(bytes).trim()
 
 const cloneResult = Bun.spawnSync(['git', 'clone', '--depth', '1', chartRepoUrl, chartRepoDir])
 if (cloneResult.exitCode !== 0) {
@@ -34,9 +38,38 @@ if (artifactHubVersion !== chartVersion) {
   throw new Error(`artifacthub-pkg.yml version (${artifactHubVersion}) does not match Chart.yaml (${chartVersion}).`)
 }
 
-await mkdir(outputDir, { recursive: true })
+await mkdir(localPackageDir, { recursive: true })
+await mkdir(existingPackageDir, { recursive: true })
 
-const packageResult = Bun.spawnSync(['helm', 'package', chartDir, '--destination', outputDir])
+const comparePackagesByContents = async (newPackagePath: string, existingPackagePath: string) => {
+  const compareDir = await mkdtemp(join(tmpdir(), 'agents-chart-compare-'))
+  const newExtractDir = resolve(compareDir, 'new')
+  const existingExtractDir = resolve(compareDir, 'existing')
+  await mkdir(newExtractDir, { recursive: true })
+  await mkdir(existingExtractDir, { recursive: true })
+
+  const extractNewResult = Bun.spawnSync(['tar', '-xzf', newPackagePath, '-C', newExtractDir])
+  if (extractNewResult.exitCode !== 0) {
+    throw new Error(`failed to unpack ${newPackagePath}: ${decode(extractNewResult.stderr) || 'unknown error'}`)
+  }
+
+  const extractExistingResult = Bun.spawnSync(['tar', '-xzf', existingPackagePath, '-C', existingExtractDir])
+  if (extractExistingResult.exitCode !== 0) {
+    throw new Error(`failed to unpack ${existingPackagePath}: ${decode(extractExistingResult.stderr) || 'unknown error'}`)
+  }
+
+  const diffResult = Bun.spawnSync(['diff', '-qr', newExtractDir, existingExtractDir])
+  if (diffResult.exitCode === 0) {
+    return true
+  }
+  if (diffResult.exitCode === 1) {
+    return false
+  }
+
+  throw new Error(`failed to compare unpacked charts: ${decode(diffResult.stderr) || 'unknown error'}`)
+}
+
+const packageResult = Bun.spawnSync(['helm', 'package', chartDir, '--destination', localPackageDir])
 
 if (packageResult.exitCode !== 0) {
   const stderr = new TextDecoder().decode(packageResult.stderr)
@@ -53,6 +86,23 @@ if (!packagePath) {
 
 if (!packagePath.endsWith(`-${chartVersion}.tgz`)) {
   throw new Error(`Packaged chart version does not match Chart.yaml (${chartVersion}).`)
+}
+
+const pullResult = Bun.spawnSync(['helm', 'pull', chartPackageRef, '--version', chartVersion, '--destination', existingPackageDir])
+if (pullResult.exitCode === 0) {
+  const existingPackagePath = resolve(existingPackageDir, `agents-${chartVersion}.tgz`)
+  if (!(await Bun.file(existingPackagePath).exists())) {
+    throw new Error(`helm pull succeeded but package not found at ${existingPackagePath}`)
+  }
+
+  if (await comparePackagesByContents(packagePath, existingPackagePath)) {
+    console.log(`Chart ${chartVersion} is already published with matching contents; skipping push.`)
+    process.exit(0)
+  }
+
+  throw new Error(
+    `Chart ${chartVersion} already exists in ghcr.io/proompteng/charts/agents with different contents. Bump Chart.yaml version before publishing.`,
+  )
 }
 
 const pushResult = Bun.spawnSync(['helm', 'push', packagePath, 'oci://ghcr.io/proompteng/charts'])


### PR DESCRIPTION
## Summary

- Hardened `.github/workflows/agents-sync.yml` to mirror `charts/agents/README.md` to root `README.md` in the split `proompteng/charts` repo during sync.
- Made workflow publishing idempotent: if the same chart version already exists in OCI, compare unpacked chart contents and skip push when identical; fail if content differs.
- Updated `packages/scripts/src/agents/publish-chart.ts` with the same idempotent behavior and fixed temp-dir creation for Bun 1.3.9 compatibility (`mkdtemp`).
- Updated Artifact Hub owner/maintainer metadata to `Greg Konush <greg@proompteng.ai>` in `artifacthub-repo.yml`, `charts/agents/Chart.yaml`, and `charts/agents/artifacthub-pkg.yml`.

## Related Issues

None

## Testing

- `python3 - <<'PY'\nimport yaml\nyaml.safe_load(open('.github/workflows/agents-sync.yml'))\nprint('workflow_yaml_ok')\nPY`
- `bun packages/scripts/src/agents/publish-chart.ts`
- `chart_version=$(awk '/^version:/ {print $2; exit}' charts/agents/Chart.yaml); helm pull oci://ghcr.io/proompteng/charts/agents --version "$chart_version" --destination /tmp`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
