### PR TITLE
fix(torghut): remove release PR author gate

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -38,7 +38,6 @@ jobs:
           GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           set -euo pipefail
@@ -46,7 +45,6 @@ jobs:
           echo "eligible=false" >> "$GITHUB_OUTPUT"
           echo "reason=not-evaluated" >> "$GITHUB_OUTPUT"
 
-          allowed_authors=('app/github-actions' 'github-actions[bot]')
           allowed_paths=('argocd/applications/torghut/knative-service.yaml')
 
           contains() {
@@ -62,11 +60,6 @@ jobs:
 
           if [ "${PR_HEAD_REPO}" != "${GH_REPO}" ]; then
             echo "reason=head-not-from-same-repo" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if ! contains "${PR_AUTHOR}" "${allowed_authors[@]}"; then
-            echo "reason=author-not-allowlisted:${PR_AUTHOR}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- Remove the Torghut release PR author allowlist gate from `torghut-deploy-automerge`.
- Keep existing safety gates: same-repo requirement, branch prefix guard, changed-file allowlist, and `do-not-automerge` opt-out label.
- Ensure release PRs created by workflow tokens that map to non-bot users still receive auto-merge enablement.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/torghut-deploy-automerge.yml"); puts "ok"'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
