### PR TITLE
fix(bumba): avoid pvc multi-attach with zero-surge rollout

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate
-    rollingUpdate: null
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: bumba


### PR DESCRIPTION
## Summary

- replace bumba deployment strategy with explicit zero-surge rolling update
- set `maxSurge: 0` and `maxUnavailable: 1` to guarantee single-pod handoff for the RWO PVC
- resolve Argo apply failures caused by `Recreate` + `rollingUpdate` field conflicts while still preventing multi-attach

## Related Issues

None

## Testing

- `bun run lint:argocd`
- verified live failure mode in cluster: Argo sync error `spec.strategy.rollingUpdate: Forbidden` and PVC multi-attach stall
- validated rendered deployment strategy now stays in `RollingUpdate` with `maxSurge: 0` / `maxUnavailable: 1`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
