### PR TITLE
chore(jangar): promote image 29b570d8

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: edce30e0
-  digest: sha256:919426d6340953d27fbda730177b5aa2fdd560d60dc86c1c163a78f4da168f0a
+  tag: 29b570d8
+  digest: sha256:ee8691eb5e90a26f1189703c11feb872331a3bf5d5f0893f8eb37bd90eb15fb1
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: edce30e0
-    digest: sha256:b92427b334698dc5d2cfd7d15fcb196e7b49a34b8298338338a3a05fc1ab5083
+    tag: 29b570d8
+    digest: sha256:d986f7ff60f066d769cba8c9237d4e71f273d2fbc0d4b6e45e0afa0253145c14
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: edce30e0
-    digest: sha256:919426d6340953d27fbda730177b5aa2fdd560d60dc86c1c163a78f4da168f0a
+    tag: 29b570d8
+    digest: sha256:ee8691eb5e90a26f1189703c11feb872331a3bf5d5f0893f8eb37bd90eb15fb1
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-22T22:41:26Z"
+    deploy.knative.dev/rollout: "2026-02-22T23:52:03Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-22T22:41:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-22T23:52:03Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "edce30e0"
-    digest: sha256:919426d6340953d27fbda730177b5aa2fdd560d60dc86c1c163a78f4da168f0a
+    newTag: "29b570d8"
+    digest: sha256:ee8691eb5e90a26f1189703c11feb872331a3bf5d5f0893f8eb37bd90eb15fb1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `29b570d8161c067b1bbaf959607529fb69e094e4`
- Image tag: `29b570d8`
- Image digest: `sha256:ee8691eb5e90a26f1189703c11feb872331a3bf5d5f0893f8eb37bd90eb15fb1`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`