### PR TITLE
chore(jangar): promote image b50e7b7b

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 742578ac
-  digest: sha256:bef547964af9a81d51d73823b6715f6d6ed75a01c8b2d7ec6f9e5d668cf8b918
+  tag: b50e7b7b
+  digest: sha256:537d69fd9a4453b1e7e682a7032e29e66388f08f82452a5c251a1692843de74c
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 742578ac
-    digest: sha256:1dc61128117de080894421f0c6e0a1ce2bde625d6980c2d3dc788be883c75bf9
+    tag: b50e7b7b
+    digest: sha256:c52d37ded9f5cf8b5305b71d8e0da8c36a8255d2d3414aff28346c90b0a0f6f3
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 742578ac
-    digest: sha256:bef547964af9a81d51d73823b6715f6d6ed75a01c8b2d7ec6f9e5d668cf8b918
+    tag: b50e7b7b
+    digest: sha256:537d69fd9a4453b1e7e682a7032e29e66388f08f82452a5c251a1692843de74c
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-22T19:04:51Z"
+    deploy.knative.dev/rollout: "2026-02-22T21:52:19Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-22T19:04:51Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-22T21:52:19Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "742578ac"
-    digest: sha256:bef547964af9a81d51d73823b6715f6d6ed75a01c8b2d7ec6f9e5d668cf8b918
+    newTag: "b50e7b7b"
+    digest: sha256:537d69fd9a4453b1e7e682a7032e29e66388f08f82452a5c251a1692843de74c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b50e7b7b23b7a8adf27d71cb4c3a68a7ec05511d`
- Image tag: `b50e7b7b`
- Image digest: `sha256:537d69fd9a4453b1e7e682a7032e29e66388f08f82452a5c251a1692843de74c`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`