### PR TITLE
chore(torghut): update trading account label to PA3SX7FYNUTF

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -90,7 +90,7 @@ spec:
             - name: TRADING_MODE
               value: live
             - name: TRADING_ACCOUNT_LABEL
-              value: PA3R2KWBVTJY
+              value: PA3SX7FYNUTF
             - name: TRADING_LIVE_ENABLED
               value: "true"
             - name: TRADING_SIGNAL_SOURCE


### PR DESCRIPTION
## Summary

- update Torghut GitOps Knative runtime config to use account label `PA3SX7FYNUTF`
- replace previous `TRADING_ACCOUNT_LABEL` value in `argocd/applications/torghut/knative-service.yaml`
- keep all other trading/runtime configuration unchanged

## Related Issues

None

## Testing

- `git diff --check`
- `rg -n "TRADING_ACCOUNT_LABEL|PA3SX7FYNUTF" argocd/applications/torghut/knative-service.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
