### PR TITLE
docs(torghut): add v5 production strategy design pack

### DIFF
--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -40,6 +40,10 @@ The v1 documents are written to stay consistent with:
 - `v4/` - fresh quant/LLM profitability expansion pack grounded in 2024-2025 papers and white papers.
   - Entry point: `docs/torghut/design-system/v4/index.md`
 
+- `v5/` - production-quality strategy build pack for the top 5 new quant+LLM priorities (2026-02-21),
+  with comprehensive design docs and per-paper technique synthesis.
+  - Entry point: `docs/torghut/design-system/v5/index.md`
+
 - `v1/` - first cohesive design-system pass aligned to production reality as of **2026-02-08**.
 
 ### v1 Index

--- a/docs/torghut/design-system/v5/01-tsfm-router-refinement-and-uncertainty.md
+++ b/docs/torghut/design-system/v5/01-tsfm-router-refinement-and-uncertainty.md
@@ -1,0 +1,176 @@
+# Priority 1: TSFM Router, Refinement, and Uncertainty-Aware Forecasting
+
+## Objective
+Build a production forecasting layer that routes each symbol/horizon to the best-performing time-series model family,
+optionally applies forecast refinement, and emits calibrated uncertainty that downstream gates can enforce.
+
+## Problem Statement
+Current signal flow is strategy-centric and feature-centric, but not model-family adaptive. Performance and robustness
+vary by symbol, horizon, and regime. A single static forecaster leaves measurable edge on the table and can degrade
+during shifts.
+
+## Scope
+### In Scope
+- model family routing by symbol, horizon, and regime bucket,
+- refinement stage for selected forecasts,
+- probabilistic output contract (`point`, `interval`, `epistemic`, `aleatoric`),
+- deterministic fallback to baseline model when calibration or runtime SLO fails,
+- auditability of routing decisions.
+
+### Out of Scope
+- fully autonomous model retraining in live runtime,
+- direct execution decisions from model output without existing policy chain,
+- replacing existing deterministic strategies in one cutover.
+
+## Target Architecture
+### Components
+1. `ForecastRouterV5`
+- chooses model adapter using `symbol`, `horizon`, `regime_label`, and latest calibration score.
+- route policy stored in versioned config.
+
+2. `ForecastAdapter` family
+- `chronos_adapter`
+- `moment_adapter`
+- `financial_tsfm_adapter` (for fine-tuned finance variants)
+
+3. `ForecastRefinerV5`
+- optional refinement step (bridge-style transport update) when configured and healthy.
+
+4. `ForecastCalibrationStore`
+- stores rolling calibration metrics per route key.
+
+5. `ForecastDecisionAudit`
+- immutable record for each route decision and fallback reason.
+
+### Runtime Flow
+1. receive normalized feature vector.
+2. compute route key (`symbol`, `horizon`, `regime`).
+3. select adapter from route policy + health score.
+4. generate point + interval forecast.
+5. optionally run refinement.
+6. emit structured forecast contract.
+7. pass to uncertainty gate and existing strategy/evaluation path.
+
+## Data Contracts
+### Forecast Output Contract (`forecast_contract_v1`)
+```json
+{
+  "schema_version": "forecast_contract_v1",
+  "symbol": "AAPL",
+  "horizon": "5m",
+  "event_ts": "2026-02-21T14:35:00Z",
+  "model_family": "chronos",
+  "model_version": "chronos-ft-fin-v1",
+  "route_key": "AAPL|5m|trend",
+  "point_forecast": 194.32,
+  "interval": {"p05": 193.95, "p50": 194.32, "p95": 194.77},
+  "uncertainty": {"epistemic": 0.12, "aleatoric": 0.21},
+  "calibration_score": 0.93,
+  "fallback": {"applied": false, "reason": null}
+}
+```
+
+### Route Policy Contract (`forecast_router_policy_v1`)
+- key: `symbol_glob + horizon + regime`
+- fields:
+  - `preferred_model_family`
+  - `candidate_fallbacks`
+  - `min_calibration_score`
+  - `max_inference_latency_ms`
+  - `disable_refinement`
+
+## Torghut Integration Points
+- `services/torghut/app/trading/features.py`
+  - extend normalized features with forecast-ready inputs and route tags.
+- `services/torghut/app/trading/evaluation.py`
+  - ingest `forecast_contract_v1`; compute route-level quality metrics.
+- `services/torghut/app/trading/autonomy/gates.py`
+  - add route-health gate checks (`calibration`, `latency`, `fallback_rate`).
+- `services/torghut/app/trading/autonomy/runtime.py`
+  - wire router into runtime signal path.
+- `argocd/applications/torghut/strategy-configmap.yaml`
+  - route-policy + thresholds.
+
+## Deterministic Safety Controls
+- hard fallback to deterministic baseline when:
+  - adapter error,
+  - latency SLO breach,
+  - calibration score below threshold,
+  - interval fields missing/invalid.
+- fallback behavior is deterministic and logged with reason code.
+- no bypass around existing risk, execution policy, or kill switch.
+
+## Metrics, SLOs, and Alerts
+### Core Metrics
+- `forecast_router_inference_latency_ms{model_family}`
+- `forecast_router_fallback_total{reason}`
+- `forecast_calibration_error{model_family,symbol,horizon}`
+- `forecast_route_selection_total{model_family,route_key}`
+
+### SLOs
+- p95 inference latency <= 200ms (paper), <= 120ms (live candidate path).
+- route-level calibration error <= configured bound for promotion.
+- fallback rate <= 5% per trading hour for live-eligible routes.
+
+### Alerts
+- sustained fallback rate > threshold for 3 windows.
+- calibration degradation for any live-enabled route key.
+- route policy checksum drift vs expected ConfigMap revision.
+
+## Validation Plan
+### Offline
+- rolling walk-forward by symbol/horizon/regime.
+- compare baseline vs routed/refined forecasts on:
+  - error metrics,
+  - directional hit rate,
+  - cost-aware paper PnL impact.
+
+### Paper/Shadow
+- dual-run baseline and router outputs.
+- require non-inferiority on tail-risk and superiority on net-after-cost objectives.
+
+### Promotion Gates
+- 3 consecutive trading days with gate pass in paper.
+- no critical alert during gate window.
+- reproducibility hash match across replay.
+
+## Failure Modes and Mitigations
+- regime misclassification causes poor route choice:
+  - mitigation: conservative default route + route lock timeout.
+- overconfident uncertainty estimates:
+  - mitigation: gate-level coverage checks and abstain/degrade path.
+- model drift after retrain:
+  - mitigation: canary route keys and instant fallback toggle.
+
+## Rollback Plan
+- `FORECAST_ROUTER_ENABLED=false` routes all forecasts to deterministic baseline.
+- preserve audit and metrics in shadow for diagnostics.
+- rollback target: < 5 minutes via config rollout.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v5-tsfm-router-refinement-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `strategyConfigPath`
+  - `evaluationWindow`
+  - `artifactPath`
+- Expected artifacts:
+  - router and adapter modules,
+  - route policy schema + config,
+  - migration/audit schema,
+  - replay and benchmark report.
+- Exit criteria:
+  - calibration and latency SLOs met in paper,
+  - deterministic fallback coverage tests pass,
+  - gate integration proven with no bypass.
+
+## References
+- [1] Chronos: Learning the Language of Time Series. arXiv:2403.07815. https://arxiv.org/abs/2403.07815
+- [2] MOMENT: A Family of Open Time-series Foundation Models. arXiv:2402.03885. https://arxiv.org/abs/2402.03885
+- [3] Re(Visiting) Time Series Foundation Models in Finance. arXiv:2511.18578. https://arxiv.org/abs/2511.18578
+- [4] RefineBridge: Generative Bridge Models Improve Financial Forecasting by Foundation Models. arXiv:2512.21572. https://arxiv.org/abs/2512.21572
+- [5] ProbFM: Probabilistic Time Series Foundation Model with Uncertainty Decomposition. arXiv:2601.10591. https://arxiv.org/abs/2601.10591
+- [6] FinZero: Launching Multi-modal Financial Time Series Forecast with Large Reasoning Model. arXiv:2509.08742. https://arxiv.org/abs/2509.08742

