### PR TITLE
fix(jangar): harden post-deploy verification flow

### DIFF
--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - 'argocd/applications/jangar/**'
   workflow_dispatch:
+    inputs:
+      expected_revision:
+        description: Optional full commit SHA expected in Argo sync revision
+        required: false
+        type: string
 
 concurrency:
   group: jangar-post-deploy-verify-${{ github.ref }}
@@ -21,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -84,9 +91,26 @@ jobs:
 
       - name: Verify deployment health and digest
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EXPECTED_REVISION_INPUT: ${{ inputs.expected_revision || '' }}
         run: |
           set -euo pipefail
-          bun run packages/scripts/src/jangar/verify-deployment.ts
+          ARGS=(
+            --require-synced
+            --health-attempts 90
+            --health-interval-seconds 10
+            --digest-attempts 30
+            --digest-interval-seconds 10
+          )
+
+          if [ "${EVENT_NAME}" = "push" ]; then
+            ARGS+=(--expected-revision "${GITHUB_SHA}")
+          elif [ -n "${EXPECTED_REVISION_INPUT}" ]; then
+            ARGS+=(--expected-revision "${EXPECTED_REVISION_INPUT}")
+          fi
+
+          bun run packages/scripts/src/jangar/verify-deployment.ts "${ARGS[@]}"
 
       - name: Prepare rollback manifests
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/packages/scripts/src/jangar/__tests__/verify-deployment.test.ts
+++ b/packages/scripts/src/jangar/__tests__/verify-deployment.test.ts
@@ -24,16 +24,72 @@ describe('verify-deployment', () => {
       '--deployments',
       'jangar,jangar-worker',
       '--require-synced',
+      '--expected-revision',
+      '0123456789abcdef0123456789abcdef01234567',
       '--health-attempts',
       '10',
       '--health-interval-seconds',
       '5',
+      '--digest-attempts',
+      '8',
+      '--digest-interval-seconds',
+      '4',
     ])
 
     expect(parsed.namespace).toBe('jangar')
     expect(parsed.deployments).toEqual(['jangar', 'jangar-worker'])
     expect(parsed.requireSynced).toBe(true)
+    expect(parsed.expectedRevision).toBe('0123456789abcdef0123456789abcdef01234567')
     expect(parsed.healthAttempts).toBe(10)
     expect(parsed.healthIntervalSeconds).toBe(5)
+    expect(parsed.digestAttempts).toBe(8)
+    expect(parsed.digestIntervalSeconds).toBe(4)
+  })
+
+  it('waits while Argo revision is not the expected revision', () => {
+    const waitReason = __private.getArgoWaitReason(
+      __private.parseArgoStatus('Synced Healthy abcdef0123456789abcdef0123456789abcdef01'),
+      {
+        argoApplication: 'jangar',
+        argoNamespace: 'argocd',
+        deployments: ['jangar'],
+        digestAttempts: 1,
+        digestIntervalSeconds: 1,
+        expectedRevision: 'fedcba9876543210fedcba9876543210fedcba98',
+        healthAttempts: 1,
+        healthIntervalSeconds: 1,
+        imageName: 'registry.ide-newton.ts.net/lab/jangar',
+        kustomizationPath: 'argocd/applications/jangar/kustomization.yaml',
+        namespace: 'jangar',
+        requireSynced: true,
+        rolloutTimeout: '10m',
+      },
+    )
+
+    expect(waitReason).toContain('revision=')
+    expect(waitReason).toContain('expected=')
+  })
+
+  it('returns no wait reason for synced healthy expected revision', () => {
+    const waitReason = __private.getArgoWaitReason(
+      __private.parseArgoStatus('Synced Healthy 0123456789abcdef0123456789abcdef01234567'),
+      {
+        argoApplication: 'jangar',
+        argoNamespace: 'argocd',
+        deployments: ['jangar'],
+        digestAttempts: 1,
+        digestIntervalSeconds: 1,
+        expectedRevision: '0123456789abcdef0123456789abcdef01234567',
+        healthAttempts: 1,
+        healthIntervalSeconds: 1,
+        imageName: 'registry.ide-newton.ts.net/lab/jangar',
+        kustomizationPath: 'argocd/applications/jangar/kustomization.yaml',
+        namespace: 'jangar',
+        requireSynced: true,
+        rolloutTimeout: '10m',
+      },
+    )
+
+    expect(waitReason).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- Make Jangar post-deploy verification deterministic by requiring healthy/synced Argo state and optionally matching a target revision.
- Add digest polling retries in `verify-deployment.ts` to absorb rollout propagation lag before failing.
- Fix rollback precondition by fetching enough history in `jangar-post-deploy-verify.yml` (`fetch-depth: 2`).
- Keep manual `workflow_dispatch` usable by making expected revision optional input while enforcing revision match automatically on `push`.
- Add regression tests for new CLI args and Argo wait-reason behavior.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/verify-deployment.test.ts`
- `bunx biome check packages/scripts/src/jangar/verify-deployment.ts packages/scripts/src/jangar/__tests__/verify-deployment.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
