### PR TITLE
feat(temporal): enable HA stores on ceph and document ampone memory maintenance

### DIFF
--- a/argocd/applications/temporal/kustomization.yaml
+++ b/argocd/applications/temporal/kustomization.yaml
@@ -18,9 +18,9 @@ helmCharts:
       grafana:
         enabled: false
       elasticsearch:
-        replicas: 1
-        minimumMasterNodes: 1
-        clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
+        replicas: 3
+        minimumMasterNodes: 2
+        clusterHealthCheckParams: "wait_for_status=green&timeout=1s"
         # Persist ES data so Temporal visibility index survives node restarts
         persistence:
           enabled: true
@@ -33,14 +33,20 @@ helmCharts:
           storageClassName: rook-ceph-block
       schema:
         createDatabase:
-          enabled: false
+          enabled: true
         setup:
-          enabled: false
+          enabled: true
         update:
-          enabled: false
+          enabled: true
       cassandra:
+        persistence:
+          enabled: true
+          storageClass: rook-ceph-block
+          accessMode: ReadWriteOnce
+          size: 20Gi
         config:
-          cluster_size: 1
+          cluster_size: 3
+          seed_size: 2
       web:
         # https://docs.temporal.io/references/web-ui-environment-variables
         additionalEnv:

--- a/devices/ampone/README.md
+++ b/devices/ampone/README.md
@@ -9,6 +9,7 @@ Docs:
 - `devices/ampone/docs/cluster-bootstrap.md` (Talos install/bootstrap template)
 - `devices/ampone/docs/volume-relayout.md` (repartition EPHEMERAL + local-path volumes)
 - `devices/ampone/docs/ipmi.md` (IPMI/BMC command cookbook)
+- `devices/ampone/docs/memory-upgrade-maintenance.md` (cordon/drain + IPMI shutdown for RAM work)
 - `devices/ampone/docs/memory-troubleshooting.md` (DDR training + DIMM isolation notes)
 - `devices/ampone/docs/relayout-volumes.md` (EPHEMERAL=300GB, local-path=rest)
 

