### PR TITLE
fix(saigak): provision qwen coder aliases for temporal workflows

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -130,7 +130,7 @@ spec:
             - name: OPENAI_API_BASE_URL
               value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_COMPLETION_MODEL
-              value: qwen3-coder-saigak:30b-a3b-q4_K_M
+              value: qwen3-coder-saigak:30b
             - name: OPENAI_COMPLETION_MAX_ATTEMPTS
               value: "1"
             - name: OPENAI_COMPLETION_TIMEOUT_MS

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -134,7 +134,7 @@ spec:
             - name: OPENAI_API_BASE_URL
               value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_COMPLETION_MODEL
-              value: qwen3-coder-saigak:30b-a3b-q4_K_M
+              value: qwen3-coder-saigak:30b
             - name: OPENAI_COMPLETION_MAX_ATTEMPTS
               value: "1"
             - name: OPENAI_COMPLETION_TIMEOUT_MS

--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -44,6 +44,12 @@ stringData:
           FROM qwen3-embedding:0.6b
           TEMPLATE {{ .Prompt }}
           PARAMETER num_ctx 4096
+      - path: /etc/saigak/qwen3-coder-30b.modelfile
+        owner: root:root
+        permissions: '0644'
+        content: |-
+          FROM qwen3-coder:30b
+          PARAMETER num_ctx 8192
       - path: /etc/netplan/99-saigak.yaml
         owner: root:root
         permissions: '0600'
@@ -104,3 +110,8 @@ stringData:
       - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama pull qwen3-embedding:0.6b' ]
       - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama create qwen3-embedding-saigak:0.6b -f /etc/saigak/qwen3-embedding-0-6b.modelfile' ]
       - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama show qwen3-embedding-saigak:0.6b >/dev/null' ]
+      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama pull qwen3-coder:30b' ]
+      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama create qwen3-coder-saigak:30b -f /etc/saigak/qwen3-coder-30b.modelfile' ]
+      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama show qwen3-coder-saigak:30b >/dev/null' ]
+      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama create qwen3-coder-saigak:30b-a3b-q4_K_M -f /etc/saigak/qwen3-coder-30b.modelfile' ]
+      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama show qwen3-coder-saigak:30b-a3b-q4_K_M >/dev/null' ]

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -199,7 +199,7 @@ spec:
             - name: LLM_SELF_HOSTED_BASE_URL
               value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: LLM_SELF_HOSTED_MODEL
-              value: qwen3-coder-saigak:30b-a3b-q4_K_M
+              value: qwen3-coder-saigak:30b
             - name: TA_CLICKHOUSE_URL
               value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
             - name: TA_CLICKHOUSE_USERNAME


### PR DESCRIPTION
## Summary

- Provision Qwen coder model on saigak during cloud-init (`qwen3-coder:30b`) and create aliases for both `qwen3-coder-saigak:30b` and legacy `qwen3-coder-saigak:30b-a3b-q4_K_M`.
- Update GitOps completion model references in Bumba, Jangar worker, and Torghut to the stable alias `qwen3-coder-saigak:30b`.
- Keep backward compatibility so existing live workers still using the legacy alias do not fail with model-not-found.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applications/saigak/cloud-init-secret.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/jangar/jangar-worker-deployment.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/bumba/deployment.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/torghut/knative-service.yaml`
- Applied cloud-init secret live and verified coder lines present:
  - `kubectl apply -n saigak -f argocd/applications/saigak/cloud-init-secret.yaml`
  - `kubectl get secret -n saigak saigak-cloud-init -o jsonpath='{.data.userdata}' | base64 --decode | rg -n 'qwen3-coder:30b|qwen3-coder-saigak:30b|qwen3-coder-saigak:30b-a3b-q4_K_M'`
- Provisioned live models on saigak:
  - pulled `qwen3-coder:30b`
  - created aliases `qwen3-coder-saigak:30b` and `qwen3-coder-saigak:30b-a3b-q4_K_M`
  - verified via `curl http://saigak:11434/v1/models`
- Temporal end-to-end validation on queue `jangar`:
  - Started workflow `bumba-apps-reestr-src-index.css-4ae6e11c-ccee-4a9b-aa1a-29c871d6a8a9`
  - Run `019c7f0f-7d97-7291-b8f9-29a036aa4612` reached `enrichWithModel` and completed successfully (`Status COMPLETED`).

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
