### PR TITLE
chore(torghut): promote image 626a4415

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:10b31bee4d26f140d595e5a90c969978c21d33dc5531d3b2c8f369d2e5c5c10f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8de7683c55c08bc1eba57f75cbffc090698e3601c2dab20e355406976e4f3b4f
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-24T06:07:59Z"
+        client.knative.dev/updateTimestamp: "2026-02-24T07:08:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:10b31bee4d26f140d595e5a90c969978c21d33dc5531d3b2c8f369d2e5c5c10f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8de7683c55c08bc1eba57f75cbffc090698e3601c2dab20e355406976e4f3b4f
           ports:
             - name: http1
               containerPort: 8181
@@ -330,9 +330,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.560.0-199-gdc89188f
+              value: v0.561.0
             - name: TORGHUT_COMMIT
-              value: dc89188f29b5f6a82ec3b9160f408e749255bfe0
+              value: 626a4415809e6916ea23afb56dee19a6cb363f00
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `626a4415809e6916ea23afb56dee19a6cb363f00`
- Image tag: `626a4415`
- Image digest: `sha256:8de7683c55c08bc1eba57f75cbffc090698e3601c2dab20e355406976e4f3b4f`