### PR TITLE
fix(torghut): harden data-plane observability and replay recovery controls

### DIFF
--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -178,6 +178,23 @@ data:
             annotations:
               summary: Torghut ClickHouse guardrails scrape failing
               description: Guardrails exporter is up but cannot query ClickHouse successfully.
+          - alert: TorghutClickHouseFreshnessQueryFallbacks
+            expr: |
+              increase(
+                torghut_clickhouse_guardrails_freshness_fallback_total{
+                  namespace="torghut",
+                  service="torghut-clickhouse-guardrails-exporter"
+                }[15m]
+              ) > 0
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut ClickHouse freshness queries are using fallback mode
+              description: |
+                Guardrails freshness checks are falling back from precise to low-memory mode.
+                This usually indicates ClickHouse query pressure or tight memory headroom.
+              runbook_url: docs/torghut/design-system/v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md
       - name: torghut-ws.rules
         rules:
           - alert: TorghutWSForwarderDown
@@ -209,6 +226,30 @@ data:
               description: |
                 torghut-ws /readyz is failing for 5 minutes (Alpaca/Kafka gates not healthy).
               runbook_url: docs/torghut/design-system/v1/operations-ws-connection-limit-and-auth.md
+          - alert: TorghutWSDesiredSymbolsFetchFailing
+            expr: |
+              max_over_time(
+                torghut_ws_desired_symbols_fetch_degraded{
+                  namespace="torghut",
+                  service="torghut-ws"
+                }[15m]
+              ) >= 1
+              * on() group_left()
+              (
+                (day_of_week(vector(time())) >= bool 1)
+                * (day_of_week(vector(time())) <= bool 5)
+                * (hour(vector(time())) >= bool 14)
+                * (hour(vector(time())) < bool 21)
+              )
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Torghut WS desired-symbol polling degraded
+              description: |
+                torghut-ws has failed desired symbol polls for at least 15 minutes and is running on cached symbols.
+                Verify Jangar symbols endpoint health and recent symbol updates.
+              runbook_url: docs/runbooks/torghut-quant-control-plane.md
           - alert: TorghutWSKafkaSendErrors
             expr: |
               rate(

--- a/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml
@@ -25,6 +25,7 @@ data:
     CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", "8123"))
     EXPORTER_PORT = int(os.environ.get("EXPORTER_PORT", "9108"))
     SCRAPE_INTERVAL_SECONDS = int(os.environ.get("SCRAPE_INTERVAL_SECONDS", "30"))
+    FRESHNESS_QUERY_MODE = os.environ.get("CLICKHOUSE_FRESHNESS_QUERY_MODE", "auto").strip().lower()
 
     DEFAULT_DISK_NAME = os.environ.get("CLICKHOUSE_DISK_NAME", "default")
     TABLES = os.environ.get("CLICKHOUSE_REPLICATED_TABLES", "ta_signals,ta_microbars").split(",")
@@ -71,6 +72,8 @@ data:
             self.last_scrape_success = 0.0
             self.last_scrape_ts_seconds = 0.0
             self.last_error = ""
+            self.freshness_low_memory_total: dict[str, float] = {"ta_signals": 0.0, "ta_microbars": 0.0}
+            self.freshness_fallback_total: dict[str, float] = {"ta_signals": 0.0, "ta_microbars": 0.0}
 
         def snapshot(self) -> dict:
             with self.lock:
@@ -78,6 +81,8 @@ data:
                     "replicas": dict(self.replicas),
                     "last_scrape_success": self.last_scrape_success,
                     "last_scrape_ts_seconds": self.last_scrape_ts_seconds,
+                    "freshness_low_memory_total": dict(self.freshness_low_memory_total),
+                    "freshness_fallback_total": dict(self.freshness_fallback_total),
                 }
 
 
@@ -89,6 +94,53 @@ data:
             return float(value)
         except Exception:
             return float("nan")
