### PR TITLE
fix(ci): prevent bumba release PR merge feedback loop

### DIFF
--- a/.github/workflows/bumba-ci.yml
+++ b/.github/workflows/bumba-ci.yml
@@ -7,8 +7,6 @@ on:
     paths:
       - 'services/bumba/**'
       - 'packages/scripts/src/bumba/**'
-      - 'argocd/applications/bumba/**'
-      - 'argocd/applicationsets/product.yaml'
       - '.github/workflows/bumba-ci.yml'
       - '.github/workflows/docker-build-common.yaml'
       - 'package.json'
@@ -44,7 +42,12 @@ jobs:
     secrets: inherit
 
   deploy-main:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      ${{
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/main' &&
+        !contains(github.event.head_commit.message || '', 'automated release PR')
+      }}
     uses: ./.github/workflows/docker-build-common.yaml
     with:
       image_name: bumba


### PR DESCRIPTION
## Summary

- Stop `bumba` main-branch image rebuilds from Argo manifest-only changes that are produced by image-updater release PRs.
- Keep PR validation coverage for Argo manifest and ApplicationSet changes by retaining those paths under `pull_request` triggers.
- Add a deploy guard to skip `deploy-main` when the triggering main commit message indicates an automated release PR merge.

## Related Issues

None

## Testing

- `actionlint .github/workflows/bumba-ci.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/bumba-ci.yml'); puts 'OK: yaml parse'"`
- Manual logic check of `/Users/gregkonush/.codex/worktrees/578e/lab/.github/workflows/bumba-ci.yml` to confirm:
  - `push` no longer includes `argocd/applications/bumba/**` or `argocd/applicationsets/product.yaml`
  - `pull_request` still includes both Argo paths
  - `deploy-main` includes `!contains(github.event.head_commit.message || '', 'automated release PR')`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