--- a/docs/torghut/design-system/v5/02-conformal-uncertainty-and-regime-gates.md
+++ b/docs/torghut/design-system/v5/02-conformal-uncertainty-and-regime-gates.md
@@ -1,0 +1,158 @@
+# Priority 2: Conformal Uncertainty and Regime-Shift Gates
+
+## Objective
+Introduce a production uncertainty control plane that enforces calibrated prediction intervals, detects regime shifts,
+and deterministically abstains or degrades trading when calibration fails.
+
+## Problem Statement
+Model confidence is currently not enforced as a first-class promotion and runtime gate. Under market change points,
+point forecasts can remain directionally plausible while calibration quality collapses, leading to oversized and
+poorly-timed trades.
+
+## Scope
+### In Scope
+- conformal interval engine for per-symbol/horizon coverage control,
+- temporal/change-point aware recalibration policies,
+- abstain/degrade gate outcomes wired into autonomy and sizing,
+- calibration SLOs and alerting with runbook actions.
+
+### Out of Scope
+- replacing all model families,
+- discretionary/manual overrides in code path,
+- live auto-retraining without approval gates.
+
+## Target Architecture
+### Components
+1. `ConformalEngineV5`
+- computes prediction sets from model residual history.
+- supports rolling and weighted windows.
+
+2. `ShiftDetectorV5`
+- monitors residual distribution drift and change-point indicators.
+- emits `shift_state` with severity.
+
+3. `CalibrationGateV5`
+- evaluates coverage error, interval sharpness, and shift severity.
+- returns deterministic action: `pass`, `degrade`, `abstain`, `fail`.
+
+4. `RecalibrationOrchestrator`
+- schedules recalibration tasks and writes artifact chain.
+
+### Gate Decision Policy
+- `pass`: normal routing/sizing.
+- `degrade`: reduce max notional and require higher confidence.
+- `abstain`: skip new entries, allow risk-reducing exits.
+- `fail`: block promotion and trigger rollback to baseline mode.
+
+## Data Contracts
+### Calibration Snapshot (`calibration_snapshot_v1`)
+```json
+{
+  "schema_version": "calibration_snapshot_v1",
+  "symbol": "MSFT",
+  "horizon": "5m",
+  "window_start": "2026-02-21T13:00:00Z",
+  "window_end": "2026-02-21T14:00:00Z",
+  "target_coverage": 0.9,
+  "observed_coverage": 0.86,
+  "coverage_error": 0.04,
+  "avg_interval_width": 0.72,
+  "shift_state": "elevated",
+  "shift_score": 0.63,
+  "gate_action": "degrade"
+}
+```
+
+### Gate Output Extension
+Add to autonomy gate payload:
+- `uncertainty_gate_action`
+- `coverage_error`
+- `shift_score`
+- `recalibration_run_id`
+
+## Torghut Integration Points
+- `services/torghut/app/trading/evaluation.py`
+  - implement conformal statistics and calibration snapshots.
+- `services/torghut/app/trading/autonomy/gates.py`
+  - add uncertainty gate stage and deterministic action mapping.
+- `services/torghut/app/trading/portfolio.py`
+  - apply degrade multipliers and abstain constraints.
+- `services/torghut/app/trading/autonomy/runtime.py`
+  - ensure gate action is applied before decision execution.
+- `docs/torghut/design-system/v3/full-loop/02-gate-policy-matrix.md`
+  - add uncertainty gate policy envelope.
+
+## Deterministic Safety Rules
+- if uncertainty fields are missing or invalid, default to `abstain`.
+- no live/paper promotion when calibration SLO fails.
+- uncertainty gate cannot be bypassed by LLM advisory output.
+
+## Metrics, SLOs, and Alerts
+### Metrics
+- `calibration_coverage_error{symbol,horizon}`
+- `conformal_interval_width{symbol,horizon}`
+- `uncertainty_gate_action_total{action}`
+- `regime_shift_score{symbol,horizon}`
+- `recalibration_runs_total{status}`
+
+### SLOs
+- `|observed_coverage - target_coverage| <= 0.03` over rolling live-eligibility window.
+- abstain/degrade actions must be logged at 100% rate.
+- recalibration completion latency <= 15 minutes for paper pipelines.
+
+### Alerts
+- 3 consecutive windows with coverage error > threshold.
+- shift score sustained high while gate action remains `pass`.
+- failed recalibration pipeline or missing artifact chain.
+
+## Verification Plan
+### Offline
+- historical replay with synthetic and real change-point segments.
+- validate empirical coverage and false-abstain rate.
+
+### Paper
+- run baseline vs conformal-gated path.
+- evaluate net-after-cost performance and drawdown tails.
+
+### Promotion Criteria
+- calibration SLO pass for 3+ trading days in paper.
+- no unresolved critical uncertainty alerts.
+- reproducible recalibration artifacts available for audit.
+
+## Failure Modes and Mitigations
+- under-coverage during volatility spike:
+  - mitigation: widen intervals + force degrade.
+- over-wide intervals causing strategy paralysis:
+  - mitigation: cap abstain rate and trigger model investigation lane.
+- stale residual buffers:
+  - mitigation: hard staleness checks, fail closed.
+
+## Rollback Plan
+- set `UNCERTAINTY_GATE_MODE=observe` to stop blocking promotions while keeping telemetry.
+- set `UNCERTAINTY_GATE_ENABLED=false` only as emergency fallback with explicit incident record.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v5-conformal-uncertainty-gates-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `gateConfigPath`
+  - `evaluationWindow`
+  - `artifactPath`
+- Expected artifacts:
+  - conformal engine + shift detector,
+  - gate policy extensions,
+  - recalibration job and reports,
+  - replay validation output.
+- Exit criteria:
+  - target coverage SLO achieved,
+  - deterministic abstain/degrade behavior validated,
+  - gate integration blocks unsafe promotion paths.
+
+## References
+- [1] Flow-based Conformal Prediction for Multi-dimensional Time Series. arXiv:2502.05709. https://arxiv.org/abs/2502.05709
+- [2] Conformal Prediction for Time-series Forecasting with Change Points. arXiv:2509.02844. https://arxiv.org/abs/2509.02844
+- [3] Temporal Conformal Prediction (TCP): A Distribution-Free Statistical and Machine Learning Framework for Adaptive Risk Forecasting. arXiv:2507.05470. https://arxiv.org/abs/2507.05470
+- [4] ProbFM: Probabilistic Time Series Foundation Model with Uncertainty Decomposition. arXiv:2601.10591. https://arxiv.org/abs/2601.10591

