### PR TITLE
chore(jangar): promote image 9854d227

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: b44481d7
-  digest: sha256:48f6018ec8a75bec94942b10e8b808077d6533f3da2bcc745ba63ae6f1c5f482
+  tag: 9854d227
+  digest: sha256:049244e12c30630142640f5a8f8dd0b0ed4c29d82121b2b22e071c7ae545e72b
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: b44481d7
-    digest: sha256:3597be0afea91e2575d6422b05583be7b712a8151c26d075e7a0e11b0058c9ed
+    tag: 9854d227
+    digest: sha256:5e723e2874372ca75c449061ebc89aebbeeceede5cf865561c48dc3ccbb8d33b
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: b44481d7
-    digest: sha256:48f6018ec8a75bec94942b10e8b808077d6533f3da2bcc745ba63ae6f1c5f482
+    tag: 9854d227
+    digest: sha256:049244e12c30630142640f5a8f8dd0b0ed4c29d82121b2b22e071c7ae545e72b
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-23T00:41:37Z"
+    deploy.knative.dev/rollout: "2026-02-23T00:59:31Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-23T00:41:37Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-23T00:59:31Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -57,5 +57,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "b44481d7"
-    digest: sha256:48f6018ec8a75bec94942b10e8b808077d6533f3da2bcc745ba63ae6f1c5f482
+    newTag: "9854d227"
+    digest: sha256:049244e12c30630142640f5a8f8dd0b0ed4c29d82121b2b22e071c7ae545e72b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `9854d227f4f70195ab595e01d6e49b26ca9c3e7c`
- Image tag: `9854d227`
- Image digest: `sha256:049244e12c30630142640f5a8f8dd0b0ed4c29d82121b2b22e071c7ae545e72b`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`