### PR TITLE
feat(torghut): implement v5 p4 llm committee deterministic veto

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -627,6 +627,19 @@ class Settings(BaseSettings):
     llm_adjustment_approved: bool = Field(
         default=False, alias="LLM_ADJUSTMENT_APPROVED"
     )
+    llm_committee_enabled: bool = Field(default=True, alias="LLM_COMMITTEE_ENABLED")
+    llm_committee_roles_raw: str = Field(
+        default="researcher,risk_critic,execution_critic,policy_judge",
+        alias="LLM_COMMITTEE_ROLES",
+    )
+    llm_committee_mandatory_roles_raw: str = Field(
+        default="risk_critic,execution_critic,policy_judge",
+        alias="LLM_COMMITTEE_MANDATORY_ROLES",
+    )
+    llm_committee_fail_closed_verdict: Literal["veto", "abstain"] = Field(
+        default="veto",
+        alias="LLM_COMMITTEE_FAIL_CLOSED_VERDICT",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -716,6 +729,20 @@ class Settings(BaseSettings):
             normalized_model_version_lock = self.llm_model_version_lock.strip()
             # Model lock evidence must be explicitly configured; never backfill from llm_model.
             self.llm_model_version_lock = normalized_model_version_lock or None
+        self.llm_committee_roles_raw = ",".join(
+            [
+                item.strip()
+                for item in self.llm_committee_roles_raw.split(",")
+                if item.strip()
+            ]
+        )
+        self.llm_committee_mandatory_roles_raw = ",".join(
+            [
+                item.strip()
+                for item in self.llm_committee_mandatory_roles_raw.split(",")
+                if item.strip()
+            ]
+        )
         self.trading_allocator_default_regime = (
             self.trading_allocator_default_regime.strip() or "neutral"
         )
@@ -833,6 +860,14 @@ class Settings(BaseSettings):
         if self.llm_live_fail_open_requested and self.llm_fail_open_live_approved:
             exceptions.append("live_fail_open_approved")
         return exceptions
+
+    @property
+    def llm_committee_roles(self) -> list[str]:
+        return [item.strip() for item in self.llm_committee_roles_raw.split(",") if item.strip()]
+
+    @property
+    def llm_committee_mandatory_roles(self) -> list[str]:
+        return [item.strip() for item in self.llm_committee_mandatory_roles_raw.split(",") if item.strip()]
 
     @property
     def llm_live_fail_open_requested(self) -> bool:

--- a/services/torghut/app/trading/llm/guardrails.py
+++ b/services/torghut/app/trading/llm/guardrails.py
@@ -16,6 +16,7 @@ class LLMRiskGuardrails:
     effective_fail_mode: str
     rollout_stage: str
     governance_evidence_complete: bool
+    committee_enabled: bool
     reasons: tuple[str, ...]
 
 
@@ -94,6 +95,26 @@ def evaluate_llm_guardrails() -> LLMRiskGuardrails:
         adjustment_allowed = False
         reasons.append("llm_adjustment_not_approved")
 
+    committee_enabled = settings.llm_committee_enabled
+    if committee_enabled:
+        roles = settings.llm_committee_roles
+        mandatory_roles = settings.llm_committee_mandatory_roles
+        allowed_roles = {
+            "researcher",
+            "risk_critic",
+            "execution_critic",
+            "policy_judge",
+        }
+        invalid_roles = sorted({role for role in roles if role not in allowed_roles})
+        invalid_mandatory_roles = sorted(
+            {role for role in mandatory_roles if role not in allowed_roles}
+        )
+        if invalid_roles or invalid_mandatory_roles:
+            allow_requests = False
+            shadow_mode = True
+            committee_enabled = False
+            reasons.append("llm_committee_roles_invalid")
+
     return LLMRiskGuardrails(
         allow_requests=allow_requests,
         shadow_mode=shadow_mode,
@@ -101,6 +122,7 @@ def evaluate_llm_guardrails() -> LLMRiskGuardrails:
         effective_fail_mode=effective_fail_mode,
         rollout_stage=rollout_stage,
         governance_evidence_complete=governance_evidence_complete,
+        committee_enabled=committee_enabled,
         reasons=tuple(reasons),
     )
 

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 from collections.abc import Callable, Mapping
@@ -149,6 +150,18 @@ class TradingMetrics:
     )
     llm_tokens_prompt_total: int = 0
     llm_tokens_completion_total: int = 0
