### PR TITLE
fix(bumba): auto-fail stale nonterminal ingestions

### DIFF
--- a/services/bumba/src/event-consumer.test.ts
+++ b/services/bumba/src/event-consumer.test.ts
@@ -9,6 +9,7 @@ const ENV_KEYS = [
   'BUMBA_GITHUB_EVENT_BATCH_SIZE',
   'BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS',
   'BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES',
+  'BUMBA_GITHUB_EVENT_NONTERMINAL_STALE_MS',
   'TEMPORAL_TASK_QUEUE',
   'BUMBA_WORKSPACE_ROOT',
   'CODEX_CWD',
@@ -101,6 +102,7 @@ test('resolveConsumerConfig reads environment overrides', () => {
   process.env.BUMBA_GITHUB_EVENT_BATCH_SIZE = '11'
   process.env.BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS = '55'
   process.env.BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES = '3'
+  process.env.BUMBA_GITHUB_EVENT_NONTERMINAL_STALE_MS = '600000'
   process.env.TEMPORAL_TASK_QUEUE = 'jangar'
   process.env.BUMBA_WORKSPACE_ROOT = '/workspace/lab'
 
@@ -111,6 +113,7 @@ test('resolveConsumerConfig reads environment overrides', () => {
   expect(config.batchSize).toBe(11)
   expect(config.maxEventFileTargets).toBe(55)
   expect(config.maxDispatchFailures).toBe(3)
+  expect(config.nonterminalIngestionStaleMs).toBe(600000)
   expect(config.taskQueue).toBe('jangar')
   expect(config.repoRoot).toBe('/workspace/lab')
 })


### PR DESCRIPTION
## Summary

- Add stale nonterminal-ingestion reconciliation in the bumba GitHub event consumer.
- Auto-fail stale `running`/`accepted` ingestion rows for a delivery before retrying event dispatch so old blocked rows cannot starve newer events.
- Add and test `BUMBA_GITHUB_EVENT_NONTERMINAL_STALE_MS` config parsing (default 12h).

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bumba test -- src/event-consumer.test.ts` (fails in this environment: `Cannot find module '@proompteng/temporal-bun-sdk'`)
- Manual production validation during incident recovery:
  - `temporal --namespace default --address temporal-grpc.ide-newton.ts.net:7233 task-queue describe --task-queue bumba --select-unversioned --select-all-active`
  - `kubectl cnpg psql -n jangar jangar-db -- --dbname=jangar -c "select count(*) as pending from atlas.github_events where processed_at is null;"`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
