### PR TITLE
fix(argocd): ignore temporal cassandra statefulset server-default fields

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -418,6 +418,18 @@ spec:
             - .spec.volumeClaimTemplates[].kind
         - kind: StatefulSet
           group: apps
+          namespace: temporal
+          name: temporal-cassandra
+          jqPathExpressions:
+            - .spec.persistentVolumeClaimRetentionPolicy
+            - .spec.revisionHistoryLimit
+            - .spec.updateStrategy
+            - .spec.volumeClaimTemplates[].apiVersion
+            - .spec.volumeClaimTemplates[].kind
+            - .spec.volumeClaimTemplates[].spec.volumeMode
+            - .spec.volumeClaimTemplates[].status
+        - kind: StatefulSet
+          group: apps
           namespace: nats
           name: nats
           jqPathExpressions:


### PR DESCRIPTION
## Summary

- Add an `ignoreDifferences` rule for `StatefulSet/temporal-cassandra` in the platform ApplicationSet.
- Ignore Kubernetes server-default StatefulSet/PVC template fields that cause false Argo drift.
- Keep Temporal app sync status aligned with GitOps after enabling Cassandra PVC-backed storage.

## Related Issues

None

## Testing

- `kubectl get app -n argocd temporal -o json | jq -r '.status.resources[] | select(.status=="OutOfSync") | [.group,.kind,.namespace,.name] | @tsv'`
- `kubectl get sts -n temporal temporal-cassandra -o json | jq '.spec.persistentVolumeClaimRetentionPolicy, .spec.updateStrategy, .spec.volumeClaimTemplates[0].spec.volumeMode'`
- Manual validation: confirmed only `StatefulSet/temporal-cassandra` remained `OutOfSync` before this change and that the ignored fields are server-default metadata/spec fields.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
