### PR TITLE
feat(torghut): enforce profitability evidence v4 promotion gate

### DIFF
--- a/docs/torghut/design-system/v3/full-loop/10-audit-compliance-evidence-spec.md
+++ b/docs/torghut/design-system/v3/full-loop/10-audit-compliance-evidence-spec.md
@@ -9,6 +9,16 @@ reproducibility, and compliance-aligned controls.
 - strategy/config diff,
 - dataset and feature version manifests,
 - gate pass/fail outputs,
+- profitability evidence contract (`profitability-evidence-v4.json`) with:
+  - risk-adjusted metrics (`return_over_drawdown`, `sharpe_like`, regime pass ratio),
+  - cost/fill realism (`cost_bps`, turnover, recorded-vs-fallback impact assumptions),
+  - confidence/calibration summary (sample count, mean/std confidence, calibration error),
+  - reproducibility hashes (artifact sha256 map + manifest hash),
+- benchmark comparison (`profitability-benchmark-v4.json`) baseline vs candidate across:
+  - `market:all`,
+  - one or more `regime:*` slices,
+- validator output (`profitability-evidence-validation.json`) with machine-readable pass/fail reasons,
+- promotion gate decision (`promotion-evidence-gate.json`) with reason codes and artifact pointers,
 - shadow/paper/live metrics,
 - risk and execution control logs,
 - approval records and reviewer identities.
@@ -30,6 +40,7 @@ reproducibility, and compliance-aligned controls.
 - role-scoped read access,
 - hash verification for artifact integrity,
 - no sensitive secret leakage in evidence payloads.
+- no promotion when profitability evidence artifacts or reproducibility hashes are missing.
 
 ## Compliance Mapping
 - pre-trade control evidence,

--- a/docs/torghut/design-system/v3/full-loop/13-research-ledger-promotion-evidence-spec.md
+++ b/docs/torghut/design-system/v3/full-loop/13-research-ledger-promotion-evidence-spec.md
@@ -2,7 +2,7 @@
 
 ## Status
 - Version: `v3-ledger-spec`
-- Last updated: `2026-02-12`
+- Last updated: `2026-02-20`
 - Maturity: `draft`
 
 ## Objective
@@ -62,12 +62,18 @@ Create an immutable promotion evidence contract so every candidate can be replay
   - policy checksum
   - gate pass/fail per gate
   - unresolved reasons with reproducible evidence refs
+- Gate `gate6_profitability_evidence` is mandatory for `paper` and `live` promotion targets.
+  - Requires `profitability-evidence-v4` + `profitability-benchmark-v4` schemas.
+  - Requires validator status `passed=true`.
+  - Enforces configured thresholds for market uplift, regime coverage, cost realism,
+    calibration error, and reproducibility hash count.
 - A promotion is valid only when:
   1. `run_id` exists and is immutable,
   2. required folds >= minimum,
   3. null-ratio and staleness gates pass,
-  4. reproducibility check passes,
-  5. selection-bias checks are within guardrail thresholds.
+  4. profitability evidence validator passes with complete artifacts,
+  5. reproducibility check passes,
+  6. selection-bias checks are within guardrail thresholds.
 
 ## Reproducibility Contract
 - Inputs for every run are addressable and versioned.
@@ -78,6 +84,10 @@ Create an immutable promotion evidence contract so every candidate can be replay
 - `research-report.json` (machine-readable)
 - `research-report.md` (human readable)
 - `gate-evaluation.json` reference hash
+- `profitability-benchmark-v4.json` (baseline vs candidate by market/regime slices)
+- `profitability-evidence-v4.json` (risk-adjusted + realism + calibration + reproducibility contract)
+- `profitability-evidence-validation.json` (machine-readable pass/fail + reason codes)
+- `promotion-evidence-gate.json` (final promotion gate aggregation + artifact pointers)
 - `paper-candidate/strategy-configmap-patch.yaml` when promotion_allowed
 
 ## Acceptance Criteria
@@ -85,3 +95,4 @@ Create an immutable promotion evidence contract so every candidate can be replay
 - Every deny has a reason code + evidence refs.
 - `run_autonomous_lane` fails fast when ledger write fails in strict mode.
 - Evidence export can be replayed by an operator to reproduce the lane outcome.
+- Promotion cannot proceed when profitability evidence artifacts are missing, non-reproducible, or below threshold.

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+import json
 from pathlib import Path
 from typing import Any, cast
 
@@ -14,13 +15,17 @@ class PromotionPrerequisiteResult:
     reasons: list[str]
     required_artifacts: list[str]
     missing_artifacts: list[str]
+    reason_details: list[dict[str, object]]
+    artifact_refs: list[str]
 
     def to_payload(self) -> dict[str, object]:
         return {
-            'allowed': self.allowed,
-            'reasons': list(self.reasons),
-            'required_artifacts': list(self.required_artifacts),
-            'missing_artifacts': list(self.missing_artifacts),
+            "allowed": self.allowed,
+            "reasons": list(self.reasons),
+            "required_artifacts": list(self.required_artifacts),
+            "missing_artifacts": list(self.missing_artifacts),
+            "reason_details": [dict(item) for item in self.reason_details],
+            "artifact_refs": list(self.artifact_refs),
         }
 
 
@@ -33,10 +38,10 @@ class RollbackReadinessResult:
 
     def to_payload(self) -> dict[str, object]:
         return {
-            'ready': self.ready,
-            'reasons': list(self.reasons),
-            'required_checks': list(self.required_checks),
-            'missing_checks': list(self.missing_checks),
+            "ready": self.ready,
+            "reasons": list(self.reasons),
+            "required_checks": list(self.required_checks),
+            "missing_checks": list(self.missing_checks),
         }
 
 
@@ -49,40 +54,157 @@ def evaluate_promotion_prerequisites(
     artifact_root: Path,
 ) -> PromotionPrerequisiteResult:
     reasons: list[str] = []
-    required_artifacts = _required_artifacts_for_target(policy_payload, promotion_target)
-    missing_artifacts = [item for item in required_artifacts if not (artifact_root / item).exists()]
+    reason_details: list[dict[str, object]] = []
+    required_artifacts = _required_artifacts_for_target(
+        policy_payload, promotion_target
+    )
+    missing_artifacts = [
+        item for item in required_artifacts if not (artifact_root / item).exists()
+    ]
+    artifact_refs = [str(artifact_root / item) for item in required_artifacts]
 
     if missing_artifacts:
-        reasons.append('required_artifacts_missing')
+        reasons.append("required_artifacts_missing")
+        reason_details.append(
+            {
+                "reason": "required_artifacts_missing",
+                "missing_artifacts": list(missing_artifacts),
+            }
+        )
 
-    if candidate_state_payload.get('paused', False):
-        reasons.append('candidate_paused_for_review')
+    if candidate_state_payload.get("paused", False):
+        reasons.append("candidate_paused_for_review")
+        reason_details.append({"reason": "candidate_paused_for_review"})
 
-    if not bool(gate_report_payload.get('promotion_allowed', False)):
-        reasons.append('gate_report_not_promotable')
+    if not bool(gate_report_payload.get("promotion_allowed", False)):
+        reasons.append("gate_report_not_promotable")
+        reason_details.append({"reason": "gate_report_not_promotable"})
 
     requested_rank = _promotion_rank(promotion_target)
-    recommended_rank = _promotion_rank(str(gate_report_payload.get('recommended_mode', 'shadow')))
+    recommended_rank = _promotion_rank(
+        str(gate_report_payload.get("recommended_mode", "shadow"))
+    )
     if recommended_rank < requested_rank:
-        reasons.append('gate_recommended_mode_below_target')
+        reasons.append("gate_recommended_mode_below_target")
+        reason_details.append(
+            {
+                "reason": "gate_recommended_mode_below_target",
+                "requested_target": promotion_target,
+                "recommended_mode": str(
+                    gate_report_payload.get("recommended_mode", "shadow")
+                ),
+            }
+        )
 
-    gate_index = {str(gate.get('gate_id', '')): gate for gate in _gates(gate_report_payload)}
-    for required_gate in ('gate0_data_integrity', 'gate1_statistical_robustness', 'gate2_risk_capacity'):
-        status = str(gate_index.get(required_gate, {}).get('status', 'fail'))
-        if status != 'pass':
-            reasons.append(f'{required_gate}_not_passed')
+    gate_index = {
+        str(gate.get("gate_id", "")): gate for gate in _gates(gate_report_payload)
+    }
+    for required_gate in (
+        "gate0_data_integrity",
+        "gate1_statistical_robustness",
+        "gate2_risk_capacity",
+    ):
+        status = str(gate_index.get(required_gate, {}).get("status", "fail"))
+        if status != "pass":
+            reasons.append(f"{required_gate}_not_passed")
+            reason_details.append(
+                {
+                    "reason": f"{required_gate}_not_passed",
+                    "gate_id": required_gate,
+                    "status": status,
+                }
+            )
 
-    if str(candidate_state_payload.get('runId', '')).strip() != str(gate_report_payload.get('run_id', '')).strip():
+    if (
+        str(candidate_state_payload.get("runId", "")).strip()
+        != str(gate_report_payload.get("run_id", "")).strip()
+    ):
         # gate report payload may not always include run_id; only enforce when available.
-        run_id = str(gate_report_payload.get('run_id', '')).strip()
+        run_id = str(gate_report_payload.get("run_id", "")).strip()
         if run_id:
