### PR TITLE
chore(jangar): promote image edce30e0

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c2a5ec50
-  digest: sha256:e3f3162699f6fc2857a14db871369c790f87d1507d11a7c46d341c89156687e5
+  tag: edce30e0
+  digest: sha256:919426d6340953d27fbda730177b5aa2fdd560d60dc86c1c163a78f4da168f0a
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c2a5ec50
-    digest: sha256:a0f4f6f02f549ee0991eb4f733c4efc85c5e5bd119c6bd8fba0020252bf7ff36
+    tag: edce30e0
+    digest: sha256:b92427b334698dc5d2cfd7d15fcb196e7b49a34b8298338338a3a05fc1ab5083
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c2a5ec50
-    digest: sha256:e3f3162699f6fc2857a14db871369c790f87d1507d11a7c46d341c89156687e5
+    tag: edce30e0
+    digest: sha256:919426d6340953d27fbda730177b5aa2fdd560d60dc86c1c163a78f4da168f0a
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-22T22:05:08Z"
+    deploy.knative.dev/rollout: "2026-02-22T22:41:26Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-22T22:05:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-22T22:41:26Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c2a5ec50"
-    digest: sha256:e3f3162699f6fc2857a14db871369c790f87d1507d11a7c46d341c89156687e5
+    newTag: "edce30e0"
+    digest: sha256:919426d6340953d27fbda730177b5aa2fdd560d60dc86c1c163a78f4da168f0a


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `edce30e0d70fd4fc472eba1b6ea3492715bb4621`
- Image tag: `edce30e0`
- Image digest: `sha256:919426d6340953d27fbda730177b5aa2fdd560d60dc86c1c163a78f4da168f0a`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`