### PR TITLE
fix(torghut): clean up legacy trade cursor uniqueness

### DIFF
--- a/services/torghut/migrations/versions/0014_trade_cursor_legacy_source_uniqueness_cleanup.py
+++ b/services/torghut/migrations/versions/0014_trade_cursor_legacy_source_uniqueness_cleanup.py
@@ -1,0 +1,41 @@
+"""Remove legacy trade_cursor source-only uniqueness left by older revisions."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision = '0014_trade_cursor_legacy_source_uniqueness_cleanup'
+down_revision = '0013_multi_account_execution_isolation'
+branch_labels = None
+depends_on = None
+
+
+def _index_names(inspector: sa.Inspector, table: str) -> set[str]:
+    return {index['name'] for index in inspector.get_indexes(table)}
+
+
+def upgrade() -> None:
+    # Legacy environments can keep either of these names for source-only uniqueness.
+    op.execute('ALTER TABLE trade_cursor DROP CONSTRAINT IF EXISTS trade_cursor_source_key')
+    op.execute('ALTER TABLE trade_cursor DROP CONSTRAINT IF EXISTS uq_trade_cursor_source')
+    op.execute('DROP INDEX IF EXISTS uq_trade_cursor_source')
+
+    inspector = inspect(op.get_bind())
+    trade_cursor_indexes = _index_names(inspector, 'trade_cursor')
+    if 'uq_trade_cursor_source_account' not in trade_cursor_indexes:
+        op.create_index(
+            'uq_trade_cursor_source_account',
+            'trade_cursor',
+            ['source', 'account_label'],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    inspector = inspect(op.get_bind())
+    trade_cursor_indexes = _index_names(inspector, 'trade_cursor')
+    if 'uq_trade_cursor_source_account' in trade_cursor_indexes:
+        op.drop_index('uq_trade_cursor_source_account', table_name='trade_cursor')
+    op.execute('ALTER TABLE trade_cursor ADD CONSTRAINT trade_cursor_source_key UNIQUE (source)')


### PR DESCRIPTION
## Summary

- Add Alembic migration `0014_trade_cursor_legacy_source_uniqueness_cleanup` to remove legacy source-only uniqueness on `trade_cursor`.
- Handle both known legacy object names (`trade_cursor_source_key`, `uq_trade_cursor_source`) idempotently so partially-migrated environments are fixed safely.
- Ensure account-scoped uniqueness index (`uq_trade_cursor_source_account`) exists after cleanup.
- Prevent recurring scheduler `UniqueViolation` failures for multi-account cursor writes.

## Related Issues

None

## Testing

- `python3 -m py_compile services/torghut/migrations/versions/0014_trade_cursor_legacy_source_uniqueness_cleanup.py`
- `kubectl cnpg psql -n torghut torghut-db -- -d torghut -v ON_ERROR_STOP=1 -c "BEGIN; ALTER TABLE trade_cursor DROP CONSTRAINT IF EXISTS trade_cursor_source_key; ALTER TABLE trade_cursor DROP CONSTRAINT IF EXISTS uq_trade_cursor_source; DROP INDEX IF EXISTS uq_trade_cursor_source; COMMIT;"`
- `kubectl cnpg psql -n torghut torghut-db -- -d torghut -c "SELECT conname, pg_get_constraintdef(oid) AS def FROM pg_constraint WHERE conrelid = 'public.trade_cursor'::regclass ORDER BY conname; SELECT indexname FROM pg_indexes WHERE schemaname='public' AND tablename='trade_cursor' ORDER BY indexname;"`
- `kubectl -n torghut logs -l serving.knative.dev/revision=torghut-00021 --since=3m --tail=1200 --timestamps` (manual verification: repeated `uq_trade_cursor_source` failures stopped after cleanup)

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Adds a forward-only corrective migration that removes stale uniqueness metadata and preserves account-scoped cursor uniqueness.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
