### PR TITLE
fix(agents): update Artifact Hub icon metadata

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -5,9 +5,9 @@ home: https://github.com/proompteng/charts/tree/main/charts/agents
 sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: "0.9.0"
-icon: https://avatars.githubusercontent.com/u/165504663?s=200&v=4
+icon: https://avatars.githubusercontent.com/u/234536857
 keywords:
   - agents
   - jangar

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.1
+version: 0.9.2
 name: agents
 displayName: Agents Control Plane (Jangar)
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Update the Agents Helm chart icon URL to the new GitHub avatar used for Artifact Hub package metadata.
- Bump `/Users/gregkonush/.codex/worktrees/a043/lab/charts/agents/Chart.yaml` version from `0.9.1` to `0.9.2` so chart content changes publish cleanly.
- Bump `/Users/gregkonush/.codex/worktrees/a043/lab/charts/agents/artifacthub-pkg.yml` version from `0.9.1` to `0.9.2` to keep Artifact Hub package metadata aligned.

## Related Issues

None

## Testing

- `helm lint /Users/gregkonush/.codex/worktrees/a043/lab/charts/agents`
- `helm template agents /Users/gregkonush/.codex/worktrees/a043/lab/charts/agents --values /Users/gregkonush/.codex/worktrees/a043/lab/charts/agents/values-local.yaml >/tmp/agents-template.out`
- `wc -l /tmp/agents-template.out` (render output generated successfully, 741 lines)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
