### PR TITLE
fix(feature-flags): switch jangar flag keys to flipt-safe format

### DIFF
--- a/argocd/applications/feature-flags/gitops/default/features.yaml
+++ b/argocd/applications/feature-flags/gitops/default/features.yaml
@@ -1,36 +1,36 @@
 namespace: default
 flags:
-  - key: jangar.market_context.enabled
+  - key: jangar_market_context_enabled
     name: Jangar Market Context
     description: Enables market context fetching and health checks in Jangar.
     type: BOOLEAN_FLAG_TYPE
     enabled: true
-  - key: jangar.orchestration_controller.enabled
+  - key: jangar_orchestration_controller_enabled
     name: Jangar Orchestration Controller
     description: Enables orchestration controller startup in Jangar.
     type: BOOLEAN_FLAG_TYPE
     enabled: true
-  - key: jangar.supporting_controller.enabled
+  - key: jangar_supporting_controller_enabled
     name: Jangar Supporting Controller
     description: Enables supporting controller startup in Jangar.
     type: BOOLEAN_FLAG_TYPE
     enabled: true
-  - key: jangar.agents_controller.enabled
+  - key: jangar_agents_controller_enabled
     name: Jangar Agents Controller
     description: Enables agents controller startup in Jangar.
     type: BOOLEAN_FLAG_TYPE
     enabled: false
-  - key: jangar.primitives_reconciler.enabled
+  - key: jangar_primitives_reconciler_enabled
     name: Jangar Primitives Reconciler
     description: Enables primitives reconciler startup in Jangar.
     type: BOOLEAN_FLAG_TYPE
     enabled: false
-  - key: jangar.ci_event_stream.enabled
+  - key: jangar_ci_event_stream_enabled
     name: Jangar CI Event Stream
     description: Enables CI event stream updates in Codex judge.
     type: BOOLEAN_FLAG_TYPE
     enabled: true
-  - key: jangar.torghut.decision_engine.enabled
+  - key: jangar_torghut_decision_engine_enabled
     name: Jangar Torghut Decision Engine
     description: Enables Torghut decision engine execution in Jangar.
     type: BOOLEAN_FLAG_TYPE

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -106,7 +106,7 @@ spec:
             - name: JANGAR_CI_EVENT_STREAM_ENABLED
               value: "true"
             - name: JANGAR_CI_EVENT_STREAM_ENABLED_FLAG_KEY
-              value: jangar.ci_event_stream.enabled
+              value: jangar_ci_event_stream_enabled
             - name: JANGAR_MODELS
               value: gpt-5.3-codex
             - name: JANGAR_DEFAULT_MODEL
@@ -132,13 +132,13 @@ spec:
             - name: JANGAR_PRIMITIVES_RECONCILER
               value: "false"
             - name: JANGAR_ORCHESTRATION_CONTROLLER_ENABLED_FLAG_KEY
-              value: jangar.orchestration_controller.enabled
+              value: jangar_orchestration_controller_enabled
             - name: JANGAR_SUPPORTING_CONTROLLER_ENABLED_FLAG_KEY
-              value: jangar.supporting_controller.enabled
+              value: jangar_supporting_controller_enabled
             - name: JANGAR_AGENTS_CONTROLLER_ENABLED_FLAG_KEY
-              value: jangar.agents_controller.enabled
+              value: jangar_agents_controller_enabled
             - name: JANGAR_PRIMITIVES_RECONCILER_FLAG_KEY
-              value: jangar.primitives_reconciler.enabled
+              value: jangar_primitives_reconciler_enabled
             - name: JANGAR_CI_MAX_WAIT_MS
               value: "3600000"
             - name: JANGAR_REVIEW_MAX_WAIT_MS
@@ -267,7 +267,7 @@ spec:
             - name: JANGAR_MARKET_CONTEXT_ENABLED
               value: "true"
             - name: JANGAR_MARKET_CONTEXT_ENABLED_FLAG_KEY
-              value: jangar.market_context.enabled
+              value: jangar_market_context_enabled
             - name: JANGAR_MARKET_CONTEXT_CACHE_SECONDS
               value: "60"
             - name: JANGAR_MARKET_CONTEXT_MAX_STALENESS_SECONDS
@@ -299,7 +299,7 @@ spec:
             - name: JANGAR_TORGHUT_DECISION_ENGINE_ENABLED
               value: "true"
             - name: JANGAR_TORGHUT_DECISION_ENGINE_ENABLED_FLAG_KEY
-              value: jangar.torghut.decision_engine.enabled
+              value: jangar_torghut_decision_engine_enabled
             - name: JANGAR_TORGHUT_DECISION_RUN_TIMEOUT_MS
               value: "120000"
             - name: JANGAR_TORGHUT_DECISION_STREAM_HEARTBEAT_MS


### PR DESCRIPTION
## Summary

- Fix Flipt v2 Git write failures caused by invalid flag keys containing `.`.
- Rename migrated Jangar flag keys in GitOps state to underscore format allowed by Flipt v2 validation.
- Update Jangar `*_FLAG_KEY` environment overrides to use the renamed underscore keys so runtime lookups match stored flags.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/feature-flags > /tmp/feature-flags-render-2.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar > /tmp/jangar-render-2.yaml`
- Manual in-cluster check (pre-fix) reproduced server error: `out of bound =~"^[-_,A-Za-z0-9]+$"` for dotted keys on Flipt write API.
- Confirmed updated manifests now contain underscore-form keys for all non-control-plane migrated Jangar flags.

## Screenshots (if applicable)

N/A

## Breaking Changes

- Existing Flipt keys for migrated Jangar flags move from dotted names to underscore names.
- Jangar deployment is updated in the same change to preserve behavior via env override keys.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
