### PR TITLE
chore(torghut): promote image 5904b612

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-21T23:50:26Z"
+        client.knative.dev/updateTimestamp: "2026-02-22T00:02:52Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `5904b61293a4a4bf761b3a5e43e0d811f2fb5e6e`
- Image tag: `5904b612`
- Image digest: `sha256:a9dd5674bc6d42ede441c3800af382811a524408272853c5ef64a30e37d56ff0`