### PR TITLE
feat(torghut): add continuous drift governance and trigger controls

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -228,6 +228,110 @@ class Settings(BaseSettings):
         alias="TRADING_AUTONOMY_ARTIFACT_DIR",
         description="Output directory for autonomous lane artifacts.",
     )
+    trading_drift_governance_enabled: bool = Field(
+        default=True,
+        alias="TRADING_DRIFT_GOVERNANCE_ENABLED",
+        description="Enable autonomous drift detection, trigger decisions, and audited governance artifacts.",
+    )
+    trading_drift_max_required_null_rate: float = Field(
+        default=0.02,
+        alias="TRADING_DRIFT_MAX_REQUIRED_NULL_RATE",
+        description="Drift threshold for maximum required feature null-rate.",
+    )
+    trading_drift_max_staleness_ms_p95: int = Field(
+        default=180000,
+        alias="TRADING_DRIFT_MAX_STALENESS_MS_P95",
+        description="Drift threshold for p95 feature staleness in milliseconds.",
+    )
+    trading_drift_max_duplicate_ratio: float = Field(
+        default=0.05,
+        alias="TRADING_DRIFT_MAX_DUPLICATE_RATIO",
+        description="Drift threshold for duplicate event ratio.",
+    )
+    trading_drift_max_schema_mismatch_total: int = Field(
+        default=0,
+        alias="TRADING_DRIFT_MAX_SCHEMA_MISMATCH_TOTAL",
+        description="Drift threshold for schema mismatch count.",
+    )
+    trading_drift_max_model_calibration_error: float = Field(
+        default=0.45,
+        alias="TRADING_DRIFT_MAX_MODEL_CALIBRATION_ERROR",
+        description="Drift threshold for model calibration error from profitability evidence.",
+    )
+    trading_drift_max_model_llm_error_ratio: float = Field(
+        default=0.10,
+        alias="TRADING_DRIFT_MAX_MODEL_LLM_ERROR_RATIO",
+        description="Drift threshold for LLM runtime error ratio.",
+    )
+    trading_drift_min_performance_net_pnl: float = Field(
+        default=0.0,
+        alias="TRADING_DRIFT_MIN_PERFORMANCE_NET_PNL",
+        description="Drift floor for net PnL.",
+    )
+    trading_drift_max_performance_drawdown: float = Field(
+        default=0.08,
+        alias="TRADING_DRIFT_MAX_PERFORMANCE_DRAWDOWN",
+        description="Drift threshold for absolute drawdown.",
+    )
+    trading_drift_max_performance_cost_bps: float = Field(
+        default=35.0,
+        alias="TRADING_DRIFT_MAX_PERFORMANCE_COST_BPS",
+        description="Drift threshold for execution cost in bps.",
+    )
+    trading_drift_max_execution_fallback_ratio: float = Field(
+        default=0.25,
+        alias="TRADING_DRIFT_MAX_EXECUTION_FALLBACK_RATIO",
+        description="Drift threshold for execution fallback ratio.",
+    )
+    trading_drift_trigger_retrain_reason_codes_raw: Optional[str] = Field(
+        default=(
+            "data_required_null_rate_exceeded,data_staleness_p95_exceeded,data_duplicate_ratio_exceeded,"
+            "data_schema_mismatch_detected,model_calibration_error_exceeded,model_llm_error_ratio_exceeded"
+        ),
+        alias="TRADING_DRIFT_TRIGGER_RETRAIN_REASON_CODES",
+        description="Comma-separated reason codes that trigger retraining workflows.",
+    )
+    trading_drift_trigger_reselection_reason_codes_raw: Optional[str] = Field(
+        default=(
+            "performance_net_pnl_below_floor,performance_drawdown_exceeded,performance_cost_bps_exceeded,"
+            "performance_execution_fallback_ratio_exceeded"
+        ),
+        alias="TRADING_DRIFT_TRIGGER_RESELECTION_REASON_CODES",
+        description="Comma-separated reason codes that trigger reselection workflows.",
+    )
+    trading_drift_retrain_cooldown_seconds: int = Field(
+        default=3600,
+        alias="TRADING_DRIFT_RETRAIN_COOLDOWN_SECONDS",
+        description="Cooldown between retraining triggers for repeated drift incidents.",
+    )
+    trading_drift_reselection_cooldown_seconds: int = Field(
+        default=3600,
+        alias="TRADING_DRIFT_RESELECTION_COOLDOWN_SECONDS",
+        description="Cooldown between reselection triggers for repeated drift incidents.",
+    )
+    trading_drift_live_promotion_requires_evidence: bool = Field(
+        default=True,
+        alias="TRADING_DRIFT_LIVE_PROMOTION_REQUIRES_EVIDENCE",
+        description="Require explicit drift-governance evidence before autonomous live promotion.",
+    )
+    trading_drift_live_promotion_max_evidence_age_seconds: int = Field(
+        default=1800,
+        alias="TRADING_DRIFT_LIVE_PROMOTION_MAX_EVIDENCE_AGE_SECONDS",
+        description="Maximum age for drift evidence used to authorize live promotion.",
+    )
+    trading_drift_rollback_on_performance: bool = Field(
+        default=True,
+        alias="TRADING_DRIFT_ROLLBACK_ON_PERFORMANCE",
+        description="Trigger emergency rollback hooks when configured performance drift reason codes are detected.",
+    )
+    trading_drift_rollback_reason_codes_raw: Optional[str] = Field(
+        default=(
+            "performance_net_pnl_below_floor,performance_drawdown_exceeded,performance_cost_bps_exceeded,"
+            "performance_execution_fallback_ratio_exceeded"
+        ),
+        alias="TRADING_DRIFT_ROLLBACK_REASON_CODES",
+        description="Comma-separated drift reason codes that trigger rollback hooks.",
+    )
     trading_evidence_continuity_enabled: bool = Field(
         default=True,
         alias="TRADING_EVIDENCE_CONTINUITY_ENABLED",
@@ -676,6 +780,36 @@ class Settings(BaseSettings):
                     if item.strip()
                 ]
             )
+        if self.trading_drift_trigger_retrain_reason_codes_raw:
+            self.trading_drift_trigger_retrain_reason_codes_raw = ",".join(
+                [
+                    item.strip()
+                    for item in self.trading_drift_trigger_retrain_reason_codes_raw.split(
+                        ","
+                    )
+                    if item.strip()
+                ]
+            )
+        if self.trading_drift_trigger_reselection_reason_codes_raw:
+            self.trading_drift_trigger_reselection_reason_codes_raw = ",".join(
+                [
+                    item.strip()
+                    for item in self.trading_drift_trigger_reselection_reason_codes_raw.split(
+                        ","
+                    )
+                    if item.strip()
+                ]
+            )
+        if self.trading_drift_rollback_reason_codes_raw:
+            self.trading_drift_rollback_reason_codes_raw = ",".join(
+                [
+                    item.strip()
+                    for item in self.trading_drift_rollback_reason_codes_raw.split(
+                        ","
+                    )
+                    if item.strip()
+                ]
+            )
         if self.trading_autonomy_approval_token:
             self.trading_autonomy_approval_token = (
                 self.trading_autonomy_approval_token.strip() or None
@@ -724,6 +858,22 @@ class Settings(BaseSettings):
         if self.trading_allocator_default_capacity_multiplier < 0:
             raise ValueError(
                 "TRADING_ALLOCATOR_DEFAULT_CAPACITY_MULTIPLIER must be >= 0"
+            )
+        if self.trading_drift_max_required_null_rate < 0:
+            raise ValueError("TRADING_DRIFT_MAX_REQUIRED_NULL_RATE must be >= 0")
+        if self.trading_drift_max_staleness_ms_p95 < 0:
+            raise ValueError("TRADING_DRIFT_MAX_STALENESS_MS_P95 must be >= 0")
+        if self.trading_drift_max_duplicate_ratio < 0:
+            raise ValueError("TRADING_DRIFT_MAX_DUPLICATE_RATIO must be >= 0")
+        if self.trading_drift_max_schema_mismatch_total < 0:
+            raise ValueError("TRADING_DRIFT_MAX_SCHEMA_MISMATCH_TOTAL must be >= 0")
+        if self.trading_drift_retrain_cooldown_seconds < 0:
+            raise ValueError("TRADING_DRIFT_RETRAIN_COOLDOWN_SECONDS must be >= 0")
+        if self.trading_drift_reselection_cooldown_seconds < 0:
+            raise ValueError("TRADING_DRIFT_RESELECTION_COOLDOWN_SECONDS must be >= 0")
+        if self.trading_drift_live_promotion_max_evidence_age_seconds < 0:
+            raise ValueError(
+                "TRADING_DRIFT_LIVE_PROMOTION_MAX_EVIDENCE_AGE_SECONDS must be >= 0"
             )
         if self.trading_allocator_min_multiplier < 0:
             raise ValueError("TRADING_ALLOCATOR_MIN_MULTIPLIER must be >= 0")
@@ -800,6 +950,38 @@ class Settings(BaseSettings):
             for reason in self.trading_signal_staleness_alert_critical_reasons_raw.split(
                 ","
             )
+            if reason.strip()
+        }
+
+    @property
+    def trading_drift_trigger_retrain_reason_codes(self) -> set[str]:
+        if not self.trading_drift_trigger_retrain_reason_codes_raw:
+            return set()
+        return {
+            reason.strip()
+            for reason in self.trading_drift_trigger_retrain_reason_codes_raw.split(",")
+            if reason.strip()
+        }
+
+    @property
+    def trading_drift_trigger_reselection_reason_codes(self) -> set[str]:
+        if not self.trading_drift_trigger_reselection_reason_codes_raw:
+            return set()
+        return {
+            reason.strip()
+            for reason in self.trading_drift_trigger_reselection_reason_codes_raw.split(
+                ","
+            )
+            if reason.strip()
+        }
+
+    @property
+    def trading_drift_rollback_reason_codes(self) -> set[str]:
+        if not self.trading_drift_rollback_reason_codes_raw:
+            return set()
+        return {
+            reason.strip()
+            for reason in self.trading_drift_rollback_reason_codes_raw.split(",")
             if reason.strip()
         }
 

