### PR TITLE
fix(torghut): address v5 forecast gate and route normalization comments

### DIFF
--- a/services/torghut/app/trading/autonomy/gates.py
+++ b/services/torghut/app/trading/autonomy/gates.py
@@ -549,18 +549,24 @@ def _gate3_shadow_paper_quality(
     if llm_error_ratio > policy.gate3_max_llm_error_ratio:
         reasons.append("llm_error_ratio_exceeds_threshold")
     fallback_rate = _decimal(inputs.forecast_metrics.get("fallback_rate"))
+    if fallback_rate is None:
+        reasons.append("forecast_fallback_rate_missing")
     if (
         fallback_rate is not None
         and fallback_rate > policy.gate3_max_forecast_fallback_rate
     ):
         reasons.append("forecast_fallback_rate_exceeds_threshold")
     latency_ms_p95 = _decimal(inputs.forecast_metrics.get("inference_latency_ms_p95"))
+    if latency_ms_p95 is None:
+        reasons.append("forecast_inference_latency_p95_missing")
     if (
         latency_ms_p95 is not None
         and latency_ms_p95 > Decimal(policy.gate3_max_forecast_latency_ms_p95)
     ):
         reasons.append("forecast_inference_latency_exceeds_threshold")
     calibration_score_min = _decimal(inputs.forecast_metrics.get("calibration_score_min"))
+    if calibration_score_min is None:
+        reasons.append("forecast_calibration_score_missing")
     if (
         calibration_score_min is not None
         and calibration_score_min < policy.gate3_min_forecast_calibration_score

--- a/services/torghut/app/trading/features.py
+++ b/services/torghut/app/trading/features.py
@@ -314,7 +314,7 @@ def _route_regime_label(
 ) -> str:
     explicit = payload.get('regime_label')
     if isinstance(explicit, str) and explicit.strip():
-        return explicit.strip()
+        return _normalize_route_regime(explicit)
     if macd is None or macd_signal is None:
         return 'unknown'
     delta = macd - macd_signal
@@ -323,6 +323,10 @@ def _route_regime_label(
     if delta <= Decimal('-0.02'):
         return 'mean_revert'
     return 'range'
+
+
+def _normalize_route_regime(value: str) -> str:
+    return value.strip().lower()
 
 
 def _validate_signal_schema_version(signal: SignalEnvelope) -> None:

--- a/services/torghut/app/trading/forecasting.py
+++ b/services/torghut/app/trading/forecasting.py
@@ -558,7 +558,7 @@ class ForecastRouterV5:
     def _resolve_regime(self, feature_vector: FeatureVectorV3) -> str:
         explicit = feature_vector.values.get('route_regime_label')
         if isinstance(explicit, str) and explicit.strip():
-            return explicit.strip()
+            return explicit.strip().lower()
         macd = optional_decimal(feature_vector.values.get('macd')) or Decimal('0')
         signal = optional_decimal(feature_vector.values.get('macd_signal')) or Decimal('0')
         spread = macd - signal

--- a/services/torghut/tests/test_feature_contract_v3.py
+++ b/services/torghut/tests/test_feature_contract_v3.py
@@ -102,3 +102,19 @@ class TestFeatureContractV3(TestCase):
 
         with self.assertRaises(FeatureNormalizationError):
             normalize_feature_vector_v3(signal)
+
+    def test_normalization_lowercases_explicit_route_regime_label(self) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Min',
+            payload={
+                'macd': {'macd': '0.4', 'signal': '0.2'},
+                'rsi14': '50',
+                'price': '100',
+                'regime_label': '  TREND  ',
+            },
+        )
+
+        feature_vector = normalize_feature_vector_v3(signal)
+        self.assertEqual(feature_vector.values.get('route_regime_label'), 'trend')

--- a/services/torghut/tests/test_forecasting.py
+++ b/services/torghut/tests/test_forecasting.py
@@ -144,3 +144,50 @@ class TestForecastRouterV5(TestCase):
         self.assertEqual(first.contract.to_payload(), second.contract.to_payload())
         self.assertEqual(first.audit.to_payload(), second.audit.to_payload())
         self.assertEqual(first.telemetry.to_payload(), second.telemetry.to_payload())
+
+    def test_router_normalizes_explicit_regime_label_for_route_matching(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            policy_path = Path(tmpdir) / 'router-policy.json'
+            policy_path.write_text(
+                json.dumps(
+                    {
+                        'routes': [
+                            {
+                                'symbol_glob': '*',
+                                'horizon': '*',
+                                'regime': 'trend',
+                                'preferred_model_family': 'financial_tsfm',
+                                'candidate_fallbacks': [],
+                                'min_calibration_score': '0.80',
+                                'max_inference_latency_ms': 400,
+                                'disable_refinement': True,
+                            },
+                            {
+                                'symbol_glob': '*',
+                                'horizon': '*',
+                                'regime': '*',
+                                'preferred_model_family': 'chronos',
+                                'candidate_fallbacks': [],
+                                'min_calibration_score': '0.80',
+                                'max_inference_latency_ms': 400,
+                                'disable_refinement': True,
+                            },
+                        ]
+                    }
+                ),
+                encoding='utf-8',
+            )
+            router = build_default_forecast_router(
+                policy_path=str(policy_path), refinement_enabled=False
+            )
+
+        signal = _signal()
+        signal.payload['regime_label'] = 'TREND'
+        result = router.route_and_forecast(
+            feature_vector=normalize_feature_vector_v3(signal),
+            horizon='1Min',
+            event_ts=signal.event_ts,
+        )
+
+        self.assertEqual(result.contract.route_key.split('|')[-1], 'trend')
+        self.assertEqual(result.contract.model_family, 'financial_tsfm')


### PR DESCRIPTION
## Summary

- Fail-closed Gate3 forecast health checks by adding explicit missing-metric reasons for fallback rate, latency p95, and calibration score.
- Populate `GateInputs.forecast_metrics` in autonomous lane by deterministically running forecast routing over the lane signal window.
- Normalize explicit `regime_label` values to lowercase before route matching, with regression coverage for route selection and feature normalization paths.

## Related Issues

None

## Testing

- `cd services/torghut && uv run pytest tests/test_autonomy_gates.py tests/test_feature_contract_v3.py tests/test_forecasting.py tests/test_autonomous_lane.py -q`
- `cd services/torghut && uv run pyright`
- `cd services/torghut && uv run ruff check app/trading/autonomy/gates.py app/trading/autonomy/lane.py app/trading/features.py app/trading/forecasting.py tests/test_autonomy_gates.py tests/test_feature_contract_v3.py tests/test_forecasting.py tests/test_autonomous_lane.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
