### PR TITLE
fix(jangar): add codex-5.3-spark to model inventory

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -108,7 +108,7 @@ spec:
             - name: JANGAR_CI_EVENT_STREAM_ENABLED_FLAG_KEY
               value: jangar_ci_event_stream_enabled
             - name: JANGAR_MODELS
-              value: gpt-5.3-codex
+              value: gpt-5.3-codex,codex-5.3-spark
             - name: JANGAR_DEFAULT_MODEL
               value: gpt-5.3-codex
             - name: JANGAR_GIT_LOCK_RETRY_ATTEMPTS


### PR DESCRIPTION
## Summary

- Adds `codex-5.3-spark` to Jangar model inventory in GitOps deployment config.
- Keeps `gpt-5.3-codex` in the allowlist to avoid breaking existing callers.
- Leaves `JANGAR_DEFAULT_MODEL` unchanged (`gpt-5.3-codex`) for a safe staged rollout.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar >/tmp/jangar-kustomize.yaml && wc -l /tmp/jangar-kustomize.yaml`
- `rg -n "JANGAR_MODELS|JANGAR_DEFAULT_MODEL" argocd/applications/jangar/deployment.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
