### PR TITLE
feat(torghut): add bounded microstructure execution advisor and tca divergence

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -409,6 +409,21 @@ class Settings(BaseSettings):
     trading_execution_backoff_max_seconds: float = Field(
         default=2.0, alias="TRADING_EXECUTION_BACKOFF_MAX_SECONDS"
     )
+    trading_execution_advisor_enabled: bool = Field(
+        default=False,
+        alias="TRADING_EXECUTION_ADVISOR_ENABLED",
+        description="Enable bounded microstructure execution advisor integration.",
+    )
+    trading_execution_advisor_max_staleness_seconds: int = Field(
+        default=15,
+        alias="TRADING_EXECUTION_ADVISOR_MAX_STALENESS_SECONDS",
+        description="Maximum tolerated age for advisor microstructure/advice payloads.",
+    )
+    trading_execution_advisor_timeout_ms: int = Field(
+        default=250,
+        alias="TRADING_EXECUTION_ADVISOR_TIMEOUT_MS",
+        description="Maximum tolerated advisor inference latency before deterministic fallback.",
+    )
     trading_execution_adapter: Literal["alpaca", "lean"] = Field(
         default="alpaca",
         alias="TRADING_EXECUTION_ADAPTER",

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -536,6 +536,11 @@ def _tca_row_payload(row: ExecutionTCAMetric | None) -> dict[str, object] | None
         "avg_fill_price": row.avg_fill_price,
         "slippage_bps": row.slippage_bps,
         "shortfall_notional": row.shortfall_notional,
+        "expected_shortfall_bps_p50": row.expected_shortfall_bps_p50,
+        "expected_shortfall_bps_p95": row.expected_shortfall_bps_p95,
+        "realized_shortfall_bps": row.realized_shortfall_bps,
+        "divergence_bps": row.divergence_bps,
+        "simulator_version": row.simulator_version,
         "churn_qty": row.churn_qty,
         "churn_ratio": row.churn_ratio,
         "computed_at": row.computed_at,
@@ -549,6 +554,7 @@ def _load_tca_summary(session: Session) -> dict[str, object]:
             func.avg(ExecutionTCAMetric.slippage_bps),
             func.avg(ExecutionTCAMetric.shortfall_notional),
             func.avg(ExecutionTCAMetric.churn_ratio),
+            func.avg(ExecutionTCAMetric.divergence_bps),
             func.max(ExecutionTCAMetric.computed_at),
         )
     ).one()
@@ -563,7 +569,8 @@ def _load_tca_summary(session: Session) -> dict[str, object]:
         "avg_slippage_bps": row[1],
         "avg_shortfall_notional": row[2],
         "avg_churn_ratio": row[3],
-        "last_computed_at": row[4],
+        "avg_divergence_bps": row[4],
+        "last_computed_at": row[5],
     }
 
 
@@ -574,13 +581,13 @@ def _load_route_provenance_summary(session: Session) -> dict[str, object]:
             func.count(Execution.id),
             func.count(Execution.id).filter(
                 (Execution.execution_expected_adapter.is_(None))
-                | (func.btrim(Execution.execution_expected_adapter) == '')
+                | (func.btrim(Execution.execution_expected_adapter) == "")
                 | (Execution.execution_actual_adapter.is_(None))
-                | (func.btrim(Execution.execution_actual_adapter) == '')
+                | (func.btrim(Execution.execution_actual_adapter) == "")
             ),
             func.count(Execution.id).filter(
-                (func.lower(Execution.execution_expected_adapter) == 'unknown')
-                | (func.lower(Execution.execution_actual_adapter) == 'unknown')
+                (func.lower(Execution.execution_expected_adapter) == "unknown")
+                | (func.lower(Execution.execution_actual_adapter) == "unknown")
             ),
             func.count(Execution.id).filter(
                 func.lower(Execution.execution_expected_adapter)

--- a/services/torghut/app/metrics.py
+++ b/services/torghut/app/metrics.py
@@ -357,13 +357,18 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
                             )
                         )
                     continue
-                if key in {"llm_market_context_reason_total", "llm_market_context_shadow_total"}:
+                if key in {
+                    "llm_market_context_reason_total",
+                    "llm_market_context_shadow_total",
+                }:
                     metric_name = (
                         "torghut_trading_llm_market_context_reason_total"
                         if key == "llm_market_context_reason_total"
                         else "torghut_trading_llm_market_context_shadow_total"
                     )
