### PR TITLE
fix(temporal-bun-sdk): simplify deployment client request typing

### DIFF
--- a/packages/temporal-bun-sdk/tests/client/ops-client.test.ts
+++ b/packages/temporal-bun-sdk/tests/client/ops-client.test.ts
@@ -350,16 +350,22 @@ test('workflow, worker, and deployment ops call WorkflowService RPCs with defaul
     expect(lastCall(calls, 'getDeploymentReachability')?.request.namespace).toBe(config.namespace)
 
     await client.deployments.setWorkerDeploymentCurrentVersion(
-      { deploymentName: 'deploy-5', version: 'v1', buildId: 'build-5' },
+      { deploymentName: 'deploy-5', buildId: 'build-5' },
       callOptions,
     )
-    expect(lastCall(calls, 'setWorkerDeploymentCurrentVersion')?.request.namespace).toBe(config.namespace)
+    const setCurrentVersionCall = lastCall(calls, 'setWorkerDeploymentCurrentVersion')
+    expect(setCurrentVersionCall?.request.namespace).toBe(config.namespace)
+    expect(setCurrentVersionCall?.request.version).toBe('')
+    expect(setCurrentVersionCall?.request.conflictToken).toEqual(new Uint8Array())
 
     await client.deployments.setWorkerDeploymentRampingVersion(
-      { deploymentName: 'deploy-6', version: 'v2', buildId: 'build-6', percentage: 10 },
+      { deploymentName: 'deploy-6', buildId: 'build-6', percentage: 10 },
       callOptions,
     )
-    expect(lastCall(calls, 'setWorkerDeploymentRampingVersion')?.request.namespace).toBe(config.namespace)
+    const setRampingVersionCall = lastCall(calls, 'setWorkerDeploymentRampingVersion')
+    expect(setRampingVersionCall?.request.namespace).toBe(config.namespace)
+    expect(setRampingVersionCall?.request.version).toBe('')
+    expect(setRampingVersionCall?.request.conflictToken).toEqual(new Uint8Array())
 
     await client.deployments.updateWorkerDeploymentVersionMetadata(
       { deploymentVersion: { deploymentName: 'deploy-7', buildId: 'build-7' }, version: 'v3' },

--- a/services/bumba/src/event-consumer.ts
+++ b/services/bumba/src/event-consumer.ts
@@ -656,11 +656,8 @@ export const createGithubEventConsumer = (
     }
 
     try {
-      const describeRequest = { deploymentName: workerDeploymentName } as Parameters<
-        TemporalClient['deployments']['describeWorkerDeployment']
-      >[0]
       const deployment = await client.deployments.describeWorkerDeployment(
-        describeRequest,
+        { deploymentName: workerDeploymentName },
         temporalCallOptions({ timeoutMs: DEFAULT_ROUTING_ALIGNMENT_RPC_TIMEOUT_MS }),
       )
       const currentBuildId = extractCurrentDeploymentBuildId(deployment)
@@ -673,17 +670,14 @@ export const createGithubEventConsumer = (
         return true
       }
 
-      const setCurrentVersionRequest = {
-        deploymentName: workerDeploymentName,
-        buildId: workerBuildId,
-        version: '',
-        conflictToken: new Uint8Array(),
-        allowNoPollers: false,
-        ignoreMissingTaskQueues: false,
-        identity: `bumba-event-consumer/${process.pid}`,
-      } as Parameters<TemporalClient['deployments']['setWorkerDeploymentCurrentVersion']>[0]
       await client.deployments.setWorkerDeploymentCurrentVersion(
-        setCurrentVersionRequest,
+        {
+          deploymentName: workerDeploymentName,
+          buildId: workerBuildId,
+          allowNoPollers: false,
+          ignoreMissingTaskQueues: false,
+          identity: `bumba-event-consumer/${process.pid}`,
+        },
         temporalCallOptions({ timeoutMs: DEFAULT_ROUTING_ALIGNMENT_RPC_TIMEOUT_MS }),
       )
 


### PR DESCRIPTION
## Summary

- Cleaned `TemporalDeploymentClient` deployment APIs to accept ergonomic input types instead of protobuf-generated request shapes.
- Added explicit request normalization in `setWorkerDeploymentCurrentVersion` and `setWorkerDeploymentRampingVersion` so deprecated/internal fields (`version`, `conflictToken`) are defaulted by the client.
- Updated SDK ops tests to validate the simplified deployment API inputs and defaulted payload behavior.
- Removed Bumba-side type-cast workarounds now that deployment client typing is clean.

## Related Issues

None

## Testing

- `bunx biome check packages/temporal-bun-sdk/src/client.ts packages/temporal-bun-sdk/tests/client/ops-client.test.ts services/bumba/src/event-consumer.ts`
- `bun run --filter @proompteng/temporal-bun-sdk test tests/client/ops-client.test.ts`
- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun run --filter @proompteng/bumba tsc`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
