### PR TITLE
chore(argocd): standardize applicationset sync policy defaults

### DIFF
--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -145,6 +145,8 @@ spec:
           - CreateNamespace=true
           - ServerSideApply=true
           - RespectIgnoreDifferences=true
+          - ApplyOutOfSyncOnly=true
+          - PruneLast=true
           - ClientSideApplyMigration=false
   templatePatch: |
     {{- if .annotations }}
@@ -181,8 +183,16 @@ spec:
       syncPolicy:
       {{- if $auto }}
         automated:
+          enabled: true
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+          refresh: true
       {{- end }}
       {{- if $hasManagedNS }}
         managedNamespaceMetadata:

--- a/argocd/applicationsets/cdk8s.yaml
+++ b/argocd/applicationsets/cdk8s.yaml
@@ -55,6 +55,9 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - ApplyOutOfSyncOnly=true
+          - PruneLast=true
+          - ClientSideApplyMigration=false
   templatePatch: |
     {{- if .annotations }}
     metadata:
@@ -82,7 +85,15 @@ spec:
       {{- if $auto }}
       syncPolicy:
         automated:
+          enabled: true
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+          refresh: true
       {{- end }}
     {{- end }}

--- a/argocd/applicationsets/helm-apps.yaml
+++ b/argocd/applicationsets/helm-apps.yaml
@@ -32,11 +32,22 @@ spec:
         namespace: "{{.namespace}}"
       syncPolicy:
         automated:
+          enabled: true
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+          refresh: true
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - ApplyOutOfSyncOnly=true
+          - PruneLast=true
+          - ClientSideApplyMigration=false
       source:
         repoURL: "{{.repoUrl}}"
         chart: "{{.chart}}"

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -293,7 +293,7 @@ spec:
                 namespace: inngest
                 annotations:
                   argocd.argoproj.io/sync-wave: "4"
-                automation: manual
+                automation: auto
                 enabled: "true"
               - name: airbyte
                 path: argocd/applications/airbyte
@@ -424,6 +424,9 @@ spec:
           - CreateNamespace=true
           - ServerSideApply=true
           - RespectIgnoreDifferences=true
+          - ApplyOutOfSyncOnly=true
+          - PruneLast=true
+          - ClientSideApplyMigration=false
       ignoreDifferences:
         - kind: StatefulSet
           group: apps
@@ -618,8 +621,16 @@ spec:
       syncPolicy:
       {{- if $auto }}
         automated:
+          enabled: true
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+          refresh: true
       {{- end }}
       {{- if $hasManagedNS }}
         managedNamespaceMetadata:

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -297,6 +297,9 @@ spec:
           - CreateNamespace=true
           - ServerSideApply=true
           - RespectIgnoreDifferences=true
+          - ApplyOutOfSyncOnly=true
+          - PruneLast=true
+          - ClientSideApplyMigration=false
   templatePatch: |
     {{- if .annotations }}
     metadata:
@@ -335,8 +338,16 @@ spec:
       {{- end }}
       {{- if $auto }}
         automated:
+          enabled: true
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+          refresh: true
       {{- end }}
     {{- end }}
     {{- if hasKey . "ignoreDifferences" }}


### PR DESCRIPTION
## Summary

- enable Argo CD auto-sync for the `inngest` app in the platform ApplicationSet
- standardize ApplicationSet sync defaults across `platform`, `product`, `bootstrap`, `helm-apps`, and `cdk8s`
- add `ApplyOutOfSyncOnly=true`, `PruneLast=true`, and `ClientSideApplyMigration=false` to template sync options
- add `automated.enabled: true` and `syncPolicy.retry` backoff settings for auto-managed apps

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A (manifest-only change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
