### PR TITLE
fix(torghut): enable whitepaper kafka trigger path

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -176,6 +176,8 @@ spec:
                   optional: true
             - name: WHITEPAPER_WORKFLOW_ENABLED
               value: "true"
+            - name: WHITEPAPER_KAFKA_ENABLED
+              value: "true"
             - name: WHITEPAPER_KAFKA_BOOTSTRAP_SERVERS
               value: kafka-kafka-bootstrap.kafka:9092
             - name: WHITEPAPER_KAFKA_TOPIC


### PR DESCRIPTION
## Summary

- Enabled `WHITEPAPER_KAFKA_ENABLED=true` in Torghut Knative service manifest.
- This turns on the whitepaper Kafka worker in production so Trigger Path A (`GitHub issue -> Kafka -> Torghut`) can execute.
- No image digest or code-path changes were included in this PR.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl -n torghut port-forward deploy/torghut-00040-deployment 18181:8181` + `curl -sS http://127.0.0.1:18181/whitepapers/status` (before change showed `kafka_enabled=false`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
