### PR TITLE
fix(torghut): handle async Inngest send in whitepaper intake

### DIFF
--- a/services/torghut/app/whitepapers/workflow.py
+++ b/services/torghut/app/whitepapers/workflow.py
@@ -801,7 +801,11 @@ class WhitepaperWorkflowService:
             id=run.run_id,
             data=event_payload,
         )
-        event_ids = cast(list[str], client.send(event))
+        send_result = client.send(event)
+        if asyncio.iscoroutine(send_result):
+            event_ids = cast(list[str], asyncio.run(send_result))
+        else:
+            event_ids = cast(list[str], send_result)
         return {
             "event_name": event_name,
             "event_ids": event_ids,


### PR DESCRIPTION
## Summary
- fix whitepaper Inngest enqueue path to handle `client.send()` returning a coroutine
- run coroutine with `asyncio.run(...)` in synchronous intake path
- add regression test covering async send client behavior

## Why
Real E2E run via GitHub issues `#3563` and `#3564` failed with:
- `inngest_dispatch_failed:TypeError:'coroutine' object is not subscriptable`

## Validation
- `cd services/torghut && uv run ruff check app/whitepapers/workflow.py tests/test_whitepaper_workflow.py`
- `cd services/torghut && uv run pyright app/whitepapers/workflow.py`
- `cd services/torghut && uv run python -m unittest tests.test_whitepaper_workflow tests.test_whitepaper_api`
