### PR TITLE
fix(arc): raise arm64 runner max capacity to 10

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -26,7 +26,7 @@ spec:
           githubConfigSecret: github-token
           runnerScaleSetName: arc-arm64
           minRunners: 3
-          maxRunners: 5
+          maxRunners: 10
           containerMode:
             type: "kubernetes"
             kubernetesModeWorkVolumeClaim:


### PR DESCRIPTION
## Summary

- Increase ARC runner scale-set `maxRunners` from `5` to `10` for `arc-arm64`.
- Keep `minRunners` unchanged at `3`.
- Expand available `arc-arm64` CI capacity to reduce queueing under concurrent heavy workflows.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl get autoscalingrunnersets.actions.github.com -n arc arc-arm64 -o yaml` (post-merge verification step)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
