### PR TITLE
chore(torghut): promote image a03dc80d

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ffe98f330f5fe04bad1370422974267b6d9daffeb5b40a1f72c9d19de42c2544
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:66754cde33faa910a1b9f0096b0f142b060e66f6c9d8ffbc7a906efac124eb4e
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-23T05:53:44Z"
+        client.knative.dev/updateTimestamp: "2026-02-23T06:16:44Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ffe98f330f5fe04bad1370422974267b6d9daffeb5b40a1f72c9d19de42c2544
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:66754cde33faa910a1b9f0096b0f142b060e66f6c9d8ffbc7a906efac124eb4e
           ports:
             - name: http1
               containerPort: 8181
@@ -250,9 +250,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-166-gaa132a89
+              value: v0.560.0-168-ga03dc80d
             - name: TORGHUT_COMMIT
-              value: aa132a89b6124e838e219a1851968892797082ef
+              value: a03dc80d3cc2e0960280486ac5797e6b14bf61fe
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `a03dc80d3cc2e0960280486ac5797e6b14bf61fe`
- Image tag: `a03dc80d`
- Image digest: `sha256:66754cde33faa910a1b9f0096b0f142b060e66f6c9d8ffbc7a906efac124eb4e`