### PR TITLE
chore(torghut): promote image 0a210f53

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:25e46a741f03fcc15a47f07dc9501dd39dd5d22d08ce72d6016ebff4b8aedc00
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:eae6193a4fd7241096d830a03bd917cc3afcfe13d22332133f913000b8a4bb99
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-24T03:28:26Z"
+        client.knative.dev/updateTimestamp: "2026-02-24T03:45:25Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:25e46a741f03fcc15a47f07dc9501dd39dd5d22d08ce72d6016ebff4b8aedc00
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:eae6193a4fd7241096d830a03bd917cc3afcfe13d22332133f913000b8a4bb99
           ports:
             - name: http1
               containerPort: 8181
@@ -328,9 +328,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-185-g401fa41c
+              value: v0.560.0-187-g0a210f53
             - name: TORGHUT_COMMIT
-              value: 401fa41c6441314383794fb93e5c083f5edf64ac
+              value: 0a210f53fffa9162f3b934bcfca5ce161bb11683
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `0a210f53fffa9162f3b934bcfca5ce161bb11683`
- Image tag: `0a210f53`
- Image digest: `sha256:eae6193a4fd7241096d830a03bd917cc3afcfe13d22332133f913000b8a4bb99`