+
+
+    def fetch_freshness_ms(replica_url: str, table: str, time_column: str, alias: str) -> tuple[float, float, float]:
+        precise_query = (
+            f"SELECT ifNull(toUnixTimestamp64Milli(max({time_column})), 0) AS {alias} "
+            f"FROM {DATABASE}.{table} "
+            "FORMAT JSONEachRow"
+        )
+        # Low-memory fallback path based on active parts metadata. This avoids scanning full table data.
+        low_memory_query = (
+            "SELECT ifNull(toUnixTimestamp(max(max_time)) * 1000, 0) AS "
+            f"{alias} "
+            "FROM system.parts "
+            "WHERE active "
+            f"AND database = {clickhouse_str(DATABASE)} "
+            f"AND table = {clickhouse_str(table)} "
+            "FORMAT JSONEachRow"
+        )
+
+        mode = FRESHNESS_QUERY_MODE if FRESHNESS_QUERY_MODE in ("auto", "precise", "low_memory") else "auto"
+        if mode == "precise":
+            rows = clickhouse_query_rows(replica_url, precise_query)
+            if not rows:
+                raise RuntimeError(f"{table} freshness query returned no rows")
+            return float_or_nan(rows[0].get(alias, 0.0)), 0.0, 0.0
+
+        if mode == "low_memory":
+            rows = clickhouse_query_rows(replica_url, low_memory_query)
+            if not rows:
+                raise RuntimeError(f"{table} low-memory freshness query returned no rows")
+            return float_or_nan(rows[0].get(alias, 0.0)), 1.0, 0.0
+
+        try:
+            rows = clickhouse_query_rows(replica_url, precise_query)
+            if not rows:
+                raise RuntimeError(f"{table} freshness query returned no rows")
+            return float_or_nan(rows[0].get(alias, 0.0)), 0.0, 0.0
+        except Exception as precise_error:
+            try:
+                rows = clickhouse_query_rows(replica_url, low_memory_query)
+                if not rows:
+                    raise RuntimeError(f"{table} low-memory freshness query returned no rows")
+                return float_or_nan(rows[0].get(alias, 0.0)), 1.0, 1.0
+            except Exception as low_memory_error:
+                raise RuntimeError(
+                    f"{table} freshness query failed (precise={precise_error}; low_memory={low_memory_error})"
+                ) from low_memory_error
 
 
     def scrape_once():
@@ -125,20 +177,10 @@ data:
                     "FORMAT JSONEachRow"
                 )
 
-            signals_freshness_query = (
-                "SELECT ifNull(toUnixTimestamp64Milli(max(event_ts)), 0) AS max_event_ts_ms "
-                f"FROM {DATABASE}.ta_signals "
-                "FORMAT JSONEachRow"
-            )
-
-            microbars_freshness_query = (
-                "SELECT ifNull(toUnixTimestamp64Milli(max(window_end)), 0) AS max_window_end_ms "
-                f"FROM {DATABASE}.ta_microbars "
-                "FORMAT JSONEachRow"
-            )
-
             replicas: dict[str, dict] = {}
             scrape_errors: list[str] = []
+            low_memory_increments = {"ta_signals": 0.0, "ta_microbars": 0.0}
+            fallback_increments = {"ta_signals": 0.0, "ta_microbars": 0.0}
 
             for replica in replica_names:
                 replica_url = f"http://{replica}.{CLICKHOUSE_NAMESPACE}.svc.cluster.local:{CLICKHOUSE_PORT}"
@@ -155,17 +197,22 @@ data:
                             raise RuntimeError("readonly query returned no rows")
                         readonly_row = readonly_rows[0]
 
-                    signals_rows = clickhouse_query_rows(replica_url, signals_freshness_query)
-                    if not signals_rows:
-                        raise RuntimeError("signals freshness query returned no rows")
-                    signals_row = signals_rows[0]
-                    max_event_ts_ms = float_or_nan(signals_row.get("max_event_ts_ms", 0.0))
-
-                    microbars_rows = clickhouse_query_rows(replica_url, microbars_freshness_query)
-                    if not microbars_rows:
-                        raise RuntimeError("microbars freshness query returned no rows")
-                    microbars_row = microbars_rows[0]
-                    max_window_end_ms = float_or_nan(microbars_row.get("max_window_end_ms", 0.0))
+                    max_event_ts_ms, signals_low_memory_mode, signals_fallback_mode = fetch_freshness_ms(
+                        replica_url=replica_url,
+                        table="ta_signals",
+                        time_column="event_ts",
+                        alias="max_event_ts_ms",
+                    )
+                    max_window_end_ms, microbars_low_memory_mode, microbars_fallback_mode = fetch_freshness_ms(
+                        replica_url=replica_url,
+                        table="ta_microbars",
+                        time_column="window_end",
+                        alias="max_window_end_ms",
+                    )
+                    low_memory_increments["ta_signals"] += signals_low_memory_mode
+                    low_memory_increments["ta_microbars"] += microbars_low_memory_mode
+                    fallback_increments["ta_signals"] += signals_fallback_mode
+                    fallback_increments["ta_microbars"] += microbars_fallback_mode
 
                     free_space = float_or_nan(disk_row.get("free_space"))
                     total_space = float_or_nan(disk_row.get("total_space"))
