### PR TITLE
chore(torghut): promote image ed6b80b2

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe5864b9baf86962f36677afd17f362fdb6d14bebe14c2b7045bc1504049368
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1931afbb653aec21aab659225c614064492a5ac3215f40ecbd104a3913d0c1d
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-23T01:51:50Z"
+        client.knative.dev/updateTimestamp: "2026-02-23T02:02:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe5864b9baf86962f36677afd17f362fdb6d14bebe14c2b7045bc1504049368
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1931afbb653aec21aab659225c614064492a5ac3215f40ecbd104a3913d0c1d
           ports:
             - name: http1
               containerPort: 8181
@@ -258,9 +258,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-154-g1936db9e
+              value: v0.560.0-160-ged6b80b2
             - name: TORGHUT_COMMIT
-              value: 1936db9edb4da343e19aee140e34199d4dfd29a7
+              value: ed6b80b2c2f0dd97b97b990926c1477b71d7ee4e
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `ed6b80b2c2f0dd97b97b990926c1477b71d7ee4e`
- Image tag: `ed6b80b2`
- Image digest: `sha256:c1931afbb653aec21aab659225c614064492a5ac3215f40ecbd104a3913d0c1d`
- Migration change detected under `services/torghut/migrations/**`
- Added `do-not-automerge`; manual DB migration approval required before merge