### PR TITLE
fix(dorvud): align crypto ws channels and symbol refresh behavior

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/SymbolsTracker.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/SymbolsTracker.kt
@@ -35,6 +35,14 @@ internal class SymbolsTracker(
       return SymbolsRefreshResult(lastKnown, hadError = true)
     }
 
+    if (fetched.isEmpty() && lastKnown.isNotEmpty()) {
+      if (lastFailureFingerprint != "empty_result") {
+        lastFailureFingerprint = "empty_result"
+        logger.warn { "desired symbols fetch returned empty list; keeping last-known list" }
+      }
+      return SymbolsRefreshResult(lastKnown, hadError = true)
+    }
+
     lastFailureFingerprint = null
     lastKnown = fetched
     return SymbolsRefreshResult(lastKnown, hadError = false)

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderEndpointsTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderEndpointsTest.kt
@@ -59,6 +59,7 @@ class ForwarderEndpointsTest {
     assertEquals("wss://stream.data.alpaca.markets/v2/iex", alpacaMarketDataStreamUrl(cfg))
     assertEquals("https://data.alpaca.markets/v2/stocks/bars", alpacaBarsBackfillUrl(cfg))
     assertTrue(alpacaBarsBackfillNeedsFeed(cfg))
+    assertEquals(listOf("trades", "quotes", "bars", "updatedBars"), alpacaMarketDataChannels(cfg))
   }
 
   @Test
@@ -67,6 +68,7 @@ class ForwarderEndpointsTest {
     assertEquals("wss://stream.data.alpaca.markets/v1beta3/crypto/us", alpacaMarketDataStreamUrl(cfg))
     assertEquals("https://data.alpaca.markets/v1beta3/crypto/us/bars", alpacaBarsBackfillUrl(cfg))
     assertFalse(alpacaBarsBackfillNeedsFeed(cfg))
+    assertEquals(listOf("trades", "quotes", "bars"), alpacaMarketDataChannels(cfg))
   }
 
   @Test

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/SymbolsTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/SymbolsTrackerTest.kt
@@ -65,4 +65,18 @@ class SymbolsTrackerTest {
       assertEquals(listOf("TSLA", "MSFT"), second.symbols)
       assertTrue(second.hadError)
     }
+
+  @Test
+  fun `keeps last known when fetch returns empty list`() =
+    runBlocking {
+      val tracker =
+        SymbolsTracker(
+          listOf("BTC/USD", "ETH/USD", "SOL/USD"),
+          fetcher = { emptyList() },
+        )
+
+      val result = tracker.refresh()
+      assertEquals(listOf("BTC/USD", "ETH/USD", "SOL/USD"), result.symbols)
+      assertTrue(result.hadError)
+    }
 }


### PR DESCRIPTION
## Summary

- Remove `updatedBars` subscriptions for Alpaca crypto streams while preserving full equity channel coverage.
- Make symbol refresh fail-soft: when fetch returns an empty list, keep last-known symbols instead of dropping all active subscriptions.
- Add/extend websocket tests to cover market-type channel selection and empty-symbol refresh behavior.

## Related Issues

None

## Testing

- `./gradlew :websockets:ktlintMainSourceSetCheck :websockets:ktlintTestSourceSetCheck :websockets:test --tests 'ai.proompteng.dorvud.ws.ForwarderConfigTest' --tests 'ai.proompteng.dorvud.ws.ForwarderEndpointsTest' --tests 'ai.proompteng.dorvud.ws.SymbolsTrackerTest'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
