### PR TITLE
fix(torghut): make whitepaper bootstrap hook idempotent

### DIFF
--- a/argocd/applications/torghut/whitepapers-bucket-bootstrap-job.yaml
+++ b/argocd/applications/torghut/whitepapers-bucket-bootstrap-job.yaml
@@ -61,7 +61,7 @@ spec:
             - -ec
             - |
               mc alias set ceph "http://${BUCKET_HOST}:${BUCKET_PORT}" "${AWS_ACCESS_KEY_ID}" "${AWS_SECRET_ACCESS_KEY}"
-              mc mb --ignore-existing "ceph/${BUCKET_NAME}"
+              mc stat "ceph/${BUCKET_NAME}" >/dev/null 2>&1 || mc mb "ceph/${BUCKET_NAME}"
 
               for prefix in \
                 "raw/github" \
@@ -78,5 +78,5 @@ spec:
                 "index/manifests" \
                 "ops/failed" \
                 "ops/quarantine"; do
-                mc cp /dev/null "ceph/${BUCKET_NAME}/${prefix}/.keep"
+                printf "" | mc pipe "ceph/${BUCKET_NAME}/${prefix}/.keep"
               done


### PR DESCRIPTION
## Summary

- fix `torghut-whitepapers-bootstrap` hook to be idempotent when bucket already exists
- replace `mc mb --ignore-existing` with `mc stat ... || mc mb ...` to avoid `TooManyBuckets` failure
- replace `mc cp /dev/null` with `mc pipe` for reliable zero-byte `.keep` object creation

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut > /tmp/torghut-kustomize-hotfix.yaml`
- manual in-cluster repro + validation with `quay.io/minio/mc` against `torghut-whitepapers` OBC credentials:
  - previous command pattern failed with `mc mb --ignore-existing` (`TooManyBuckets`)
  - patched command pattern (`mc stat || mc mb` + `mc pipe`) succeeded and wrote `.keep` objects

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
