### PR TITLE
fix(bumba): harden event processing and rollout automation

### DIFF
--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -102,8 +102,8 @@ spec:
         - alias: bumba
           imageName: registry.ide-newton.ts.net/lab/bumba:latest
           commonUpdateSettings:
-            updateStrategy: latest
-            allowTags: '^[0-9a-f]{40}$'
+            updateStrategy: newest-build
+            allowTags: 'regexp:^[0-9a-f]{40}$'
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/bumba

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -30,6 +30,10 @@ spec:
               if [ ! -d /workspace/lab/.git ]; then
                 rm -rf /workspace/lab
                 git clone --depth 1 https://github.com/proompteng/lab.git /workspace/lab
+              else
+                git -C /workspace/lab remote set-url origin https://github.com/proompteng/lab.git
+                git -C /workspace/lab fetch --depth 1 origin main
+                git -C /workspace/lab reset --hard FETCH_HEAD
               fi
               mkdir -p /workspace/lab/.worktrees /workspace/.bun-install-cache
           volumeMounts:

--- a/services/bumba/README.md
+++ b/services/bumba/README.md
@@ -9,8 +9,10 @@ Temporal worker that enriches repository files using AST context + self-hosted m
 - `enrichWithModel` uses the same Temporal task queue as the workflow (`TEMPORAL_TASK_QUEUE`); do not run a separate model queue.
 - The worker can consume pending `atlas.github_events` and start `enrichFile` workflows directly. Controls:
   `BUMBA_GITHUB_EVENT_CONSUMER_ENABLED`, `BUMBA_GITHUB_EVENT_POLL_INTERVAL_MS`,
-  `BUMBA_GITHUB_EVENT_BATCH_SIZE`, `BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS`.
+  `BUMBA_GITHUB_EVENT_BATCH_SIZE`, `BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS`,
+  `BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES`.
 - Enrichment skips directory paths; model completion failures (including timeouts) fail the workflow to avoid placeholders.
+- Repository listing sync can be tuned with `BUMBA_REPO_SYNC_INTERVAL_MS` (set `0` to disable periodic origin fetches).
 - Performance knobs: `OPENAI_API_BASE_URL`, `OPENAI_COMPLETION_TIMEOUT_MS`, `OPENAI_COMPLETION_MAX_OUTPUT_TOKENS`, `BUMBA_MODEL_CONCURRENCY`,
   `OPENAI_EMBEDDING_API_BASE_URL` (set to Ollama `/api` for batching), `OPENAI_EMBEDDING_BATCH_SIZE`, `OPENAI_EMBEDDING_KEEP_ALIVE`,
   `OPENAI_EMBEDDING_TRUNCATE` (defaults to false for quality), and `OPENAI_EMBEDDING_TIMEOUT_MS`.

--- a/services/bumba/src/workflows/index.test.ts
+++ b/services/bumba/src/workflows/index.test.ts
@@ -319,16 +319,6 @@ test('enrichFile completes when all activities are resolved', async () => {
         value: {},
       },
     ],
-    [
-      'activity-13',
-      {
-        status: 'completed',
-        value: {
-          ingestionId: 'ingestion-id',
-          eventId: 'event-id',
-        },
-      },
-    ],
   ])
 
   const output = await execute(executor, {
@@ -346,7 +336,13 @@ test('enrichFile completes when all activities are resolved', async () => {
       command.attributes.value.activityType?.name === 'enrichWithModel',
   )
 
-  expect(scheduleCommands).toHaveLength(13)
+  expect(scheduleCommands).toHaveLength(12)
+  const scheduledActivityTypes = scheduleCommands.flatMap((command) =>
+    command.attributes?.case === 'scheduleActivityTaskCommandAttributes'
+      ? [command.attributes.value.activityType?.name]
+      : [],
+  )
+  expect(scheduledActivityTypes).not.toContain('markEventProcessed')
   if (!modelSchedule || modelSchedule.attributes?.case !== 'scheduleActivityTaskCommandAttributes') {
     throw new Error('Expected enrichWithModel to be scheduled.')
   }
@@ -623,16 +619,6 @@ test('enrichFile schedules cleanup when force is enabled', async () => {
         value: {},
       },
     ],
-    [
-      'activity-14',
-      {
-        status: 'completed',
-        value: {
-          ingestionId: 'ingestion-id',
-          eventId: 'event-id',
-        },
-      },
-    ],
   ])
 
   const output = await execute(executor, {
@@ -645,7 +631,7 @@ test('enrichFile schedules cleanup when force is enabled', async () => {
     (command: Command) => command.commandType === CommandType.SCHEDULE_ACTIVITY_TASK,
   )
 
-  expect(scheduleCommands).toHaveLength(14)
+  expect(scheduleCommands).toHaveLength(13)
   expect(output.commands.at(-1)?.commandType).toBe(CommandType.COMPLETE_WORKFLOW_EXECUTION)
   expect(output.completion).toBe('completed')
   expect(output.result).toEqual({ id: 'enrichment-id', filename: input.filePath })

--- a/services/bumba/src/workflows/index.ts
+++ b/services/bumba/src/workflows/index.ts
@@ -96,11 +96,6 @@ const upsertIngestionTargetTimeouts = {
   scheduleToCloseTimeoutMs: 120_000,
 }
 
-const markEventProcessedTimeouts = {
-  startToCloseTimeoutMs: 30_000,
-  scheduleToCloseTimeoutMs: 120_000,
-}
-
 const cleanupEnrichmentTimeouts = {
   startToCloseTimeoutMs: 120_000,
   scheduleToCloseTimeoutMs: 600_000,
@@ -325,20 +320,6 @@ export const workflows = [
         )) as ReadRepoFileOutput | null
 
         if (!fileResult) {
-          if (eventDeliveryId) {
-            yield* activities.schedule(
-              'markEventProcessed',
-              [
-                {
-                  deliveryId: eventDeliveryId,
-                },
-              ],
-              {
-                ...markEventProcessedTimeouts,
-                retry: activityRetry,
-              },
-            )
-          }
           yield* finalizeIngestion('skipped', 'directory')
           return {
             id: 'skipped-directory',
@@ -595,21 +576,6 @@ export const workflows = [
         if (!usePreModelChunkIndexing) {
           chunkIndexing = (yield* indexChunks(fileVersion)) as IndexFileChunksOutput
           logChunkIndexing(chunkIndexing)
-        }
-
-        if (eventDeliveryId) {
-          yield* activities.schedule(
-            'markEventProcessed',
-            [
-              {
-                deliveryId: eventDeliveryId,
-              },
-            ],
-            {
-              ...markEventProcessedTimeouts,
-              retry: activityRetry,
-            },
-          )
         }
 
         yield* finalizeIngestion('completed')


### PR DESCRIPTION
## Summary

- Fix Argo ImageUpdater config for `bumba` by moving to `newest-build` and valid regex tag matching so new image tags are detected and promoted.
- Remove premature `markEventProcessed` calls from child workflows and keep event finalization in consumer/ingestion terminal flow.
- Harden consumer startup/readiness by failing fast when DB is required but unavailable and exposing consumer state in health readiness.
- Add bounded retry handling for repeated workflow dispatch failures to avoid infinite pending event loops.
- Refresh repository state for file listing/indexing with periodic origin fetch support and document new runtime knobs.

## Related Issues

None

## Testing

- `bun run --cwd services/bumba test src/event-consumer.test.ts src/workflows/index.test.ts`
- `bun run --cwd services/bumba tsc`
- `bunx biome check services/bumba/src services/bumba/README.md argocd/applications/bumba/deployment.yaml argocd/applications/argocd/base/image-updater-product.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
