### PR TITLE
feat(torghut): enable live crypto trading gate

### DIFF
--- a/argocd/applications/feature-flags/gitops/default/features.yaml
+++ b/argocd/applications/feature-flags/gitops/default/features.yaml
@@ -64,7 +64,7 @@ flags:
     name: Torghut Trading Crypto Live Enabled
     description: Live trading gate for crypto symbol execution paths.
     type: BOOLEAN_FLAG_TYPE
-    enabled: false
+    enabled: true
   - key: torghut_trading_order_feed_enabled
     name: Torghut Trading Order Feed Enabled
     description: Enables Kafka order-feed ingestion in Torghut.

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -113,7 +113,7 @@ spec:
             - name: TRADING_CRYPTO_ENABLED
               value: "true"
             - name: TRADING_CRYPTO_LIVE_ENABLED
-              value: "false"
+              value: "true"
             - name: TRADING_WS_CRYPTO_ENABLED
               value: "true"
             - name: TRADING_UNIVERSE_CRYPTO_ENABLED


### PR DESCRIPTION
## Summary

- Enable Torghut live crypto trading by setting `TRADING_CRYPTO_LIVE_ENABLED=true` in the Knative service manifest.
- Enable the matching feature flag `torghut_trading_crypto_live_enabled` in feature-flags GitOps defaults.
- Keep runtime env gating and feature-flag gating aligned so rollout cannot drift into a partial state.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut > /tmp/torghut-kustomize.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/feature-flags > /tmp/feature-flags-kustomize.yaml`
- `rg -n "TRADING_CRYPTO_LIVE_ENABLED|torghut_trading_crypto_live_enabled" argocd/applications/torghut/knative-service.yaml argocd/applications/feature-flags/gitops/default/features.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