+    llm_committee_requests_total: dict[str, int] = field(
+        default_factory=lambda: cast(dict[str, int], {})
+    )
+    llm_committee_latency_ms: dict[str, int] = field(
+        default_factory=lambda: cast(dict[str, int], {})
+    )
+    llm_committee_verdict_total: dict[str, int] = field(
+        default_factory=lambda: cast(dict[str, int], {})
+    )
+    llm_committee_schema_error_total: int = 0
+    llm_committee_veto_alignment_total: int = 0
+    llm_committee_veto_total: int = 0
     execution_requests_total: dict[str, int] = field(
         default_factory=lambda: cast(dict[str, int], {})
     )
@@ -282,6 +295,38 @@ class TradingMetrics:
             normalized = "unknown"
         current = self.llm_policy_resolution_total.get(normalized, 0)
         self.llm_policy_resolution_total[normalized] = current + 1
+
+    def record_llm_committee_member(
+        self,
+        *,
+        role: str,
+        verdict: str,
+        latency_ms: int | None,
+        schema_error: bool,
+    ) -> None:
+        self.llm_committee_requests_total[role] = (
+            self.llm_committee_requests_total.get(role, 0) + 1
+        )
+        if latency_ms is not None:
+            self.llm_committee_latency_ms[role] = latency_ms
+        verdict_key = f"{role}:{verdict}"
+        self.llm_committee_verdict_total[verdict_key] = (
+            self.llm_committee_verdict_total.get(verdict_key, 0) + 1
+        )
+        if schema_error:
+            self.llm_committee_schema_error_total += 1
+
+    def record_llm_committee_veto_alignment(
+        self,
+        *,
+        committee_veto: bool,
+        deterministic_veto: bool,
+    ) -> None:
+        if not committee_veto:
+            return
+        self.llm_committee_veto_total += 1
+        if deterministic_veto:
+            self.llm_committee_veto_alignment_total += 1
 
     def record_strategy_runtime(self, telemetry: DecisionRuntimeTelemetry) -> None:
         if not telemetry.runtime_enabled:
@@ -1072,12 +1117,34 @@ class TradingPipeline:
             )
 
             response_json: dict[str, Any] = dict(outcome.response_json)
+            response_json["advisory_only"] = True
+            response_json["request_hash"] = outcome.request_hash
+            response_json["response_hash"] = outcome.response_hash
             if policy_outcome.reason:
                 response_json["policy_override"] = policy_outcome.reason
                 response_json["policy_verdict"] = policy_outcome.verdict
             if guardrails.reasons:
                 response_json["mrm_guardrails"] = list(guardrails.reasons)
             response_json["policy_resolution"] = policy_resolution
+
+            committee_payload = response_json.get("committee")
+            if isinstance(committee_payload, Mapping):
+                committee_roles = cast(Mapping[str, Any], committee_payload).get(
+                    "roles", {}
+                )
+                if isinstance(committee_roles, Mapping):
+                    for role, role_payload in cast(
+                        Mapping[str, Any], committee_roles
+                    ).items():
+                        if not isinstance(role_payload, Mapping):
+                            continue
+                        role_data = cast(Mapping[str, Any], role_payload)
+                        self.state.metrics.record_llm_committee_member(
+                            role=str(role),
+                            verdict=str(role_data.get("verdict", "unknown")),
+                            latency_ms=_optional_int(role_data.get("latency_ms")),
+                            schema_error=bool(role_data.get("schema_error", False)),
+                        )
 
             if outcome.tokens_prompt is not None:
                 self.state.metrics.llm_tokens_prompt_total += outcome.tokens_prompt
@@ -1131,6 +1198,10 @@ class TradingPipeline:
                     self.state.metrics.llm_guardrail_shadow_total += 1
                 return decision, None
             if policy_outcome.verdict == "veto":
+                self.state.metrics.record_llm_committee_veto_alignment(
+                    committee_veto=bool(outcome.response.committee),
+                    deterministic_veto=True,
+                )
                 return decision, policy_outcome.reason or "llm_veto"
 
             return policy_outcome.decision, None
@@ -1154,6 +1225,9 @@ class TradingPipeline:
                 response_json["mrm_guardrails"] = list(guardrails.reasons)
             if not request_json:
                 request_json = {"decision": decision.model_dump(mode="json")}