--- a/docs/torghut/design-system/v5/03-microstructure-execution-intelligence.md
+++ b/docs/torghut/design-system/v5/03-microstructure-execution-intelligence.md
@@ -1,0 +1,164 @@
+# Priority 3: Microstructure Execution Intelligence (Hawkes + Friction-Aware Policy)
+
+## Objective
+Improve realized trading performance by making execution policy explicitly microstructure-aware, using simulator-backed
+calibration, friction-aware decisioning, and deterministic protections against adverse selection.
+
+## Problem Statement
+Signal quality can be positive while net performance degrades from slippage, shortfall, and churn. Existing execution
+logic has policy checks and TCA, but it does not yet use a model-driven microstructure state and simulation loop for
+continuous policy calibration.
+
+## Scope
+### In Scope
+- microstructure state features for execution policy,
+- simulator-backed TCA benchmarking and drift monitoring,
+- friction-aware regime-conditioned execution controls,
+- deterministic throttles for spread shocks and liquidity compression.
+
+### Out of Scope
+- high-frequency market-making replacement of current core strategy engine,
+- venue-specific colocation optimizations,
+- any direct bypass of risk/kill-switch flow.
+
+## Target Architecture
+### Components
+1. `MicrostructureStateV5`
+- real-time state from spread, depth, imbalance, fill hazard, and latency proxy features.
+
+2. `ExecutionPolicyAdvisorV5`
+- computes recommended order type, urgency tier, and participation ceiling.
+- recommendation remains bounded by deterministic execution policy.
+
+3. `SimulatorBackedTCAService`
+- runs deterministic Hawkes-driven LOB simulations to estimate expected shortfall distributions.
+- compares simulated distribution to realized fills for drift detection.
+
+4. `FrictionRegimeController`
+- applies FR-LUX style regime-conditioned constraints on participation and turnover budget.
+
+### Decision Flow
+1. build `MicrostructureStateV5` from incoming market + internal fills.
+2. compute advisor output.
+3. intersect advisor output with hard deterministic constraints in `execution_policy.py`.
+4. execute with provenance fields.
+5. update TCA and simulator divergence metrics.
+
+## Data Contracts
+### Microstructure State (`microstructure_state_v1`)
+```json
+{
+  "schema_version": "microstructure_state_v1",
+  "symbol": "NVDA",
+  "event_ts": "2026-02-21T14:41:00Z",
+  "spread_bps": 3.8,
+  "depth_top5_usd": 1745000,
+  "order_flow_imbalance": 0.24,
+  "latency_ms_estimate": 42,
+  "fill_hazard": 0.61,
+  "liquidity_regime": "normal"
+}
+```
+
+### Execution Recommendation (`execution_advice_v1`)
+- `urgency_tier`: `low|normal|high`
+- `max_participation_rate`
+- `preferred_order_type`
+- `quote_offset_bps`
+- `adverse_selection_risk`
+
+### TCA Divergence (`tca_divergence_v1`)
+- `expected_shortfall_bps_p50/p95`
+- `realized_shortfall_bps`
+- `divergence_bps`
+- `simulator_version`
+
+## Torghut Integration Points
+- `services/torghut/app/trading/execution_policy.py`
+  - add advisor input contract and bounded integration.
+- `services/torghut/app/trading/tca.py`
+  - add simulator divergence metrics.
+- `services/torghut/app/trading/risk.py`
+  - add adverse-selection risk checks.
+- `services/torghut/app/trading/execution.py`
+  - persist execution-advice provenance metadata.
+- `services/torghut/app/trading/features.py`
+  - add microstructure feature extraction helpers.
+
+## Deterministic Safety Controls
+- execution approval still requires existing deterministic checks.
+- advisor cannot increase risk limits, only tighten or suggest less aggressive action.
+- if advisor data is stale/missing, fallback to baseline execution policy.
+
+## Metrics, SLOs, and Alerts
+### Metrics
+- `execution_slippage_bps{symbol,strategy}`
+- `execution_shortfall_notional{symbol,strategy}`
+- `execution_adverse_selection_flag_total{symbol}`
+- `tca_simulator_divergence_bps{symbol}`
+- `execution_policy_override_total{reason}`
+
+### SLOs
+- reduce average slippage bps versus baseline by configured target in paper.
+- p95 divergence between simulator and realized shortfall within tolerance.
+- 100% provenance on execution advice application.
+
+### Alerts
+- divergence exceeds threshold for consecutive windows.
+- adverse-selection flags spike while participation remains high.
+- advisor recommendation stream stale beyond timeout.
+
+## Verification Plan
+### Offline
+- replay execution decisions with historical microstructure snapshots.
+- validate slippage and shortfall deltas vs baseline policy.
+
+### Paper
+- split-book style comparison: baseline vs advisor-bounded execution.
+- evaluate net-after-cost PnL, shortfall tails, and fill rate.
+
+### Promotion Criteria
+- stable improvement in cost-adjusted outcomes across regimes.
+- no increase in critical risk incidents.
+- deterministic override behavior validated by tests.
+
+## Failure Modes and Mitigations
+- simulator miscalibration leads to false confidence:
+  - mitigation: divergence-based guardrail and periodic recalibration.
+- advisor overreacts to transient spread spikes:
+  - mitigation: hysteresis on regime transitions and capped response slope.
+- performance overhead increases latency:
+  - mitigation: low-latency feature cache and timeout-based fallback.
+
+## Rollback Plan
+- disable advisor with `EXECUTION_ADVISOR_ENABLED=false`.
+- keep divergence and TCA telemetry active for diagnostics.
+- retain schema compatibility with baseline execution path.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v5-microstructure-execution-intelligence-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `riskConfigPath`
+  - `artifactPath`
+  - `evaluationWindow`
+- Expected artifacts:
+  - microstructure state module,
+  - advisor integration patch,
+  - simulator-backed TCA pipeline,
+  - validation report and gate evidence.
+- Exit criteria:
+  - cost and slippage targets pass in paper,
+  - deterministic policy precedence proven,
+  - fallback behavior tested under timeout/staleness faults.
+
+## References
+- [1] FR-LUX: Friction-Aware, Regime-Conditioned Policy Optimization for Implementable Portfolio Management. arXiv:2510.02986. https://arxiv.org/abs/2510.02986
+- [2] A Deterministic Limit Order Book Simulator with Hawkes-Driven Order Flow. arXiv:2510.08085. https://arxiv.org/abs/2510.08085
+- [3] Diffusive Limit of Hawkes Driven Order Book Dynamics With Liquidity Migration. arXiv:2511.18117. https://arxiv.org/abs/2511.18117
+- [4] Explainable Patterns in Cryptocurrency Microstructure. arXiv:2602.00776. https://arxiv.org/abs/2602.00776
+- [5] Resolving Latency and Inventory Risk in Market Making with Reinforcement Learning. arXiv:2505.12465. https://arxiv.org/abs/2505.12465
+- [6] Market Making without Regret. arXiv:2411.13993. https://arxiv.org/abs/2411.13993

