### PR TITLE
feat(temporal-bun-sdk): bundle temporal skill and installer CLI

### DIFF
--- a/packages/temporal-bun-sdk/README.md
+++ b/packages/temporal-bun-sdk/README.md
@@ -9,6 +9,7 @@ A Bun-first Temporal SDK implemented entirely in TypeScript. It speaks gRPC over
 - **Connect-powered client** – `createTemporalClient` gives you a fully typed Temporal WorkflowService client backed by @bufbuild/protobuf.
 - **Simple data conversion** – JSON payload conversion out of the box with hooks for custom codecs.
 - **Bun CLI** – `temporal-bun` scaffolds workers and ships lightweight Docker helpers (no Zig build steps required).
+- **Bundled agent skills** – install a ready-to-use Temporal operations skill for Codex-compatible agents via `temporal-bun skill install`.
 
 ## Prerequisites
 - **Bun ≥ 1.1.20** – required for the runtime and CLI.
@@ -438,7 +439,36 @@ temporal-bun init [directory]        Scaffold a new worker project
 temporal-bun docker-build            Build a Docker image for the current project
 temporal-bun doctor                  Validate config + observability sinks
 temporal-bun replay                  Replay workflow histories and diff determinism
+temporal-bun skill                   Install/list bundled agent skills
 temporal-bun help                    Show available commands
