### PR TITLE
feat(ci): automate safe release PR auto-merge

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -1,0 +1,151 @@
+name: release-pr-automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-pr-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable:
+    if: >-
+      ${{
+        github.event.pull_request.base.ref == 'main' &&
+        startsWith(github.event.pull_request.head.ref, 'release/') &&
+        github.event.pull_request.draft == false
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Evaluate automerge eligibility
+        id: gates
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+
+          echo "eligible=false" >> "$GITHUB_OUTPUT"
+          echo "reason=not-evaluated" >> "$GITHUB_OUTPUT"
+
+          allowed_authors=("app/github-actions" "github-actions[bot]")
+          allowed_paths=("argocd/applications/proompteng/kustomization.yaml")
+
+          contains() {
+            local needle="$1"
+            shift
+            for item in "$@"; do
+              if [[ "$item" == "$needle" ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          if [[ "$PR_BASE_REF" != "main" ]]; then
+            echo "reason=base-not-main" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$PR_HEAD_REF" != release/* ]]; then
+            echo "reason=head-not-release-branch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$PR_IS_DRAFT" == "true" ]]; then
+            echo "reason=pr-is-draft" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$PR_HEAD_REPO" != "$GH_REPO" ]]; then
+            echo "reason=head-not-from-same-repo" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! contains "$PR_AUTHOR" "${allowed_authors[@]}"; then
+            echo "reason=author-not-allowlisted" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          has_opt_out_label=$(
+            gh pr view "$PR_NUMBER" \
+              -R "$GH_REPO" \
+              --json labels \
+              --jq 'any(.labels[]?; .name == "do-not-automerge")'
+          )
+
+          if [[ "$has_opt_out_label" == "true" ]]; then
+            echo "reason=opt-out-label-present" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t changed_files < <(
+            gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename'
+          )
+
+          if [[ "${#changed_files[@]}" -eq 0 ]]; then
+            echo "reason=no-files-changed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          for path in "${changed_files[@]}"; do
+            if ! contains "$path" "${allowed_paths[@]}"; then
+              echo "reason=changed-file-not-allowlisted:$path" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+          echo "reason=eligible" >> "$GITHUB_OUTPUT"
+
+      - name: Eligibility summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "eligible=${{ steps.gates.outputs.eligible }}"
+          echo "reason=${{ steps.gates.outputs.reason }}"
+
+      - name: Enable squash auto-merge
+        if: steps.gates.outputs.eligible == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          auto_merge_enabled="$(
+            gh pr view "$PR_NUMBER" \
+              -R "$GH_REPO" \
+              --json autoMergeRequest \
+              --jq '.autoMergeRequest != null'
+          )"
+
+          if [[ "$auto_merge_enabled" == "true" ]]; then
+            echo "Auto-merge already enabled for PR #$PR_NUMBER"
+            exit 0
+          fi
+
+          gh pr merge "$PR_NUMBER" -R "$GH_REPO" --auto --squash

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -2,6 +2,30 @@
 
 This workflow opens pull requests whenever Argo CD Image Updater commits to a `release/<app>` branch or when a maintainer triggers the `workflow_dispatch` input. The automation relies on standard GitHub Actions branching semantics and the release workflow documented in GitHub’s [manual dispatch guide](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch).
 
+## Release PR Automerge
+
+PRs created from release branches can be auto-merged by [`.github/workflows/release-pr-automerge.yml`](../.github/workflows/release-pr-automerge.yml) when they match strict safety gates:
+
+- Base branch is `main`.
+- Head branch starts with `release/`.
+- PR is not draft.
+- PR author is allowlisted GitHub Actions identity.
+- PR head repository matches the base repository.
+- Label `do-not-automerge` is not present.
+- All changed files are allowlisted release artifacts (currently:
+  - `argocd/applications/proompteng/kustomization.yaml`
+  ).
+
+The workflow enables squash auto-merge (`gh pr merge --auto --squash`) only after all eligibility checks pass. GitHub still enforces required checks and merge rules before the merge actually executes.
+
+### Operator Controls
+
+- To block automerge for a specific release PR, add label `do-not-automerge`.
+- To inspect automerge decisions:
+  - `gh pr view <num> -R proompteng/lab --json labels,author,baseRefName,headRefName,files`
+  - `gh run view <run-id> -R proompteng/lab`
+  - `gh pr checks <num> -R proompteng/lab`
+
 ## Enrolling a New Application
 
 1. Configure the application's Argo CD manifests with the Image Updater annotations that target a `release/<app>` branch.

--- a/docs/release-pr-automerge-plan.md
+++ b/docs/release-pr-automerge-plan.md
@@ -1,0 +1,89 @@
+# Release PR Automerge Plan (PRs like #3290)
+
+## Goal
+- Automatically squash-merge low-risk release PRs like [#3290](https://github.com/proompteng/lab/pull/3290) without manual intervention.
+- Keep strong safety gates so only expected bot-generated Argo CD image bump PRs are merged.
+
+## Target PR Shape
+- Base branch: `main`
+- Head branch: `release/<sha256>`
+- Author: GitHub Actions bot (`app/github-actions` or `github-actions[bot]`)
+- File changes: allowlist only
+  - `argocd/applications/proompteng/kustomization.yaml` (phase 1 scope)
+- Merge method: `squash` (matches repo ruleset)
+
+## Existing Foundation
+- PR creation is already automated in `.github/workflows/auto-pr-release-branches.yml`.
+- Repo ruleset already allows squash merges to `main`.
+- Pattern for enabling auto-merge already exists in `.github/workflows/jangar-deploy-automerge.yml`.
+
+## Proposed Implementation
+
+### 1. Add a dedicated automerge workflow
+- Create `.github/workflows/release-pr-automerge.yml`.
+- Trigger on `pull_request_target` for:
+  - `opened`
+  - `reopened`
+  - `synchronize`
+  - `ready_for_review`
+
+### 2. Add strict eligibility gates
+- In workflow/job `if` and validation script, require:
+  - `github.event.pull_request.base.ref == 'main'`
+  - `startsWith(github.event.pull_request.head.ref, 'release/')`
+  - PR is not draft
+  - PR author login is in allowlist (`app/github-actions`, `github-actions[bot]`)
+  - No opt-out label (for example `do-not-automerge`)
+  - Changed files are only allowed paths (phase 1: exactly `argocd/applications/proompteng/kustomization.yaml`)
+
+### 3. Enable auto-merge through GitHub CLI
+- Use:
+  - `gh pr merge "$PR_NUMBER" -R "$REPO" --auto --squash`
+- This keeps merge behavior compatible with branch/ruleset protections.
+
+### 4. Add observability and operator control
+- Emit explicit log lines for each gate decision (`eligible=true|false`, failed reason).
+- Add manual override paths:
+  - Label `do-not-automerge` to block automation.
+  - Optional label `force-automerge` (maintainers only) for future use.
+
+## Rollout Stages
+
+### Stage 0: Dry run
+- Implement workflow logic but replace merge command with logging.
+- Validate against real release PR events for 1-2 days.
+
+### Stage 1: Enable for proompteng only
+- Turn on real `gh pr merge --auto --squash`.
+- Keep file allowlist restricted to:
+  - `argocd/applications/proompteng/kustomization.yaml`
+
+### Stage 2: Expand safely
+- Expand allowlist to other release-managed app kustomizations after observing stability.
+- Keep branch/author/draft/label gates unchanged.
+
+## Safety Constraints
+- Never automerge if:
+  - Any changed file is outside allowlist.
+  - PR author is not expected bot identity.
+  - PR is draft.
+  - Opt-out label is present.
+- Prefer fail-closed behavior (exit without merge on any ambiguity).
+
+## Validation Checklist
+- Create a test PR from `release/<sha256>` with only the allowed file changed.
+- Confirm workflow logs all gates as passing.
+- Confirm auto-merge gets enabled and PR merges by squash.
+- Create a negative test:
+  - Add a second changed file and verify automerge is skipped.
+  - Add `do-not-automerge` and verify skip.
+
+## Documentation Updates
+- Update `docs/release-automation.md` with:
+  - Eligibility rules
+  - Opt-out label behavior
+  - Troubleshooting commands (`gh pr view`, `gh run view`, `gh pr checks`)
+
+## Suggested Ownership
+- Primary: platform/release automation maintainers
+- Review: Argo CD/GitOps owners


### PR DESCRIPTION
## Summary

- Added `.github/workflows/release-pr-automerge.yml` to enable squash auto-merge for safe release PRs.
- Implemented strict eligibility gates: `main` base, `release/*` head, non-draft, same-repo head, allowlisted bot author, no `do-not-automerge` label, and allowlisted changed files.
- Added fail-closed gating behavior with explicit eligibility reason logging before merge enablement.
- Updated `docs/release-automation.md` with automerge rules, operator controls, and troubleshooting commands.
- Added `docs/release-pr-automerge-plan.md` with phased rollout and safety constraints.

## Related Issues

None

## Testing

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-pr-automerge.yml'); puts 'workflow yaml ok'"`
- `gh pr view 3290 -R proompteng/lab --json author,baseRefName,headRefName,labels,files`
- Simulated workflow gate logic against PR `#3290` and verified `eligible=true`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
