### PR TITLE
fix(jangar): roll out parser-fix image

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-21T09:09:45Z"
+    deploy.knative.dev/rollout: "2026-02-21T21:16:37.468Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T09:09:45Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T21:16:37.468Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "9adeca26"
-    digest: sha256:e0e991c1f4379a391738a760ebb2548c45b793d10a4df527ff163ccc90c347b4
+    newTag: "050d7def"
+    digest: sha256:6176538dfeb34624461a4e5df8e1b8b9b07fa3597f67933690915353b264a963


### PR DESCRIPTION
## Summary

- Bump Jangar GitOps image in Argo manifests to `registry.ide-newton.ts.net/lab/jangar:050d7def` with digest `sha256:6176538dfeb34624461a4e5df8e1b8b9b07fa3597f67933690915353b264a963`.
- Update Jangar service rollout annotation to force the Knative deployment refresh.
- Update Jangar worker rollout annotation to restart worker pods on sync.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/jangar/build-image.ts`
- `bun run packages/scripts/src/jangar/update-manifests.ts --tag 050d7def`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A (manifest-only rollout)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
