### PR TITLE
fix(bumba): remove stale otel steps from Docker build

### DIFF
--- a/services/bumba/Dockerfile
+++ b/services/bumba/Dockerfile
@@ -17,7 +17,6 @@ RUN --mount=type=cache,target=/root/.cache/bun \
 
 FROM deps AS build
 COPY full/ .
-RUN bun --cwd=packages/otel run build
 RUN bun --cwd=packages/temporal-bun-sdk run build
 
 FROM oven/bun:${BUN_VERSION} AS deps-prod
@@ -43,6 +42,5 @@ RUN --mount=type=cache,target=/var/cache/apt \
 COPY --from=deps-prod /app/node_modules ./node_modules
 COPY --from=build /app/services/bumba ./services/bumba
 COPY --from=build /app/tsconfig.base.json ./tsconfig.base.json
-COPY --from=build /app/packages/otel ./packages/otel
 COPY --from=build /app/packages/temporal-bun-sdk ./packages/temporal-bun-sdk
 CMD ["bun", "services/bumba/src/worker.ts"]


### PR DESCRIPTION
## Summary

- Remove stale `packages/otel` build step from `services/bumba/Dockerfile` build stage.
- Remove stale `packages/otel` copy from runtime image stage.
- Keep bumba image build aligned with the pruned workspace produced after temporal-bun-sdk OTEL vendoring.

## Related Issues

None

## Testing

- `bun run --cwd services/bumba test`
- `bunx turbo prune --scope=@proompteng/bumba --docker --out-dir="$TMP_DIR"` (manual run in temp dir)
- `docker build --progress=plain -f services/bumba/Dockerfile "$TMP_DIR" -t bumba-prune-test:local`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
