### PR TITLE
fix(bumba): set image-updater platform to arm64

### DIFF
--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -104,6 +104,8 @@ spec:
           commonUpdateSettings:
             updateStrategy: newest-build
             allowTags: 'regexp:^(sha-[0-9a-f]{7}|[0-9a-f]{40})$'
+            platforms:
+              - linux/arm64
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- add `platforms: [linux/arm64]` to bumba image-updater settings
- keep bumba tag matching on `sha-<short>` and full SHA while ensuring metadata resolution works for arm64-only images
- unblock automated bumba release PR generation so update/automerge flow can proceed end-to-end

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl explain imageupdater.spec.applicationRefs.images.commonUpdateSettings --recursive` (validated `platforms` field support)
- `kubectl -n argocd logs deploy/argocd-image-updater-controller --since=10m | rg -n "Manifest list did not contain any usable reference|No metadata found for lab/bumba" -i` (confirmed current failure mode before fix)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
