### PR TITLE
chore(jangar): promote image 1144bcdf

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-21T06:06:32Z"
+    deploy.knative.dev/rollout: "2026-02-21T07:16:46Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T06:06:32Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T07:16:46Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -56,5 +56,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "1d1732e7"
-    digest: sha256:98f73643e384295900f0e75636f421e93ad352501d938f72234d96f9c57d9f36
+    newTag: "1144bcdf"
+    digest: sha256:821ce539d7b0dcb126ebe3714f1c7872430ee589bbd7d3bac609138538d3fbf3


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `1144bcdfc42f4f2fd54299a2c58e49104b24573f`
- Image tag: `1144bcdf`
- Image digest: `sha256:821ce539d7b0dcb126ebe3714f1c7872430ee589bbd7d3bac609138538d3fbf3`
- Updated API and worker rollout annotations