### PR TITLE
fix(inngest): use torghut namespace for torghut sdkUrl

### DIFF
--- a/argocd/applications/inngest/values.yaml
+++ b/argocd/applications/inngest/values.yaml
@@ -8,7 +8,7 @@ inngest:
   eventKey: ''
   signingKey: ''
   sdkUrl:
-    - 'http://torghut.proompteng.svc.cluster.local/api/inngest'
+    - 'http://torghut.torghut.svc.cluster.local/api/inngest'
     - 'http://khoshut.khoshut.svc.cluster.local:3000/api/inngest'
   logLevel: info
 


### PR DESCRIPTION
## Summary
- fix Inngest `sdkUrl` for Torghut to use the correct namespace DNS name
- from `http://torghut.proompteng.svc.cluster.local/api/inngest`
- to `http://torghut.torghut.svc.cluster.local/api/inngest`

## Why
Real whitepaper E2E showed runs stuck at `inngest_dispatched` because Inngest could not reach Torghut function endpoint in the wrong namespace.
