### PR TITLE
fix(jangar-release): publish control-plane image and digest

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build-and-push:
     runs-on: arc-arm64
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -54,6 +54,13 @@ jobs:
           JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
         run: bun run packages/scripts/src/jangar/build-image.ts
 
+      - name: Build and push jangar control-plane image
+        env:
+          JANGAR_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          JANGAR_IMAGE_PLATFORMS: linux/arm64
+          JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
+        run: bun run packages/scripts/src/jangar/build-control-plane-image.ts
+
       - name: Resolve pushed image digest
         id: digest
         shell: bash
@@ -67,6 +74,21 @@ jobs:
             exit 1
           fi
           echo "${DIGEST}" > jangar-image-digest.txt
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve pushed control-plane image digest
+        id: control_plane_digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE="registry.ide-newton.ts.net/lab/jangar-control-plane"
+          TAG="${{ steps.meta.outputs.tag }}"
+          DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" | awk '/^Digest:/ { print $2; exit }')"
+          if [ -z "${DIGEST}" ]; then
+            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
+            exit 1
+          fi
+          echo "${DIGEST}" > jangar-control-plane-image-digest.txt
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Write release contract artifact
@@ -92,7 +114,11 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE="registry.ide-newton.ts.net/lab/jangar"
+          CONTROL_PLANE_IMAGE="registry.ide-newton.ts.net/lab/jangar-control-plane"
           TAG="${{ steps.meta.outputs.tag }}"
           docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${TAG}"
+          docker buildx imagetools create -t "${CONTROL_PLANE_IMAGE}:latest" "${CONTROL_PLANE_IMAGE}:${TAG}"
           docker buildx imagetools inspect "${IMAGE}:${TAG}"
           docker buildx imagetools inspect "${IMAGE}:latest"
+          docker buildx imagetools inspect "${CONTROL_PLANE_IMAGE}:${TAG}"
+          docker buildx imagetools inspect "${CONTROL_PLANE_IMAGE}:latest"

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -130,6 +130,7 @@ jobs:
             echo "tag=${TAG}"
             echo "contract_digest=${CONTRACT_DIGEST}"
             echo "image=${IMAGE}"
+            echo "control_plane_image=registry.ide-newton.ts.net/lab/jangar-control-plane"
             echo "promote=${PROMOTE}"
           } >> "$GITHUB_OUTPUT"
 
@@ -176,16 +177,48 @@ jobs:
 
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve control-plane image digest
+        if: steps.meta.outputs.promote == 'true'
+        id: control_plane_digest
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.control_plane_image }}
+          IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          DIGEST="$(
+            bun --eval "
+              import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
+              const image = process.env.IMAGE_NAME + ':' + process.env.IMAGE_TAG
+              const repoDigest = inspectImageDigest(image)
+              const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
+              console.log(digest)
+            "
+          )"
+
+          DIGEST="${DIGEST#*@}"
+          if [ -z "${DIGEST}" ]; then
+            echo "Resolved control-plane digest is empty"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
       - name: Update Jangar manifests
         if: steps.meta.outputs.promote == 'true'
         env:
           JANGAR_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
           JANGAR_IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
+          JANGAR_CONTROL_PLANE_IMAGE_NAME: ${{ steps.meta.outputs.control_plane_image }}
+          JANGAR_CONTROL_PLANE_IMAGE_DIGEST: ${{ steps.control_plane_digest.outputs.digest }}
         run: |
           TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           bun run packages/scripts/src/jangar/update-manifests.ts \
             --tag "${JANGAR_IMAGE_TAG}" \
             --digest "${JANGAR_IMAGE_DIGEST}" \
+            --control-plane-image-name "${JANGAR_CONTROL_PLANE_IMAGE_NAME}" \
+            --control-plane-digest "${JANGAR_CONTROL_PLANE_IMAGE_DIGEST}" \
             --rollout-timestamp "${TIMESTAMP}" \
             --agents-values-path "argocd/applications/agents/values.yaml"
 

--- a/packages/scripts/src/jangar/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/jangar/__tests__/update-manifests.test.ts
@@ -156,8 +156,39 @@ describe('updateJangarManifests', () => {
     })
     expect(parsed.controlPlane?.image).toEqual({
       repository: 'registry.ide-newton.ts.net/lab/jangar-control-plane',
+      tag: 'keep-tag',
+      digest: 'sha256:keep',
+    })
+    expect(result.changed.agentsValues).toBe(true)
+
+    rmSync(fixture.dir, { recursive: true, force: true })
+  })
+
+  it('updates control-plane values when control-plane image metadata is provided', () => {
+    const fixture = createFixture()
+
+    const result = updateJangarManifests({
+      imageName,
       tag: 'agents-tag',
       digest: 'sha256:agentsdigest',
+      controlPlaneImageName: 'registry.ide-newton.ts.net/lab/jangar-control-plane',
+      controlPlaneDigest: 'sha256:controlplanedigest',
+      rolloutTimestamp: '2026-02-20T08:30:00.000Z',
+      kustomizationPath: relative(repoRoot, fixture.kustomizationPath),
+      serviceManifestPath: relative(repoRoot, fixture.serviceManifestPath),
+      workerManifestPath: relative(repoRoot, fixture.workerManifestPath),
+      agentsValuesPath: relative(repoRoot, fixture.agentsValuesPath),
+    })
+
+    const values = readFileSync(fixture.agentsValuesPath, 'utf8')
+    const parsed = YAML.parse(values) as {
+      controlPlane?: { image?: { repository?: string; tag?: string; digest?: string } }
+    }
+
+    expect(parsed.controlPlane?.image).toEqual({
+      repository: 'registry.ide-newton.ts.net/lab/jangar-control-plane',
+      tag: 'agents-tag',
+      digest: 'sha256:controlplanedigest',
     })
     expect(result.changed.agentsValues).toBe(true)
 


### PR DESCRIPTION
## Summary

- Update `jangar-build-push` to build/push both `lab/jangar` and `lab/jangar-control-plane` images for each promoted tag, and increase timeout to 60 minutes to avoid build timeout churn.
- Update `jangar-release` to resolve a dedicated control-plane digest and pass it to manifest promotion.
- Update `update-manifests.ts` so `agents` and `runner` use the main Jangar digest, while `controlPlane.image` is only updated when explicit control-plane image metadata is provided.
- Add regression tests covering both behaviors: preserving control-plane values by default and updating them when control-plane image name/digest are supplied.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/update-manifests.test.ts`
- `bunx biome check packages/scripts/src/jangar/update-manifests.ts packages/scripts/src/jangar/__tests__/update-manifests.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