@@ -181,6 +228,8 @@ data:
                         "any_replica_readonly": float_or_nan(readonly_row.get("any_readonly", 0.0)),
                         "ta_signals_max_event_ts_seconds": max_event_ts_ms / 1000.0,
                         "ta_microbars_max_window_end_seconds": max_window_end_ms / 1000.0,
+                        "ta_signals_freshness_low_memory_mode": signals_low_memory_mode,
+                        "ta_microbars_freshness_low_memory_mode": microbars_low_memory_mode,
                     }
                 except Exception as e:
                     scrape_errors.append(f"{replica}: {e}")
@@ -192,6 +241,8 @@ data:
                         "any_replica_readonly": float("nan"),
                         "ta_signals_max_event_ts_seconds": float("nan"),
                         "ta_microbars_max_window_end_seconds": float("nan"),
+                        "ta_signals_freshness_low_memory_mode": float("nan"),
+                        "ta_microbars_freshness_low_memory_mode": float("nan"),
                     }
 
             last_scrape_success = 1.0 if scrape_errors == [] else 0.0
@@ -201,6 +252,10 @@ data:
                 state.last_scrape_success = last_scrape_success
                 state.last_scrape_ts_seconds = now
                 state.last_error = "; ".join(scrape_errors)
+                state.freshness_low_memory_total["ta_signals"] += low_memory_increments["ta_signals"]
+                state.freshness_low_memory_total["ta_microbars"] += low_memory_increments["ta_microbars"]
+                state.freshness_fallback_total["ta_signals"] += fallback_increments["ta_signals"]
+                state.freshness_fallback_total["ta_microbars"] += fallback_increments["ta_microbars"]
         except Exception as e:
             with state.lock:
                 state.replicas = {}
@@ -282,6 +337,41 @@ data:
             lines.append(
                 f'torghut_clickhouse_guardrails_ta_microbars_max_window_end_seconds{{replica="{label}"}} {metrics["ta_microbars_max_window_end_seconds"]}'
             )
+
+        lines.append(
+            "# HELP torghut_clickhouse_guardrails_freshness_low_memory_mode 1 if freshness query used low-memory path for this replica/table on last scrape."
+        )
+        lines.append("# TYPE torghut_clickhouse_guardrails_freshness_low_memory_mode gauge")
+        for replica, metrics in snapshot["replicas"].items():
+            label = prom_label_value(replica)
+            lines.append(
+                'torghut_clickhouse_guardrails_freshness_low_memory_mode{replica="%s",table="ta_signals"} %s'
+                % (label, metrics["ta_signals_freshness_low_memory_mode"])
+            )
+            lines.append(
+                'torghut_clickhouse_guardrails_freshness_low_memory_mode{replica="%s",table="ta_microbars"} %s'
+                % (label, metrics["ta_microbars_freshness_low_memory_mode"])
+            )
+
+        lines.append("# HELP torghut_clickhouse_guardrails_freshness_low_memory_total Freshness queries served via low-memory mode.")
+        lines.append("# TYPE torghut_clickhouse_guardrails_freshness_low_memory_total counter")
+        lines.append(
+            f'torghut_clickhouse_guardrails_freshness_low_memory_total{{table="ta_signals"}} {snapshot["freshness_low_memory_total"]["ta_signals"]}'
+        )
+        lines.append(
+            f'torghut_clickhouse_guardrails_freshness_low_memory_total{{table="ta_microbars"}} {snapshot["freshness_low_memory_total"]["ta_microbars"]}'
+        )
+
+        lines.append(
+            "# HELP torghut_clickhouse_guardrails_freshness_fallback_total Freshness queries that fell back from precise to low-memory mode."
+        )
+        lines.append("# TYPE torghut_clickhouse_guardrails_freshness_fallback_total counter")
+        lines.append(
+            f'torghut_clickhouse_guardrails_freshness_fallback_total{{table="ta_signals"}} {snapshot["freshness_fallback_total"]["ta_signals"]}'
+        )
+        lines.append(
+            f'torghut_clickhouse_guardrails_freshness_fallback_total{{table="ta_microbars"}} {snapshot["freshness_fallback_total"]["ta_microbars"]}'
+        )
 
         lines.append("# HELP torghut_clickhouse_guardrails_last_scrape_success 1 if the last scrape succeeded.")
         lines.append("# TYPE torghut_clickhouse_guardrails_last_scrape_success gauge")

