### PR TITLE
fix(feature-flags): use flagd proxy service account

### DIFF
--- a/argocd/applications/feature-flags/flagd.yaml
+++ b/argocd/applications/feature-flags/flagd.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 2
   serviceType: ClusterIP
-  serviceAccountName: default
+  serviceAccountName: open-feature-operator-flagd-proxy
   featureFlagSource: platform-flags
   ingress:
     enabled: false


### PR DESCRIPTION
## Summary

- Update `Flagd` in `argocd/applications/feature-flags/flagd.yaml` to run with `serviceAccountName: open-feature-operator-flagd-proxy`.
- Align runtime identity with the ClusterRoleBinding created by `open-feature-operator` for Kubernetes-backed `FeatureFlag` reads.
- Resolve `flagd` crash loop caused by `forbidden` errors when using the default service account.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -n feature-flags -f argocd/applications/feature-flags/flagd.yaml`
- `kubectl get clusterrolebinding open-feature-operator-flagd-kubernetes-sync -o yaml`
- `kubectl logs -n feature-flags <flagd-pod> --tail=200` (confirmed previous `forbidden` error before fix)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
