### PR TITLE
chore(torghut): bump prod digest after whitepaper merge

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:61173a143ce49de1b374feb956dee6bd71e51712796ec168c3dcfd24410c1901
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10b31bee4d26f140d595e5a90c969978c21d33dc5531d3b2c8f369d2e5c5c10f
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:61173a143ce49de1b374feb956dee6bd71e51712796ec168c3dcfd24410c1901
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10b31bee4d26f140d595e5a90c969978c21d33dc5531d3b2c8f369d2e5c5c10f
           ports:
             - name: http1
               containerPort: 8181


### PR DESCRIPTION
## Summary

- Rebuilt `lab/torghut:latest` from merged `main` commit `dc89188f29b5f6a82ec3b9160f408e749255bfe0`.
- Updated Torghut GitOps manifests to pin digest `sha256:10b31bee4d26f140d595e5a90c969978c21d33dc5531d3b2c8f369d2e5c5c10f`.
- Updated `TORGHUT_VERSION` / `TORGHUT_COMMIT` env metadata in Knative manifest to match the rebuilt image source.

## Related Issues

None

## Testing

- `bun run build:torghut`
- `bun run packages/scripts/src/torghut/update-manifests.ts --registry registry.ide-newton.ts.net --repository lab/torghut --digest sha256:10b31bee4d26f140d595e5a90c969978c21d33dc5531d3b2c8f369d2e5c5c10f --version v0.560.0-199-gdc89188f --commit dc89188f29b5f6a82ec3b9160f408e749255bfe0`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
