### PR TITLE
fix(jangar): migrate cnpg backups to dedicated bucket

### DIFF
--- a/argocd/applications/jangar/cnpg-jangar-db-bucket-migration-job.yaml
+++ b/argocd/applications/jangar/cnpg-jangar-db-bucket-migration-job.yaml
@@ -1,0 +1,104 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: jangar-db-backup-bucket-migration
+  namespace: jangar
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: RGW_ENDPOINT_URL
+              value: http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80
+            - name: SOURCE_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-rgw-jangar
+                  key: accesskey
+            - name: SOURCE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-rgw-jangar
+                  key: secretkey
+            - name: TARGET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cnpg-jangar-db
+                  key: AWS_ACCESS_KEY_ID
+            - name: TARGET_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cnpg-jangar-db
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: HOME
+              value: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              set -euo pipefail
+
+              SRC_ROOT="src/argo-workflows/cnpg/jangar"
+              DST_ROOT="dst/cnpg/jangar-db"
+
+              until mc alias set src "$RGW_ENDPOINT_URL" "$SOURCE_ACCESS_KEY" "$SOURCE_SECRET_KEY" --api S3v4; do
+                echo "waiting for source RGW auth..."
+                sleep 5
+              done
+
+              until mc alias set dst "$RGW_ENDPOINT_URL" "$TARGET_ACCESS_KEY" "$TARGET_SECRET_KEY" --api S3v4; do
+                echo "waiting for target RGW auth..."
+                sleep 5
+              done
+
+              mc mb -p "dst/cnpg" >/dev/null 2>&1 || true
+
+              attempt=1
+              max_attempts=10
+
+              while [ "$attempt" -le "$max_attempts" ]; do
+                src_count="$(mc ls --recursive "$SRC_ROOT" | wc -l | tr -d ' ')"
+                if [ "$src_count" = "0" ]; then
+                  echo "no objects found under $SRC_ROOT; nothing to migrate"
+                  exit 0
+                fi
+
+                echo "mirror attempt $attempt/$max_attempts (source objects: $src_count)"
+                mc mirror --overwrite "$SRC_ROOT" "$DST_ROOT" || true
+
+                dst_count="$(mc ls --recursive "$DST_ROOT" | wc -l | tr -d ' ')"
+                if [ "$dst_count" -ge "$src_count" ]; then
+                  echo "migration complete: source=$src_count destination=$dst_count"
+                  exit 0
+                fi
+
+                echo "attempt $attempt incomplete: source=$src_count destination=$dst_count"
+                attempt=$((attempt + 1))
+                sleep 5
+              done
+
+              src_count="$(mc ls --recursive "$SRC_ROOT" | wc -l | tr -d ' ')"
+              dst_count="$(mc ls --recursive "$DST_ROOT" | wc -l | tr -d ' ')"
+              echo "migration incomplete after retries: source=$src_count destination=$dst_count"
+              exit 1

--- a/argocd/applications/jangar/cnpg-jangar-db-objectbucketclaim.yaml
+++ b/argocd/applications/jangar/cnpg-jangar-db-objectbucketclaim.yaml
@@ -1,0 +1,8 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: cnpg-jangar-db
+  namespace: jangar
+spec:
+  bucketName: cnpg
+  storageClassName: rook-ceph-bucket

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: jangar
 resources:
   - torghut-db-ca-sealedsecret.yaml
   - rook-ceph-rgw-jangar-sealedsecret.yaml
+  - cnpg-jangar-db-objectbucketclaim.yaml
+  - cnpg-jangar-db-bucket-migration-job.yaml
   - deployment.yaml
   - jangar-worker-deployment.yaml
   - service.yaml

--- a/argocd/applications/jangar/postgres-cluster.yaml
+++ b/argocd/applications/jangar/postgres-cluster.yaml
@@ -19,15 +19,15 @@ spec:
         - CREATE EXTENSION IF NOT EXISTS vector;
   backup:
     barmanObjectStore:
-      destinationPath: s3://argo-workflows/cnpg/jangar
+      destinationPath: s3://cnpg/jangar-db
       endpointURL: http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80
       s3Credentials:
         accessKeyId:
-          name: rook-ceph-rgw-jangar
-          key: accesskey
+          name: cnpg-jangar-db
+          key: AWS_ACCESS_KEY_ID
         secretAccessKey:
-          name: rook-ceph-rgw-jangar
-          key: secretkey
+          name: cnpg-jangar-db
+          key: AWS_SECRET_ACCESS_KEY
     retentionPolicy: "14d"
   inheritedMetadata:
     annotations:

--- a/argocd/applications/jangar/postgres-scheduled-backup.yaml
+++ b/argocd/applications/jangar/postgres-scheduled-backup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jangar-db-daily
   namespace: jangar
 spec:
-  schedule: "0 0 0 * * *"
+  schedule: "0 0 11 * * *"
   backupOwnerReference: self
   method: barmanObjectStore
   cluster:


### PR DESCRIPTION
## Summary

- Create a dedicated Ceph bucket claim for Jangar CNPG backups (`ObjectBucketClaim/cnpg-jangar-db` for bucket `cnpg`).
- Repoint `Cluster/jangar-db` CNPG `barmanObjectStore` backups to `s3://cnpg/jangar-db` and use OBC-provisioned credentials (`cnpg-jangar-db` secret).
- Add a `PostSync` migration job that mirrors historical objects from `s3://argo-workflows/cnpg/jangar` into `s3://cnpg/jangar-db` with retry logic and count-based verification.
- Update scheduled backups from `00:00 UTC` to `11:00 UTC` (3:00 AM PST target).

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar`
- `kubectl -n jangar apply -f argocd/applications/jangar/cnpg-jangar-db-objectbucketclaim.yaml`
- `kubectl -n jangar wait --for=jsonpath='{.status.phase}'=Bound obc/cnpg-jangar-db --timeout=180s`
- `kubectl -n jangar apply -f argocd/applications/jangar/cnpg-jangar-db-bucket-migration-job.yaml`
- `kubectl -n jangar wait --for=condition=Complete job/jangar-db-backup-bucket-migration --timeout=1800s`
- `kubectl -n jangar logs job/jangar-db-backup-bucket-migration | tail -n 40` (includes `migration complete: source=1213 destination=1213`)

## Screenshots (if applicable)

N/A

## Breaking Changes

- Backup object-storage destination for `jangar-db` changes from `s3://argo-workflows/cnpg/jangar` to `s3://cnpg/jangar-db`.
- Backup credentials source changes from `Secret/rook-ceph-rgw-jangar` (`accesskey`/`secretkey`) to `Secret/cnpg-jangar-db` (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
