### PR TITLE
fix(argocd): stop masking torghut knative env updates

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -201,10 +201,10 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
                 # Keep torghut on client-side apply while recovering from manual kubectl-patch SSA ownership conflicts.
+                # Do not use RespectIgnoreDifferences here: it can prevent nested Knative Service env updates from applying.
                 syncOptions:
                   - CreateNamespace=true
                   - ServerSideApply=false
-                  - RespectIgnoreDifferences=true
                 ignoreDifferences:
                   - group: serving.knative.dev
                     kind: Service


### PR DESCRIPTION
## Summary

- Removes `RespectIgnoreDifferences=true` from the torghut app sync options in the product ApplicationSet.
- Keeps torghut on `ServerSideApply=false` while SSA ownership recovery remains in progress.
- Adds an inline note explaining this prevents Knative Service env updates from being skipped during sync.

## Related Issues

None

## Testing

- `kubectl -n argocd get application torghut -o json | jq '{syncStatus:.status.sync.status,health:.status.health.status,nonSynced:(.status.resources // [] | map(select(.status != "Synced") | {kind,name,status}))}'`
- `kubectl -n argocd exec argocd-application-controller-0 -- sh -lc '... argocd app diff torghut --core --kube-context in ...'` to confirm the exact Knative env drift keys.
- `kubectl apply -n torghut -f argocd/applications/torghut/knative-service.yaml` (incident recovery) and verified creation of `torghut-00017` with LEAN env keys present.
- Reconcile monitoring: four polls at ~20s intervals confirmed `sync=Synced`, `health=Healthy`, and `envLeanCount=9`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
