### PR TITLE
fix(feature-flags): run flipt with single replica for RWO PVC

### DIFF
--- a/argocd/applications/feature-flags/flipt-values.yaml
+++ b/argocd/applications/feature-flags/flipt-values.yaml
@@ -1,6 +1,6 @@
 fullnameOverride: feature-flags
 
-replicaCount: 2
+replicaCount: 1
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

- Reduce Flipt Helm `replicaCount` from `2` to `1` in `argocd/applications/feature-flags/flipt-values.yaml`.
- Resolve rollout issue caused by a single `ReadWriteOnce` PVC being shared by multiple replicas.
- Ensure Argo CD `feature-flags` app can become fully healthy after Flipt migration.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/feature-flags >/tmp/feature-flags.render.yaml`
- Verified rendered Deployment now uses `replicas: 1`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
