### PR TITLE
chore(jangar): promote image 9ce84b30

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 9854d227
-  digest: sha256:049244e12c30630142640f5a8f8dd0b0ed4c29d82121b2b22e071c7ae545e72b
+  tag: 9ce84b30
+  digest: sha256:cdc55eed51cc8fe7eed9fdb80a35418f6f03c80cf824ba52603cba26432593d0
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 9854d227
-    digest: sha256:5e723e2874372ca75c449061ebc89aebbeeceede5cf865561c48dc3ccbb8d33b
+    tag: 9ce84b30
+    digest: sha256:ee1cdde7425bbb0b58f9e825988b3dae908238703740daba3a07816b22daa645
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 9854d227
-    digest: sha256:049244e12c30630142640f5a8f8dd0b0ed4c29d82121b2b22e071c7ae545e72b
+    tag: 9ce84b30
+    digest: sha256:cdc55eed51cc8fe7eed9fdb80a35418f6f03c80cf824ba52603cba26432593d0
 controllers:
   enabled: true
   replicaCount: 2
@@ -34,10 +34,8 @@ resources:
 controller:
   namespaces:
     - agents
-  # Keep runner jobs around long enough to inspect no-op/failure runs in-cluster.
   jobTtlSeconds: 86400
   jobTtlSecondsAfterFinished: 86400
-  # Persist run logs/artifacts for one week for debugging and audits.
   logRetentionSeconds: 604800
   authSecret:
     name: codex-auth

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-23T05:39:58Z"
+    deploy.knative.dev/rollout: "2026-02-23T08:30:40Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-23T00:59:31Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-23T08:30:40Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -58,5 +58,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "9854d227"
-    digest: sha256:049244e12c30630142640f5a8f8dd0b0ed4c29d82121b2b22e071c7ae545e72b
+    newTag: "9ce84b30"
+    digest: sha256:cdc55eed51cc8fe7eed9fdb80a35418f6f03c80cf824ba52603cba26432593d0


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `9ce84b30e32c97739ae0d6f4b63a1008012d34a8`
- Image tag: `9ce84b30`
- Image digest: `sha256:cdc55eed51cc8fe7eed9fdb80a35418f6f03c80cf824ba52603cba26432593d0`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`