### PR TITLE
chore(jangar): promote image eaf8d021

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -7,8 +7,8 @@ image:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: "95765432"
-    digest: sha256:823207a83a29c58e7064c0bd49d170188061f69c798e923540e36531b456dd63
+    tag: eaf8d021
+    digest: sha256:dd81fd7225b7e805e50e34b01dedc0301388e22d46b2ee75a145e04d3ed2a2ab
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-21T11:06:45Z"
+    deploy.knative.dev/rollout: "2026-02-21T11:08:07Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T11:06:45Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T11:08:07Z"
     spec:
       initContainers:
         - name: bootstrap-workspace


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `fea82f9ecb4935703f1f6410830f27c64ea54a23`
- Image tag: `eaf8d021`
- Image digest: `sha256:dd81fd7225b7e805e50e34b01dedc0301388e22d46b2ee75a145e04d3ed2a2ab`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`