### PR TITLE
fix(torghut): align whitepaper kafka topic with froussard

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -181,7 +181,7 @@ spec:
             - name: WHITEPAPER_KAFKA_BOOTSTRAP_SERVERS
               value: kafka-kafka-bootstrap.kafka:9092
             - name: WHITEPAPER_KAFKA_TOPIC
-              value: froussard.github.webhooks
+              value: github.webhook.events
             - name: WHITEPAPER_KAFKA_GROUP_ID
               value: torghut-whitepaper-v1
             - name: WHITEPAPER_KAFKA_CLIENT_ID

--- a/services/torghut/app/whitepapers/workflow.py
+++ b/services/torghut/app/whitepapers/workflow.py
@@ -1198,7 +1198,7 @@ class WhitepaperKafkaIssueIngestor:
         if not bootstrap:
             raise RuntimeError("whitepaper_kafka_bootstrap_missing")
 
-        topic = _str_env("WHITEPAPER_KAFKA_TOPIC", "froussard.github.webhooks") or "froussard.github.webhooks"
+        topic = _str_env("WHITEPAPER_KAFKA_TOPIC", "github.webhook.events") or "github.webhook.events"
         security_protocol = _str_env("WHITEPAPER_KAFKA_SECURITY_PROTOCOL")
         sasl_mechanism = _str_env("WHITEPAPER_KAFKA_SASL_MECHANISM")
         sasl_username = _str_env("WHITEPAPER_KAFKA_SASL_USERNAME")


### PR DESCRIPTION
## Summary

- change Torghut whitepaper Kafka topic env to `github.webhook.events` to match Froussard producer topic
- update whitepaper workflow default fallback topic to `github.webhook.events` to avoid future drift
- keep existing group/client/security settings unchanged

## Related Issues

None

## Testing

- `cd services/torghut && uv run ruff check app/whitepapers/workflow.py`
- `cd services/torghut && uv run pyright app/whitepapers/workflow.py`
- `cd services/torghut && uv run python -m unittest tests.test_whitepaper_workflow tests.test_whitepaper_api`
- `cd /home/coder/github.com/lab-pr-parity-consistency && kubectl kustomize argocd/applications/torghut > /tmp/torghut-kustomize-topic-fix.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