+```
+
+## Bundled agent skills
+
+`@proompteng/temporal-bun-sdk` ships with a packaged Temporal skill bundle under `skills/` plus CLI helpers:
+
+```bash
+# list available bundled skills
+bunx temporal-bun skill list
+
+# install default bundled skill into Codex skills directory
+bunx temporal-bun skill install temporal
+
+# install into a custom directory
+bunx temporal-bun skill install temporal --to /tmp/my-skills
+```
+
+For direct scripting, use the exported API from `@proompteng/temporal-bun-sdk/skills`:
+
+```ts
+import { installBundledSkill, listBundledSkills } from '@proompteng/temporal-bun-sdk/skills'
+
+const skills = await listBundledSkills()
+await installBundledSkill({
+  skillName: skills[0]?.name ?? 'temporal',
+  destinationDir: '/tmp/skills',
+  force: true,
+})
 ```
 
 ### Replay workflow histories

--- a/packages/temporal-bun-sdk/package.json
+++ b/packages/temporal-bun-sdk/package.json
@@ -14,11 +14,13 @@
   "files": [
     "dist",
     "dist/native",
+    "skills",
     "README.md"
   ],
   "bin": {
-    "temporal-bun-worker": "./dist/bin/start-worker.js",
-    "temporal-bun": "./dist/bin/temporal-bun.js"
+    "temporal-bun-worker": "./dist/src/bin/start-worker.js",
+    "temporal-bun": "./dist/src/bin/temporal-bun.js",
+    "temporal-bun-skill": "./dist/src/bin/temporal-bun-skill.js"
   },
   "exports": {
     ".": {
@@ -49,8 +51,13 @@
       "types": "./dist/src/testing/index.d.ts",
       "default": "./dist/src/testing/index.js"
     },
-    "./bin/start-worker": "./dist/bin/start-worker.js",
-    "./bin/cli": "./dist/bin/temporal-bun.js"
+    "./skills": {
+      "types": "./dist/src/skills/index.d.ts",
+      "default": "./dist/src/skills/index.js"
+    },
+    "./bin/start-worker": "./dist/src/bin/start-worker.js",
+    "./bin/cli": "./dist/src/bin/temporal-bun.js",
+    "./bin/skill": "./dist/src/bin/temporal-bun-skill.js"
   },
   "scripts": {
     "clean": "rm -rf dist",
@@ -60,7 +67,7 @@
     "test": "bun test",
     "test:load": "bun scripts/run-worker-load.ts",
     "test:coverage": "bun test --coverage",
-    "start:worker": "bun run dist/bin/start-worker.js",
+    "start:worker": "bun run dist/src/bin/start-worker.js",
     "temporal:start": "bun scripts/start-temporal-cli.ts",
     "temporal:stop": "bun scripts/stop-temporal-cli.ts",
     "prepack": "bun run build",

--- a/packages/temporal-bun-sdk/skills/manifest.json
+++ b/packages/temporal-bun-sdk/skills/manifest.json
@@ -1,0 +1,10 @@
+{
+  "skills": [
+    {
+      "name": "temporal",
+      "description": "Operate Temporal workflows from CLI: inspect history, diagnose nondeterminism, reset, cancel, terminate, and validate task queues.",
+      "path": "temporal",
+      "entry": "SKILL.md"
+    }
+  ]
+}

--- a/packages/temporal-bun-sdk/skills/temporal/SKILL.md
+++ b/packages/temporal-bun-sdk/skills/temporal/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: temporal
+description: "Operate Temporal workflows with explicit namespace/address: inspect runs, fetch history, debug nondeterminism, reset/cancel/terminate, and inspect task queues."
+---
+
+# Temporal
+
+## Overview
+
+Use explicit namespace, address, and task queue variables for every command so diagnostics are repeatable.
+
+## Connection
+
+```bash
+export TEMPORAL_ADDRESS=127.0.0.1:7233
+export TEMPORAL_NAMESPACE=default
+export TEMPORAL_TASK_QUEUE=my-task-queue
+```
+
+Validate connectivity:
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow list --limit 5
+```
+
+If your shell environment already has these values, use `scripts/temporal-run.sh` to avoid repeating flags.
+
+## From UI URL to CLI args
+
+Example UI URL:
+
+```
+http://temporal/namespaces/default/workflows/my-workflow-id/01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22/history
+```
+
+Derive:
+
+```bash
+export WORKFLOW_ID=my-workflow-id
+export RUN_ID=01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22
+```
+
+## Inspect workflows
+
+Describe:
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow describe \
+  --workflow-id "$WORKFLOW_ID" \
+  --run-id "$RUN_ID"
+```
+
+History (JSON):
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow show \
+  --workflow-id "$WORKFLOW_ID" \
+  --run-id "$RUN_ID" \
+  --output json > /tmp/workflow-history.json
+```
+
+Trace:
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow trace \
+  --workflow-id "$WORKFLOW_ID" \
+  --run-id "$RUN_ID"
+```
+
+## List and filter
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow list --limit 20
+
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow list \
+  --query 'WorkflowType="MyWorkflow" and ExecutionStatus="Running"'
+
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow list \
+  --query 'ExecutionStatus="Failed"'
+```
+
+## Replay and nondeterminism triage
+
+1. Fetch workflow history JSON.
+2. Replay with your worker code.
+3. Compare mismatch location to the command stream.
+4. If needed, reset to a safe event.
+
+```bash
+bunx temporal-bun replay \
+  --history-file /tmp/workflow-history.json \
+  --workflow-type MyWorkflow \
+  --json
+```
+
+## Reset nondeterminism
+
+1. Use `workflow show` to locate the last good event ID.
+2. Reset to `FirstWorkflowTask` or a known-safe event.
+3. Confirm the new run replays deterministically.
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow reset \
+  --workflow-id "$WORKFLOW_ID" \
+  --run-id "$RUN_ID" \
+  --reason "reset to known-good event" \
+  --event-id 31 \
+  --reset-type FirstWorkflowTask
+```
+
+## Cancel and terminate
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow cancel \
+  --workflow-id "$WORKFLOW_ID"
+
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow terminate \
+  --workflow-id "$WORKFLOW_ID" \
+  --reason "manual cleanup"
+```
+
+## Task queues and workers
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" task-queue describe \
+  --task-queue "$TEMPORAL_TASK_QUEUE"
+```
+
+## Resources
+
+- Reference: `references/temporal-cli.md`
+- Runner: `scripts/temporal-run.sh`
+- Triage template: `assets/temporal-triage.md`

--- a/packages/temporal-bun-sdk/skills/temporal/assets/temporal-triage.md
+++ b/packages/temporal-bun-sdk/skills/temporal/assets/temporal-triage.md
@@ -1,0 +1,32 @@
+# Temporal triage template
+
+## Context
+
+- UI URL: http://temporal/namespaces/default/workflows/my-workflow-id/01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22/history
+- Namespace: default
+- Task queue: my-task-queue
+- Workflow type: MyWorkflow
+- Workflow ID: my-workflow-id
+- Run ID: 01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22
+
+## Failure snapshot
+
+- Failure summary: workflow stalled or replay mismatch
+- Last event ID: <event-id>
+- Worker build ID/image tag: <build-id>
+
+Common cause: workflow code changed in a way that altered command ordering for in-flight runs
+(e.g., reordered `activities.schedule(...)` without versioning guards).
+
+## Diagnostics
+
+- Describe: `temporal workflow describe --workflow-id my-workflow-id --run-id 01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22`
+- History JSON: `/tmp/workflow-history.json`
+- Worker logs: `<your log source>`
+- Replay summary: `bunx temporal-bun replay --history-file /tmp/workflow-history.json --workflow-type MyWorkflow --json`
+
+## Mitigation
+
+- Identify a safe reset event (often the last `WorkflowTaskCompleted` before divergence), then reset.
+- If replay mismatch reproduces, patch workflow determinism and deploy a new compatible build.
+- Re-run workflow and confirm child workflows complete.

--- a/packages/temporal-bun-sdk/skills/temporal/references/temporal-cli.md
+++ b/packages/temporal-bun-sdk/skills/temporal/references/temporal-cli.md
@@ -1,0 +1,82 @@
+# Temporal CLI quick reference
+
+## Connection
+
+```bash
+export TEMPORAL_ADDRESS=127.0.0.1:7233
+export TEMPORAL_NAMESPACE=default
+```
+
+## List
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow list --limit 20
+```
+
+## Filter
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow list \
+  --query 'WorkflowType="MyWorkflow" and ExecutionStatus="Running"'
+```
+
+## Describe, show, result
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow describe \
+  --workflow-id my-workflow-id \
+  --run-id 01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22
+
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow show \
+  --workflow-id my-workflow-id \
+  --run-id 01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22 \
+  --output json > /tmp/workflow-history.json
+
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow result \
+  --workflow-id my-workflow-id \
+  --run-id 01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22
+```
+
+## Reset
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow reset \
+  --workflow-id my-workflow-id \
+  --run-id 01f0fdc1-b5f2-7f11-b8b5-0dc1f9a91a22 \
+  --event-id 31 \
+  --reset-type FirstWorkflowTask \
+  --reason "reset to known-good event"
+```
+
+## Cancel and terminate
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow cancel \
+  --workflow-id my-workflow-id
+
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" workflow terminate \
+  --workflow-id my-workflow-id \
+  --reason "manual cleanup"
+```
+
+## Task queues
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" task-queue describe \
+  --task-queue my-task-queue
+```
+
+## Batch operations
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" batch start \
+  --query 'ExecutionStatus="Failed"' \
+  --reason "cleanup failed runs" \
+  --terminate
+```
+
+## Schedules
+
+```bash
+temporal --namespace "$TEMPORAL_NAMESPACE" --address "$TEMPORAL_ADDRESS" schedule list
+```