--- a/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml
@@ -40,6 +40,8 @@ spec:
               value: torghut
             - name: CLICKHOUSE_CLUSTER
               value: default
+            - name: CLICKHOUSE_FRESHNESS_QUERY_MODE
+              value: auto
             - name: PYTHONDONTWRITEBYTECODE
               value: "1"
           ports:

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -85,6 +85,8 @@ spec:
   flinkConfiguration:
     state.checkpoints.dir: s3a://flink-checkpoints/torghut/technical-analysis/checkpoints
     state.savepoints.dir: s3a://flink-checkpoints/torghut/technical-analysis/savepoints
+    execution.checkpointing.mode: EXACTLY_ONCE
+    execution.checkpointing.externalized-checkpoint-retention: RETAIN_ON_CANCELLATION
     taskmanager.numberOfTaskSlots: "2"
     restart-strategy.type: fixed-delay
     restart-strategy.fixed-delay.attempts: "5"
@@ -111,7 +113,7 @@ spec:
                 name: torghut-ta-config
           env:
             - name: TA_KAFKA_DELIVERY_GUARANTEE
-              value: AT_LEAST_ONCE
+              value: EXACTLY_ONCE
             - name: TA_KAFKA_USERNAME
               value: torghut-ws
             - name: TA_KAFKA_PASSWORD
@@ -183,5 +185,5 @@ spec:
     entryClass: ai.proompteng.dorvud.ta.flink.FlinkTechnicalAnalysisJobKt
     jarURI: local:///opt/flink/usrlib/app.jar
     parallelism: 8
-    upgradeMode: stateless
+    upgradeMode: last-state
     state: running

