### PR TITLE
chore(jangar): promote image 9adeca26

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-21T08:08:07Z"
+    deploy.knative.dev/rollout: "2026-02-21T09:09:45Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T08:08:07Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T09:09:45Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "594d8844"
-    digest: sha256:a9ffe25e1d84820dbfebd717e10237cca754980916b30d6534e19e49b7cac71b
+    newTag: "9adeca26"
+    digest: sha256:e0e991c1f4379a391738a760ebb2548c45b793d10a4df527ff163ccc90c347b4


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `9adeca26c22f29c92fe5f2ae655e35473173ee88`
- Image tag: `9adeca26`
- Image digest: `sha256:e0e991c1f4379a391738a760ebb2548c45b793d10a4df527ff163ccc90c347b4`
- Updated API and worker rollout annotations