### PR TITLE
chore(arc): cap max runners at 5

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -26,7 +26,7 @@ spec:
           githubConfigSecret: github-token
           runnerScaleSetName: arc-arm64
           minRunners: 3
-          maxRunners: 10
+          maxRunners: 5
           containerMode:
             type: "kubernetes"
             kubernetesModeWorkVolumeClaim:


### PR DESCRIPTION
## Summary

- Reduce ARC `maxRunners` from `10` to `5` for the `arc-arm64` runner scale set.
- Keep `minRunners` unchanged at `3`.
- Limit CI runner fan-out to avoid over-consuming shared cluster capacity.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applications/arc/application.yaml`
- Verified diff only updates `maxRunners` in `argocd/applications/arc/application.yaml`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
