### PR TITLE
feat(landing): add live online presence counter

### DIFF
--- a/apps/landing/.env.example
+++ b/apps/landing/.env.example
@@ -1,6 +1,11 @@
 # Copy the Convex deployment URL from packages/backend/.env.local after running
 # `bun run dev:setup:convex`
 NEXT_PUBLIC_CONVEX_URL=
+# Set to "false" to disable the live "online now" badge.
+NEXT_PUBLIC_ENABLE_LIVE_PRESENCE_COUNTER=true
+# Optional heartbeat override in seconds (5-60).
+NEXT_PUBLIC_PRESENCE_HEARTBEAT_SECONDS=15
+# Presence TTL in seconds (15-600). Sessions are considered offline after this window.
+PRESENCE_TTL_SECONDS=45
 # URL of the Payload CMS instance (e.g. https://cms.proompteng.ai)
-LANDING_CMS_URL=
 LANDING_CMS_URL=

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -13,11 +13,14 @@ Deployment: changes under `apps/landing/**` (or `packages/design/**`) merged to 
    This prompts for or creates a Convex deployment and writes `packages/backend/.env.local`.
 2. Copy the generated `NEXT_PUBLIC_CONVEX_URL` into `apps/landing/.env.local` (use the provided `.env.example` as a template).
 3. If you want CMS-driven content, set `LANDING_CMS_URL` to your Payload instance (for example `https://cms.proompteng.ai`).
-4. Seed the Convex models catalog once so the UI has initial data:
+4. Live presence badge:
+   - keep `NEXT_PUBLIC_ENABLE_LIVE_PRESENCE_COUNTER=true` to show `LIVE • N online` in the terminal title bar;
+   - tune `NEXT_PUBLIC_PRESENCE_HEARTBEAT_SECONDS` and `PRESENCE_TTL_SECONDS` if needed.
+5. Seed the Convex models catalog once so the UI has initial data:
    ```sh
    bun run seed:models
    ```
-5. Launch the Next.js app together with the Convex dev backend (one command):
+6. Launch the Next.js app together with the Convex dev backend (one command):
    ```sh
    bun run dev:landing
    ```

--- a/apps/landing/src/app/api/presence/route.ts
+++ b/apps/landing/src/app/api/presence/route.ts
@@ -1,0 +1,151 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { ConvexHttpClient } from 'convex/browser'
+import { makeFunctionReference } from 'convex/server'
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  getPresenceTtlSeconds,
+  isPresenceEvent,
+  LIVE_PRESENCE_COOKIE_NAME,
+  LIVE_PRESENCE_ENABLED,
+  LIVE_PRESENCE_SITE,
+  normalizePresencePath,
+} from '@/lib/live-presence'
+
+const BOT_USER_AGENT_RE =
+  /(bot|spider|crawler|headless|slurp|curl|wget|python-requests|httpclient|scrapy|facebookexternalhit|preview)/i
+const SESSION_ID_RE = /^[a-zA-Z0-9_-]{8,128}$/
+const VISITOR_ID_RE = /^[a-zA-Z0-9-]{16,128}$/
+const trackPresenceMutation = makeFunctionReference<'mutation'>('presence:track')
+
+type PresenceRequestBody = {
+  event?: unknown
+  sessionId?: unknown
+  path?: unknown
+}
+
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest) {
+  if (!LIVE_PRESENCE_ENABLED) {
+    return emptySuccess()
+  }
+
+  const userAgent = request.headers.get('user-agent') ?? ''
+  if (isLikelyBot(userAgent)) {
+    return emptySuccess()
+  }
+
+  const payload = await parseBody(request)
+  if (!payload || !isPresenceEvent(payload.event) || !isValidSessionId(payload.sessionId)) {
+    return NextResponse.json({ error: 'invalid presence payload' }, { status: 400, headers: noStoreHeaders() })
+  }
+
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL
+  if (!convexUrl) {
+    return emptySuccess()
+  }
+
+  const existingVisitorId = request.cookies.get(LIVE_PRESENCE_COOKIE_NAME)?.value
+  const visitorId = isValidVisitorId(existingVisitorId) ? existingVisitorId : randomUUID()
+  const shouldSetCookie = visitorId !== existingVisitorId
+  const now = Date.now()
+  const ttlMs = getPresenceTtlSeconds() * 1000
+  const convex = new ConvexHttpClient(convexUrl)
+
+  try {
+    await convex.mutation(trackPresenceMutation, {
+      site: LIVE_PRESENCE_SITE,
+      sessionId: payload.sessionId,
+      visitorIdHash: hashValue(visitorId),
+      path: normalizePresencePath(payload.path ?? '/'),
+      event: payload.event,
+      now,
+      ttlMs,
+    })
+  } catch (error) {
+    console.error('presence tracking failed', error)
+    return NextResponse.json({ error: 'failed to track presence' }, { status: 500, headers: noStoreHeaders() })
+  }
+
+  const response = NextResponse.json({ ok: true }, { headers: noStoreHeaders() })
+  if (shouldSetCookie) {
+    response.cookies.set({
+      name: LIVE_PRESENCE_COOKIE_NAME,
+      value: visitorId,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 24 * 365,
+      path: '/',
+    })
+  }
+
+  return response
+}
+
+async function parseBody(
+  request: NextRequest,
+): Promise<{ event: 'join' | 'heartbeat' | 'leave'; sessionId: string; path?: string } | null> {
+  let parsed: PresenceRequestBody
+
+  try {
+    parsed = (await request.json()) as PresenceRequestBody
+  } catch {
+    return null
+  }
+
+  if (!isPresenceEvent(parsed.event)) {
+    return null
+  }
+
+  if (typeof parsed.sessionId !== 'string') {
+    return null
+  }
+
+  if (parsed.path !== undefined && typeof parsed.path !== 'string') {
+    return null
+  }
+
+  return {
+    event: parsed.event,
+    sessionId: parsed.sessionId,
+    path: parsed.path,
+  }
+}
+
+function isLikelyBot(userAgent: string) {
+  return BOT_USER_AGENT_RE.test(userAgent)
+}
+
+function isValidSessionId(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false
+  }
+
+  return SESSION_ID_RE.test(value)
+}
+
+function isValidVisitorId(value: string | undefined): value is string {
+  if (!value) {
+    return false
+  }
+
+  return VISITOR_ID_RE.test(value)
+}
+
+function hashValue(value: string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function noStoreHeaders() {
+  return {
+    'Cache-Control': 'no-store',
+  }
+}
+
+function emptySuccess() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: noStoreHeaders(),
+  })
+}