--- a/docs/torghut/design-system/v5/04-llm-multi-agent-committee-with-deterministic-veto.md
+++ b/docs/torghut/design-system/v5/04-llm-multi-agent-committee-with-deterministic-veto.md
@@ -1,0 +1,132 @@
+# Priority 4: LLM Multi-Agent Committee with Deterministic Veto
+
+## Objective
+Upgrade LLM advisory from single-agent review to a bounded committee architecture that improves reasoning diversity
+while preserving strict deterministic veto authority and execution safety.
+
+## Problem Statement
+Single-agent LLM advisory can miss adversarial failure cases and may overfit prompt behavior. Multi-agent designs can
+improve robustness, but without hard policy boundaries they also increase coordination, hallucination, and latency risk.
+
+## Scope
+### In Scope
+- role-based committee orchestration,
+- structured outputs with confidence and abstain semantics,
+- deterministic veto path that blocks unsafe outputs,
+- trace storage for audit and replay.
+
+### Out of Scope
+- direct order placement by LLM outputs,
+- unconstrained autonomous prompt self-modification in live,
+- bypass of risk/portfolio/execution policy checks.
+
+## Committee Topology
+### Roles
+- `researcher`: explains thesis and expected edge.
+- `risk_critic`: stress-tests downside and constraint violations.
+- `execution_critic`: checks feasibility under microstructure and policy limits.
+- `policy_judge`: validates schema, thresholds, and mandatory contracts.
+
+### Required Output Schema
+Each agent returns:
+- `verdict`: `approve|adjust|veto|abstain|escalate`
+- `confidence`: `[0,1]`
+- `uncertainty`: `low|medium|high`
+- `rationale_short`: <= 280 chars
+- `required_checks`: list of deterministic check IDs
+
+### Decision Aggregation
+- committee output is advisory-only.
+- any mandatory critic `veto` forces final `veto`.
+- missing/invalid schema defaults to `veto` or `abstain` (policy-configurable fail-closed).
+
+## Torghut Integration Points
+- `services/torghut/app/trading/llm/review_engine.py`
+  - add committee orchestrator and aggregator.
+- `services/torghut/app/trading/llm/schema.py`
+  - extend response schema for multi-agent outputs.
+- `services/torghut/app/trading/llm/guardrails.py`
+  - enforce parser and safety contracts.
+- `services/torghut/app/trading/llm/circuit.py`
+  - per-role breaker and global breaker policies.
+- `services/torghut/app/trading/autonomy/policy_checks.py`
+  - hard deterministic veto bridge.
+
+## Deterministic Safety Contract
+- LLM committee is advisory, never authoritative.
+- final execution requires pass from deterministic gate chain.
+- if committee runtime fails or times out, path falls back to deterministic-only mode.
+- all committee inputs/outputs must be persisted with immutable request/response hashes.
+
+## Metrics, SLOs, and Alerts
+### Metrics
+- `llm_committee_requests_total{role}`
+- `llm_committee_latency_ms{role}`
+- `llm_committee_verdict_total{role,verdict}`
+- `llm_committee_schema_error_total`
+- `llm_committee_veto_alignment_rate`
+
+### SLOs
+- schema validation success >= 99.5%.
+- p95 end-to-end committee latency <= configured budget.
+- deterministic veto precedence = 100%.
+
+### Alerts
+- schema/parsing failures above threshold.
+- critic disagreement spikes with low confidence.
+- circuit breaker open events for any mandatory role.
+
+## Evaluation Framework
+### Offline
+- replay historical decisions with shadow committee.
+- compare outcome quality, refusal quality, and false-veto rate.
+
+### Paper
+- bounded advisory rollout by symbol bucket.
+- evaluate net impact on rejected bad trades and approved good trades.
+
+### Promotion Criteria
+- improvement in paper decision quality metrics.
+- no deterministic safety regressions.
+- stable latency and parser error budget.
+
+## Failure Modes and Mitigations
+- role collusion and correlated hallucinations:
+  - mitigation: prompt diversity + independent templates + randomization of context slices.
+- critic over-veto suppresses strategy throughput:
+  - mitigation: calibrated veto thresholds and periodic review dataset.
+- committee latency jeopardizes timely decisions:
+  - mitigation: strict timeout budgets and degrade-to-single-review fallback.
+
+## Rollback Plan
+- `LLM_COMMITTEE_ENABLED=false` restores single-agent advisory.
+- preserve committee traces for diagnostics and tuning.
+- keep deterministic gates unchanged through rollback.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v5-llm-committee-deterministic-veto-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `policyConfigPath`
+  - `artifactPath`
+  - `torghutNamespace`
+- Expected artifacts:
+  - committee runtime + schema updates,
+  - deterministic veto integration,
+  - latency/reliability benchmark report,
+  - replay evaluation pack.
+- Exit criteria:
+  - schema and veto SLOs pass,
+  - advisory-only boundary verified,
+  - rollback rehearsal documented.
+
+## References
+- [1] TradingAgents: Multi-Agents LLM Financial Trading Framework. arXiv:2412.20138. https://arxiv.org/abs/2412.20138
+- [2] QuantAgent: Price-Driven Multi-Agent LLMs for High-Frequency Trading. arXiv:2509.09995. https://arxiv.org/abs/2509.09995
+- [3] QuantAgents: Towards Multi-agent Financial System via Simulated Trading. arXiv:2510.04643. https://arxiv.org/abs/2510.04643
+- [4] TradingGroup: A Multi-Agent Trading System with Self-Reflection and Data-Synthesis. arXiv:2508.17565. https://arxiv.org/abs/2508.17565
+- [5] ATLAS: Adaptive Trading with LLM AgentS Through Dynamic Prompt Optimization and Multi-Agent Coordination. arXiv:2510.15949. https://arxiv.org/abs/2510.15949
+- [6] Enhancing Financial RAG with Agentic AI and Multi-HyDE: A Novel Approach to Knowledge Retrieval and Hallucination Reduction. arXiv:2509.16369. https://arxiv.org/abs/2509.16369

