### PR TITLE
chore(jangar): promote image 594d8844

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-21T07:16:46Z"
+    deploy.knative.dev/rollout: "2026-02-21T08:08:07Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T07:16:46Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T08:08:07Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -56,5 +56,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "1144bcdf"
-    digest: sha256:821ce539d7b0dcb126ebe3714f1c7872430ee589bbd7d3bac609138538d3fbf3
+    newTag: "594d8844"
+    digest: sha256:a9ffe25e1d84820dbfebd717e10237cca754980916b30d6534e19e49b7cac71b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `594d884470ca9c459a8125a7fa416ee3cfed67aa`
- Image tag: `594d8844`
- Image digest: `sha256:a9ffe25e1d84820dbfebd717e10237cca754980916b30d6534e19e49b7cac71b`
- Updated API and worker rollout annotations