### PR TITLE
fix(temporal): sync jangar routing and unify bumba queue

### DIFF
--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -32,6 +32,17 @@ jobs:
         with:
           version: v1.31.2
 
+      - name: Install Temporal CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sSfL https://temporal.download/cli.sh | bash -s -- -b "${HOME}/.temporalio/bin"
+          echo "${HOME}/.temporalio/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Temporal CLI
+        shell: bash
+        run: temporal --version
+
       - name: Configure in-cluster kubeconfig when context is missing
         shell: bash
         run: |
@@ -87,6 +98,18 @@ jobs:
         run: |
           set -euo pipefail
           bun run packages/scripts/src/jangar/verify-deployment.ts
+
+      - name: Sync Temporal routing after rollout
+        shell: bash
+        env:
+          TEMPORAL_ADDRESS: temporal-frontend.temporal.svc.cluster.local:7233
+          TEMPORAL_NAMESPACE: default
+        run: |
+          set -euo pipefail
+          bun run packages/scripts/src/jangar/sync-temporal-routing.ts \
+            --task-queue jangar \
+            --deployment-name jangar-deployment \
+            --migrate-stale-running
 
       - name: Prepare rollback manifests
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -60,8 +60,6 @@ spec:
               value: default
             - name: TEMPORAL_TASK_QUEUE
               value: jangar
-            - name: TEMPORAL_WORKER_BUILD_ID
-              value: jangar@dev
             - name: JANGAR_WORKER_TEMPORAL_TASK_QUEUE
               value: jangar
             - name: TEMPORAL_WORKFLOW_CONCURRENCY

--- a/docs/jangar/primitives/code-search.md
+++ b/docs/jangar/primitives/code-search.md
@@ -290,7 +290,7 @@ Response (shape):
       "repository": "proompteng/lab",
       "ref": "main",
       "commit": "91a766394ea8d8469071d8463ec8979f7da80956",
-      "path": "argocd/applications/bumba/deployment-model.yaml",
+      "path": "argocd/applications/bumba/deployment.yaml",
       "startLine": 35,
       "endLine": 75,
       "symbol": null,
@@ -300,7 +300,7 @@ Response (shape):
         "lexicalScore": 0.22,
         "matchedIdentifiers": ["TEMPORAL_TASK_QUEUE"]
       },
-      "snippet": "...\n- name: TEMPORAL_TASK_QUEUE\n  value: bumba-model\n..."
+      "snippet": "...\n- name: TEMPORAL_TASK_QUEUE\n  value: bumba\n..."
     }
   ]
 }

--- a/packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts
+++ b/packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test'
+
+import { __private } from '../sync-temporal-routing'
+
+describe('sync-temporal-routing', () => {
+  it('parses boolean and value args', () => {
+    const parsed = __private.parseArgs([
+      '--address',
+      'temporal.example:7233',
+      '--namespace',
+      'default',
+      '--task-queue',
+      'jangar',
+      '--deployment-name',
+      'jangar-deployment',
+      '--migrate-stale-running',
+      '--migrate-unversioned-running',
+      '--dry-run',
+      '--reason',
+      'test',
+    ])
+
+    expect(parsed.address).toBe('temporal.example:7233')
+    expect(parsed.namespace).toBe('default')
+    expect(parsed.taskQueue).toBe('jangar')
+    expect(parsed.deploymentName).toBe('jangar-deployment')
+    expect(parsed.migrateStaleRunning).toBe(true)
+    expect(parsed.migrateUnversionedRunning).toBe(true)
+    expect(parsed.dryRun).toBe(true)
+    expect(parsed.reason).toBe('test')
+  })
+
+  it('extracts versioned workflow poller build IDs', () => {
+    const buildIds = __private.extractVersionedPollerBuildIds(
+      [
+        {
+          buildId: 'jangar-deployment:workflow-code@abc123',
+          taskQueueType: 'workflow',
+          identity: 'worker-1',
+        },
+        {
+          buildId: 'jangar-deployment:workflow-code@abc123',
+          taskQueueType: 'activity',
+          identity: 'worker-1',
+        },
+      ],
+      'jangar-deployment',
+    )
+
+    expect(buildIds).toEqual(['workflow-code@abc123'])
+  })
+
+  it('selects a single poller build ID and fails on multiple', () => {
+    expect(__private.selectTargetBuildId(['workflow-code@abc123'], 'jangar-deployment')).toBe('workflow-code@abc123')
+
+    expect(() =>
+      __private.selectTargetBuildId(['workflow-code@abc123', 'workflow-code@def456'], 'jangar-deployment'),
+    ).toThrow('Multiple workflow poller build IDs detected')
+  })
+
+  it('strips deployment prefix from poller build ID', () => {
+    expect(__private.stripDeploymentPrefix('jangar-deployment:jangar@dev', 'jangar-deployment')).toBe('jangar@dev')
+    expect(__private.stripDeploymentPrefix('UNVERSIONED', 'jangar-deployment')).toBeUndefined()
+  })
+})