--- a/devices/ampone/docs/memory-upgrade-maintenance.md
+++ b/devices/ampone/docs/memory-upgrade-maintenance.md
@@ -1,0 +1,116 @@
+# Ampone memory-upgrade maintenance (cordon, drain, IPMI power-off)
+
+Goal: safely power down `ampone` for physical memory work while minimizing cluster risk.
+
+Targets:
+- Kubernetes node: `talos-192-168-1-203` (`ampone`)
+- BMC/IPMI: `192.168.1.224`
+
+## Preconditions / Safety
+
+- Schedule a maintenance window.
+- Keep the other control-plane nodes healthy and online (`192.168.1.85`, `192.168.1.194`).
+- Understand impact:
+  - `drain` may be blocked by PodDisruptionBudgets (PDBs).
+  - forced drain (`--disable-eviction --force`) bypasses PDB protections and can cause downtime.
+- Ensure IPMI credentials are available locally (see `devices/ampone/docs/ipmi.md`).
+
+## 1) Cordon ampone
+
+```bash
+kubectl cordon talos-192-168-1-203
+
+kubectl get node talos-192-168-1-203 \
+  -o jsonpath='{.metadata.name}{" unschedulable="}{.spec.unschedulable}{"\n"}'
+```
+
+Expected: `unschedulable=true`.
+
+## 2) Try a standard drain first
+
+```bash
+kubectl drain talos-192-168-1-203 \
+  --ignore-daemonsets \
+  --delete-emptydir-data \
+  --grace-period=60 \
+  --timeout=15m
+```
+
+## 3) If blocked by PDBs, force drain (maintenance-only)
+
+Use this only when you intentionally accept disruption for hardware maintenance.
+
+```bash
+kubectl drain talos-192-168-1-203 \
+  --ignore-daemonsets \
+  --delete-emptydir-data \
+  --disable-eviction \
+  --force \
+  --grace-period=60 \
+  --timeout=10m
+```
+
+## 4) Verify the node is drained
+
+```bash
+kubectl get pods -A \
+  --field-selector spec.nodeName=talos-192-168-1-203 \
+  -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,OWNER:.metadata.ownerReferences[0].kind,STATUS:.status.phase'
+```
+
+Expected:
+- only `DaemonSet` and static control-plane pods (`OWNER=Node`) remain
+- no regular workload Deployments/StatefulSets remain on this node
+
+## 5) Power off via IPMI
+
+```bash
+export IPMI_PASSWORD="$(cat ~/.secrets/ampone-ipmi-password)"
+
+ipmitool -I lanplus -H 192.168.1.224 -U admin -E chassis power status
+ipmitool -I lanplus -H 192.168.1.224 -U admin -E chassis power off
+sleep 5
+ipmitool -I lanplus -H 192.168.1.224 -U admin -E chassis power status
+```
+
+Expected final status: `Chassis Power is off`.
+
+## 6) Confirm Kubernetes sees the node down
+
+The API can lag briefly after power-off.
+
+```bash
+kubectl get node talos-192-168-1-203 \
+  -o jsonpath='{.metadata.name}{" ready="}{range .status.conditions[?(@.type=="Ready")]}{.status}{" lastHeartbeat="}{.lastHeartbeatTime}{end}{" unschedulable="}{.spec.unschedulable}{"\n"}'
+
+kubectl get lease -n kube-node-lease talos-192-168-1-203 \
+  -o jsonpath='{.spec.renewTime}{"\n"}'
+```
+
+Expected shortly after shutdown:
+- node transitions from `Ready=True` to `Ready=Unknown`/`NotReady`
+- lease `renewTime` stops advancing
+
+## 7) After memory upgrade: power on and return to service
+
+```bash
+export IPMI_PASSWORD="$(cat ~/.secrets/ampone-ipmi-password)"
+ipmitool -I lanplus -H 192.168.1.224 -U admin -E chassis power on
+```
+
+Wait for node recovery:
+
+```bash
+kubectl get node talos-192-168-1-203 -w
+```
+
+When `Ready=True`, allow scheduling again:
+
+```bash
+kubectl uncordon talos-192-168-1-203
+```
+
+## References
+
+- IPMI command cookbook: `devices/ampone/docs/ipmi.md`
+- Memory troubleshooting signals and DIMM workflow: `devices/ampone/docs/memory-troubleshooting.md`


### PR DESCRIPTION
## Summary

- Increase Temporal Elasticsearch to 3 replicas and require green cluster health checks.
- Enable Temporal Cassandra persistence on Ceph (`rook-ceph-block`) and scale Cassandra to 3 nodes.
- Re-enable Temporal schema create/setup/update jobs for automated bootstrap and migrations.
- Add Ampone maintenance runbook for cordon/drain/IPMI shutdown and link it from device docs.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/temporal >/tmp/temporal-ha-final.yaml`
- `kubectl apply --dry-run=server -f /tmp/temporal-ha-final.yaml`
- `kubectl get pods -n temporal -o wide`
- `kubectl rollout status -n temporal deploy/temporal-frontend --timeout=10m`
- `kubectl rollout status -n temporal deploy/temporal-history --timeout=10m`
- `kubectl rollout status -n temporal deploy/temporal-matching --timeout=10m`
- `kubectl rollout status -n temporal deploy/temporal-worker --timeout=10m`
- `kubectl exec -n temporal deploy/temporal-admintools -- tctl --address temporal-frontend.temporal.svc.cluster.local:7233 cluster health`

## Screenshots (if applicable)

N/A

## Breaking Changes

- Temporal Cassandra StatefulSet must be recreated once when moving from ephemeral storage to PVC-backed `volumeClaimTemplates` (immutable field limitation).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
