### PR TITLE
fix(bumba): prevent unversioned workflow startup stalls

### DIFF
--- a/services/bumba/README.md
+++ b/services/bumba/README.md
@@ -10,7 +10,10 @@ Temporal worker that enriches repository files using AST context + self-hosted m
 - The worker can consume pending `atlas.github_events` and start `enrichFile` workflows directly. Controls:
   `BUMBA_GITHUB_EVENT_CONSUMER_ENABLED`, `BUMBA_GITHUB_EVENT_POLL_INTERVAL_MS`,
   `BUMBA_GITHUB_EVENT_BATCH_SIZE`, `BUMBA_GITHUB_EVENT_MAX_FILE_TARGETS`,
-  `BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES`.
+  `BUMBA_GITHUB_EVENT_MAX_DISPATCH_FAILURES`, `BUMBA_GITHUB_EVENT_ROUTING_ALIGNMENT_ENABLED`.
+- When routing alignment is enabled, the event-consumer waits to confirm/set Temporal worker deployment
+  routing to the active `TEMPORAL_WORKER_BUILD_ID` before dispatching new event workflows. This avoids
+  unversioned workflow starts when the deployment current version drifts.
 - Enrichment skips directory paths; model completion failures (including timeouts) fail the workflow to avoid placeholders.
 - Repository listing sync can be tuned with `BUMBA_REPO_SYNC_INTERVAL_MS` (set `0` to disable periodic origin fetches).
 - Performance knobs: `OPENAI_API_BASE_URL`, `OPENAI_COMPLETION_TIMEOUT_MS`, `OPENAI_COMPLETION_MAX_OUTPUT_TOKENS`, `BUMBA_MODEL_CONCURRENCY`,


### PR DESCRIPTION
## Summary

- Guard Bumba event dispatch behind Temporal worker-deployment routing alignment so new event workflows are not started while routing is unset/drifted.
- Expand already-started detection to treat Temporal `[already_exists] ... already running` responses as non-fatal duplicate starts.
- Add regression tests for routing helper behavior and already-started error classification.
- Document the `HistoryLength=2` unversioned stall signature and remediation in the Bumba failure-mode runbook and README.

## Related Issues

None

## Testing

- `bun install`
- `bun run --filter @proompteng/bumba lint`
- `bun run --filter @proompteng/bumba test ./src/event-consumer.test.ts`
- `bun run --filter @proompteng/bumba tsc`
- `temporal --address temporal-grpc.ide-newton.ts.net:7233 --namespace default task-queue describe --task-queue bumba --select-all-active --select-unversioned`
- `temporal --address temporal-grpc.ide-newton.ts.net:7233 --namespace default workflow describe --workflow-id bumba-event-31eff4aadce9-f3775eb09f1c --run-id 019c877c-74c7-7433-9ae0-7e64835297eb`
- `bun run packages/scripts/src/jangar/sync-temporal-routing.ts --address temporal-grpc.ide-newton.ts.net:7233 --namespace default --task-queue bumba --deployment-name bumba-deployment --migrate-unversioned-running --reason "incident recovery: bumba stalled unversioned workflows"`
- `kubectl cnpg psql -n jangar jangar-db -- -d jangar -c "select count(*) as unprocessed from atlas.github_events where processed_at is null; select count(*) as running_ingestions from atlas.ingestions where status in ('accepted','running');"`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
