### PR TITLE
fix(jangar): prevent CI vite transform stalls

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   build-and-push:
     runs-on: arc-arm64
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -1,1 +1,8 @@
 @import "@proompteng/design/globals.css";
+
+@source "./**/*.{js,jsx,ts,tsx}";
+@source not "../node_modules";
+@source not "../.output";
+@source not "../.next";
+@source not "../../../.pnpm-store";
+@source not "../../../.bun";

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -1,3 +1,10 @@
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 @import "@proompteng/design/globals.css";
+
+@source "./**/*.{js,jsx,ts,tsx,mdx}";
+@source "../content/**/*.{md,mdx}";
+@source not "../../node_modules";
+@source not "../../.next";
+@source not "../../../../.pnpm-store";
+@source not "../../../../.bun";

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -1,5 +1,11 @@
 @import "@proompteng/design/globals.css";
 
+@source "../**/*.{js,jsx,ts,tsx,mdx}";
+@source not "../../node_modules";
+@source not "../../.next";
+@source not "../../../../.pnpm-store";
+@source not "../../../../.bun";
+
 @keyframes hero-glow {
   0%,
   100% {

--- a/docs/jangar/vite-transforming-ci-stall.md
+++ b/docs/jangar/vite-transforming-ci-stall.md
@@ -1,0 +1,64 @@
+# Jangar CI `vite ... transforming...` stall (2026-02-20)
+
+## Incident
+
+- GitHub Actions run: `22211750152`
+- Job: `64247366876` (`build-and-push`)
+- Start: `2026-02-20T04:50:47Z`
+- Canceled: `2026-02-20T09:07:48Z`
+- Symptom: build logs stopped at:
+
+```text
+vite v7.3.1 building nitro environment for production...
+transforming...
+```
+
+The step kept running for ~4 hours with no forward progress.
+
+## Why this happens
+
+Upstream reports match this pattern:
+
+- Vite CI builds can appear stuck on `transforming...` when Tailwind processing hits CSS recursion or expensive scanning:
+  - `vitejs/vite#20910`
+  - `vitejs/vite#15076` and fix `vitejs/vite#15093`
+- Tailwind maintainers identified source scanning explosions in CI (for example `.pnpm-store`) and recommend excluding paths with `@source not` or using explicit sources:
+  - `tailwindlabs/tailwindcss#18148`
+  - Tailwind docs: Detecting classes in source files (`@source`, `@source not`, `source(none)`)
+
+## Production fix applied in this repo
+
+1. Added explicit scan roots in each consumer stylesheet:
+   - `services/jangar/src/styles.css`
+   - `apps/app/src/styles.css`
+   - `apps/landing/src/app/globals.css`
+   - `apps/docs/app/global.css`
+2. Added explicit scan exclusions (`@source not`) for heavy CI paths (`node_modules`, build output dirs, workspace package stores) in those same stylesheets.
+3. Kept shared Tailwind import syntax tooling-compatible:
+   - `packages/design/src/styles/tailwind.css`
+   - `@import "tailwindcss";`
+4. Added CI guardrail:
+   - `.github/workflows/jangar-build-push.yaml`
+   - `timeout-minutes: 45` on the `build-and-push` job
+
+## Why this fix is preferred
+
+- It removes auto-discovery variance between local and containerized CI environments.
+- It prevents Tailwind from scanning unrelated filesystem trees.
+- It limits blast radius if a future plugin/version regression reappears.
+- It keeps normal successful builds unchanged while failing fast instead of hanging for hours.
+
+## Validation checklist
+
+1. Run `bun run --cwd services/jangar build` locally.
+2. Confirm classes from Jangar routes render correctly (no missing utilities).
+3. Trigger `jangar-build-push` workflow and verify build duration returns to normal range.
+4. If a stall reappears, rerun with `DEBUG=*` to capture Tailwind scan diagnostics and compare scanned paths.
+
+## References
+
+- <https://github.com/vitejs/vite/issues/20910>
+- <https://github.com/vitejs/vite/issues/15076>
+- <https://github.com/vitejs/vite/pull/15093>
+- <https://github.com/tailwindlabs/tailwindcss/issues/18148>
+- <https://tailwindcss.com/docs/detecting-classes-in-source-files>

--- a/services/jangar/src/styles.css
+++ b/services/jangar/src/styles.css
@@ -1,6 +1,13 @@
 @import "@proompteng/design/globals.css";
 @import "@xterm/xterm/css/xterm.css";
 
+@source "./**/*.{js,jsx,ts,tsx}";
+@source not "../node_modules";
+@source not "../.output";
+@source not "../.nitro";
+@source not "../../../.pnpm-store";
+@source not "../../../.bun";
+
 @font-face {
   font-family: "JetBrains Mono Nerd Font";
   font-style: normal;


### PR DESCRIPTION
## Summary

- Hardened Tailwind source scanning in consumer stylesheets with explicit `@source` roots and `@source not` exclusions for heavy CI paths.
- Added a workflow guardrail by setting a 45-minute timeout on `jangar-build-push` to prevent multi-hour hangs.
- Added incident documentation with timeline, root-cause analysis, upstream references, and validation guidance.

## Related Issues

None

## Testing

- `bunx biome check --config-path ./biome.json .github/workflows/jangar-build-push.yaml apps/app/src/styles.css apps/docs/app/global.css apps/landing/src/app/globals.css packages/design/src/styles/tailwind.css services/jangar/src/styles.css docs/jangar/vite-transforming-ci-stall.md`
- `cd services/jangar && bun run build`
- `bun run build:app`
- `bun run build:docs`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
