### PR TITLE
feat(bumba): enable image updater auto-release and autosync

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -50,7 +50,10 @@ jobs:
           echo "reason=not-evaluated" >> "$GITHUB_OUTPUT"
 
           allowed_authors=("app/github-actions" "github-actions[bot]")
-          allowed_paths=("argocd/applications/proompteng/kustomization.yaml")
+          allowed_paths=(
+            "argocd/applications/proompteng/kustomization.yaml"
+            "argocd/applications/bumba/kustomization.yaml"
+          )
 
           contains() {
             local needle="$1"

--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -78,3 +78,19 @@ spec:
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/dernier
+    - namePattern: bumba
+      writeBackConfig:
+        method: git:secret:argocd/image-updater-git-ssh
+        gitConfig:
+          repository: git@github.com:proompteng/lab.git
+          branch: main:release/{{.SHA256}}
+          writeBackTarget: kustomization:/argocd/applications/bumba
+      images:
+        - alias: bumba
+          imageName: registry.ide-newton.ts.net/lab/bumba:latest
+          commonUpdateSettings:
+            updateStrategy: latest
+            allowTags: '^[0-9a-f]{40}$'
+          manifestTargets:
+            kustomize:
+              name: registry.ide-newton.ts.net/lab/bumba

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -132,7 +132,7 @@ spec:
                 namespace: jangar
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
-                automation: manual
+                automation: auto
                 enabled: "true"
               - name: oirat
                 path: argocd/applications/oirat


### PR DESCRIPTION
## Summary

- Add `bumba` to `product-image-updater` so Argo CD Image Updater writes image bumps to `argocd/applications/bumba/kustomization.yaml` on `release/<sha256>` branches.
- Configure `bumba` image updates to use `latest` strategy with an allowlist for commit-SHA tags (`^[0-9a-f]{40}$`).
- Change product ApplicationSet automation mode for `bumba` from `manual` to `auto` so merged manifest updates self-sync.
- Extend release PR automerge allowlist to include `argocd/applications/bumba/kustomization.yaml`.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/jangar/check-automation-policy.ts --require jangar=auto --require bumba=auto`
- `kubectl apply --dry-run=client -f argocd/applications/argocd/base/image-updater-product.yaml -f argocd/applicationsets/product.yaml`
- `kubectl explain imageupdater.spec.applicationRefs.images.commonUpdateSettings.allowTags --api-version=argocd-image-updater.argoproj.io/v1alpha1`
- Manual validation of workflow gates in `.github/workflows/release-pr-automerge.yml` allowlist and Argo ImageUpdater spec diff.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