--- a/docs/runbooks/torghut-quant-control-plane.md
+++ b/docs/runbooks/torghut-quant-control-plane.md
@@ -9,13 +9,16 @@ control-plane stream health.
 ## Alert thresholds
 
 Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.yaml` under
-`torghut-quant-control-plane.rules`.
+`torghut-quant-control-plane.rules` plus upstream signal chain groups (`torghut-ws.rules`,
+`torghut-clickhouse.guardrails.rules`).
 
 - **TorghutQuantDecisionsStalledDuringMarketHours**: No trading decisions for 15 minutes during market hours.
 - **TorghutAutonomyNoSignalStreakDuringMarketHours**: Autonomy has consecutive no-signal windows in market hours.
 - **TorghutAutonomyCursorAheadOfStreamDuringMarketHours**: Autonomy repeatedly reports cursor_ahead_of_stream in market hours.
+- **TorghutWSDesiredSymbolsFetchFailing**: WS forwarder is stuck on cached symbols (desired-symbol polling degraded) for 15 minutes in market hours.
 - **TorghutQuantOrderRejectionRateHigh**: Rejected orders >20% of submitted orders for 10 minutes.
 - **TorghutQuantLLMErrorRateHigh**: Trading LLM errors >10% of requests for 10 minutes.
+- **TorghutClickHouseFreshnessQueryFallbacks**: ClickHouse guardrails freshness checks repeatedly fall back to low-memory mode for 15 minutes.
 - **JangarQuantControlPlaneStreamErrors**: Control-plane SSE errors >0.05/sec for 10 minutes.
 - **JangarTorghutQuantFramesMissingDuringMarketHours**: No computed `1d` frames for 5 minutes during market hours.
 - **JangarTorghutQuantComputeErrors**: Quant compute loop errors >0 for 10 minutes.
@@ -33,7 +36,19 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
    - `curl -fsS "http://127.0.0.1:8081/metrics" | rg '^torghut_trading_'`
 3. Validate signal freshness and TA pipeline health.
    - `kubectl -n torghut get deploy torghut-clickhouse-guardrails-exporter torghut-ws torghut-ta`
-   - Check `TorghutSignalsStaleDuringMarketHours` and `TorghutMicrobarsStaleDuringMarketHours` alerts.
+   - `kubectl -n torghut port-forward svc/torghut-ws 19090:9090`
+   - `curl -fsS http://127.0.0.1:19090/metrics | rg '^torghut_ws_desired_symbols_fetch_(degraded|failures_total|success_total|last_.*_ts_seconds)'`
+   - `kubectl -n torghut port-forward svc/torghut-clickhouse-guardrails-exporter 19108:9108`
+   - `curl -fsS http://127.0.0.1:19108/metrics | rg '^torghut_clickhouse_guardrails_(ta_signals_max_event_ts_seconds|ta_microbars_max_window_end_seconds|freshness_low_memory_mode|freshness_fallback_total)'`
+   - Pass criteria:
+     - `torghut_ws_desired_symbols_fetch_degraded` is `0`.
+     - `increase(torghut_ws_desired_symbols_fetch_failures_total[15m]) == 0` (or failure bursts are short and self-healed).
+     - `increase(torghut_clickhouse_guardrails_freshness_fallback_total[15m]) == 0` under normal steady state.
+     - `time() - max(torghut_clickhouse_guardrails_ta_signals_max_event_ts_seconds) < 900` and
+       `time() - max(torghut_clickhouse_guardrails_ta_microbars_max_window_end_seconds) < 300` in market hours.
+   - Fail criteria:
+     - `TorghutSignalsStaleDuringMarketHours`, `TorghutMicrobarsStaleDuringMarketHours`, `TorghutWSDesiredSymbolsFetchFailing`,
+       or `TorghutClickHouseFreshnessQueryFallbacks` is firing.
 4. Check Jangar SSE health for control-plane dashboards.
    - Review Jangar logs for `torghut-quant` stream errors.
    - Verify the quant control-plane UI connection in Jangar (`/control-plane/torghut/quant/`).
@@ -43,6 +58,14 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
 - If decisions are stalled or LLM errors spike, force LLM shadow-only mode and keep trading in paper mode until
   upstream failures resolve.
 - If trading decisions are stalled due to missing TA data, prioritize restoring torghut-ws + torghut-ta pipelines.
+- If `TorghutWSDesiredSymbolsFetchFailing` is active:
+  - Validate Jangar symbol API: `curl -fsS "http://127.0.0.1:8080/api/torghut/symbols" | jq .`
+  - If the API is unhealthy, restore Jangar first; if healthy, restart `torghut-ws` and verify
+    `torghut_ws_desired_symbols_fetch_degraded` returns to `0`.
+- If `TorghutClickHouseFreshnessQueryFallbacks` is active:
+  - Treat this as ClickHouse query pressure. Check disk pressure/read-only alerts and run `SYSTEM RELOAD CONFIG` only if
+    ClickHouse config changed.
+  - Keep monitoring on low-memory mode until fallback rate returns to zero.
 - If SSE errors persist, restart Jangar and verify `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` connectivity.
 - As a rollback, disable quant control-plane compute:
   - Set `JANGAR_TORGHUT_QUANT_CONTROL_PLANE_ENABLED=false` in GitOps and sync the Jangar app.

--- a/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+++ b/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
@@ -27,7 +27,7 @@ Provide oncall operational procedures for recovering TA outputs when:
 - ClickHouse: `svc/torghut-clickhouse:8123` (auth via `Secret/torghut-clickhouse-auth`)
 - Checkpoints/savepoints: MinIO/S3 path from `state.checkpoints.dir` + `state.savepoints.dir` in `argocd/applications/torghut/ta/flinkdeployment.yaml`
 - Kafka topics (current names): `TA_TRADES_TOPIC`, `TA_QUOTES_TOPIC`, `TA_BARS1M_TOPIC`, `TA_MICROBARS_TOPIC`, `TA_SIGNALS_TOPIC` in `argocd/applications/torghut/ta/configmap.yaml`
