### PR TITLE
fix(agents): extend runner job ttl and retention overrides

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -34,6 +34,11 @@ resources:
 controller:
   namespaces:
     - agents
+  # Keep runner jobs around long enough to inspect no-op/failure runs in-cluster.
+  jobTtlSeconds: 86400
+  jobTtlSecondsAfterFinished: 86400
+  # Persist run logs/artifacts for one week for debugging and audits.
+  logRetentionSeconds: 604800
   authSecret:
     name: codex-auth
     key: auth.json


### PR DESCRIPTION
## Summary

- Increase Agent runner Job TTL from 10 minutes to 24 hours for post-run debugging.
- Set both `controller.jobTtlSeconds` and `controller.jobTtlSecondsAfterFinished` to `86400` to cover both chart deployment paths.
- Keep controller log retention explicit at `604800` seconds (7 days).

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-app-kustomize.yaml`
- `rg -n "JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS|JANGAR_AGENT_RUNNER_LOG_RETENTION_SECONDS|value: \"86400\"|value: \"604800\"" /tmp/agents-app-kustomize.yaml -S`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