--- a/docs/torghut/design-system/v5/05-fragility-aware-regime-allocation.md
+++ b/docs/torghut/design-system/v5/05-fragility-aware-regime-allocation.md
@@ -1,0 +1,166 @@
+# Priority 5: Fragility-Aware Regime Allocation and Stability Mode
+
+## Objective
+Implement a portfolio/risk allocation layer that dynamically adjusts risk budgets based on regime and market fragility
+signals, reducing tail losses and crowding risk while preserving deterministic control.
+
+## Problem Statement
+Static allocation and risk budgets underperform when liquidity compresses, spreads accelerate, or strategy crowding
+increases. Existing constraints limit gross/notional exposure but do not explicitly encode market fragility states as a
+first-class allocation input.
+
+## Scope
+### In Scope
+- fragility indicator computation (liquidity, spread acceleration, crowding proxies),
+- regime-aware allocation multipliers,
+- stability mode with deterministic notional and turnover clamps,
+- integration with existing autonomy gate and execution policy.
+
+### Out of Scope
+- discretionary human override logic in runtime,
+- replacing the full risk engine,
+- introducing leverage or exposure classes not supported by current policy.
+
+## Target Architecture
+### Components
+1. `FragilityMonitorV5`
+- computes composite fragility score per symbol and portfolio level.
+- emits `normal|elevated|stress|crisis` state.
+
+2. `RegimeAllocatorV5`
+- converts regime + fragility state into budget multipliers.
+- applies symbol, sector, and gross exposure clamps.
+
+3. `StabilityModeController`
+- deterministic behavior under `stress|crisis`:
+  - reduce notional,
+  - cap participation,
+  - raise confidence threshold,
+  - bias to risk-reducing exits.
+
+4. `PromotionGuard`
+- blocks promotion when fragility SLOs fail.
+
+## Allocation Policy Model
+### Inputs
+- `regime_label` from strategy runtime,
+- `fragility_score` and state,
+- realized slippage/churn from TCA,
+- current gross/net and concentration exposure.
+
+### Outputs
+- `budget_multiplier`,
+- `capacity_multiplier`,
+- `max_participation_rate_override`,
+- `abstain_probability_bias`,
+- `stability_mode_active`.
+
+### Deterministic Constraints
+- allocator can only tighten, not loosen, hard risk maxima.
+- any unknown fragility state defaults to conservative (`elevated`).
+- crisis state forces entry restrictions regardless of model confidence.
+
+## Torghut Integration Points
+- `services/torghut/app/trading/portfolio.py`
+  - apply fragility-aware multipliers and allocation audit payload.
+- `services/torghut/app/trading/risk.py`
+  - add fragility-triggered reject reasons.
+- `services/torghut/app/trading/autonomy/gates.py`
+  - include fragility in promotion and runtime gates.
+- `services/torghut/app/trading/execution_policy.py`
+  - accept dynamic participation clamps from stability mode.
+- `argocd/applications/torghut/strategy-configmap.yaml`
+  - policy thresholds and mode toggles.
+
+## Data Contracts
+### Fragility Snapshot (`fragility_snapshot_v1`)
+```json
+{
+  "schema_version": "fragility_snapshot_v1",
+  "event_ts": "2026-02-21T14:50:00Z",
+  "symbol": "SPY",
+  "spread_acceleration": 0.42,
+  "liquidity_compression": 0.37,
+  "crowding_proxy": 0.58,
+  "correlation_concentration": 0.66,
+  "fragility_score": 0.59,
+  "fragility_state": "stress"
+}
+```
+
+### Allocation Audit Extension
+- `fragility_state`
+- `stability_mode_active`
+- `applied_multipliers`
+- `clamp_reasons`
+
+## Metrics, SLOs, and Alerts
+### Metrics
+- `fragility_score{symbol}`
+- `stability_mode_active_total`
+- `allocation_multiplier{regime,fragility_state}`
+- `portfolio_turnover_ratio`
+- `portfolio_drawdown`
+
+### SLOs
+- stress/crisis states trigger deterministic clamp actions at 100% rate.
+- concentration and gross exposure limits never exceeded in stress mode.
+- drawdown tail metrics improve versus baseline over evaluation windows.
+
+### Alerts
+- fragility state elevated/stress without stability mode activation.
+- repeated concentration near limit while crowding proxy remains high.
+- gate/policy mismatch between fragility state and allocation output.
+
+## Verification Plan
+### Offline
+- replay known stress windows and synthetic fragility shocks.
+- compare drawdown, turnover, and recovery vs baseline allocator.
+
+### Paper
+- shadow stress-mode activation by regime bucket.
+- evaluate retained upside vs reduced downside under instability.
+
+### Promotion Criteria
+- improved downside metrics with acceptable opportunity cost.
+- deterministic clamp and rollback behavior validated.
+- complete audit trail for every fragility-triggered allocation decision.
+
+## Failure Modes and Mitigations
+- excessive conservatism during transient noise:
+  - mitigation: hysteresis bands and minimum dwell-time before state transitions.
+- missed fragility detection:
+  - mitigation: ensemble indicators + conservative default policy on missing data.
+- allocator instability during rapid regime transitions:
+  - mitigation: transition smoothing + max step size for multiplier changes.
+
+## Rollback Plan
+- set `FRAGILITY_MODE=observe` to disable enforcement but keep telemetry.
+- set `FRAGILITY_MODE=off` only during incident response with explicit approval.
+- revert to baseline multipliers while preserving snapshot artifacts.
+
+## AgentRun Handoff Bundle
+- `ImplementationSpec`: `torghut-v5-fragility-regime-allocation-v1`
+- Required keys:
+  - `repository`
+  - `base`
+  - `head`
+  - `designDoc`
+  - `riskConfigPath`
+  - `strategyConfigPath`
+  - `artifactPath`
+- Expected artifacts:
+  - fragility monitor module,
+  - allocator integration,
+  - stability-mode policy and tests,
+  - stress replay report.
+- Exit criteria:
+  - clamp behavior deterministic under stress,
+  - risk and drawdown gates pass,
+  - rollback rehearsal complete.
+
+## References
+- [1] BIS Working Paper 1229: Artificial intelligence and market fragility. https://www.bis.org/publ/work1229.htm
+- [2] NBER Working Paper 33351: Artificial Intelligence and Asset Prices. https://www.nber.org/papers/w33351
+- [3] FR-LUX: Friction-Aware, Regime-Conditioned Policy Optimization for Implementable Portfolio Management. arXiv:2510.02986. https://arxiv.org/abs/2510.02986
+- [4] Conformal Prediction for Time-series Forecasting with Change Points. arXiv:2509.02844. https://arxiv.org/abs/2509.02844

