### PR TITLE
fix(feature-flags): use writable branch for flipt state

### DIFF
--- a/argocd/applications/feature-flags/flipt-values.yaml
+++ b/argocd/applications/feature-flags/flipt-values.yaml
@@ -28,7 +28,7 @@ flipt:
     storage:
       default:
         remote: https://github.com/proompteng/lab.git
-        branch: main
+        branch: feature-flags-state
         poll_interval: 30s
         credentials: github
         backend:


### PR DESCRIPTION
## Summary

- Fix Flipt write-path failures caused by repository rules that block direct pushes to the default branch.
- Change Flipt storage sync target from `main` to writable branch `feature-flags-state` in `proompteng/lab`.
- Keep GitOps path and credentials unchanged so reads/writes remain in the same repository.

## Related Issues

None

## Testing

- `git push origin origin/main:refs/heads/feature-flags-state` (created writable state branch from current main).
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/feature-flags > /tmp/feature-flags-render-3.yaml`
- Verified rendered Flipt config includes:
  - `remote: https://github.com/proompteng/lab.git`
  - `branch: feature-flags-state`
  - `credentials: github`
- Manual in-cluster write test before this change returned: `push declined due to repository rule violations` on `refs/heads/main`.

## Screenshots (if applicable)

N/A

## Breaking Changes

- Flipt state source-of-truth branch changes from `main` to `feature-flags-state`.
- Feature flag mutations made through Flipt now commit to `feature-flags-state`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
