### PR TITLE
chore(arc): upgrade ARC charts and right-size runner storage

### DIFF
--- a/argocd/applications/arc/README.md
+++ b/argocd/applications/arc/README.md
@@ -2,10 +2,10 @@
 
 These runners are not pinned to any specific node by default.
 
-- Chart version pinned in `application.yaml` is `0.12.1` for both the controller and the runner scale set.
+- Chart version pinned in `application.yaml` is `0.13.1` for both the controller and the runner scale set.
 - Upgrading from ≤0.9.x requires deleting the legacy `actions.github.com` CRDs and reinstalling the controller/runner charts before letting Argo CD reconcile.
 - Keep the custom template (init container + privileged `docker:dind` sidecar with `DOCKER_HOST=unix:///var/run/docker.sock`) when reapplying so Docker builds continue to work under Kubernetes mode.
-- Runner workspace storage uses dynamic PVCs (60Gi) and must target an existing RWO StorageClass (currently `rook-ceph-block`).
+- Runner workspace storage uses dynamic PVCs (20Gi) and must target an existing RWO StorageClass (currently `local-path`).
 - Tailscale connectivity now comes from the node-level installation managed by OpenTofu (`tofu/harvester/main.tf`) and Ansible (`ansible/playbooks/install_tailscale.yml`); no sidecar or additional secret is required in the runner pods.
 - Generate the `github-token` SealedSecret with `scripts/generate-arc-github-token-secret.sh`. The script reads the token from 1Password via `${ARC_GITHUB_TOKEN_OP_PATH}` (defaults to `op://infra/github personal token/token`) and writes the sealed manifest to `argocd/applications/arc/github-token.yaml`.
 

--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -8,13 +8,13 @@ spec:
   sources:
     - repoURL: ghcr.io
       chart: actions/actions-runner-controller-charts/gha-runner-scale-set-controller
-      targetRevision: 0.12.1
+      targetRevision: 0.13.1
       helm:
         releaseName: arc-controller
         skipCrds: false
     - repoURL: ghcr.io
       chart: actions/actions-runner-controller-charts/gha-runner-scale-set
-      targetRevision: 0.12.1
+      targetRevision: 0.13.1
       helm:
         releaseName: arc-runner-set
         skipCrds: false
@@ -31,10 +31,10 @@ spec:
             type: "kubernetes"
             kubernetesModeWorkVolumeClaim:
               accessModes: ["ReadWriteOnce"]
-              storageClassName: "rook-ceph-block"
+              storageClassName: "local-path"
               resources:
                 requests:
-                  storage: 60Gi
+                  storage: 20Gi
           listenerTemplate:
             spec:
               containers:
@@ -121,10 +121,10 @@ spec:
                     volumeClaimTemplate:
                       spec:
                         accessModes: ["ReadWriteOnce"]
-                        storageClassName: "rook-ceph-block"
+                        storageClassName: "local-path"
                         resources:
                           requests:
-                            storage: 60Gi
+                            storage: 20Gi
                 - name: dind-sock
                   emptyDir: {}
                 - name: dind-externals


### PR DESCRIPTION
## Summary

- Upgrade ARC Helm charts for both controller and runner scale set from `0.12.1` to `0.13.1`.
- Switch ARC runner work-volume PVCs from `rook-ceph-block` to `local-path`.
- Right-size ARC runner work-volume PVC request from `60Gi` to `20Gi` in both work-volume claim definitions.
- Update ARC README to reflect chart version and runner workspace storage defaults.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl apply --dry-run=server -f argocd/applications/arc/application.yaml`
- Verified upstream chart availability with:
  - `helm show chart oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller --version 0.13.1`
  - `helm show chart oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --version 0.13.1`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
