### PR TITLE
feat(inngest): expose ui via tailscale hostname

### DIFF
--- a/argocd/applications/inngest/kustomization.yaml
+++ b/argocd/applications/inngest/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - postgres-cluster.yaml
   - redis.yaml
   - sealed-secret.yaml
+  - tailscale-service.yaml
 patches:
   - target:
       kind: Secret

--- a/argocd/applications/inngest/tailscale-service.yaml
+++ b/argocd/applications/inngest/tailscale-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: inngest-tailscale
+  namespace: inngest
+  annotations:
+    tailscale.com/hostname: inngest
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/instance: inngest
+    app.kubernetes.io/name: inngest
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8288


### PR DESCRIPTION
## Summary

- Add `inngest-tailscale` `Service` in `argocd/applications/inngest`.
- Configure Tailscale exposure with `loadBalancerClass: tailscale` and `tailscale.com/hostname: inngest`.
- Wire the new service into the Inngest kustomization so Argo CD manages it via GitOps.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/inngest >/tmp/inngest-render.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
