### PR TITLE
chore(jangar): promote image 742578ac

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 9fc4d64b
-  digest: sha256:a00a75d8d6657b62ca0159b176e2ccd5100165ffb7ab91c19a00ad7fa6b60692
+  tag: 742578ac
+  digest: sha256:bef547964af9a81d51d73823b6715f6d6ed75a01c8b2d7ec6f9e5d668cf8b918
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 9fc4d64b
-    digest: sha256:e2852db22a2563fd8d06d034687cfa383f9310866a3c176d2c5f0a0bd8b16d89
+    tag: 742578ac
+    digest: sha256:1dc61128117de080894421f0c6e0a1ce2bde625d6980c2d3dc788be883c75bf9
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 9fc4d64b
-    digest: sha256:a00a75d8d6657b62ca0159b176e2ccd5100165ffb7ab91c19a00ad7fa6b60692
+    tag: 742578ac
+    digest: sha256:bef547964af9a81d51d73823b6715f6d6ed75a01c8b2d7ec6f9e5d668cf8b918
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-21T21:16:37.468Z"
+    deploy.knative.dev/rollout: "2026-02-22T19:04:51Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-21T21:16:37.468Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-22T19:04:51Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "050d7def"
-    digest: sha256:6176538dfeb34624461a4e5df8e1b8b9b07fa3597f67933690915353b264a963
+    newTag: "742578ac"
+    digest: sha256:bef547964af9a81d51d73823b6715f6d6ed75a01c8b2d7ec6f9e5d668cf8b918


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `742578ace5cb48d416bd2684b6c34e8273519435`
- Image tag: `742578ac`
- Image digest: `sha256:bef547964af9a81d51d73823b6715f6d6ed75a01c8b2d7ec6f9e5d668cf8b918`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`