### PR TITLE
chore(jangar): promote image eaf8d021

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-21T11:00:12Z"
+    deploy.knative.dev/rollout: "2026-02-21T11:06:45Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T11:00:12Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T11:06:45Z"
     spec:
       initContainers:
         - name: bootstrap-workspace


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `eaf8d021974d921cc0e99b236ae7050bdded24c1`
- Image tag: `eaf8d021`
- Image digest: `sha256:dd81fd7225b7e805e50e34b01dedc0301388e22d46b2ee75a145e04d3ed2a2ab`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`