### PR TITLE
fix(temporal-bun-sdk): skip integration setup on unavailable endpoint

### DIFF
--- a/packages/temporal-bun-sdk/tests/integration/signal-query.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/signal-query.integration.test.ts
@@ -7,6 +7,7 @@ import { loadTemporalConfig } from '../../src/config'
 import { EventType } from '../../src/proto/temporal/api/enums/v1/event_type_pb'
 import { WorkerRuntime } from '../../src/worker/runtime'
 import {
+  findTemporalCliUnavailableError,
   TemporalCliCommandError,
   TemporalCliUnavailableError,
   createIntegrationHarness,
@@ -36,15 +37,25 @@ describeIntegration('Signal + query integration', () => {
   beforeAll(async () => {
     const harnessExit = await Effect.runPromiseExit(createIntegrationHarness(CLI_CONFIG))
     if (Exit.isFailure(harnessExit)) {
-      if (harnessExit.cause instanceof TemporalCliUnavailableError) {
+      const unavailable = findTemporalCliUnavailableError(harnessExit.cause)
+      if (unavailable) {
         cliUnavailable = true
-        console.warn(`[temporal-bun-sdk] skipping signal/query integration: ${harnessExit.cause.message}`)
+        console.warn(`[temporal-bun-sdk] skipping signal/query integration: ${unavailable.message}`)
         return
       }
       throw harnessExit.cause
     }
     harness = harnessExit.value
-    await Effect.runPromise(harness.setup)
+    const setupExit = await Effect.runPromiseExit(harness.setup)
+    if (Exit.isFailure(setupExit)) {
+      const unavailable = findTemporalCliUnavailableError(setupExit.cause)
+      if (unavailable) {
+        cliUnavailable = true
+        console.warn(`[temporal-bun-sdk] skipping signal/query integration: ${unavailable.message}`)
+        return
+      }
+      throw setupExit.cause
+    }
 
     const runtimeConfig = await loadTemporalConfig({
       defaults: {


### PR DESCRIPTION
## Summary

- Preserve endpoint-unavailable failures as `TemporalCliUnavailableError` in integration harness CLI/setup/teardown paths.
- Add `findTemporalCliUnavailableError` to unwrap Effect failure wrappers and detect unavailable endpoint errors consistently.
- Update integration suite setup to use `Effect.runPromiseExit(harness.setup)` and skip scenarios when the Temporal endpoint is unavailable.
- Add explicit skip guards in worker runtime integration tests when setup cannot reach Temporal.

## Related Issues

None

## Testing

- `TEMPORAL_INTEGRATION_TESTS=1 TEMPORAL_TEST_SERVER=1 TEMPORAL_ADDRESS=nonexistent-temporal.invalid:7233 TEMPORAL_NAMESPACE=default TEMPORAL_NAMESPACE_READY_MAX_ATTEMPTS=2 TEMPORAL_NAMESPACE_READY_RETRY_MS=10 bun run --filter @proompteng/temporal-bun-sdk test -- tests/integration/history-replay.test.ts tests/integration/worker.runtime.integration.test.ts`
- `TEMPORAL_INTEGRATION_TESTS=1 TEMPORAL_TEST_SERVER=1 TEMPORAL_ADDRESS=temporal-grpc:7233 TEMPORAL_NAMESPACE=default bun run --filter @proompteng/temporal-bun-sdk test -- tests/integration/worker.runtime.integration.test.ts tests/integration/signal-query.integration.test.ts`
- `bunx biome check packages/temporal-bun-sdk/src packages/temporal-bun-sdk/tests`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
