### PR TITLE
fix(bumba): handle null-commit file version upserts

### DIFF
--- a/services/bumba/src/activities/index.test.ts
+++ b/services/bumba/src/activities/index.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Language } from 'web-tree-sitter'
 
-import { activities, parseCompletionOutput } from './index'
+import { __test__, activities, parseCompletionOutput } from './index'
 
 const runGit = (args: string[], cwd: string) => {
   const result = Bun.spawnSync(['git', ...args], { cwd, stdout: 'pipe', stderr: 'pipe' })
@@ -386,6 +386,17 @@ describe('bumba completion parsing', () => {
 
   it('rejects non-JSON responses', () => {
     expect(() => parseCompletionOutput('plain text response')).toThrow('completion response was not valid JSON')
+  })
+})
+
+describe('bumba file-version conflict target', () => {
+  it('uses null-commit conflict target when commit is missing', () => {
+    expect(__test__.shouldUseNullCommitConflictTarget(null)).toBe(true)
+    expect(__test__.shouldUseNullCommitConflictTarget('')).toBe(false)
+  })
+
+  it('uses commit-aware conflict target when commit is present', () => {
+    expect(__test__.shouldUseNullCommitConflictTarget('deadbeef')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

- Fix `persistFileVersion` in Bumba to use a null-commit-specific `ON CONFLICT` target that matches `atlas_file_versions_hash_null_commit_idx`.
- Fix `upsertFileVersion` in Jangar Atlas store with the same null-safe conflict behavior and normalize optional commit values to nullable text.
- Add regression tests in `atlas-store.test.ts` for both null-commit and commit-aware conflict SQL generation.
- Add Bumba activity test coverage for null-commit conflict-target branch selection.

## Related Issues

None

## Testing

- `bun test services/bumba/src/activities/index.test.ts`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/atlas-store.test.ts`
- `bunx biome check services/jangar/src/server/atlas-store.ts services/jangar/src/server/__tests__/atlas-store.test.ts services/bumba/src/activities/index.ts services/bumba/src/activities/index.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
