### PR TITLE
chore(bumba): promote image sha-a97df86

### DIFF
--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: sha-b6e2fd2
+    newTag: sha-a97df86
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote bumba Argo image tag to `registry.ide-newton.ts.net/lab/bumba:sha-a97df86`.
- Align cluster rollout with merged Dockerfile fix from PR #3528.
- Keep rollout change minimal to a single GitOps manifest line.

## Related Issues

None

## Testing

- `gh run list -R proompteng/lab --workflow bumba-ci.yml --limit 10 --json databaseId,status,conclusion,headSha,displayTitle,event,createdAt,url` (confirmed push run for `a97df86b` succeeded)
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/bumba:sha-a97df86`
- `kubectl get deployment bumba -n jangar -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'` (baseline before promotion)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
