### PR TITLE
fix(argocd): reconcile torghut by allowing client-side apply override

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -200,6 +200,11 @@ spec:
                 namespace: torghut
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
+                # Keep torghut on client-side apply while recovering from manual kubectl-patch SSA ownership conflicts.
+                syncOptions:
+                  - CreateNamespace=true
+                  - ServerSideApply=false
+                  - RespectIgnoreDifferences=true
                 ignoreDifferences:
                   - group: serving.knative.dev
                     kind: Service
@@ -304,7 +309,8 @@ spec:
     {{- $hasDestName := hasKey . "destinationName" -}}
     {{- $useLovely := or (not (hasKey . "renderWithLovely")) .renderWithLovely -}}
     {{- $auto := eq .automation "auto" -}}
-    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto (hasKey . "ignoreDifferences") -}}
+    {{- $hasSyncOptions := hasKey . "syncOptions" -}}
+    {{- $needsSpec := or $hasDestServer $hasDestName $useLovely $auto $hasSyncOptions (hasKey . "ignoreDifferences") -}}
     {{- if $needsSpec }}
     spec:
     {{- if or $hasDestServer $hasDestName }}
@@ -322,11 +328,16 @@ spec:
         plugin:
           name: lovely
     {{- end }}
-    {{- if $auto }}
+    {{- if or $auto $hasSyncOptions }}
       syncPolicy:
+      {{- if $hasSyncOptions }}
+        syncOptions: {{ toJson .syncOptions }}
+      {{- end }}
+      {{- if $auto }}
         automated:
           prune: true
           selfHeal: true
+      {{- end }}
     {{- end }}
     {{- if hasKey . "ignoreDifferences" }}
       ignoreDifferences: {{ toJson .ignoreDifferences }}


### PR DESCRIPTION
## Summary

- Add per-application `syncOptions` support to `argocd/applicationsets/product.yaml` template patch logic.
- Configure `torghut` to use `ServerSideApply=false` while keeping `CreateNamespace=true` and `RespectIgnoreDifferences=true`.
- Unblock Argo reconciliation of `serving.knative.dev/Service` fields that were stuck behind SSA field-manager conflicts.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl apply --server-side --field-manager argocd-controller --dry-run=server -f argocd/applications/torghut/knative-service.yaml -n torghut` (confirmed pre-fix SSA conflict against `kubectl-patch` manager on `.spec.template.spec.containers`)
- `kubectl apply --dry-run=server -f argocd/applications/torghut/knative-service.yaml -n torghut` (confirmed client-side apply path accepts manifest)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