--- a/apps/landing/src/components/desktop-hero.tsx
+++ b/apps/landing/src/components/desktop-hero.tsx
@@ -13,7 +13,7 @@ import {
   useRef,
   useState,
 } from 'react'
-
+import LivePresenceTracker from '@/components/live-presence-tracker'
 import TerminalWindow, { type TerminalWindowHandle } from '@/components/terminal-window'
 import { cn } from '@/lib/utils'
 
@@ -253,9 +253,7 @@ export default function DesktopHero() {
                           >
                             {(topMenus.find((menu) => menu.id === activeMenu)?.items ?? []).map((item) => {
                               if (item.separatorBefore) {
-                                return (
-                                  <div key={item.id} className="my-1 h-px bg-[rgb(84_92_126/0.38)]" role="separator" />
-                                )
+                                return <hr key={item.id} className="my-1 h-px border-0 bg-[rgb(84_92_126/0.38)]" />
                               }
 
                               return (
@@ -294,6 +292,7 @@ export default function DesktopHero() {
         </header>
 
         <div ref={desktopStageRef} className="relative z-10 flex-1 overflow-hidden">
+          <LivePresenceTracker />
           <TerminalWindow
             ref={terminalWindowRef}
             desktopBoundsRef={desktopStageRef}
@@ -465,7 +464,7 @@ function DockTooltip({ label }: { label: string }) {
     return () => {
       resizeObserver.disconnect()
     }
-  }, [label])
+  }, [])
 
   const bodyWidth = Math.max(DOCK_TOOLTIP_MIN_WIDTH_PX, labelWidth + DOCK_TOOLTIP_PADDING_X_PX * 2)
   const bodyHeight = Math.max(

--- a/apps/landing/src/components/live-online-counter.tsx
+++ b/apps/landing/src/components/live-online-counter.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useQuery } from 'convex/react'
+import { makeFunctionReference } from 'convex/server'
+import { LIVE_PRESENCE_ENABLED, LIVE_PRESENCE_SITE } from '@/lib/live-presence'
+
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL
+const getOnlineNowQuery = makeFunctionReference<'query'>('presence:getOnlineNow')
+
+export default function LiveOnlineCounter() {
+  if (!LIVE_PRESENCE_ENABLED || !convexUrl) {
+    return null
+  }
+
+  return <LiveOnlineCounterValue />
+}
+
+function LiveOnlineCounterValue() {
+  const result = useQuery(getOnlineNowQuery, { site: LIVE_PRESENCE_SITE })
+  const onlineNow = result?.onlineNow
+
+  return (
+    <div className="inline-flex items-center gap-1.5 rounded-full border border-[rgb(var(--terminal-shell-border)/0.5)] bg-[rgb(var(--terminal-window-bg-top)/0.66)] px-2.5 py-1 text-[10px] tracking-[0.08em] text-[rgb(var(--terminal-text-faint)/0.88)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur">
+      <span className="relative inline-flex size-2">
+        <span className="absolute inline-flex size-2 animate-ping rounded-full bg-[rgb(var(--terminal-text-green)/0.8)]" />
+        <span className="relative inline-flex size-2 rounded-full bg-[rgb(var(--terminal-text-green))]" />
+      </span>
+      <span className="font-semibold uppercase text-[rgb(var(--terminal-text-green)/0.95)]">Live</span>
+      <span className="font-medium text-[rgb(var(--terminal-text-primary)/0.88)]">
+        {onlineNow === undefined ? '--' : onlineNow} online
+      </span>
+    </div>
+  )
+}

--- a/apps/landing/src/components/live-presence-tracker.tsx
+++ b/apps/landing/src/components/live-presence-tracker.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import {
+  getPresenceHeartbeatSeconds,
+  LIVE_PRESENCE_ENABLED,
+  normalizePresencePath,
+  type PresenceEvent,
+} from '@/lib/live-presence'
+
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL
+
+type PresencePayload = {
+  event: PresenceEvent
+  sessionId: string
+  path: string
+}
+
+export default function LivePresenceTracker() {
+  if (!LIVE_PRESENCE_ENABLED || !convexUrl) {
+    return null
+  }
+
+  return <PresenceRuntime />
+}
+
+function PresenceRuntime() {
+  const sessionIdRef = useRef<string>('')
+  const heartbeatTimerRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    sessionIdRef.current = createSessionId()
+    const heartbeatIntervalMs = getPresenceHeartbeatSeconds() * 1000
+
+    const sendEvent = (event: PresenceEvent, preferBeacon: boolean) => {
+      const payload: PresencePayload = {
+        event,
+        sessionId: sessionIdRef.current,
+        path: normalizePresencePath(window.location.pathname),
+      }
+
+      const encoded = JSON.stringify(payload)
+      if (preferBeacon && typeof navigator.sendBeacon === 'function') {
+        const sent = navigator.sendBeacon('/api/presence', new Blob([encoded], { type: 'application/json' }))
+        if (sent) {
+          return
+        }
+      }
+
+      void fetch('/api/presence', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: encoded,
+        keepalive: preferBeacon,
+        cache: 'no-store',
+      })
+    }
+
+    const stopHeartbeat = () => {
+      if (heartbeatTimerRef.current === null) {
+        return
+      }
+
+      window.clearInterval(heartbeatTimerRef.current)
+      heartbeatTimerRef.current = null
+    }
+
+    const startHeartbeat = () => {
+      if (heartbeatTimerRef.current !== null) {
+        return
+      }
+
+      heartbeatTimerRef.current = window.setInterval(() => {
+        if (document.visibilityState !== 'visible') {
+          return
+        }
+
+        sendEvent('heartbeat', false)
+      }, heartbeatIntervalMs)
+    }
+
+    sendEvent('join', false)
+    startHeartbeat()
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        sendEvent('join', false)
+        startHeartbeat()
+      } else {
+        stopHeartbeat()
+        sendEvent('leave', true)
+      }
+    }
+
+    const handlePageHide = () => {
+      stopHeartbeat()
+      sendEvent('leave', true)
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('pagehide', handlePageHide)
+
+    return () => {
+      stopHeartbeat()
+      sendEvent('leave', true)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('pagehide', handlePageHide)
+    }
+  }, [])
+
+  return null
+}
+
+function createSessionId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`
+}

--- a/apps/landing/src/components/terminal-window.tsx
+++ b/apps/landing/src/components/terminal-window.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'motion/react'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import LiveOnlineCounter from '@/components/live-online-counter'
 import { cn } from '@/lib/utils'
 
 const AGENTRUN_FILE = 'charts/agents/examples/agentrun-workflow-smoke.yaml'
@@ -1051,6 +1052,9 @@ const TerminalWindow = forwardRef<TerminalWindowHandle, TerminalWindowProps>(
             <p className="font-display truncate text-center text-sm font-medium tracking-[0.01em] text-[rgb(var(--terminal-titlebar-text))]">
               control plane
             </p>
+          </div>
+          <div className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2">
+            <LiveOnlineCounter />
           </div>
           <div className="w-10" />
         </div>

--- a/apps/landing/src/lib/live-presence.ts
+++ b/apps/landing/src/lib/live-presence.ts
@@ -1,0 +1,64 @@
+export const LIVE_PRESENCE_SITE = 'proompteng.ai'
+export const LIVE_PRESENCE_COOKIE_NAME = 'pv_id'
+export const LIVE_PRESENCE_HEARTBEAT_SECONDS = 15
+export const LIVE_PRESENCE_TTL_SECONDS = 45
+export const LIVE_PRESENCE_ENABLED = process.env.NEXT_PUBLIC_ENABLE_LIVE_PRESENCE_COUNTER !== 'false'
+
+const DEFAULT_HEARTBEAT_SECONDS = LIVE_PRESENCE_HEARTBEAT_SECONDS
+const DEFAULT_TTL_SECONDS = LIVE_PRESENCE_TTL_SECONDS
+const MIN_HEARTBEAT_SECONDS = 5
+const MAX_HEARTBEAT_SECONDS = 60
+const MIN_TTL_SECONDS = 15
+const MAX_TTL_SECONDS = 600
+
+export type PresenceEvent = 'join' | 'heartbeat' | 'leave'
+
+export function isPresenceEvent(value: unknown): value is PresenceEvent {
+  return value === 'join' || value === 'heartbeat' || value === 'leave'
+}
+
+export function getPresenceHeartbeatSeconds() {
+  return parseOptionalNumber(
+    process.env.NEXT_PUBLIC_PRESENCE_HEARTBEAT_SECONDS,
+    DEFAULT_HEARTBEAT_SECONDS,
+    MIN_HEARTBEAT_SECONDS,
+    MAX_HEARTBEAT_SECONDS,
+  )
+}
+
+export function getPresenceTtlSeconds() {
+  return parseOptionalNumber(process.env.PRESENCE_TTL_SECONDS, DEFAULT_TTL_SECONDS, MIN_TTL_SECONDS, MAX_TTL_SECONDS)
+}
+
+export function normalizePresencePath(path: string) {
+  if (!path) {
+    return '/'
+  }
+
+  if (path.startsWith('/')) {
+    return path
+  }
+
+  return `/${path}`
+}
+
+function parseOptionalNumber(value: string | undefined, fallback: number, min: number, max: number) {
+  if (!value) {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isNaN(parsed)) {
+    return fallback
+  }
+
+  if (parsed < min) {
+    return min
+  }
+
+  if (parsed > max) {
+    return max
+  }
+
+  return parsed
+}

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,19 +19,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/docs/proompteng-ai-live-presence-counter-plan.md
+++ b/docs/proompteng-ai-live-presence-counter-plan.md
@@ -1,0 +1,120 @@
+# proompteng.ai Live Presence Counter Plan
+
+## Objective
+- Ship a live `online now` counter on `https://proompteng.ai`.
+- Prioritize current presence, not cumulative historical visits.
+- Keep the implementation anonymous and lightweight on the existing stack (`apps/landing` + `packages/backend/convex`).
+
+## Scope
+- In scope:
+  - Public counter for people currently on the site.
+  - Near real-time updates via Convex subscriptions.
+  - Session heartbeat and expiry-based presence logic.
+  - Basic bot filtering.
+- Out of scope:
+  - Full analytics funnels/attribution.
+  - User identity or PII collection.
+  - Cumulative visit totals as a primary metric.
+
+## Presence Definition
+- `online now` = unique active sessions seen in the last TTL window.
+- Proposed defaults:
+  - Heartbeat every 15 seconds while tab is visible.
+  - Session expires after 45 seconds without heartbeat.
+- Counter decreases automatically when users close the tab or go inactive past TTL.
+
+## Proposed Architecture
+
+### 1. Presence Tracker (Client)
+- Add `apps/landing/src/components/live-presence-tracker.tsx`.
+- On load:
+  - Create/restore anonymous visitor cookie (`pv_id`).
+  - Create page session ID (`ps_id`).
+  - Send `join` ping to `apps/landing/src/app/api/presence/route.ts`.
+- While page is visible:
+  - Send heartbeat every `PRESENCE_HEARTBEAT_SECONDS`.
+- On `visibilitychange` hidden and `pagehide`:
+  - Send `leave` best-effort beacon.
+
+### 2. Presence Endpoint (Server)
+- Implement `POST /api/presence` in `apps/landing/src/app/api/presence/route.ts`.
+- Validate and normalize:
+  - event type: `join | heartbeat | leave`
+  - site/path/session identifiers
+  - user-agent heuristics for obvious bots
+- Forward accepted events to Convex mutation.
+
+### 3. Convex Data Model
+- Extend `packages/backend/convex/schema.ts` with `liveSessions` table:
+  - `site`: string
+  - `sessionId`: string
+  - `visitorIdHash`: string
+  - `path`: string
+  - `lastSeenAt`: number
+  - `expiresAt`: number
+  - `updatedAt`: number
+- Indexes:
+  - `bySession`: `['sessionId']`
+  - `bySiteExpires`: `['site', 'expiresAt']`
+- Add `packages/backend/convex/presence.ts` with:
+  - `upsertPresence` mutation (`join`/`heartbeat` refreshes expiry).
+  - `markLeft` mutation (`leave` expires session immediately).
+  - `getOnlineNow` query (counts sessions where `expiresAt > now`).
+
+### 4. Live UI Counter
+- Add `apps/landing/src/components/live-online-counter.tsx`:
+  - Uses `useQuery(api.presence.getOnlineNow, { site: 'proompteng.ai' })`.
+  - Displays `N online now`.
+  - Includes loading/fallback state.
+- Mount in hero/metrics area from `apps/landing/src/components/desktop-hero.tsx`.
+
+## Rollout Plan
+1. Phase 1: Convex presence foundation
+   - Add schema and `presence.ts`.
+   - Run `bun run --filter @proompteng/backend codegen`.
+   - Validate with local mutation/query checks.
+2. Phase 2: API route + tracker
+   - Add `/api/presence`.
+   - Add client tracker with join/heartbeat/leave.
+   - Validate TTL-based decrement behavior manually.
+3. Phase 3: UI integration
+   - Add `live-online-counter` component.
+   - Place in landing hero and confirm live updates across multiple devices/tabs.
+4. Phase 4: Hardening
+   - Add edge rate limiting if abuse appears.
+   - Tune heartbeat/TTL windows for stability and cost.
+
+## Feature Flags and Config
+- `NEXT_PUBLIC_ENABLE_LIVE_PRESENCE_COUNTER=true|false`
+- `PRESENCE_HEARTBEAT_SECONDS=15`
+- `PRESENCE_TTL_SECONDS=45`
+
+Default: deploy with flag off, enable after production verification.
+
+## Validation Plan
+- Local/manual:
+  - Open 2-3 browsers/devices and verify counter rises within seconds.
+  - Close a browser and confirm counter drops after TTL.
+  - Keep one tab hidden and confirm presence pauses/expires.
+  - Verify obvious bot user agents are rejected.
+- Automated:
+  - Unit tests for `/api/presence` validation and bot filtering.
+  - Convex tests for session upsert, expiry, and online count query.
+- Post-deploy:
+  - Monitor route error rate and Convex mutation latency.
+  - Confirm no visible performance regression on landing page.
+
+## Risks and Mitigations
+- Overcount from multiple tabs:
+  - Mitigation: count by session (or unique visitor if preferred) and document behavior.
+- Undercount due to aggressive throttling/background tabs:
+  - Mitigation: use conservative TTL and visibility-aware heartbeat.
+- Bot inflation:
+  - Mitigation: UA heuristics + optional edge rate limits.
+- Privacy concerns:
+  - Mitigation: anonymous IDs only, no PII.
+
+## Success Criteria
+- Counter reflects current online presence with <5 second perceived lag.
+- Counter decays correctly when sessions expire.
+- Landing page performance remains stable.

