### PR TITLE
fix(argocd): narrow torghut knative ignoreDifferences

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -197,11 +197,11 @@ spec:
                   - group: serving.knative.dev
                     kind: Service
                     jsonPointers:
+                      # Keep metadata ignores granular; ignoring /spec/template/metadata can block SSA reconciliation.
                       - /metadata/annotations
                       - /metadata/labels
                       - /spec/traffic
                       - /spec/template/metadata/annotations
-                      - /spec/template/metadata
                       - /spec/template/metadata/creationTimestamp
                       - /spec/template/metadata/labels
                       - /spec/template/spec/containers/0/ports/0/protocol


### PR DESCRIPTION
## Summary

- Remove the over-broad `/spec/template/metadata` ignore pointer from the `torghut` Knative Service `ignoreDifferences` block in the product ApplicationSet.
- Keep metadata ignores granular and document why this pointer must stay excluded.
- Restore effective Argo CD reconciliation for `torghut` so sync operations can apply desired Knative template/image/env changes.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl -n argocd apply -f argocd/applicationsets/product.yaml`
- `argocd app diff torghut --hard-refresh`
- `kubectl -n argocd get application torghut -o json | jq '{sync:.status.sync.status, health:.status.health.status}'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
