### PR TITLE
chore(torghut): promote image 4f03d6b7

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c141aaa74a60f2c0c426f3bd6d814dfbbe4390e2bf91cec6aadf11b3d4ab3571
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:67293bdd93b7737a57537fa0ec71d0839e143c2288cf06bc7d4f034ae3d9c1b6
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-22T00:54:01Z"
+        client.knative.dev/updateTimestamp: "2026-02-22T06:30:20Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c141aaa74a60f2c0c426f3bd6d814dfbbe4390e2bf91cec6aadf11b3d4ab3571
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:67293bdd93b7737a57537fa0ec71d0839e143c2288cf06bc7d4f034ae3d9c1b6
           ports:
             - name: http1
               containerPort: 8181
@@ -232,9 +232,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-11-gcfbb7aa6
+              value: v0.560.0-36-g4f03d6b7
             - name: TORGHUT_COMMIT
-              value: cfbb7aa69f9e03187ef4d5d6dae369a6dc25a7f2
+              value: 4f03d6b7c3cabb4b526a40adc1cabe0ab24ab71f
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `4f03d6b7c3cabb4b526a40adc1cabe0ab24ab71f`
- Image tag: `4f03d6b7`
- Image digest: `sha256:67293bdd93b7737a57537fa0ec71d0839e143c2288cf06bc7d4f034ae3d9c1b6`