### PR TITLE
chore(torghut): promote image bc5696cf

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:66754cde33faa910a1b9f0096b0f142b060e66f6c9d8ffbc7a906efac124eb4e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dd015b4fb2b86e72f1a823e7b20cfe85e91e58e010d5f5a5f3ee90c8ff2c0dd1
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-23T06:16:44Z"
+        client.knative.dev/updateTimestamp: "2026-02-24T01:29:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:66754cde33faa910a1b9f0096b0f142b060e66f6c9d8ffbc7a906efac124eb4e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:dd015b4fb2b86e72f1a823e7b20cfe85e91e58e010d5f5a5f3ee90c8ff2c0dd1
           ports:
             - name: http1
               containerPort: 8181
@@ -246,9 +246,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-168-ga03dc80d
+              value: v0.560.0-176-gbc5696cf
             - name: TORGHUT_COMMIT
-              value: a03dc80d3cc2e0960280486ac5797e6b14bf61fe
+              value: bc5696cfdb8bfe71809b6ae8c03eb34e18253204
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `bc5696cfdb8bfe71809b6ae8c03eb34e18253204`
- Image tag: `bc5696cf`
- Image digest: `sha256:dd015b4fb2b86e72f1a823e7b20cfe85e91e58e010d5f5a5f3ee90c8ff2c0dd1`