### PR TITLE
feat(jangar): improve memories semantic search relevance UI

### DIFF
--- a/services/jangar/src/routes/memories.tsx
+++ b/services/jangar/src/routes/memories.tsx
@@ -1,24 +1,74 @@
-import { Button, Input } from '@proompteng/design/ui'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  Input,
+  Separator,
+  Spinner,
+} from '@proompteng/design/ui'
 import { createFileRoute } from '@tanstack/react-router'
+import { Clock3, Hash, Search } from 'lucide-react'
 import * as React from 'react'
+import { cn } from '@/lib/utils'
 
 export const Route = createFileRoute('/memories')({
   component: MemoriesPage,
 })
 
+type MemoryResult = {
+  id: string
+  namespace: string
+  content: string
+  summary: string | null
+  tags: string[]
+  metadata: Record<string, unknown>
+  createdAt: string
+  distance?: number
+}
+
+const MAX_RESULTS = 12
+
+const truncate = (value: string, maxLength: number) => {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`
+}
+
+const formatTimestamp = (value: string) => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+const toRelevanceScore = (distance: number | undefined) => {
+  if (typeof distance !== 'number' || !Number.isFinite(distance)) return null
+  return Math.max(0, Math.min(100, Math.round((1 - distance) * 100)))
+}
+
 function MemoriesPage() {
-  const [namespace, setNamespace] = React.useState('default')
   const [query, setQuery] = React.useState('')
   const [isSearching, setIsSearching] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
-  const [results, setResults] = React.useState<unknown>(null)
+  const [results, setResults] = React.useState<MemoryResult[]>([])
+  const [lastQuery, setLastQuery] = React.useState<string | null>(null)
+  const [hasSearched, setHasSearched] = React.useState(false)
 
   const submitQuery = async () => {
     const trimmedQuery = query.trim()
     setError(null)
 
     if (!trimmedQuery) {
-      setResults(null)
+      setResults([])
       setError('Query is required.')
       return
     }
@@ -26,25 +76,28 @@ function MemoriesPage() {
     setIsSearching(true)
     try {
       const params = new URLSearchParams({
-        namespace: namespace.trim() || 'default',
         query: trimmedQuery,
-        limit: '10',
+        limit: String(MAX_RESULTS),
       })
       const response = await fetch(`/api/memories?${params.toString()}`)
       const payload = (await response.json().catch(() => null)) as {
         ok?: boolean
-        memories?: unknown[]
+        memories?: MemoryResult[]
         error?: string
         message?: string
       } | null
       if (!response.ok || !payload || payload.ok !== true) {
         const message = payload?.error ?? payload?.message ?? 'Unable to query right now. Please try again.'
-        setResults(null)
+        setResults([])
         setError(message)
         return
       }
-      setResults(payload)
+      const nextResults = Array.isArray(payload.memories) ? payload.memories : []
+      setResults(nextResults)
+      setLastQuery(trimmedQuery)
+      setHasSearched(true)
     } catch {
+      setResults([])
       setError('Unable to query right now. Please try again.')
     } finally {
       setIsSearching(false)
@@ -52,50 +105,134 @@ function MemoriesPage() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-4xl p-4">
-      <form
-        className="flex items-center gap-2"
-        onSubmit={(event) => {
-          event.preventDefault()
-          void submitQuery()
-        }}
-      >
-        <label className="sr-only" htmlFor="memories-namespace">
-          Namespace
-        </label>
-        <Input
-          id="memories-namespace"
-          name="namespace"
-          value={namespace}
-          onChange={(event) => setNamespace(event.target.value)}
-          placeholder="Namespace"
-          autoComplete="off"
-          className="w-40"
-        />
+    <main className="relative mx-auto flex w-full max-w-6xl flex-col gap-5 p-5">
+      <section className="relative overflow-hidden rounded-lg border border-zinc-500/20 bg-card">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-zinc-200/40 via-transparent to-zinc-500/10" />
+        <div className="relative flex flex-col gap-4 p-5">
+          <header className="flex flex-col gap-2">
+            <p className="text-[11px] font-semibold tracking-[0.12em] text-zinc-500">semantic search</p>
+            <h1 className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+              Relevant matches across all namespaces
+            </h1>
+            <p className="max-w-3xl text-xs text-zinc-600 dark:text-zinc-300">
+              Queries run globally and return only relevant results. Weak semantic tail matches are filtered out.
+            </p>
+          </header>
 
-        <label className="sr-only" htmlFor="memories-query">
-          Query
-        </label>
-        <Input
-          id="memories-query"
-          name="query"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search…"
-          autoComplete="off"
-          className="min-w-0 flex-1"
-        />
+          <form
+            className="flex flex-col gap-3 md:flex-row md:items-center"
+            onSubmit={(event) => {
+              event.preventDefault()
+              void submitQuery()
+            }}
+          >
+            <label className="sr-only" htmlFor="memories-query">
+              Query
+            </label>
+            <div className="relative flex-1">
+              <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-zinc-400" />
+              <Input
+                id="memories-query"
+                name="query"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search memories by concept, topic, or phrase"
+                autoComplete="off"
+                className="pl-9"
+              />
+            </div>
+            <Button type="submit" disabled={isSearching}>
+              {isSearching ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="size-3.5" />
+                  Searching
+                </span>
+              ) : (
+                'Search'
+              )}
+            </Button>
+          </form>
+        </div>
+      </section>
 
-        <Button type="submit" disabled={isSearching}>
-          Search
-        </Button>
-      </form>
+      {error ? (
+        <Card className="border-destructive/30 bg-destructive/5">
+          <CardHeader>
+            <CardTitle className="text-sm text-destructive">Search failed</CardTitle>
+            <CardDescription className="text-destructive/90">{error}</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
 
-      {error ? <div className="mt-3 text-xs text-destructive">{error}</div> : null}
-      {results ? (
-        <pre className="mt-3 overflow-auto rounded-none border bg-background p-4 text-xs">
-          <code className="font-mono tabular-nums">{JSON.stringify(results, null, 2)}</code>
-        </pre>
+      {!error && hasSearched && results.length === 0 ? (
+        <Empty className="border-zinc-500/30 bg-zinc-500/5">
+          <EmptyHeader>
+            <EmptyTitle>No relevant matches found</EmptyTitle>
+            <EmptyDescription>
+              {lastQuery ? `No strong matches for "${lastQuery}".` : 'No strong matches for this query.'}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : null}
+
+      {!error && results.length > 0 ? (
+        <section className="grid gap-3">
+          {results.map((result) => {
+            const relevanceScore = toRelevanceScore(result.distance)
+            const relevanceClassName = cn('bg-zinc-100 text-zinc-700', {
+              'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300':
+                relevanceScore != null && relevanceScore >= 75,
+              'bg-amber-500/15 text-amber-700 dark:text-amber-300':
+                relevanceScore != null && relevanceScore < 75 && relevanceScore >= 60,
+            })
+            return (
+              <Card
+                key={result.id}
+                className="border-zinc-500/20 bg-card/80 transition-colors hover:border-zinc-500/40"
+              >
+                <CardHeader className="gap-2">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <CardTitle className="text-sm text-zinc-900 dark:text-zinc-50">
+                        {result.summary ? truncate(result.summary, 140) : truncate(result.content, 140)}
+                      </CardTitle>
+                      <CardDescription>{truncate(result.content, 260)}</CardDescription>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {relevanceScore != null ? (
+                        <Badge className={relevanceClassName}>{relevanceScore}% relevance</Badge>
+                      ) : null}
+                      <Badge variant="outline">{result.namespace}</Badge>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <Separator />
+                  <div className="flex flex-wrap items-center gap-3 text-[11px] text-zinc-500 dark:text-zinc-400">
+                    <span className="inline-flex items-center gap-1">
+                      <Clock3 className="size-3.5" />
+                      {formatTimestamp(result.createdAt)}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <Hash className="size-3.5" />
+                      {result.id}
+                    </span>
+                    {typeof result.distance === 'number' ? <span>distance {result.distance.toFixed(3)}</span> : null}
+                  </div>
+                  {result.tags.length > 0 ? (
+                    <div className="flex flex-wrap gap-1.5">
+                      {result.tags.map((tag) => (
+                        <Badge key={`${result.id}-${tag}`} variant="outline">
+                          #{tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
+            )
+          })}
+        </section>
       ) : null}
     </main>
   )


### PR DESCRIPTION
## Summary

- Removed namespace from `/memories` search UI so queries run across all namespaces by default.
- Replaced raw JSON output with design-system cards showing summary/content snippets, relevance, namespace, tags, and metadata; updated lead label text to `semantic search`.
- Added server-side relevance filtering for memory retrieval using semantic-distance gating plus lexical fallback to suppress irrelevant tail matches.
- Added regression tests for distant-result filtering and lexical fallback behavior.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/memories-store.test.ts` (from `services/jangar`)
- `bunx biome check --config-path biome.json services/jangar/src/routes/memories.tsx services/jangar/src/server/memories-store.ts services/jangar/src/server/__tests__/memories-store.test.ts`
- `bunx tsc --noEmit -p services/jangar/tsconfig.app.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
