### PR TITLE
chore(temporal): bump helm chart to 0.73.1

### DIFF
--- a/argocd/applications/temporal/kustomization.yaml
+++ b/argocd/applications/temporal/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 helmCharts:
   - name: temporal
     repo: https://go.temporal.io/helm-charts
-    version: 0.65.0
+    version: 0.73.1
     releaseName: temporal
     namespace: temporal
     includeCRDs: true


### PR DESCRIPTION
## Summary

- Bump Temporal Helm chart version in Argo CD app manifest from `0.65.0` to `0.73.1`.
- Keep existing Temporal values configuration unchanged (only chart upgrade).
- Prepare GitOps rollout so Argo CD can sync Temporal from updated `main`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/temporal >/tmp/temporal-kustomize-render.yaml`
- `wc -l /tmp/temporal-kustomize-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