- - Delivery guarantee: `TA_KAFKA_DELIVERY_GUARANTEE` is set in `argocd/applications/torghut/ta/flinkdeployment.yaml` (currently `AT_LEAST_ONCE`).
+ - Delivery guarantee: `TA_KAFKA_DELIVERY_GUARANTEE` is set in `argocd/applications/torghut/ta/flinkdeployment.yaml` (currently `EXACTLY_ONCE`).
 
 ## Quick architecture reminder
 

--- a/docs/torghut/design-system/v1/torghut-autonomous-trading-system.md
+++ b/docs/torghut/design-system/v1/torghut-autonomous-trading-system.md
@@ -138,7 +138,7 @@ As deployed config is in:
 - `argocd/applications/torghut/ta/flinkdeployment.yaml` (Flink + secrets + checkpoint config)
 
 Delivery semantics:
-- Kafka can be `EXACTLY_ONCE`, but as deployed `TA_KAFKA_DELIVERY_GUARANTEE=AT_LEAST_ONCE`.
+- Kafka is configured with `TA_KAFKA_DELIVERY_GUARANTEE=EXACTLY_ONCE`.
 - ClickHouse writes are at-least-once; design assumes duplicates are tolerable.
 
 Known production failure: ClickHouse disk pressure causing JDBC failures and TA job failure.

--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -415,7 +415,12 @@ class ForwarderApp(
       suspend fun desiredSymbols(): SymbolsRefreshResult {
         val refreshed = symbolsTracker.refresh()
         if (refreshed.hadError) {
-          logger.warn { "failed to poll desired symbols; keeping last-known list" }
+          metrics.recordDesiredSymbolsFetchFailure(refreshed.failureReason ?: "unknown")
+          logger.warn {
+            "failed to poll desired symbols; keeping last-known list reason=${refreshed.failureReason ?: "unknown"}"
+          }
+        } else {
+          metrics.recordDesiredSymbolsFetchSuccess()
         }
         return refreshed
       }

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderMetricsTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderMetricsTest.kt
@@ -1,0 +1,78 @@
+package ai.proompteng.dorvud.ws
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ForwarderMetricsTest {
+  @Test
+  fun `records desired symbols fetch success and failure metrics`() {
+    val registry = SimpleMeterRegistry()
+    val metrics = ForwarderMetrics(registry)
+
+    metrics.recordDesiredSymbolsFetchSuccess()
+    metrics.recordDesiredSymbolsFetchFailure("fetch_error")
+    metrics.recordDesiredSymbolsFetchFailure("empty_result")
+
+    assertEquals(
+      1.0,
+      registry
+        .find("torghut_ws_desired_symbols_fetch_success_total")
+        .counter()
+        ?.count(),
+    )
+    assertEquals(
+      1.0,
+      registry
+        .find("torghut_ws_desired_symbols_fetch_failures_total")
+        .tag("reason", "fetch_error")
+        .counter()
+        ?.count(),
+    )
+    assertEquals(
+      1.0,
+      registry
+        .find("torghut_ws_desired_symbols_fetch_failures_total")
+        .tag("reason", "empty_result")
+        .counter()
+        ?.count(),
+    )
+  }
+
+  @Test
+  fun `tracks degraded and last timestamp gauges for desired symbols fetch`() {
+    val registry = SimpleMeterRegistry()
+    val metrics = ForwarderMetrics(registry)
+
+    metrics.recordDesiredSymbolsFetchFailure("fetch_error")
+    val degradedAfterFailure =
+      registry
+        .find("torghut_ws_desired_symbols_fetch_degraded")
+        .gauge()
+        ?.value()
+    assertEquals(1.0, degradedAfterFailure)
+
+    val lastFailureTs =
+      registry
+        .find("torghut_ws_desired_symbols_fetch_last_failure_ts_seconds")
+        .gauge()
+        ?.value()
+    assertTrue((lastFailureTs ?: 0.0) > 0.0)
+
+    metrics.recordDesiredSymbolsFetchSuccess()
+    val degradedAfterSuccess =
+      registry
+        .find("torghut_ws_desired_symbols_fetch_degraded")
+        .gauge()
+        ?.value()
+    assertEquals(0.0, degradedAfterSuccess)
+
+    val lastSuccessTs =
+      registry
+        .find("torghut_ws_desired_symbols_fetch_last_success_ts_seconds")
+        .gauge()
+        ?.value()
+    assertTrue((lastSuccessTs ?: 0.0) > 0.0)
+  }
+}

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/SymbolsTrackerTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/SymbolsTrackerTest.kt
@@ -13,6 +13,7 @@ class SymbolsTrackerTest {
       val result = tracker.refresh()
       assertEquals(listOf("AAPL", "MSFT"), result.symbols)
       assertTrue(result.hadError.not())
+      assertEquals(null, result.failureReason)
     }
 
   @Test
@@ -27,6 +28,7 @@ class SymbolsTrackerTest {
       val result = tracker.refresh()
       assertEquals(listOf("AAPL"), result.symbols)
       assertTrue(result.hadError)
+      assertEquals("fetch_error", result.failureReason)
     }
 
   @Test
@@ -41,6 +43,7 @@ class SymbolsTrackerTest {
       val result = tracker.refresh()
       assertEquals(listOf("TSLA"), result.symbols)
       assertTrue(result.hadError.not())
+      assertEquals(null, result.failureReason)
     }
 
   @Test
@@ -64,6 +67,7 @@ class SymbolsTrackerTest {
       val second = tracker.refresh()
       assertEquals(listOf("TSLA", "MSFT"), second.symbols)
       assertTrue(second.hadError)
+      assertEquals("fetch_error", second.failureReason)
     }
 
   @Test
@@ -78,5 +82,6 @@ class SymbolsTrackerTest {
       val result = tracker.refresh()
       assertEquals(listOf("BTC/USD", "ETH/USD", "SOL/USD"), result.symbols)
       assertTrue(result.hadError)
+      assertEquals("empty_result", result.failureReason)
     }
 }