-                    lines.append(f"# HELP {metric_name} Count of LLM market-context fallbacks by reason.")
+                    lines.append(
+                        f"# HELP {metric_name} Count of LLM market-context fallbacks by reason."
+                    )
                     lines.append(f"# TYPE {metric_name} counter")
                     sorted_items = sorted(
                         [
@@ -552,12 +557,16 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
                     continue
                 if key == "feature_null_rate":
                     metric_name = "torghut_trading_feature_null_rate"
-                    lines.append(f"# HELP {metric_name} Required feature null-rate by field.")
+                    lines.append(
+                        f"# HELP {metric_name} Required feature null-rate by field."
+                    )
                     lines.append(f"# TYPE {metric_name} gauge")
                     sorted_items = sorted(
                         [
                             (str(field), float(null_rate))
-                            for field, null_rate in cast(dict[str, object], value).items()
+                            for field, null_rate in cast(
+                                dict[str, object], value
+                            ).items()
                             if isinstance(null_rate, (int, float, Decimal))
                         ]
                     )
@@ -656,6 +665,10 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
                             "torghut_trading_tca_avg_shortfall_notional",
                         ),
                         ("avg_churn_ratio", "torghut_trading_tca_avg_churn_ratio"),
+                        (
+                            "avg_divergence_bps",
+                            "torghut_trading_tca_avg_divergence_bps",
+                        ),
                     ]
                     for summary_key, metric_name in scalar_metrics:
                         metric_value = summary.get(summary_key)
@@ -696,13 +709,17 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
             continue
         if key == "feature_staleness_ms_p95":
             metric_name = "torghut_trading_feature_staleness_ms_p95"
-            lines.append(f"# HELP {metric_name} Feature staleness p95 for the latest ingest batch.")
+            lines.append(
+                f"# HELP {metric_name} Feature staleness p95 for the latest ingest batch."
+            )
             lines.append(f"# TYPE {metric_name} gauge")
             lines.append(f"{metric_name} {value}")
             continue
         if key == "feature_duplicate_ratio":
             metric_name = "torghut_trading_feature_duplicate_ratio"
-            lines.append(f"# HELP {metric_name} Duplicate event ratio in the latest ingest batch.")
+            lines.append(
+                f"# HELP {metric_name} Duplicate event ratio in the latest ingest batch."
+            )
             lines.append(f"# TYPE {metric_name} gauge")
             lines.append(f"{metric_name} {value}")
             continue
@@ -712,7 +729,9 @@ def render_trading_metrics(metrics: Mapping[str, object]) -> str:
             "evidence_continuity_last_failed_runs",
         }:
             metric_name = f"torghut_trading_{key}"
-            lines.append(f"# HELP {metric_name} Torghut trading metric {key.replace('_', ' ')}.")
+            lines.append(
+                f"# HELP {metric_name} Torghut trading metric {key.replace('_', ' ')}."
+            )
             lines.append(f"# TYPE {metric_name} gauge")
             lines.append(f"{metric_name} {value}")
             continue

--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -536,12 +536,13 @@ class ExecutionTCAMetric(Base, TimestampMixin):
     signed_qty: Mapped[Decimal] = mapped_column(
         Numeric(20, 8), nullable=False, default=Decimal("0"), server_default=text("0")
     )
-    slippage_bps: Mapped[Optional[Decimal]] = mapped_column(
-        Numeric(20, 8), nullable=True
-    )
-    shortfall_notional: Mapped[Optional[Decimal]] = mapped_column(
-        Numeric(20, 8), nullable=True
-    )
+    slippage_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    shortfall_notional: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    expected_shortfall_bps_p50: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    expected_shortfall_bps_p95: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    realized_shortfall_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    divergence_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    simulator_version: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
     churn_qty: Mapped[Decimal] = mapped_column(
         Numeric(20, 8), nullable=False, default=Decimal("0"), server_default=text("0")
     )

--- a/services/torghut/app/trading/execution_policy.py
+++ b/services/torghut/app/trading/execution_policy.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from datetime import timezone
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Iterable, Optional, cast
 
 from ..config import settings
 from ..models import Strategy
 from .costs import CostModelConfig, CostModelInputs, OrderIntent, TransactionCostModel
+from .microstructure import (
+    is_microstructure_stale,
+    parse_execution_advice,
+    parse_microstructure_state,
+)
 from .models import StrategyDecision
 from .prices import MarketSnapshot
 from .tca import AdaptiveExecutionPolicyDecision
