### PR TITLE
fix(torghut): switch readiness probe to /healthz

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -324,7 +324,7 @@ spec:
               port: http1
           readinessProbe:
             httpGet:
-              path: /db-check
+              path: /healthz
               port: http1
           resources:
             requests:


### PR DESCRIPTION
## Summary

- change Torghut Knative readiness probe from `/db-check` to `/healthz`
- unblock rollout convergence while preserving schema safety via the PreSync migration hook
- keep `/db-check` available for explicit schema/database diagnostics

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut > /tmp/torghut-kustomize-readiness.yaml`
- in-cluster observation before patch: revision `torghut-00030` stuck `1/2` with repeated `/db-check` readiness timeouts and Argo app `Progressing`

## Breaking Changes

- Readiness no longer gates on Alembic-head alignment at request-probe time; this is now enforced primarily by the PreSync migration job.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
