### PR TITLE
fix(jangar-release): include control-plane image in agents promotion

### DIFF
--- a/packages/scripts/src/jangar/update-manifests.ts
+++ b/packages/scripts/src/jangar/update-manifests.ts
@@ -127,6 +127,21 @@ const updateAgentsValuesManifest = (valuesPath: string, imageName: string, tag: 
   runner.image = runnerImage
   doc.runner = runner
 
+  const controlPlane = asRecord(doc.controlPlane) ?? {}
+  const controlPlaneImage = asRecord(controlPlane.image) ?? {}
+  const fallbackControlPlaneRepository = imageName.endsWith('/jangar')
+    ? `${imageName.slice(0, -'/jangar'.length)}/jangar-control-plane`
+    : `${imageName}-control-plane`
+  const currentControlPlaneRepository = controlPlaneImage.repository
+  controlPlaneImage.repository =
+    typeof currentControlPlaneRepository === 'string' && currentControlPlaneRepository.trim().length > 0
+      ? currentControlPlaneRepository
+      : fallbackControlPlaneRepository
+  controlPlaneImage.tag = tag
+  controlPlaneImage.digest = digest
+  controlPlane.image = controlPlaneImage
+  doc.controlPlane = controlPlane
+
   const updated = YAML.stringify(doc, { lineWidth: 120 })
   if (source === updated) {
     console.warn('Warning: agents values were not updated; values already match requested image.')


### PR DESCRIPTION
## Summary

- Update `packages/scripts/src/jangar/update-manifests.ts` to also update `controlPlane.image.tag` and `controlPlane.image.digest` when promoting Jangar images.
- Preserve existing `controlPlane.image.repository` in `argocd/applications/agents/values.yaml`, with a safe fallback to `<jangar-image>-control-plane` when missing.
- Strengthen `packages/scripts/src/jangar/__tests__/update-manifests.test.ts` by parsing YAML and asserting `image`, `runner.image`, and `controlPlane.image` are all promoted consistently.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/update-manifests.test.ts`
- `bunx biome check packages/scripts/src/jangar/update-manifests.ts packages/scripts/src/jangar/__tests__/update-manifests.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
