### PR TITLE
fix(temporal-bun-sdk): route activities to workflow build id

### DIFF
--- a/packages/temporal-bun-sdk/src/workflow/commands.ts
+++ b/packages/temporal-bun-sdk/src/workflow/commands.ts
@@ -307,6 +307,8 @@ const buildScheduleActivityCommand = async (
     heartbeatTimeout: durationFromMillis(intent.timeouts.heartbeatTimeoutMs),
     retryPolicy: intent.retry ? buildRetryPolicy(intent.retry) : undefined,
     requestEagerExecution: intent.requestEagerExecution ?? false,
+    // Ensure activity tasks are routed to the same worker deployment build as the workflow task.
+    useWorkflowBuildId: true,
     header: intent.header,
   })
 

--- a/packages/temporal-bun-sdk/tests/workflow.executor.test.ts
+++ b/packages/temporal-bun-sdk/tests/workflow.executor.test.ts
@@ -64,6 +64,7 @@ test('schedules an activity command and completes after result', async () => {
   const scheduleAttrs = scheduleCmd.attributes?.value
   expect(scheduleAttrs?.activityType?.name).toBe('sendEmail')
   expect(scheduleAttrs?.activityId).toBe('activity-0')
+  expect(scheduleAttrs?.useWorkflowBuildId).toBe(true)
   const decoded = await decodePayloadsToValues(dataConverter, scheduleAttrs?.input?.payloads ?? [])
   expect(decoded).toEqual(['hello@acme.test'])
 


### PR DESCRIPTION
## Summary

- Set `useWorkflowBuildId: true` when creating `SCHEDULE_ACTIVITY_TASK` commands in `temporal-bun-sdk`.
- Ensure activity tasks inherit workflow build routing under worker versioning instead of falling into unversioned activity routing.
- Add a regression assertion in workflow executor tests to verify scheduled activities set `useWorkflowBuildId`.

## Related Issues

None

## Testing

- `bun install`
- `bun test packages/temporal-bun-sdk/tests/workflow.executor.test.ts`
- `bunx biome check packages/temporal-bun-sdk/src/workflow/commands.ts packages/temporal-bun-sdk/tests/workflow.executor.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked (N/A: no user-facing behavior/documentation changes required).