--- a/services/torghut/app/trading/autonomy/__init__.py
+++ b/services/torghut/app/trading/autonomy/__init__.py
@@ -1,6 +1,12 @@
 """Torghut v3 autonomous runtime and gate modules."""
 
-from .gates import GateEvaluationReport, GateInputs, GatePolicyMatrix, PromotionTarget, evaluate_gate_matrix
+from .gates import (
+    GateEvaluationReport,
+    GateInputs,
+    GatePolicyMatrix,
+    PromotionTarget,
+    evaluate_gate_matrix,
+)
 from .lane import (
     AutonomousLaneResult,
     load_runtime_strategy_config,
@@ -14,6 +20,17 @@ from .policy_checks import (
     evaluate_rollback_readiness,
 )
 from .evidence import EvidenceContinuityCheckReport, evaluate_evidence_continuity
+from .drift import (
+    DriftActionDecision,
+    DriftDetectionReport,
+    DriftPromotionEvidence,
+    DriftSignal,
+    DriftThresholds,
+    DriftTriggerPolicy,
+    decide_drift_action,
+    detect_drift,
+    evaluate_live_promotion_evidence,
+)
 from .runtime import (
     LegacyMacdRsiPlugin,
     RuntimeEvaluationResult,
@@ -27,28 +44,37 @@ from .runtime import (
 )
 
 __all__ = [
-    'AutonomousLaneResult',
-    'GateEvaluationReport',
-    'GateInputs',
-    'GatePolicyMatrix',
-    'LegacyMacdRsiPlugin',
-    'PromotionTarget',
-    'PromotionPrerequisiteResult',
-    'RuntimeEvaluationResult',
-    'RollbackReadinessResult',
-    'StrategyContext',
-    'StrategyIntent',
-    'StrategyPlugin',
-    'StrategyPluginRegistry',
-    'StrategyRuntime',
-    'StrategyRuntimeConfig',
-    'default_runtime_registry',
-    'EvidenceContinuityCheckReport',
-    'evaluate_gate_matrix',
-    'evaluate_evidence_continuity',
-    'load_runtime_strategy_config',
-    'evaluate_promotion_prerequisites',
-    'evaluate_rollback_readiness',
-    'upsert_autonomy_no_signal_run',
-    'run_autonomous_lane',
+    "AutonomousLaneResult",
+    "GateEvaluationReport",
+    "GateInputs",
+    "GatePolicyMatrix",
+    "LegacyMacdRsiPlugin",
+    "PromotionTarget",
+    "PromotionPrerequisiteResult",
+    "RuntimeEvaluationResult",
+    "RollbackReadinessResult",
+    "StrategyContext",
+    "StrategyIntent",
+    "StrategyPlugin",
+    "StrategyPluginRegistry",
+    "StrategyRuntime",
+    "StrategyRuntimeConfig",
+    "default_runtime_registry",
+    "EvidenceContinuityCheckReport",
+    "DriftActionDecision",
+    "DriftDetectionReport",
+    "DriftPromotionEvidence",
+    "DriftSignal",
+    "DriftThresholds",
+    "DriftTriggerPolicy",
+    "decide_drift_action",
+    "detect_drift",
+    "evaluate_live_promotion_evidence",
+    "evaluate_gate_matrix",
+    "evaluate_evidence_continuity",
+    "load_runtime_strategy_config",
+    "evaluate_promotion_prerequisites",
+    "evaluate_rollback_readiness",
+    "upsert_autonomy_no_signal_run",
+    "run_autonomous_lane",
 ]

--- a/services/torghut/app/trading/autonomy/drift.py
+++ b/services/torghut/app/trading/autonomy/drift.py
@@ -1,0 +1,477 @@
+"""Deterministic drift governance for autonomous promotion and rollback safety."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Mapping, cast
+
+from ..feature_quality import FeatureQualityReport
+
+DriftCategory = str
+DriftActionType = str
+
+REASON_DATA_NULL_RATE = "data_required_null_rate_exceeded"
+REASON_DATA_STALENESS = "data_staleness_p95_exceeded"
+REASON_DATA_DUPLICATE_RATIO = "data_duplicate_ratio_exceeded"
+REASON_DATA_SCHEMA_MISMATCH = "data_schema_mismatch_detected"
+REASON_MODEL_CALIBRATION_ERROR = "model_calibration_error_exceeded"
+REASON_MODEL_LLM_ERROR_RATIO = "model_llm_error_ratio_exceeded"
+REASON_PERF_NET_PNL = "performance_net_pnl_below_floor"
+REASON_PERF_DRAWDOWN = "performance_drawdown_exceeded"
+REASON_PERF_COST_BPS = "performance_cost_bps_exceeded"
+REASON_PERF_FALLBACK_RATIO = "performance_execution_fallback_ratio_exceeded"
+_EMPTY_MAPPING: Mapping[str, Any] = cast(Mapping[str, Any], {})
+
+
+@dataclass(frozen=True)
+class DriftThresholds:
+    max_required_null_rate: Decimal = Decimal("0.02")
+    max_staleness_ms_p95: int = 180000
+    max_duplicate_ratio: Decimal = Decimal("0.05")
+    max_schema_mismatch_total: int = 0
+    max_model_calibration_error: Decimal = Decimal("0.45")
+    max_model_llm_error_ratio: Decimal = Decimal("0.10")
+    min_performance_net_pnl: Decimal = Decimal("0")
+    max_performance_drawdown: Decimal = Decimal("0.08")
+    max_performance_cost_bps: Decimal = Decimal("35")
+    max_execution_fallback_ratio: Decimal = Decimal("0.25")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "max_required_null_rate": str(self.max_required_null_rate),
+            "max_staleness_ms_p95": self.max_staleness_ms_p95,
+            "max_duplicate_ratio": str(self.max_duplicate_ratio),
+            "max_schema_mismatch_total": self.max_schema_mismatch_total,
+            "max_model_calibration_error": str(self.max_model_calibration_error),
+            "max_model_llm_error_ratio": str(self.max_model_llm_error_ratio),
+            "min_performance_net_pnl": str(self.min_performance_net_pnl),
+            "max_performance_drawdown": str(self.max_performance_drawdown),
+            "max_performance_cost_bps": str(self.max_performance_cost_bps),
+            "max_execution_fallback_ratio": str(self.max_execution_fallback_ratio),
+        }
+
+
+@dataclass(frozen=True)
+class DriftSignal:
+    category: DriftCategory
+    reason_code: str
+    observed: str
+    threshold: str
+    comparator: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "category": self.category,
+            "reason_code": self.reason_code,
+            "observed": self.observed,
+            "threshold": self.threshold,
+            "comparator": self.comparator,
+        }
+
+
+@dataclass(frozen=True)
+class DriftDetectionReport:
+    run_id: str
+    detected_at: datetime
+    incident_id: str
+    drift_detected: bool
+    reason_codes: list[str]
+    signals: list[DriftSignal]
+    thresholds: DriftThresholds
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "detected_at": self.detected_at.isoformat(),
+            "incident_id": self.incident_id,
+            "drift_detected": self.drift_detected,
+            "reason_codes": list(self.reason_codes),
+            "signals": [item.to_payload() for item in self.signals],
+            "thresholds": self.thresholds.to_payload(),
+        }
+
+
+@dataclass(frozen=True)
+class DriftTriggerPolicy:
+    retrain_reason_codes: set[str] = field(
+        default_factory=lambda: {
+            REASON_DATA_NULL_RATE,
+            REASON_DATA_STALENESS,
+            REASON_DATA_DUPLICATE_RATIO,
+            REASON_DATA_SCHEMA_MISMATCH,
+            REASON_MODEL_CALIBRATION_ERROR,
+            REASON_MODEL_LLM_ERROR_RATIO,
+        }
+    )
+    reselection_reason_codes: set[str] = field(
+        default_factory=lambda: {
+            REASON_PERF_NET_PNL,
+            REASON_PERF_DRAWDOWN,
+            REASON_PERF_COST_BPS,
+            REASON_PERF_FALLBACK_RATIO,
+        }
+    )
+    retrain_cooldown_seconds: int = 3600
+    reselection_cooldown_seconds: int = 3600
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "retrain_reason_codes": sorted(self.retrain_reason_codes),
+            "reselection_reason_codes": sorted(self.reselection_reason_codes),
+            "retrain_cooldown_seconds": self.retrain_cooldown_seconds,
+            "reselection_cooldown_seconds": self.reselection_cooldown_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class DriftActionDecision:
+    action_id: str
+    action_type: DriftActionType
+    triggered: bool
+    cooldown_active: bool
+    cooldown_remaining_seconds: int
+    reason_codes: list[str]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "action_id": self.action_id,
+            "action_type": self.action_type,
+            "triggered": self.triggered,
+            "cooldown_active": self.cooldown_active,
+            "cooldown_remaining_seconds": self.cooldown_remaining_seconds,
+            "reason_codes": list(self.reason_codes),
+        }
+
+
+@dataclass(frozen=True)
+class DriftPromotionEvidence:
+    checked_at: datetime
+    incident_id: str | None
+    eligible_for_live_promotion: bool
+    reasons: list[str]
+    reason_codes: list[str]
+    evidence_artifact_refs: list[str]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "checked_at": self.checked_at.isoformat(),
+            "incident_id": self.incident_id,
+            "eligible_for_live_promotion": self.eligible_for_live_promotion,
+            "reasons": list(self.reasons),
+            "reason_codes": list(self.reason_codes),
+            "evidence_artifact_refs": list(self.evidence_artifact_refs),
+        }
+
+
+def detect_drift(
+    *,
+    run_id: str,
+    feature_quality_report: FeatureQualityReport,
+    gate_report_payload: Mapping[str, Any],
+    fallback_ratio: Decimal,
+    thresholds: DriftThresholds,
+    detected_at: datetime | None = None,
+) -> DriftDetectionReport:
+    now = detected_at or datetime.now(timezone.utc)
+    signals: list[DriftSignal] = []
+
+    max_null_rate = max(
+        (
+            Decimal(str(value))
+            for value in feature_quality_report.null_rate_by_field.values()
+        ),
+        default=Decimal("0"),
+    )
+    if max_null_rate > thresholds.max_required_null_rate:
+        signals.append(
+            DriftSignal(
+                category="data",
+                reason_code=REASON_DATA_NULL_RATE,
+                observed=str(max_null_rate),
+                threshold=str(thresholds.max_required_null_rate),
+                comparator=">",
+            )
+        )
+
+    staleness = int(feature_quality_report.staleness_ms_p95)
+    if staleness > thresholds.max_staleness_ms_p95:
+        signals.append(
+            DriftSignal(
+                category="data",
+                reason_code=REASON_DATA_STALENESS,
+                observed=str(staleness),
+                threshold=str(thresholds.max_staleness_ms_p95),
+                comparator=">",
+            )
+        )
+
+    duplicate_ratio = Decimal(str(feature_quality_report.duplicate_ratio))
+    if duplicate_ratio > thresholds.max_duplicate_ratio:
+        signals.append(
+            DriftSignal(
+                category="data",
+                reason_code=REASON_DATA_DUPLICATE_RATIO,
+                observed=str(duplicate_ratio),
+                threshold=str(thresholds.max_duplicate_ratio),
+                comparator=">",
+            )
+        )
+
+    if (
+        int(feature_quality_report.schema_mismatch_total)
+        > thresholds.max_schema_mismatch_total
+    ):
+        signals.append(
+            DriftSignal(
+                category="data",
+                reason_code=REASON_DATA_SCHEMA_MISMATCH,
+                observed=str(feature_quality_report.schema_mismatch_total),
+                threshold=str(thresholds.max_schema_mismatch_total),
+                comparator=">",
+            )
+        )
+
+    metrics_payload = _as_mapping(gate_report_payload.get("metrics"))
+    llm_payload = _as_mapping(gate_report_payload.get("llm_metrics"))
+    profitability_payload = _as_mapping(
+        gate_report_payload.get("profitability_evidence")
+    )
+
+    calibration = _extract_profitability_decimal(
+        profitability_payload, ["confidence_calibration", "calibration_error"]
+    )
+    if calibration is not None and calibration > thresholds.max_model_calibration_error:
+        signals.append(
+            DriftSignal(
+                category="model",
+                reason_code=REASON_MODEL_CALIBRATION_ERROR,
+                observed=str(calibration),
+                threshold=str(thresholds.max_model_calibration_error),
+                comparator=">",
+            )
+        )
+
+    llm_error_ratio = _to_decimal(llm_payload.get("error_ratio"))
+    if (
+        llm_error_ratio is not None
+        and llm_error_ratio > thresholds.max_model_llm_error_ratio
+    ):
+        signals.append(
+            DriftSignal(
+                category="model",
+                reason_code=REASON_MODEL_LLM_ERROR_RATIO,
+                observed=str(llm_error_ratio),
+                threshold=str(thresholds.max_model_llm_error_ratio),
+                comparator=">",
+            )
+        )
+
+    net_pnl = _to_decimal(metrics_payload.get("net_pnl"))
+    if net_pnl is not None and net_pnl < thresholds.min_performance_net_pnl:
+        signals.append(
+            DriftSignal(
+                category="performance",
+                reason_code=REASON_PERF_NET_PNL,
+                observed=str(net_pnl),
+                threshold=str(thresholds.min_performance_net_pnl),
+                comparator="<",
+            )
+        )
+
+    max_drawdown = _to_decimal(metrics_payload.get("max_drawdown"))
+    if (
+        max_drawdown is not None
+        and abs(max_drawdown) > thresholds.max_performance_drawdown
+    ):
+        signals.append(
+            DriftSignal(
+                category="performance",
+                reason_code=REASON_PERF_DRAWDOWN,
+                observed=str(abs(max_drawdown)),
+                threshold=str(thresholds.max_performance_drawdown),
+                comparator=">",
+            )
+        )
+
+    cost_bps = _to_decimal(metrics_payload.get("cost_bps"))
+    if cost_bps is not None and cost_bps > thresholds.max_performance_cost_bps:
+        signals.append(
+            DriftSignal(
+                category="performance",
+                reason_code=REASON_PERF_COST_BPS,
+                observed=str(cost_bps),
+                threshold=str(thresholds.max_performance_cost_bps),
+                comparator=">",
+            )
+        )
+
+    if fallback_ratio > thresholds.max_execution_fallback_ratio:
+        signals.append(
+            DriftSignal(
+                category="performance",
+                reason_code=REASON_PERF_FALLBACK_RATIO,
+                observed=str(fallback_ratio),
+                threshold=str(thresholds.max_execution_fallback_ratio),
+                comparator=">",
+            )
+        )
+
+    reason_codes = sorted({item.reason_code for item in signals})
+    incident_id = _stable_digest(
+        {
+            "run_id": run_id,
+            "reason_codes": reason_codes,
+            "thresholds": thresholds.to_payload(),
+        }
+    )
+    return DriftDetectionReport(
+        run_id=run_id,
+        detected_at=now,
+        incident_id=incident_id,
+        drift_detected=bool(reason_codes),
+        reason_codes=reason_codes,
+        signals=signals,
+        thresholds=thresholds,
+    )
+
+
+def decide_drift_action(
+    *,
+    detection: DriftDetectionReport,
+    policy: DriftTriggerPolicy,
+    last_action_type: str | None,
+    last_action_at: datetime | None,
+    now: datetime | None = None,
+) -> DriftActionDecision:
+    current = now or datetime.now(timezone.utc)
+    if not detection.drift_detected:
+        action_id = _stable_digest(
+            {"incident_id": detection.incident_id, "action": "none"}
+        )
+        return DriftActionDecision(
+            action_id=action_id,
+            action_type="none",
+            triggered=False,
+            cooldown_active=False,
+            cooldown_remaining_seconds=0,
+            reason_codes=[],
+        )
+
+    reasons = set(detection.reason_codes)
+    if reasons & policy.reselection_reason_codes:
+        action_type = "reselection"
+        cooldown_seconds = max(0, int(policy.reselection_cooldown_seconds))
+    elif reasons & policy.retrain_reason_codes:
+        action_type = "retrain"
+        cooldown_seconds = max(0, int(policy.retrain_cooldown_seconds))
+    else:
+        action_type = "retrain"
+        cooldown_seconds = max(0, int(policy.retrain_cooldown_seconds))
+
+    cooldown_remaining = 0
+    cooldown_active = False
+    if last_action_type == action_type and last_action_at is not None:
+        elapsed = int((current - last_action_at).total_seconds())
+        cooldown_remaining = max(0, cooldown_seconds - max(0, elapsed))
+        cooldown_active = cooldown_remaining > 0
+
+    action_id = _stable_digest(
+        {
+            "incident_id": detection.incident_id,
+            "action": action_type,
+            "reason_codes": sorted(detection.reason_codes),
+        }
+    )
+
+    return DriftActionDecision(
+        action_id=action_id,
+        action_type=action_type,
+        triggered=not cooldown_active,
+        cooldown_active=cooldown_active,
+        cooldown_remaining_seconds=cooldown_remaining,
+        reason_codes=sorted(detection.reason_codes),
+    )
+
+
+def evaluate_live_promotion_evidence(
+    *,
+    detection: DriftDetectionReport,
+    action: DriftActionDecision,
+    evidence_refs: list[str],
+    now: datetime | None = None,
+) -> DriftPromotionEvidence:
+    checked_at = now or datetime.now(timezone.utc)
+    reasons: list[str] = []
+    if detection.drift_detected:
+        reasons.append("drift_detected")
+    if action.cooldown_active:
+        reasons.append("drift_action_cooldown_active")
+    if action.triggered and action.action_type in {"retrain", "reselection"}:
+        reasons.append(f"drift_action_triggered:{action.action_type}")
+
+    return DriftPromotionEvidence(
+        checked_at=checked_at,
+        incident_id=detection.incident_id if detection.drift_detected else None,
+        eligible_for_live_promotion=not reasons,
+        reasons=reasons,
+        reason_codes=sorted(detection.reason_codes),
+        evidence_artifact_refs=sorted(set(evidence_refs)),
+    )
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+def _to_decimal(raw: Any) -> Decimal | None:
+    if raw is None:
+        return None
+    try:
+        return Decimal(str(raw))
+    except Exception:
+        return None
+
+
+def _extract_profitability_decimal(
+    payload: Mapping[str, Any], path: list[str]
+) -> Decimal | None:
+    current: Any = payload
+    for key in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = cast(Mapping[str, Any], current).get(key)
+    return _to_decimal(current)
+
+
+def _as_mapping(raw: Any) -> Mapping[str, Any]:
+    if isinstance(raw, Mapping):
+        return cast(Mapping[str, Any], raw)
+    return _EMPTY_MAPPING
+
+
+__all__ = [
+    "DriftActionDecision",
+    "DriftPromotionEvidence",
+    "DriftSignal",
+    "DriftThresholds",
+    "DriftTriggerPolicy",
+    "DriftDetectionReport",
+    "REASON_DATA_NULL_RATE",
+    "REASON_DATA_STALENESS",
+    "REASON_DATA_DUPLICATE_RATIO",
+    "REASON_DATA_SCHEMA_MISMATCH",
+    "REASON_MODEL_CALIBRATION_ERROR",
+    "REASON_MODEL_LLM_ERROR_RATIO",
+    "REASON_PERF_NET_PNL",
+    "REASON_PERF_DRAWDOWN",
+    "REASON_PERF_COST_BPS",
+    "REASON_PERF_FALLBACK_RATIO",
+    "decide_drift_action",
+    "detect_drift",
+    "evaluate_live_promotion_evidence",
+]

--- a/services/torghut/app/trading/feature_quality.py
+++ b/services/torghut/app/trading/feature_quality.py
@@ -13,7 +13,14 @@ from .features import (
 )
 from .models import SignalEnvelope
 
-QUALITY_GATED_REQUIRED_FIELDS = tuple([field for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS if field != 'price'])
+QUALITY_GATED_REQUIRED_FIELDS = tuple(
+    [field for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS if field != "price"]
+)
+REASON_NON_MONOTONIC = "non_monotonic_progression"
+REASON_SCHEMA_MISMATCH = "schema_mismatch"
+REASON_REQUIRED_NULL_RATE = "required_feature_null_rate_exceeds_threshold"
+REASON_STALENESS = "feature_staleness_exceeds_budget"
+REASON_DUPLICATE_RATIO = "duplicate_ratio_exceeds_threshold"
 
 
 @dataclass(frozen=True)
@@ -21,6 +28,13 @@ class FeatureQualityThresholds:
     max_required_null_rate: float = 0.01
     max_staleness_ms: int = 120_000
     max_duplicate_ratio: float = 0.02
+
+    def to_payload(self) -> dict[str, float | int]:
+        return {
+            "max_required_null_rate": self.max_required_null_rate,
+            "max_staleness_ms": self.max_staleness_ms,
+            "max_duplicate_ratio": self.max_duplicate_ratio,
+        }
 
 
 @dataclass(frozen=True)
@@ -32,6 +46,17 @@ class FeatureQualityReport:
     duplicate_ratio: float
     schema_mismatch_total: int
     reasons: list[str]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "accepted": self.accepted,
+            "rows_total": self.rows_total,
+            "null_rate_by_field": dict(self.null_rate_by_field),
+            "staleness_ms_p95": self.staleness_ms_p95,
+            "duplicate_ratio": self.duplicate_ratio,
+            "schema_mismatch_total": self.schema_mismatch_total,
+            "reasons": list(self.reasons),
+        }
 
 
 class FeatureQualityError(RuntimeError):
@@ -49,7 +74,9 @@ def evaluate_feature_batch_quality(
         return FeatureQualityReport(
             accepted=True,
             rows_total=0,
-            null_rate_by_field={field: 0.0 for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS},
+            null_rate_by_field={
+                field: 0.0 for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS
+            },
             staleness_ms_p95=0,
             duplicate_ratio=0.0,
             schema_mismatch_total=0,
@@ -73,7 +100,7 @@ def evaluate_feature_batch_quality(
             if values.get(field) is None:
                 null_counts[field] += 1
 
-        staleness_raw = values.get('staleness_ms')
+        staleness_raw = values.get("staleness_ms")
         staleness = int(staleness_raw) if isinstance(staleness_raw, (int, float)) else 0
         staleness_values.append(staleness)
 
@@ -84,23 +111,29 @@ def evaluate_feature_batch_quality(
             seen_keys.add(key)
 
         if previous is not None and key < previous:
-            reasons.append('non_monotonic_progression')
+            reasons.append(REASON_NON_MONOTONIC)
         previous = key
 
-    null_rate_by_field = {field: null_counts[field] / rows_total for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS}
+    null_rate_by_field = {
+        field: null_counts[field] / rows_total
+        for field in FEATURE_VECTOR_V3_REQUIRED_FIELDS
+    }
     duplicate_ratio = duplicate_total / rows_total
     staleness_ms_p95 = _p95(staleness_values)
 
     if schema_mismatch_total > 0:
-        reasons.append('schema_mismatch')
+        reasons.append(REASON_SCHEMA_MISMATCH)
     # Price can be enriched downstream by price fetchers, so null-rate gating is applied
     # only to indicator fields that must be present at signal ingest time.
-    if any(null_rate_by_field[field] > policy.max_required_null_rate for field in QUALITY_GATED_REQUIRED_FIELDS):
-        reasons.append('required_feature_null_rate_exceeds_threshold')
+    if any(
+        null_rate_by_field[field] > policy.max_required_null_rate
+        for field in QUALITY_GATED_REQUIRED_FIELDS
+    ):
+        reasons.append(REASON_REQUIRED_NULL_RATE)
     if staleness_ms_p95 > policy.max_staleness_ms:
-        reasons.append('feature_staleness_exceeds_budget')
+        reasons.append(REASON_STALENESS)
     if duplicate_ratio > policy.max_duplicate_ratio:
-        reasons.append('duplicate_ratio_exceeds_threshold')
+        reasons.append(REASON_DUPLICATE_RATIO)
 
     unique_reasons = sorted(set(reasons))
     return FeatureQualityReport(
@@ -126,11 +159,11 @@ def enforce_feature_batch_quality(
     parts: list[str] = []
     if report.reasons:
         parts.append(f"reasons={','.join(report.reasons)}")
-    parts.append(f'rows={report.rows_total}')
-    parts.append(f'schema_mismatch_total={report.schema_mismatch_total}')
-    parts.append(f'staleness_ms_p95={report.staleness_ms_p95}')
-    parts.append(f'duplicate_ratio={report.duplicate_ratio:.6f}')
-    raise FeatureQualityError('feature_quality_gate_failed ' + ' '.join(parts))
+    parts.append(f"rows={report.rows_total}")
+    parts.append(f"schema_mismatch_total={report.schema_mismatch_total}")
+    parts.append(f"staleness_ms_p95={report.staleness_ms_p95}")
+    parts.append(f"duplicate_ratio={report.duplicate_ratio:.6f}")
+    raise FeatureQualityError("feature_quality_gate_failed " + " ".join(parts))
 
 
 def _p95(values: list[int]) -> int:
@@ -138,16 +171,21 @@ def _p95(values: list[int]) -> int:
         return 0
     if len(values) == 1:
         return values[0]
-    quantized = quantiles(values, n=100, method='inclusive')
+    quantized = quantiles(values, n=100, method="inclusive")
     if not quantized:
         return max(values)
     return int(quantized[94])
 
 
 __all__ = [
-    'FeatureQualityError',
-    'FeatureQualityReport',
-    'FeatureQualityThresholds',
-    'enforce_feature_batch_quality',
-    'evaluate_feature_batch_quality',
+    "FeatureQualityError",
+    "FeatureQualityReport",
+    "FeatureQualityThresholds",
+    "REASON_DUPLICATE_RATIO",
+    "REASON_NON_MONOTONIC",
+    "REASON_REQUIRED_NULL_RATE",
+    "REASON_SCHEMA_MISMATCH",
+    "REASON_STALENESS",
+    "enforce_feature_batch_quality",
+    "evaluate_feature_batch_quality",
 ]

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -52,6 +52,11 @@ from .order_feed import OrderFeedIngestor
 from .reconcile import Reconciler
 from .risk import RiskEngine
 from .autonomy import (
+    DriftThresholds,
+    DriftTriggerPolicy,
+    decide_drift_action,
+    detect_drift,
+    evaluate_live_promotion_evidence,
     evaluate_evidence_continuity,
     run_autonomous_lane,
     upsert_autonomy_no_signal_run,
@@ -203,6 +208,17 @@ class TradingMetrics:
     feature_schema_mismatch_total: int = 0
     feature_quality_rejections_total: int = 0
     feature_parity_drift_total: int = 0
+    drift_detection_checks_total: int = 0
+    drift_incidents_total: int = 0
+    drift_incident_reason_total: dict[str, int] = field(
+        default_factory=lambda: cast(dict[str, int], {})
+    )
+    drift_action_total: dict[str, int] = field(
+        default_factory=lambda: cast(dict[str, int], {})
+    )
+    drift_action_cooldown_skip_total: int = 0
+    drift_promotion_block_total: int = 0
+    drift_rollback_trigger_total: int = 0
     evidence_continuity_checks_total: int = 0
     evidence_continuity_failures_total: int = 0
     evidence_continuity_last_checked_ts_seconds: float = 0
@@ -362,6 +378,21 @@ class TradingState:
     emergency_stop_recovery_streak: int = 0
     rollback_incidents_total: int = 0
     rollback_incident_evidence_path: Optional[str] = None
+    drift_status: str = "unknown"
+    drift_active_incident_id: Optional[str] = None
+    drift_active_reason_codes: list[str] = field(
+        default_factory=lambda: cast(list[str], [])
+    )
+    drift_last_detection_at: Optional[datetime] = None
+    drift_last_detection_path: Optional[str] = None
+    drift_last_action_type: Optional[str] = None
+    drift_last_action_at: Optional[datetime] = None
+    drift_last_action_path: Optional[str] = None
+    drift_last_outcome_path: Optional[str] = None
+    drift_live_promotion_eligible: bool = False
+    drift_live_promotion_reasons: list[str] = field(
+        default_factory=lambda: cast(list[str], [])
+    )
     metrics: TradingMetrics = field(default_factory=TradingMetrics)
 
 
@@ -773,7 +804,10 @@ class TradingPipeline:
 
             if not settings.trading_enabled:
                 return
-            if settings.trading_emergency_stop_enabled and self.state.emergency_stop_active:
+            if (
+                settings.trading_emergency_stop_enabled
+                and self.state.emergency_stop_active
+            ):
                 self.state.metrics.orders_rejected_total += 1
                 reason = self.state.emergency_stop_reason or "emergency_stop_active"
                 self.executor.mark_rejected(session, decision_row, reason)
@@ -1679,7 +1713,9 @@ def _build_llm_policy_resolution(
             "trading_mode": settings.trading_mode,
             "trading_parity_policy": settings.trading_parity_policy,
             "llm_fail_mode_enforcement": settings.llm_fail_mode_enforcement,
-            "llm_live_fail_open_requested": settings.llm_live_fail_open_requested_for_stage(normalized_stage),
+            "llm_live_fail_open_requested": settings.llm_live_fail_open_requested_for_stage(
+                normalized_stage
+            ),
             "llm_fail_open_live_approved": settings.llm_fail_open_live_approved,
         },
     }
@@ -1756,6 +1792,255 @@ class TradingScheduler:
             order_feed_ingestor=OrderFeedIngestor(),
         )
 
+    def _drift_thresholds(self) -> DriftThresholds:
+        return DriftThresholds(
+            max_required_null_rate=Decimal(
+                str(settings.trading_drift_max_required_null_rate)
+            ),
+            max_staleness_ms_p95=max(
+                0, int(settings.trading_drift_max_staleness_ms_p95)
+            ),
+            max_duplicate_ratio=Decimal(
+                str(settings.trading_drift_max_duplicate_ratio)
+            ),
+            max_schema_mismatch_total=max(
+                0, int(settings.trading_drift_max_schema_mismatch_total)
+            ),
+            max_model_calibration_error=Decimal(
+                str(settings.trading_drift_max_model_calibration_error)
+            ),
+            max_model_llm_error_ratio=Decimal(
+                str(settings.trading_drift_max_model_llm_error_ratio)
+            ),
+            min_performance_net_pnl=Decimal(
+                str(settings.trading_drift_min_performance_net_pnl)
+            ),
+            max_performance_drawdown=Decimal(
+                str(settings.trading_drift_max_performance_drawdown)
+            ),
+            max_performance_cost_bps=Decimal(
+                str(settings.trading_drift_max_performance_cost_bps)
+            ),
+            max_execution_fallback_ratio=Decimal(
+                str(settings.trading_drift_max_execution_fallback_ratio)
+            ),
+        )
+
+    def _drift_trigger_policy(self) -> DriftTriggerPolicy:
+        return DriftTriggerPolicy(
+            retrain_reason_codes=set(
+                settings.trading_drift_trigger_retrain_reason_codes
+            ),
+            reselection_reason_codes=set(
+                settings.trading_drift_trigger_reselection_reason_codes
+            ),
+            retrain_cooldown_seconds=max(
+                0, int(settings.trading_drift_retrain_cooldown_seconds)
+            ),
+            reselection_cooldown_seconds=max(
+                0, int(settings.trading_drift_reselection_cooldown_seconds)
+            ),
+        )
+
+    def _current_drift_gate_evidence(self, *, now: datetime) -> dict[str, Any]:
+        refs: list[str] = []
+        reasons = list(self.state.drift_live_promotion_reasons)
+        eligible = bool(self.state.drift_live_promotion_eligible)
+        checked_at_raw: str | None = None
+        if self.state.drift_last_detection_path:
+            refs.append(self.state.drift_last_detection_path)
+        if self.state.drift_last_action_path:
+            refs.append(self.state.drift_last_action_path)
+        if self.state.drift_last_outcome_path:
+            refs.append(self.state.drift_last_outcome_path)
+            try:
+                payload = json.loads(
+                    Path(self.state.drift_last_outcome_path).read_text(encoding="utf-8")
+                )
+            except Exception:
+                payload = {}
+            if isinstance(payload, Mapping):
+                payload_mapping = cast(Mapping[str, Any], payload)
+                checked_at_raw = (
+                    str(payload_mapping.get("checked_at") or "").strip() or None
+                )
+                eligible = bool(
+                    payload_mapping.get("eligible_for_live_promotion", eligible)
+                )
+                raw_reasons = payload_mapping.get("reasons")
+                if isinstance(raw_reasons, list):
+                    reasons = [
+                        str(item)
+                        for item in cast(list[Any], raw_reasons)
+                        if str(item).strip()
+                    ]
+
+        max_age_seconds = max(
+            0, settings.trading_drift_live_promotion_max_evidence_age_seconds
+        )
+        if checked_at_raw:
+            parsed_checked_at = _parse_iso_datetime(checked_at_raw)
+            if parsed_checked_at is not None and max_age_seconds > 0:
+                age_seconds = (now - parsed_checked_at).total_seconds()
+                if age_seconds > max_age_seconds:
+                    eligible = False
+                    reasons.append("drift_evidence_stale")
+        else:
+            eligible = False
+            reasons.append("drift_evidence_missing")
+
+        return {
+            "checked_at": checked_at_raw,
+            "eligible_for_live_promotion": eligible,
+            "reasons": sorted(set(reasons)),
+            "reason_codes": list(self.state.drift_active_reason_codes),
+            "evidence_artifact_refs": sorted(set(refs)),
+        }
+
+    def _evaluate_drift_governance(
+        self,
+        *,
+        run_output_dir: Path,
+        run_id: str,
+        signals: list[SignalEnvelope],
+        gate_report_payload: Mapping[str, Any],
+        now: datetime,
+    ) -> dict[str, Any]:
+        drift_dir = run_output_dir / "drift"
+        drift_dir.mkdir(parents=True, exist_ok=True)
+
+        feature_report = evaluate_feature_batch_quality(
+            signals,
+            thresholds=FeatureQualityThresholds(
+                max_required_null_rate=settings.trading_feature_max_required_null_rate,
+                max_staleness_ms=settings.trading_feature_max_staleness_ms,
+                max_duplicate_ratio=settings.trading_feature_max_duplicate_ratio,
+            ),
+        )
+        fallback_total = sum(self.state.metrics.execution_fallback_total.values())
+        submitted_total = max(1, self.state.metrics.orders_submitted_total)
+        fallback_ratio = Decimal(str(fallback_total / submitted_total))
+
+        thresholds = self._drift_thresholds()
+        detection = detect_drift(
+            run_id=run_id,
+            feature_quality_report=feature_report,
+            gate_report_payload=gate_report_payload,
+            fallback_ratio=fallback_ratio,
+            thresholds=thresholds,
+            detected_at=now,
+        )
+        self.state.metrics.drift_detection_checks_total += 1
+        detection_payload = detection.to_payload()
+        detection_payload["governance_enabled"] = (
+            settings.trading_drift_governance_enabled
+        )
+        detection_payload["feature_quality"] = feature_report.to_payload()
+        detection_path = drift_dir / "drift-detection.json"
+        detection_path.write_text(
+            json.dumps(detection_payload, indent=2), encoding="utf-8"
+        )
+        self.state.drift_last_detection_path = str(detection_path)
+        self.state.drift_last_detection_at = detection.detected_at
+
+        if detection.drift_detected:
+            self.state.metrics.drift_incidents_total += 1
+            self.state.drift_active_incident_id = detection.incident_id
+            self.state.drift_active_reason_codes = list(detection.reason_codes)
+            for reason_code in detection.reason_codes:
+                self.state.metrics.drift_incident_reason_total[reason_code] = (
+                    self.state.metrics.drift_incident_reason_total.get(reason_code, 0)
+                    + 1
+                )
+        else:
+            self.state.drift_active_incident_id = None
+            self.state.drift_active_reason_codes = []
+
+        action = decide_drift_action(
+            detection=detection,
+            policy=self._drift_trigger_policy(),
+            last_action_type=self.state.drift_last_action_type,
+            last_action_at=self.state.drift_last_action_at,
+            now=now,
+        )
+        action_payload = action.to_payload()
+        action_payload["run_id"] = run_id
+        action_payload["incident_id"] = detection.incident_id
+        action_payload["governance_enabled"] = settings.trading_drift_governance_enabled
+        action_path = drift_dir / "drift-action.json"
+        action_path.write_text(json.dumps(action_payload, indent=2), encoding="utf-8")
+        self.state.drift_last_action_path = str(action_path)
+        self.state.drift_last_action_type = action.action_type
+        if action.triggered and action.action_type != "none":
+            self.state.drift_last_action_at = now
+            self.state.metrics.drift_action_total[action.action_type] = (
+                self.state.metrics.drift_action_total.get(action.action_type, 0) + 1
+            )
+        if action.cooldown_active:
+            self.state.metrics.drift_action_cooldown_skip_total += 1
+
+        evidence = evaluate_live_promotion_evidence(
+            detection=detection,
+            action=action,
+            evidence_refs=[str(detection_path), str(action_path)],
+            now=now,
+        )
+        outcome_payload = evidence.to_payload()
+        outcome_payload["run_id"] = run_id
+        outcome_payload["governance_enabled"] = (
+            settings.trading_drift_governance_enabled
+        )
+        outcome_payload["action"] = action.to_payload()
+        outcome_payload["detection"] = detection.to_payload()
+        outcome_payload["drift_status"] = (
+            "cooldown"
+            if action.cooldown_active
+            else ("drift_detected" if detection.drift_detected else "stable")
+        )
+        outcome_path = drift_dir / "drift-outcome.json"
+        outcome_path.write_text(json.dumps(outcome_payload, indent=2), encoding="utf-8")
+        self.state.drift_last_outcome_path = str(outcome_path)
+        self.state.drift_live_promotion_eligible = evidence.eligible_for_live_promotion
+        self.state.drift_live_promotion_reasons = list(evidence.reasons)
+        self.state.drift_status = str(outcome_payload["drift_status"])
+        if not evidence.eligible_for_live_promotion:
+            self.state.metrics.drift_promotion_block_total += 1
+
+        rollback_reasons = settings.trading_drift_rollback_reason_codes
+        has_rollback_reason = any(
+            code in rollback_reasons for code in detection.reason_codes
+        )
+        if (
+            settings.trading_drift_rollback_on_performance
+            and detection.drift_detected
+            and has_rollback_reason
+            and not self.state.emergency_stop_active
+        ):
+            self.state.metrics.drift_rollback_trigger_total += 1
+            self._trigger_emergency_stop(
+                reasons=[
+                    f"drift_reason_detected:{code}"
+                    for code in detection.reason_codes
+                    if code in rollback_reasons
+                ],
+                fallback_ratio=float(fallback_ratio),
+                drawdown=self._drawdown_from_gate_payload(gate_report_payload),
+            )
+        return outcome_payload
+
+    def _drawdown_from_gate_payload(self, payload: Mapping[str, Any]) -> float | None:
+        metrics_raw = payload.get("metrics")
+        if not isinstance(metrics_raw, Mapping):
+            return None
+        metrics_payload = cast(Mapping[str, Any], metrics_raw)
+        drawdown_raw = metrics_payload.get("max_drawdown")
+        if drawdown_raw is None:
+            return None
+        try:
+            return abs(float(drawdown_raw))
+        except (TypeError, ValueError):
+            return None
+
     def _evaluate_safety_controls(self) -> None:
         if self._pipeline is None:
             return
@@ -1828,13 +2113,16 @@ class TradingScheduler:
             )
 
     def _evaluate_emergency_stop_recovery(self, current_reasons: list[str]) -> None:
-        latched_reasons = _split_emergency_stop_reasons(self.state.emergency_stop_reason)
+        latched_reasons = _split_emergency_stop_reasons(
+            self.state.emergency_stop_reason
+        )
         if not latched_reasons:
             self.state.emergency_stop_recovery_streak = 0
             return
 
         has_nonrecoverable_latched_reason = any(
-            not _is_recoverable_emergency_stop_reason(reason) for reason in latched_reasons
+            not _is_recoverable_emergency_stop_reason(reason)
+            for reason in latched_reasons
         )
         if has_nonrecoverable_latched_reason:
             self.state.emergency_stop_recovery_streak = 0
@@ -1846,7 +2134,9 @@ class TradingScheduler:
             if not _is_recoverable_emergency_stop_reason(reason)
         ]
         if nonrecoverable_current_reasons:
-            merged_reasons = sorted(set(latched_reasons + nonrecoverable_current_reasons))
+            merged_reasons = sorted(
+                set(latched_reasons + nonrecoverable_current_reasons)
+            )
             self.state.emergency_stop_reason = ";".join(merged_reasons)
             self.state.emergency_stop_recovery_streak = 0
             logger.error(
@@ -1856,7 +2146,9 @@ class TradingScheduler:
             return
 
         recoverable_current_reasons = [
-            reason for reason in current_reasons if _is_recoverable_emergency_stop_reason(reason)
+            reason
+            for reason in current_reasons
+            if _is_recoverable_emergency_stop_reason(reason)
         ]
         if recoverable_current_reasons:
             self.state.emergency_stop_recovery_streak = 0
@@ -1865,7 +2157,9 @@ class TradingScheduler:
                 self.state.emergency_stop_reason = refreshed
             return
 
-        required_recovery_cycles = max(1, settings.trading_emergency_stop_recovery_cycles)
+        required_recovery_cycles = max(
+            1, settings.trading_emergency_stop_recovery_cycles
+        )
         self.state.emergency_stop_recovery_streak += 1
         if self.state.emergency_stop_recovery_streak < required_recovery_cycles:
             logger.info(
@@ -1893,7 +2187,9 @@ class TradingScheduler:
         self.state.emergency_stop_triggered_at = None
         self.state.emergency_stop_resolved_at = now
         self.state.emergency_stop_recovery_streak = 0
-        logger.info("Emergency stop cleared reason=%s resolved_at=%s", reason, now.isoformat())
+        logger.info(
+            "Emergency stop cleared reason=%s resolved_at=%s", reason, now.isoformat()
+        )
 
     def _is_market_session_open(self, now: datetime | None = None) -> bool:
         trading_client: Any | None = None
@@ -1983,9 +2279,15 @@ class TradingScheduler:
             "triggered_at": now.isoformat(),
             "reasons": reasons,
             "safety_snapshot": {
-                "no_signal_reason_streak": dict(self.state.metrics.no_signal_reason_streak),
-                "signal_staleness_alert_total": dict(self.state.metrics.signal_staleness_alert_total),
-                "execution_fallback_total": dict(self.state.metrics.execution_fallback_total),
+                "no_signal_reason_streak": dict(
+                    self.state.metrics.no_signal_reason_streak
+                ),
+                "signal_staleness_alert_total": dict(
+                    self.state.metrics.signal_staleness_alert_total
+                ),
+                "execution_fallback_total": dict(
+                    self.state.metrics.execution_fallback_total
+                ),
             },
             "signal_lag_seconds": self.state.metrics.signal_lag_seconds,
             "autonomy_failure_streak": self.state.autonomy_failure_streak,
@@ -2032,13 +2334,13 @@ class TradingScheduler:
                 payload = {}
         provenance_raw = payload.get("provenance")
         provenance: dict[str, Any] = (
-            cast(dict[str, Any], provenance_raw) if isinstance(provenance_raw, dict) else {}
+            cast(dict[str, Any], provenance_raw)
+            if isinstance(provenance_raw, dict)
+            else {}
         )
         return {
             "run_id": str(payload.get("run_id")).strip() or None,
-            "gate_report_trace_id": str(
-                provenance.get("gate_report_trace_id")
-            ).strip()
+            "gate_report_trace_id": str(provenance.get("gate_report_trace_id")).strip()
             or None,
             "recommendation_trace_id": str(
                 provenance.get("recommendation_trace_id")
@@ -2276,6 +2578,7 @@ class TradingScheduler:
         self.state.metrics.no_signal_reason_streak = {}
         self.state.metrics.signal_lag_seconds = None
         self.state.autonomy_signals_total = len(signals)
+        drift_gate_evidence = self._current_drift_gate_evidence(now=now)
 
         promotion_target: Literal["paper", "live"]
         approval_token: str | None
@@ -2283,8 +2586,19 @@ class TradingScheduler:
             settings.trading_autonomy_allow_live_promotion
             and settings.trading_autonomy_approval_token
         ):
-            promotion_target = "live"
-            approval_token = settings.trading_autonomy_approval_token
+            if settings.trading_drift_live_promotion_requires_evidence and not bool(
+                drift_gate_evidence.get("eligible_for_live_promotion", False)
+            ):
+                logger.warning(
+                    "Autonomy live promotion denied by drift evidence gate reasons=%s; fallback to paper target.",
+                    drift_gate_evidence.get("reasons"),
+                )
+                self.state.metrics.drift_promotion_block_total += 1
+                promotion_target = "paper"
+                approval_token = None
+            else:
+                promotion_target = "live"
+                approval_token = settings.trading_autonomy_approval_token
         elif (
             settings.trading_autonomy_allow_live_promotion
             and not settings.trading_autonomy_approval_token
@@ -2308,6 +2622,7 @@ class TradingScheduler:
                 strategy_configmap_path=Path("/etc/torghut/strategies.yaml"),
                 code_version="live",
                 approval_token=approval_token,
+                drift_promotion_evidence=drift_gate_evidence,
                 persist_results=True,
                 session_factory=self._pipeline.session_factory,
             )
@@ -2330,6 +2645,18 @@ class TradingScheduler:
             gate_report.get("recommended_mode")
         )
         self.state.last_autonomy_error = None
+        if settings.trading_drift_governance_enabled:
+            self._evaluate_drift_governance(
+                run_output_dir=run_output_dir,
+                run_id=result.run_id,
+                signals=signals,
+                gate_report_payload=gate_report,
+                now=now,
+            )
+        else:
+            self.state.drift_status = "disabled"
+            self.state.drift_live_promotion_eligible = False
+            self.state.drift_live_promotion_reasons = ["drift_governance_disabled"]
 
         if result.paper_patch_path is not None:
             self.state.last_autonomy_patch = str(result.paper_patch_path)
@@ -2366,3 +2693,17 @@ def _incident_payload_complete(payload: Mapping[str, Any]) -> bool:
     if not isinstance(safety_snapshot, Mapping):
         return False
     return True
+
+
+def _parse_iso_datetime(raw: str) -> datetime | None:
+    text = raw.strip()
+    if not text:
+        return None
+    normalized = text.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed

--- a/services/torghut/tests/test_autonomy_drift.py
+++ b/services/torghut/tests/test_autonomy_drift.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.autonomy.drift import (
+    DriftThresholds,
+    DriftTriggerPolicy,
+    REASON_DATA_DUPLICATE_RATIO,
+    REASON_DATA_NULL_RATE,
+    REASON_DATA_SCHEMA_MISMATCH,
+    REASON_DATA_STALENESS,
+    REASON_MODEL_CALIBRATION_ERROR,
+    REASON_MODEL_LLM_ERROR_RATIO,
+    REASON_PERF_COST_BPS,
+    REASON_PERF_DRAWDOWN,
+    REASON_PERF_FALLBACK_RATIO,
+    REASON_PERF_NET_PNL,
+    decide_drift_action,
+    detect_drift,
+    evaluate_live_promotion_evidence,
+)
+from app.trading.feature_quality import FeatureQualityReport
+
+
+class TestAutonomyDrift(TestCase):
+    def test_detect_drift_emits_reason_codes_for_data_model_and_performance(
+        self,
+    ) -> None:
+        report = FeatureQualityReport(
+            accepted=False,
+            rows_total=100,
+            null_rate_by_field={"macd": 0.21},
+            staleness_ms_p95=300_000,
+            duplicate_ratio=0.15,
+            schema_mismatch_total=2,
+            reasons=[],
+        )
+        gate_payload = {
+            "metrics": {
+                "net_pnl": "-50",
+                "max_drawdown": "0.20",
+                "cost_bps": "65",
+            },
+            "llm_metrics": {"error_ratio": "0.30"},
+            "profitability_evidence": {
+                "confidence_calibration": {"calibration_error": "0.80"},
+            },
+        }
+        detected = detect_drift(
+            run_id="run-1",
+            feature_quality_report=report,
+            gate_report_payload=gate_payload,
+            fallback_ratio=Decimal("0.90"),
+            thresholds=DriftThresholds(),
+            detected_at=datetime(2026, 2, 21, tzinfo=timezone.utc),
+        )
+
+        self.assertTrue(detected.drift_detected)
+        for code in (
+            REASON_DATA_NULL_RATE,
+            REASON_DATA_STALENESS,
+            REASON_DATA_DUPLICATE_RATIO,
+            REASON_DATA_SCHEMA_MISMATCH,
+            REASON_MODEL_CALIBRATION_ERROR,
+            REASON_MODEL_LLM_ERROR_RATIO,
+            REASON_PERF_NET_PNL,
+            REASON_PERF_DRAWDOWN,
+            REASON_PERF_COST_BPS,
+            REASON_PERF_FALLBACK_RATIO,
+        ):
+            self.assertIn(code, detected.reason_codes)
+
+    def test_drift_trigger_policy_respects_action_cooldown(self) -> None:
+        report = FeatureQualityReport(
+            accepted=False,
+            rows_total=10,
+            null_rate_by_field={"macd": 0.20},
+            staleness_ms_p95=100,
+            duplicate_ratio=0.0,
+            schema_mismatch_total=0,
+            reasons=[],
+        )
+        detection = detect_drift(
+            run_id="run-2",
+            feature_quality_report=report,
+            gate_report_payload={},
+            fallback_ratio=Decimal("0"),
+            thresholds=DriftThresholds(max_required_null_rate=Decimal("0.01")),
+            detected_at=datetime(2026, 2, 21, 0, 0, tzinfo=timezone.utc),
+        )
+        now = datetime(2026, 2, 21, 0, 30, tzinfo=timezone.utc)
+        policy = DriftTriggerPolicy(
+            retrain_cooldown_seconds=3600, reselection_cooldown_seconds=10
+        )
+
+        decision = decide_drift_action(
+            detection=detection,
+            policy=policy,
+            last_action_type="retrain",
+            last_action_at=now - timedelta(minutes=10),
+            now=now,
+        )
+
+        self.assertEqual(decision.action_type, "retrain")
+        self.assertFalse(decision.triggered)
+        self.assertTrue(decision.cooldown_active)
+        self.assertGreater(decision.cooldown_remaining_seconds, 0)
+
+    def test_live_promotion_evidence_blocks_when_drift_or_cooldown_active(self) -> None:
+        report = FeatureQualityReport(
+            accepted=False,
+            rows_total=10,
+            null_rate_by_field={"macd": 0.2},
+            staleness_ms_p95=100,
+            duplicate_ratio=0.0,
+            schema_mismatch_total=0,
+            reasons=[],
+        )
+        detection = detect_drift(
+            run_id="run-3",
+            feature_quality_report=report,
+            gate_report_payload={},
+            fallback_ratio=Decimal("0"),
+            thresholds=DriftThresholds(max_required_null_rate=Decimal("0.01")),
+        )
+        action = decide_drift_action(
+            detection=detection,
+            policy=DriftTriggerPolicy(),
+            last_action_type="retrain",
+            last_action_at=datetime.now(timezone.utc),
+        )
+
+        evidence = evaluate_live_promotion_evidence(
+            detection=detection,
+            action=action,
+            evidence_refs=["/tmp/a.json", "/tmp/b.json"],
+        )
+
+        self.assertFalse(evidence.eligible_for_live_promotion)
+        self.assertIn("drift_detected", evidence.reasons)
+        self.assertGreaterEqual(len(evidence.evidence_artifact_refs), 2)

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -160,3 +160,18 @@ class TestConfig(TestCase):
             settings.trading_signal_staleness_alert_critical_reasons,
             {"cursor_ahead_of_stream", "universe_source_unavailable"},
         )
+
+    def test_parses_drift_reason_code_sets(self) -> None:
+        settings = Settings(
+            TRADING_DRIFT_TRIGGER_RETRAIN_REASON_CODES="a,b",
+            TRADING_DRIFT_TRIGGER_RESELECTION_REASON_CODES="c,d",
+            TRADING_DRIFT_ROLLBACK_REASON_CODES="x,y",
+            DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+        )
+        self.assertEqual(
+            settings.trading_drift_trigger_retrain_reason_codes, {"a", "b"}
+        )
+        self.assertEqual(
+            settings.trading_drift_trigger_reselection_reason_codes, {"c", "d"}
+        )
+        self.assertEqual(settings.trading_drift_rollback_reason_codes, {"x", "y"})


### PR DESCRIPTION
## Summary

- Added deterministic drift governance in Torghut autonomy with explicit data/model/performance drift thresholds and stable reason codes.
- Added policy-driven trigger decisions for retraining/reselection with per-action cooldown controls and auditable incident/action/outcome artifacts under autonomy run outputs.
- Integrated drift governance into autonomous promotion gating so live promotion requires explicit drift gate evidence; otherwise promotion safely degrades to paper.
- Integrated drift state into scheduler runtime state/metrics and rollback hooks so configured performance drift reasons can trigger emergency stop artifacts deterministically.
- Added regression coverage for drift detection, cooldown trigger gating, live-promotion drift evidence gating, and rollback semantics.

## Related Issues

None (no linked issue number was provided in environment context).

## Testing

- `cd services/torghut && .venv/bin/python -m pytest tests/test_autonomy_drift.py tests/test_trading_scheduler_autonomy.py tests/test_feature_quality.py tests/test_config.py tests/test_autonomy_gates.py`
- `cd services/torghut && .venv/bin/ruff check app/trading/autonomy app/trading/feature_quality.py app/trading/scheduler.py tests/test_autonomy_drift.py tests/test_trading_scheduler_autonomy.py tests/test_config.py`
- `cd services/torghut && .venv/bin/pyright app/trading/autonomy app/trading/feature_quality.py app/trading/scheduler.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
