### PR TITLE
fix(feature-flags): satisfy Flagd ingress hosts schema

### DIFF
--- a/argocd/applications/feature-flags/flagd.yaml
+++ b/argocd/applications/feature-flags/flagd.yaml
@@ -9,3 +9,4 @@ spec:
   featureFlagSource: platform-flags
   ingress:
     enabled: false
+    hosts: []


### PR DESCRIPTION
## Summary

- Add `spec.ingress.hosts: []` to the `Flagd` resource for the `feature-flags` app.
- Keep ingress disabled (`enabled: false`) while satisfying the `flagds.core.openfeature.dev/v1beta1` CRD validation requirement.
- Unblock Argo CD sync failures caused by `spec.ingress.hosts: Required value`.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -n feature-flags -f argocd/applications/feature-flags/flagd.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/feature-flags >/tmp/feature-flags-render.yaml`
- `rg -n "^kind: Flagd$|^  ingress:$|^    hosts:" /tmp/feature-flags-render.yaml`
- `kubectl get application feature-flags -n argocd -o json | jq -r '.status.operationState.message'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
