### PR TITLE
fix(observability): point grafana tempo datasource to query frontend port

### DIFF
--- a/argocd/applications/observability/grafana-values.yaml
+++ b/argocd/applications/observability/grafana-values.yaml
@@ -32,7 +32,7 @@ datasources:
         uid: tempo
         type: tempo
         access: proxy
-        url: http://observability-tempo-query-frontend.observability.svc.cluster.local:3100
+        url: http://observability-tempo-query-frontend.observability.svc.cluster.local:3200
         isDefault: false
         jsonData:
           tracesToLogsV2:


### PR DESCRIPTION
## Summary

- Fix Grafana Tempo datasource URL in observability values to use Tempo query-frontend port `3200`.
- Resolve Grafana datasource proxy `502 Bad Gateway` errors caused by dialing Tempo on closed port `3100`.
- Restore Grafana trace query path for Tempo-backed Explore/dashboards.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl logs -n observability deploy/observability-grafana --since=20m | rg "datasources/proxy/3|connection refused|502"` (validated current failure mode before fix)
- `curl -u <admin>:<password> http://127.0.0.1:3000/api/datasources/3` via `kubectl -n observability port-forward svc/observability-grafana 3000:80` (validated datasource currently points to `:3100`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
