### PR TITLE
fix(argocd): correct inngest helm oci repo path

### DIFF
--- a/argocd/applications/inngest/kustomization.yaml
+++ b/argocd/applications/inngest/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
                     value: redis://inngest-redis:6379/0
 helmCharts:
   - name: inngest
-    repo: oci://ghcr.io/inngest/inngest-helm/inngest
+    repo: oci://ghcr.io/inngest/inngest-helm
     version: 0.3.0
     releaseName: inngest
     namespace: inngest


### PR DESCRIPTION
## Summary

- Fixed `argocd/applications/inngest/kustomization.yaml` Helm OCI repo to the base path expected by Argo CD Kustomize Helm integration.
- This resolves Argo render failures that attempted to pull `.../inngest/inngest` and returned `403`.
- Unblocks `inngest` application sync, SealedSecret materialization, and reflected secret propagation to `khoshut`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/inngest`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
