### PR TITLE
chore(torghut): promote image 7843f141

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67293bdd93b7737a57537fa0ec71d0839e143c2288cf06bc7d4f034ae3d9c1b6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4c687a1381ece8a6c572a794a6a46d82aaf5d94e3669c5e6c3a9c84eadfd439e
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -9,14 +9,13 @@ metadata:
     app.kubernetes.io/part-of: lab
     networking.knative.dev/visibility: cluster-local
   annotations:
-    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
     serving.knative.dev/rollout-duration: 10s
     argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut
 spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-22T06:30:20Z"
+        client.knative.dev/updateTimestamp: "2026-02-22T06:57:28Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67293bdd93b7737a57537fa0ec71d0839e143c2288cf06bc7d4f034ae3d9c1b6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4c687a1381ece8a6c572a794a6a46d82aaf5d94e3669c5e6c3a9c84eadfd439e
           ports:
             - name: http1
               containerPort: 8181
@@ -233,9 +232,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-36-g4f03d6b7
+              value: v0.560.0-52-g7843f141
             - name: TORGHUT_COMMIT
-              value: 4f03d6b7c3cabb4b526a40adc1cabe0ab24ab71f
+              value: 7843f14165be973dbf661653efa692f4948369e9
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `7843f14165be973dbf661653efa692f4948369e9`
- Image tag: `7843f141`
- Image digest: `sha256:4c687a1381ece8a6c572a794a6a46d82aaf5d94e3669c5e6c3a9c84eadfd439e`