--- a/packages/backend/convex/presence.ts
+++ b/packages/backend/convex/presence.ts
@@ -1,0 +1,117 @@
+import { v } from 'convex/values'
+import { type MutationCtx, mutation, type QueryCtx, query } from './_generated/server'
+
+const MIN_TTL_MS = 15_000
+const MAX_TTL_MS = 10 * 60_000
+const EXPIRED_PRUNE_BATCH_SIZE = 128
+
+export const track = mutation({
+  args: {
+    site: v.string(),
+    sessionId: v.string(),
+    visitorIdHash: v.string(),
+    path: v.string(),
+    event: v.union(v.literal('join'), v.literal('heartbeat'), v.literal('leave')),
+    now: v.number(),
+    ttlMs: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const ttlMs = clamp(args.ttlMs, MIN_TTL_MS, MAX_TTL_MS)
+    await pruneExpiredSessions(ctx, args.site, args.now)
+
+    const existing = await ctx.db
+      .query('liveSessions')
+      .withIndex('bySession', (q) => q.eq('sessionId', args.sessionId))
+      .unique()
+
+    if (args.event === 'leave') {
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          lastSeenAt: args.now,
+          expiresAt: args.now,
+          updatedAt: args.now,
+        })
+      }
+
+      return {
+        onlineNow: await countOnlineVisitors(ctx, args.site, args.now),
+        updatedAt: args.now,
+      }
+    }
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        site: args.site,
+        visitorIdHash: args.visitorIdHash,
+        path: args.path,
+        lastSeenAt: args.now,
+        expiresAt: args.now + ttlMs,
+        updatedAt: args.now,
+      })
+    } else {
+      await ctx.db.insert('liveSessions', {
+        site: args.site,
+        sessionId: args.sessionId,
+        visitorIdHash: args.visitorIdHash,
+        path: args.path,
+        lastSeenAt: args.now,
+        expiresAt: args.now + ttlMs,
+        updatedAt: args.now,
+      })
+    }
+
+    return {
+      onlineNow: await countOnlineVisitors(ctx, args.site, args.now),
+      updatedAt: args.now,
+    }
+  },
+})
+
+export const getOnlineNow = query({
+  args: {
+    site: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now()
+    const onlineNow = await countOnlineVisitors(ctx, args.site, now)
+
+    return {
+      site: args.site,
+      onlineNow,
+      updatedAt: now,
+    }
+  },
+})
+
+async function countOnlineVisitors(ctx: QueryCtx | MutationCtx, site: string, now: number) {
+  const activeSessions = await ctx.db
+    .query('liveSessions')
+    .withIndex('bySiteExpires', (q) => q.eq('site', site).gt('expiresAt', now))
+    .collect()
+
+  const uniqueVisitors = new Set(activeSessions.map((session) => session.visitorIdHash))
+  return uniqueVisitors.size
+}
+
+async function pruneExpiredSessions(ctx: MutationCtx, site: string, now: number) {
+  const expired = await ctx.db
+    .query('liveSessions')
+    .withIndex('bySiteExpires', (q) => q.eq('site', site).lte('expiresAt', now))
+    .take(EXPIRED_PRUNE_BATCH_SIZE)
+
+  for (const session of expired) {
+    await ctx.db.delete(session._id)
+  }
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (value < min) {
+    return min
+  }
+
+  if (value > max) {
+    return max
+  }
+
+  return value
+}

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -30,4 +30,15 @@ export default defineSchema({
   })
     .index('bySlug', ['slug'])
     .index('byStatus', ['status', 'updatedAt']),