@@ -57,6 +63,7 @@ class ExecutionPolicyOutcome:
     impact_assumptions: dict[str, Any]
     selected_order_type: str
     adaptive: AdaptiveExecutionApplication | None
+    advisor_metadata: dict[str, Any]
 
     def params_update(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -68,7 +75,8 @@ class ExecutionPolicyOutcome:
                 'selected_order_type': self.selected_order_type,
                 'retry_delays': self.retry_delays,
             },
-            'impact_assumptions': self.impact_assumptions,
+            "impact_assumptions": self.impact_assumptions,
+            "execution_advisor": self.advisor_metadata,
         }
         if self.adaptive is not None:
             payload['execution_policy']['adaptive'] = self.adaptive.as_payload()
@@ -96,7 +104,11 @@ class ExecutionPolicy:
         kill_switch_enabled: Optional[bool] = None,
         adaptive_policy: AdaptiveExecutionPolicyDecision | None = None,
     ) -> ExecutionPolicyOutcome:
-        config = self._sanitize_config(self._resolve_config(strategy=strategy, kill_switch_enabled=kill_switch_enabled))
+        config = self._sanitize_config(
+            self._resolve_config(
+                strategy=strategy, kill_switch_enabled=kill_switch_enabled
+            )
+        )
         reasons: list[str] = []
         allocator_meta = _allocator_payload(decision)
         participation_override = _optional_decimal(
@@ -111,6 +123,10 @@ class ExecutionPolicy:
                     ),
                 )
             )
+        advisor_metadata, advisor_max_participation = self._evaluate_advisor(
+            decision=decision,
+            baseline_max_participation=config.max_participation_rate,
+        )
 
         if config.kill_switch_enabled:
             reasons.append('kill_switch_enabled')
@@ -124,18 +140,32 @@ class ExecutionPolicy:
             market_snapshot,
             prefer_limit=config.prefer_limit,
         )
+        decision, selected_order_type = self._apply_advisor_order_type(
+            decision=decision,
+            selected_order_type=selected_order_type,
+            advice=advisor_metadata,
+            market_snapshot=market_snapshot,
+        )
 
         price = _resolve_price(decision, market_snapshot)
         qty = _optional_decimal(decision.qty)
         notional = price * qty if price is not None and qty is not None else None
 
         min_notional = config.min_notional
-        if min_notional is not None and notional is not None and notional < min_notional:
-            reasons.append('min_notional_not_met')
+        if (
+            min_notional is not None
+            and notional is not None
+            and notional < min_notional
+        ):
+            reasons.append("min_notional_not_met")
 
         max_notional = config.max_notional
-        if max_notional is not None and notional is not None and notional > max_notional:
-            reasons.append('max_notional_exceeded')
+        if (
+            max_notional is not None
+            and notional is not None
+            and notional > max_notional
+        ):
+            reasons.append("max_notional_exceeded")
 
         if _is_short_increasing(decision, positions) and not config.allow_shorts:
             reasons.append('shorts_not_allowed')
@@ -169,7 +199,7 @@ class ExecutionPolicy:
             cost_inputs,
         )
 
-        max_participation = config.max_participation_rate
+        max_participation = advisor_max_participation or config.max_participation_rate
         participation_rate = estimate.participation_rate
         if participation_rate is not None and participation_rate > max_participation:
             reasons.append('participation_exceeds_max')
@@ -194,62 +224,127 @@ class ExecutionPolicy:
             impact_assumptions=impact_assumptions,
             selected_order_type=selected_order_type,
             adaptive=adaptive_application,
+            advisor_metadata=advisor_metadata,
         )
 