--- a/packages/temporal-bun-sdk/skills/temporal/scripts/temporal-run.sh
+++ b/packages/temporal-bun-sdk/skills/temporal/scripts/temporal-run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ADDRESS=${TEMPORAL_ADDRESS:-}
+NAMESPACE=${TEMPORAL_NAMESPACE:-default}
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: temporal-run.sh workflow list --limit 5" >&2
+  exit 1
+fi
+
+ARGS=("--namespace" "$NAMESPACE")
+if [[ -n "$ADDRESS" ]]; then
+  ARGS+=("--address" "$ADDRESS")
+fi
+
+exec temporal "${ARGS[@]}" "$@"

--- a/packages/temporal-bun-sdk/src/bin/temporal-bun-skill.ts
+++ b/packages/temporal-bun-sdk/src/bin/temporal-bun-skill.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env bun
+
+import { exit } from 'node:process'
+import { runSkillCli } from '../skills/cli'
+
+export const main = async () => {
+  const { args, flags } = parseArgs(process.argv.slice(2))
+
+  try {
+    const result = await runSkillCli(args, flags)
+    if (result && typeof result.exitCode === 'number') {
+      exit(result.exitCode)
+      return
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    exit(1)
+    return
+  }
+}
+
+export function parseArgs(argv: string[]) {
+  const args: string[] = []
+  const flags: Record<string, string | boolean> = {}
+
+  for (let index = 0; index < argv.length; index++) {
+    const value = argv[index]
+    if (!value.startsWith('-')) {
+      args.push(value)
+      continue
+    }
+
+    const trimmed = value.replace(/^-+/, '')
+    if (trimmed.length === 0) {
+      continue
+    }
+
+    const equalsIndex = trimmed.indexOf('=')
+    if (equalsIndex !== -1) {
+      const key = trimmed.slice(0, equalsIndex)
+      const flagValue = trimmed.slice(equalsIndex + 1)
+      flags[key] = flagValue
+      continue
+    }
+
+    const key = trimmed
+    const next = argv[index + 1]
+    if (next && !next.startsWith('-')) {
+      flags[key] = next
+      index++
+      continue
+    }
+
+    flags[key] = true
+  }
+
+  return { args, flags }
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/packages/temporal-bun-sdk/src/bin/temporal-bun.ts
+++ b/packages/temporal-bun-sdk/src/bin/temporal-bun.ts
@@ -10,6 +10,7 @@ import { makeDefaultClientInterceptors } from '../interceptors/client'
 import { makeDefaultWorkerInterceptors } from '../interceptors/worker'
 import { runTemporalCliEffect } from '../runtime/cli-layer'
 import { ObservabilityService, TemporalConfigService } from '../runtime/effect-layers'
+import { runSkillCli } from '../skills/cli'
 import { executeLintWorkflows, parseLintWorkflowsFlags, printLintWorkflows } from './lint-workflows-command'
 import { executeReplay, parseReplayOptions, printReplaySummary } from './replay-command'
 
@@ -156,12 +157,15 @@ const handleLintWorkflows: CommandHandler = (_args, flags) =>
     return result.exitCode !== 0 ? { exitCode: result.exitCode } : undefined
   })
 