-            reasons.append('run_id_mismatch_between_state_and_gate_report')
+            reasons.append("run_id_mismatch_between_state_and_gate_report")
+            reason_details.append(
+                {
+                    "reason": "run_id_mismatch_between_state_and_gate_report",
+                    "candidate_run_id": str(
+                        candidate_state_payload.get("runId", "")
+                    ).strip(),
+                    "gate_report_run_id": run_id,
+                }
+            )
+
+    evidence_validation_relpath = str(
+        policy_payload.get(
+            "promotion_profitability_validation_artifact",
+            "gates/profitability-evidence-validation.json",
+        )
+    )
+    evidence_validation_path = artifact_root / evidence_validation_relpath
+    evidence_validation_payload = _load_json_if_exists(evidence_validation_path)
+    if evidence_validation_payload is None:
+        reasons.append("profitability_evidence_validation_missing")
+        reason_details.append(
+            {
+                "reason": "profitability_evidence_validation_missing",
+                "artifact_ref": str(evidence_validation_path),
+            }
+        )
+    elif not bool(evidence_validation_payload.get("passed", False)):
+        reasons.append("profitability_evidence_validation_failed")
+        reason_details.append(
+            {
+                "reason": "profitability_evidence_validation_failed",
+                "artifact_ref": str(evidence_validation_path),
+                "validation_reasons": _list_of_strings(
+                    evidence_validation_payload.get("reasons")
+                ),
+            }
+        )
+
+    benchmark_relpath = str(
+        policy_payload.get(
+            "promotion_profitability_benchmark_artifact",
+            "gates/profitability-benchmark-v4.json",
+        )
+    )
+    benchmark_path = artifact_root / benchmark_relpath
+    benchmark_payload = _load_json_if_exists(benchmark_path)
+    minimum_regime_slices = int(
+        policy_payload.get("promotion_profitability_min_regime_slices", 1)
+    )
+    if benchmark_payload is None:
+        reasons.append("profitability_benchmark_missing")
+        reason_details.append(
+            {
+                "reason": "profitability_benchmark_missing",
+                "artifact_ref": str(benchmark_path),
+            }
+        )
+    else:
+        regime_slices = 0
+        for item in _list_from_any(benchmark_payload.get("slices")):
+            if isinstance(item, dict):
+                payload = cast(dict[str, Any], item)
+                if str(payload.get("slice_type", "")).strip() == "regime":
+                    regime_slices += 1
+        if regime_slices < minimum_regime_slices:
+            reasons.append("profitability_benchmark_regime_coverage_insufficient")
+            reason_details.append(
+                {
+                    "reason": "profitability_benchmark_regime_coverage_insufficient",
+                    "artifact_ref": str(benchmark_path),
+                    "actual_regime_slices": regime_slices,
+                    "minimum_regime_slices": minimum_regime_slices,
+                }
+            )
 
     return PromotionPrerequisiteResult(
         allowed=not reasons,
         reasons=sorted(set(reasons)),
         required_artifacts=required_artifacts,
         missing_artifacts=missing_artifacts,
+        reason_details=reason_details,
+        artifact_refs=sorted(set(artifact_refs)),
     )
 
 
@@ -94,31 +216,37 @@ def evaluate_rollback_readiness(
 ) -> RollbackReadinessResult:
     reasons: list[str] = []
     required_checks = _required_rollback_checks(policy_payload)
-    rollback_raw = candidate_state_payload.get('rollbackReadiness')
+    rollback_raw = candidate_state_payload.get("rollbackReadiness")
     rollback: dict[str, Any]
     if isinstance(rollback_raw, dict):
         rollback = cast(dict[str, Any], rollback_raw)
     else:
         rollback = {}
 
-    missing_checks = [name for name in required_checks if not bool(rollback.get(name, False))]
+    missing_checks = [
+        name for name in required_checks if not bool(rollback.get(name, False))
+    ]
     if missing_checks:
-        reasons.append('rollback_checks_missing_or_failed')
+        reasons.append("rollback_checks_missing_or_failed")
 
-    max_age_hours = int(policy_payload.get('rollback_dry_run_max_age_hours', 72))
-    dry_run_completed_at = _parse_datetime(str(rollback.get('dryRunCompletedAt', '')).strip())
+    max_age_hours = int(policy_payload.get("rollback_dry_run_max_age_hours", 72))
+    dry_run_completed_at = _parse_datetime(
+        str(rollback.get("dryRunCompletedAt", "")).strip()
+    )
     current = now or datetime.now(timezone.utc)
     if dry_run_completed_at is None:
-        reasons.append('rollback_dry_run_timestamp_missing')
+        reasons.append("rollback_dry_run_timestamp_missing")
     else:
         if current - dry_run_completed_at > timedelta(hours=max_age_hours):
-            reasons.append('rollback_dry_run_stale')
+            reasons.append("rollback_dry_run_stale")
 
-    if policy_payload.get('rollback_require_human_approval', True) and not bool(rollback.get('humanApproved', False)):
-        reasons.append('rollback_human_approval_missing')
+    if policy_payload.get("rollback_require_human_approval", True) and not bool(
+        rollback.get("humanApproved", False)
+    ):
+        reasons.append("rollback_human_approval_missing")
 
-    if not str(rollback.get('rollbackTarget', '')).strip():
-        reasons.append('rollback_target_missing')
+    if not str(rollback.get("rollbackTarget", "")).strip():
+        reasons.append("rollback_target_missing")
 
     return RollbackReadinessResult(
         ready=not reasons,
@@ -128,31 +256,55 @@ def evaluate_rollback_readiness(
     )
 
 
-def _required_artifacts_for_target(policy_payload: dict[str, Any], promotion_target: str) -> list[str]:
+def _required_artifacts_for_target(
+    policy_payload: dict[str, Any], promotion_target: str
+) -> list[str]:
     base_raw = policy_payload.get(
-        'promotion_required_artifacts',
-        ['research/candidate-spec.json', 'backtest/evaluation-report.json', 'gates/gate-evaluation.json'],
+        "promotion_required_artifacts",
+        [
+            "research/candidate-spec.json",
+            "backtest/evaluation-report.json",
+            "gates/gate-evaluation.json",
+        ],
     )
     base = _list_from_any(base_raw)
     required = [str(item) for item in base if isinstance(item, str)]
-    patch_targets_raw = policy_payload.get('promotion_require_patch_targets', ['paper', 'live'])
+    patch_targets_raw = policy_payload.get(
+        "promotion_require_patch_targets", ["paper", "live"]
+    )
     patch_targets = _list_from_any(patch_targets_raw)
     if promotion_target in patch_targets:
-        required.append('paper-candidate/strategy-configmap-patch.yaml')
+        required.append("paper-candidate/strategy-configmap-patch.yaml")
+    profitability_artifacts_raw = policy_payload.get(
+        "promotion_profitability_required_artifacts",
+        [
+            "gates/profitability-evidence-v4.json",
+            "gates/profitability-benchmark-v4.json",
+            "gates/profitability-evidence-validation.json",
+        ],
+    )
+    profitability_artifacts = _list_from_any(profitability_artifacts_raw)
+    for artifact in profitability_artifacts:
+        if isinstance(artifact, str):
+            required.append(artifact)
     return sorted(set(required))
 
 
 def _required_rollback_checks(policy_payload: dict[str, Any]) -> list[str]:
     checks_raw = policy_payload.get(
-        'rollback_required_checks',
-        ['killSwitchDryRunPassed', 'gitopsRevertDryRunPassed', 'strategyDisableDryRunPassed'],
+        "rollback_required_checks",
+        [
+            "killSwitchDryRunPassed",
+            "gitopsRevertDryRunPassed",
+            "strategyDisableDryRunPassed",
+        ],
     )
     checks = _list_from_any(checks_raw)
     return [str(item) for item in checks if isinstance(item, str)]
 
 
 def _gates(gate_report_payload: dict[str, Any]) -> list[dict[str, Any]]:
-    gates_raw = gate_report_payload.get('gates')
+    gates_raw = gate_report_payload.get("gates")
     gates_list = _list_from_any(gates_raw)
     gates: list[dict[str, Any]] = []
     for item in gates_list:
@@ -167,8 +319,25 @@ def _list_from_any(value: Any) -> list[object]:
     return cast(list[object], value)
 
 
+def _list_of_strings(value: Any) -> list[str]:
+    raw = _list_from_any(value)
+    return [str(item) for item in raw if isinstance(item, str)]
+
+
+def _load_json_if_exists(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return cast(dict[str, Any], payload)
+
+
 def _promotion_rank(target: str) -> int:
-    ranking = {'shadow': 1, 'paper': 2, 'live': 3}
+    ranking = {"shadow": 1, "paper": 2, "live": 3}
     return ranking.get(target, 0)
 
 
@@ -176,7 +345,7 @@ def _parse_datetime(value: str) -> datetime | None:
     if not value:
         return None
     try:
-        parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
     if parsed.tzinfo is None:
@@ -185,8 +354,8 @@ def _parse_datetime(value: str) -> datetime | None:
 
 
 __all__ = [
-    'PromotionPrerequisiteResult',
-    'RollbackReadinessResult',
-    'evaluate_promotion_prerequisites',
-    'evaluate_rollback_readiness',
+    "PromotionPrerequisiteResult",
+    "RollbackReadinessResult",
+    "evaluate_promotion_prerequisites",
+    "evaluate_rollback_readiness",
 ]

--- a/services/torghut/scripts/run_autonomous_lane.py
+++ b/services/torghut/scripts/run_autonomous_lane.py
@@ -13,26 +13,47 @@ from app.trading.autonomy.lane import run_autonomous_lane
 
 def _resolve_git_sha() -> str:
     try:
-        result = subprocess.run(['git', 'rev-parse', 'HEAD'], check=True, capture_output=True, text=True)
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+        )
     except (subprocess.SubprocessError, FileNotFoundError):
-        return 'unknown'
-    return result.stdout.strip() or 'unknown'
+        return "unknown"
+    return result.stdout.strip() or "unknown"
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description='Run deterministic autonomous Torghut lane.')
-    parser.add_argument('--signals', type=Path, required=True, help='Path to signal fixture JSON.')
-    parser.add_argument('--strategy-config', type=Path, required=True, help='Path to runtime strategy YAML/JSON.')
-    parser.add_argument('--gate-policy', type=Path, required=True, help='Path to gate policy JSON.')
-    parser.add_argument('--output-dir', type=Path, required=True, help='Artifact output directory.')
-    parser.add_argument('--promotion-target', choices=('shadow', 'paper', 'live'), default='paper')
-    parser.add_argument(
-        '--strategy-configmap',
-        type=Path,
-        default=Path('argocd/applications/torghut/strategy-configmap.yaml'),
-        help='GitOps strategy configmap source for candidate patch generation.',
+    parser = argparse.ArgumentParser(
+        description="Run deterministic autonomous Torghut lane."
     )
-    parser.add_argument('--approval-token', type=str, help='Required for live target when enabled by policy.')
+    parser.add_argument(
+        "--signals", type=Path, required=True, help="Path to signal fixture JSON."
+    )
+    parser.add_argument(
+        "--strategy-config",
+        type=Path,
+        required=True,
+        help="Path to runtime strategy YAML/JSON.",
+    )
+    parser.add_argument(
+        "--gate-policy", type=Path, required=True, help="Path to gate policy JSON."
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, required=True, help="Artifact output directory."
+    )
+    parser.add_argument(
+        "--promotion-target", choices=("shadow", "paper", "live"), default="paper"
+    )
+    parser.add_argument(
+        "--strategy-configmap",
+        type=Path,
+        default=Path("argocd/applications/torghut/strategy-configmap.yaml"),
+        help="GitOps strategy configmap source for candidate patch generation.",
+    )
+    parser.add_argument(
+        "--approval-token",
+        type=str,
+        help="Required for live target when enabled by policy.",
+    )
     args = parser.parse_args()
 
     result = run_autonomous_lane(
@@ -47,15 +68,29 @@ def main() -> int:
     )
 
     payload = {
-        'run_id': result.run_id,
-        'candidate_id': result.candidate_id,
-        'output_dir': str(result.output_dir),
-        'gate_report_path': str(result.gate_report_path),
-        'paper_patch_path': str(result.paper_patch_path) if result.paper_patch_path else None,
+        "run_id": result.run_id,
+        "candidate_id": result.candidate_id,
+        "output_dir": str(result.output_dir),
+        "gate_report_path": str(result.gate_report_path),
+        "paper_patch_path": str(result.paper_patch_path)
+        if result.paper_patch_path
+        else None,
+        "profitability_benchmark_path": str(
+            result.output_dir / "gates" / "profitability-benchmark-v4.json"
+        ),
+        "profitability_evidence_path": str(
+            result.output_dir / "gates" / "profitability-evidence-v4.json"
+        ),
+        "profitability_validation_path": str(
+            result.output_dir / "gates" / "profitability-evidence-validation.json"
+        ),
+        "promotion_gate_path": str(
+            result.output_dir / "gates" / "promotion-evidence-gate.json"
+        ),
     }
     print(json.dumps(payload, indent=2))
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/services/torghut/scripts/run_governance_policy_dry_run.py
+++ b/services/torghut/scripts/run_governance_policy_dry_run.py
@@ -8,35 +8,46 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import Any, cast
 
-from app.trading.autonomy.policy_checks import evaluate_promotion_prerequisites, evaluate_rollback_readiness
+from app.trading.autonomy.policy_checks import (
+    evaluate_promotion_prerequisites,
+    evaluate_rollback_readiness,
+)
 
 
 def _json(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding='utf-8'))
