### PR TITLE
fix(jangar): improve shared frontend accessibility and chart layout

### DIFF
--- a/services/jangar/src/components/app-shell.tsx
+++ b/services/jangar/src/components/app-shell.tsx
@@ -15,9 +15,9 @@ import * as React from 'react'
 import { AppSidebar } from '@/components/app-sidebar'
 
 export function AppShell({ mainId, children }: { mainId: string; children: React.ReactNode }) {
-  const pathname = useRouterState({ select: (state) => state.location.pathname })
-  const searchStr = useRouterState({ select: (state) => state.location.searchStr })
-  const breadcrumbs = buildBreadcrumbs(pathname, searchStr)
+  const location = useRouterState({ select: (state) => state.location })
+  const { pathname, searchStr } = location
+  const breadcrumbs = React.useMemo(() => buildBreadcrumbs(pathname, searchStr), [pathname, searchStr])
   const isFullscreen = pathname.endsWith('/fullscreen')
 
   React.useEffect(() => {
@@ -30,9 +30,9 @@ export function AppShell({ mainId, children }: { mainId: string; children: React
   if (isFullscreen) {
     return (
       <SidebarProvider>
-        <div id={mainId} className="h-svh w-full overflow-hidden" tabIndex={-1}>
+        <section id={mainId} className="h-svh w-full overflow-hidden" tabIndex={-1} aria-label="Page content">
           {children}
-        </div>
+        </section>
         <Toaster richColors position="top-right" />
       </SidebarProvider>
     )
@@ -44,29 +44,31 @@ export function AppShell({ mainId, children }: { mainId: string; children: React
       <div className="flex h-svh min-w-0 flex-1 flex-col overflow-hidden">
         <header className="flex h-12 items-center gap-3 border-b px-3">
           <SidebarTrigger />
-          <Breadcrumb className="min-w-0 flex-1">
-            <BreadcrumbList>
-              {breadcrumbs.map((crumb, index) => {
-                const isLast = index === breadcrumbs.length - 1
-                return (
-                  <React.Fragment key={crumb.to}>
-                    <BreadcrumbItem>
-                      {isLast ? (
-                        <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
-                      ) : (
-                        <BreadcrumbLink render={<Link to={crumb.to} />}>{crumb.label}</BreadcrumbLink>
-                      )}
-                    </BreadcrumbItem>
-                    {!isLast ? <BreadcrumbSeparator /> : null}
-                  </React.Fragment>
-                )
-              })}
-            </BreadcrumbList>
-          </Breadcrumb>
+          <nav className="min-w-0 flex-1" aria-label="Breadcrumb">
+            <Breadcrumb className="min-w-0">
+              <BreadcrumbList>
+                {breadcrumbs.map((crumb, index) => {
+                  const isLast = index === breadcrumbs.length - 1
+                  return (
+                    <React.Fragment key={crumb.to}>
+                      <BreadcrumbItem>
+                        {isLast ? (
+                          <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                        ) : (
+                          <BreadcrumbLink render={<Link to={crumb.to} />}>{crumb.label}</BreadcrumbLink>
+                        )}
+                      </BreadcrumbItem>
+                      {!isLast ? <BreadcrumbSeparator /> : null}
+                    </React.Fragment>
+                  )
+                })}
+              </BreadcrumbList>
+            </Breadcrumb>
+          </nav>
         </header>
-        <div id={mainId} className="flex-1 min-h-0" tabIndex={-1}>
+        <section id={mainId} className="flex-1 min-h-0" tabIndex={-1} aria-label="Page content">
           <ScrollArea className="h-full">{children}</ScrollArea>
-        </div>
+        </section>
       </div>
       <Toaster richColors position="top-right" />
     </SidebarProvider>

--- a/services/jangar/src/components/app-sidebar.tsx
+++ b/services/jangar/src/components/app-sidebar.tsx
@@ -291,7 +291,9 @@ function SidebarNavButton({
     <SidebarMenuButton
       isActive={isActive}
       className={isCollapsed ? 'justify-center' : undefined}
-      render={<Link to={to} />}
+      title={isCollapsed ? label : undefined}
+      aria-label={label}
+      render={<Link to={to} aria-label={label} aria-current={isActive ? 'page' : undefined} />}
     >
       <Icon />
       {isCollapsed ? null : <span>{label}</span>}

--- a/services/jangar/src/components/torghut-visuals-chart.tsx
+++ b/services/jangar/src/components/torghut-visuals-chart.tsx
@@ -62,10 +62,10 @@ export function TorghutVisualsChart({ bars, signals, indicators, className }: To
   }, [indicators, oscillators])
 
   return (
-    <div className={cn('space-y-4', className)}>
-      <div className="space-y-2">
+    <div className={cn('flex flex-col gap-4 min-h-0', className)}>
+      <div className="flex flex-col gap-2 flex-1 min-h-0">
         <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Price</div>
-        <div className="relative rounded-none border bg-background">
+        <div className="relative flex-1 min-h-0 rounded-none border bg-background">
           <PriceChart
             candles={candleData}
             overlays={overlays}
@@ -119,6 +119,8 @@ function PriceChart({
   const chartRef = React.useRef<EChartsInstance | null>(null)
   const resizeRef = React.useRef<ResizeObserver | null>(null)
   const option = React.useMemo(() => buildPriceOption(candles, overlays, indicators), [candles, overlays, indicators])
+  const optionRef = React.useRef(option)
+  optionRef.current = option
 
   React.useEffect(() => {
     let active = true
@@ -128,7 +130,7 @@ function PriceChart({
       if (!active || !containerRef.current) return
 
       const chart = echarts.init(containerRef.current, undefined, { renderer: 'canvas' })
-      chart.setOption(option, { notMerge: true, lazyUpdate: true })
+      chart.setOption(optionRef.current, { notMerge: true, lazyUpdate: true })
       chartRef.current = chart
 
       const observer = new ResizeObserver(() => chart.resize())
@@ -145,7 +147,7 @@ function PriceChart({
       chartRef.current?.dispose()
       chartRef.current = null
     }
-  }, [option])
+  }, [])
 
   React.useEffect(() => {
     if (!chartRef.current) return
@@ -155,7 +157,7 @@ function PriceChart({
   return (
     <div
       ref={containerRef}
-      className="min-h-[18rem] w-full"
+      className="w-full h-full min-h-[18rem]"
       role="img"
       aria-label="Candlestick chart with indicator overlays"
       data-overlay-count={overlayCount}
@@ -177,6 +179,8 @@ function SignalChart({
   const chartRef = React.useRef<EChartsInstance | null>(null)
   const resizeRef = React.useRef<ResizeObserver | null>(null)
   const option = React.useMemo(() => buildSignalOption(oscillators, indicators), [oscillators, indicators])
+  const optionRef = React.useRef(option)
+  optionRef.current = option
 
   React.useEffect(() => {
     let active = true
@@ -186,7 +190,7 @@ function SignalChart({
       if (!active || !containerRef.current) return
 
       const chart = echarts.init(containerRef.current, undefined, { renderer: 'canvas' })
-      chart.setOption(option, { notMerge: true, lazyUpdate: true })
+      chart.setOption(optionRef.current, { notMerge: true, lazyUpdate: true })
       chartRef.current = chart
 
       const observer = new ResizeObserver(() => chart.resize())
@@ -203,7 +207,7 @@ function SignalChart({
       chartRef.current?.dispose()
       chartRef.current = null
     }
-  }, [option])
+  }, [])
 
   React.useEffect(() => {
     if (!chartRef.current) return

--- a/services/jangar/src/components/torghut-visuals-controls.tsx
+++ b/services/jangar/src/components/torghut-visuals-controls.tsx
@@ -46,9 +46,18 @@ export function TorghutVisualsControls({
     <section className="space-y-3 rounded-none border bg-card p-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Controls</div>
-        <Button variant="outline" size="sm" onClick={onRefresh} disabled={disabled || isRefreshing}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRefresh}
+          disabled={disabled || isRefreshing}
+          aria-busy={isRefreshing}
+        >
           {isRefreshing ? (
-            <span className="mr-2 size-3 animate-spin rounded-full border border-current border-t-transparent motion-reduce:animate-none" />
+            <span
+              className="mr-2 size-3 animate-spin rounded-full border border-current border-t-transparent motion-reduce:animate-none"
+              aria-hidden="true"
+            />
           ) : null}
           <span>Refresh</span>
         </Button>

--- a/services/jangar/src/routes/__root.tsx
+++ b/services/jangar/src/routes/__root.tsx
@@ -27,7 +27,10 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body className="min-h-screen bg-background text-foreground antialiased overflow-hidden">
-        <a href={`#${mainId}`} className="sr-only focus:not-sr-only">
+        <a
+          href={`#${mainId}`}
+          className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-50 focus:rounded-none focus:border focus:bg-card focus:px-3 focus:py-2 focus:text-xs"
+        >
           Skip to content
         </a>
         <AppShell mainId={mainId}>{children}</AppShell>

--- a/services/jangar/src/routes/torghut/charts.tsx
+++ b/services/jangar/src/routes/torghut/charts.tsx
@@ -197,7 +197,7 @@ function TorghutCharts() {
   const lagTone = lagMs === null ? 'neutral' : lagMs < 60_000 ? 'good' : lagMs < 180_000 ? 'warn' : 'bad'
 
   return (
-    <main className="mx-auto w-full max-w-6xl space-y-6 p-6">
+    <main className="mx-auto flex flex-col gap-6 p-6 h-full min-h-0 w-full max-w-6xl">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div className="space-y-2">
           <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Torghut</p>
@@ -238,7 +238,7 @@ function TorghutCharts() {
           enable the charts.
         </section>
       ) : (
-        <>
+        <div className="flex flex-col gap-6 flex-1 min-h-0">
           {symbolsError ? (
             <section className="rounded-none border border-destructive/40 bg-card p-4 text-xs text-destructive">
               {symbolsError}
@@ -273,7 +273,7 @@ function TorghutCharts() {
               to load charts.
             </section>
           ) : (
-            <section className="space-y-4 rounded-none border bg-card p-4">
+            <section className="flex flex-col gap-4 p-4 flex-1 min-h-0 rounded-none border bg-card">
               {dataError ? (
                 <div className="rounded-none border border-destructive/40 bg-background p-3 text-xs text-destructive">
                   {dataError}
@@ -285,13 +285,13 @@ function TorghutCharts() {
                   {selectedSymbol} · {range.label} · {resolution.label}
                 </span>
               </div>
-              <TorghutVisualsChart bars={bars} signals={signals} indicators={indicators} />
+              <TorghutVisualsChart bars={bars} signals={signals} indicators={indicators} className="min-h-0 flex-1" />
               {bars.length === 0 && !isLoading ? (
                 <div className="text-xs text-muted-foreground">No bar data returned for this range.</div>
               ) : null}
             </section>
           )}
-        </>
+        </div>
       )}
     </main>
   )

--- a/services/jangar/src/styles.css
+++ b/services/jangar/src/styles.css
@@ -31,12 +31,50 @@
   --font-mono:
     "JetBrains Mono Nerd Font", "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, monospace;
+  --jangar-grid-line: color-mix(in oklch, var(--border) 45%, transparent);
+  --jangar-glow: color-mix(in oklch, var(--accent) 16%, transparent);
 }
 
 @layer base {
+  body {
+    background-color: var(--background);
+    background-image:
+      radial-gradient(circle at 12% 12%, var(--jangar-glow) 0, transparent 36%),
+      radial-gradient(circle at 88% 18%, color-mix(in oklch, var(--accent) 10%, transparent) 0, transparent 40%),
+      linear-gradient(to right, var(--jangar-grid-line) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--jangar-grid-line) 1px, transparent 1px);
+    background-position: center;
+    background-size:
+      auto,
+      auto,
+      24px 24px,
+      24px 24px;
+  }
+
+  ::selection {
+    background: color-mix(in oklch, var(--accent) 40%, transparent);
+    color: var(--foreground);
+  }
+
+  :focus-visible {
+    outline: 1px solid color-mix(in oklch, var(--ring) 80%, transparent);
+    outline-offset: 2px;
+  }
+
   /* Preserve native option contrast across Chromium dark-theme dropdown renderers. */
   select {
     color-scheme: light;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+    scroll-behavior: auto;
+    transition-duration: 0.01ms;
   }
 }
 


### PR DESCRIPTION
## Summary

- Improved shared Jangar shell accessibility/performance by consolidating router-state subscriptions, memoizing breadcrumbs, and wrapping breadcrumb UI in semantic navigation.
- Improved global navigation accessibility by adding explicit labels/current-page semantics for collapsed sidebar icon links and strengthening skip-link visibility.
- Updated Torghut charts UX/performance by making the chart panel fill remaining height, preventing ECharts re-initialization on every option update, and adding loading semantics for refresh controls.
- Added app-wide visual/accessibility refinements in global styles: subtle terminal-grid backdrop, stronger focus-visible outlines, selection styling, and reduced-motion behavior.

## Related Issues

None

## Testing

- `bunx @biomejs/biome@2.3.8 check services/jangar/src/components/app-shell.tsx services/jangar/src/components/app-sidebar.tsx services/jangar/src/components/torghut-visuals-chart.tsx services/jangar/src/components/torghut-visuals-controls.tsx services/jangar/src/routes/__root.tsx services/jangar/src/routes/torghut/charts.tsx services/jangar/src/styles.css`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
