### PR TITLE
docs(torghut): refresh v5 implementation status

### DIFF
--- a/docs/torghut/design-system/implementation-status-matrix-2026-02-21.md
+++ b/docs/torghut/design-system/implementation-status-matrix-2026-02-21.md
@@ -144,8 +144,8 @@
 | `docs/torghut/design-system/v4/09-ai-market-fragility-and-stability-controls.md` | Not Implemented | `v4 design pack; advanced features pending` |
 | `docs/torghut/design-system/v4/10-profitability-evidence-standard-and-benchmark-suite.md` | Not Implemented | `v4 design pack; advanced features pending` |
 | `docs/torghut/design-system/v4/index.md` | N/A | `index/meta/snapshot` |
-| `docs/torghut/design-system/v5/01-tsfm-router-refinement-and-uncertainty.md` | Partial | `core router implemented; full design deliverables not strictly verified end-to-end` |
-| `docs/torghut/design-system/v5/02-conformal-uncertainty-and-regime-gates.md` | Not Implemented | `v5 design pack; advanced features pending` |
+| `docs/torghut/design-system/v5/01-tsfm-router-refinement-and-uncertainty.md` | Partial | `code: services/torghut/app/trading/forecasting.py, services/torghut/app/trading/decisions.py; test: services/torghut/tests/test_forecasting.py; runtime: argocd/applications/torghut/autonomy-configmap.yaml + strategy-configmap forecast-router-policy.json; note: runtime uncertainty-gate action enforcement is now wired in services/torghut/app/trading/scheduler.py` |
+| `docs/torghut/design-system/v5/02-conformal-uncertainty-and-regime-gates.md` | Partial | `code: services/torghut/app/trading/autonomy/gates.py, services/torghut/app/trading/autonomy/policy_checks.py, services/torghut/app/trading/evaluation.py, services/torghut/app/trading/scheduler.py; test: services/torghut/tests/test_trading_pipeline.py, services/torghut/tests/test_profitability_evidence_v4.py, services/torghut/tests/test_governance_policy_dry_run.py, services/torghut/tests/test_metrics.py; runtime: argocd/applications/torghut/autonomy-gate-policy-configmap.yaml` |
 | `docs/torghut/design-system/v5/03-microstructure-execution-intelligence.md` | Not Implemented | `v5 design pack; advanced features pending` |
 | `docs/torghut/design-system/v5/04-llm-multi-agent-committee-with-deterministic-veto.md` | Not Implemented | `v5 design pack; advanced features pending` |
 | `docs/torghut/design-system/v5/05-fragility-aware-regime-allocation.md` | Not Implemented | `v5 design pack; advanced features pending` |
@@ -153,6 +153,8 @@
 | `docs/torghut/design-system/v5/07-autonomous-research-to-engineering-pipeline.md` | Not Implemented | `v5 design pack; advanced features pending` |
 | `docs/torghut/design-system/v5/08-leading-quant-firms-public-research-and-systems-2026-02-21.md` | Not Implemented | `v5 design pack; advanced features pending` |
 | `docs/torghut/design-system/v5/09-fully-autonomous-quant-llm-torghut-novel-alpha-system.md` | Not Implemented | `v5 design pack; advanced features pending` |
+| `docs/torghut/design-system/v5/10-crypto-market-data-pipeline-production-design-2026-02-22.md` | Partial | `code: services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/SymbolsTracker.kt, ForwarderApp.kt, ForwarderMetrics.kt; runtime: argocd/applications/torghut/ta/flinkdeployment.yaml, argocd/applications/observability/graf-mimir-rules.yaml (TorghutWSDesiredSymbolsFetchFailing); remaining: full cutover/rollout validation` |
+| `docs/torghut/design-system/v5/11-multi-account-trading-architecture-and-rollout-2026-02-22.md` | Partial | `code: services/torghut/app/config.py (account registry + feature-flag mapping), services/torghut/app/trading/scheduler.py (multi-lane per-account pipelines), services/torghut/app/trading/execution.py + ingest.py + order_feed.py (account-scoped idempotency/cursor/topic dual-read), services/torghut/migrations/versions/0013_multi_account_execution_isolation.py; tests: services/torghut/tests/test_config.py, services/torghut/tests/test_signal_ingest.py, services/torghut/tests/test_order_feed.py; runtime default-off flag: argocd/applications/torghut/knative-service.yaml` |
 | `docs/torghut/design-system/v5/index.md` | N/A | `index/meta/snapshot` |
 
 ## Completed Documents (Strict)

--- a/docs/torghut/design-system/v5/index.md
+++ b/docs/torghut/design-system/v5/index.md
@@ -33,6 +33,12 @@ This pack expands the top 5 strategy priorities into implementation-grade design
 10. `10-crypto-market-data-pipeline-production-design-2026-02-22.md`
 11. `11-multi-account-trading-architecture-and-rollout-2026-02-22.md`
 
+## Source-Verified Implementation Snapshot (2026-02-23)
+- `01-tsfm-router-refinement-and-uncertainty.md`: Implemented (partial). Router/refinement/fallback paths and tests exist, and runtime uncertainty gate action handling is now wired in the trading scheduler.
+- `02-conformal-uncertainty-and-regime-gates.md`: Implemented (partial). Uncertainty gate outputs (`pass/degrade/abstain/fail`) and promotion checks are wired, with runtime execution-path enforcement covered in scheduler logic and trading-pipeline tests.
+- `10-crypto-market-data-pipeline-production-design-2026-02-22.md`: Implemented (partial). Desired-symbol fetch failure metrics and alerting are now wired (`ForwarderMetrics` + `TorghutWSDesiredSymbolsFetchFailing`); remaining work is full cutover/rollout validation.
+- `11-multi-account-trading-architecture-and-rollout-2026-02-22.md`: Implemented (partial, feature-flagged). Account registry, per-account scheduler lanes, account-scoped idempotency/cursor constraints, and trade-updates v2 dual-read are merged; runtime keeps `TRADING_MULTI_ACCOUNT_ENABLED=false` by default.
+
 ## Recommended Build Order
 1. `02-conformal-uncertainty-and-regime-gates.md`
 2. `01-tsfm-router-refinement-and-uncertainty.md`


### PR DESCRIPTION
## Summary

- Updated Torghut v5 implementation status docs to reflect source-verified merged state on `main`.
- Revised status/evidence for v5/01 and v5/02 to include runtime uncertainty-gate enforcement in scheduler path.
- Revised v5/10 status to include desired-symbol fetch degradation metrics and alert wiring.
- Revised v5/11 status to reflect merged multi-account implementation elements and default-off rollout posture.

## Related Issues

None

## Testing

- `git diff --check`
- Verified evidence paths and runtime/config references used in doc claims via targeted `rg`/`sed` checks across `services/torghut/**`, `services/dorvud/**`, and `argocd/applications/**`.
- Verified merged PR state for referenced implementation branches with `gh pr list --state all --search "head:codex/torghut-p2-multi-account-isolation-20260223"` (and related branch checks).

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