--- a/docs/torghut/design-system/v5/06-whitepaper-technique-synthesis.md
+++ b/docs/torghut/design-system/v5/06-whitepaper-technique-synthesis.md
@@ -1,0 +1,83 @@
+# Whitepaper Synthesis: Techniques and Discoveries for Torghut v5
+
+## Purpose
+This document provides a per-paper synthesis of primary research used in the v5 strategy build pack. For each paper,
+it captures the main technique/discovery and the direct implementation implication for Torghut.
+
+## Priority Mapping Legend
+- `P1`: TSFM router + refinement + uncertainty outputs
+- `P2`: conformal uncertainty + regime-shift gates
+- `P3`: microstructure execution intelligence
+- `P4`: LLM multi-agent committee + deterministic veto
+- `P5`: fragility-aware regime allocation
+
+## Synthesis Catalog
+| Paper | Main Technique or Discovery | Torghut Implication | Priority |
+| --- | --- | --- | --- |
+| Chronos: Learning the Language of Time Series (arXiv:2403.07815) | Tokenization + language-model style pretraining for generic time-series forecasting. | Use as a baseline adapter in `ForecastRouterV5`; compare route-level quality by symbol/horizon. | P1 |
+| MOMENT: A Family of Open Time-series Foundation Models (arXiv:2402.03885) | Open TSFM family with transferability across tasks and datasets. | Add as second model family in routing policy for diversity and fallback robustness. | P1 |
+| Re(Visiting) Time Series Foundation Models in Finance (arXiv:2511.18578) | Finance-domain retraining can outperform generic TSFMs for financial excess returns. | Introduce financial fine-tuned adapter variants and require evidence against generic baseline. | P1 |
+| RefineBridge (arXiv:2512.21572) | Bridge-style generative refinement improves financial forecasts from TSFM priors. | Implement optional refinement stage after base adapter inference with strict latency controls. | P1 |
+| ProbFM (arXiv:2601.10591) | Single-pass decomposition of epistemic vs aleatoric uncertainty. | Emit decomposed uncertainty fields in forecast contract and use in gate thresholds. | P1, P2 |
+| FinZero (arXiv:2509.08742) | Large reasoning model with uncertainty-aware optimization for financial forecasting. | Incorporate uncertainty-weighted evaluation metrics for route scoring and promotion decisions. | P1, P2 |
+| Flow-based Conformal Prediction for Multi-dimensional Time Series (arXiv:2502.05709) | Conformalized predictive sets for multi-dimensional series with coverage guarantees. | Build `ConformalEngineV5` and calibrate per-symbol/horizon intervals. | P2 |
+| Conformal Prediction for Time-series Forecasting with Change Points (arXiv:2509.02844) | Change-point-aware conformal procedure for non-stationary series. | Add shift-triggered recalibration and deterministic degrade/abstain policies. | P2, P5 |
+| Temporal Conformal Prediction (TCP) (arXiv:2507.05470) | Distribution-free temporal risk forecasting with adaptive uncertainty handling. | Track temporal coverage drift and enforce uncertainty SLO gates in autonomy. | P2 |
+| FR-LUX (arXiv:2510.02986) | Friction-aware, regime-conditioned optimization to make policies implementable under costs. | Add regime-conditioned execution/adaptation constraints and participation caps. | P3, P5 |
+| A Deterministic LOB Simulator with Hawkes-Driven Order Flow (arXiv:2510.08085) | Reproducible LOB simulator for stress-testing execution assumptions. | Add simulator-backed TCA divergence monitoring and policy calibration lane. | P3 |
+| Diffusive Limit of Hawkes Driven Order Book Dynamics With Liquidity Migration (arXiv:2511.18117) | Theoretical diffusion approximation for Hawkes LOB dynamics with migration effects. | Use as grounding for liquidity-state transitions and risk-aware execution throttles. | P3 |
+| Explainable Patterns in Cryptocurrency Microstructure (arXiv:2602.00776) | Interpretable microstructure features with cross-asset predictive value. | Extend microstructure feature stack and adverse-selection risk signals. | P3 |
+| Resolving Latency and Inventory Risk in Market Making with RL (arXiv:2505.12465) | RL policy balancing latency and inventory risk under practical constraints. | Add bounded execution advisor logic around urgency and participation. | P3 |
+| Market Making without Regret (arXiv:2411.13993) | No-regret style market-making framework with robust learning guarantees. | Add conservative adaptation bounds and regret diagnostics for advisor updates. | P3 |
+| TradingAgents: Multi-Agents LLM Financial Trading Framework (arXiv:2412.20138) | Role-based LLM trading agents can improve reasoning breadth. | Implement committee topology with separated roles and policy-bound outputs. | P4 |
+| QuantAgent: Price-Driven Multi-Agent LLMs for HFT (arXiv:2509.09995) | Price-driven multi-agent architecture for short-horizon financial decisions. | Add structured high-frequency decision context fields and stricter timing budgets. | P4 |
+| QuantAgents: Towards Multi-agent Financial System via Simulated Trading (arXiv:2510.04643) | Simulated market environment for evaluating multi-agent finance workflows. | Use simulation-backed replay suite for committee policy regression and tuning. | P4 |
+| TradingGroup: Multi-Agent Trading with Self-Reflection and Data-Synthesis (arXiv:2508.17565) | Multi-agent self-reflection can improve strategy iteration quality. | Add bounded self-critique stage with deterministic veto precedence. | P4 |
+| ATLAS: Adaptive Trading with LLM AgentS (arXiv:2510.15949) | Dynamic prompt optimization and multi-agent coordination for trading adaptation. | Restrict adaptive prompt updates to paper-only lanes with approval and replay evidence. | P4 |
+| Enhancing Financial RAG with Agentic AI and Multi-HyDE (arXiv:2509.16369) | Multi-query retrieval design reduces hallucination and improves retrieval quality. | Upgrade financial context retrieval for committee inputs with provenance and confidence scores. | P4 |
+| BIS Working Paper 1229: Artificial intelligence and market fragility | Evidence that AI adoption can amplify fragility under stress and crowding conditions. | Justifies stability mode and fragility-aware allocation clamps. | P5 |
+| NBER Working Paper 33351: Artificial Intelligence and Asset Prices | AI can alter price efficiency and crowding dynamics in asset pricing. | Add crowding proxies and regime-aware risk budget throttles in allocator policy. | P5 |
+| Towards Temporal-Aware Multi-Modal RAG in Finance (arXiv:2503.05185) | Temporal alignment in financial RAG improves relevance and downstream reliability. | Improve LLM committee context quality and temporal grounding for policy checks. | P4 |
+
+## Technique Clusters
+### Forecasting and Uncertainty (P1/P2)
+- Core discovery: gains come from adaptive model selection and calibrated uncertainty, not single-model confidence.
+- Engineering implication: route decisions and uncertainty need first-class audit contracts and promotion gates.
+
+### Execution and Microstructure (P3)
+- Core discovery: realized edge depends on friction-aware policy and microstructure-state adaptation.
+- Engineering implication: TCA must be simulator-calibrated and continuously compared to realized fills.
+
+### LLM Committee Intelligence (P4)
+- Core discovery: multi-agent setups improve coverage but need strict role boundaries and fail-closed policy checks.
+- Engineering implication: deterministic veto remains authoritative, with full traceability and replay tests.
+
+### Fragility and Allocation (P5)
+- Core discovery: AI-driven crowding and liquidity fragility require explicit stability controls.
+- Engineering implication: allocator/risk policy should consume fragility state and degrade safely under stress.
+
+## Source Links
+- https://arxiv.org/abs/2403.07815
+- https://arxiv.org/abs/2402.03885
+- https://arxiv.org/abs/2511.18578
+- https://arxiv.org/abs/2512.21572
+- https://arxiv.org/abs/2601.10591
+- https://arxiv.org/abs/2509.08742
+- https://arxiv.org/abs/2502.05709
+- https://arxiv.org/abs/2509.02844
+- https://arxiv.org/abs/2507.05470
+- https://arxiv.org/abs/2510.02986
+- https://arxiv.org/abs/2510.08085
+- https://arxiv.org/abs/2511.18117
+- https://arxiv.org/abs/2602.00776
+- https://arxiv.org/abs/2505.12465
+- https://arxiv.org/abs/2411.13993
+- https://arxiv.org/abs/2412.20138
+- https://arxiv.org/abs/2509.09995
+- https://arxiv.org/abs/2510.04643
+- https://arxiv.org/abs/2508.17565
+- https://arxiv.org/abs/2510.15949
+- https://arxiv.org/abs/2509.16369
+- https://arxiv.org/abs/2503.05185
+- https://www.bis.org/publ/work1229.htm
+- https://www.nber.org/papers/w33351

