### PR TITLE
feat(feature-flags): enable flipt github write-back

### DIFF
--- a/argocd/applications/feature-flags/flipt-values.yaml
+++ b/argocd/applications/feature-flags/flipt-values.yaml
@@ -11,11 +11,32 @@ persistence:
   size: 5Gi
 
 flipt:
+  extraEnvVars:
+    - name: FLIPT_GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-token
+          key: token
+          optional: true
   config:
     authentication:
       required: false
+    credentials:
+      github:
+        type: access_token
+        access_token: ${env:FLIPT_GITHUB_TOKEN}
     storage:
       default:
+        remote: https://github.com/proompteng/lab.git
+        branch: main
+        poll_interval: 30s
+        credentials: github
         backend:
           type: local
-          path: /var/opt/flipt
+          path: /var/opt/flipt/repositories/default
+    environments:
+      default:
+        name: Default
+        default: true
+        storage: default
+        directory: argocd/applications/feature-flags/gitops

--- a/argocd/applications/feature-flags/gitops/default/features.yaml
+++ b/argocd/applications/feature-flags/gitops/default/features.yaml
@@ -1,0 +1,37 @@
+namespace: default
+flags:
+  - key: jangar.market_context.enabled
+    name: Jangar Market Context
+    description: Enables market context fetching and health checks in Jangar.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: true
+  - key: jangar.orchestration_controller.enabled
+    name: Jangar Orchestration Controller
+    description: Enables orchestration controller startup in Jangar.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: true
+  - key: jangar.supporting_controller.enabled
+    name: Jangar Supporting Controller
+    description: Enables supporting controller startup in Jangar.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: true
+  - key: jangar.agents_controller.enabled
+    name: Jangar Agents Controller
+    description: Enables agents controller startup in Jangar.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: false
+  - key: jangar.primitives_reconciler.enabled
+    name: Jangar Primitives Reconciler
+    description: Enables primitives reconciler startup in Jangar.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: false
+  - key: jangar.ci_event_stream.enabled
+    name: Jangar CI Event Stream
+    description: Enables CI event stream updates in Codex judge.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: true
+  - key: jangar.torghut.decision_engine.enabled
+    name: Jangar Torghut Decision Engine
+    description: Enables Torghut decision engine execution in Jangar.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: true

--- a/argocd/applications/jangar/github-token.yaml
+++ b/argocd/applications/jangar/github-token.yaml
@@ -15,6 +15,6 @@ spec:
       namespace: jangar
       annotations:
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "agents,argo-workflows,froussard"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "agents,argo-workflows,froussard,feature-flags"
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "agents,argo-workflows,froussard"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "agents,argo-workflows,froussard,feature-flags"


### PR DESCRIPTION
## Summary

- Configure Flipt v2 to use `proompteng/lab` as Git remote with a write-capable Git credential.
- Wire `FLIPT_GITHUB_TOKEN` from `Secret/github-token` and map Flipt `credentials.github` as `access_token` for push support.
- Add initial GitOps flag state under `argocd/applications/feature-flags/gitops/default/features.yaml` for migrated non-control-plane Jangar flags.
- Extend `github-token` reflector annotations so the secret auto-reflects into the `feature-flags` namespace.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/feature-flags > /tmp/feature-flags-render.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar-render.yaml`
- Verified rendered Flipt ConfigMap contains `remote`, `credentials: github`, and `access_token: ${env:FLIPT_GITHUB_TOKEN}`.
- Verified rendered Flipt Deployment includes `FLIPT_GITHUB_TOKEN` from `secretKeyRef` `github-token/token`.
- Verified rendered Jangar SealedSecret reflector annotations include `feature-flags` namespace.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
