### PR TITLE
fix(ci): harden release PR automerge triggering

### DIFF
--- a/.github/workflows/auto-pr-release-branches.yml
+++ b/.github/workflows/auto-pr-release-branches.yml
@@ -13,6 +13,7 @@ on:
         required: false
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -23,6 +24,7 @@ concurrency:
 jobs:
   create-pr:
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     # Run automatically for image-updater commits or manually via workflow_dispatch
@@ -59,6 +61,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       - name: Create PR if not exists
+        id: create_pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -67,6 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           BASE_BRANCH="main"
+          pr_number=""
 
           existing_pr_number=$(gh pr list \
             -R "$GH_REPO" \
@@ -78,34 +82,71 @@ jobs:
 
           if [ -n "${existing_pr_number:-}" ]; then
             echo "Open PR already exists: #$existing_pr_number"
-            exit 0
-          fi
-
-          # Derive a concise title from the branch name
-          pr_title="chore(${SHORT_NAME}): automated release PR"
-          pr_body="Automated PR created on push to ${HEAD_BRANCH}. Contains Argo CD Image Updater changes for ${SHORT_NAME}."
-
-          response_file=$(mktemp)
-          err_file=$(mktemp)
-          if gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${GH_REPO}/pulls" \
-            -f base="$BASE_BRANCH" \
-            -f head="$HEAD_BRANCH" \
-            -f title="$pr_title" \
-            -f body="$pr_body" \
-            --jq '.number' > "$response_file" 2>"$err_file"; then
-            new_pr_number=$(cat "$response_file")
-            echo "Created PR #$new_pr_number"
+            pr_number="$existing_pr_number"
           else
-            status=$?
-            err_output=$(cat "$err_file")
-            if echo "$err_output" | grep -qi 'already exists'; then
-              echo "A PR already exists for $HEAD_BRANCH but was not detected as open."
-              exit 0
+            # Derive a concise title from the branch name
+            pr_title="chore(${SHORT_NAME}): automated release PR"
+            pr_body="Automated PR created on push to ${HEAD_BRANCH}. Contains Argo CD Image Updater changes for ${SHORT_NAME}."
+
+            response_file=$(mktemp)
+            err_file=$(mktemp)
+            if gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${GH_REPO}/pulls" \
+              -f base="$BASE_BRANCH" \
+              -f head="$HEAD_BRANCH" \
+              -f title="$pr_title" \
+              -f body="$pr_body" \
+              --jq '.number' > "$response_file" 2>"$err_file"; then
+              pr_number=$(cat "$response_file")
+              echo "Created PR #$pr_number"
+            else
+              status=$?
+              err_output=$(cat "$err_file")
+              if echo "$err_output" | grep -qi 'already exists'; then
+                # Handle a race where the PR was created between list and create.
+                pr_number=$(gh pr list \
+                  -R "$GH_REPO" \
+                  --head "$HEAD_BRANCH" \
+                  --base "$BASE_BRANCH" \
+                  --state open \
+                  --json number \
+                  --jq '.[0].number // empty' || true)
+
+                if [ -z "${pr_number:-}" ]; then
+                  echo "PR already exists but the open PR number could not be resolved."
+                  echo "$err_output"
+                  exit 1
+                fi
+
+                echo "Open PR already exists: #$pr_number"
+              else
+                echo "$err_output"
+                exit $status
+              fi
             fi
-            echo "$err_output"
-            exit $status
+            rm -f "$response_file" "$err_file"
           fi
-          rm -f "$response_file" "$err_file"
+
+          if [ -z "${pr_number:-}" ]; then
+            echo "Could not resolve a PR number for ${HEAD_BRANCH}."
+            exit 1
+          fi
+
+          echo "pr_number=${pr_number}" >> "${GITHUB_OUTPUT}"
+
+      - name: Trigger release auto-merge evaluation
+        if: ${{ steps.create_pr.outputs.pr_number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.create_pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          gh workflow run release-pr-automerge.yml \
+            -R "$GH_REPO" \
+            -f pr_number="$PR_NUMBER"
+
+          echo "Dispatched release-pr-automerge for PR #$PR_NUMBER"

--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -9,22 +9,31 @@ on:
       - ready_for_review
       - labeled
       - unlabeled
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to evaluate for auto-merge'
+        required: true
+        type: string
 
 permissions:
   contents: write
   pull-requests: write
 
 concurrency:
-  group: release-pr-automerge-${{ github.event.pull_request.number }}
+  group: release-pr-automerge-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   enable:
     if: >-
       ${{
-        github.event.pull_request.base.ref == 'main' &&
-        startsWith(github.event.pull_request.head.ref, 'release/') &&
-        github.event.pull_request.draft == false
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.pull_request.base.ref == 'main' &&
+          startsWith(github.event.pull_request.head.ref, 'release/') &&
+          github.event.pull_request.draft == false
+        )
       }}
     runs-on: ubuntu-latest
     permissions:
@@ -37,17 +46,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          PR_IS_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         run: |
           set -euo pipefail
 
           echo "eligible=false" >> "$GITHUB_OUTPUT"
           echo "reason=not-evaluated" >> "$GITHUB_OUTPUT"
+
+          if [[ -z "${PR_NUMBER}" ]] || ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "reason=invalid-pr-number" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           allowed_authors=("app/github-actions" "github-actions[bot]")
           allowed_paths=(
@@ -66,6 +75,23 @@ jobs:
             done
             return 1
           }
+
+          if ! pr_json="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER")"; then
+            echo "reason=pr-not-found" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_STATE="$(jq -r '.state // ""' <<< "$pr_json")"
+          PR_AUTHOR="$(jq -r '.user.login // ""' <<< "$pr_json")"
+          PR_HEAD_REF="$(jq -r '.head.ref // ""' <<< "$pr_json")"
+          PR_BASE_REF="$(jq -r '.base.ref // ""' <<< "$pr_json")"
+          PR_HEAD_REPO="$(jq -r '.head.repo.full_name // ""' <<< "$pr_json")"
+          PR_IS_DRAFT="$(jq -r '.draft // false' <<< "$pr_json")"
+
+          if [[ "$PR_STATE" != "open" ]]; then
+            echo "reason=pr-not-open" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [[ "$PR_BASE_REF" != "main" ]]; then
             echo "reason=base-not-main" >> "$GITHUB_OUTPUT"
@@ -104,9 +130,18 @@ jobs:
             exit 0
           fi
 
-          mapfile -t changed_files < <(
-            gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename'
-          )
+          changed_files=()
+          for attempt in 1 2 3; do
+            mapfile -t changed_files < <(
+              gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename'
+            )
+
+            if [[ "${#changed_files[@]}" -gt 0 ]]; then
+              break
+            fi
+
+            sleep 2
+          done
 
           if [[ "${#changed_files[@]}" -eq 0 ]]; then
             echo "reason=no-files-changed" >> "$GITHUB_OUTPUT"
@@ -136,7 +171,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Add a deterministic handoff from `auto-pr-release-branches` to `release-pr-automerge` by dispatching automerge with the resolved PR number.
- Extend `release-pr-automerge` to support `workflow_dispatch` input and evaluate PR metadata through the GitHub API instead of relying only on event payload fields.
- Harden automerge gating with invalid/missing PR handling, open-state checks, and a short retry loop when reading changed files right after PR creation.

## Related Issues

None

## Testing

- `ruby -e "require 'yaml'; YAML.safe_load(File.read('.github/workflows/auto-pr-release-branches.yml')); puts 'ok auto-pr'"`
- `ruby -e "require 'yaml'; YAML.safe_load(File.read('.github/workflows/release-pr-automerge.yml')); puts 'ok automerge'"`
- `gh pr merge 3398 -R proompteng/lab --auto --squash` (immediate remediation to unblock the already-created stuck release PR)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
