### PR TITLE
chore(agents): harden codex-agent PR workflow and reasoning

### DIFF
--- a/argocd/applications/agents/codex-agent-system-prompt-configmap.yaml
+++ b/argocd/applications/agents/codex-agent-system-prompt-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: codex-agent-system-prompt
 data:
   system-prompt.md: |-
-    Implement the requested task end to end and open a ready-to-merge PR.
+    Implement the requested task end to end and OPEN A READY-TO-MERGE PR.
 
     Requirements:
     - Work only on the provided head branch based on the provided base branch.
@@ -13,7 +13,6 @@ data:
     - Keep the progress comment anchored by <!-- codex:progress --> current using
       services/jangar/scripts/codex/codex-progress-comment.ts.
     - Run all required formatters/linters/tests per repo instructions; fix and rerun until green.
-    - To emit workflow updates, use `/usr/local/bin/codex-nats-publish` (see examples below).
     - Commit in logical units (reference the issue number if provided); push the branch.
     - Open a ready-to-merge PR using the default template per repo instructions; link the issue.
     - Finish only when required CI is green; fix failures and re-run the smallest necessary checks until it is.
@@ -22,18 +21,20 @@ data:
     - Do not stop until the PR is opened and in a mergeable state; resolve merge conflicts, address all review comments from anyone, and keep CI checks green.
     - Use relevant repo skills in `skills/` when applicable; do not restate their instructions.
 
+    Non-negotiable PR completion rules:
+    - You MUST run `git add` for all requested changes before finalizing.
+    - You MUST run `git commit` on the provided head branch.
+    - You MUST run `git push` for the provided head branch.
+    - You MUST run `gh pr create` (or equivalent provider CLI) and provide a mergeable PR link/URL.
+    - Do not report completion without the PR URL.
+    - If PR creation fails, treat the run as not complete and continue until it succeeds.
+
     Memory:
     - Retrieve relevant memories before and during work.
     - Save a memory for every change made.
 
     If blocked:
     - Stop only for missing access/secrets/infra; capture exact error and smallest unblocker.
-
-    Publishing examples:
-    - Status update (also to general):
-      /usr/local/bin/codex-nats-publish --kind status --status started --content "work started" --publish-general
-    - Tail a log file:
-      /usr/local/bin/codex-nats-publish --kind log --log-file "$AGENT_LOG_PATH"
 
     Final reply (concise):
     - Summary (2-4 bullets)

--- a/argocd/applications/agents/codex-agentprovider.yaml
+++ b/argocd/applications/agents/codex-agentprovider.yaml
@@ -13,7 +13,7 @@ spec:
       content: |-
         model = "gpt-5.3-codex"
         model_reasoning_summary = "detailed"
-        model_reasoning_effort = "medium"
+        model_reasoning_effort = "high"
         model_verbosity = "medium"
         preferred_auth_method = "apikey"
         approval_policy = "never"


### PR DESCRIPTION
## Summary

- Set `codex-agent` runtime reasoning to `high` in `codex-agentprovider` so longer-depth analysis is enabled for run execution.
- Tightened the Codex system prompt in the agent ConfigMap to require explicit PR workflow completion (`git add/commit/push`, `gh pr create` if possible) and explicit PR URL reporting on success.
- Removed outdated instructions from the system prompt: workflow update emission guidance and publishing examples.

## Related Issues

None

## Testing

- Verified committed files include only the intended AgentRun prompt/provider updates.
- Not run execution/integration runtime validation in this step (config-only change).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
