### PR TITLE
fix(argocd): deploy metrics-server HA for HPA metrics

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -37,6 +37,26 @@ spec:
                   argocd.argoproj.io/sync-wave: "-1"
                 automation: auto
                 enabled: "true"
+              - name: metrics-server
+                path: manifests/overlays/release-ha-1.21+
+                repoURL: https://github.com/kubernetes-sigs/metrics-server.git
+                targetRevision: v0.8.1
+                namespace: kube-system
+                renderWithLovely: false
+                kustomize:
+                  patches:
+                    - target:
+                        kind: Deployment
+                        name: metrics-server
+                        namespace: kube-system
+                      patch: |-
+                        - op: add
+                          path: /spec/template/spec/containers/0/args/-
+                          value: --kubelet-insecure-tls
+                annotations:
+                  argocd.argoproj.io/sync-wave: "-1"
+                automation: auto
+                enabled: "true"
               - name: feature-flags
                 path: argocd/applications/feature-flags
                 namespace: feature-flags
@@ -396,8 +416,8 @@ spec:
       destination:
         namespace: '{{ if hasKey . "namespace" }}{{ .namespace }}{{ else }}{{ .name }}{{ end }}'
       source:
-        repoURL: https://github.com/proompteng/lab.git
-        targetRevision: main
+        repoURL: '{{ if hasKey . "repoURL" }}{{ .repoURL }}{{ else }}https://github.com/proompteng/lab.git{{ end }}'
+        targetRevision: '{{ if hasKey . "targetRevision" }}{{ .targetRevision }}{{ else }}main{{ end }}'
         path: "{{ .path }}"
       syncPolicy:
         syncOptions:
@@ -568,9 +588,10 @@ spec:
     {{- $hasDestServer := hasKey . "destinationServer" -}}
     {{- $hasDestName := hasKey . "destinationName" -}}
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
+    {{- $hasKustomize := hasKey . "kustomize" -}}
     {{- $auto := eq .automation "auto" -}}
     {{- $hasManagedNS := hasKey . "managedNamespaceMetadata" -}}
-    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasManagedNS (hasKey . "ignoreDifferences") -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $hasKustomize $auto $hasManagedNS (hasKey . "ignoreDifferences") -}}
     {{- if $needsSpec }}
     spec:
     {{- if or $hasDestServer $hasDestName }}
@@ -583,10 +604,15 @@ spec:
         name: '{{ .destinationName }}'
       {{- end }}
     {{- end }}
-    {{- if $useLovely }}
+    {{- if or $useLovely $hasKustomize }}
       source:
+      {{- if $useLovely }}
         plugin:
           name: lovely
+      {{- end }}
+      {{- if $hasKustomize }}
+        kustomize: {{ toJson .kustomize }}
+      {{- end }}
     {{- end }}
     {{- if or $auto $hasManagedNS }}
       syncPolicy:


### PR DESCRIPTION
## Summary

- Add a `metrics-server` platform ApplicationSet entry using the upstream HA manifests (`v0.8.1`) in `kube-system`.
- Enable per-app `repoURL`/`targetRevision` overrides in the `platform` ApplicationSet template source block.
- Enable optional per-app `kustomize` source configuration in the `platform` template patch logic.
- Patch metrics-server args with `--kubelet-insecure-tls` to handle Talos kubelet certificates without IP SANs and restore resource metrics availability for HPA.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applicationsets/platform.yaml`
- `bun run lint:argocd`
- `kubectl -n argocd get app metrics-server -o wide` (Synced/Healthy)
- `kubectl get apiservice v1beta1.metrics.k8s.io -o jsonpath='{.status.conditions[0].status} {.status.conditions[0].reason}{"\n"}'` (True Passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked (not required for this infra fix).
