### PR TITLE
chore(jangar): promote image b44481d7

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 29b570d8
-  digest: sha256:ee8691eb5e90a26f1189703c11feb872331a3bf5d5f0893f8eb37bd90eb15fb1
+  tag: b44481d7
+  digest: sha256:48f6018ec8a75bec94942b10e8b808077d6533f3da2bcc745ba63ae6f1c5f482
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 29b570d8
-    digest: sha256:d986f7ff60f066d769cba8c9237d4e71f273d2fbc0d4b6e45e0afa0253145c14
+    tag: b44481d7
+    digest: sha256:3597be0afea91e2575d6422b05583be7b712a8151c26d075e7a0e11b0058c9ed
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 29b570d8
-    digest: sha256:ee8691eb5e90a26f1189703c11feb872331a3bf5d5f0893f8eb37bd90eb15fb1
+    tag: b44481d7
+    digest: sha256:48f6018ec8a75bec94942b10e8b808077d6533f3da2bcc745ba63ae6f1c5f482
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-22T23:52:03Z"
+    deploy.knative.dev/rollout: "2026-02-23T00:41:37Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-22T23:52:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-23T00:41:37Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "29b570d8"
-    digest: sha256:ee8691eb5e90a26f1189703c11feb872331a3bf5d5f0893f8eb37bd90eb15fb1
+    newTag: "b44481d7"
+    digest: sha256:48f6018ec8a75bec94942b10e8b808077d6533f3da2bcc745ba63ae6f1c5f482


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b44481d779dc03a429fa41ca89404a7fc7f8e0cd`
- Image tag: `b44481d7`
- Image digest: `sha256:48f6018ec8a75bec94942b10e8b808077d6533f3da2bcc745ba63ae6f1c5f482`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`