### PR TITLE
fix(torghut): preserve knative creator in release promotions

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
     networking.knative.dev/visibility: cluster-local
   annotations:
+    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
     serving.knative.dev/rollout-duration: 10s
     argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut
 spec:

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -14,6 +14,10 @@ const createFixture = () => {
     serviceManifestPath,
     `apiVersion: serving.knative.dev/v1
 kind: Service
+metadata:
+  annotations:
+    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
+    serving.knative.dev/lastModifier: admin
 spec:
   template:
     metadata:
@@ -66,6 +70,10 @@ describe('update-manifests', () => {
     expect(serviceManifest).toContain(
       'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
+    expect(serviceManifest).toContain(
+      'serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller',
+    )
+    expect(serviceManifest).not.toContain('serving.knative.dev/lastModifier:')
     expect(serviceManifest).toContain('value: v0.600.0')
     expect(serviceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     expect(migrationManifest).toContain(

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -84,7 +84,6 @@ const updateTorghutManifest = (options: UpdateManifestsOptions) => {
     `$1${options.commit}`,
     'TORGHUT_COMMIT',
   )
-  updated = updated.replace(/^\s*serving\.knative\.dev\/creator:\s*[^\n]+\n/gm, '')
   updated = updated.replace(/^\s*serving\.knative\.dev\/lastModifier:\s*[^\n]+\n/gm, '')
 
   if (updated !== source) {


### PR DESCRIPTION
## Summary

- Restore `serving.knative.dev/creator` in Torghut Knative Service GitOps manifest.
- Update Torghut release manifest updater to preserve `serving.knative.dev/creator` during image promotions.
- Extend updater tests to assert creator is retained and `serving.knative.dev/lastModifier` continues to be stripped.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `kustomize build argocd/applications/torghut >/tmp/torghut-kustomize-creator.yaml`
- `rg -n "serving.knative.dev/creator|name: torghut$|image: registry.ide-newton.ts.net/lab/torghut@sha256:4c687a1381ece8a6c572a794a6a46d82aaf5d94e3669c5e6c3a9c84eadfd439e" /tmp/torghut-kustomize-creator.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
