### PR TITLE
docs(shirya): organize spreadsheet design docs

### DIFF
--- a/docs/shirya/shirya-library-selection-research.md
+++ b/docs/shirya/shirya-library-selection-research.md
@@ -1,0 +1,93 @@
+# Shirya Library Selection Research (OSS-Only, High Excel Compatibility)
+
+Status: Completed (2026-02-21)
+
+## Requirement Baseline
+- Must be truly open-source for the required runtime components.
+- Must provide high compatibility with Excel formulas/behavior.
+- Must be actively maintained (no stale or abandoned core dependency).
+
+## What Changed From Prior Recommendation
+`FortuneSheet` was removed from the primary recommendation.
+
+Reason: while not fully dead, its release cadence and formula stack confidence are weaker for a high-compatibility requirement compared to currently active alternatives. For this requirement, we should optimize for compatibility guarantees first.
+
+## Final Recommended Stack
+1. UI/runtime: `jspreadsheet-ce` (MIT)
+2. Formula engine: `hyperformula` (GPL-3.0-only)
+3. CRDT model: `yjs` (MIT)
+4. Offline provider: `y-indexeddb` (MIT)
+5. Realtime provider: `y-websocket` (MIT)
+6. Collaboration backend: `@hocuspocus/server` (MIT)
+7. Browser persistence for non-CRDT state: `dexie` (Apache-2.0)
+8. Backend event stream between sync/calc services: `nats` (Apache-2.0)
+
+## Why This Stack
+- `HyperFormula` explicitly documents Excel and Google Sheets compatibility tracks, a differences list, and a large built-in function set (~400). This is the strongest OSS formula compatibility path currently available in JS.
+- `Jspreadsheet CE` gives an actively maintained OSS spreadsheet UI with Excel-like interactions (copy/paste shortcuts, formulas, keyboard navigation) and MIT licensing.
+- `Yjs + Hocuspocus` remains the most mature OSS local-first collaboration path in the web ecosystem.
+
+## Maintenance Evidence (as of 2026-02-21)
+
+| Component | npm latest | npm latest publish | Weekly npm downloads | Last Git commit | License | Decision |
+|---|---|---|---:|---|---|---|
+| `jspreadsheet-ce` | `5.0.4` | 2025-08-25 | 43,108 | 2026-02-20 | MIT (repo license file) | Selected |
+| `hyperformula` | `3.2.0` | 2026-02-19 | 194,635 | 2026-02-20 | GPL-3.0-only | Selected |
+| `yjs` | `13.6.29` | 2026-01-03 | 2,391,925 | 2026-02-15 | MIT | Selected |
+| `y-websocket` | `3.0.0` | 2025-04-02 | 218,477 | 2026-02-18 | MIT | Selected |
+| `y-indexeddb` | `9.0.12` | 2023-11-02 | 187,267 | N/A (provider package) | MIT | Selected |
+| `@hocuspocus/server` | `3.4.4` | 2026-01-25 | 175,874 | 2026-02-20 | MIT | Selected |
+| `dexie` | `4.3.0` | 2025-12-20 | 989,535 | 2026-02-18 | Apache-2.0 | Selected |
+| `nats` | `2.29.3` | 2025-03-19 | 460,865 | 2026-02-11 | Apache-2.0 | Selected |
+| `@fortune-sheet/core` | `1.0.4` | 2025-11-06 | 17,950 | 2025-11-06 | MIT | Not selected |
+
+## Rejected / Conditional
+- `FortuneSheet`: removed as primary due lower confidence for high Excel compatibility and slower activity signal versus alternatives.
+- `AG Grid Community`: MIT and actively maintained, but spreadsheet-like features are split by Community vs Enterprise boundaries; not ideal as the primary OSS spreadsheet runtime for this project.
+- `Univer`: OSS core exists, but mixed OSS + Pro product model does not align with strict OSS-only policy for this project.
+
+## Build-From-Scratch Considerations
+Even with the selected stack, some critical components must be built in-house.
+
+### Must Build In-House (recommended regardless)
+1. Shirya workbook model and operation protocol.
+2. CRDT-to-grid binding layer (Yjs doc <-> UI updates).
+3. Backend authoritative calc pipeline (op log -> calc run -> patch stream).
+4. Conflict UX and reconciliation telemetry.
+5. Compatibility harness against real Excel fixtures.
+
+### Full Scratch Option (if you reject GPL formula engines)
+You would need to build a full formula engine stack:
+1. Parser + AST + dependency graph.
+2. Function library semantics + type coercion matching Excel.
+3. Volatile function behavior (`NOW`, `RAND`, etc.).
+4. Error model parity (`#REF!`, `#VALUE!`, etc.).
+5. Array formula and named range semantics.
+
+This is high-risk and requires substantial engineering investment before reliable Excel-level behavior.
+
+### Recommended Path
+1. Use `hyperformula` as compatibility core now.
+2. Build Shirya-specific UX/sync/calc orchestration around it.
+3. Keep formula API abstracted so engine can be swapped later if licensing strategy changes.
+
+## Sources
+- HyperFormula docs: https://hyperformula.handsontable.com/
+- HyperFormula compatibility pages:
+  - https://hyperformula.handsontable.com/guide/compatibility-with-microsoft-excel.html
+  - https://hyperformula.handsontable.com/guide/list-of-differences.html
+- HyperFormula licensing page: https://hyperformula.handsontable.com/guide/licensing.html
+- Jspreadsheet CE repo: https://github.com/jspreadsheet/ce
+- Jspreadsheet CE npm: https://www.npmjs.com/package/jspreadsheet-ce
+- AG Grid Community vs Enterprise: https://www.ag-grid.com/javascript-data-grid/community-vs-enterprise/
+- Yjs docs: https://docs.yjs.dev/
+- y-websocket docs: https://docs.yjs.dev/ecosystem/connection-provider/y-websocket
+- y-indexeddb docs: https://docs.yjs.dev/getting-started/allowing-offline-editing
+- Hocuspocus docs: https://tiptap.dev/docs/hocuspocus/getting-started/overview
+- Dexie docs: https://dexie.org/docs/Tutorial/Getting-started
+- NATS.js repo: https://github.com/nats-io/nats.js
+
+## Data Collection Method
+- npm metadata: `npm view <package> version time license`
+- npm download velocity: `https://api.npmjs.org/downloads/point/last-week/<package>`
+- Repository recency: `git clone --depth 1` + `git log -1 --date=iso-strict`