+    payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
-        raise ValueError(f'Expected JSON object at {path}')
-    return payload
+        raise ValueError(f"Expected JSON object at {path}")
+    return cast(dict[str, Any], payload)
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Run dry-run policy enforcement harness for Torghut governance checks.')
-    parser.add_argument('--policy', type=Path, required=True, help='Policy JSON (autonomy-gates-v3).')
-    parser.add_argument('--gate-report', type=Path, required=True, help='Gate evaluation JSON payload.')
-    parser.add_argument('--promotion-target', choices=('shadow', 'paper', 'live'), default='paper')
-    parser.add_argument('--output', type=Path, help='Optional output file path.')
-    parser.add_argument(
-        '--simulate-missing-artifact',
-        action='store_true',
-        default=False,
-        help='Delete paper patch artifact before checks to prove enforcement behavior.',
+    parser = argparse.ArgumentParser(
+        description="Run dry-run policy enforcement harness for Torghut governance checks."
     )
     parser.add_argument(
-        '--simulate-stale-rollback',
-        action='store_true',
+        "--policy", type=Path, required=True, help="Policy JSON (autonomy-gates-v3)."
+    )
+    parser.add_argument(
+        "--gate-report", type=Path, required=True, help="Gate evaluation JSON payload."
+    )
+    parser.add_argument(
+        "--promotion-target", choices=("shadow", "paper", "live"), default="paper"
+    )
+    parser.add_argument("--output", type=Path, help="Optional output file path.")
+    parser.add_argument(
+        "--simulate-missing-artifact",
+        action="store_true",
         default=False,
-        help='Use stale rollback dry-run timestamp to trigger readiness failure.',
+        help="Delete paper patch artifact before checks to prove enforcement behavior.",
+    )
+    parser.add_argument(
+        "--simulate-stale-rollback",
+        action="store_true",
+        default=False,
+        help="Use stale rollback dry-run timestamp to trigger readiness failure.",
     )
     return parser
 
@@ -49,36 +60,56 @@ def main() -> int:
 
     with TemporaryDirectory() as tmpdir:
         root = Path(tmpdir)
-        (root / 'research').mkdir(parents=True, exist_ok=True)
-        (root / 'backtest').mkdir(parents=True, exist_ok=True)
-        (root / 'gates').mkdir(parents=True, exist_ok=True)
-        (root / 'paper-candidate').mkdir(parents=True, exist_ok=True)
+        (root / "research").mkdir(parents=True, exist_ok=True)
+        (root / "backtest").mkdir(parents=True, exist_ok=True)
+        (root / "gates").mkdir(parents=True, exist_ok=True)
+        (root / "paper-candidate").mkdir(parents=True, exist_ok=True)
 
-        (root / 'research' / 'candidate-spec.json').write_text('{"candidate":"ok"}\n', encoding='utf-8')
-        (root / 'backtest' / 'evaluation-report.json').write_text('{"report":"ok"}\n', encoding='utf-8')
-        (root / 'gates' / 'gate-evaluation.json').write_text(json.dumps(gate_report, indent=2), encoding='utf-8')
-        (root / 'paper-candidate' / 'strategy-configmap-patch.yaml').write_text(
-            'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: dry-run\n',
-            encoding='utf-8',
+        (root / "research" / "candidate-spec.json").write_text(
+            '{"candidate":"ok"}\n', encoding="utf-8"
+        )
+        (root / "backtest" / "evaluation-report.json").write_text(
+            '{"report":"ok"}\n', encoding="utf-8"
+        )
+        (root / "gates" / "gate-evaluation.json").write_text(
+            json.dumps(gate_report, indent=2), encoding="utf-8"
+        )
+        (root / "gates" / "profitability-evidence-v4.json").write_text(
+            '{"schema_version":"profitability-evidence-v4"}\n',
+            encoding="utf-8",
+        )
+        (root / "gates" / "profitability-benchmark-v4.json").write_text(
+            '{"schema_version":"profitability-benchmark-v4","slices":[{"slice_type":"regime","slice_key":"regime:neutral"}]}\n',
+            encoding="utf-8",
+        )
+        (root / "gates" / "profitability-evidence-validation.json").write_text(
+            '{"passed":true,"reasons":[]}\n',
+            encoding="utf-8",
+        )
+        (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
+            "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: dry-run\n",
+            encoding="utf-8",
         )
 
         if args.simulate_missing_artifact:
-            (root / 'paper-candidate' / 'strategy-configmap-patch.yaml').unlink()
+            (root / "paper-candidate" / "strategy-configmap-patch.yaml").unlink()
 
-        stale_ts = '2025-01-01T00:00:00+00:00'
+        stale_ts = "2025-01-01T00:00:00+00:00"
         recent_ts = datetime.now(timezone.utc).isoformat()
         state = {
-            'candidateId': 'cand-dry-run',
-            'runId': str(gate_report.get('run_id', 'run-dry-run')),
-            'activeStage': 'gate-evaluation',
-            'paused': False,
-            'rollbackReadiness': {
-                'killSwitchDryRunPassed': True,
-                'gitopsRevertDryRunPassed': True,
-                'strategyDisableDryRunPassed': True,
-                'dryRunCompletedAt': stale_ts if args.simulate_stale_rollback else recent_ts,
-                'humanApproved': True,
-                'rollbackTarget': 'main@abcdef0',
+            "candidateId": "cand-dry-run",
+            "runId": str(gate_report.get("run_id", "run-dry-run")),
+            "activeStage": "gate-evaluation",
+            "paused": False,
+            "rollbackReadiness": {
+                "killSwitchDryRunPassed": True,
+                "gitopsRevertDryRunPassed": True,
+                "strategyDisableDryRunPassed": True,
+                "dryRunCompletedAt": stale_ts
+                if args.simulate_stale_rollback
+                else recent_ts,
+                "humanApproved": True,
+                "rollbackTarget": "main@abcdef0",
             },
         }
         promotion = evaluate_promotion_prerequisites(
@@ -88,16 +119,18 @@ def main() -> int:
             promotion_target=args.promotion_target,
             artifact_root=root,
         )
-        rollback = evaluate_rollback_readiness(policy_payload=policy, candidate_state_payload=state)
+        rollback = evaluate_rollback_readiness(
+            policy_payload=policy, candidate_state_payload=state
+        )
 
         payload = {
-            'promotion_target': args.promotion_target,
-            'promotion_prerequisites': promotion.to_payload(),
-            'rollback_readiness': rollback.to_payload(),
-            'promotion_progression_allowed': promotion.allowed and rollback.ready,
-            'simulation': {
-                'missing_artifact': args.simulate_missing_artifact,
-                'stale_rollback': args.simulate_stale_rollback,
+            "promotion_target": args.promotion_target,
+            "promotion_prerequisites": promotion.to_payload(),
+            "rollback_readiness": rollback.to_payload(),
+            "promotion_progression_allowed": promotion.allowed and rollback.ready,
+            "simulation": {
+                "missing_artifact": args.simulate_missing_artifact,
+                "stale_rollback": args.simulate_stale_rollback,
             },
         }
 
@@ -105,9 +138,9 @@ def main() -> int:
     print(rendered)
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(rendered + '\n', encoding='utf-8')
+        args.output.write_text(rendered + "\n", encoding="utf-8")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/services/torghut/tests/test_autonomous_lane.py
+++ b/services/torghut/tests/test_autonomous_lane.py
@@ -12,97 +12,144 @@ from sqlalchemy.orm import sessionmaker
 from yaml import safe_load
 
 from app.trading.autonomy.lane import run_autonomous_lane, upsert_autonomy_no_signal_run
-from app.models import Base, ResearchCandidate, ResearchFoldMetrics, ResearchPromotion, ResearchRun, ResearchStressMetrics
+from app.models import (
+    Base,
+    ResearchCandidate,
+    ResearchFoldMetrics,
+    ResearchPromotion,
+    ResearchRun,
+    ResearchStressMetrics,
+)
 
 
 class TestAutonomousLane(TestCase):
     def test_lane_emits_gate_report_and_paper_patch(self) -> None:
-        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
-        strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
-        gate_policy_path = Path(__file__).parent.parent / 'config' / 'autonomous-gate-policy.json'
+        fixture_path = Path(__file__).parent / "fixtures" / "walkforward_signals.json"
+        strategy_config_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-strategy-sample.yaml"
+        )
+        gate_policy_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-gate-policy.json"
+        )
         strategy_configmap_path = (
-            Path(__file__).parent.parent.parent.parent / 'argocd' / 'applications' / 'torghut' / 'strategy-configmap.yaml'
+            Path(__file__).parent.parent.parent.parent
+            / "argocd"
+            / "applications"
+            / "torghut"
+            / "strategy-configmap.yaml"
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_dir = Path(tmpdir) / 'lane'
+            output_dir = Path(tmpdir) / "lane"
             result = run_autonomous_lane(
                 signals_path=fixture_path,
                 strategy_config_path=strategy_config_path,
                 gate_policy_path=gate_policy_path,
                 output_dir=output_dir,
-                promotion_target='paper',
+                promotion_target="paper",
                 strategy_configmap_path=strategy_configmap_path,
-                code_version='test-sha',
+                code_version="test-sha",
             )
 
-            gate_payload = json.loads(result.gate_report_path.read_text(encoding='utf-8'))
-            self.assertIn('gates', gate_payload)
-            self.assertEqual(gate_payload['recommended_mode'], 'paper')
+            gate_payload = json.loads(
+                result.gate_report_path.read_text(encoding="utf-8")
+            )
+            self.assertIn("gates", gate_payload)
+            self.assertEqual(gate_payload["recommended_mode"], "paper")
+            self.assertTrue(
+                (output_dir / "gates" / "profitability-benchmark-v4.json").exists()
+            )
+            self.assertTrue(
+                (output_dir / "gates" / "profitability-evidence-v4.json").exists()
+            )
+            self.assertTrue(
+                (
+                    output_dir / "gates" / "profitability-evidence-validation.json"
+                ).exists()
+            )
+            self.assertTrue(
+                (output_dir / "gates" / "promotion-evidence-gate.json").exists()
+            )
             self.assertIsNotNone(result.paper_patch_path)
             assert result.paper_patch_path is not None
             self.assertTrue(result.paper_patch_path.exists())
 
     def test_lane_blocks_live_without_policy_enablement(self) -> None:
-        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
-        strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
-        gate_policy_path = Path(__file__).parent.parent / 'config' / 'autonomous-gate-policy.json'
+        fixture_path = Path(__file__).parent / "fixtures" / "walkforward_signals.json"
+        strategy_config_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-strategy-sample.yaml"
+        )
+        gate_policy_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-gate-policy.json"
+        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_dir = Path(tmpdir) / 'lane-live'
+            output_dir = Path(tmpdir) / "lane-live"
             result = run_autonomous_lane(
                 signals_path=fixture_path,
                 strategy_config_path=strategy_config_path,
                 gate_policy_path=gate_policy_path,
                 output_dir=output_dir,
-                promotion_target='live',
-                code_version='test-sha',
+                promotion_target="live",
+                code_version="test-sha",
             )
 
-            gate_payload = json.loads(result.gate_report_path.read_text(encoding='utf-8'))
-            self.assertFalse(gate_payload['promotion_allowed'])
-            self.assertIn('live_rollout_disabled_by_policy', gate_payload['reasons'])
+            gate_payload = json.loads(
+                result.gate_report_path.read_text(encoding="utf-8")
+            )
+            self.assertFalse(gate_payload["promotion_allowed"])
+            self.assertIn("live_rollout_disabled_by_policy", gate_payload["reasons"])
             self.assertIsNone(result.paper_patch_path)
 
     def test_lane_uses_repo_relative_default_configmap_path(self) -> None:
-        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
-        strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
-        gate_policy_path = Path(__file__).parent.parent / 'config' / 'autonomous-gate-policy.json'
+        fixture_path = Path(__file__).parent / "fixtures" / "walkforward_signals.json"
+        strategy_config_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-strategy-sample.yaml"
+        )
+        gate_policy_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-gate-policy.json"
+        )
         previous_cwd = Path.cwd()
         try:
             os.chdir(Path(__file__).parent.parent)
             with tempfile.TemporaryDirectory() as tmpdir:
