### PR TITLE
fix(jangar): null rollingUpdate for recreate worker strategy

### DIFF
--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -10,6 +10,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/name: jangar-worker


### PR DESCRIPTION
## Summary

- Fixes Argo CD sync failure for `jangar-worker` when `strategy.type` is `Recreate`.
- Adds `spec.strategy.rollingUpdate: null` so server-side apply removes stale rolling update settings.
- Preserves current rollout behavior while preventing invalid Deployment validation during sync.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applications/jangar/jangar-worker-deployment.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar | rg -n "name: jangar-worker$|rollingUpdate: null|type: Recreate"`
- `kubectl get application jangar -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.operationState.phase}{"\\n"}'` (returned `Synced Healthy Succeeded`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
