### PR TITLE
fix(bumba): align updater tags and rollout strategy

### DIFF
--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -103,7 +103,7 @@ spec:
           imageName: registry.ide-newton.ts.net/lab/bumba:latest
           commonUpdateSettings:
             updateStrategy: newest-build
-            allowTags: 'regexp:^[0-9a-f]{40}$'
+            allowTags: 'regexp:^(sha-[0-9a-f]{7}|[0-9a-f]{40})$'
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/bumba

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/part-of: lab
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: bumba


### PR DESCRIPTION
## Summary

- update bumba Image Updater tag filter to accept both `sha-<short>` and full 40-char SHA tags
- keep `newest-build` strategy for bumba while matching actual tags produced by `docker-build-common`
- set `bumba` deployment strategy to `Recreate` to avoid RWO PVC multi-attach rollout stalls

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl -n jangar describe pod bumba-7fb6d49455-hxcxx` (confirmed current rollout stall is due to RWO PVC multi-attach with rolling update)
- `kubectl -n argocd get imageupdater product-image-updater -o yaml` (validated current bumba updater settings before patch)
- `crane ls registry.ide-newton.ts.net/lab/bumba | tail -n 120` (validated registry tags include `sha-<short>` format)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
