### PR TITLE
ci(torghut): automate argocd deploy on main

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -1,44 +1,93 @@
-name: Torghut Docker Build and Push
+name: torghut-build-push
 
 permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/torghut/**'
+      - 'packages/scripts/src/torghut/**'
+      - 'packages/scripts/src/shared/**'
+      - 'package.json'
+      - 'bun.lock'
+      - '.github/workflows/torghut-build-push.yaml'
   workflow_dispatch:
-  workflow_run:
-    workflows: ["torghut-ci"]
-    types:
-      - completed
+
+concurrency:
+  group: torghut-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-push:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     runs-on: arc-arm64
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          images: registry.ide-newton.ts.net/lab/torghut
-          tags: |
-            type=ref,event=branch
-            type=sha
-            type=raw,value=latest
+          bun-version: 1.3.9
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Build and push torghut image
+        env:
+          TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          TORGHUT_IMAGE_PLATFORMS: linux/arm64
+        run: bun run packages/scripts/src/torghut/build-image.ts
+
+      - name: Resolve pushed image digest
+        id: digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE='registry.ide-newton.ts.net/lab/torghut'
+          TAG='${{ steps.meta.outputs.tag }}'
+          DIGEST="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" | awk '/^Digest:/ { print $2; exit }')"
+          if [ -z "${DIGEST}" ]; then
+            echo "Failed to resolve digest for ${IMAGE}:${TAG}"
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Write release contract artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun run packages/scripts/src/torghut/release-contract.ts write \
+            --path torghut-release-contract.json \
+            --source-sha "${GITHUB_SHA}" \
+            --tag "${{ steps.meta.outputs.tag }}" \
+            --digest "${{ steps.digest.outputs.digest }}" \
+            --image 'registry.ide-newton.ts.net/lab/torghut'
+
+      - name: Upload release contract artifact
+        uses: actions/upload-artifact@v4
         with:
-          context: services/torghut
-          file: services/torghut/Dockerfile
-          platforms: linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=registry.ide-newton.ts.net/lab/torghut:latest
-          cache-to: type=inline
+          name: torghut-release-contract
+          path: torghut-release-contract.json
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Update latest tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE='registry.ide-newton.ts.net/lab/torghut'
+          TAG='${{ steps.meta.outputs.tag }}'
+          docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${TAG}"
+          docker buildx imagetools inspect "${IMAGE}:${TAG}"
+          docker buildx imagetools inspect "${IMAGE}:latest"

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -1,0 +1,130 @@
+name: torghut-deploy-automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: torghut-deploy-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable:
+    if: >-
+      ${{
+        startsWith(github.event.pull_request.head.ref, 'codex/torghut-release-') &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.draft == false
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Evaluate automerge eligibility
+        id: gates
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+
+          echo "eligible=false" >> "$GITHUB_OUTPUT"
+          echo "reason=not-evaluated" >> "$GITHUB_OUTPUT"
+
+          allowed_authors=('app/github-actions' 'github-actions[bot]')
+          allowed_paths=('argocd/applications/torghut/knative-service.yaml')
+
+          contains() {
+            local needle="$1"
+            shift
+            for item in "$@"; do
+              if [ "${item}" = "${needle}" ]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          if [ "${PR_HEAD_REPO}" != "${GH_REPO}" ]; then
+            echo "reason=head-not-from-same-repo" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! contains "${PR_AUTHOR}" "${allowed_authors[@]}"; then
+            echo "reason=author-not-allowlisted:${PR_AUTHOR}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          has_opt_out_label="$(
+            gh pr view "${PR_NUMBER}" \
+              -R "${GH_REPO}" \
+              --json labels \
+              --jq 'any(.labels[]?; .name == "do-not-automerge")'
+          )"
+
+          if [ "${has_opt_out_label}" = 'true' ]; then
+            echo "reason=opt-out-label-present" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t changed_files < <(
+            gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename'
+          )
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "reason=no-files-changed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          for path in "${changed_files[@]}"; do
+            if ! contains "${path}" "${allowed_paths[@]}"; then
+              echo "reason=changed-file-not-allowlisted:${path}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+          echo "reason=eligible" >> "$GITHUB_OUTPUT"
+
+      - name: Eligibility summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "eligible=${{ steps.gates.outputs.eligible }}"
+          echo "reason=${{ steps.gates.outputs.reason }}"
+
+      - name: Enable squash auto-merge
+        if: steps.gates.outputs.eligible == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          auto_merge_enabled="$(
+            gh pr view "${PR_NUMBER}" \
+              -R "${GH_REPO}" \
+              --json autoMergeRequest \
+              --jq '.autoMergeRequest != null'
+          )"
+          if [ "${auto_merge_enabled}" = 'true' ]; then
+            echo "Auto-merge already enabled for PR #${PR_NUMBER}"
+            exit 0
+          fi
+          gh pr merge "${PR_NUMBER}" -R "${GH_REPO}" --auto --squash

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -1,0 +1,284 @@
+name: torghut-release
+
+on:
+  workflow_run:
+    workflows:
+      - torghut-build-push
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to promote (defaults to current main HEAD)
+        required: false
+        type: string
+      image_tag:
+        description: Image tag to promote (defaults to source short SHA)
+        required: false
+        type: string
+      image_digest:
+        description: Image digest override (sha256:...)
+        required: false
+        type: string
+
+concurrency:
+  group: torghut-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+      }}
+    runs-on: arc-arm64
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download release contract artifact from triggering build
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: torghut-release-contract
+          path: .artifacts/torghut
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_SHA_INPUT: ${{ inputs.commit_sha }}
+          IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+
+          MAIN_HEAD="$(git rev-parse origin/main)"
+          IMAGE='registry.ide-newton.ts.net/lab/torghut'
+          SOURCE_SHA=''
+          TAG=''
+          CONTRACT_DIGEST=''
+          PROMOTE='true'
+
+          if [ "${EVENT_NAME}" = 'workflow_run' ]; then
+            CONTRACT_PATH='.artifacts/torghut/torghut-release-contract.json'
+            if [ ! -f "${CONTRACT_PATH}" ]; then
+              echo "Release contract artifact is missing at ${CONTRACT_PATH}"
+              exit 1
+            fi
+
+            SOURCE_SHA="$(bun run packages/scripts/src/torghut/release-contract.ts get --path "${CONTRACT_PATH}" --field sourceSha)"
+            TAG="$(bun run packages/scripts/src/torghut/release-contract.ts get --path "${CONTRACT_PATH}" --field tag)"
+            CONTRACT_DIGEST="$(bun run packages/scripts/src/torghut/release-contract.ts get --path "${CONTRACT_PATH}" --field digest)"
+            CONTRACT_IMAGE="$(bun run packages/scripts/src/torghut/release-contract.ts get --path "${CONTRACT_PATH}" --field image)"
+
+            if [ "${CONTRACT_IMAGE}" != "${IMAGE}" ]; then
+              echo "Release contract image mismatch: expected ${IMAGE}, got ${CONTRACT_IMAGE}"
+              exit 1
+            fi
+
+            if [ "${SOURCE_SHA}" != "${WORKFLOW_RUN_HEAD_SHA}" ]; then
+              echo "Release contract source SHA ${SOURCE_SHA} does not match workflow_run head ${WORKFLOW_RUN_HEAD_SHA}"
+              exit 1
+            fi
+
+            if [ "${SOURCE_SHA}" != "${MAIN_HEAD}" ]; then
+              echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; latest main is ${MAIN_HEAD}"
+              PROMOTE='false'
+            fi
+          else
+            if [ -n "${COMMIT_SHA_INPUT}" ]; then
+              SOURCE_SHA="$(git rev-parse "${COMMIT_SHA_INPUT}^{commit}")"
+            else
+              SOURCE_SHA="${MAIN_HEAD}"
+            fi
+
+            if [ -n "${IMAGE_TAG_INPUT}" ]; then
+              TAG="${IMAGE_TAG_INPUT}"
+            else
+              TAG="$(git rev-parse --short=8 "${SOURCE_SHA}")"
+            fi
+          fi
+
+          if [ "${PROMOTE}" = 'true' ] && ! git cat-file -e "${SOURCE_SHA}^{commit}" >/dev/null 2>&1; then
+            echo "Source SHA ${SOURCE_SHA} is not present in local git history"
+            exit 1
+          fi
+
+          {
+            echo "main_head=${MAIN_HEAD}"
+            echo "source_sha=${SOURCE_SHA}"
+            echo "tag=${TAG}"
+            echo "contract_digest=${CONTRACT_DIGEST}"
+            echo "image=${IMAGE}"
+            echo "promote=${PROMOTE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout source revision
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout --force "${{ steps.meta.outputs.source_sha }}"
+
+      - name: Resolve image digest
+        if: steps.meta.outputs.promote == 'true'
+        id: digest
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ steps.meta.outputs.image }}
+          IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          CONTRACT_DIGEST: ${{ steps.meta.outputs.contract_digest }}
+          DIGEST_INPUT: ${{ inputs.image_digest }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${DIGEST_INPUT}" ]; then
+            DIGEST="${DIGEST_INPUT}"
+          elif [ -n "${CONTRACT_DIGEST}" ]; then
+            DIGEST="${CONTRACT_DIGEST}"
+          else
+            DIGEST="$(
+              bun --eval "
+                import { inspectImageDigest } from './packages/scripts/src/shared/docker.ts'
+                const image = process.env.IMAGE_NAME + ':' + process.env.IMAGE_TAG
+                const repoDigest = inspectImageDigest(image)
+                const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
+                console.log(digest)
+              "
+            )"
+          fi
+
+          DIGEST="${DIGEST#*@}"
+          if ! printf '%s' "${DIGEST}" | grep -Eiq '^sha256:[0-9a-f]{64}$'; then
+            echo "Resolved digest '${DIGEST}' is invalid"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate migration safety gate
+        if: steps.meta.outputs.promote == 'true'
+        id: migration
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r "${{ steps.meta.outputs.source_sha }}")"
+          if printf '%s\n' "${CHANGED_FILES}" | grep -Eq '^services/torghut/migrations/'; then
+            echo "requires_approval=true" >> "$GITHUB_OUTPUT"
+            echo "label=do-not-automerge" >> "$GITHUB_OUTPUT"
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "requires_approval=false" >> "$GITHUB_OUTPUT"
+            echo "label=" >> "$GITHUB_OUTPUT"
+            echo "draft=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update Torghut manifests
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        env:
+          TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          TORGHUT_IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
+          TORGHUT_COMMIT: ${{ steps.meta.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          bun run packages/scripts/src/torghut/update-manifests.ts \
+            --tag "${TORGHUT_IMAGE_TAG}" \
+            --digest "${TORGHUT_IMAGE_DIGEST}" \
+            --commit "${TORGHUT_COMMIT}" \
+            --rollout-timestamp "${TIMESTAMP}"
+
+      - name: Check for manifest changes
+        if: steps.meta.outputs.promote == 'true'
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- argocd/applications/torghut/knative-service.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create deploy pull request (manual approval required)
+        if: >-
+          ${{
+            steps.meta.outputs.promote == 'true' &&
+            steps.changes.outputs.changed == 'true' &&
+            steps.migration.outputs.requires_approval == 'true'
+          }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: codex/torghut-release-${{ steps.meta.outputs.tag }}
+          base: main
+          title: 'chore(torghut): promote image ${{ steps.meta.outputs.tag }}'
+          commit-message: 'chore(torghut): promote image ${{ steps.meta.outputs.tag }}'
+          delete-branch: true
+          labels: do-not-automerge
+          draft: true
+          add-paths: |
+            argocd/applications/torghut/knative-service.yaml
+          body: |
+            ## Summary
+            Promote Torghut image into GitOps manifests.
+
+            - Source commit: `${{ steps.meta.outputs.source_sha }}`
+            - Image tag: `${{ steps.meta.outputs.tag }}`
+            - Image digest: `${{ steps.digest.outputs.digest }}`
+            - Migration change detected under `services/torghut/migrations/**`
+            - Added `do-not-automerge`; manual DB migration approval required before merge
+
+      - name: Create deploy pull request (auto-merge eligible)
+        if: >-
+          ${{
+            steps.meta.outputs.promote == 'true' &&
+            steps.changes.outputs.changed == 'true' &&
+            steps.migration.outputs.requires_approval != 'true'
+          }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: codex/torghut-release-${{ steps.meta.outputs.tag }}
+          base: main
+          title: 'chore(torghut): promote image ${{ steps.meta.outputs.tag }}'
+          commit-message: 'chore(torghut): promote image ${{ steps.meta.outputs.tag }}'
+          delete-branch: true
+          add-paths: |
+            argocd/applications/torghut/knative-service.yaml
+          body: |
+            ## Summary
+            Promote Torghut image into GitOps manifests.
+
+            - Source commit: `${{ steps.meta.outputs.source_sha }}`
+            - Image tag: `${{ steps.meta.outputs.tag }}`
+            - Image digest: `${{ steps.digest.outputs.digest }}`
+
+      - name: No manifest changes detected
+        if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'
+        run: echo 'No Torghut manifest changes detected.'
+
+      - name: Promotion skipped (stale workflow_run)
+        if: steps.meta.outputs.promote != 'true'
+        run: echo 'Skipping stale workflow_run promotion because source SHA is not current main.'

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -214,7 +214,7 @@ spec:
                       - /spec/template/spec/containers/0/ports/0/protocol
                       - /spec/template/spec/containers/0/readinessProbe
                       - /spec/template/spec/enableServiceLinks
-                automation: manual
+                automation: auto
                 enabled: "true"
               - name: miel
                 path: argocd/applications/miel

--- a/packages/scripts/src/torghut/__tests__/release-contract.test.ts
+++ b/packages/scripts/src/torghut/__tests__/release-contract.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+import { readReleaseContract, writeReleaseContract } from '../release-contract'
+
+describe('torghut release-contract', () => {
+  it('writes and reads a valid contract', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'torghut-release-contract-'))
+    const contractPath = join(dir, 'contract.json')
+
+    writeReleaseContract(relative(repoRoot, contractPath), {
+      sourceSha: '1234567890abcdef1234567890abcdef12345678',
+      tag: '12345678',
+      digest: 'sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe',
+      image: 'registry.ide-newton.ts.net/lab/torghut',
+      createdAt: '2026-02-21T00:00:00.000Z',
+    })
+
+    const parsed = readReleaseContract(relative(repoRoot, contractPath))
+    expect(parsed).toEqual({
+      sourceSha: '1234567890abcdef1234567890abcdef12345678',
+      tag: '12345678',
+      digest: 'sha256:6af34b1781155267ed6821833feb0ee8856b2b08128cb0ac9b0c388615b380fe',
+      image: 'registry.ide-newton.ts.net/lab/torghut',
+      createdAt: '2026-02-21T00:00:00.000Z',
+    })
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('normalizes digest values with repository prefix', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'torghut-release-contract-'))
+    const contractPath = join(dir, 'contract.json')
+
+    writeReleaseContract(relative(repoRoot, contractPath), {
+      sourceSha: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      tag: 'abcdefab',
+      digest:
+        'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+      image: 'registry.ide-newton.ts.net/lab/torghut',
+      createdAt: '2026-02-21T00:01:00.000Z',
+    })
+
+    const parsed = readReleaseContract(relative(repoRoot, contractPath))
+    expect(parsed.digest).toBe('sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import { repoRoot } from '../../shared/cli'
+import { __private } from '../update-manifests'
+
+const createFixture = () => {
+  const dir = mkdtempSync(join(tmpdir(), 'torghut-manifests-test-'))
+  const manifestPath = join(dir, 'knative-service.yaml')
+  writeFileSync(
+    manifestPath,
+    `apiVersion: serving.knative.dev/v1
+kind: Service
+spec:
+  template:
+    metadata:
+      annotations:
+        client.knative.dev/updateTimestamp: "2025-01-01T00:00:00Z"
+    spec:
+      containers:
+        - name: user-container
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111
+          env:
+            - name: TORGHUT_VERSION
+              value: old-version
+            - name: TORGHUT_COMMIT
+              value: old-commit
+`,
+    'utf8',
+  )
+  return { dir, manifestPath }
+}
+
+describe('update-manifests', () => {
+  it('updates image digest, rollout timestamp, and metadata env values', () => {
+    const fixture = createFixture()
+    const result = __private.updateTorghutManifest({
+      imageName: 'registry.ide-newton.ts.net/lab/torghut',
+      digest: 'sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+      version: 'v0.600.0',
+      commit: '1234567890abcdef1234567890abcdef12345678',
+      rolloutTimestamp: '2026-02-21T04:00:00Z',
+      manifestPath: relative(repoRoot, fixture.manifestPath),
+    })
+
+    const manifest = readFileSync(fixture.manifestPath, 'utf8')
+    expect(manifest).toContain('client.knative.dev/updateTimestamp: "2026-02-21T04:00:00Z"')
+    expect(manifest).toContain(
+      'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+    )
+    expect(manifest).toContain('value: v0.600.0')
+    expect(manifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(result.changed).toBe(true)
+    expect(result.imageRef).toBe(
+      'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+    )
+
+    rmSync(fixture.dir, { recursive: true, force: true })
+  })
+
+  it('returns changed=false when manifest already matches requested state', () => {
+    const fixture = createFixture()
+    const options = {
+      imageName: 'registry.ide-newton.ts.net/lab/torghut',
+      digest: 'sha256:ef4a4f754c30705019667f7aa6c89ca95b8ca4f2f1539ca0f8ce62d56a4be63c',
+      version: 'v0.601.0',
+      commit: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      rolloutTimestamp: '2026-02-21T05:00:00Z',
+      manifestPath: relative(repoRoot, fixture.manifestPath),
+    }
+
+    __private.updateTorghutManifest(options)
+    const second = __private.updateTorghutManifest(options)
+    expect(second.changed).toBe(false)
+
+    rmSync(fixture.dir, { recursive: true, force: true })
+  })
+})

--- a/packages/scripts/src/torghut/release-contract.ts
+++ b/packages/scripts/src/torghut/release-contract.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+import { fatal, repoRoot } from '../shared/cli'
+
+const defaultContractPath = 'torghut-release-contract.json'
+
+const sourceShaPattern = /^[0-9a-f]{40}$/i
+const tagPattern = /^[A-Za-z0-9._-]{1,128}$/
+const digestPattern = /^sha256:[0-9a-f]{64}$/i
+
+export type TorghutReleaseContract = {
+  sourceSha: string
+  tag: string
+  digest: string
+  image: string
+  createdAt: string
+}
+
+type ContractField = keyof TorghutReleaseContract
+
+type CliOptions = {
+  command?: 'write' | 'get' | 'emit-github-output'
+  path?: string
+  sourceSha?: string
+  tag?: string
+  digest?: string
+  image?: string
+  field?: ContractField
+}
+
+const normalizeDigest = (value: string): string => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return trimmed
+  }
+  return trimmed.includes('@') ? trimmed.slice(trimmed.lastIndexOf('@') + 1) : trimmed
+}
+
+const resolveContractPath = (path: string) => resolve(repoRoot, path)
+
+const parseArgs = (argv: string[]): CliOptions => {
+  const options: CliOptions = {}
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: bun run packages/scripts/src/torghut/release-contract.ts <command> [options]
+
+Commands:
+  write
+    --path <path>
+    --source-sha <sha40>
+    --tag <tag>
+    --digest <sha256:...>
+    --image <registry/repo>
+  get
+    --path <path>
+    --field <sourceSha|tag|digest|image|createdAt>
+  emit-github-output
+    --path <path>`)
+      process.exit(0)
+    }
+
+    if (!options.command && (arg === 'write' || arg === 'get' || arg === 'emit-github-output')) {
+      options.command = arg
+      continue
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+
+    const [flag, inlineValue] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    const value = inlineValue ?? argv[i + 1]
+    if (inlineValue === undefined) {
+      i += 1
+    }
+    if (value === undefined) {
+      throw new Error(`Missing value for ${flag}`)
+    }
+
+    switch (flag) {
+      case '--path':
+        options.path = value
+        break
+      case '--source-sha':
+        options.sourceSha = value
+        break
+      case '--tag':
+        options.tag = value
+        break
+      case '--digest':
+        options.digest = value
+        break
+      case '--image':
+        options.image = value
+        break
+      case '--field':
+        if (!['sourceSha', 'tag', 'digest', 'image', 'createdAt'].includes(value)) {
+          throw new Error(`Unknown field: ${value}`)
+        }
+        options.field = value as ContractField
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
+  }
+
+  return options
+}
+
+const assertValidContract = (contract: TorghutReleaseContract) => {
+  if (!sourceShaPattern.test(contract.sourceSha)) {
+    throw new Error(`Invalid sourceSha '${contract.sourceSha}'`)
+  }
+  if (!tagPattern.test(contract.tag)) {
+    throw new Error(`Invalid tag '${contract.tag}'`)
+  }
+  if (!digestPattern.test(contract.digest)) {
+    throw new Error(`Invalid digest '${contract.digest}'`)
+  }
+  if (!contract.image.trim()) {
+    throw new Error('image cannot be empty')
+  }
+  if (!contract.createdAt.trim()) {
+    throw new Error('createdAt cannot be empty')
+  }
+  if (Number.isNaN(Date.parse(contract.createdAt))) {
+    throw new Error(`Invalid createdAt '${contract.createdAt}'`)
+  }
+}
+
+export const writeReleaseContract = (path: string, contract: TorghutReleaseContract) => {
+  const normalized: TorghutReleaseContract = {
+    ...contract,
+    digest: normalizeDigest(contract.digest),
+  }
+  assertValidContract(normalized)
+  writeFileSync(resolveContractPath(path), `${JSON.stringify(normalized, null, 2)}\n`, 'utf8')
+}
+
+export const readReleaseContract = (path: string): TorghutReleaseContract => {
+  const source = readFileSync(resolveContractPath(path), 'utf8')
+  const parsed = JSON.parse(source) as Partial<TorghutReleaseContract>
+  const contract: TorghutReleaseContract = {
+    sourceSha: parsed.sourceSha ?? '',
+    tag: parsed.tag ?? '',
+    digest: normalizeDigest(parsed.digest ?? ''),
+    image: parsed.image ?? '',
+    createdAt: parsed.createdAt ?? '',
+  }
+  assertValidContract(contract)
+  return contract
+}
+
+export const main = (cliOptions?: CliOptions) => {
+  const parsed = cliOptions ?? parseArgs(process.argv.slice(2))
+  const command = parsed.command
+  const path = parsed.path ?? defaultContractPath
+
+  if (!command) {
+    throw new Error('Missing command (write|get|emit-github-output)')
+  }
+
+  if (command === 'write') {
+    const sourceSha = parsed.sourceSha?.trim() ?? ''
+    const tag = parsed.tag?.trim() ?? ''
+    const digest = normalizeDigest(parsed.digest ?? '')
+    const image = parsed.image?.trim() ?? ''
+    const createdAt = new Date().toISOString()
+
+    writeReleaseContract(path, {
+      sourceSha,
+      tag,
+      digest,
+      image,
+      createdAt,
+    })
+    return
+  }
+
+  const contract = readReleaseContract(path)
+
+  if (command === 'get') {
+    if (!parsed.field) {
+      throw new Error('get requires --field')
+    }
+    console.log(contract[parsed.field])
+    return
+  }
+
+  console.log(`source_sha=${contract.sourceSha}`)
+  console.log(`tag=${contract.tag}`)
+  console.log(`digest=${contract.digest}`)
+  console.log(`image=${contract.image}`)
+  console.log(`created_at=${contract.createdAt}`)
+}
+
+if (import.meta.main) {
+  try {
+    main()
+  } catch (error) {
+    fatal('Failed to process torghut release contract', error)
+  }
+}
+
+export const __private = {
+  assertValidContract,
+  normalizeDigest,
+  parseArgs,
+}

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+import { fatal, repoRoot } from '../shared/cli'
+import { inspectImageDigest } from '../shared/docker'
+import { execGit } from '../shared/git'
+
+const defaultRegistry = 'registry.ide-newton.ts.net'
+const defaultRepository = 'lab/torghut'
+const defaultManifestPath = 'argocd/applications/torghut/knative-service.yaml'
+
+const digestPattern = /^sha256:[0-9a-f]{64}$/i
+
+type UpdateManifestsOptions = {
+  imageName: string
+  digest: string
+  version: string
+  commit: string
+  rolloutTimestamp: string
+  manifestPath?: string
+}
+
+type CliOptions = {
+  registry?: string
+  repository?: string
+  tag?: string
+  digest?: string
+  version?: string
+  commit?: string
+  rolloutTimestamp?: string
+  manifestPath?: string
+}
+
+const resolvePath = (path: string) => resolve(repoRoot, path)
+
+const normalizeDigest = (value: string): string => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return trimmed
+  }
+  return trimmed.includes('@') ? trimmed.slice(trimmed.lastIndexOf('@') + 1) : trimmed
+}
+
+const replaceSingle = (source: string, pattern: RegExp, replacement: string, label: string): string => {
+  if (!pattern.test(source)) {
+    throw new Error(`Unable to locate ${label} in torghut manifest`)
+  }
+  return source.replace(pattern, replacement)
+}
+
+const updateTorghutManifest = (options: UpdateManifestsOptions) => {
+  const manifestPath = resolvePath(options.manifestPath ?? defaultManifestPath)
+  const source = readFileSync(manifestPath, 'utf8')
+  const imageRef = `${options.imageName}@${options.digest}`
+
+  let updated = source
+  updated = replaceSingle(
+    updated,
+    /(client\.knative\.dev\/updateTimestamp:\s*)(?:"[^"]*"|'[^']*'|[^\n]+)/,
+    `$1"${options.rolloutTimestamp}"`,
+    'rollout timestamp annotation',
+  )
+  updated = replaceSingle(
+    updated,
+    /(- name:\s*user-container[\s\S]*?\n\s*image:\s*)([^\n]+)/,
+    `$1${imageRef}`,
+    'user-container image reference',
+  )
+  updated = replaceSingle(
+    updated,
+    /(- name:\s*TORGHUT_VERSION\s*\n\s*value:\s*)([^\n]+)/,
+    `$1${options.version}`,
+    'TORGHUT_VERSION',
+  )
+  updated = replaceSingle(
+    updated,
+    /(- name:\s*TORGHUT_COMMIT\s*\n\s*value:\s*)([^\n]+)/,
+    `$1${options.commit}`,
+    'TORGHUT_COMMIT',
+  )
+
+  if (updated !== source) {
+    writeFileSync(manifestPath, updated, 'utf8')
+  }
+
+  return {
+    manifestPath,
+    imageRef,
+    changed: updated !== source,
+  }
+}
+
+const parseArgs = (argv: string[]): CliOptions => {
+  const options: CliOptions = {}
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: bun run packages/scripts/src/torghut/update-manifests.ts [options]
+
+Options:
+  --registry <value>
+  --repository <value>
+  --tag <value>
+  --digest <sha256:...>
+  --version <value>
+  --commit <sha40>
+  --rollout-timestamp <ISO8601>
+  --manifest-path <path>`)
+      process.exit(0)
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+
+    const [flag, inlineValue] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [arg, undefined]
+    const value = inlineValue ?? argv[i + 1]
+    if (inlineValue === undefined) {
+      i += 1
+    }
+    if (value === undefined) {
+      throw new Error(`Missing value for ${flag}`)
+    }
+
+    switch (flag) {
+      case '--registry':
+        options.registry = value
+        break
+      case '--repository':
+        options.repository = value
+        break
+      case '--tag':
+        options.tag = value
+        break
+      case '--digest':
+        options.digest = value
+        break
+      case '--version':
+        options.version = value
+        break
+      case '--commit':
+        options.commit = value
+        break
+      case '--rollout-timestamp':
+        options.rolloutTimestamp = value
+        break
+      case '--manifest-path':
+        options.manifestPath = value
+        break
+      default:
+        throw new Error(`Unknown option: ${flag}`)
+    }
+  }
+
+  return options
+}
+
+export const main = (cliOptions?: CliOptions) => {
+  const parsed = cliOptions ?? parseArgs(process.argv.slice(2))
+  const registry = parsed.registry ?? process.env.TORGHUT_IMAGE_REGISTRY ?? defaultRegistry
+  const repository = parsed.repository ?? process.env.TORGHUT_IMAGE_REPOSITORY ?? defaultRepository
+  const tag = parsed.tag ?? process.env.TORGHUT_IMAGE_TAG ?? execGit(['rev-parse', '--short=8', 'HEAD'])
+  const imageName = `${registry}/${repository}`
+  const digest = normalizeDigest(
+    parsed.digest ?? process.env.TORGHUT_IMAGE_DIGEST ?? inspectImageDigest(`${imageName}:${tag}`),
+  )
+
+  if (!digestPattern.test(digest)) {
+    throw new Error(`Resolved digest '${digest}' is invalid; expected sha256:<64 hex>`)
+  }
+
+  const version = parsed.version ?? process.env.TORGHUT_VERSION ?? execGit(['describe', '--tags', '--always'])
+  const commit = parsed.commit ?? process.env.TORGHUT_COMMIT ?? execGit(['rev-parse', 'HEAD'])
+  const rolloutTimestamp = parsed.rolloutTimestamp ?? process.env.TORGHUT_ROLLOUT_TIMESTAMP ?? new Date().toISOString()
+
+  const result = updateTorghutManifest({
+    imageName,
+    digest,
+    version,
+    commit,
+    rolloutTimestamp,
+    manifestPath: parsed.manifestPath ?? process.env.TORGHUT_MANIFEST_PATH,
+  })
+
+  if (result.changed) {
+    console.log(`Updated ${result.manifestPath} with ${result.imageRef}`)
+  } else {
+    console.log(`No manifest changes required for ${result.imageRef}`)
+  }
+}
+
+if (import.meta.main) {
+  try {
+    main()
+  } catch (error) {
+    fatal('Failed to update torghut manifests', error)
+  }
+}
+
+export const __private = {
+  normalizeDigest,
+  parseArgs,
+  replaceSingle,
+  updateTorghutManifest,
+}

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -42,6 +42,13 @@ Health checks:
 - Canonical flag inventory is in `argocd/applications/feature-flags/gitops/default/features.yaml` (`torghut_*` keys).
 - Migration and rollout runbook: `docs/torghut/feature-flags-rollout.md`.
 
+## Deploy automation (main -> Argo CD)
+- `torghut-ci` validates code changes on PR and push.
+- `torghut-build-push` runs on `main` merges touching Torghut sources/scripts, builds/pushes image, and emits a release contract artifact.
+- `torghut-release` consumes that artifact, updates `argocd/applications/torghut/knative-service.yaml` digest/version metadata, and opens a release PR (`codex/torghut-release-<tag>`).
+- `torghut-deploy-automerge` enables squash auto-merge for eligible release PRs.
+- Migration safety gate: if the promoted source commit touches `services/torghut/migrations/**`, the release PR is created as draft with `do-not-automerge` and requires manual approval before merge.
+
 ## Order-feed ingestion (v3 execution accuracy)
 - `TRADING_ORDER_FEED_ENABLED=true` enables Kafka order-update ingestion in the main trading runtime.
 - `TRADING_ORDER_FEED_BOOTSTRAP_SERVERS=<host:port,...>` must be set when enabled.


### PR DESCRIPTION
## Summary

- Enable automatic Argo CD sync for the Torghut ApplicationSet entry (`automation: auto`).
- Replace the Torghut image workflow with `torghut-build-push` on `main` pushes and publish a release contract artifact.
- Add `torghut-release` workflow to promote image digest/version metadata into `argocd/applications/torghut/knative-service.yaml` via PR.
- Add `torghut-deploy-automerge` workflow with guardrails (author allowlist, same-repo check, changed-file allowlist, `do-not-automerge` opt-out).
- Add Torghut release helper scripts and regression tests for release-contract + manifest updater behavior.

## Related Issues

None

## Testing

- `bunx @biomejs/biome@2.3.8 check packages/scripts/src/torghut/release-contract.ts packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/release-contract.test.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/release-contract.test.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `ruby -e 'require "yaml"; %w[.github/workflows/torghut-build-push.yaml .github/workflows/torghut-release.yml .github/workflows/torghut-deploy-automerge.yml].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