### PR DESCRIPTION
## Summary

- Added explicit torghut-ws desired-symbol fetch observability: success/failure counters, degraded state gauge, last success/failure timestamps, and test coverage in `services/dorvud/websockets`.
- Added low-memory-safe ClickHouse freshness query behavior in the guardrails exporter with `CLICKHOUSE_FRESHNESS_QUERY_MODE` (`auto`/`precise`/`low_memory`) plus fallback/usage metrics.
- Wired new GitOps alerting rules for WS symbol polling degradation and ClickHouse freshness fallback pressure in `argocd/applications/observability/graf-mimir-rules.yaml`.
- Hardened Flink replay/recovery posture by setting `job.upgradeMode=last-state`, checkpoint externalized retention, and `TA_KAFKA_DELIVERY_GUARANTEE=EXACTLY_ONCE` in GitOps manifests.
- Updated Torghut runbook/design docs with exact operational commands, explicit pass/fail criteria, and rollout/rollback guidance for these controls.

## Related Issues

None

## Testing

- `python3 -m py_compile /tmp/torghut_exporter.py` (exporter script extracted from `argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml`)
- `./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.SymbolsTrackerTest' --tests 'ai.proompteng.dorvud.ws.ForwarderMetricsTest'` (failed in this environment: Java 21 toolchain unavailable)

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

Rollout notes:
- Sync `argocd/applications/torghut/clickhouse/*`, `argocd/applications/torghut/ta/flinkdeployment.yaml`, and `argocd/applications/observability/graf-mimir-rules.yaml` together.
- After sync, verify new metrics are present on `torghut-ws` and `torghut-clickhouse-guardrails-exporter`, then confirm new alerts are loaded.
- Watch Flink deployment after delivery-guarantee/upgrade-mode change and ensure checkpoints continue completing.

Rollback notes:
- Revert this PR to restore prior alert rules and exporter behavior.
- If needed for immediate stabilization, set `TA_KAFKA_DELIVERY_GUARANTEE=AT_LEAST_ONCE` and `spec.job.upgradeMode=stateless` in `argocd/applications/torghut/ta/flinkdeployment.yaml`, then resync.
- For exporter behavior only, set `CLICKHOUSE_FRESHNESS_QUERY_MODE=precise` in `argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter.yaml` and resync.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
