### PR TITLE
chore(torghut): promote torghut-ws image for quote-size fix

### DIFF
--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2026-02-22T01:05:00.000Z
+        kubectl.kubernetes.io/restartedAt: 2026-02-22T01:16:00.000Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:
@@ -27,7 +27,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:fec40cdba6c8694ec96ece8e542a17ae61b74f5f605ee688bd1a56f27254fa11
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:cba0965b792ad9a5d22dbec146185bf11c39ae265697089f6a09cc605dafb484
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -51,9 +51,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: v0.560.0-13-g51bb9aa9
+              value: v0.560.0-15-gb37bb641
             - name: TORGHUT_WS_COMMIT
-              value: 51bb9aa97ba608f775da6e1194536ea195ec84ca
+              value: b37bb641a6e50081eb2e2c6a5e85ad13d665a44b
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
## Summary

- Promote `torghut-ws` to digest `sha256:cba0965b792ad9a5d22dbec146185bf11c39ae265697089f6a09cc605dafb484` built from commit `b37bb64`.
- Update websocket version/commit env metadata to match the promoted image.
- Bump pod template restart annotation to force Argo rollout.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Verified image build run succeeded: `gh run view 22267855651 -R proompteng/lab --json status,conclusion,headSha`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
