### PR TITLE
chore(jangar): promote image 9fc4d64b

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: eaf8d021
-  digest: sha256:dd81fd7225b7e805e50e34b01dedc0301388e22d46b2ee75a145e04d3ed2a2ab
+  tag: 9fc4d64b
+  digest: sha256:a00a75d8d6657b62ca0159b176e2ccd5100165ffb7ab91c19a00ad7fa6b60692
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: eaf8d021
-    digest: sha256:dd81fd7225b7e805e50e34b01dedc0301388e22d46b2ee75a145e04d3ed2a2ab
+    tag: 9fc4d64b
+    digest: sha256:e2852db22a2563fd8d06d034687cfa383f9310866a3c176d2c5f0a0bd8b16d89
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: eaf8d021
-    digest: sha256:dd81fd7225b7e805e50e34b01dedc0301388e22d46b2ee75a145e04d3ed2a2ab
+    tag: 9fc4d64b
+    digest: sha256:a00a75d8d6657b62ca0159b176e2ccd5100165ffb7ab91c19a00ad7fa6b60692
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-21T11:08:07Z"
+    deploy.knative.dev/rollout: "2026-02-21T11:24:19Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T11:08:07Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T11:24:19Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "eaf8d021"
-    digest: sha256:dd81fd7225b7e805e50e34b01dedc0301388e22d46b2ee75a145e04d3ed2a2ab
+    newTag: "9fc4d64b"
+    digest: sha256:a00a75d8d6657b62ca0159b176e2ccd5100165ffb7ab91c19a00ad7fa6b60692


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `9fc4d64b596dbcbeabac84cfe651fe441e554154`
- Image tag: `9fc4d64b`
- Image digest: `sha256:a00a75d8d6657b62ca0159b176e2ccd5100165ffb7ab91c19a00ad7fa6b60692`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`