### PR TITLE
chore(torghut): promote image 1cef5cf2

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e563a73cecda9840cd6525ce3fcd53151cc414916a17864a84b073d42c3fcb9d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:37c15246e8f4dbf5eeca93a6da1a64aa3a77c1505ab8f0d670457c5e215d7168
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-24T02:43:26Z"
+        client.knative.dev/updateTimestamp: "2026-02-24T02:57:53Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e563a73cecda9840cd6525ce3fcd53151cc414916a17864a84b073d42c3fcb9d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:37c15246e8f4dbf5eeca93a6da1a64aa3a77c1505ab8f0d670457c5e215d7168
           ports:
             - name: http1
               containerPort: 8181
@@ -312,9 +312,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-179-gb059fc65
+              value: v0.560.0-182-g1cef5cf2
             - name: TORGHUT_COMMIT
-              value: b059fc653ee85d1056f6d8aa26dad6f5f5ab6f49
+              value: 1cef5cf2709db9b823aa0c0132ca203861da45cd
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `1cef5cf2709db9b823aa0c0132ca203861da45cd`
- Image tag: `1cef5cf2`
- Image digest: `sha256:37c15246e8f4dbf5eeca93a6da1a64aa3a77c1505ab8f0d670457c5e215d7168`
- Migration change detected under `services/torghut/migrations/**`
- Added `do-not-automerge`; manual DB migration approval required before merge