### PR TITLE
fix(agents): set github commit author defaults

### DIFF
--- a/argocd/applications/agents/codex-versioncontrolprovider.yaml
+++ b/argocd/applications/agents/codex-versioncontrolprovider.yaml
@@ -24,8 +24,8 @@ spec:
     baseBranch: main
     branchTemplate: codex/{{issueNumber}}
     branchConflictSuffixTemplate: "{{agentRun.name}}"
-    commitAuthorName: codex
-    commitAuthorEmail: codex@proompt.com
+    commitAuthorName: "Greg Konush"
+    commitAuthorEmail: 12027037+gregkonush@users.noreply.github.com
     pullRequest:
       enabled: true
       draft: false


### PR DESCRIPTION
## Summary

- Update the agents `VersionControlProvider` defaults to use the GitHub account identity for commit attribution.
- Set `commitAuthorName` to `Greg Konush`.
- Set `commitAuthorEmail` to `12027037+gregkonush@users.noreply.github.com`.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applications/agents/codex-versioncontrolprovider.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
