### PR TITLE
fix(torghut): preserve knative creator annotation for gitops sync

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -10,6 +10,7 @@ metadata:
     networking.knative.dev/visibility: cluster-local
   annotations:
     serving.knative.dev/rollout-duration: 10s
+    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
     argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut
 spec:
   template:


### PR DESCRIPTION
## Summary

- Preserve `serving.knative.dev/creator` in Torghut Knative Service metadata so Argo sync does not attempt to mutate an immutable Knative annotation.
- Fixes GitOps apply failures caused by Knative webhook rejection (`annotation value is immutable`).
- Keeps the existing live crypto-trading gate configuration (`TRADING_CRYPTO_LIVE_ENABLED=true`) manageable through GitOps.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut > /tmp/torghut-kustomize-sync-fix.yaml`
- `rg -n "serving.knative.dev/creator|TRADING_CRYPTO_LIVE_ENABLED" /tmp/torghut-kustomize-sync-fix.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
