### PR TITLE
fix(jangar): parse flipt boolean evaluation payload robustly

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-market-context.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context.test.ts
@@ -100,7 +100,11 @@ describe('torghut market context', () => {
 
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ enabled: false }),
+      json: async () => ({
+        enabled: false,
+        reason: 'DEFAULT_EVALUATION_REASON',
+        requestId: 'test-request-id',
+      }),
     })
     vi.stubGlobal('fetch', fetchMock)
 

--- a/services/jangar/src/server/feature-flags.ts
+++ b/services/jangar/src/server/feature-flags.ts
@@ -17,9 +17,7 @@ const DEFAULT_TIMEOUT_MS = 500
 const DEFAULT_NAMESPACE_KEY = 'default'
 const DEFAULT_ENTITY_ID = 'jangar'
 
-const BooleanEvaluationResponseSchema = S.Struct({
-  enabled: S.Boolean,
-})
+const BooleanEnabledSchema = S.Boolean
 
 const TRUE_BOOLEAN_VALUES = new Set(['1', 'true', 'yes', 'on', 'enabled'])
 const FALSE_BOOLEAN_VALUES = new Set(['0', 'false', 'no', 'off', 'disabled'])
@@ -108,9 +106,9 @@ export const getBooleanFeatureFlag = async (request: BooleanFlagRequest): Promis
     if (!response.ok) return request.defaultValue
 
     const body = await response.json()
-    const decoded = S.decodeUnknownEither(BooleanEvaluationResponseSchema)(body)
+    const decoded = S.decodeUnknownEither(BooleanEnabledSchema)((body as { enabled?: unknown } | null)?.enabled)
     if (Either.isLeft(decoded)) return request.defaultValue
-    return decoded.right.enabled
+    return decoded.right
   } catch {
     return request.defaultValue
   } finally {


### PR DESCRIPTION
## Summary

- Fix Flipt evaluation response parsing in Jangar by decoding only the `enabled` field instead of strict-decoding the full response payload.
- Preserve fallback behavior to `defaultValue` when the `enabled` value is missing or invalid.
- Update the Torghut market-context feature-flag test fixture to include additional response fields and prevent regression with real Flipt payload shapes.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-market-context.test.ts -t "uses feature-flags service for market context enablement when configured"`

## Screenshots (if applicable)

N/A (backend-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