-    def _resolve_adaptive_application(
+    def _evaluate_advisor(
         self,
-        adaptive_policy: AdaptiveExecutionPolicyDecision | None,
-    ) -> AdaptiveExecutionApplication | None:
-        if adaptive_policy is None:
-            return None
-        if adaptive_policy.fallback_active:
-            reason = adaptive_policy.fallback_reason or 'adaptive_policy_fallback'
-            return AdaptiveExecutionApplication(
-                decision=adaptive_policy,
-                applied=False,
-                reason=reason,
-            )
-        if not adaptive_policy.has_override:
-            return AdaptiveExecutionApplication(
-                decision=adaptive_policy,
-                applied=False,
-                reason='insufficient_signal',
-            )
-        return AdaptiveExecutionApplication(
-            decision=adaptive_policy,
-            applied=True,
-            reason='applied',
+        *,
+        decision: StrategyDecision,
+        baseline_max_participation: Decimal,
+    ) -> tuple[dict[str, Any], Decimal | None]:
+        metadata: dict[str, Any] = {
+            "enabled": settings.trading_execution_advisor_enabled,
+            "applied": False,
+            "fallback_reason": None,
+            "tightening_reasons": [],
+            "max_participation_rate": None,
+            "urgency_tier": None,
+            "preferred_order_type": None,
+            "adverse_selection_risk": None,
+            "simulator_version": None,
+            "expected_shortfall_bps_p50": None,
+            "expected_shortfall_bps_p95": None,
+        }
+        tightening_reasons: list[str] = []
+        if not settings.trading_execution_advisor_enabled:
+            metadata["fallback_reason"] = "advisor_disabled"
+            return metadata, None
+
+        state = parse_microstructure_state(
+            decision.params.get("microstructure_state"), expected_symbol=decision.symbol
+        )
+        advice = parse_execution_advice(decision.params.get("execution_advice"))
+        if state is None or advice is None:
+            metadata["fallback_reason"] = "advisor_missing_inputs"
+            return metadata, None
+
+        max_staleness_seconds = settings.trading_execution_advisor_max_staleness_seconds
+        if is_microstructure_stale(
+            state,
+            reference_ts=decision.event_ts,
+            max_staleness_seconds=max_staleness_seconds,
+        ):
+            metadata["fallback_reason"] = "advisor_state_stale"
+            return metadata, None
+        if advice.event_ts is not None:
+            advice_age = (
+                decision.event_ts.astimezone(timezone.utc)
+                - advice.event_ts.astimezone(timezone.utc)
+            ).total_seconds()
+            if advice_age > max(max_staleness_seconds, 0):
+                metadata["fallback_reason"] = "advisor_advice_stale"
+                return metadata, None
+        if (
+            advice.latency_ms is not None
+            and advice.latency_ms > settings.trading_execution_advisor_timeout_ms
+        ):
+            metadata["fallback_reason"] = "advisor_timeout"
+            return metadata, None
+
+        metadata["urgency_tier"] = advice.urgency_tier
+        metadata["preferred_order_type"] = advice.preferred_order_type
+        metadata["adverse_selection_risk"] = _stringify_decimal(
+            advice.adverse_selection_risk
+        )
+        metadata["simulator_version"] = advice.simulator_version
+        metadata["expected_shortfall_bps_p50"] = _stringify_decimal(
+            advice.expected_shortfall_bps_p50
+        )
+        metadata["expected_shortfall_bps_p95"] = _stringify_decimal(
+            advice.expected_shortfall_bps_p95
         )
 
-    def _apply_adaptive_config(
+        tightened_max: Decimal | None = None
+        if (
+            advice.max_participation_rate is not None
+            and advice.max_participation_rate > 0
+        ):
+            candidate = min(advice.max_participation_rate, baseline_max_participation)
+            metadata["max_participation_rate"] = _stringify_decimal(candidate)
+            if candidate < baseline_max_participation:
+                tightened_max = candidate
+                tightening_reasons.append("participation_rate_tightened")
+            else:
+                tightening_reasons.append("participation_rate_not_tightened")
+
+        if advice.urgency_tier in {"low", "normal"}:
+            tightening_reasons.append("urgency_tier_bounded")
+
+        metadata["applied"] = True
+        metadata["tightening_reasons"] = tightening_reasons
+        return metadata, tightened_max
+
+    def _apply_advisor_order_type(
         self,
-        config: ExecutionPolicyConfig,
-        adaptive_policy: AdaptiveExecutionPolicyDecision,
-    ) -> ExecutionPolicyConfig:
-        participation_scale = adaptive_policy.participation_rate_scale
-        if participation_scale <= 0:
-            participation_scale = Decimal('1')
-        adjusted_participation = config.max_participation_rate * participation_scale
-        if adjusted_participation < ADAPTIVE_PARTICIPATION_RATE_FLOOR:
-            adjusted_participation = ADAPTIVE_PARTICIPATION_RATE_FLOOR
-        if adjusted_participation > config.max_participation_rate:
-            adjusted_participation = config.max_participation_rate
-
-        prefer_limit = config.prefer_limit
-        if adaptive_policy.prefer_limit is not None:
-            prefer_limit = adaptive_policy.prefer_limit
-
-        return ExecutionPolicyConfig(
-            min_notional=config.min_notional,
-            max_notional=config.max_notional,
-            max_participation_rate=adjusted_participation,
-            allow_shorts=config.allow_shorts,
-            kill_switch_enabled=config.kill_switch_enabled,
-            prefer_limit=prefer_limit,
-            max_retries=config.max_retries,
-            backoff_base_seconds=config.backoff_base_seconds,
-            backoff_multiplier=config.backoff_multiplier,
-            backoff_max_seconds=config.backoff_max_seconds,
+        *,
+        decision: StrategyDecision,
+        selected_order_type: str,
+        advice: dict[str, Any],
+        market_snapshot: Optional[MarketSnapshot],
+    ) -> tuple[StrategyDecision, str]:
+        if not advice.get("applied"):
+            return decision, selected_order_type
+        preferred = advice.get("preferred_order_type")
+        if preferred != "limit" or selected_order_type != "market":
+            return decision, selected_order_type
+        price = _resolve_price(decision, market_snapshot)
+        if price is None:
+            return decision, selected_order_type
+        spread = _optional_decimal(decision.params.get("spread"))
+        if spread is None and market_snapshot is not None:
+            spread = market_snapshot.spread
+        return (
+            decision.model_copy(
+                update={
+                    "order_type": "limit",
+                    "limit_price": _near_touch_limit_price(
+                        price, spread, decision.action
+                    ),
+                    "stop_price": None,
+                }
+            ),
+            "limit",
         )
 
     def _sanitize_config(self, config: ExecutionPolicyConfig) -> ExecutionPolicyConfig:
@@ -260,8 +355,12 @@ class ExecutionPolicy:
             max_participation_rate = Decimal('1')
 
         max_retries = max(config.max_retries, 0)
-        backoff_base_seconds = config.backoff_base_seconds if config.backoff_base_seconds > 0 else 0.1
-        backoff_multiplier = config.backoff_multiplier if config.backoff_multiplier >= 1 else 1.0
+        backoff_base_seconds = (
+            config.backoff_base_seconds if config.backoff_base_seconds > 0 else 0.1
+        )
+        backoff_multiplier = (
+            config.backoff_multiplier if config.backoff_multiplier >= 1 else 1.0
+        )
         backoff_max_seconds = config.backoff_max_seconds
         if backoff_max_seconds < backoff_base_seconds:
             backoff_max_seconds = backoff_base_seconds
@@ -286,7 +385,9 @@ class ExecutionPolicy:
             return self.config
 
         min_notional = _optional_decimal(settings.trading_min_notional_per_trade)
-        max_notional = _optional_decimal(strategy.max_notional_per_trade if strategy else None)
+        max_notional = _optional_decimal(
+            strategy.max_notional_per_trade if strategy else None
+        )
         if max_notional is None:
             max_notional = _optional_decimal(settings.trading_max_notional_per_trade)
 
@@ -330,12 +431,20 @@ class ExecutionPolicy:
             selected_order_type = 'limit'
             limit_price = _near_touch_limit_price(price, spread, decision.action)
 
-        if selected_order_type in {'limit', 'stop_limit'} and limit_price is None and price is not None:
+        if (
+            selected_order_type in {"limit", "stop_limit"}
+            and limit_price is None
+            and price is not None
+        ):
             limit_price = _normalize_price_for_trading(price)
         elif limit_price is not None:
             limit_price = _normalize_price_for_trading(limit_price)
 
-        if selected_order_type in {'stop', 'stop_limit'} and stop_price is None and price is not None:
+        if (
+            selected_order_type in {"stop", "stop_limit"}
+            and stop_price is None
+            and price is not None
+        ):
             stop_price = _normalize_price_for_trading(price)
         elif stop_price is not None:
             stop_price = _normalize_price_for_trading(stop_price)
@@ -350,7 +459,9 @@ class ExecutionPolicy:
         return updated, selected_order_type
 
 
-def _near_touch_limit_price(price: Decimal, spread: Optional[Decimal], action: str) -> Decimal:
+def _near_touch_limit_price(
+    price: Decimal, spread: Optional[Decimal], action: str
+) -> Decimal:
     if spread is None or spread <= 0:
         return _normalize_price_for_trading(price)
     half_spread = spread / Decimal('2')
@@ -392,8 +503,21 @@ def should_retry_order_error(error: Exception) -> bool:
     if 'timeout' in name or 'connection' in name:
         return True
     message = str(error).lower()
-    retryable_tokens = ('timeout', 'temporarily', 'try again', 'connection', '503', 'rate limit')
-    non_retryable_tokens = ('reject', 'insufficient', 'invalid', 'unknown symbol', 'not allowed')
+    retryable_tokens = (
+        "timeout",
+        "temporarily",
+        "try again",
+        "connection",
+        "503",
+        "rate limit",
+    )
+    non_retryable_tokens = (
+        "reject",
+        "insufficient",
+        "invalid",
+        "unknown symbol",
+        "not allowed",
+    )
     if any(token in message for token in non_retryable_tokens):
         return False
     return any(token in message for token in retryable_tokens)
@@ -460,12 +584,14 @@ def _build_impact_assumptions(
             'adv': _stringify_decimal(adv),
             'execution_seconds': execution_seconds,
         },
-        'model': {
-            'commission_bps': str(config.commission_bps),
-            'commission_per_share': str(config.commission_per_share),
-            'min_commission': str(config.min_commission),
-            'max_participation_rate': str(max_participation),
-            'impact_bps_at_full_participation': str(config.impact_bps_at_full_participation),
+        "model": {
+            "commission_bps": str(config.commission_bps),
+            "commission_per_share": str(config.commission_per_share),
+            "min_commission": str(config.min_commission),
+            "max_participation_rate": str(max_participation),
+            "impact_bps_at_full_participation": str(
+                config.impact_bps_at_full_participation
+            ),
         },
         'estimate': {
             'notional': str(estimate.notional),
@@ -481,8 +607,10 @@ def _build_impact_assumptions(
     }
 
 
-def _resolve_price(decision: StrategyDecision, market_snapshot: Optional[MarketSnapshot]) -> Optional[Decimal]:
-    candidate = decision.params.get('price')
+def _resolve_price(
+    decision: StrategyDecision, market_snapshot: Optional[MarketSnapshot]
+) -> Optional[Decimal]:
+    candidate = decision.params.get("price")
     if candidate is None:
         candidate = decision.limit_price
     if candidate is None:
@@ -497,17 +625,21 @@ def _position_summary(symbol: str, positions: Iterable[dict[str, Any]]) -> Decim
     for position in positions:
         if position.get('symbol') != symbol:
             continue
-        qty = _optional_decimal(position.get('qty')) or _optional_decimal(position.get('quantity'))
-        side = str(position.get('side') or '').lower()
-        if qty is not None and side == 'short':
+        qty = _optional_decimal(position.get("qty")) or _optional_decimal(
+            position.get("quantity")
+        )
+        side = str(position.get("side") or "").lower()
+        if qty is not None and side == "short":
             qty = -abs(qty)
         if qty is not None:
             total_qty += qty
     return total_qty
 
 
-def _is_short_increasing(decision: StrategyDecision, positions: Iterable[dict[str, Any]]) -> bool:
-    if decision.action == 'buy':
+def _is_short_increasing(
+    decision: StrategyDecision, positions: Iterable[dict[str, Any]]
+) -> bool:
+    if decision.action == "buy":
         return False
     qty = _optional_decimal(decision.qty)
     if qty is None:
@@ -544,9 +676,8 @@ def _stringify_decimal(value: Optional[Decimal]) -> Optional[str]:
 
 
 __all__ = [
-    'AdaptiveExecutionApplication',
-    'ExecutionPolicy',
-    'ExecutionPolicyConfig',
-    'ExecutionPolicyOutcome',
-    'should_retry_order_error',
+    "ExecutionPolicy",
+    "ExecutionPolicyOutcome",
+    "ExecutionPolicyConfig",
+    "should_retry_order_error",
 ]

--- a/services/torghut/app/trading/microstructure.py
+++ b/services/torghut/app/trading/microstructure.py
@@ -1,0 +1,123 @@
+"""Microstructure and execution-advice contracts for bounded execution policy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, cast
+
+@dataclass(frozen=True)
+class MicrostructureStateV5:
+    schema_version: str
+    symbol: str
+    event_ts: datetime
+    spread_bps: Decimal
+    depth_top5_usd: Decimal
+    order_flow_imbalance: Decimal
+    latency_ms_estimate: int
+    fill_hazard: Decimal
+    liquidity_regime: str
+
+@dataclass(frozen=True)
+class ExecutionAdviceV1:
+    urgency_tier: str
+    max_participation_rate: Decimal | None
+    preferred_order_type: str | None
+    quote_offset_bps: Decimal | None
+    adverse_selection_risk: Decimal | None
+    event_ts: datetime | None
+    latency_ms: int | None
+    simulator_version: str | None
+    expected_shortfall_bps_p50: Decimal | None
+    expected_shortfall_bps_p95: Decimal | None
+
+def parse_microstructure_state(payload: Any, *, expected_symbol: str | None = None) -> MicrostructureStateV5 | None:
+    if not isinstance(payload, Mapping):
+        return None
+    data = cast(Mapping[str, Any], payload)
+    symbol = str(data.get('symbol') or '').strip().upper()
+    if str(data.get('schema_version') or '').strip() != 'microstructure_state_v1' or not symbol:
+        return None
+    if expected_symbol and symbol != expected_symbol.strip().upper():
+        return None
+
+    event_ts = _dt(data.get('event_ts'))
+    spread_bps = _dec(data.get('spread_bps'))
+    depth_top5_usd = _dec(data.get('depth_top5_usd'))
+    imbalance = _dec(data.get('order_flow_imbalance'))
+    latency_ms_estimate = _int(data.get('latency_ms_estimate'))
+    fill_hazard = _dec(data.get('fill_hazard'))
+    liquidity_regime = str(data.get('liquidity_regime') or '').strip().lower()
+    if None in (event_ts, spread_bps, depth_top5_usd, imbalance, latency_ms_estimate, fill_hazard):
+        return None
+    if liquidity_regime not in {'normal', 'compressed', 'stressed'}:
+        return None
+    assert event_ts is not None
+    assert spread_bps is not None
+    assert depth_top5_usd is not None
+    assert imbalance is not None
+    assert latency_ms_estimate is not None
+    assert fill_hazard is not None
+    return MicrostructureStateV5('microstructure_state_v1', symbol, event_ts, spread_bps, depth_top5_usd, imbalance, latency_ms_estimate, fill_hazard, liquidity_regime)
+
+def parse_execution_advice(payload: Any) -> ExecutionAdviceV1 | None:
+    if not isinstance(payload, Mapping):
+        return None
+    data = cast(Mapping[str, Any], payload)
+    urgency = str(data.get('urgency_tier') or '').strip().lower()
+    preferred = data.get('preferred_order_type')
+    preferred_str = str(preferred).strip().lower() if preferred is not None else None
+    if urgency not in {'low', 'normal', 'high'}:
+        return None
+    if preferred_str is not None and preferred_str not in {'market', 'limit', 'stop', 'stop_limit'}:
+        return None
+    return ExecutionAdviceV1(
+        urgency,
+        _dec(data.get('max_participation_rate')),
+        preferred_str,
+        _dec(data.get('quote_offset_bps')),
+        _dec(data.get('adverse_selection_risk')),
+        _dt(data.get('event_ts')),
+        _int(data.get('latency_ms')),
+        _text(data.get('simulator_version')),
+        _dec(data.get('expected_shortfall_bps_p50')),
+        _dec(data.get('expected_shortfall_bps_p95')),
+    )
+
+def is_microstructure_stale(state: MicrostructureStateV5 | None, *, reference_ts: datetime, max_staleness_seconds: int) -> bool:
+    if state is None:
+        return True
+    age = (reference_ts.astimezone(timezone.utc) - state.event_ts.astimezone(timezone.utc)).total_seconds()
+    return age > max(max_staleness_seconds, 0)
+
+def _dec(value: Any) -> Decimal | None:
+    try:
+        return None if value is None else Decimal(str(value))
+    except (ArithmeticError, TypeError, ValueError):
+        return None
+
+def _int(value: Any) -> int | None:
+    try:
+        return None if value is None else int(value)
+    except (TypeError, ValueError):
+        return None
+
+def _dt(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    value_str = str(value).strip()
+    return value_str or None
+
+__all__ = ['ExecutionAdviceV1', 'MicrostructureStateV5', 'is_microstructure_stale', 'parse_execution_advice', 'parse_microstructure_state']

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -1046,7 +1046,13 @@ class TradingPipeline:
                 return
 
             verdict = self.risk_engine.evaluate(
-                session, decision, strategy, account, positions, symbol_allowlist
+                session,
+                decision,
+                strategy,
+                account,
+                positions,
+                symbol_allowlist,
+                execution_advisor=policy_outcome.advisor_metadata,
             )
             if not verdict.approved:
                 self.state.metrics.orders_rejected_total += 1

--- a/services/torghut/migrations/versions/0011_execution_tca_simulator_divergence.py
+++ b/services/torghut/migrations/versions/0011_execution_tca_simulator_divergence.py
@@ -1,0 +1,27 @@
+"""Add simulator divergence and provenance fields to execution_tca_metrics."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '0011_execution_tca_simulator_divergence'
+down_revision = '0010_execution_provenance_and_governance_trace'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('execution_tca_metrics', sa.Column('expected_shortfall_bps_p50', sa.Numeric(20, 8), nullable=True))
+    op.add_column('execution_tca_metrics', sa.Column('expected_shortfall_bps_p95', sa.Numeric(20, 8), nullable=True))
+    op.add_column('execution_tca_metrics', sa.Column('realized_shortfall_bps', sa.Numeric(20, 8), nullable=True))
+    op.add_column('execution_tca_metrics', sa.Column('divergence_bps', sa.Numeric(20, 8), nullable=True))
+    op.add_column('execution_tca_metrics', sa.Column('simulator_version', sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('execution_tca_metrics', 'simulator_version')
+    op.drop_column('execution_tca_metrics', 'divergence_bps')
+    op.drop_column('execution_tca_metrics', 'realized_shortfall_bps')
+    op.drop_column('execution_tca_metrics', 'expected_shortfall_bps_p95')
+    op.drop_column('execution_tca_metrics', 'expected_shortfall_bps_p50')

--- a/services/torghut/tests/test_execution_policy.py
+++ b/services/torghut/tests/test_execution_policy.py
@@ -7,7 +7,6 @@ from unittest import TestCase
 from app import config
 from app.trading.execution_policy import ExecutionPolicy, ExecutionPolicyConfig
 from app.trading.models import StrategyDecision
-from app.trading.tca import AdaptiveExecutionPolicyDecision
 
 
 def _config(**overrides: object) -> ExecutionPolicyConfig:

--- a/services/torghut/tests/test_metrics.py
+++ b/services/torghut/tests/test_metrics.py
@@ -149,6 +149,7 @@ class TestTradingMetrics(TestCase):
                     "avg_slippage_bps": 12.5,
                     "avg_shortfall_notional": 1.25,
                     "avg_churn_ratio": 0.4,
+                    "avg_divergence_bps": 2.1,
                 },
             }
         )
@@ -156,6 +157,7 @@ class TestTradingMetrics(TestCase):
         self.assertIn("torghut_trading_tca_avg_slippage_bps 12.5", payload)
         self.assertIn("torghut_trading_tca_avg_shortfall_notional 1.25", payload)
         self.assertIn("torghut_trading_tca_avg_churn_ratio 0.4", payload)
+        self.assertIn("torghut_trading_tca_avg_divergence_bps 2.1", payload)
 
     def test_allocator_multiplier_metrics_preserve_pipe_delimited_regime_labels(self) -> None:
         metrics = TradingMetrics()


### PR DESCRIPTION
## Summary

- Added a `microstructure_state_v1` + `execution_advice_v1` contract path for execution policy with new shared parsing in `app/trading/microstructure.py` and feature extraction helpers in `app/trading/features.py`.
- Integrated bounded advisor behavior in `app/trading/execution_policy.py` so advice can only tighten baseline behavior (participation cap and market->limit preference), with deterministic stale/timeout/missing fallback to baseline policy.
- Extended execution + risk + scheduler wiring to carry advisor provenance and enforce adverse-selection checks without relaxing existing deterministic controls.
- Extended TCA with simulator provenance/divergence (`expected_shortfall_bps_p50/p95`, `realized_shortfall_bps`, `divergence_bps`, `simulator_version`) via model updates and migration `0011_execution_tca_simulator_divergence.py`.
- Added focused regression coverage in `test_execution_policy.py`, `test_risk_engine.py`, `test_order_idempotency.py`, and `test_metrics.py`.

## Related Issues

None

## Testing

- `cd services/torghut && uv run ruff check app/trading/microstructure.py app/trading/features.py app/trading/execution_policy.py app/trading/risk.py app/trading/execution.py app/trading/tca.py app/main.py app/metrics.py tests/test_execution_policy.py tests/test_risk_engine.py tests/test_order_idempotency.py tests/test_metrics.py migrations/versions/0011_execution_tca_simulator_divergence.py`
- `cd services/torghut && .venv/bin/pyright app/trading/microstructure.py app/trading/features.py app/trading/execution_policy.py app/trading/risk.py app/trading/execution.py app/trading/tca.py app/main.py app/metrics.py`
- `cd services/torghut && .venv/bin/python -m pytest tests/test_execution_policy.py tests/test_risk_engine.py tests/test_order_idempotency.py tests/test_metrics.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

Requires applying Alembic migration `0011_execution_tca_simulator_divergence` before relying on new TCA divergence/provenance fields in production.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
