### PR TITLE
chore(jangar): promote image c2a5ec50

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: b50e7b7b
-  digest: sha256:537d69fd9a4453b1e7e682a7032e29e66388f08f82452a5c251a1692843de74c
+  tag: c2a5ec50
+  digest: sha256:e3f3162699f6fc2857a14db871369c790f87d1507d11a7c46d341c89156687e5
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: b50e7b7b
-    digest: sha256:c52d37ded9f5cf8b5305b71d8e0da8c36a8255d2d3414aff28346c90b0a0f6f3
+    tag: c2a5ec50
+    digest: sha256:a0f4f6f02f549ee0991eb4f733c4efc85c5e5bd119c6bd8fba0020252bf7ff36
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: b50e7b7b
-    digest: sha256:537d69fd9a4453b1e7e682a7032e29e66388f08f82452a5c251a1692843de74c
+    tag: c2a5ec50
+    digest: sha256:e3f3162699f6fc2857a14db871369c790f87d1507d11a7c46d341c89156687e5
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-22T21:52:19Z"
+    deploy.knative.dev/rollout: "2026-02-22T22:05:08Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-22T21:52:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-22T22:05:08Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "b50e7b7b"
-    digest: sha256:537d69fd9a4453b1e7e682a7032e29e66388f08f82452a5c251a1692843de74c
+    newTag: "c2a5ec50"
+    digest: sha256:e3f3162699f6fc2857a14db871369c790f87d1507d11a7c46d341c89156687e5


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c2a5ec50154c63b5929281917c681bba690b9a83`
- Image tag: `c2a5ec50`
- Image digest: `sha256:e3f3162699f6fc2857a14db871369c790f87d1507d11a7c46d341c89156687e5`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`