--- a/docs/torghut/design-system/v5/index.md
+++ b/docs/torghut/design-system/v5/index.md
@@ -1,0 +1,43 @@
+# Torghut Design System v5: Production Quant + LLM Strategy Build Pack
+
+## Status
+- Version: `v5`
+- Date: `2026-02-21`
+- Maturity: `production-quality design pack`
+- Scope: 5 prioritized new-feature strategy builds plus whitepaper synthesis
+
+## Purpose
+This pack expands the top 5 strategy priorities into implementation-grade designs with:
+- explicit architecture and data contracts,
+- deterministic safety boundaries,
+- rollout, rollback, and SLO gates,
+- verification plans and acceptance criteria,
+- direct citations to original white papers.
+
+## Non-Negotiable Invariants
+- `paper` remains default mode; live requires explicit gates and approval token flow.
+- deterministic risk/kill-switch controls remain final authority.
+- LLM components can propose, critique, and abstain but cannot bypass deterministic execution policy.
+- each promotion decision must include reproducible evidence artifacts.
+
+## Document Set
+1. `01-tsfm-router-refinement-and-uncertainty.md`
+2. `02-conformal-uncertainty-and-regime-gates.md`
+3. `03-microstructure-execution-intelligence.md`
+4. `04-llm-multi-agent-committee-with-deterministic-veto.md`
+5. `05-fragility-aware-regime-allocation.md`
+6. `06-whitepaper-technique-synthesis.md`
+
+## Recommended Build Order
+1. `02-conformal-uncertainty-and-regime-gates.md`
+2. `01-tsfm-router-refinement-and-uncertainty.md`
+3. `03-microstructure-execution-intelligence.md`
+4. `05-fragility-aware-regime-allocation.md`
+5. `04-llm-multi-agent-committee-with-deterministic-veto.md`
+
+## Why This Sequence
+- uncertainty gates are foundational controls for every downstream model path.
+- TSFM routing/refinement upgrades signal quality once gating exists.
+- execution intelligence captures realized PnL improvements by lowering slippage/impact.
+- fragility-aware allocation protects tails before wider autonomy.
+- committee-style LLM orchestration is highest complexity and should sit on hardened controls.


### PR DESCRIPTION
## Summary

- Added a new `v5` Torghut design pack with 5 production-grade strategy build documents and one whitepaper synthesis document.
- Expanded each priority into implementation-ready details: architecture, contracts, deterministic safety controls, SLOs, rollout/rollback, and AgentRun handoff bundles.
- Added a design-system README entry for `v5` with entrypoint and scope.

## Related Issues

None

## Testing

- `rg -o 'https://[^ )]+' docs/torghut/design-system/v5/*.md | cut -d: -f2- | sort -u > /tmp/v5_urls.txt && while IFS= read -r u; do code=$(curl -L -s -o /dev/null -w "%{http_code}" "$u"); echo "$code $u"; done < /tmp/v5_urls.txt`
- Manual validation: reviewed all new docs for structure, completeness, and citation consistency.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
