### PR TITLE
chore(jangar): promote image f770b943

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-20T06:36:43Z"
+    deploy.knative.dev/rollout: "2026-02-20T16:42:00Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-20T06:36:43Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-20T16:42:00Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -56,5 +56,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "0c902a0c"
-    digest: sha256:6e52596041b625c1341a26475133acded44ba1a0e7c8067e0a28791e712fbf93
+    newTag: "f770b943"
+    digest: sha256:c59879cf60ab2e783ae96933891d7fbc24bfa9d19db0896722a925c20738e76f


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `f770b94332c26478fd3ac4e709bd9295a0ccf6a3`
- Image tag: `f770b943`
- Image digest: `sha256:c59879cf60ab2e783ae96933891d7fbc24bfa9d19db0896722a925c20738e76f`
- Updated API and worker rollout annotations