### PR TITLE
chore(torghut): promote image dc89188f

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:842015e9e37738f9e97bbcf0cd6ef085c5f1dea3e7c1c184a755cdd4aeb1b5e4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:61173a143ce49de1b374feb956dee6bd71e51712796ec168c3dcfd24410c1901
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-24T05:53:34.360Z"
+        client.knative.dev/updateTimestamp: "2026-02-24T06:07:59Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:842015e9e37738f9e97bbcf0cd6ef085c5f1dea3e7c1c184a755cdd4aeb1b5e4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:61173a143ce49de1b374feb956dee6bd71e51712796ec168c3dcfd24410c1901
           ports:
             - name: http1
               containerPort: 8181
@@ -328,9 +328,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-194-g2d671912
+              value: v0.560.0-199-gdc89188f
             - name: TORGHUT_COMMIT
-              value: 2d671912fd2dffeb83afcf7e0d3419a8a4f7c839
+              value: dc89188f29b5f6a82ec3b9160f408e749255bfe0
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `dc89188f29b5f6a82ec3b9160f408e749255bfe0`
- Image tag: `dc89188f`
- Image digest: `sha256:61173a143ce49de1b374feb956dee6bd71e51712796ec168c3dcfd24410c1901`