+  liveSessions: defineTable({
+    site: v.string(),
+    sessionId: v.string(),
+    visitorIdHash: v.string(),
+    path: v.string(),
+    lastSeenAt: v.number(),
+    expiresAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index('bySession', ['sessionId'])
+    .index('bySiteExpires', ['site', 'expiresAt']),
 })


### PR DESCRIPTION
## Summary

- Added a live presence backend in Convex (`liveSessions` table + `presence` functions) to track active sessions and compute `online now` by unique visitor.
- Added a Next.js API route at `POST /api/presence` with anonymous cookie handling, bot filtering, and presence event forwarding.
- Added a client tracker that sends `join`, `heartbeat`, and `leave` events based on page visibility and lifecycle.
- Added a live `LIVE • N online` badge in the terminal title bar (`control plane`) on the landing hero.
- Documented env/config behavior for the live presence feature and added a scoped implementation plan doc.

## Related Issues

None

## Testing

- `bun run lint:landing`
- `bun run build:landing`
- `bun run --filter landing lint:oxlint:type`
- `bunx @biomejs/biome@2.3.8 check apps/landing/src/app/api/presence/route.ts apps/landing/src/components/live-presence-tracker.tsx apps/landing/src/components/live-online-counter.tsx apps/landing/src/components/desktop-hero.tsx apps/landing/src/components/terminal-window.tsx apps/landing/src/lib/live-presence.ts packages/backend/convex/presence.ts packages/backend/convex/schema.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