+const handleSkill: CommandHandler = (args, flags) => Effect.tryPromise(() => runSkillCli(args, flags))
+
 const commands: Record<string, CommandHandler> = {
   init: handleInit,
   'docker-build': handleDockerBuild,
   doctor: handleDoctor,
   replay: handleReplay,
   'lint-workflows': handleLintWorkflows,
+  skill: handleSkill,
   help: handleHelp,
 }
 
@@ -244,6 +248,7 @@ Commands:
   docker-build            Build a Docker image for the current project
   doctor                  Validate configuration + observability sinks
   replay                  Replay workflow histories to diff determinism
+  skill                   Install/list bundled agent skills
   lint-workflows           Lint workflow modules for nondeterminism hazards
   help                    Show this help message
 
@@ -276,6 +281,8 @@ Options:
   --format <format>       Lint output format (text|json)
   --config <path>         Workflow lint config path (default: .temporal-bun-workflows.json)
   --changed-only          Lint only entries impacted by git diff (best-effort)
+  --to <path>             Install root directory for temporal-bun skill install
+  --skill <name>          Skill name override for temporal-bun skill commands
 `)
 }
 

--- a/packages/temporal-bun-sdk/src/index.ts
+++ b/packages/temporal-bun-sdk/src/index.ts
@@ -56,6 +56,8 @@ export {
 export { createWorkerAppLayer, runWorkerApp, WorkerAppLayer } from './runtime/worker-app'
 export type { SearchAttributeSchemaMap, TypedSearchAttributes } from './search-attributes'
 export { createTypedSearchAttributes, defineSearchAttributes } from './search-attributes'
+export type { BundledSkill, InstallBundledSkillOptions, InstallBundledSkillResult } from './skills'
+export { getBundledSkill, installBundledSkill, listBundledSkills, resolveBundledSkillsDirectory } from './skills'
 export type { TestWorkflowEnvironmentOptions, TimeSkippingTestWorkflowEnvironmentOptions } from './testing'
 export {
   createExistingWorkflowEnvironment,

--- a/packages/temporal-bun-sdk/src/skills/cli.ts
+++ b/packages/temporal-bun-sdk/src/skills/cli.ts
@@ -1,0 +1,90 @@
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { getBundledSkill, installBundledSkill, listBundledSkills } from './index'
+
+const DEFAULT_SKILL_INSTALL_DIR = join(homedir(), '.codex', 'skills')
+
+export type SkillCliResult = {
+  exitCode?: number
+}
+
+export type SkillCliIo = {
+  log: (message: string) => void
+  error: (message: string) => void
+}
+
+export async function runSkillCli(
+  args: string[],
+  flags: Record<string, string | boolean>,
+  io: SkillCliIo = { log: console.log, error: console.error },
+): Promise<SkillCliResult | undefined> {
+  const [subcommand = 'help', ...rest] = args
+
+  if (subcommand === 'help') {
+    printSkillHelp(io.log)
+    return undefined
+  }
+
+  if (subcommand === 'list') {
+    const skills = await listBundledSkills()
+    if (skills.length === 0) {
+      io.log('No bundled skills found.')
+      return undefined
+    }
+
+    for (const skill of skills) {
+      io.log(`${skill.name}\t${skill.description}`)
+    }
+    return undefined
+  }
+
+  if (subcommand === 'path') {
+    const skillName = rest[0] ?? normalizeStringFlag(flags.skill) ?? 'temporal'
+    const skill = await getBundledSkill(skillName)
+    io.log(skill.sourceDir)
+    return undefined
+  }
+
+  if (subcommand === 'install') {
+    const skillName = rest[0] ?? normalizeStringFlag(flags.skill) ?? 'temporal'
+    const installRoot = resolve(normalizeStringFlag(flags.to) ?? DEFAULT_SKILL_INSTALL_DIR)
+    const force = Boolean(flags.force)
+
+    const result = await installBundledSkill({
+      skillName,
+      destinationDir: installRoot,
+      force,
+    })
+
+    const overwriteLabel = result.overwritten ? ' (overwritten)' : ''
+    io.log(`Installed ${result.skill.name} to ${result.installedPath}${overwriteLabel}`)
+    return undefined
+  }
+
+  io.error(`Unknown skill subcommand "${subcommand}".`)
+  printSkillHelp(io.log)
+  return { exitCode: 1 }
+}
+
+export function printSkillHelp(print: (message: string) => void = console.log) {
+  print(`temporal-bun skill <command> [options]\n
+Commands:
+  list                    List bundled skills
+  install [name]          Install a bundled skill (default: temporal)
+  path [name]             Print bundled skill source path
+  help                    Show this help message
+
+Options:
+  --to <path>             Install root directory (default: ~/.codex/skills)
+  --skill <name>          Skill name (alternative to positional arg)
+  --force                 Overwrite existing installed skill directory
+`)
+}
+
+function normalizeStringFlag(value: string | boolean | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}

--- a/packages/temporal-bun-sdk/src/skills/index.ts
+++ b/packages/temporal-bun-sdk/src/skills/index.ts
@@ -1,0 +1,184 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { cp, mkdir, readFile, rm } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PACKAGE_NAME = '@proompteng/temporal-bun-sdk'
+
+type BundledSkillsManifest = {
+  skills: BundledSkillDefinition[]
+}
+
+type BundledSkillDefinition = {
+  name: string
+  description: string
+  path: string
+  entry: string
+}
+
+export type BundledSkill = {
+  name: string
+  description: string
+  sourceDir: string
+  entryFile: string
+  entryPath: string
+}
+
+export type InstallBundledSkillOptions = {
+  skillName: string
+  destinationDir: string
+  force?: boolean
+}
+
+export type InstallBundledSkillResult = {
+  skill: BundledSkill
+  installedPath: string
+  overwritten: boolean
+}
+
+export function resolveBundledSkillsDirectory(): string {
+  const packageRoot = resolvePackageRoot()
+  const skillsDirectory = join(packageRoot, 'skills')
+  const manifestPath = join(skillsDirectory, 'manifest.json')
+
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Bundled skills manifest not found at ${manifestPath}`)
+  }
+
+  return skillsDirectory
+}
+
+export async function listBundledSkills(): Promise<BundledSkill[]> {
+  const { skillsDirectory, manifest } = await loadBundledSkillsManifest()
+  return manifest.skills.map((skill) => {
+    const sourceDir = join(skillsDirectory, skill.path)
+    return {
+      name: skill.name,
+      description: skill.description,
+      sourceDir,
+      entryFile: skill.entry,
+      entryPath: join(sourceDir, skill.entry),
+    }
+  })
+}
+
+export async function getBundledSkill(skillName: string): Promise<BundledSkill> {
+  const normalizedName = normalizeSkillName(skillName)
+  const skills = await listBundledSkills()
+  const skill = skills.find((entry) => entry.name === normalizedName)
+  if (!skill) {
+    const available = skills.map((entry) => entry.name).join(', ')
+    throw new Error(`Unknown bundled skill "${skillName}". Available: ${available}`)
+  }
+  return skill
+}
+
+export async function installBundledSkill(options: InstallBundledSkillOptions): Promise<InstallBundledSkillResult> {
+  const destinationDir = resolve(options.destinationDir)
+  const skill = await getBundledSkill(options.skillName)
+  const targetDir = join(destinationDir, skill.name)
+  const force = options.force ?? false
+
+  await mkdir(destinationDir, { recursive: true })
+
+  const targetExists = existsSync(targetDir)
+  if (targetExists && !force) {
+    throw new Error(`Skill destination already exists: ${targetDir} (use --force to overwrite)`)
+  }
+
+  if (targetExists && force) {
+    await rm(targetDir, { recursive: true, force: true })
+  }
+
+  await cp(skill.sourceDir, targetDir, { recursive: true })
+
+  return {
+    skill,
+    installedPath: targetDir,
+    overwritten: targetExists,
+  }
+}
+
+async function loadBundledSkillsManifest(): Promise<{ skillsDirectory: string; manifest: BundledSkillsManifest }> {
+  const skillsDirectory = resolveBundledSkillsDirectory()
+  const manifestPath = join(skillsDirectory, 'manifest.json')
+  const manifestRaw = await readFile(manifestPath, 'utf8')
+  const manifest = parseManifest(manifestRaw, manifestPath)
+  return { skillsDirectory, manifest }
+}
+
+function parseManifest(contents: string, manifestPath: string): BundledSkillsManifest {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(contents)
+  } catch (error) {
+    throw new Error(
+      `Failed to parse bundled skills manifest at ${manifestPath}: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  if (!parsed || typeof parsed !== 'object' || !('skills' in parsed) || !Array.isArray(parsed.skills)) {
+    throw new Error(`Invalid bundled skills manifest at ${manifestPath}: expected { skills: [] }`)
+  }
+
+  const normalizedSkills: BundledSkillDefinition[] = []
+  for (const entry of parsed.skills) {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error(`Invalid bundled skill entry in ${manifestPath}: expected object`)
+    }
+
+    const name = getStringField(entry, 'name', manifestPath)
+    const description = getStringField(entry, 'description', manifestPath)
+    const path = getStringField(entry, 'path', manifestPath)
+    const entryFile = getStringField(entry, 'entry', manifestPath)
+
+    normalizedSkills.push({
+      name: normalizeSkillName(name),
+      description,
+      path,
+      entry: entryFile,
+    })
+  }
+
+  return { skills: normalizedSkills }
+}
+
+function getStringField(value: object, field: string, manifestPath: string): string {
+  const record = value as Record<string, unknown>
+  const raw = record[field]
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new Error(`Invalid bundled skills manifest at ${manifestPath}: field "${field}" must be a non-empty string`)
+  }
+  return raw.trim()
+}
+
+function normalizeSkillName(skillName: string): string {
+  return skillName.trim().toLowerCase()
+}
+
+function resolvePackageRoot(): string {
+  let currentDirectory = dirname(fileURLToPath(import.meta.url))
+
+  while (true) {
+    const packageJsonPath = join(currentDirectory, 'package.json')
+    if (existsSync(packageJsonPath)) {
+      try {
+        const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { name?: string }
+        if (packageJson.name === PACKAGE_NAME) {
+          return currentDirectory
+        }
+      } catch {
+        // ignore malformed package.json entries while walking upward
+      }
+    }
+
+    const parentDirectory = dirname(currentDirectory)
+    if (parentDirectory === currentDirectory) {
+      break
+    }
+
+    currentDirectory = parentDirectory
+  }
+
+  throw new Error(`Unable to resolve package root for ${PACKAGE_NAME} from ${import.meta.url}`)
+}

--- a/packages/temporal-bun-sdk/tests/cli/temporal-bun-skill-cli.test.ts
+++ b/packages/temporal-bun-sdk/tests/cli/temporal-bun-skill-cli.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { runSkillCli } from '../../src/skills/cli'
+
+const tempDirectories: string[] = []
+
+afterEach(async () => {
+  while (tempDirectories.length > 0) {
+    const directory = tempDirectories.pop()
+    if (directory) {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }
+})
+
+describe('temporal-bun skill CLI', () => {
+  test('list prints bundled skills', async () => {
+    const logs: string[] = []
+    const errors: string[] = []
+
+    const result = await runSkillCli(['list'], {}, { log: (message) => logs.push(message), error: (message) => errors.push(message) })
+
+    expect(result).toBeUndefined()
+    expect(errors).toHaveLength(0)
+    expect(logs.some((line) => line.startsWith('temporal\t'))).toBeTrue()
+  })
+
+  test('install installs bundled temporal skill to explicit directory', async () => {
+    const installRoot = await mkdtemp(join(tmpdir(), 'temporal-bun-skill-cli-'))
+    tempDirectories.push(installRoot)
+
+    const logs: string[] = []
+    const errors: string[] = []
+
+    const result = await runSkillCli(
+      ['install', 'temporal'],
+      { to: installRoot },
+      { log: (message) => logs.push(message), error: (message) => errors.push(message) },
+    )
+
+    expect(result).toBeUndefined()
+    expect(errors).toHaveLength(0)
+    expect(logs.some((line) => line.includes('Installed temporal to'))).toBeTrue()
+  })
+})

--- a/packages/temporal-bun-sdk/tests/skills/bundled-skills.test.ts
+++ b/packages/temporal-bun-sdk/tests/skills/bundled-skills.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { installBundledSkill, listBundledSkills, resolveBundledSkillsDirectory } from '../../src/skills'
+
+const tempDirectories: string[] = []
+
+afterEach(async () => {
+  while (tempDirectories.length > 0) {
+    const directory = tempDirectories.pop()
+    if (directory) {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }
+})
+
+describe('bundled skills', () => {
+  test('lists temporal skill from bundled manifest', async () => {
+    const skills = await listBundledSkills()
+    expect(skills.some((skill) => skill.name === 'temporal')).toBeTrue()
+
+    const skillsRoot = resolveBundledSkillsDirectory()
+    expect(skillsRoot.endsWith('/skills')).toBeTrue()
+  })
+
+  test('installs bundled skill and enforces overwrite opt-in', async () => {
+    const installRoot = await mkdtemp(join(tmpdir(), 'temporal-bun-skill-'))
+    tempDirectories.push(installRoot)
+
+    const firstInstall = await installBundledSkill({
+      skillName: 'temporal',
+      destinationDir: installRoot,
+    })
+
+    const skillDocument = await readFile(join(firstInstall.installedPath, 'SKILL.md'), 'utf8')
+    expect(skillDocument).toContain('name: temporal')
+
+    await expect(
+      installBundledSkill({
+        skillName: 'temporal',
+        destinationDir: installRoot,
+      }),
+    ).rejects.toThrow('Skill destination already exists')
+
+    const overwriteInstall = await installBundledSkill({
+      skillName: 'temporal',
+      destinationDir: installRoot,
+      force: true,
+    })
+
+    expect(overwriteInstall.overwritten).toBeTrue()
+  })
+})


### PR DESCRIPTION
## Summary

- Bundle a generic Temporal operations skill inside `@proompteng/temporal-bun-sdk` under `skills/` so npm consumers can install it directly.
- Add first-party skills APIs (`listBundledSkills`, `installBundledSkill`, `getBundledSkill`, `resolveBundledSkillsDirectory`) and export them from both root and `@proompteng/temporal-bun-sdk/skills`.
- Add `temporal-bun skill` subcommands and a dedicated `temporal-bun-skill` binary for listing/installing bundled skills.
- Fix SDK bin/export runtime paths to `dist/src/bin/*` so built CLI entrypoints match TypeScript output layout.
- Add unit tests for bundled skills APIs and skill CLI plus README docs for agent/developer usage.

## Related Issues

None

## Testing

- `bun test tests/skills/bundled-skills.test.ts tests/cli/temporal-bun-skill-cli.test.ts tests/cli/temporal-bun-cli.test.ts` (run in `packages/temporal-bun-sdk`)
- `bun run build` (run in `packages/temporal-bun-sdk`)
- `bunx biome check packages/temporal-bun-sdk/src/skills/index.ts packages/temporal-bun-sdk/src/skills/cli.ts packages/temporal-bun-sdk/src/bin/temporal-bun-skill.ts packages/temporal-bun-sdk/src/bin/temporal-bun.ts packages/temporal-bun-sdk/src/index.ts packages/temporal-bun-sdk/tests/skills/bundled-skills.test.ts packages/temporal-bun-sdk/tests/cli/temporal-bun-skill-cli.test.ts` (run from repo root)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
