### PR TITLE
chore(jangar): promote image 1d1732e7

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-20T16:42:00Z"
+    deploy.knative.dev/rollout: "2026-02-21T06:06:32Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-20T16:42:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T06:06:32Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -56,5 +56,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f770b943"
-    digest: sha256:c59879cf60ab2e783ae96933891d7fbc24bfa9d19db0896722a925c20738e76f
+    newTag: "1d1732e7"
+    digest: sha256:98f73643e384295900f0e75636f421e93ad352501d938f72234d96f9c57d9f36


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `1d1732e7f76727f0a696d1540c7b7eb9a9c25a26`
- Image tag: `1d1732e7`
- Image digest: `sha256:98f73643e384295900f0e75636f421e93ad352501d938f72234d96f9c57d9f36`
- Updated API and worker rollout annotations