--- a/docs/shirya/shirya-local-first-spreadsheet-design.md
+++ b/docs/shirya/shirya-local-first-spreadsheet-design.md
@@ -1,0 +1,281 @@
+# Shirya: Local-First Realtime Spreadsheet Design
+
+Status: Proposed (2026-02-21)
+
+## Name
+- Product/library name: `Shirya`
+- Origin: from Kalmyk `ширә` (table)
+
+## Summary
+`Shirya` is a local-first spreadsheet platform for web apps with Excel-like formulas, interactive editing, and near-real-time collaboration.
+
+The system has two cooperating runtime layers:
+1. A frontend library that provides interactive spreadsheet UX, local persistence, formula evaluation, and optimistic updates.
+2. A backend sync+calc layer that streams operations/results in near real time, performs server-side recalculation for consistency, and fans out updates to other clients.
+
+## Problem Statement
+The website needs Excel-replicated behavior but cannot depend exclusively on remote round-trips for every edit. Users must keep working with low latency while offline/intermittent, and still converge to a shared, correct workbook state.
+
+## Goals
+- Excel-compatible formula authoring and evaluation for core business functions.
+- Interactive editing experience (keyboard, selection, fill handle, copy/paste, formula assist) with immediate feedback.
+- Local-first behavior: edits apply locally first, then sync in background.
+- Near-real-time multi-user sync with conflict resolution and deterministic convergence.
+- Dual calculation execution: local engine for immediacy, backend engine for authoritative consistency and streaming fan-out.
+
+## Non-Goals (v1)
+- Full 100% parity with every Excel feature (macros/VBA, PowerQuery, PivotTables).
+- Binary `.xlsx` runtime as storage of truth (import/export supported later as adapters).
+- Arbitrary user-defined native code execution in formulas.
+
+## Functional Requirements
+1. Workbook primitives: sheets, cells, ranges, row/column ops, named ranges, basic formatting metadata.
+2. Formula support:
+   - A1 notation and cross-sheet references.
+   - Core Excel functions (minimum): `SUM`, `AVERAGE`, `MIN`, `MAX`, `COUNT`, `COUNTA`, `IF`, `IFS`, `AND`, `OR`, `NOT`, `XLOOKUP` or `INDEX/MATCH`, `VLOOKUP` (compat), `SUMIF`, `SUMIFS`, `DATE`, `TODAY`, `NOW`, text functions (`LEFT`, `RIGHT`, `MID`, `CONCAT`, `TEXT`).
+   - Relative/absolute references (`A1`, `$A$1`, `A$1`, `$A1`).
+   - Dependency recalculation after every edit.
+3. Interactivity:
+   - Cell selection and range selection.
+   - Keyboard-first editing and navigation.
+   - Multi-cell paste.
+   - Fill handle and drag operations.
+   - Formula bar + in-cell edit mode.
+4. Local-first:
+   - Works offline with local queue.
+   - Local writes visible immediately.
+   - Sync resumes automatically when connection returns.
+5. Realtime collaboration:
+   - Multi-client updates propagate in near real time.
+   - Remote edits update local grid and affected formula outputs.
+6. Backend stream:
+   - Server streams op deltas and authoritative calc outputs to subscribers.
+
+## Non-Functional Requirements
+- Local edit-to-paint latency (p95): < 16 ms for visible cells.
+- Local recalc latency (p95): < 50 ms for medium dependency graphs (target: 10k formula cells).
+- Remote propagation latency (p95): < 300 ms intra-region.
+- Deterministic recomputation: same inputs and function set => same outputs.
+- Durability: acknowledged operations persist server-side before broadcast.
+
+## Architecture Overview
+```mermaid
+flowchart LR
+  U[User] --> UI[Frontend Spreadsheet UI]
+  UI --> FE[Shirya Frontend Library]
+  FE --> LDB[(IndexedDB Local Store)]
+  FE --> LCalc[Local Formula Engine]
+  FE <-->|WebSocket| SG[Sync Gateway]
+  SG --> OLog[(Operation Log)]
+  SG --> BCalc[Backend Calc Engine]
+  BCalc --> Snap[(Workbook Snapshot Store)]
+  SG --> PubSub[(Stream Fanout)]
+  PubSub --> FE
+```
+
+## Selected Libraries
+- Spreadsheet runtime: `jspreadsheet-ce` (MIT)
+- Formula engine (high Excel compatibility): `hyperformula` (GPL-3.0-only)
+- CRDT/local-first core: `yjs`
+- Offline browser persistence: `y-indexeddb`
+- Collaboration transport: `y-websocket`
+- Collaboration backend: `@hocuspocus/server`
+- Local app IndexedDB abstraction: `dexie`
+- Backend service event stream: `nats` (JetStream)
+
+If GPL copyleft is not acceptable for your distribution model:
+- Replace `hyperformula` with a Shirya in-house formula engine and treat this as a dedicated build-from-scratch stream.
+
+Library research and maintenance evidence is documented in:
+- `docs/shirya/shirya-library-selection-research.md`
+
+## Frontend Library Design
+Package split:
+- `@proompteng/shirya-core`: workbook model, op log, formula parser/evaluator, dependency graph.
+- `@proompteng/shirya-react`: React bindings, hooks, keyboard handlers, virtualization adapters.
+- `@proompteng/shirya-sync`: websocket transport, retry, ack tracking, snapshot/bootstrap.
+
+Core responsibilities:
+- Keep local authoritative working state for UI responsiveness.
+- Apply user operations optimistically and enqueue for sync.
+- Recalculate impacted dependency subgraphs immediately.
+- Merge remote ops and authoritative calc corrections.
+
+Frontend state model:
+- `WorkbookState`: sheet metadata, cell payloads, dependency graph index, version vector.
+- `PendingOpsQueue`: ordered operations not yet acknowledged.
+- `CalcState`: dirty nodes, recompute batches, error states (`#REF!`, `#VALUE!`, circular).
+
+## Backend Design
+Services:
+1. Sync Gateway
+- Authenticates clients.
+- Accepts operation batches.
+- Assigns monotonic commit sequence.
+- Persists ops to durable log.
+- Broadcasts committed ops to subscribers.
+
+2. Calc Engine Service
+- Rebuilds workbook state from snapshot + op stream.
+- Runs authoritative recomputation for impacted graph.
+- Emits calc result patches (value, type, error, provenance).
+- Supports horizontal sharding by workbook id.
+
+3. Snapshot Service/Store
+- Periodic compact snapshots to bound replay cost.
+- Provides fast bootstrap for reconnecting clients.
+
+## Data Model
+Cell payload:
+```ts
+interface CellPayload {
+  address: string;           // e.g., "B12"
+  input?: string;            // raw user input, including formula string "=SUM(A1:A10)"
+  value?: ScalarValue;       // computed or literal value
+  valueType: 'number' | 'string' | 'boolean' | 'date' | 'error' | 'blank';
+  formulaAst?: FormulaAst;
+  format?: CellFormat;
+  revision: string;          // op revision/version
+}
+```
+
+Operation envelope:
+```ts
+interface WorkbookOp {
+  opId: string;
+  workbookId: string;
+  actorId: string;
+  baseVersion: string;
+  timestampMs: number;
+  type: 'set_cell' | 'clear_cell' | 'insert_row' | 'delete_row' | 'insert_col' | 'delete_col' | 'rename_sheet';
+  payload: Record<string, unknown>;
+}
+```
+
+## Formula Engine Strategy
+Parser and evaluator:
+- Parse Excel-style syntax into AST.
+- Maintain dependency graph keyed by cell address.
+- Recompute only dirty descendants (incremental topological recalc).
+- Detect cycles and emit deterministic circular-reference errors.
+
+Compatibility strategy:
+- Function registry with compatibility tiers (`core`, `extended`, `beta`).
+- Strict argument coercion rules aligned to Excel behavior where feasible.
+- Unsupported functions return explicit `#NAME?` with telemetry for prioritization.
+
+Determinism rules:
+- Normalize floating-point operations with configurable precision policy.
+- Track timezone and locale as workbook-level settings for date/time formulas.
+- Volatile functions (`NOW`, `TODAY`, `RAND`) are evaluated under explicit recalculation policy.
+
+## Local-First Sync Model
+Approach:
+- Op-based replication with per-workbook ordered commits.
+- Client generates ops locally and applies immediately.
+- Server acks each op with committed sequence.
+- Client rebases pending local ops on incoming remote commits.
+
+Conflict handling:
+- Same-cell concurrent edits: last-committed-wins on input layer, with conflict event stream for audit/UX indicators.
+- Structural conflicts (row/col insert/delete): resolve via stable row/column ids, not positional indexes only.
+- Formula/value races: formula input always owns computed output field; manual value entry clears formula unless explicit override mode is enabled.
+
+## Streaming Protocol
+Transport:
+- WebSocket primary; SSE fallback for read-only streams.
+
+Client -> server messages:
+- `hello`, `subscribe`, `op_batch`, `ack`, `resync_request`.
+
+Server -> client messages:
+- `snapshot_chunk`, `op_commit`, `calc_patch`, `presence`, `resync_required`.
+
+Backpressure:
+- Sequence-based catch-up windows.
+- Snapshot handoff when lag exceeds configured threshold.
+
+## Interaction Model (UX)
+Interactive guarantees:
+- Editing never blocks on network.
+- Formula preview updates while typing.
+- Error highlights and dependency tracing are immediate.
+- Undo/redo stack is local-first and sync-aware.
+
+Accessibility and ergonomics:
+- Keyboard parity for common spreadsheet actions.
+- Screen-reader labels for active cell/range and formula errors.
+- Large-sheet virtualization for smooth scrolling.
+
+## Consistency Contract
+- Frontend local calc is immediate but provisional.
+- Backend calc is authoritative for shared state.
+- If divergence occurs, backend `calc_patch` wins and client records a reconciliation event.
+
+This preserves interactive speed without sacrificing cross-client correctness.
+
+## Security and Multi-Tenancy
+- Workbook access controlled by tenant/workspace authn/authz.
+- All websocket channels scoped by workbook ACL.
+- Operation and calc logs are tenant-partitioned.
+- Formula execution sandboxed; no direct network/file access from formula runtime.
+
+## Observability
+Metrics:
+- `local_edit_latency_ms`
+- `local_recalc_latency_ms`
+- `sync_ack_latency_ms`
+- `remote_apply_latency_ms`
+- `calc_divergence_count`
+- `unsupported_formula_function_count`
+
+Tracing:
+- Correlate user op -> server commit -> calc patch -> client paint.
+
+## Rollout Plan
+Phase 1: Single-user local-first MVP
+- Local engine + IndexedDB + snapshot import/export.
+- No collaboration, no backend authoritative calc.
+
+Phase 2: Realtime sync collaboration
+- Sync gateway, op log, subscriptions, optimistic ack flow.
+
+Phase 3: Authoritative backend calc
+- Calc engine service + correction patches + divergence telemetry.
+
+Phase 4: Excel compatibility expansion
+- Add high-demand functions based on telemetry.
+- Import/export adapters for `.xlsx`.
+
+## Testing Strategy
+Unit:
+- Parser/evaluator tests for each supported function and coercion edge cases.
+- Dependency graph/cycle detection tests.
+
+Integration:
+- Client/server op replay determinism.
+- Concurrent edit conflict cases.
+- Offline -> reconnect -> rebase correctness.
+
+Regression:
+- Golden workbook fixtures compared against expected outputs.
+- Formula compatibility suite against selected Excel-equivalent cases.
+
+Load:
+- Recalc and fan-out under concurrent editors.
+- Lag and recovery behavior for slow clients.
+
+## Risks and Mitigations
+- Risk: Excel parity gaps cause user distrust.
+- Mitigation: publish compatibility matrix and telemetry-driven prioritization.
+
+- Risk: Divergence between local and server calc semantics.
+- Mitigation: shared evaluator core/library and deterministic numeric/date settings.
+
+- Risk: Large-sheet performance degradation.
+- Mitigation: incremental recompute, viewport virtualization, snapshot compaction.
+
+## Open Questions
+1. Should v1 include collaborative presence (cursor/selection) or defer to phase 2.5?
+2. Should backend authoritative calc be mandatory for all tenants or configurable by workbook size/risk profile?
+3. Do we need strict Excel date serial compatibility mode from day one?