--- a/packages/scripts/src/jangar/sync-temporal-routing.ts
+++ b/packages/scripts/src/jangar/sync-temporal-routing.ts
@@ -1,0 +1,422 @@
+#!/usr/bin/env bun
+
+import process from 'node:process'
+
+import { ensureCli, fatal } from '../shared/cli'
+
+type CliOptions = {
+  address?: string
+  namespace?: string
+  taskQueue?: string
+  deploymentName?: string
+  migrateStaleRunning?: boolean
+  migrateUnversionedRunning?: boolean
+  reason?: string
+  dryRun?: boolean
+}
+
+type ResolvedOptions = {
+  address: string
+  namespace: string
+  taskQueue: string
+  deploymentName: string
+  migrateStaleRunning: boolean
+  migrateUnversionedRunning: boolean
+  reason: string
+  dryRun: boolean
+}
+
+type CommandResult = {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+type TaskQueueDescribePoller = {
+  buildId?: string
+  taskQueueType?: string
+  identity?: string
+}
+
+type TaskQueueDescribeResponse = {
+  pollers?: TaskQueueDescribePoller[]
+}
+
+type WorkerDeploymentDescribeResponse = {
+  routingConfig?: {
+    currentVersionBuildID?: string
+  }
+  versionSummaries?: Array<{
+    BuildID?: string
+    buildId?: string
+  }>
+}
+
+type SyncResult = {
+  changed: boolean
+  previousBuildId?: string
+  targetBuildId: string
+  deploymentBuildIds: string[]
+}
+
+const defaultAddress = 'temporal-frontend.temporal.svc.cluster.local:7233'
+const defaultNamespace = 'default'
+const defaultTaskQueue = 'jangar'
+const defaultReason = 'post-deploy temporal routing sync'
+const defaultBatchRetryDelayMs = 5_000
+const defaultBatchRetryAttempts = 5
+
+const parseArgs = (argv: string[]): CliOptions => {
+  const options: CliOptions = {}
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: bun run packages/scripts/src/jangar/sync-temporal-routing.ts [options]
+
+Options:
+  --address <host:port>                 Temporal gRPC address
+  --namespace <name>                    Temporal namespace (default: default)
+  --task-queue <name>                   Task queue to inspect (default: jangar)
+  --deployment-name <name>              Temporal worker deployment name (default: <task-queue>-deployment)
+  --migrate-stale-running               Move stale pinned running workflows to auto_upgrade after routing update
+  --migrate-unversioned-running         Move unversioned running workflows to auto_upgrade
+  --reason <text>                       Reason recorded in workflow update-options
+  --dry-run                             Print intended actions without mutating Temporal`)
+      process.exit(0)
+    }
+
+    if (arg === '--migrate-stale-running') {
+      options.migrateStaleRunning = true
+      continue
+    }
+    if (arg === '--migrate-unversioned-running') {
+      options.migrateUnversionedRunning = true
+      continue
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true
+      continue
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+
+    const [flag, inlineValue] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    const value = inlineValue ?? argv[i + 1]
+    if (inlineValue === undefined) {
+      i += 1
+    }
+    if (!value) {
+      throw new Error(`Missing value for ${flag}`)
+    }
+
+    switch (flag) {
+      case '--address':
+        options.address = value
+        break
+      case '--namespace':
+        options.namespace = value
+        break
+      case '--task-queue':
+        options.taskQueue = value
+        break
+      case '--deployment-name':
+        options.deploymentName = value
+        break
+      case '--reason':
+        options.reason = value
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
+  }
+
+  return options
+}
+
+const resolveOptions = (options: CliOptions): ResolvedOptions => {
+  const taskQueue = options.taskQueue?.trim() || process.env.TEMPORAL_TASK_QUEUE?.trim() || defaultTaskQueue
+  const deploymentName =
+    options.deploymentName?.trim() || process.env.TEMPORAL_WORKER_DEPLOYMENT_NAME?.trim() || `${taskQueue}-deployment`
+
+  return {
+    address: options.address?.trim() || process.env.TEMPORAL_ADDRESS?.trim() || defaultAddress,
+    namespace: options.namespace?.trim() || process.env.TEMPORAL_NAMESPACE?.trim() || defaultNamespace,
+    taskQueue,
+    deploymentName,
+    migrateStaleRunning: options.migrateStaleRunning ?? false,
+    migrateUnversionedRunning: options.migrateUnversionedRunning ?? false,
+    reason: options.reason?.trim() || defaultReason,
+    dryRun: options.dryRun ?? false,
+  }
+}
+
+const runTemporal = async (
+  options: Pick<ResolvedOptions, 'address' | 'namespace'>,
+  args: string[],
+  allowFailure = false,
+): Promise<CommandResult> => {
+  const subprocess = Bun.spawn(['temporal', '--address', options.address, '--namespace', options.namespace, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    subprocess.stdout ? new Response(subprocess.stdout).text() : Promise.resolve(''),
+    subprocess.stderr ? new Response(subprocess.stderr).text() : Promise.resolve(''),
+    subprocess.exited,
+  ])
+
+  if (exitCode !== 0 && !allowFailure) {
+    throw new Error(`Command failed (${exitCode}): temporal ${args.join(' ')}\n${stderr || stdout}`.trim())
+  }
+
+  return { stdout, stderr, exitCode }
+}
+
+const parseJson = <T>(json: string, label: string): T => {
+  try {
+    return JSON.parse(json) as T
+  } catch (error) {
+    throw new Error(`Unable to parse ${label}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+const stripDeploymentPrefix = (pollerBuildId: string, deploymentName: string): string | undefined => {
+  const prefix = `${deploymentName}:`
+  if (!pollerBuildId.startsWith(prefix)) {
+    return undefined
+  }
+  return pollerBuildId.slice(prefix.length)
+}
+
+const extractVersionedPollerBuildIds = (
+  pollers: TaskQueueDescribePoller[] | undefined,
+  deploymentName: string,
+): string[] => {
+  if (!pollers || pollers.length === 0) {
+    return []
+  }
+
+  const workflowBuildIds = new Set<string>()
+  for (const poller of pollers) {
+    if (poller.taskQueueType !== 'workflow') {
+      continue
+    }
+    if (!poller.buildId) {
+      continue
+    }
+    const parsed = stripDeploymentPrefix(poller.buildId, deploymentName)
+    if (parsed) {
+      workflowBuildIds.add(parsed)
+    }
+  }
+
+  return [...workflowBuildIds]
+}
+
+const selectTargetBuildId = (candidateBuildIds: string[], deploymentName: string): string => {
+  if (candidateBuildIds.length === 0) {
+    throw new Error(
+      `No versioned workflow pollers found for deployment '${deploymentName}'. Ensure worker pods are healthy before syncing routing.`,
+    )
+  }
+  if (candidateBuildIds.length > 1) {
+    throw new Error(
+      `Multiple workflow poller build IDs detected for deployment '${deploymentName}': ${candidateBuildIds.join(', ')}`,
+    )
+  }
+  return candidateBuildIds[0] as string
+}
+
+const countWorkflows = async (
+  options: Pick<ResolvedOptions, 'address' | 'namespace'>,
+  query: string,
+): Promise<number> => {
+  const response = await runTemporal(options, ['workflow', 'count', '--query', query, '-o', 'json'])
+  const payload = parseJson<{ count?: string | number }>(response.stdout, 'workflow count output')
+  const raw = payload.count
+  if (raw === undefined || raw === null || raw === '') {
+    return 0
+  }
+  const parsed = typeof raw === 'number' ? raw : Number.parseInt(raw ?? '', 10)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid workflow count response for query '${query}': ${response.stdout.trim()}`)
+  }
+  return parsed
+}
+
+const updateRunningWorkflowsToAutoUpgrade = async (
+  options: ResolvedOptions,
+  query: string,
+  reason: string,
+): Promise<number> => {
+  const count = await countWorkflows(options, query)
+  if (count === 0) {
+    return 0
+  }
+
+  if (options.dryRun) {
+    console.log(`[dry-run] Would update ${count} workflow(s): ${query}`)
+    return count
+  }
+
+  for (let attempt = 1; attempt <= defaultBatchRetryAttempts; attempt += 1) {
+    try {
+      await runTemporal(options, [
+        'workflow',
+        'update-options',
+        '--query',
+        query,
+        '--versioning-override-behavior',
+        'auto_upgrade',
+        '--reason',
+        reason,
+        '--yes',
+      ])
+      return count
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const isBatchLimitError = message.includes('Max concurrent batch operations is reached')
+      if (!isBatchLimitError || attempt === defaultBatchRetryAttempts) {
+        throw error
+      }
+      console.log(
+        `Batch slot unavailable (attempt ${attempt}/${defaultBatchRetryAttempts}); retrying in ${defaultBatchRetryDelayMs}ms`,
+      )
+      await Bun.sleep(defaultBatchRetryDelayMs)
+    }
+  }
+
+  return count
+}
+
+const syncCurrentVersion = async (options: ResolvedOptions): Promise<SyncResult> => {
+  const deploymentResponse = await runTemporal(options, [
+    'worker',
+    'deployment',
+    'describe',
+    '--name',
+    options.deploymentName,
+    '-o',
+    'json',
+  ])
+  const deployment = parseJson<WorkerDeploymentDescribeResponse>(
+    deploymentResponse.stdout,
+    'worker deployment describe output',
+  )
+  const currentBuildId = deployment.routingConfig?.currentVersionBuildID
+
+  const queueResponse = await runTemporal(options, [
+    'task-queue',
+    'describe',
+    '--task-queue',
+    options.taskQueue,
+    '--select-all-active',
+    '--select-unversioned',
+    '-o',
+    'json',
+  ])
+  const queueDetails = parseJson<TaskQueueDescribeResponse>(queueResponse.stdout, 'task-queue describe output')
+  const pollerBuildIds = extractVersionedPollerBuildIds(queueDetails.pollers, options.deploymentName)
+  const targetBuildId = selectTargetBuildId(pollerBuildIds, options.deploymentName)
+
+  if (currentBuildId === targetBuildId) {
+    console.log(`Temporal routing already aligned: ${options.deploymentName} -> ${targetBuildId}`)
+    const deploymentBuildIds = (deployment.versionSummaries ?? [])
+      .map((entry) => entry.BuildID ?? entry.buildId)
+      .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    return { changed: false, previousBuildId: currentBuildId, targetBuildId, deploymentBuildIds }
+  }
+
+  if (options.dryRun) {
+    console.log(
+      `[dry-run] Would set current version: ${options.deploymentName} ${currentBuildId ?? '<none>'} -> ${targetBuildId}`,
+    )
+    const deploymentBuildIds = (deployment.versionSummaries ?? [])
+      .map((entry) => entry.BuildID ?? entry.buildId)
+      .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    return { changed: true, previousBuildId: currentBuildId, targetBuildId, deploymentBuildIds }
+  }
+
+  await runTemporal(options, [
+    'worker',
+    'deployment',
+    'set-current-version',
+    '--deployment-name',
+    options.deploymentName,
+    '--build-id',
+    targetBuildId,
+    '--yes',
+  ])
+  console.log(`Updated current version: ${options.deploymentName} ${currentBuildId ?? '<none>'} -> ${targetBuildId}`)
+
+  const deploymentBuildIds = (deployment.versionSummaries ?? [])
+    .map((entry) => entry.BuildID ?? entry.buildId)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+  return { changed: true, previousBuildId: currentBuildId, targetBuildId, deploymentBuildIds }
+}
+
+export const main = async (cliOptions?: CliOptions) => {
+  ensureCli('temporal')
+
+  const options = resolveOptions(cliOptions ?? parseArgs(process.argv.slice(2)))
+  const sync = await syncCurrentVersion(options)
+
+  let migratedStale = 0
+  let migratedUnversioned = 0
+
+  if (options.migrateStaleRunning) {
+    const staleBuildIds = [...new Set(sync.deploymentBuildIds)].filter((buildId) => buildId !== sync.targetBuildId)
+    for (const buildId of staleBuildIds) {
+      const query = `TaskQueue="${options.taskQueue}" and ExecutionStatus="Running" and TemporalWorkerDeploymentVersion="${options.deploymentName}:${buildId}"`
+      migratedStale += await updateRunningWorkflowsToAutoUpgrade(options, query, options.reason)
+    }
+    if (migratedStale > 0) {
+      console.log(
+        `${options.dryRun ? 'Would update' : 'Updated'} ${migratedStale} stale pinned workflow(s) to auto_upgrade`,
+      )
+    }
+  }
+
+  if (options.migrateUnversionedRunning) {
+    const query = `TaskQueue="${options.taskQueue}" and ExecutionStatus="Running" and TemporalWorkerDeploymentVersion is null`
+    migratedUnversioned = await updateRunningWorkflowsToAutoUpgrade(options, query, options.reason)
+    if (migratedUnversioned > 0) {
+      console.log(
+        `${options.dryRun ? 'Would update' : 'Updated'} ${migratedUnversioned} unversioned workflow(s) to auto_upgrade`,
+      )
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        deploymentName: options.deploymentName,
+        taskQueue: options.taskQueue,
+        previousBuildId: sync.previousBuildId,
+        targetBuildId: sync.targetBuildId,
+        changed: sync.changed,
+        migratedStale,
+        migratedUnversioned,
+        dryRun: options.dryRun,
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+if (import.meta.main) {
+  main().catch((error) => fatal('Failed to sync Temporal worker deployment routing', error))
+}
+
+export const __private = {
+  parseArgs,
+  stripDeploymentPrefix,
+  extractVersionedPollerBuildIds,
+  selectTargetBuildId,
+  resolveOptions,
+}

--- a/services/bumba/README.md
+++ b/services/bumba/README.md
@@ -6,6 +6,7 @@ Temporal worker that enriches repository files using AST context + self-hosted m
 - Schema is owned by Jangar; this service only reads/writes through shared tables.
 - Configure Temporal connection via `TEMPORAL_*` env vars.
 - Mount the Jangar workspace PVC at `/workspace` for file access.
+- `enrichWithModel` uses the same Temporal task queue as the workflow (`TEMPORAL_TASK_QUEUE`); do not run a separate model queue.
 - Enrichment skips directory paths; model completion failures (including timeouts) fail the workflow to avoid placeholders.
 - Performance knobs: `OPENAI_API_BASE_URL`, `OPENAI_COMPLETION_TIMEOUT_MS`, `OPENAI_COMPLETION_MAX_OUTPUT_TOKENS`, `BUMBA_MODEL_CONCURRENCY`,
   `OPENAI_EMBEDDING_API_BASE_URL` (set to Ollama `/api` for batching), `OPENAI_EMBEDDING_BATCH_SIZE`, `OPENAI_EMBEDDING_KEEP_ALIVE`,

--- a/services/bumba/src/workflows/index.test.ts
+++ b/services/bumba/src/workflows/index.test.ts
@@ -340,8 +340,17 @@ test('enrichFile completes when all activities are resolved', async () => {
   const scheduleCommands = output.commands.filter(
     (command: Command) => command.commandType === CommandType.SCHEDULE_ACTIVITY_TASK,
   )
+  const modelSchedule = scheduleCommands.find(
+    (command) =>
+      command.attributes?.case === 'scheduleActivityTaskCommandAttributes' &&
+      command.attributes.value.activityType?.name === 'enrichWithModel',
+  )
 
   expect(scheduleCommands).toHaveLength(13)
+  if (!modelSchedule || modelSchedule.attributes?.case !== 'scheduleActivityTaskCommandAttributes') {
+    throw new Error('Expected enrichWithModel to be scheduled.')
+  }
+  expect(modelSchedule.attributes.value.taskQueue?.name).toBe('bumba')
   expect(output.commands.at(-1)?.commandType).toBe(CommandType.COMPLETE_WORKFLOW_EXECUTION)
   expect(output.completion).toBe('completed')
   expect(output.result).toEqual({ id: 'enrichment-id', filename: input.filePath })

--- a/services/bumba/src/workflows/index.ts
+++ b/services/bumba/src/workflows/index.ts
@@ -29,10 +29,6 @@ const childWorkflowRetry = {
   maximumAttempts: 3,
 }
 
-// Route GPU-heavy model calls to a dedicated worker/task queue so slow inference cannot
-// starve DB/bookkeeping activities and cause ScheduleToClose timeouts.
-const MODEL_ACTIVITY_TASK_QUEUE = 'bumba-model'
-
 const readRepoFileTimeouts = {
   startToCloseTimeoutMs: 90_000,
   scheduleToCloseTimeoutMs: 600_000,
@@ -50,7 +46,7 @@ const extractAstSummaryTimeouts = {
 
 const enrichWithModelTimeouts = {
   // StartToClose needs to cover slow/large prompts (streaming + model latency).
-  // ScheduleToClose must be large enough to tolerate queueing when the model worker is intentionally low-concurrency.
+  // ScheduleToClose must be large enough to tolerate transient queueing during load spikes.
   startToCloseTimeoutMs: 720_000,
   scheduleToCloseTimeoutMs: 10_800_000,
 }
@@ -415,7 +411,6 @@ export const workflows = [
               ],
               {
                 ...enrichWithModelTimeouts,
-                taskQueue: MODEL_ACTIVITY_TASK_QUEUE,
                 retry: activityRetry,
               },
             ),

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -108,9 +108,11 @@ bun --cwd services/jangar run start:worker
 - Worker consume path: `JANGAR_WORKER_TEMPORAL_TASK_QUEUE` (falls back to `TEMPORAL_TASK_QUEUE`, then `jangar`).
 - Decoupled rollout: run API and `jangar-worker` as separate deployments and point both queue vars to the same queue (for example `jangar`).
 - Bumba starts now set workflow `versioningOverride=auto_upgrade`; keep worker deployment current versions configured or workflows can remain at history length `2` (`WORKFLOW_TASK_SCHEDULED` with no dispatch).
-- `jangar-worker` should use a stable `TEMPORAL_WORKER_BUILD_ID` (for example `jangar@dev`) unless you also automate `set-current-version` during every rollout.
-- Recovery/rollout command:
-  `temporal worker deployment set-current-version --deployment-name <name> --build-id <build-id> -n default --address <temporal-address> -y`
+- Do not pin `TEMPORAL_WORKER_BUILD_ID` in manifests. Let the worker derive `workflow-code@<digest>` from workflow code and then sync deployment routing after rollout.
+- Post-rollout routing command:
+  `bun run packages/scripts/src/jangar/sync-temporal-routing.ts --task-queue jangar --deployment-name jangar-deployment --migrate-stale-running`
+- Incident recovery command (includes unversioned running workflows):
+  `bun run packages/scripts/src/jangar/sync-temporal-routing.ts --task-queue jangar --deployment-name jangar-deployment --migrate-stale-running --migrate-unversioned-running`
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

- Added `packages/scripts/src/jangar/sync-temporal-routing.ts` to align Temporal worker deployment current version with active pollers and optionally migrate stale/unversioned running workflows to `auto_upgrade`.
- Added regression tests for routing sync logic in `packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts` and wired post-deploy execution into `.github/workflows/jangar-post-deploy-verify.yml`.
- Removed static `TEMPORAL_WORKER_BUILD_ID` pinning from `argocd/applications/jangar/jangar-worker-deployment.yaml` and updated `services/jangar/README.md` rollout guidance.
- Removed dedicated `bumba-model` activity queue routing so `enrichWithModel` uses the workflow queue in `services/bumba/src/workflows/index.ts`, and added assertion coverage in `services/bumba/src/workflows/index.test.ts`.
- Updated docs examples that referenced a non-existent model queue deployment in `docs/jangar/primitives/code-search.md` and clarified queue behavior in `services/bumba/README.md`.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/verify-deployment.test.ts packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts`
- `bun run --filter @proompteng/bumba test -- src/workflows/index.test.ts`
- `bunx biome check packages/scripts/src/jangar/sync-temporal-routing.ts packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts services/bumba/src/workflows/index.ts services/bumba/src/workflows/index.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
