### PR TITLE
fix(torghut): preserve knative creator annotation for gitops sync

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
     networking.knative.dev/visibility: cluster-local
   annotations:
+    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
     serving.knative.dev/rollout-duration: 10s
     argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut
 spec:


### PR DESCRIPTION
## Summary

- Add `serving.knative.dev/creator` to Torghut Knative Service manifest with the stable controller service-account value.
- Keep Argo GitOps ownership for Torghut while avoiding Knative immutable-annotation admission failures during sync/apply migration.
- Unblock rollout of the new Torghut image digest and readiness config via Argo sync.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/torghut >/tmp/torghut-kustomize.yaml`
- `rg -n "serving.knative.dev/creator|name: torghut$|image: registry.ide-newton.ts.net/lab/torghut@sha256:67293bdd|/db-check" /tmp/torghut-kustomize.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