-                output_dir = Path(tmpdir) / 'lane-default-path'
+                output_dir = Path(tmpdir) / "lane-default-path"
                 result = run_autonomous_lane(
                     signals_path=fixture_path,
                     strategy_config_path=strategy_config_path,
                     gate_policy_path=gate_policy_path,
                     output_dir=output_dir,
-                    promotion_target='paper',
-                    code_version='test-sha',
+                    promotion_target="paper",
+                    code_version="test-sha",
                 )
                 self.assertIsNotNone(result.paper_patch_path)
                 assert result.paper_patch_path is not None
                 self.assertTrue(result.paper_patch_path.exists())
 
-                patch_payload = safe_load(result.paper_patch_path.read_text(encoding='utf-8'))
+                patch_payload = safe_load(
+                    result.paper_patch_path.read_text(encoding="utf-8")
+                )
                 self.assertIsNotNone(patch_payload)
-                strategies_payload = safe_load(patch_payload['data']['strategies.yaml'])
+                strategies_payload = safe_load(patch_payload["data"]["strategies.yaml"])
                 self.assertIsInstance(strategies_payload, dict)
-                strategies = strategies_payload.get('strategies', [])
+                strategies = strategies_payload.get("strategies", [])
                 self.assertTrue(strategies)
-                self.assertFalse(any('symbols' in strategy for strategy in strategies))
-                self.assertEqual(strategies[0]['universe_type'], 'static')
+                self.assertFalse(any("symbols" in strategy for strategy in strategies))
+                self.assertEqual(strategies[0]["universe_type"], "static")
         finally:
             os.chdir(previous_cwd)
 
     def test_lane_persists_research_ledger_when_enabled(self) -> None:
-        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
-        strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
-        gate_policy_path = Path(__file__).parent.parent / 'config' / 'autonomous-gate-policy.json'
+        fixture_path = Path(__file__).parent / "fixtures" / "walkforward_signals.json"
+        strategy_config_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-strategy-sample.yaml"
+        )
+        gate_policy_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-gate-policy.json"
+        )
 
         engine = create_engine(
-            'sqlite+pysqlite:///:memory:',
+            "sqlite+pysqlite:///:memory:",
             future=True,
             connect_args={"check_same_thread": False},
         )
@@ -110,50 +157,72 @@ class TestAutonomousLane(TestCase):
         session_factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_dir = Path(tmpdir) / 'lane-ledger'
+            output_dir = Path(tmpdir) / "lane-ledger"
             result = run_autonomous_lane(
                 signals_path=fixture_path,
                 strategy_config_path=strategy_config_path,
                 gate_policy_path=gate_policy_path,
                 output_dir=output_dir,
-                promotion_target='paper',
-                code_version='test-sha',
+                promotion_target="paper",
+                code_version="test-sha",
                 persist_results=True,
                 session_factory=session_factory,
             )
 
             self.assertIsNotNone(result.paper_patch_path)
             with session_factory() as session:
