### PR TITLE
fix(khoshut): rename inngest app id to khoshut

### DIFF
--- a/argocd/applications/khoshut/configmap.yaml
+++ b/argocd/applications/khoshut/configmap.yaml
@@ -8,5 +8,5 @@ metadata:
 data:
   HOST: 0.0.0.0
   PORT: "3000"
-  INNGEST_APP_ID: khoshut-bun
+  INNGEST_APP_ID: khoshut
   INNGEST_BASE_URL: http://inngest.inngest.svc.cluster.local:8288

--- a/argocd/applications/khoshut/deployment.yaml
+++ b/argocd/applications/khoshut/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/name: khoshut
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T00:00:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-21T23:59:24Z"
     spec:
       containers:
         - name: khoshut

--- a/services/khoshut/src/config.test.ts
+++ b/services/khoshut/src/config.test.ts
@@ -45,7 +45,7 @@ describe('loadConfig', () => {
     const cfg = loadConfig()
     expect(cfg.host).toBe('0.0.0.0')
     expect(cfg.port).toBe(3000)
-    expect(cfg.appId).toBe('khoshut-bun')
+    expect(cfg.appId).toBe('khoshut')
   })
 
   it('rejects an invalid port', () => {

--- a/services/khoshut/src/config.ts
+++ b/services/khoshut/src/config.ts
@@ -9,7 +9,7 @@ export type KhoshutConfig = {
 
 const DEFAULT_HOST = '0.0.0.0'
 const DEFAULT_PORT = 3000
-const DEFAULT_APP_ID = 'khoshut-bun'
+const DEFAULT_APP_ID = 'khoshut'
 const DEFAULT_BASE_URL = 'http://inngest.inngest.svc.cluster.local:8288'
 
 const HEX_VALUE = /^[a-f0-9]+$/i


### PR DESCRIPTION
## Summary

- Rename the Inngest app id from `khoshut-bun` to `khoshut` in service defaults.
- Update the `khoshut` Argo ConfigMap `INNGEST_APP_ID` to `khoshut`.
- Bump `khoshut` deployment restart annotation so Argo rollout applies the new env value to pods.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/khoshut test`
- `bun run --filter @proompteng/khoshut tsc`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