+            response_json["advisory_only"] = True
+            response_json["request_hash"] = _hash_payload(request_json)
+            response_json["response_hash"] = _hash_payload(response_json)
             self._persist_llm_review(
                 session=session,
                 decision_row=decision_row,
@@ -1222,23 +1296,27 @@ class TradingPipeline:
             market_context=market_context,
             recent_decisions=recent_decisions,
         ).model_dump(mode="json")
+        response_payload = {
+            "error": reason,
+            "fallback": fallback,
+            "effective_verdict": effective_verdict,
+            "policy_resolution": policy_resolution
+            or _build_llm_policy_resolution(
+                rollout_stage=_normalize_rollout_stage(settings.llm_rollout_stage),
+                effective_fail_mode=fallback,
+                guardrail_reasons=risk_flags or [],
+            ),
+            "advisory_only": True,
+        }
+        response_payload["request_hash"] = _hash_payload(request_payload)
+        response_payload["response_hash"] = _hash_payload(response_payload)
         self._persist_llm_review(
             session=session,
             decision_row=decision_row,
             model=settings.llm_model,
             prompt_version=settings.llm_prompt_version,
             request_json=request_payload,
-            response_json={
-                "error": reason,
-                "fallback": fallback,
-                "effective_verdict": effective_verdict,
-                "policy_resolution": policy_resolution
-                or _build_llm_policy_resolution(
-                    rollout_stage=_normalize_rollout_stage(settings.llm_rollout_stage),
-                    effective_fail_mode=fallback,
-                    guardrail_reasons=risk_flags or [],
-                ),
-            },
+            response_json=response_payload,
             verdict="error",
             confidence=None,
             adjusted_qty=None,
@@ -1591,6 +1669,22 @@ def _optional_decimal(value: Any) -> Optional[Decimal]:
         return None
 
 
+def _optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _hash_payload(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def _is_llm_stage_policy_violation(rollout_stage: str) -> bool:
     if rollout_stage == "stage0":
         return (
@@ -1727,6 +1821,7 @@ class TradingScheduler:
                 "allow_requests": guardrails.allow_requests,
                 "governance_evidence_complete": guardrails.governance_evidence_complete,
                 "effective_adjustment_allowed": guardrails.adjustment_allowed,
+                "committee_enabled": guardrails.committee_enabled,
                 "reasons": list(guardrails.reasons),
             },
         }

--- a/services/torghut/tests/test_llm_policy.py
+++ b/services/torghut/tests/test_llm_policy.py
@@ -6,11 +6,98 @@ from unittest import TestCase
 
 from app import config
 from app.trading.llm.policy import apply_policy
-from app.trading.llm.schema import LLMReviewResponse
+from app.trading.llm.schema import LLMCommitteeMemberResponse, LLMCommitteeTrace, LLMReviewResponse
 from app.trading.models import StrategyDecision
 
 
 class TestLLMPolicy(TestCase):
+    def test_committee_mandatory_veto_forces_veto(self) -> None:
+        original = {
+            "llm_adjustment_allowed": config.settings.llm_adjustment_allowed,
+            "llm_min_confidence": config.settings.llm_min_confidence,
+        }
+        config.settings.llm_adjustment_allowed = True
+        config.settings.llm_min_confidence = 0.0
+
+        try:
+            decision = StrategyDecision(
+                strategy_id="strategy",
+                symbol="AAPL",
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                order_type="market",
+                time_in_force="day",
+            )
+            review = LLMReviewResponse(
+                verdict="approve",
+                confidence=1.0,
+                rationale="committee",
+                rationale_short="committee",
+                required_checks=["risk_engine"],
+                risk_flags=[],
+                committee=LLMCommitteeTrace(
+                    roles={
+                        "risk_critic": LLMCommitteeMemberResponse(
+                            role="risk_critic",
+                            verdict="veto",
+                            confidence=1.0,
+                            uncertainty="low",
+                            rationale_short="risk veto",
+                            required_checks=["risk_engine"],
+                        ),
+                        "execution_critic": LLMCommitteeMemberResponse(
+                            role="execution_critic",
+                            verdict="approve",
+                            confidence=1.0,
+                            uncertainty="low",
+                            rationale_short="ok",
+                            required_checks=["execution_policy"],
+                        ),
+                        "policy_judge": LLMCommitteeMemberResponse(
+                            role="policy_judge",
+                            verdict="approve",
+                            confidence=1.0,
+                            uncertainty="low",
+                            rationale_short="ok",
+                            required_checks=["order_firewall"],
+                        ),
+                    },
+                    mandatory_roles=["risk_critic", "execution_critic", "policy_judge"],
+                    fail_closed_verdict="veto",
+                ),
+            )
+            outcome = apply_policy(decision, review)
+            self.assertEqual(outcome.verdict, "veto")
+            self.assertEqual(outcome.reason, "llm_committee_mandatory_veto")
+        finally:
+            config.settings.llm_adjustment_allowed = original["llm_adjustment_allowed"]
+            config.settings.llm_min_confidence = original["llm_min_confidence"]
+
+    def test_escalate_is_advisory_only_veto(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy",
+            symbol="AAPL",
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            order_type="market",
+            time_in_force="day",
+        )
+        review = LLMReviewResponse(
+            verdict="escalate",
+            confidence=1.0,
+            rationale="needs human",
+            rationale_short="needs human",
+            required_checks=["risk_engine"],
+            risk_flags=[],
+        )
+        outcome = apply_policy(decision, review, adjustment_allowed=False)
+        self.assertEqual(outcome.verdict, "veto")
+        self.assertEqual(outcome.reason, "llm_escalate")
+
     def test_adjust_to_limit_requires_limit_price(self) -> None:
         original = {
             "llm_adjustment_allowed": config.settings.llm_adjustment_allowed,

--- a/services/torghut/tests/test_metrics.py
+++ b/services/torghut/tests/test_metrics.py
@@ -85,6 +85,42 @@ class TestTradingMetrics(TestCase):
         )
         self.assertIn("torghut_trading_llm_fail_mode_exception_total 2", payload)
 
+    def test_committee_metrics_are_exported(self) -> None:
+        metrics = TradingMetrics()
+        metrics.record_llm_committee_member(
+            role="risk_critic",
+            verdict="veto",
+            latency_ms=42,
+            schema_error=False,
+        )
+        metrics.record_llm_committee_member(
+            role="policy_judge",
+            verdict="approve",
+            latency_ms=17,
+            schema_error=True,
+        )
+        metrics.record_llm_committee_veto_alignment(
+            committee_veto=True,
+            deterministic_veto=True,
+        )
+
+        payload = render_trading_metrics(metrics.__dict__)
+
+        self.assertIn(
+            'torghut_trading_llm_committee_requests_total{role="risk_critic"} 1',
+            payload,
+        )
+        self.assertIn(
+            'torghut_trading_llm_committee_latency_ms{role="risk_critic"} 42', payload
+        )
+        self.assertIn(
+            'torghut_trading_llm_committee_verdict_total{role="risk_critic",verdict="veto"} 1',
+            payload,
+        )
+        self.assertIn("torghut_trading_llm_committee_schema_error_total 1", payload)
+        self.assertIn("torghut_trading_llm_committee_veto_alignment_total 1", payload)
+        self.assertIn("torghut_trading_llm_committee_veto_alignment_rate 1.0", payload)
+
     def test_order_feed_counters_are_exported(self) -> None:
         metrics = TradingMetrics()
         metrics.order_feed_messages_total = 3

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -280,6 +280,8 @@ class FakeLLMReviewEngine:
             prompt_version="test",
             tokens_prompt=12,
             tokens_completion=7,
+            request_hash="test-request-hash",
+            response_hash="test-response-hash",
         )
 
 


### PR DESCRIPTION
## Summary

- Added Torghut LLM committee orchestration with role-separated outputs (`researcher`, `risk_critic`, `execution_critic`, `policy_judge`) and fail-closed aggregation.
- Extended LLM schemas/guardrails for structured `verdict`, `confidence`, `uncertainty`, `rationale_short`, and `required_checks`, with committee trace embedding.
- Enforced deterministic veto precedence for mandatory committee critics and advisory-only behavior (no direct execution authority).
- Persisted request/response hashes and committee traces in review payloads, and added committee reliability metrics for requests, latency, verdicts, schema errors, and veto alignment.
- Added focused regression tests for committee aggregation/policy behavior, metrics export, and trading pipeline compatibility.

## Related Issues

None (ISSUE_NUMBER is 0 in this environment).

## Testing

- `cd services/torghut && uv run --extra dev ruff check app tests`
- `cd services/torghut && uv run --extra dev pyright`
- `cd services/torghut && uv run python -m unittest tests.test_llm_review_engine tests.test_llm_policy tests.test_metrics tests.test_llm_guardrails tests.test_trading_pipeline`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