-                run_row = session.execute(select(ResearchRun).where(ResearchRun.run_id == result.run_id)).scalar_one()
-                candidate = session.execute(
-                    select(ResearchCandidate).where(ResearchCandidate.candidate_id == result.candidate_id)
+                run_row = session.execute(
+                    select(ResearchRun).where(ResearchRun.run_id == result.run_id)
                 ).scalar_one()
-                fold_rows = session.execute(
-                    select(ResearchFoldMetrics).where(ResearchFoldMetrics.candidate_id == result.candidate_id)
-                ).scalars().all()
-                stress_rows = session.execute(
-                    select(ResearchStressMetrics).where(ResearchStressMetrics.candidate_id == result.candidate_id)
-                ).scalars().all()
+                candidate = session.execute(
+                    select(ResearchCandidate).where(
+                        ResearchCandidate.candidate_id == result.candidate_id
+                    )
+                ).scalar_one()
+                fold_rows = (
+                    session.execute(
+                        select(ResearchFoldMetrics).where(
+                            ResearchFoldMetrics.candidate_id == result.candidate_id
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                stress_rows = (
+                    session.execute(
+                        select(ResearchStressMetrics).where(
+                            ResearchStressMetrics.candidate_id == result.candidate_id
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
                 promotion_row = session.execute(
-                    select(ResearchPromotion).where(ResearchPromotion.candidate_id == result.candidate_id)
+                    select(ResearchPromotion).where(
+                        ResearchPromotion.candidate_id == result.candidate_id
+                    )
                 ).scalar_one()
 
-            self.assertEqual(run_row.status, 'passed')
+            self.assertEqual(run_row.status, "passed")
             self.assertIsNotNone(run_row.dataset_from)
             self.assertIsNotNone(run_row.dataset_to)
             self.assertIsInstance(candidate.decision_count, int)
             self.assertGreaterEqual(candidate.decision_count, 0)
             self.assertTrue(fold_rows)
             self.assertEqual(len(stress_rows), 4)
-            self.assertEqual(promotion_row.requested_mode, 'paper')
-            self.assertIn(promotion_row.approved_mode, {'paper', None})
+            self.assertEqual(promotion_row.requested_mode, "paper")
+            self.assertIn(promotion_row.approved_mode, {"paper", None})
 
     def test_upsert_no_signal_run_records_skipped_research_run(self) -> None:
-        strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
-        gate_policy_path = Path(__file__).parent.parent / 'config' / 'autonomous-gate-policy.json'
+        strategy_config_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-strategy-sample.yaml"
+        )
+        gate_policy_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-gate-policy.json"
+        )
 
         engine = create_engine(
-            'sqlite+pysqlite:///:memory:',
+            "sqlite+pysqlite:///:memory:",
             future=True,
             connect_args={"check_same_thread": False},
         )
@@ -169,31 +238,43 @@ class TestAutonomousLane(TestCase):
             query_end=query_end,
             strategy_config_path=strategy_config_path,
             gate_policy_path=gate_policy_path,
-            no_signal_reason='cursor_ahead_of_stream',
+            no_signal_reason="cursor_ahead_of_stream",
             now=query_start,
-            code_version='test-sha',
+            code_version="test-sha",
         )
 
         with session_factory() as session:
-            run_row = session.execute(select(ResearchRun).where(ResearchRun.run_id == run_id)).scalar_one()
+            run_row = session.execute(
+                select(ResearchRun).where(ResearchRun.run_id == run_id)
+            ).scalar_one()
 
         def _as_utc(value: datetime) -> datetime:
-            return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+            return (
+                value
+                if value.tzinfo is not None
+                else value.replace(tzinfo=timezone.utc)
+            )
 
-        self.assertEqual(run_row.status, 'skipped')
+        self.assertEqual(run_row.status, "skipped")
         self.assertEqual(_as_utc(run_row.dataset_from), query_start)
         self.assertEqual(_as_utc(run_row.dataset_to), query_end)
-        self.assertEqual(run_row.runner_version, 'run_autonomous_lane_no_signals')
-        self.assertEqual(run_row.dataset_snapshot_ref, 'no_signal_window')
+        self.assertEqual(run_row.runner_version, "run_autonomous_lane_no_signals")
+        self.assertEqual(run_row.dataset_snapshot_ref, "no_signal_window")
 
     @patch("app.trading.autonomy.lane._persist_run_outputs")
-    def test_lane_persistence_failure_marks_run_failed(self, mock_persist: object) -> None:
-        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
-        strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
-        gate_policy_path = Path(__file__).parent.parent / 'config' / 'autonomous-gate-policy.json'
+    def test_lane_persistence_failure_marks_run_failed(
+        self, mock_persist: object
+    ) -> None:
+        fixture_path = Path(__file__).parent / "fixtures" / "walkforward_signals.json"
+        strategy_config_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-strategy-sample.yaml"
+        )
+        gate_policy_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-gate-policy.json"
+        )
 
         engine = create_engine(
-            'sqlite+pysqlite:///:memory:',
+            "sqlite+pysqlite:///:memory:",
             future=True,
             connect_args={"check_same_thread": False},
         )
@@ -202,15 +283,15 @@ class TestAutonomousLane(TestCase):
         mock_persist.side_effect = RuntimeError("ledger_write_failed")
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_dir = Path(tmpdir) / 'lane-ledger-fail'
+            output_dir = Path(tmpdir) / "lane-ledger-fail"
             with self.assertRaises(RuntimeError) as ctx:
                 run_autonomous_lane(
                     signals_path=fixture_path,
                     strategy_config_path=strategy_config_path,
                     gate_policy_path=gate_policy_path,
                     output_dir=output_dir,
-                    promotion_target='paper',
-                    code_version='test-sha',
+                    promotion_target="paper",
+                    code_version="test-sha",
                     persist_results=True,
                     session_factory=session_factory,
                 )
@@ -218,60 +299,66 @@ class TestAutonomousLane(TestCase):
 
             with session_factory() as session:
                 run_rows = session.execute(select(ResearchRun)).scalars().all()
-                candidate_rows = session.execute(select(ResearchCandidate)).scalars().all()
+                candidate_rows = (
+                    session.execute(select(ResearchCandidate)).scalars().all()
+                )
 
             self.assertEqual(len(run_rows), 1)
             self.assertEqual(run_rows[0].status, "failed")
             self.assertEqual(len(candidate_rows), 0)
 
     def test_lane_counts_rsi_alias_for_gate_null_rate(self) -> None:
-        strategy_config_path = Path(__file__).parent.parent / 'config' / 'autonomous-strategy-sample.yaml'
+        strategy_config_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-strategy-sample.yaml"
+        )
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
-            signals_path = tmp / 'signals.json'
-            policy_path = tmp / 'policy.json'
-            output_dir = tmp / 'lane-rsi-alias'
+            signals_path = tmp / "signals.json"
+            policy_path = tmp / "policy.json"
+            output_dir = tmp / "lane-rsi-alias"
 
             signals_path.write_text(
                 json.dumps(
                     [
                         {
-                            'event_ts': datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc).isoformat(),
-                            'symbol': 'AAPL',
-                            'timeframe': '1Min',
-                            'payload': {
-                                'macd': {'macd': '1.2', 'signal': '0.8'},
-                                'rsi': '24',
-                                'price': '101.5',
+                            "event_ts": datetime(
+                                2026, 1, 1, 0, 0, tzinfo=timezone.utc
+                            ).isoformat(),
+                            "symbol": "AAPL",
+                            "timeframe": "1Min",
+                            "payload": {
+                                "macd": {"macd": "1.2", "signal": "0.8"},
+                                "rsi": "24",
+                                "price": "101.5",
                             },
-                            'seq': 1,
-                            'source': 'fixture',
+                            "seq": 1,
+                            "source": "fixture",
                         }
                     ]
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
             policy_path.write_text(
                 json.dumps(
                     {
-                        'policy_version': 'v3-gates-1',
-                        'required_feature_schema_version': '3.0.0',
-                        'gate0_max_null_rate': '0',
-                        'gate0_max_staleness_ms': 120000,
-                        'gate0_min_symbol_coverage': 1,
-                        'gate1_min_decision_count': 0,
-                        'gate1_min_trade_count': 0,
-                        'gate1_min_net_pnl': '-100000',
-                        'gate1_max_negative_fold_ratio': '1',
-                        'gate1_max_net_pnl_cv': '100',
-                        'gate2_max_drawdown': '100000',
-                        'gate2_max_turnover_ratio': '1000',
-                        'gate2_max_cost_bps': '1000',
-                        'gate3_max_llm_error_ratio': '1',
-                        'gate5_live_enabled': False,
+                        "policy_version": "v3-gates-1",
+                        "required_feature_schema_version": "3.0.0",
+                        "gate0_max_null_rate": "0",
+                        "gate0_max_staleness_ms": 120000,
+                        "gate0_min_symbol_coverage": 1,
+                        "gate1_min_decision_count": 0,
+                        "gate1_min_trade_count": 0,
+                        "gate1_min_net_pnl": "-100000",
+                        "gate1_max_negative_fold_ratio": "1",
+                        "gate1_max_net_pnl_cv": "100",
+                        "gate2_max_drawdown": "100000",
+                        "gate2_max_turnover_ratio": "1000",
+                        "gate2_max_cost_bps": "1000",
+                        "gate3_max_llm_error_ratio": "1",
+                        "gate5_live_enabled": False,
                     }
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
 
             result = run_autonomous_lane(
@@ -279,70 +366,140 @@ class TestAutonomousLane(TestCase):
                 strategy_config_path=strategy_config_path,
                 gate_policy_path=policy_path,
                 output_dir=output_dir,
-                promotion_target='paper',
-                code_version='test-sha',
+                promotion_target="paper",
+                code_version="test-sha",
             )
-            gate_payload = json.loads(result.gate_report_path.read_text(encoding='utf-8'))
-            gate0 = next(item for item in gate_payload['gates'] if item['gate_id'] == 'gate0_data_integrity')
-            self.assertEqual(gate0['status'], 'pass')
+            gate_payload = json.loads(
+                result.gate_report_path.read_text(encoding="utf-8")
+            )
+            gate0 = next(
+                item
+                for item in gate_payload["gates"]
+                if item["gate_id"] == "gate0_data_integrity"
+            )
+            self.assertEqual(gate0["status"], "pass")
 
     def test_intraday_strategy_candidate_uses_intraday_universe_type(self) -> None:
-        fixture_path = Path(__file__).parent / 'fixtures' / 'walkforward_signals.json'
+        fixture_path = Path(__file__).parent / "fixtures" / "walkforward_signals.json"
         with tempfile.TemporaryDirectory() as tmpdir:
-            config_dir = Path(tmpdir) / 'configs'
+            config_dir = Path(tmpdir) / "configs"
             config_dir.mkdir(parents=True, exist_ok=True)
-            strategy_config_path = config_dir / 'intraday_strategy_candidate.json'
-            gate_policy_path = config_dir / 'autonomous_gate_policy_short.json'
+            strategy_config_path = config_dir / "intraday_strategy_candidate.json"
+            gate_policy_path = config_dir / "autonomous_gate_policy_short.json"
 
             strategy_config_path.write_text(
                 json.dumps(
                     {
-                        'strategies': [
+                        "strategies": [
                             {
-                                'strategy_id': 'candidate-intraday',
-                                'strategy_type': 'intraday_tsmom_v1',
-                                'version': '1.1.0',
-                                'enabled': True,
+                                "strategy_id": "candidate-intraday",
+                                "strategy_type": "intraday_tsmom_v1",
+                                "version": "1.1.0",
+                                "enabled": True,
                             }
                         ]
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
             gate_policy_path.write_text(
                 json.dumps(
                     {
-                        'policy_version': 'test-policy',
-                        'required_feature_schema_version': '3.0.0',
-                        'gate1_min_decision_count': 0,
-                        'gate1_min_trade_count': 0,
-                        'gate1_min_net_pnl': '-100000',
-                        'gate1_max_negative_fold_ratio': '1',
-                        'gate1_max_net_pnl_cv': '100',
-                        'gate2_max_drawdown': '100000',
-                        'gate2_max_turnover_ratio': '1000',
-                        'gate2_max_cost_bps': '1000',
-                        'gate3_max_llm_error_ratio': '1',
-                        'gate5_live_enabled': False,
+                        "policy_version": "test-policy",
+                        "required_feature_schema_version": "3.0.0",
+                        "gate1_min_decision_count": 0,
+                        "gate1_min_trade_count": 0,
+                        "gate1_min_net_pnl": "-100000",
+                        "gate1_max_negative_fold_ratio": "1",
+                        "gate1_max_net_pnl_cv": "100",
+                        "gate2_max_drawdown": "100000",
+                        "gate2_max_turnover_ratio": "1000",
+                        "gate2_max_cost_bps": "1000",
+                        "gate3_max_llm_error_ratio": "1",
+                        "gate6_min_market_net_pnl_delta": "-100000",
+                        "gate6_min_regime_slice_pass_ratio": "0",
+                        "gate6_min_return_over_drawdown": "-100000",
+                        "gate6_max_calibration_error": "1",
+                        "gate6_min_confidence_samples": 0,
+                        "gate6_min_reproducibility_hashes": 1,
+                        "gate5_live_enabled": False,
                     },
                     sort_keys=True,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
 
-            output_dir = Path(tmpdir) / 'lane-tsmom'
+            output_dir = Path(tmpdir) / "lane-tsmom"
             result = run_autonomous_lane(
                 signals_path=fixture_path,
                 strategy_config_path=strategy_config_path,
                 gate_policy_path=gate_policy_path,
                 output_dir=output_dir,
-                promotion_target='paper',
-                code_version='test-sha',
+                promotion_target="paper",
+                code_version="test-sha",
             )
             self.assertIsNotNone(result.paper_patch_path)
             assert result.paper_patch_path is not None
-            patch_payload = safe_load(result.paper_patch_path.read_text(encoding='utf-8'))
-            strategies_payload = safe_load(patch_payload['data']['strategies.yaml'])
-            strategies = strategies_payload['strategies']
-            self.assertEqual(strategies[0]['universe_type'], 'intraday_tsmom_v1')
+            patch_payload = safe_load(
+                result.paper_patch_path.read_text(encoding="utf-8")
+            )
+            strategies_payload = safe_load(patch_payload["data"]["strategies.yaml"])
+            strategies = strategies_payload["strategies"]
+            self.assertEqual(strategies[0]["universe_type"], "intraday_tsmom_v1")
+
+    def test_lane_blocks_promotion_when_profitability_threshold_not_met(self) -> None:
+        fixture_path = Path(__file__).parent / "fixtures" / "walkforward_signals.json"
+        strategy_config_path = (
+            Path(__file__).parent.parent / "config" / "autonomous-strategy-sample.yaml"
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "lane-profitability-block"
+            policy_path = Path(tmpdir) / "strict-policy.json"
+            policy_path.write_text(
+                json.dumps(
+                    {
+                        "policy_version": "v3-gates-1",
+                        "required_feature_schema_version": "3.0.0",
+                        "gate0_max_null_rate": "0.01",
+                        "gate0_max_staleness_ms": 120000,
+                        "gate0_min_symbol_coverage": 1,
+                        "gate1_min_decision_count": 1,
+                        "gate1_min_trade_count": 1,
+                        "gate1_min_net_pnl": "0",
+                        "gate1_max_negative_fold_ratio": "1",
+                        "gate1_max_net_pnl_cv": "100",
+                        "gate2_max_drawdown": "100000",
+                        "gate2_max_turnover_ratio": "1000",
+                        "gate2_max_cost_bps": "1000",
+                        "gate3_max_llm_error_ratio": "1",
+                        "gate6_min_market_net_pnl_delta": "999999",
+                        "gate6_min_regime_slice_pass_ratio": "1",
+                        "gate6_min_return_over_drawdown": "999999",
+                        "gate6_max_cost_bps": "1",
+                        "gate6_max_calibration_error": "0.01",
+                        "gate6_min_reproducibility_hashes": 20,
+                        "gate5_live_enabled": False,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = run_autonomous_lane(
+                signals_path=fixture_path,
+                strategy_config_path=strategy_config_path,
+                gate_policy_path=policy_path,
+                output_dir=output_dir,
+                promotion_target="paper",
+                code_version="test-sha",
+            )
+
+            gate_payload = json.loads(
+                result.gate_report_path.read_text(encoding="utf-8")
+            )
+            self.assertFalse(gate_payload["promotion_allowed"])
+            self.assertIn(
+                "profitability_evidence_validation_failed", gate_payload["reasons"]
+            )
+            self.assertIsNone(result.paper_patch_path)

--- a/services/torghut/tests/test_autonomy_gates.py
+++ b/services/torghut/tests/test_autonomy_gates.py
@@ -6,114 +6,176 @@ from decimal import Decimal
 from pathlib import Path
 from unittest import TestCase
 
-from app.trading.autonomy.gates import GateInputs, GatePolicyMatrix, evaluate_gate_matrix
+from app.trading.autonomy.gates import (
+    GateInputs,
+    GatePolicyMatrix,
+    evaluate_gate_matrix,
+)
 
 
 class TestAutonomyGates(TestCase):
     def test_gate_matrix_passes_paper_with_safe_metrics(self) -> None:
         policy = GatePolicyMatrix()
         inputs = GateInputs(
-            feature_schema_version='3.0.0',
-            required_feature_null_rate=Decimal('0.00'),
+            feature_schema_version="3.0.0",
+            required_feature_null_rate=Decimal("0.00"),
             staleness_ms_p95=0,
             symbol_coverage=3,
             metrics={
-                'decision_count': 20,
-                'trade_count': 10,
-                'net_pnl': '50',
-                'max_drawdown': '100',
-                'turnover_ratio': '1.5',
-                'cost_bps': '5',
+                "decision_count": 20,
+                "trade_count": 10,
+                "net_pnl": "50",
+                "max_drawdown": "100",
+                "turnover_ratio": "1.5",
+                "cost_bps": "5",
             },
             robustness={
-                'fold_count': 4,
-                'negative_fold_count': 1,
-                'net_pnl_cv': '0.3',
+                "fold_count": 4,
+                "negative_fold_count": 1,
+                "net_pnl_cv": "0.3",
             },
+            profitability_evidence=_profitability_evidence_payload(),
         )
 
-        report = evaluate_gate_matrix(inputs, policy=policy, promotion_target='paper', code_version='test')
+        report = evaluate_gate_matrix(
+            inputs, policy=policy, promotion_target="paper", code_version="test"
+        )
 
         self.assertTrue(report.promotion_allowed)
-        self.assertEqual(report.recommended_mode, 'paper')
+        self.assertEqual(report.recommended_mode, "paper")
 
     def test_live_remains_gated_by_default(self) -> None:
         policy = GatePolicyMatrix(gate5_live_enabled=False)
         inputs = GateInputs(
-            feature_schema_version='3.0.0',
-            required_feature_null_rate=Decimal('0.00'),
+            feature_schema_version="3.0.0",
+            required_feature_null_rate=Decimal("0.00"),
             staleness_ms_p95=0,
             symbol_coverage=2,
             metrics={
-                'decision_count': 20,
-                'trade_count': 10,
-                'net_pnl': '50',
-                'max_drawdown': '100',
-                'turnover_ratio': '1.5',
-                'cost_bps': '5',
+                "decision_count": 20,
+                "trade_count": 10,
+                "net_pnl": "50",
+                "max_drawdown": "100",
+                "turnover_ratio": "1.5",
+                "cost_bps": "5",
             },
-            robustness={'fold_count': 4, 'negative_fold_count': 0, 'net_pnl_cv': '0.2'},
+            robustness={"fold_count": 4, "negative_fold_count": 0, "net_pnl_cv": "0.2"},
+            profitability_evidence=_profitability_evidence_payload(),
         )
 
-        report = evaluate_gate_matrix(inputs, policy=policy, promotion_target='live', code_version='test')
+        report = evaluate_gate_matrix(
+            inputs, policy=policy, promotion_target="live", code_version="test"
+        )
 
         self.assertFalse(report.promotion_allowed)
-        self.assertIn('live_rollout_disabled_by_policy', report.reasons)
+        self.assertIn("live_rollout_disabled_by_policy", report.reasons)
 
     def test_policy_loader_preserves_explicit_zero_thresholds(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            policy_path = Path(tmpdir) / 'policy.json'
+            policy_path = Path(tmpdir) / "policy.json"
             policy_path.write_text(
                 json.dumps(
                     {
-                        'gate0_max_null_rate': '0',
-                        'gate1_min_net_pnl': '0',
-                        'gate3_max_llm_error_ratio': '0',
+                        "gate0_max_null_rate": "0",
+                        "gate1_min_net_pnl": "0",
+                        "gate3_max_llm_error_ratio": "0",
                     }
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
             policy = GatePolicyMatrix.from_path(policy_path)
 
-        self.assertEqual(policy.gate0_max_null_rate, Decimal('0'))
-        self.assertEqual(policy.gate1_min_net_pnl, Decimal('0'))
-        self.assertEqual(policy.gate3_max_llm_error_ratio, Decimal('0'))
+        self.assertEqual(policy.gate0_max_null_rate, Decimal("0"))
+        self.assertEqual(policy.gate1_min_net_pnl, Decimal("0"))
+        self.assertEqual(policy.gate3_max_llm_error_ratio, Decimal("0"))
 
     def test_gate_matrix_fails_when_tca_degrades_beyond_thresholds(self) -> None:
         policy = GatePolicyMatrix(
-            gate2_max_tca_slippage_bps=Decimal('10'),
-            gate2_max_tca_shortfall_notional=Decimal('5'),
-            gate2_max_tca_churn_ratio=Decimal('0.20'),
+            gate2_max_tca_slippage_bps=Decimal("10"),
+            gate2_max_tca_shortfall_notional=Decimal("5"),
+            gate2_max_tca_churn_ratio=Decimal("0.20"),
         )
         inputs = GateInputs(
-            feature_schema_version='3.0.0',
-            required_feature_null_rate=Decimal('0.00'),
+            feature_schema_version="3.0.0",
+            required_feature_null_rate=Decimal("0.00"),
             staleness_ms_p95=0,
             symbol_coverage=3,
             metrics={
-                'decision_count': 20,
-                'trade_count': 10,
-                'net_pnl': '50',
-                'max_drawdown': '100',
-                'turnover_ratio': '1.5',
-                'cost_bps': '5',
+                "decision_count": 20,
+                "trade_count": 10,
+                "net_pnl": "50",
+                "max_drawdown": "100",
+                "turnover_ratio": "1.5",
+                "cost_bps": "5",
             },
             robustness={
-                'fold_count': 4,
-                'negative_fold_count': 1,
-                'net_pnl_cv': '0.3',
+                "fold_count": 4,
+                "negative_fold_count": 1,
+                "net_pnl_cv": "0.3",
             },
             tca_metrics={
-                'order_count': 12,
-                'avg_slippage_bps': '18',
-                'avg_shortfall_notional': '7',
-                'avg_churn_ratio': '0.45',
+                "order_count": 12,
+                "avg_slippage_bps": "18",
+                "avg_shortfall_notional": "7",
+                "avg_churn_ratio": "0.45",
             },
+            profitability_evidence=_profitability_evidence_payload(),
         )
 
-        report = evaluate_gate_matrix(inputs, policy=policy, promotion_target='paper', code_version='test')
+        report = evaluate_gate_matrix(
+            inputs, policy=policy, promotion_target="paper", code_version="test"
+        )
 
         self.assertFalse(report.promotion_allowed)
-        self.assertIn('tca_slippage_exceeds_maximum', report.reasons)
-        self.assertIn('tca_shortfall_exceeds_maximum', report.reasons)
-        self.assertIn('tca_churn_ratio_exceeds_maximum', report.reasons)
+        self.assertIn("tca_slippage_exceeds_maximum", report.reasons)
+        self.assertIn("tca_shortfall_exceeds_maximum", report.reasons)
+        self.assertIn("tca_churn_ratio_exceeds_maximum", report.reasons)
+
+    def test_gate_matrix_fails_when_profitability_evidence_missing(self) -> None:
+        policy = GatePolicyMatrix()
+        inputs = GateInputs(
+            feature_schema_version="3.0.0",
+            required_feature_null_rate=Decimal("0.00"),
+            staleness_ms_p95=0,
+            symbol_coverage=2,
+            metrics={
+                "decision_count": 20,
+                "trade_count": 10,
+                "net_pnl": "50",
+                "max_drawdown": "100",
+                "turnover_ratio": "1.5",
+                "cost_bps": "5",
+            },
+            robustness={"fold_count": 4, "negative_fold_count": 0, "net_pnl_cv": "0.2"},
+        )
+
+        report = evaluate_gate_matrix(
+            inputs, policy=policy, promotion_target="paper", code_version="test"
+        )
+
+        self.assertFalse(report.promotion_allowed)
+        self.assertIn("profitability_evidence_missing", report.reasons)
+
+
+def _profitability_evidence_payload() -> dict[str, object]:
+    return {
+        "schema_version": "profitability-evidence-v4",
+        "risk_adjusted_metrics": {
+            "market_net_pnl_delta": "0",
+            "regime_slice_pass_ratio": "1",
+            "return_over_drawdown": "0.5",
+        },
+        "cost_fill_realism": {"cost_bps": "5"},
+        "confidence_calibration": {"calibration_error": "0.2"},
+        "reproducibility": {
+            "artifact_hashes": {
+                "signals": "a",
+                "strategy_config": "b",
+                "gate_policy": "c",
+                "candidate_report": "d",
+                "baseline_report": "e",
+            }
+        },
+        "benchmark": {"schema_version": "profitability-benchmark-v4"},
+        "validation": {"passed": True},
+    }

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -1,71 +1,115 @@
 from __future__ import annotations
 
+import json
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest import TestCase
 
-from app.trading.autonomy.policy_checks import evaluate_promotion_prerequisites, evaluate_rollback_readiness
+from app.trading.autonomy.policy_checks import (
+    evaluate_promotion_prerequisites,
+    evaluate_rollback_readiness,
+)
 
 
 class TestPolicyChecks(TestCase):
     def test_promotion_prerequisites_fail_when_patch_missing_for_paper(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'research').mkdir(parents=True, exist_ok=True)
-            (root / 'backtest').mkdir(parents=True, exist_ok=True)
-            (root / 'gates').mkdir(parents=True, exist_ok=True)
-            (root / 'research' / 'candidate-spec.json').write_text('{}', encoding='utf-8')
-            (root / 'backtest' / 'evaluation-report.json').write_text('{}', encoding='utf-8')
-            (root / 'gates' / 'gate-evaluation.json').write_text('{}', encoding='utf-8')
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "gates" / "gate-evaluation.json").write_text("{}", encoding="utf-8")
+            (root / "gates" / "profitability-evidence-v4.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "gates" / "profitability-benchmark-v4.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "gates" / "profitability-evidence-validation.json").write_text(
+                json.dumps({"passed": True}),
+                encoding="utf-8",
+            )
 
             result = evaluate_promotion_prerequisites(
                 policy_payload={},
                 gate_report_payload=_gate_report(),
                 candidate_state_payload=_candidate_state(),
-                promotion_target='paper',
+                promotion_target="paper",
                 artifact_root=root,
             )
 
         self.assertFalse(result.allowed)
-        self.assertIn('required_artifacts_missing', result.reasons)
-        self.assertIn('paper-candidate/strategy-configmap-patch.yaml', result.missing_artifacts)
+        self.assertIn("required_artifacts_missing", result.reasons)
+        self.assertIn(
+            "paper-candidate/strategy-configmap-patch.yaml", result.missing_artifacts
+        )
 
     def test_rollback_readiness_fails_when_dry_run_stale(self) -> None:
         state = _candidate_state()
-        state['rollbackReadiness'] = {
-            'killSwitchDryRunPassed': True,
-            'gitopsRevertDryRunPassed': True,
-            'strategyDisableDryRunPassed': True,
-            'dryRunCompletedAt': '2025-01-01T00:00:00+00:00',
-            'humanApproved': True,
-            'rollbackTarget': 'main@deadbeef',
+        state["rollbackReadiness"] = {
+            "killSwitchDryRunPassed": True,
+            "gitopsRevertDryRunPassed": True,
+            "strategyDisableDryRunPassed": True,
+            "dryRunCompletedAt": "2025-01-01T00:00:00+00:00",
+            "humanApproved": True,
+            "rollbackTarget": "main@deadbeef",
         }
         result = evaluate_rollback_readiness(
-            policy_payload={'rollback_dry_run_max_age_hours': 1},
+            policy_payload={"rollback_dry_run_max_age_hours": 1},
             candidate_state_payload=state,
             now=datetime(2026, 2, 1, tzinfo=timezone.utc),
         )
         self.assertFalse(result.ready)
-        self.assertIn('rollback_dry_run_stale', result.reasons)
+        self.assertIn("rollback_dry_run_stale", result.reasons)
 
     def test_allows_progression_when_artifacts_and_rollback_are_ready(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'research').mkdir(parents=True, exist_ok=True)
-            (root / 'backtest').mkdir(parents=True, exist_ok=True)
-            (root / 'gates').mkdir(parents=True, exist_ok=True)
-            (root / 'paper-candidate').mkdir(parents=True, exist_ok=True)
-            (root / 'research' / 'candidate-spec.json').write_text('{}', encoding='utf-8')
-            (root / 'backtest' / 'evaluation-report.json').write_text('{}', encoding='utf-8')
-            (root / 'gates' / 'gate-evaluation.json').write_text('{}', encoding='utf-8')
-            (root / 'paper-candidate' / 'strategy-configmap-patch.yaml').write_text('kind: ConfigMap', encoding='utf-8')
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "paper-candidate").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "gates" / "gate-evaluation.json").write_text("{}", encoding="utf-8")
+            (root / "gates" / "profitability-evidence-v4.json").write_text(
+                json.dumps({"schema_version": "profitability-evidence-v4"}),
+                encoding="utf-8",
+            )
+            (root / "gates" / "profitability-benchmark-v4.json").write_text(
+                json.dumps(
+                    {
+                        "slices": [
+                            {"slice_type": "regime", "slice_key": "regime:neutral"}
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "gates" / "profitability-evidence-validation.json").write_text(
+                json.dumps({"passed": True, "reasons": []}),
+                encoding="utf-8",
+            )
+            (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
+                "kind: ConfigMap", encoding="utf-8"
+            )
 
             promotion = evaluate_promotion_prerequisites(
                 policy_payload={},
                 gate_report_payload=_gate_report(),
                 candidate_state_payload=_candidate_state(),
-                promotion_target='paper',
+                promotion_target="paper",
                 artifact_root=root,
             )
             rollback = evaluate_rollback_readiness(
@@ -77,32 +121,92 @@ class TestPolicyChecks(TestCase):
         self.assertTrue(promotion.allowed)
         self.assertTrue(rollback.ready)
 
+    def test_promotion_prerequisites_fail_when_profitability_validation_fails(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "paper-candidate").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "gates" / "gate-evaluation.json").write_text("{}", encoding="utf-8")
+            (root / "gates" / "profitability-evidence-v4.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "gates" / "profitability-benchmark-v4.json").write_text(
+                json.dumps(
+                    {
+                        "slices": [
+                            {"slice_type": "regime", "slice_key": "regime:neutral"}
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            validation_path = root / "gates" / "profitability-evidence-validation.json"
+            validation_path.write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "reasons": ["market_net_pnl_delta_below_threshold"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
+                "kind: ConfigMap", encoding="utf-8"
+            )
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={},
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn("profitability_evidence_validation_failed", promotion.reasons)
+        self.assertTrue(
+            any(
+                item.get("artifact_ref") == str(validation_path)
+                for item in promotion.reason_details
+            )
+        )
+
 
 def _candidate_state() -> dict[str, object]:
     return {
-        'candidateId': 'cand-test',
-        'runId': 'run-test',
-        'activeStage': 'gate-evaluation',
-        'paused': False,
-        'rollbackReadiness': {
-            'killSwitchDryRunPassed': True,
-            'gitopsRevertDryRunPassed': True,
-            'strategyDisableDryRunPassed': True,
-            'dryRunCompletedAt': datetime.now(timezone.utc).isoformat(),
-            'humanApproved': True,
-            'rollbackTarget': 'main@a1b2c3d',
+        "candidateId": "cand-test",
+        "runId": "run-test",
+        "activeStage": "gate-evaluation",
+        "paused": False,
+        "rollbackReadiness": {
+            "killSwitchDryRunPassed": True,
+            "gitopsRevertDryRunPassed": True,
+            "strategyDisableDryRunPassed": True,
+            "dryRunCompletedAt": datetime.now(timezone.utc).isoformat(),
+            "humanApproved": True,
+            "rollbackTarget": "main@a1b2c3d",
         },
     }
 
 
 def _gate_report() -> dict[str, object]:
     return {
-        'run_id': 'run-test',
-        'promotion_allowed': True,
-        'recommended_mode': 'paper',
-        'gates': [
-            {'gate_id': 'gate0_data_integrity', 'status': 'pass'},
-            {'gate_id': 'gate1_statistical_robustness', 'status': 'pass'},
-            {'gate_id': 'gate2_risk_capacity', 'status': 'pass'},
+        "run_id": "run-test",
+        "promotion_allowed": True,
+        "recommended_mode": "paper",
+        "gates": [
+            {"gate_id": "gate0_data_integrity", "status": "pass"},
+            {"gate_id": "gate1_statistical_robustness", "status": "pass"},
+            {"gate_id": "gate2_risk_capacity", "status": "pass"},
         ],
     }

--- a/services/torghut/tests/test_profitability_evidence_v4.py
+++ b/services/torghut/tests/test_profitability_evidence_v4.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.evaluation import (
+    ProfitabilityEvidenceThresholdsV4,
+    build_profitability_evidence_v4,
+    execute_profitability_benchmark_v4,
+    validate_profitability_evidence_v4,
+)
+
+
+class TestProfitabilityEvidenceV4(TestCase):
+    def test_benchmark_and_validation_emit_expected_schema(self) -> None:
+        candidate_report = _report_payload(
+            net_pnl="12",
+            max_drawdown="6",
+            cost_bps="4",
+            regime_label="bullish",
+            regime_net_pnl="12",
+        )
+        baseline_report = _report_payload(
+            net_pnl="10",
+            max_drawdown="8",
+            cost_bps="5",
+            regime_label="bullish",
+            regime_net_pnl="8",
+        )
+
+        benchmark = execute_profitability_benchmark_v4(
+            candidate_id="cand-1",
+            baseline_id="baseline-legacy",
+            candidate_report_payload=candidate_report,
+            baseline_report_payload=baseline_report,
+            required_slice_keys=["market:all", "regime:bullish"],
+            executed_at=datetime(2026, 2, 20, tzinfo=timezone.utc),
+        )
+        evidence = build_profitability_evidence_v4(
+            run_id="run-1",
+            candidate_id="cand-1",
+            baseline_id="baseline-legacy",
+            candidate_report_payload=candidate_report,
+            benchmark=benchmark,
+            confidence_values=[Decimal("0.7"), Decimal("0.8")],
+            reproducibility_hashes={
+                "signals": "a",
+                "strategy_config": "b",
+                "gate_policy": "c",
+                "candidate_report": "d",
+                "baseline_report": "e",
+            },
+            artifact_refs=["/tmp/a.json", "/tmp/b.json"],
+            generated_at=datetime(2026, 2, 20, tzinfo=timezone.utc),
+        )
+        validation = validate_profitability_evidence_v4(evidence)
+
+        benchmark_payload = benchmark.to_payload()
+        self.assertEqual(
+            benchmark_payload["schema_version"], "profitability-benchmark-v4"
+        )
+        self.assertEqual(len(benchmark_payload["slices"]), 2)
+        self.assertEqual(
+            evidence.to_payload()["schema_version"], "profitability-evidence-v4"
+        )
+        self.assertTrue(validation.passed)
+        self.assertEqual(validation.reasons, [])
+
+    def test_validation_fails_when_contract_is_incomplete(self) -> None:
+        candidate_report = _report_payload(
+            net_pnl="-2",
+            max_drawdown="10",
+            cost_bps="80",
+            regime_label="volatile",
+            regime_net_pnl="-2",
+        )
+        baseline_report = _report_payload(
+            net_pnl="3",
+            max_drawdown="6",
+            cost_bps="5",
+            regime_label="volatile",
+            regime_net_pnl="3",
+        )
+        benchmark = execute_profitability_benchmark_v4(
+            candidate_id="cand-2",
+            baseline_id="baseline-legacy",
+            candidate_report_payload=candidate_report,
+            baseline_report_payload=baseline_report,
+        )
+        evidence = build_profitability_evidence_v4(
+            run_id="run-2",
+            candidate_id="cand-2",
+            baseline_id="baseline-legacy",
+            candidate_report_payload=candidate_report,
+            benchmark=benchmark,
+            confidence_values=[],
+            reproducibility_hashes={"signals": "only-one-hash"},
+            artifact_refs=["/tmp/c.json"],
+        )
+        validation = validate_profitability_evidence_v4(
+            evidence,
+            thresholds=ProfitabilityEvidenceThresholdsV4(),
+        )
+
+        self.assertFalse(validation.passed)
+        self.assertIn("market_net_pnl_delta_below_threshold", validation.reasons)
+        self.assertIn("cost_bps_exceeds_threshold", validation.reasons)
+        self.assertIn("reproducibility_hash_keys_missing", validation.reasons)
+
+
+def _report_payload(
+    *,
+    net_pnl: str,
+    max_drawdown: str,
+    cost_bps: str,
+    regime_label: str,
+    regime_net_pnl: str,
+) -> dict[str, object]:
+    return {
+        "metrics": {
+            "net_pnl": net_pnl,
+            "max_drawdown": max_drawdown,
+            "cost_bps": cost_bps,
+            "trade_count": 4,
+            "decision_count": 8,
+            "turnover_ratio": "1.1",
+        },
+        "robustness": {
+            "folds": [
+                {
+                    "fold_name": "fold_1",
+                    "trade_count": 4,
+                    "net_pnl": regime_net_pnl,
+                    "max_drawdown": max_drawdown,
+                    "cost_bps": cost_bps,
+                    "turnover_ratio": "1.1",
+                    "regime_label": regime_label,
+                }
+            ]
+        },
+        "impact_assumptions": {
+            "decisions_with_spread": 4,
+            "decisions_with_volatility": 4,
+            "decisions_with_adv": 4,
+            "assumptions": {
+                "recorded_inputs_count": "4",
+                "fallback_inputs_count": "0",
+            },
+        },
+    }


### PR DESCRIPTION
## Summary

- Implemented `ProfitabilityEvidenceV4` contract in Torghut evaluation with risk-adjusted metrics, cost/fill realism, confidence-calibration summary, and reproducibility hash manifest fields.
- Added deterministic baseline-vs-candidate benchmark execution (`profitability-benchmark-v4`) across `market:all` and regime slices, plus strict validator output (`profitability-evidence-validation.json`).
- Enforced profitability evidence as a promotion gate in autonomous lane and gate matrix (`gate6_profitability_evidence`), blocking paper/live promotion when evidence is missing or below configured thresholds.
- Persisted machine-readable audit artifacts and reason payloads (`promotion-evidence-gate.json`) and updated policy checks/dry-run harness to require profitability evidence artifacts.
- Added focused tests for validator + benchmark schema + gate integration and updated v3 design docs to codify the new compliance evidence contract.

## Related Issues

None

## Testing

- `cd services/torghut && uv run ruff check app/trading/evaluation.py app/trading/autonomy/gates.py app/trading/autonomy/lane.py app/trading/autonomy/policy_checks.py scripts/run_autonomous_lane.py scripts/run_governance_policy_dry_run.py tests/test_autonomy_gates.py tests/test_policy_checks.py tests/test_autonomous_lane.py tests/test_profitability_evidence_v4.py`
- `cd services/torghut && uv run --with . pyright app/trading/evaluation.py app/trading/autonomy/gates.py app/trading/autonomy/lane.py app/trading/autonomy/policy_checks.py scripts/run_autonomous_lane.py scripts/run_governance_policy_dry_run.py`
- `cd services/torghut && uv run --with . --with pytest pytest tests/test_autonomous_lane.py tests/test_governance_policy_dry_run.py tests/test_policy_checks.py tests/test_autonomy_gates.py tests/test_profitability_evidence_v4.py`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
