### PR TITLE
Remove TRADING_PARITY_POLICY and keep LLM behavior mode-consistent

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -213,13 +213,11 @@ spec:
             - name: LLM_SHADOW_COMPLETED_AT
               value: 2026-02-12T06:45:00Z
             - name: LLM_FAIL_MODE
-              value: veto
+              value: pass_through
             - name: LLM_FAIL_MODE_ENFORCEMENT
               value: configured
             - name: LLM_FAIL_OPEN_LIVE_APPROVED
-              value: "false"
-            - name: TRADING_PARITY_POLICY
-              value: mode_coupled
+              value: "true"
             - name: LLM_TOKEN_BUDGET_MAX
               value: "1200"
             - name: LLM_TIMEOUT_SECONDS

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -2521,7 +2521,6 @@ def _build_llm_policy_resolution(
         "reasoning": reasoning,
         "source_inputs": {
             "trading_mode": settings.trading_mode,
-            "trading_parity_policy": settings.trading_parity_policy,
             "llm_fail_mode_enforcement": settings.llm_fail_mode_enforcement,
             "llm_live_fail_open_requested": settings.llm_live_fail_open_requested_for_stage(
                 normalized_stage
@@ -2571,7 +2570,6 @@ class TradingScheduler:
         return {
             "enabled": settings.llm_enabled,
             "rollout_stage": guardrails.rollout_stage,
-            "parity_policy": settings.trading_parity_policy,
             "fail_mode_enforcement": settings.llm_fail_mode_enforcement,
             # Keep configured shadow_mode for backward compatibility.
             "shadow_mode": settings.llm_shadow_mode,

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -71,18 +71,18 @@ class TestConfig(TestCase):
                 DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
             )
 
-    def test_allows_mode_coupled_configured_with_pass_through_fail_mode(self) -> None:
+    def test_allows_configured_live_pass_through_with_explicit_approval(self) -> None:
         settings = Settings(
             TRADING_MODE="live",
             TRADING_LIVE_ENABLED=True,
             TRADING_UNIVERSE_SOURCE="jangar",
             LLM_FAIL_MODE="pass_through",
             LLM_FAIL_MODE_ENFORCEMENT="configured",
-            TRADING_PARITY_POLICY="mode_coupled",
+            LLM_FAIL_OPEN_LIVE_APPROVED=True,
             DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
 
-        self.assertEqual(settings.llm_effective_fail_mode(), "veto")
+        self.assertEqual(settings.llm_effective_fail_mode(), "pass_through")
 
     def test_rejects_live_fail_open_without_explicit_approval(self) -> None:
         with self.assertRaises(ValidationError):
@@ -90,7 +90,6 @@ class TestConfig(TestCase):
                 TRADING_MODE="live",
                 TRADING_LIVE_ENABLED=True,
                 TRADING_UNIVERSE_SOURCE="jangar",
-                TRADING_PARITY_POLICY="live_equivalent",
                 LLM_FAIL_MODE="pass_through",
                 LLM_FAIL_MODE_ENFORCEMENT="configured",
                 DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
@@ -101,7 +100,6 @@ class TestConfig(TestCase):
             TRADING_MODE="live",
             TRADING_LIVE_ENABLED=True,
             TRADING_UNIVERSE_SOURCE="jangar",
-            TRADING_PARITY_POLICY="live_equivalent",
             LLM_FAIL_MODE="pass_through",
             LLM_FAIL_MODE_ENFORCEMENT="configured",
             LLM_FAIL_OPEN_LIVE_APPROVED=True,
@@ -118,7 +116,6 @@ class TestConfig(TestCase):
                 TRADING_MODE="live",
                 TRADING_LIVE_ENABLED=True,
                 TRADING_UNIVERSE_SOURCE="jangar",
-                TRADING_PARITY_POLICY="mode_coupled",
                 LLM_ROLLOUT_STAGE="stage2",
                 LLM_FAIL_MODE="veto",
                 LLM_FAIL_MODE_ENFORCEMENT="configured",
@@ -132,7 +129,6 @@ class TestConfig(TestCase):
                 TRADING_MODE="live",
                 TRADING_LIVE_ENABLED=True,
                 TRADING_UNIVERSE_SOURCE="jangar",
-                TRADING_PARITY_POLICY="live_equivalent",
                 LLM_ROLLOUT_STAGE="stage1",
                 LLM_FAIL_MODE="veto",
                 LLM_FAIL_MODE_ENFORCEMENT="configured",
@@ -140,20 +136,21 @@ class TestConfig(TestCase):
                 DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
             )
 
-    def test_stage1_mode_coupled_live_does_not_require_fail_open_approval(self) -> None:
+    def test_stage1_live_fail_open_with_explicit_approval_is_allowed(self) -> None:
         settings = Settings(
             TRADING_MODE="live",
             TRADING_LIVE_ENABLED=True,
             TRADING_UNIVERSE_SOURCE="jangar",
-            TRADING_PARITY_POLICY="mode_coupled",
             LLM_ROLLOUT_STAGE="stage1_shadow_pilot",
             LLM_FAIL_MODE="veto",
             LLM_FAIL_MODE_ENFORCEMENT="configured",
-            LLM_FAIL_OPEN_LIVE_APPROVED=False,
+            LLM_FAIL_OPEN_LIVE_APPROVED=True,
             DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
 
-        self.assertEqual(settings.llm_effective_fail_mode_for_current_rollout(), "veto")
+        self.assertEqual(
+            settings.llm_effective_fail_mode_for_current_rollout(), "pass_through"
+        )
 
     def test_allocator_regime_maps_are_normalized(self) -> None:
         settings = Settings(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -50,20 +50,20 @@ class TestLiveConfigManifestContract(TestCase):
         settings = Settings(**env)
 
         self.assertEqual(settings.trading_mode, "live")
-        self.assertEqual(settings.trading_parity_policy, "mode_coupled")
         self.assertEqual(settings.llm_rollout_stage, "stage1")
-        self.assertEqual(settings.llm_fail_mode, "veto")
+        self.assertEqual(settings.llm_fail_mode, "pass_through")
         self.assertEqual(settings.llm_fail_mode_enforcement, "configured")
-        self.assertFalse(settings.llm_live_fail_open_requested_for_stage("stage1"))
-        self.assertEqual(settings.llm_effective_fail_mode_for_current_rollout(), "veto")
+        self.assertTrue(settings.llm_live_fail_open_requested_for_stage("stage1"))
         self.assertEqual(
-            settings.llm_effective_fail_mode(rollout_stage="stage1"), "veto"
+            settings.llm_effective_fail_mode_for_current_rollout(), "pass_through"
+        )
+        self.assertEqual(
+            settings.llm_effective_fail_mode(rollout_stage="stage1"), "pass_through"
         )
 
     def test_live_pass_through_requires_explicit_approval_gate(self) -> None:
         env = _load_torghut_knative_env()
         fail_open_env = dict(env)
-        fail_open_env["TRADING_PARITY_POLICY"] = "live_equivalent"
         fail_open_env["LLM_ROLLOUT_STAGE"] = "stage3"
         fail_open_env["LLM_FAIL_MODE"] = "pass_through"
         fail_open_env["LLM_FAIL_MODE_ENFORCEMENT"] = "configured"

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -372,7 +372,6 @@ class TestTradingApi(TestCase):
             "llm_rollout_stage": settings.llm_rollout_stage,
             "trading_mode": settings.trading_mode,
             "trading_live_enabled": settings.trading_live_enabled,
-            "trading_parity_policy": settings.trading_parity_policy,
             "llm_fail_mode": settings.llm_fail_mode,
             "llm_fail_mode_enforcement": settings.llm_fail_mode_enforcement,
             "llm_fail_open_live_approved": settings.llm_fail_open_live_approved,
@@ -387,7 +386,6 @@ class TestTradingApi(TestCase):
         settings.llm_shadow_mode = False
         settings.trading_mode = "live"
         settings.trading_live_enabled = True
-        settings.trading_parity_policy = "mode_coupled"
         settings.llm_fail_mode = "pass_through"
         settings.llm_fail_mode_enforcement = "configured"
         settings.llm_fail_open_live_approved = True
@@ -405,15 +403,12 @@ class TestTradingApi(TestCase):
             self.assertEqual(llm["rollout_stage"], "stage3")
             self.assertFalse(llm["shadow_mode"])
             self.assertTrue(llm["effective_shadow_mode"])
-            self.assertEqual(llm["parity_policy"], "mode_coupled")
             self.assertEqual(llm["fail_mode_enforcement"], "configured")
-            self.assertIn("mode_coupled_behavior_enabled", llm["policy_exceptions"])
+            self.assertIn("configured_fail_mode_enabled", llm["policy_exceptions"])
             self.assertIn("policy_resolution", llm)
             self.assertIn("policy_resolution_counters", llm)
-            self.assertEqual(
-                llm["policy_resolution"]["classification"], "intentional_exception"
-            )
-            self.assertTrue(llm["policy_resolution"]["fail_mode_exception_active"])
+            self.assertEqual(llm["policy_resolution"]["classification"], "compliant")
+            self.assertFalse(llm["policy_resolution"]["fail_mode_exception_active"])
             self.assertFalse(llm["policy_resolution"]["fail_mode_violation_active"])
             self.assertIn("guardrails", llm)
             self.assertTrue(llm["guardrails"]["allow_requests"])
@@ -427,7 +422,6 @@ class TestTradingApi(TestCase):
             settings.llm_rollout_stage = original["llm_rollout_stage"]
             settings.trading_mode = original["trading_mode"]
             settings.trading_live_enabled = original["trading_live_enabled"]
-            settings.trading_parity_policy = original["trading_parity_policy"]
             settings.llm_fail_mode = original["llm_fail_mode"]
             settings.llm_fail_mode_enforcement = original["llm_fail_mode_enforcement"]
             settings.llm_fail_open_live_approved = original[

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -1945,7 +1945,6 @@ class TestTradingPipeline(TestCase):
             "llm_enabled": config.settings.llm_enabled,
             "llm_fail_mode": config.settings.llm_fail_mode,
             "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
-            "trading_parity_policy": config.settings.trading_parity_policy,
             "llm_shadow_mode": config.settings.llm_shadow_mode,
             "llm_min_confidence": config.settings.llm_min_confidence,
             "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
@@ -1960,7 +1959,6 @@ class TestTradingPipeline(TestCase):
         config.settings.llm_enabled = True
         config.settings.llm_fail_mode = "pass_through"
         config.settings.llm_fail_mode_enforcement = "configured"
-        config.settings.trading_parity_policy = "mode_coupled"
         config.settings.llm_shadow_mode = False
         config.settings.llm_min_confidence = 0.0
         _set_llm_guardrails(config)
@@ -2059,9 +2057,9 @@ class TestTradingPipeline(TestCase):
 
             with self.session_local() as session:
                 executions = session.execute(select(Execution)).scalars().all()
-                self.assertEqual(len(executions), 1)
+                self.assertEqual(len(executions), 2)
                 decisions = session.execute(select(TradeDecision)).scalars().all()
-                self.assertEqual(decisions[-1].status, "rejected")
+                self.assertEqual(decisions[-1].status, "submitted")
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
@@ -2077,7 +2075,6 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_fail_mode_enforcement = original[
                 "llm_fail_mode_enforcement"
             ]
-            config.settings.trading_parity_policy = original["trading_parity_policy"]
             config.settings.llm_shadow_mode = original["llm_shadow_mode"]
             config.settings.llm_min_confidence = original["llm_min_confidence"]
             config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
@@ -2400,7 +2397,7 @@ class TestTradingPipeline(TestCase):
                 "llm_adjustment_approved"
             ]
 
-    def test_pipeline_stage1_live_overrides_fail_mode(self) -> None:
+    def test_pipeline_stage1_live_uses_mode_consistent_fail_mode(self) -> None:
         from app import config
 
         original = {
@@ -2414,7 +2411,6 @@ class TestTradingPipeline(TestCase):
             "llm_shadow_mode": config.settings.llm_shadow_mode,
             "llm_fail_mode": config.settings.llm_fail_mode,
             "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
-            "trading_parity_policy": config.settings.trading_parity_policy,
             "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
             "llm_evaluation_report": config.settings.llm_evaluation_report,
             "llm_effective_challenge_id": config.settings.llm_effective_challenge_id,
@@ -2431,7 +2427,6 @@ class TestTradingPipeline(TestCase):
         config.settings.llm_shadow_mode = False
         config.settings.llm_fail_mode = "pass_through"
         config.settings.llm_fail_mode_enforcement = "configured"
-        config.settings.trading_parity_policy = "mode_coupled"
         _set_llm_guardrails(config)
 
         try:
@@ -2483,12 +2478,12 @@ class TestTradingPipeline(TestCase):
                 executions = session.execute(select(Execution)).scalars().all()
                 self.assertEqual(decisions[0].status, "submitted")
                 self.assertEqual(len(executions), 1)
-                self.assertEqual(pipeline.state.metrics.llm_fail_mode_override_total, 1)
+                self.assertEqual(pipeline.state.metrics.llm_fail_mode_override_total, 0)
                 self.assertEqual(
                     pipeline.state.metrics.llm_fail_mode_exception_total, 0
                 )
                 self.assertEqual(
-                    pipeline.state.metrics.llm_policy_resolution_total.get("violation"),
+                    pipeline.state.metrics.llm_policy_resolution_total.get("compliant"),
                     1,
                 )
                 self.assertEqual(
@@ -2511,7 +2506,6 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_fail_mode_enforcement = original[
                 "llm_fail_mode_enforcement"
             ]
-            config.settings.trading_parity_policy = original["trading_parity_policy"]
             config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
             config.settings.llm_evaluation_report = original["llm_evaluation_report"]
             config.settings.llm_effective_challenge_id = original[
@@ -2539,7 +2533,6 @@ class TestTradingPipeline(TestCase):
             "llm_shadow_mode": config.settings.llm_shadow_mode,
             "llm_fail_mode": config.settings.llm_fail_mode,
             "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
-            "trading_parity_policy": config.settings.trading_parity_policy,
             "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
             "llm_evaluation_report": config.settings.llm_evaluation_report,
             "llm_effective_challenge_id": config.settings.llm_effective_challenge_id,
@@ -2557,7 +2550,6 @@ class TestTradingPipeline(TestCase):
         config.settings.llm_shadow_mode = False
         config.settings.llm_fail_mode = "pass_through"
         config.settings.llm_fail_mode_enforcement = "configured"
-        config.settings.trading_parity_policy = "mode_coupled"
         _set_llm_guardrails(config)
 
         try:
@@ -2649,7 +2641,6 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_fail_mode_enforcement = original[
                 "llm_fail_mode_enforcement"
             ]
-            config.settings.trading_parity_policy = original["trading_parity_policy"]
             config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
             config.settings.llm_evaluation_report = original["llm_evaluation_report"]
             config.settings.llm_effective_challenge_id = original[


### PR DESCRIPTION
## Summary
- remove `TRADING_PARITY_POLICY` from Torghut settings/runtime and Knative manifest
- eliminate mode-coupled live-only fail-mode overrides so paper/live share the same LLM fail-mode behavior
- remove parity fields from `/trading/status` and policy-resolution source inputs
- update tests to assert consistent paper/live behavior and revised policy-resolution expectations
- align live manifest LLM fail-open wiring for the unified policy (`LLM_FAIL_MODE=pass_through`, `LLM_FAIL_OPEN_LIVE_APPROVED=true`)

## Validation
- `cd services/torghut && uv run --frozen python -m unittest discover -s tests`
- `cd services/torghut && uv run --frozen ruff check`