### PR TITLE
fix(bumba): clear rollingUpdate for recreate strategy

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -10,6 +10,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/name: bumba


### PR DESCRIPTION
## Summary

- clear `spec.strategy.rollingUpdate` in bumba deployment when `type: Recreate` is used
- fix Argo sync failure (`rollingUpdate` forbidden with `Recreate`) that left bumba degraded/out-of-sync
- unblock replacement rollout so the old PVC-attached pod can terminate and new pod can start cleanly

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `argocd app sync/status` failure context from cluster: `spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy is 'Recreate'`
- manual manifest validation: ensured deployment strategy renders with `type: Recreate` and `rollingUpdate: null`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