--- a/docs/shirya/shirya-near-excel-ux-parity-design.md
+++ b/docs/shirya/shirya-near-excel-ux-parity-design.md
@@ -1,0 +1,253 @@
+# Shirya: Near-Excel UX Parity Library Design
+
+Status: Proposed (2026-02-21)
+
+## Name
+- Product/library name: `Shirya`
+- Origin: from Kalmyk `ширә` (table)
+
+## Objective
+Design `Shirya` as a local-first, real-time spreadsheet library with near-Excel interaction parity for web applications, while remaining fully open-source in the runtime stack.
+
+## Scope
+- In scope:
+  - Excel-like interactive spreadsheet UX in browser.
+  - High formula compatibility and deterministic recalculation.
+  - Local-first editing with collaborative sync and backend authoritative reconciliation.
+  - `.xlsx` import/export adapters with defined fidelity rules.
+- Out of scope:
+  - VBA/macros execution.
+  - Power Query, OLAP pivots, and all desktop-only Excel integrations.
+  - Perfect 100% parity for every legacy Excel edge case.
+
+## Design Principles
+1. Interaction-first parity: keyboard and editing behavior must feel native to spreadsheet users.
+2. Local-first correctness: edits are instant locally, then reconciled with server authority.
+3. Deterministic outcomes: same workbook + same inputs => same computed outputs.
+4. Explicit compatibility boundaries: unsupported features surface clear messages, never silent corruption.
+5. OSS-only runtime: no required proprietary dependency for core editing/calc/sync loop.
+
+## Parity Definition
+`Near-Excel UX parity` means:
+- Familiar grid behavior for common spreadsheet workflows.
+- Formula authoring and recalculation behavior that matches Excel in high-value cases.
+- Import/export that preserves most business-critical structures and formulas.
+- Predictable, documented differences where parity is not feasible.
+
+## Capability Contract
+### Required parity domains
+1. Grid interaction:
+   - Cell/range selection, multi-range selection, keyboard navigation.
+   - In-cell edit mode and formula bar editing with commit/cancel semantics.
+   - Fill handle, drag copy, drag move, row/column insert/delete/resize/hide.
+2. Editing workflows:
+   - Clipboard interoperability (plain text/TSV/HTML table forms).
+   - Undo/redo for user and collaborative operations.
+   - Context menus and shortcut behavior for frequent operations.
+3. Formula workflows:
+   - A1 references, mixed refs, cross-sheet references, named ranges.
+   - Function autocomplete/help, error highlighting, precedent/dependent tracing.
+   - Volatile function policy with deterministic replay behavior.
+4. View/state:
+   - Frozen panes, filters, sort, tabs/sheet operations.
+   - Efficient virtualization for large grids.
+5. Collaboration:
+   - Presence indicators, remote cursor/range hints, conflict visibility.
+   - Local-first optimistic updates with server reconciliation patches.
+
+### Deferred parity domains
+- Pivot tables, chart editing parity, full conditional-format rule UI parity, advanced data tools.
+- Dynamic array corner cases requiring specialized evaluator behavior beyond initial formula scope.
+
+## System Architecture
+```mermaid
+flowchart LR
+  U["User Input"] --> UI["Shirya Grid UI Layer"]
+  UI --> INT["Interaction Engine"]
+  INT --> WM["Workbook Model"]
+  WM --> FE["Formula Engine Adapter"]
+  WM --> CRDT["CRDT Sync Adapter (Yjs)"]
+  CRDT --> LDB["Local Persistence (IndexedDB)"]
+  CRDT <-->|"WebSocket"| SG["Sync Gateway"]
+  SG --> OLOG["Operation Log"]
+  OLOG --> BCALC["Backend Calc Service"]
+  BCALC --> PATCH["Authoritative Calc Patches"]
+  PATCH --> SG
+  SG --> UI
+```
+
+## Library Modules
+1. `@proompteng/shirya-grid`
+   - Virtualized canvas/DOM hybrid grid rendering.
+   - Selection, active cell, edit-state machine.
+   - Accessibility labels, focus model, keyboard dispatcher.
+2. `@proompteng/shirya-workbook`
+   - Workbook/sheet/cell model with stable row/column IDs.
+   - Structural mutations and operation serialization.
+   - Undo/redo journal with operation grouping.
+3. `@proompteng/shirya-formula-adapter`
+   - Formula engine abstraction boundary.
+   - Runtime adapter for `hyperformula` (or compatible replacement).
+   - Dependency graph invalidation and incremental recalc triggers.
+4. `@proompteng/shirya-sync`
+   - Local op queue, ack tracking, rebase logic.
+   - CRDT bindings and transport protocol integration.
+   - Snapshot bootstrap and resync path.
+5. `@proompteng/shirya-interop`
+   - `.xlsx` import/export transformation layer.
+   - Clipboard conversion utilities and fidelity checks.
+
+## Interaction Engine Design
+State machine modes:
+- `idle`
+- `selecting`
+- `editing_cell`
+- `editing_formula_bar`
+- `drag_fill`
+- `drag_move`
+- `clipboard_paste_preview`
+
+Core interaction rules:
+1. Entering edit mode does not lose selection context.
+2. Keyboard navigation after commit mirrors spreadsheet expectations:
+   - `Enter`, `Shift+Enter`, `Tab`, `Shift+Tab`, arrow keys.
+3. Multi-cell paste applies shape-aware placement; overflow conflicts produce visible warnings.
+4. Fill handle supports:
+   - copy-fill,
+   - linear trend fill,
+   - date series fill,
+   - formula relative-reference propagation.
+5. Undo/redo is operation-aware and collaboration-safe:
+   - local operations are reversible in order,
+   - remote operations create non-reversible boundaries unless explicitly grouped by policy.
+
+## Formula Engine Integration
+### Why headless is correct
+The formula runtime should remain separate from UI. This allows:
+- deterministic server-side recomputation,
+- engine swap flexibility,
+- easier parity testing.
+
+### Adapter contract
+```ts
+interface FormulaAdapter {
+  setCellInput(sheetId: string, address: string, input: string): void;
+  clearCell(sheetId: string, address: string): void;
+  applyStructureChange(change: StructureChange): void;
+  recalc(changed: CellRef[]): CalcPatch[];
+  getCellValue(sheetId: string, address: string): EvaluatedValue;
+  getDependencies(sheetId: string, address: string): CellRef[];
+}
+```
+
+Engine behavior requirements:
+- Strict coercion policy with documented Excel-aligned behavior.
+- Stable error propagation (`#REF!`, `#VALUE!`, `#DIV/0!`, `#NAME?`, circular refs).
+- Locale/timezone normalization at workbook level.
+- Volatile function evaluation policy that supports replay consistency.
+
+## Local-First + Realtime Collaboration
+Data flow:
+1. User action emits local operation.
+2. Operation applies immediately to local model.
+3. Formula adapter recalculates impacted graph locally.
+4. Operation is sent to sync gateway for commit.
+5. Backend calc emits authoritative patches.
+6. Client reconciles provisional vs authoritative values.
+
+Conflict policy:
+- Cell input conflicts: commit-order winner for input value, plus conflict event metadata.
+- Structural conflicts: resolved against stable row/column IDs, not visual index only.
+- Formula/value conflicts: formula input controls computed value field by default.
+
+## Excel Interop Strategy
+### Import
+- Parse `.xlsx` into normalized workbook model.
+- Preserve:
+  - sheet names/order,
+  - cell formulas,
+  - key number/date formats,
+  - merged region metadata,
+  - named ranges where representable.
+- Record non-representable features in import diagnostics.
+
+### Export
+- Generate `.xlsx` from workbook model using explicit fidelity mapping.
+- Include metadata markers for unsupported constructs when round-trip loss is possible.
+
+### Fidelity classes
+1. `Exact`: round-trips with no semantic drift.
+2. `Compatible`: behavior preserved with representational changes.
+3. `Degraded`: output preserved partially; warnings required.
+4. `Unsupported`: explicit block with reason and remediation note.
+
+## Performance Model
+- Virtualize rows/columns with overscan tuned by scroll velocity.
+- Keep visible-region render path independent from full workbook size.
+- Recalc only dirty dependency descendants.
+- Batch remote patch applies into animation-frame-sized units.
+- Keep clipboard, fill, and selection logic allocation-light to avoid UI jank.
+
+## Accessibility Model
+- ARIA semantics for grid, row/column headers, active cell, and formula errors.
+- Full keyboard coverage for non-pointer workflows.
+- High-contrast mode compatibility and visible focus indicators.
+- Screen-reader announcements for:
+  - active cell changes,
+  - formula error states,
+  - range selection updates.
+
+## OSS Runtime Stack (Current)
+- Grid runtime: `jspreadsheet-ce` (MIT)
+- Formula engine: `hyperformula` (GPL-3.0-only)
+- Local-first CRDT: `yjs` (MIT)
+- Offline provider: `y-indexeddb` (MIT)
+- Realtime provider: `y-websocket` (MIT)
+- Collaboration backend: `@hocuspocus/server` (MIT)
+- Local app DB helper: `dexie` (Apache-2.0)
+- Backend event stream: `nats` (Apache-2.0)
+
+## Build-From-Scratch Considerations
+If formula engine licensing/constraints require replacement, `Shirya` must add:
+1. Excel-compatible formula parser and AST.
+2. Dependency graph and incremental recompute executor.
+3. Function semantics library with coercion and error parity.
+4. Array/range evaluation engine.
+5. Compatibility harness versus Excel fixture workbooks.
+
+Even with existing OSS libraries, these Shirya-owned components are still mandatory:
+1. Interaction engine and keyboard parity layer.
+2. Operation protocol and CRDT/model binding.
+3. Backend authoritative calc reconciliation pipeline.
+4. Import/export fidelity diagnostics and user-facing compatibility warnings.
+
+## Validation Strategy
+1. Behavioral parity suite:
+   - Golden workbooks with expected values/errors.
+   - Cross-check results against Excel-generated fixtures.
+2. Interaction parity suite:
+   - Keyboard and selection scenario playback tests.
+   - Clipboard and fill-handle cross-browser tests.
+3. Collaboration suite:
+   - Concurrent edit simulations across clients.
+   - Offline/reconnect/rebase correctness checks.
+4. Interop suite:
+   - `.xlsx` import/export round-trip checks with fidelity-class assertions.
+5. Accessibility suite:
+   - Automated a11y scans + keyboard-only manual runs.
+
+## Risks and Mitigations
+1. Formula edge-case mismatch with Excel.
+   - Mitigation: compatibility suite expansion driven by telemetry.
+2. Collaboration complexity in structural edits.
+   - Mitigation: stable IDs + deterministic transform rules.
+3. Performance regressions on very large workbooks.
+   - Mitigation: virtualization, dirty-graph recalc, patch batching, perf CI gates.
+4. Licensing drift in dependencies.
+   - Mitigation: automated OSS license audit in CI and adapter boundaries for swap options.
+
+## Success Criteria
+- Spreadsheet users can execute primary Excel-like workflows without retraining.
+- Formula behavior is reliable for core business models and visibly bounded for unsupported cases.
+- Multi-user local-first editing remains responsive and convergent.
+- Import/export preserves business-critical workbook semantics with explicit fidelity reporting.


### PR DESCRIPTION
## Summary

- Move all Shirya spreadsheet design docs into a dedicated folder at `docs/shirya/`.
- Add a near-Excel UX parity design doc for Shirya with local-first, realtime, formula, and interop architecture.
- Keep the Shirya docs timeline-free by removing schedule-style estimation wording from the design/research content.

## Related Issues

None

## Testing

- `ls -la docs/shirya`
- `rg -n "docs/shirya-library-selection-research\.md|docs/shirya-local-first-spreadsheet-design\.md|docs/shirya-near-excel-ux-parity-design\.md" docs`
- Manual review of `docs/shirya/shirya-local-first-spreadsheet-design.md` to confirm cross-reference path points to `docs/shirya/shirya-library-selection-research.md`.

## Screenshots (if applicable)

N/A (documentation-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
