### PR TITLE
feat(research): add whitepaper Library UI and reliable trigger paths

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-23T08:30:40Z"
+    deploy.knative.dev/rollout: "2026-02-24T07:11:43.496Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-23T08:30:40Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-24T07:11:43.496Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "9ce84b30"
-    digest: sha256:cdc55eed51cc8fe7eed9fdb80a35418f6f03c80cf824ba52603cba26432593d0
+    newTag: "4ab30a2e"
+    digest: sha256:ae3beabc37faadda33f80ac6ea8e21447f50bb633f2520cdd7a75808d114caf6

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -176,6 +176,8 @@ spec:
                   optional: true
             - name: WHITEPAPER_WORKFLOW_ENABLED
               value: "true"
+            - name: WHITEPAPER_KAFKA_ENABLED
+              value: "true"
             - name: WHITEPAPER_KAFKA_BOOTSTRAP_SERVERS
               value: kafka-kafka-bootstrap.kafka:9092
             - name: WHITEPAPER_KAFKA_TOPIC

--- a/services/jangar/src/components/app-sidebar.tsx
+++ b/services/jangar/src/components/app-sidebar.tsx
@@ -77,6 +77,12 @@ const appNav: AppNavItem[] = [
       { to: '/atlas/enrich', label: 'Enrichment' },
     ],
   },
+  {
+    to: '/library',
+    label: 'Library',
+    icon: IconFileText,
+    children: [{ to: '/library/whitepapers', label: 'Whitepapers' }],
+  },
 ]
 
 const agentsStudioNav: AppNavItem = {

--- a/services/jangar/src/data/whitepapers.ts
+++ b/services/jangar/src/data/whitepapers.ts
@@ -1,0 +1,302 @@
+export type WhitepaperListItem = {
+  runId: string
+  status: string
+  triggerSource: string
+  triggerActor: string | null
+  failureReason: string | null
+  createdAt: string | null
+  startedAt: string | null
+  completedAt: string | null
+  document: {
+    key: string | null
+    title: string | null
+    source: string | null
+    sourceIdentifier: string | null
+    status: string | null
+    lastProcessedAt: string | null
+  }
+  version: {
+    versionNumber: number | null
+    parseStatus: string | null
+    fileName: string | null
+    fileSizeBytes: number | null
+    checksumSha256: string | null
+    cephBucket: string | null
+    cephObjectKey: string | null
+    sourceAttachmentUrl: string | null
+  }
+  latestAgentrun: {
+    name: string | null
+    status: string | null
+    headBranch: string | null
+    startedAt: string | null
+    completedAt: string | null
+  } | null
+  verdict: {
+    verdict: string | null
+    score: number | null
+    confidence: number | null
+    requiresFollowup: boolean
+  } | null
+  designPullRequest: {
+    status: string | null
+    prNumber: number | null
+    prUrl: string | null
+    isMerged: boolean
+  } | null
+}
+
+export type WhitepaperDetail = {
+  run: {
+    id: string
+    runId: string
+    status: string
+    triggerSource: string
+    triggerActor: string | null
+    failureCode: string | null
+    failureReason: string | null
+    createdAt: string | null
+    startedAt: string | null
+    completedAt: string | null
+    requestPayload: unknown
+    resultPayload: unknown
+  }
+  document: {
+    id: string
+    key: string | null
+    title: string | null
+    source: string | null
+    sourceIdentifier: string | null
+    status: string | null
+    lastProcessedAt: string | null
+    metadata: unknown
+    createdAt: string | null
+  }
+  version: {
+    id: string
+    versionNumber: number | null
+    fileName: string | null
+    fileSizeBytes: number | null
+    checksumSha256: string | null
+    parseStatus: string | null
+    parseError: string | null
+    pageCount: number | null
+    charCount: number | null
+    tokenCount: number | null
+    cephBucket: string | null
+    cephObjectKey: string | null
+    uploadedBy: string | null
+    uploadMetadata: unknown
+    createdAt: string | null
+  }
+  pdf: {
+    fileName: string | null
+    cephBucket: string | null
+    cephObjectKey: string | null
+    sourceAttachmentUrl: string | null
+  }
+  synthesis: {
+    executiveSummary: string | null
+    methodologySummary: string | null
+    problemStatement: string | null
+    implementationPlanMd: string | null
+    confidence: number | null
+    keyFindings: string[]
+    noveltyClaims: string[]
+    riskAssessment: unknown
+    citations: unknown
+    raw: unknown
+  } | null
+  verdict: {
+    verdict: string | null
+    score: number | null
+    confidence: number | null
+    decisionPolicy: string | null
+    rationale: string | null
+    requiresFollowup: boolean
+    rejectionReasons: string[]
+    recommendations: string[]
+    gating: unknown
+  } | null
+  latestAgentrun: {
+    id: string
+    name: string
+    status: string
+    requestedBy: string | null
+    namespace: string | null
+    vcsRepository: string | null
+    vcsBaseBranch: string | null
+    vcsHeadBranch: string | null
+    startedAt: string | null
+    completedAt: string | null
+    failureReason: string | null
+    logArtifactRef: string | null
+    patchArtifactRef: string | null
+    createdAt: string | null
+  } | null
+  agentruns: {
+    id: string
+    name: string
+    status: string
+    requestedBy: string | null
+    namespace: string | null
+    vcsRepository: string | null
+    vcsBaseBranch: string | null
+    vcsHeadBranch: string | null
+    startedAt: string | null
+    completedAt: string | null
+    failureReason: string | null
+    logArtifactRef: string | null
+    patchArtifactRef: string | null
+    createdAt: string | null
+  }[]
+  designPullRequests: {
+    id: string
+    attempt: number | null
+    status: string
+    repository: string | null
+    baseBranch: string | null
+    headBranch: string | null
+    prNumber: number | null
+    prUrl: string | null
+    title: string | null
+    ciStatus: string | null
+    isMerged: boolean
+    mergedAt: string | null
+    createdAt: string | null
+  }[]
+  steps: {
+    id: string
+    stepName: string
+    attempt: number | null
+    status: string
+    executor: string | null
+    startedAt: string | null
+    completedAt: string | null
+    durationMs: number | null
+    error: unknown
+    output: unknown
+    createdAt: string | null
+  }[]
+  artifacts: {
+    id: string
+    artifactScope: string
+    artifactType: string
+    artifactRole: string | null
+    cephBucket: string | null
+    cephObjectKey: string | null
+    artifactUri: string | null
+    contentType: string | null
+    sizeBytes: number | null
+    createdAt: string | null
+  }[]
+}
+
+export type WhitepaperListResult = {
+  ok: true
+  items: WhitepaperListItem[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export type WhitepaperListError = {
+  ok: false
+  message: string
+}
+
+export type WhitepaperDetailResult =
+  | {
+      ok: true
+      item: WhitepaperDetail
+    }
+  | {
+      ok: false
+      message: string
+    }
+
+export type WhitepaperListParams = {
+  query?: string
+  status?: string
+  verdict?: string
+  limit?: number
+  offset?: number
+  signal?: AbortSignal
+}
+
+const toQueryString = (params: WhitepaperListParams) => {
+  const query = new URLSearchParams()
+  if (params.query) query.set('q', params.query)
+  if (params.status) query.set('status', params.status)
+  if (params.verdict) query.set('verdict', params.verdict)
+  if (typeof params.limit === 'number' && Number.isFinite(params.limit)) query.set('limit', String(params.limit))
+  if (typeof params.offset === 'number' && Number.isFinite(params.offset)) query.set('offset', String(params.offset))
+  return query.toString()
+}
+
+export const listWhitepapers = async (
+  params: WhitepaperListParams = {},
+): Promise<WhitepaperListResult | WhitepaperListError> => {
+  const query = toQueryString(params)
+  const url = `/api/whitepapers/${query ? `?${query}` : ''}`
+  const response = await fetch(url, {
+    method: 'GET',
+    signal: params.signal,
+  })
+
+  let payload: unknown = null
+  try {
+    payload = await response.json()
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok || !payload || typeof payload !== 'object' || (payload as Record<string, unknown>).ok !== true) {
+    const message =
+      payload && typeof payload === 'object' && typeof (payload as Record<string, unknown>).message === 'string'
+        ? String((payload as Record<string, unknown>).message)
+        : `Library request failed (${response.status})`
+    return { ok: false, message }
+  }
+
+  return payload as WhitepaperListResult
+}
+
+export const getWhitepaperDetail = async (
+  runId: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<WhitepaperDetailResult> => {
+  const response = await fetch(`/api/whitepapers/${encodeURIComponent(runId)}/`, {
+    method: 'GET',
+    signal: options.signal,
+  })
+
+  let payload: unknown = null
+  try {
+    payload = await response.json()
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok || !payload || typeof payload !== 'object') {
+    return {
+      ok: false,
+      message: `Whitepaper detail request failed (${response.status})`,
+    }
+  }
+
+  if ((payload as Record<string, unknown>).ok !== true) {
+    const message =
+      typeof (payload as Record<string, unknown>).message === 'string'
+        ? String((payload as Record<string, unknown>).message)
+        : 'Whitepaper detail request failed'
+    return {
+      ok: false,
+      message,
+    }
+  }
+
+  return payload as WhitepaperDetailResult
+}
+
+export const whitepaperPdfPath = (runId: string) => `/api/whitepapers/${encodeURIComponent(runId)}/pdf`

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as McpRouteImport } from './routes/mcp'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TerminalsIndexRouteImport } from './routes/terminals/index'
+import { Route as LibraryIndexRouteImport } from './routes/library/index'
 import { Route as ControlPlaneIndexRouteImport } from './routes/control-plane/index'
 import { Route as AtlasIndexRouteImport } from './routes/atlas/index'
 import { Route as AgentsIndexRouteImport } from './routes/agents/index'
@@ -45,6 +46,7 @@ import { Route as ApiCodeSearchRouteImport } from './routes/api/code-search'
 import { Route as AgentsGeneralRouteImport } from './routes/agents/general'
 import { Route as AgentsRunIdRouteImport } from './routes/agents/$runId'
 import { Route as TerminalsSessionIdIndexRouteImport } from './routes/terminals/$sessionId/index'
+import { Route as LibraryWhitepapersIndexRouteImport } from './routes/library/whitepapers/index'
 import { Route as GithubPullsIndexRouteImport } from './routes/github/pulls/index'
 import { Route as ControlPlaneWorkspacesIndexRouteImport } from './routes/control-plane/workspaces/index'
 import { Route as ControlPlaneToolsIndexRouteImport } from './routes/control-plane/tools/index'
@@ -65,6 +67,7 @@ import { Route as ControlPlaneApprovalsIndexRouteImport } from './routes/control
 import { Route as ControlPlaneAgentsIndexRouteImport } from './routes/control-plane/agents/index'
 import { Route as ControlPlaneAgentRunsIndexRouteImport } from './routes/control-plane/agent-runs/index'
 import { Route as ControlPlaneAgentProvidersIndexRouteImport } from './routes/control-plane/agent-providers/index'
+import { Route as ApiWhitepapersIndexRouteImport } from './routes/api/whitepapers/index'
 import { Route as V1RunsIdRouteImport } from './routes/v1/runs/$id'
 import { Route as V1OrchestrationsIdRouteImport } from './routes/v1/orchestrations/$id'
 import { Route as V1OrchestrationRunsIdRouteImport } from './routes/v1/orchestration-runs/$id'
@@ -73,6 +76,7 @@ import { Route as V1AgentsIdRouteImport } from './routes/v1/agents/$id'
 import { Route as V1AgentRunsIdRouteImport } from './routes/v1/agent-runs/$id'
 import { Route as TerminalsSessionIdFullscreenRouteImport } from './routes/terminals/$sessionId/fullscreen'
 import { Route as OpenaiV1ModelsRouteImport } from './routes/openai/v1/models'
+import { Route as LibraryWhitepapersRunIdRouteImport } from './routes/library/whitepapers/$runId'
 import { Route as ControlPlaneWorkspacesNameRouteImport } from './routes/control-plane/workspaces/$name'
 import { Route as ControlPlaneToolsNameRouteImport } from './routes/control-plane/tools/$name'
 import { Route as ControlPlaneToolRunsNameRouteImport } from './routes/control-plane/tool-runs/$name'
@@ -110,8 +114,10 @@ import { Route as ApiAtlasFileRouteImport } from './routes/api/atlas/file'
 import { Route as ApiAtlasAstRouteImport } from './routes/api/atlas/ast'
 import { Route as ApiAgentsEventsRouteImport } from './routes/api/agents/events'
 import { Route as ControlPlaneTorghutQuantIndexRouteImport } from './routes/control-plane/torghut/quant/index'
+import { Route as ApiWhitepapersRunIdIndexRouteImport } from './routes/api/whitepapers/$runId/index'
 import { Route as ApiTorghutMarketContextIndexRouteImport } from './routes/api/torghut/market-context/index'
 import { Route as OpenaiV1ChatCompletionsRouteImport } from './routes/openai/v1/chat/completions'
+import { Route as ApiWhitepapersRunIdPdfRouteImport } from './routes/api/whitepapers/$runId/pdf'
 import { Route as ApiTorghutTradingSummaryRouteImport } from './routes/api/torghut/trading/summary'
 import { Route as ApiTorghutTradingStrategiesRouteImport } from './routes/api/torghut/trading/strategies'
 import { Route as ApiTorghutTradingExecutionsRouteImport } from './routes/api/torghut/trading/executions'
@@ -185,6 +191,11 @@ const IndexRoute = IndexRouteImport.update({
 const TerminalsIndexRoute = TerminalsIndexRouteImport.update({
   id: '/terminals/',
   path: '/terminals/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LibraryIndexRoute = LibraryIndexRouteImport.update({
+  id: '/library/',
+  path: '/library/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ControlPlaneIndexRoute = ControlPlaneIndexRouteImport.update({
@@ -337,6 +348,11 @@ const TerminalsSessionIdIndexRoute = TerminalsSessionIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => TerminalsSessionIdRoute,
 } as any)
+const LibraryWhitepapersIndexRoute = LibraryWhitepapersIndexRouteImport.update({
+  id: '/library/whitepapers/',
+  path: '/library/whitepapers/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const GithubPullsIndexRoute = GithubPullsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -453,6 +469,11 @@ const ControlPlaneAgentProvidersIndexRoute =
     path: '/control-plane/agent-providers/',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiWhitepapersIndexRoute = ApiWhitepapersIndexRouteImport.update({
+  id: '/api/whitepapers/',
+  path: '/api/whitepapers/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const V1RunsIdRoute = V1RunsIdRouteImport.update({
   id: '/v1/runs/$id',
   path: '/v1/runs/$id',
@@ -492,6 +513,11 @@ const TerminalsSessionIdFullscreenRoute =
 const OpenaiV1ModelsRoute = OpenaiV1ModelsRouteImport.update({
   id: '/openai/v1/models',
   path: '/openai/v1/models',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LibraryWhitepapersRunIdRoute = LibraryWhitepapersRunIdRouteImport.update({
+  id: '/library/whitepapers/$runId',
+  path: '/library/whitepapers/$runId',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ControlPlaneWorkspacesNameRoute =
@@ -695,6 +721,12 @@ const ControlPlaneTorghutQuantIndexRoute =
     path: '/control-plane/torghut/quant/',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiWhitepapersRunIdIndexRoute =
+  ApiWhitepapersRunIdIndexRouteImport.update({
+    id: '/api/whitepapers/$runId/',
+    path: '/api/whitepapers/$runId/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiTorghutMarketContextIndexRoute =
   ApiTorghutMarketContextIndexRouteImport.update({
     id: '/api/torghut/market-context/',
@@ -704,6 +736,11 @@ const ApiTorghutMarketContextIndexRoute =
 const OpenaiV1ChatCompletionsRoute = OpenaiV1ChatCompletionsRouteImport.update({
   id: '/openai/v1/chat/completions',
   path: '/openai/v1/chat/completions',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiWhitepapersRunIdPdfRoute = ApiWhitepapersRunIdPdfRouteImport.update({
+  id: '/api/whitepapers/$runId/pdf',
+  path: '/api/whitepapers/$runId/pdf',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiTorghutTradingSummaryRoute =
@@ -999,6 +1036,7 @@ export interface FileRoutesByFullPath {
   '/agents/': typeof AgentsIndexRoute
   '/atlas/': typeof AtlasIndexRoute
   '/control-plane/': typeof ControlPlaneIndexRoute
+  '/library/': typeof LibraryIndexRoute
   '/terminals/': typeof TerminalsIndexRoute
   '/api/agents/events': typeof ApiAgentsEventsRoute
   '/api/atlas/ast': typeof ApiAtlasAstRoute
@@ -1036,6 +1074,7 @@ export interface FileRoutesByFullPath {
   '/control-plane/tool-runs/$name': typeof ControlPlaneToolRunsNameRoute
   '/control-plane/tools/$name': typeof ControlPlaneToolsNameRoute
   '/control-plane/workspaces/$name': typeof ControlPlaneWorkspacesNameRoute
+  '/library/whitepapers/$runId': typeof LibraryWhitepapersRunIdRoute
   '/openai/v1/models': typeof OpenaiV1ModelsRoute
   '/terminals/$sessionId/fullscreen': typeof TerminalsSessionIdFullscreenRoute
   '/v1/agent-runs/$id': typeof V1AgentRunsIdRoute
@@ -1044,6 +1083,7 @@ export interface FileRoutesByFullPath {
   '/v1/orchestration-runs/$id': typeof V1OrchestrationRunsIdRoute
   '/v1/orchestrations/$id': typeof V1OrchestrationsIdRoute
   '/v1/runs/$id': typeof V1RunsIdRoute
+  '/api/whitepapers/': typeof ApiWhitepapersIndexRoute
   '/control-plane/agent-providers/': typeof ControlPlaneAgentProvidersIndexRoute
   '/control-plane/agent-runs/': typeof ControlPlaneAgentRunsIndexRoute
   '/control-plane/agents/': typeof ControlPlaneAgentsIndexRoute
@@ -1064,6 +1104,7 @@ export interface FileRoutesByFullPath {
   '/control-plane/tools/': typeof ControlPlaneToolsIndexRoute
   '/control-plane/workspaces/': typeof ControlPlaneWorkspacesIndexRoute
   '/github/pulls/': typeof GithubPullsIndexRoute
+  '/library/whitepapers/': typeof LibraryWhitepapersIndexRoute
   '/terminals/$sessionId/': typeof TerminalsSessionIdIndexRoute
   '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
   '/api/agents/control-plane/logs': typeof ApiAgentsControlPlaneLogsRoute
@@ -1091,8 +1132,10 @@ export interface FileRoutesByFullPath {
   '/api/torghut/trading/executions': typeof ApiTorghutTradingExecutionsRoute
   '/api/torghut/trading/strategies': typeof ApiTorghutTradingStrategiesRoute
   '/api/torghut/trading/summary': typeof ApiTorghutTradingSummaryRoute
+  '/api/whitepapers/$runId/pdf': typeof ApiWhitepapersRunIdPdfRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
   '/api/torghut/market-context/': typeof ApiTorghutMarketContextIndexRoute
+  '/api/whitepapers/$runId/': typeof ApiWhitepapersRunIdIndexRoute
   '/control-plane/torghut/quant/': typeof ControlPlaneTorghutQuantIndexRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
@@ -1146,6 +1189,7 @@ export interface FileRoutesByTo {
   '/agents': typeof AgentsIndexRoute
   '/atlas': typeof AtlasIndexRoute
   '/control-plane': typeof ControlPlaneIndexRoute
+  '/library': typeof LibraryIndexRoute
   '/terminals': typeof TerminalsIndexRoute
   '/api/agents/events': typeof ApiAgentsEventsRoute
   '/api/atlas/ast': typeof ApiAtlasAstRoute
@@ -1183,6 +1227,7 @@ export interface FileRoutesByTo {
   '/control-plane/tool-runs/$name': typeof ControlPlaneToolRunsNameRoute
   '/control-plane/tools/$name': typeof ControlPlaneToolsNameRoute
   '/control-plane/workspaces/$name': typeof ControlPlaneWorkspacesNameRoute
+  '/library/whitepapers/$runId': typeof LibraryWhitepapersRunIdRoute
   '/openai/v1/models': typeof OpenaiV1ModelsRoute
   '/terminals/$sessionId/fullscreen': typeof TerminalsSessionIdFullscreenRoute
   '/v1/agent-runs/$id': typeof V1AgentRunsIdRoute
@@ -1191,6 +1236,7 @@ export interface FileRoutesByTo {
   '/v1/orchestration-runs/$id': typeof V1OrchestrationRunsIdRoute
   '/v1/orchestrations/$id': typeof V1OrchestrationsIdRoute
   '/v1/runs/$id': typeof V1RunsIdRoute
+  '/api/whitepapers': typeof ApiWhitepapersIndexRoute
   '/control-plane/agent-providers': typeof ControlPlaneAgentProvidersIndexRoute
   '/control-plane/agent-runs': typeof ControlPlaneAgentRunsIndexRoute
   '/control-plane/agents': typeof ControlPlaneAgentsIndexRoute
@@ -1211,6 +1257,7 @@ export interface FileRoutesByTo {
   '/control-plane/tools': typeof ControlPlaneToolsIndexRoute
   '/control-plane/workspaces': typeof ControlPlaneWorkspacesIndexRoute
   '/github/pulls': typeof GithubPullsIndexRoute
+  '/library/whitepapers': typeof LibraryWhitepapersIndexRoute
   '/terminals/$sessionId': typeof TerminalsSessionIdIndexRoute
   '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
   '/api/agents/control-plane/logs': typeof ApiAgentsControlPlaneLogsRoute
@@ -1238,8 +1285,10 @@ export interface FileRoutesByTo {
   '/api/torghut/trading/executions': typeof ApiTorghutTradingExecutionsRoute
   '/api/torghut/trading/strategies': typeof ApiTorghutTradingStrategiesRoute
   '/api/torghut/trading/summary': typeof ApiTorghutTradingSummaryRoute
+  '/api/whitepapers/$runId/pdf': typeof ApiWhitepapersRunIdPdfRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
   '/api/torghut/market-context': typeof ApiTorghutMarketContextIndexRoute
+  '/api/whitepapers/$runId': typeof ApiWhitepapersRunIdIndexRoute
   '/control-plane/torghut/quant': typeof ControlPlaneTorghutQuantIndexRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
@@ -1296,6 +1345,7 @@ export interface FileRoutesById {
   '/agents/': typeof AgentsIndexRoute
   '/atlas/': typeof AtlasIndexRoute
   '/control-plane/': typeof ControlPlaneIndexRoute
+  '/library/': typeof LibraryIndexRoute
   '/terminals/': typeof TerminalsIndexRoute
   '/api/agents/events': typeof ApiAgentsEventsRoute
   '/api/atlas/ast': typeof ApiAtlasAstRoute
@@ -1333,6 +1383,7 @@ export interface FileRoutesById {
   '/control-plane/tool-runs/$name': typeof ControlPlaneToolRunsNameRoute
   '/control-plane/tools/$name': typeof ControlPlaneToolsNameRoute
   '/control-plane/workspaces/$name': typeof ControlPlaneWorkspacesNameRoute
+  '/library/whitepapers/$runId': typeof LibraryWhitepapersRunIdRoute
   '/openai/v1/models': typeof OpenaiV1ModelsRoute
   '/terminals/$sessionId/fullscreen': typeof TerminalsSessionIdFullscreenRoute
   '/v1/agent-runs/$id': typeof V1AgentRunsIdRoute
@@ -1341,6 +1392,7 @@ export interface FileRoutesById {
   '/v1/orchestration-runs/$id': typeof V1OrchestrationRunsIdRoute
   '/v1/orchestrations/$id': typeof V1OrchestrationsIdRoute
   '/v1/runs/$id': typeof V1RunsIdRoute
+  '/api/whitepapers/': typeof ApiWhitepapersIndexRoute
   '/control-plane/agent-providers/': typeof ControlPlaneAgentProvidersIndexRoute
   '/control-plane/agent-runs/': typeof ControlPlaneAgentRunsIndexRoute
   '/control-plane/agents/': typeof ControlPlaneAgentsIndexRoute
@@ -1361,6 +1413,7 @@ export interface FileRoutesById {
   '/control-plane/tools/': typeof ControlPlaneToolsIndexRoute
   '/control-plane/workspaces/': typeof ControlPlaneWorkspacesIndexRoute
   '/github/pulls/': typeof GithubPullsIndexRoute
+  '/library/whitepapers/': typeof LibraryWhitepapersIndexRoute
   '/terminals/$sessionId/': typeof TerminalsSessionIdIndexRoute
   '/api/agents/control-plane/events': typeof ApiAgentsControlPlaneEventsRoute
   '/api/agents/control-plane/logs': typeof ApiAgentsControlPlaneLogsRoute
@@ -1388,8 +1441,10 @@ export interface FileRoutesById {
   '/api/torghut/trading/executions': typeof ApiTorghutTradingExecutionsRoute
   '/api/torghut/trading/strategies': typeof ApiTorghutTradingStrategiesRoute
   '/api/torghut/trading/summary': typeof ApiTorghutTradingSummaryRoute
+  '/api/whitepapers/$runId/pdf': typeof ApiWhitepapersRunIdPdfRoute
   '/openai/v1/chat/completions': typeof OpenaiV1ChatCompletionsRoute
   '/api/torghut/market-context/': typeof ApiTorghutMarketContextIndexRoute
+  '/api/whitepapers/$runId/': typeof ApiWhitepapersRunIdIndexRoute
   '/control-plane/torghut/quant/': typeof ControlPlaneTorghutQuantIndexRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
@@ -1447,6 +1502,7 @@ export interface FileRouteTypes {
     | '/agents/'
     | '/atlas/'
     | '/control-plane/'
+    | '/library/'
     | '/terminals/'
     | '/api/agents/events'
     | '/api/atlas/ast'
@@ -1484,6 +1540,7 @@ export interface FileRouteTypes {
     | '/control-plane/tool-runs/$name'
     | '/control-plane/tools/$name'
     | '/control-plane/workspaces/$name'
+    | '/library/whitepapers/$runId'
     | '/openai/v1/models'
     | '/terminals/$sessionId/fullscreen'
     | '/v1/agent-runs/$id'
@@ -1492,6 +1549,7 @@ export interface FileRouteTypes {
     | '/v1/orchestration-runs/$id'
     | '/v1/orchestrations/$id'
     | '/v1/runs/$id'
+    | '/api/whitepapers/'
     | '/control-plane/agent-providers/'
     | '/control-plane/agent-runs/'
     | '/control-plane/agents/'
@@ -1512,6 +1570,7 @@ export interface FileRouteTypes {
     | '/control-plane/tools/'
     | '/control-plane/workspaces/'
     | '/github/pulls/'
+    | '/library/whitepapers/'
     | '/terminals/$sessionId/'
     | '/api/agents/control-plane/events'
     | '/api/agents/control-plane/logs'
@@ -1539,8 +1598,10 @@ export interface FileRouteTypes {
     | '/api/torghut/trading/executions'
     | '/api/torghut/trading/strategies'
     | '/api/torghut/trading/summary'
+    | '/api/whitepapers/$runId/pdf'
     | '/openai/v1/chat/completions'
     | '/api/torghut/market-context/'
+    | '/api/whitepapers/$runId/'
     | '/control-plane/torghut/quant/'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/torghut/decision-engine/runs/$id'
@@ -1594,6 +1655,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/atlas'
     | '/control-plane'
+    | '/library'
     | '/terminals'
     | '/api/agents/events'
     | '/api/atlas/ast'
@@ -1631,6 +1693,7 @@ export interface FileRouteTypes {
     | '/control-plane/tool-runs/$name'
     | '/control-plane/tools/$name'
     | '/control-plane/workspaces/$name'
+    | '/library/whitepapers/$runId'
     | '/openai/v1/models'
     | '/terminals/$sessionId/fullscreen'
     | '/v1/agent-runs/$id'
@@ -1639,6 +1702,7 @@ export interface FileRouteTypes {
     | '/v1/orchestration-runs/$id'
     | '/v1/orchestrations/$id'
     | '/v1/runs/$id'
+    | '/api/whitepapers'
     | '/control-plane/agent-providers'
     | '/control-plane/agent-runs'
     | '/control-plane/agents'
@@ -1659,6 +1723,7 @@ export interface FileRouteTypes {
     | '/control-plane/tools'
     | '/control-plane/workspaces'
     | '/github/pulls'
+    | '/library/whitepapers'
     | '/terminals/$sessionId'
     | '/api/agents/control-plane/events'
     | '/api/agents/control-plane/logs'
@@ -1686,8 +1751,10 @@ export interface FileRouteTypes {
     | '/api/torghut/trading/executions'
     | '/api/torghut/trading/strategies'
     | '/api/torghut/trading/summary'
+    | '/api/whitepapers/$runId/pdf'
     | '/openai/v1/chat/completions'
     | '/api/torghut/market-context'
+    | '/api/whitepapers/$runId'
     | '/control-plane/torghut/quant'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/torghut/decision-engine/runs/$id'
@@ -1743,6 +1810,7 @@ export interface FileRouteTypes {
     | '/agents/'
     | '/atlas/'
     | '/control-plane/'
+    | '/library/'
     | '/terminals/'
     | '/api/agents/events'
     | '/api/atlas/ast'
@@ -1780,6 +1848,7 @@ export interface FileRouteTypes {
     | '/control-plane/tool-runs/$name'
     | '/control-plane/tools/$name'
     | '/control-plane/workspaces/$name'
+    | '/library/whitepapers/$runId'
     | '/openai/v1/models'
     | '/terminals/$sessionId/fullscreen'
     | '/v1/agent-runs/$id'
@@ -1788,6 +1857,7 @@ export interface FileRouteTypes {
     | '/v1/orchestration-runs/$id'
     | '/v1/orchestrations/$id'
     | '/v1/runs/$id'
+    | '/api/whitepapers/'
     | '/control-plane/agent-providers/'
     | '/control-plane/agent-runs/'
     | '/control-plane/agents/'
@@ -1808,6 +1878,7 @@ export interface FileRouteTypes {
     | '/control-plane/tools/'
     | '/control-plane/workspaces/'
     | '/github/pulls/'
+    | '/library/whitepapers/'
     | '/terminals/$sessionId/'
     | '/api/agents/control-plane/events'
     | '/api/agents/control-plane/logs'
@@ -1835,8 +1906,10 @@ export interface FileRouteTypes {
     | '/api/torghut/trading/executions'
     | '/api/torghut/trading/strategies'
     | '/api/torghut/trading/summary'
+    | '/api/whitepapers/$runId/pdf'
     | '/openai/v1/chat/completions'
     | '/api/torghut/market-context/'
+    | '/api/whitepapers/$runId/'
     | '/control-plane/torghut/quant/'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/torghut/decision-engine/runs/$id'
@@ -1893,6 +1966,7 @@ export interface RootRouteChildren {
   AgentsIndexRoute: typeof AgentsIndexRoute
   AtlasIndexRoute: typeof AtlasIndexRoute
   ControlPlaneIndexRoute: typeof ControlPlaneIndexRoute
+  LibraryIndexRoute: typeof LibraryIndexRoute
   TerminalsIndexRoute: typeof TerminalsIndexRoute
   ApiAgentsEventsRoute: typeof ApiAgentsEventsRoute
   ApiAtlasAstRoute: typeof ApiAtlasAstRoute
@@ -1927,8 +2001,10 @@ export interface RootRouteChildren {
   ControlPlaneToolRunsNameRoute: typeof ControlPlaneToolRunsNameRoute
   ControlPlaneToolsNameRoute: typeof ControlPlaneToolsNameRoute
   ControlPlaneWorkspacesNameRoute: typeof ControlPlaneWorkspacesNameRoute
+  LibraryWhitepapersRunIdRoute: typeof LibraryWhitepapersRunIdRoute
   OpenaiV1ModelsRoute: typeof OpenaiV1ModelsRoute
   V1RunsIdRoute: typeof V1RunsIdRoute
+  ApiWhitepapersIndexRoute: typeof ApiWhitepapersIndexRoute
   ControlPlaneAgentProvidersIndexRoute: typeof ControlPlaneAgentProvidersIndexRoute
   ControlPlaneAgentRunsIndexRoute: typeof ControlPlaneAgentRunsIndexRoute
   ControlPlaneAgentsIndexRoute: typeof ControlPlaneAgentsIndexRoute
@@ -1948,6 +2024,7 @@ export interface RootRouteChildren {
   ControlPlaneToolRunsIndexRoute: typeof ControlPlaneToolRunsIndexRoute
   ControlPlaneToolsIndexRoute: typeof ControlPlaneToolsIndexRoute
   ControlPlaneWorkspacesIndexRoute: typeof ControlPlaneWorkspacesIndexRoute
+  LibraryWhitepapersIndexRoute: typeof LibraryWhitepapersIndexRoute
   ApiAgentsControlPlaneEventsRoute: typeof ApiAgentsControlPlaneEventsRoute
   ApiAgentsControlPlaneLogsRoute: typeof ApiAgentsControlPlaneLogsRoute
   ApiAgentsControlPlaneResourceRoute: typeof ApiAgentsControlPlaneResourceRoute
@@ -1965,8 +2042,10 @@ export interface RootRouteChildren {
   ApiTorghutTradingExecutionsRoute: typeof ApiTorghutTradingExecutionsRoute
   ApiTorghutTradingStrategiesRoute: typeof ApiTorghutTradingStrategiesRoute
   ApiTorghutTradingSummaryRoute: typeof ApiTorghutTradingSummaryRoute
+  ApiWhitepapersRunIdPdfRoute: typeof ApiWhitepapersRunIdPdfRoute
   OpenaiV1ChatCompletionsRoute: typeof OpenaiV1ChatCompletionsRoute
   ApiTorghutMarketContextIndexRoute: typeof ApiTorghutMarketContextIndexRoute
+  ApiWhitepapersRunIdIndexRoute: typeof ApiWhitepapersRunIdIndexRoute
   ControlPlaneTorghutQuantIndexRoute: typeof ControlPlaneTorghutQuantIndexRoute
   ApiAgentsImplementationSourcesWebhooksProviderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   ApiTorghutTradingControlPlaneLlmRolloutRoute: typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
@@ -2019,6 +2098,13 @@ declare module '@tanstack/react-router' {
       path: '/terminals'
       fullPath: '/terminals/'
       preLoaderRoute: typeof TerminalsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/library/': {
+      id: '/library/'
+      path: '/library'
+      fullPath: '/library/'
+      preLoaderRoute: typeof LibraryIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/control-plane/': {
@@ -2231,6 +2317,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TerminalsSessionIdIndexRouteImport
       parentRoute: typeof TerminalsSessionIdRoute
     }
+    '/library/whitepapers/': {
+      id: '/library/whitepapers/'
+      path: '/library/whitepapers'
+      fullPath: '/library/whitepapers/'
+      preLoaderRoute: typeof LibraryWhitepapersIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/github/pulls/': {
       id: '/github/pulls/'
       path: '/'
@@ -2371,6 +2464,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ControlPlaneAgentProvidersIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/whitepapers/': {
+      id: '/api/whitepapers/'
+      path: '/api/whitepapers'
+      fullPath: '/api/whitepapers/'
+      preLoaderRoute: typeof ApiWhitepapersIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/v1/runs/$id': {
       id: '/v1/runs/$id'
       path: '/v1/runs/$id'
@@ -2425,6 +2525,13 @@ declare module '@tanstack/react-router' {
       path: '/openai/v1/models'
       fullPath: '/openai/v1/models'
       preLoaderRoute: typeof OpenaiV1ModelsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/library/whitepapers/$runId': {
+      id: '/library/whitepapers/$runId'
+      path: '/library/whitepapers/$runId'
+      fullPath: '/library/whitepapers/$runId'
+      preLoaderRoute: typeof LibraryWhitepapersRunIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/control-plane/workspaces/$name': {
@@ -2686,6 +2793,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ControlPlaneTorghutQuantIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/whitepapers/$runId/': {
+      id: '/api/whitepapers/$runId/'
+      path: '/api/whitepapers/$runId'
+      fullPath: '/api/whitepapers/$runId/'
+      preLoaderRoute: typeof ApiWhitepapersRunIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/torghut/market-context/': {
       id: '/api/torghut/market-context/'
       path: '/api/torghut/market-context'
@@ -2698,6 +2812,13 @@ declare module '@tanstack/react-router' {
       path: '/openai/v1/chat/completions'
       fullPath: '/openai/v1/chat/completions'
       preLoaderRoute: typeof OpenaiV1ChatCompletionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/whitepapers/$runId/pdf': {
+      id: '/api/whitepapers/$runId/pdf'
+      path: '/api/whitepapers/$runId/pdf'
+      fullPath: '/api/whitepapers/$runId/pdf'
+      preLoaderRoute: typeof ApiWhitepapersRunIdPdfRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/torghut/trading/summary': {
@@ -3280,6 +3401,7 @@ const rootRouteChildren: RootRouteChildren = {
   AgentsIndexRoute: AgentsIndexRoute,
   AtlasIndexRoute: AtlasIndexRoute,
   ControlPlaneIndexRoute: ControlPlaneIndexRoute,
+  LibraryIndexRoute: LibraryIndexRoute,
   TerminalsIndexRoute: TerminalsIndexRoute,
   ApiAgentsEventsRoute: ApiAgentsEventsRoute,
   ApiAtlasAstRoute: ApiAtlasAstRoute,
@@ -3318,8 +3440,10 @@ const rootRouteChildren: RootRouteChildren = {
   ControlPlaneToolRunsNameRoute: ControlPlaneToolRunsNameRoute,
   ControlPlaneToolsNameRoute: ControlPlaneToolsNameRoute,
   ControlPlaneWorkspacesNameRoute: ControlPlaneWorkspacesNameRoute,
+  LibraryWhitepapersRunIdRoute: LibraryWhitepapersRunIdRoute,
   OpenaiV1ModelsRoute: OpenaiV1ModelsRoute,
   V1RunsIdRoute: V1RunsIdRoute,
+  ApiWhitepapersIndexRoute: ApiWhitepapersIndexRoute,
   ControlPlaneAgentProvidersIndexRoute: ControlPlaneAgentProvidersIndexRoute,
   ControlPlaneAgentRunsIndexRoute: ControlPlaneAgentRunsIndexRoute,
   ControlPlaneAgentsIndexRoute: ControlPlaneAgentsIndexRoute,
@@ -3343,6 +3467,7 @@ const rootRouteChildren: RootRouteChildren = {
   ControlPlaneToolRunsIndexRoute: ControlPlaneToolRunsIndexRoute,
   ControlPlaneToolsIndexRoute: ControlPlaneToolsIndexRoute,
   ControlPlaneWorkspacesIndexRoute: ControlPlaneWorkspacesIndexRoute,
+  LibraryWhitepapersIndexRoute: LibraryWhitepapersIndexRoute,
   ApiAgentsControlPlaneEventsRoute: ApiAgentsControlPlaneEventsRoute,
   ApiAgentsControlPlaneLogsRoute: ApiAgentsControlPlaneLogsRoute,
   ApiAgentsControlPlaneResourceRoute: ApiAgentsControlPlaneResourceRoute,
@@ -3361,8 +3486,10 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTorghutTradingExecutionsRoute: ApiTorghutTradingExecutionsRoute,
   ApiTorghutTradingStrategiesRoute: ApiTorghutTradingStrategiesRoute,
   ApiTorghutTradingSummaryRoute: ApiTorghutTradingSummaryRoute,
+  ApiWhitepapersRunIdPdfRoute: ApiWhitepapersRunIdPdfRoute,
   OpenaiV1ChatCompletionsRoute: OpenaiV1ChatCompletionsRoute,
   ApiTorghutMarketContextIndexRoute: ApiTorghutMarketContextIndexRoute,
+  ApiWhitepapersRunIdIndexRoute: ApiWhitepapersRunIdIndexRoute,
   ControlPlaneTorghutQuantIndexRoute: ControlPlaneTorghutQuantIndexRoute,
   ApiAgentsImplementationSourcesWebhooksProviderRoute:
     ApiAgentsImplementationSourcesWebhooksProviderRoute,

--- a/services/jangar/src/routes/api/whitepapers/$runId/-index.test.ts
+++ b/services/jangar/src/routes/api/whitepapers/$runId/-index.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const resolveTorghutDb = vi.fn()
+const getTorghutWhitepaperDetail = vi.fn()
+
+vi.mock('~/server/torghut-trading-db', () => ({
+  resolveTorghutDb,
+}))
+
+vi.mock('~/server/torghut-whitepapers', () => ({
+  getTorghutWhitepaperDetail,
+}))
+
+describe('getWhitepaperDetailHandler', () => {
+  beforeEach(() => {
+    resolveTorghutDb.mockReset()
+    getTorghutWhitepaperDetail.mockReset()
+  })
+
+  it('returns 404 when run is missing', async () => {
+    const pool = {}
+    resolveTorghutDb.mockReturnValueOnce({ ok: true, pool })
+    getTorghutWhitepaperDetail.mockResolvedValueOnce(null)
+
+    const { getWhitepaperDetailHandler } = await import('./index')
+    const response = await getWhitepaperDetailHandler('wp-missing')
+
+    expect(response.status).toBe(404)
+    expect(getTorghutWhitepaperDetail).toHaveBeenCalledWith({ pool, runId: 'wp-missing' })
+
+    const body = await response.json()
+    expect(body).toEqual({ ok: false, message: 'whitepaper run not found' })
+  })
+
+  it('returns detail payload for run id', async () => {
+    const pool = {}
+    resolveTorghutDb.mockReturnValueOnce({ ok: true, pool })
+    getTorghutWhitepaperDetail.mockResolvedValueOnce({ run: { runId: 'wp-1' } })
+
+    const { getWhitepaperDetailHandler } = await import('./index')
+    const response = await getWhitepaperDetailHandler(' wp-1 ')
+
+    expect(response.status).toBe(200)
+    expect(getTorghutWhitepaperDetail).toHaveBeenCalledWith({ pool, runId: 'wp-1' })
+
+    const body = await response.json()
+    expect(body).toEqual({ ok: true, item: { run: { runId: 'wp-1' } } })
+  })
+})

--- a/services/jangar/src/routes/api/whitepapers/$runId/-pdf.test.ts
+++ b/services/jangar/src/routes/api/whitepapers/$runId/-pdf.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const resolveTorghutDb = vi.fn()
+const getTorghutWhitepaperPdfLocator = vi.fn()
+const streamTorghutWhitepaperPdf = vi.fn()
+
+vi.mock('~/server/torghut-trading-db', () => ({
+  resolveTorghutDb,
+}))
+
+vi.mock('~/server/torghut-whitepapers', () => ({
+  getTorghutWhitepaperPdfLocator,
+  streamTorghutWhitepaperPdf,
+}))
+
+describe('getWhitepaperPdfHandler', () => {
+  beforeEach(() => {
+    resolveTorghutDb.mockReset()
+    getTorghutWhitepaperPdfLocator.mockReset()
+    streamTorghutWhitepaperPdf.mockReset()
+  })
+
+  it('returns 404 when locator is missing', async () => {
+    const pool = {}
+    resolveTorghutDb.mockReturnValueOnce({ ok: true, pool })
+    getTorghutWhitepaperPdfLocator.mockResolvedValueOnce(null)
+
+    const { getWhitepaperPdfHandler } = await import('./pdf')
+    const response = await getWhitepaperPdfHandler('wp-missing')
+
+    expect(response.status).toBe(404)
+    expect(getTorghutWhitepaperPdfLocator).toHaveBeenCalledWith({ pool, runId: 'wp-missing' })
+    expect(streamTorghutWhitepaperPdf).not.toHaveBeenCalled()
+
+    const body = await response.json()
+    expect(body).toEqual({ ok: false, message: 'whitepaper run not found' })
+  })
+
+  it('returns pdf response when stream succeeds', async () => {
+    const pool = {}
+    resolveTorghutDb.mockReturnValueOnce({ ok: true, pool })
+    getTorghutWhitepaperPdfLocator.mockResolvedValueOnce({
+      runId: 'wp-1',
+      fileName: 'source.pdf',
+      cephBucket: 'bucket',
+      cephObjectKey: 'key',
+      sourceAttachmentUrl: null,
+    })
+    streamTorghutWhitepaperPdf.mockResolvedValueOnce(
+      new Response('pdf', {
+        status: 200,
+        headers: {
+          'content-type': 'application/pdf',
+        },
+      }),
+    )
+
+    const { getWhitepaperPdfHandler } = await import('./pdf')
+    const response = await getWhitepaperPdfHandler('wp-1')
+
+    expect(response.status).toBe(200)
+    expect(streamTorghutWhitepaperPdf).toHaveBeenCalledWith({
+      runId: 'wp-1',
+      fileName: 'source.pdf',
+      cephBucket: 'bucket',
+      cephObjectKey: 'key',
+      sourceAttachmentUrl: null,
+    })
+    expect(await response.text()).toBe('pdf')
+  })
+})

--- a/services/jangar/src/routes/api/whitepapers/$runId/index.ts
+++ b/services/jangar/src/routes/api/whitepapers/$runId/index.ts
@@ -1,0 +1,40 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { resolveTorghutDb } from '~/server/torghut-trading-db'
+import { getTorghutWhitepaperDetail } from '~/server/torghut-whitepapers'
+
+export const Route = createFileRoute('/api/whitepapers/$runId/')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => getWhitepaperDetailHandler(params.runId),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getWhitepaperDetailHandler = async (runIdRaw: string) => {
+  const torghut = resolveTorghutDb()
+  if (!torghut.ok) return jsonResponse({ ok: false, disabled: true, message: torghut.message }, 503)
+
+  const runId = runIdRaw.trim()
+  if (!runId) return jsonResponse({ ok: false, message: 'run id is required' }, 400)
+
+  try {
+    const item = await getTorghutWhitepaperDetail({ pool: torghut.pool, runId })
+    if (!item) return jsonResponse({ ok: false, message: 'whitepaper run not found' }, 404)
+
+    return jsonResponse({ ok: true, item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load whitepaper run'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/routes/api/whitepapers/$runId/pdf.ts
+++ b/services/jangar/src/routes/api/whitepapers/$runId/pdf.ts
@@ -1,0 +1,43 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { resolveTorghutDb } from '~/server/torghut-trading-db'
+import { getTorghutWhitepaperPdfLocator, streamTorghutWhitepaperPdf } from '~/server/torghut-whitepapers'
+
+export const Route = createFileRoute('/api/whitepapers/$runId/pdf')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => getWhitepaperPdfHandler(params.runId),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getWhitepaperPdfHandler = async (runIdRaw: string) => {
+  const torghut = resolveTorghutDb()
+  if (!torghut.ok) return jsonResponse({ ok: false, disabled: true, message: torghut.message }, 503)
+
+  const runId = runIdRaw.trim()
+  if (!runId) return jsonResponse({ ok: false, message: 'run id is required' }, 400)
+
+  try {
+    const locator = await getTorghutWhitepaperPdfLocator({ pool: torghut.pool, runId })
+    if (!locator) return jsonResponse({ ok: false, message: 'whitepaper run not found' }, 404)
+
+    const response = await streamTorghutWhitepaperPdf(locator)
+    if (response) return response
+
+    return jsonResponse({ ok: false, message: 'whitepaper pdf unavailable' }, 502)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to stream whitepaper pdf'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/routes/api/whitepapers/-index.test.ts
+++ b/services/jangar/src/routes/api/whitepapers/-index.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const resolveTorghutDb = vi.fn()
+const listTorghutWhitepapers = vi.fn()
+
+vi.mock('~/server/torghut-trading-db', () => ({
+  resolveTorghutDb,
+}))
+
+vi.mock('~/server/torghut-whitepapers', () => ({
+  listTorghutWhitepapers,
+}))
+
+describe('getWhitepapersHandler', () => {
+  beforeEach(() => {
+    resolveTorghutDb.mockReset()
+    listTorghutWhitepapers.mockReset()
+  })
+
+  it('returns 503 when Torghut DB is disabled', async () => {
+    resolveTorghutDb.mockReturnValueOnce({ ok: false, disabled: true, message: 'db disabled' })
+
+    const { getWhitepapersHandler } = await import('./index')
+    const response = await getWhitepapersHandler(new Request('http://localhost/api/whitepapers/'))
+
+    expect(response.status).toBe(503)
+    expect(listTorghutWhitepapers).not.toHaveBeenCalled()
+
+    const body = await response.json()
+    expect(body).toEqual({ ok: false, disabled: true, message: 'db disabled' })
+  })
+
+  it('returns list payload with parsed filters', async () => {
+    const pool = {}
+    resolveTorghutDb.mockReturnValueOnce({ ok: true, pool })
+    listTorghutWhitepapers.mockResolvedValueOnce({
+      items: [{ runId: 'wp-1' }],
+      total: 1,
+      limit: 30,
+      offset: 0,
+    })
+
+    const { getWhitepapersHandler } = await import('./index')
+    const response = await getWhitepapersHandler(
+      new Request('http://localhost/api/whitepapers/?q=janus&status=completed&verdict=implement&limit=20&offset=5'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(listTorghutWhitepapers).toHaveBeenCalledWith({
+      pool,
+      query: 'janus',
+      status: 'completed',
+      verdict: 'implement',
+      limit: 20,
+      offset: 5,
+    })
+
+    const body = await response.json()
+    expect(body).toEqual({
+      ok: true,
+      items: [{ runId: 'wp-1' }],
+      total: 1,
+      limit: 30,
+      offset: 0,
+    })
+  })
+})

--- a/services/jangar/src/routes/api/whitepapers/index.ts
+++ b/services/jangar/src/routes/api/whitepapers/index.ts
@@ -1,0 +1,66 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { resolveTorghutDb } from '~/server/torghut-trading-db'
+import { listTorghutWhitepapers } from '~/server/torghut-whitepapers'
+
+export const Route = createFileRoute('/api/whitepapers/')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getWhitepapersHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const parseInteger = (value: string | null | undefined): number | undefined => {
+  if (!value) return undefined
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) return undefined
+  return parsed
+}
+
+const parseFilterValue = (value: string | null): string | undefined => {
+  if (value === null) return undefined
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+export const getWhitepapersHandler = async (request: Request) => {
+  const torghut = resolveTorghutDb()
+  if (!torghut.ok) return jsonResponse({ ok: false, disabled: true, message: torghut.message }, 503)
+
+  const url = new URL(request.url)
+  const limit = parseInteger(url.searchParams.get('limit'))
+  const offset = parseInteger(url.searchParams.get('offset'))
+  const query = parseFilterValue(url.searchParams.get('q'))
+  const status = parseFilterValue(url.searchParams.get('status'))
+  const verdict = parseFilterValue(url.searchParams.get('verdict'))
+
+  try {
+    const result = await listTorghutWhitepapers({
+      pool: torghut.pool,
+      limit,
+      offset,
+      query,
+      status,
+      verdict,
+    })
+
+    return jsonResponse({
+      ok: true,
+      ...result,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load whitepaper library'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/routes/library/index.tsx
+++ b/services/jangar/src/routes/library/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/library/')({
+  beforeLoad: () => {
+    throw redirect({ to: '/library/whitepapers', replace: true })
+  },
+})

--- a/services/jangar/src/routes/library/whitepapers/$runId.tsx
+++ b/services/jangar/src/routes/library/whitepapers/$runId.tsx
@@ -1,0 +1,404 @@
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  ScrollArea,
+  Skeleton,
+} from '@proompteng/design/ui'
+import { IconExternalLink } from '@tabler/icons-react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import * as React from 'react'
+import ReactMarkdown from 'react-markdown'
+
+import { getWhitepaperDetail, type WhitepaperDetail, whitepaperPdfPath } from '@/data/whitepapers'
+import { cn } from '@/lib/utils'
+
+export const Route = createFileRoute('/library/whitepapers/$runId')({
+  component: LibraryWhitepaperDetailRoute,
+})
+
+const statusTone = (status: string) => {
+  if (status === 'completed') return 'bg-emerald-100 text-emerald-950 border-emerald-200'
+  if (status === 'failed') return 'bg-rose-100 text-rose-950 border-rose-200'
+  if (status === 'agentrun_dispatched') return 'bg-blue-100 text-blue-950 border-blue-200'
+  if (status === 'queued') return 'bg-amber-100 text-amber-950 border-amber-200'
+  return 'bg-zinc-100 text-zinc-950 border-zinc-200'
+}
+
+const verdictTone = (verdict: string) => {
+  if (verdict === 'implement') return 'bg-emerald-100 text-emerald-950 border-emerald-200'
+  if (verdict === 'reject') return 'bg-rose-100 text-rose-950 border-rose-200'
+  return 'bg-zinc-100 text-zinc-950 border-zinc-200'
+}
+
+const formatDate = (value: string | null) => {
+  if (!value) return 'n/a'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+const formatConfidence = (value: number | null) => {
+  if (value === null || Number.isNaN(value)) return 'n/a'
+  return value.toFixed(3)
+}
+
+const toLines = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? entry : null))
+      .filter((entry): entry is string => Boolean(entry))
+  }
+  if (typeof value === 'string' && value.trim()) return [value]
+  return []
+}
+
+function LibraryWhitepaperDetailRoute() {
+  const { runId } = Route.useParams()
+  const [detail, setDetail] = React.useState<WhitepaperDetail | null>(null)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  const loadDetail = React.useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    const result = await getWhitepaperDetail(runId)
+    if (!result.ok) {
+      setDetail(null)
+      setError(result.message)
+      setLoading(false)
+      return
+    }
+
+    setDetail(result.item)
+    setLoading(false)
+  }, [runId])
+
+  React.useEffect(() => {
+    void loadDetail()
+  }, [loadDetail])
+
+  const title = detail?.document.title ?? runId
+
+  return (
+    <div className="h-full w-full overflow-auto">
+      <div className="mx-auto w-full max-w-[1440px] p-6">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+            <p className="font-mono text-[0.72rem] text-muted-foreground">{runId}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" asChild>
+              <Link to="/library/whitepapers">Back to list</Link>
+            </Button>
+            {detail?.run.status ? (
+              <Badge
+                variant="outline"
+                className={cn('font-mono text-[0.65rem] px-2 py-0.5', statusTone(detail.run.status))}
+              >
+                {detail.run.status}
+              </Badge>
+            ) : null}
+            {detail?.verdict?.verdict ? (
+              <Badge
+                variant="outline"
+                className={cn('font-mono text-[0.65rem] px-2 py-0.5', verdictTone(detail.verdict.verdict))}
+              >
+                {detail.verdict.verdict}
+              </Badge>
+            ) : null}
+          </div>
+        </div>
+
+        {loading ? (
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-5 w-1/3" />
+              <Skeleton className="h-4 w-1/2" />
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {error ? (
+          <Card className="border-rose-300 bg-rose-50">
+            <CardHeader>
+              <CardTitle className="text-sm text-rose-950">Failed to load whitepaper details</CardTitle>
+              <CardDescription className="text-rose-900">{error}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button variant="outline" onClick={() => void loadDetail()}>
+                Retry
+              </Button>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {detail ? (
+          <>
+            <div className="hidden h-[72vh] min-h-[680px] overflow-hidden rounded-lg border md:block">
+              <div className="grid h-full grid-cols-2">
+                <div className="border-r">
+                  <PdfPane runId={runId} detail={detail} />
+                </div>
+                <AnalysisPane detail={detail} />
+              </div>
+            </div>
+
+            <div className="space-y-4 md:hidden">
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm">Whitepaper PDF</CardTitle>
+                  <CardDescription>{detail.version.fileName ?? 'source.pdf'}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="h-[52vh] overflow-hidden rounded-md border">
+                    <iframe
+                      src={whitepaperPdfPath(runId)}
+                      title={`whitepaper-${runId}`}
+                      className="h-full w-full border-0"
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+              <AnalysisPane detail={detail} />
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function PdfPane({ runId, detail }: { runId: string; detail: WhitepaperDetail }) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium">Whitepaper PDF</div>
+          <div className="truncate font-mono text-[0.7rem] text-muted-foreground">
+            {detail.version.fileName ?? 'source.pdf'}
+          </div>
+        </div>
+        {detail.pdf.sourceAttachmentUrl ? (
+          <Button variant="outline" size="sm" asChild>
+            <a href={detail.pdf.sourceAttachmentUrl} target="_blank" rel="noreferrer">
+              Source
+              <IconExternalLink className="ml-1 h-3.5 w-3.5" />
+            </a>
+          </Button>
+        ) : null}
+      </div>
+      <div className="flex-1 bg-zinc-100">
+        <iframe src={whitepaperPdfPath(runId)} title={`whitepaper-${runId}`} className="h-full w-full border-0" />
+      </div>
+    </div>
+  )
+}
+
+function AnalysisPane({ detail }: { detail: WhitepaperDetail }) {
+  const keyFindings = detail.synthesis?.keyFindings ?? []
+  const recommendations = detail.verdict?.recommendations ?? []
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="space-y-4 p-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Run summary</CardTitle>
+            <CardDescription>{detail.document.sourceIdentifier ?? 'No source identifier'}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-2 text-xs md:grid-cols-2">
+            <Row label="Created" value={formatDate(detail.run.createdAt)} />
+            <Row label="Completed" value={formatDate(detail.run.completedAt)} />
+            <Row label="Trigger" value={detail.run.triggerSource} />
+            <Row label="Parse status" value={detail.version.parseStatus ?? 'n/a'} />
+            <Row label="AgentRun" value={detail.latestAgentrun?.status ?? 'n/a'} />
+            <Row label="Verdict confidence" value={formatConfidence(detail.verdict?.confidence ?? null)} />
+            <Row label="Failure reason" value={detail.run.failureReason ?? 'n/a'} className="md:col-span-2" />
+          </CardContent>
+        </Card>
+
+        {detail.run.status === 'failed' ? (
+          <Card className="border-amber-300 bg-amber-50">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-amber-950">Requeue support</CardTitle>
+              <CardDescription className="text-amber-900">
+                Comment <code>research whitepaper</code> on the source GitHub issue to requeue this run.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        ) : null}
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Executive summary</CardTitle>
+            <CardDescription>
+              {detail.synthesis?.methodologySummary ?? 'No methodology summary available.'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-6 text-zinc-900">
+            <p>{detail.synthesis?.executiveSummary ?? 'No synthesis generated yet.'}</p>
+            {keyFindings.length ? (
+              <div>
+                <div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Key findings
+                </div>
+                <ul className="list-disc space-y-1 pl-5">
+                  {keyFindings.map((finding, index) => (
+                    <li key={`${String(index)}-${finding.slice(0, 18)}`}>{finding}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Implementation plan</CardTitle>
+            <CardDescription>Rendered from whitepaper synthesis output.</CardDescription>
+          </CardHeader>
+          <CardContent className="prose prose-zinc max-w-none text-sm">
+            {detail.synthesis?.implementationPlanMd ? (
+              <ReactMarkdown>{detail.synthesis.implementationPlanMd}</ReactMarkdown>
+            ) : (
+              <p>No implementation plan markdown available.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Verdict</CardTitle>
+            <CardDescription>{detail.verdict?.decisionPolicy ?? 'No verdict policy'}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <Row label="Verdict" value={detail.verdict?.verdict ?? 'n/a'} />
+            <Row label="Score" value={formatConfidence(detail.verdict?.score ?? null)} />
+            <Row label="Confidence" value={formatConfidence(detail.verdict?.confidence ?? null)} />
+            <Row label="Requires follow-up" value={detail.verdict?.requiresFollowup ? 'yes' : 'no'} />
+            <Row label="Rationale" value={detail.verdict?.rationale ?? 'n/a'} className="pt-1" />
+            {recommendations.length ? (
+              <div className="pt-1">
+                <div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Recommendations
+                </div>
+                <ul className="list-disc space-y-1 pl-5 text-sm">
+                  {recommendations.map((recommendation, index) => (
+                    <li key={`${String(index)}-${recommendation.slice(0, 18)}`}>{recommendation}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Design pull requests</CardTitle>
+            <CardDescription>Generated design artifacts from AgentRun output.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {detail.designPullRequests.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No design pull requests captured yet.</p>
+            ) : (
+              detail.designPullRequests.map((pr) => (
+                <div key={pr.id} className="rounded-md border p-2 text-xs">
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <div className="font-medium">Attempt {pr.attempt ?? 0}</div>
+                    <Badge variant="outline" className="font-mono text-[0.65rem] px-2 py-0.5">
+                      {pr.status}
+                    </Badge>
+                  </div>
+                  <div className="space-y-1 text-muted-foreground">
+                    <div>{pr.repository ?? 'n/a'}</div>
+                    <div>
+                      {pr.baseBranch ?? 'n/a'} → {pr.headBranch ?? 'n/a'}
+                    </div>
+                    {pr.prUrl ? (
+                      <a
+                        className="inline-flex items-center text-primary underline-offset-4 hover:underline"
+                        href={pr.prUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        PR #{pr.prNumber ?? 'n/a'}
+                        <IconExternalLink className="ml-1 h-3.5 w-3.5" />
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Workflow timeline</CardTitle>
+            <CardDescription>Step-level audit trail for this run.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {detail.steps.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No steps recorded.</p>
+            ) : (
+              detail.steps.map((step) => {
+                const errorLines = toLines(step.error)
+                return (
+                  <div key={step.id} className="rounded-md border p-2 text-xs">
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <div className="font-medium">
+                        {step.stepName} (attempt {step.attempt ?? 1})
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className={cn('font-mono text-[0.65rem] px-2 py-0.5', statusTone(step.status))}
+                      >
+                        {step.status}
+                      </Badge>
+                    </div>
+                    <div className="space-y-1 text-muted-foreground">
+                      <div>Started: {formatDate(step.startedAt)}</div>
+                      <div>Completed: {formatDate(step.completedAt)}</div>
+                      <div>Duration: {step.durationMs ? `${step.durationMs} ms` : 'n/a'}</div>
+                      {errorLines.length ? (
+                        <div className="text-rose-700">
+                          {errorLines.slice(0, 2).map((line, index) => (
+                            <div key={`${step.id}-err-${String(index)}`}>{line}</div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </ScrollArea>
+  )
+}
+
+function Row({ label, value, className }: { label: string; value: string; className?: string }) {
+  return (
+    <div className={cn('text-xs text-muted-foreground', className)}>
+      <span className="mr-1 font-medium text-foreground">{label}:</span>
+      <span>{value}</span>
+    </div>
+  )
+}

--- a/services/jangar/src/routes/library/whitepapers/index.tsx
+++ b/services/jangar/src/routes/library/whitepapers/index.tsx
@@ -1,0 +1,282 @@
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+} from '@proompteng/design/ui'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import * as React from 'react'
+
+import { listWhitepapers, type WhitepaperListItem } from '@/data/whitepapers'
+import { cn } from '@/lib/utils'
+
+export const Route = createFileRoute('/library/whitepapers/')({
+  component: LibraryWhitepapersRoute,
+})
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'queued', label: 'Queued' },
+  { value: 'agentrun_dispatched', label: 'AgentRun dispatched' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+] as const
+
+const VERDICT_OPTIONS = [
+  { value: 'all', label: 'All verdicts' },
+  { value: 'implement', label: 'Implement' },
+  { value: 'investigate', label: 'Investigate' },
+  { value: 'reject', label: 'Reject' },
+] as const
+
+const statusTone = (status: string) => {
+  if (status === 'completed') return 'bg-emerald-100 text-emerald-950 border-emerald-200'
+  if (status === 'failed') return 'bg-rose-100 text-rose-950 border-rose-200'
+  if (status === 'agentrun_dispatched') return 'bg-blue-100 text-blue-950 border-blue-200'
+  if (status === 'queued') return 'bg-amber-100 text-amber-950 border-amber-200'
+  return 'bg-zinc-100 text-zinc-950 border-zinc-200'
+}
+
+const verdictTone = (verdict: string) => {
+  if (verdict === 'implement') return 'bg-emerald-100 text-emerald-950 border-emerald-200'
+  if (verdict === 'reject') return 'bg-rose-100 text-rose-950 border-rose-200'
+  return 'bg-zinc-100 text-zinc-950 border-zinc-200'
+}
+
+const formatDate = (value: string | null) => {
+  if (!value) return 'n/a'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+const formatFileSize = (bytes: number | null) => {
+  if (!bytes || bytes <= 0) return 'n/a'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function LibraryWhitepapersRoute() {
+  const [queryInput, setQueryInput] = React.useState('')
+  const [query, setQuery] = React.useState('')
+  const [status, setStatus] = React.useState<(typeof STATUS_OPTIONS)[number]['value']>('all')
+  const [verdict, setVerdict] = React.useState<(typeof VERDICT_OPTIONS)[number]['value']>('all')
+  const [items, setItems] = React.useState<WhitepaperListItem[]>([])
+  const [total, setTotal] = React.useState(0)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  const loadWhitepapers = React.useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    const result = await listWhitepapers({
+      query: query || undefined,
+      status: status === 'all' ? undefined : status,
+      verdict: verdict === 'all' ? undefined : verdict,
+      limit: 80,
+      offset: 0,
+    })
+
+    if (!result.ok) {
+      setItems([])
+      setTotal(0)
+      setError(result.message)
+      setLoading(false)
+      return
+    }
+
+    setItems(result.items)
+    setTotal(result.total)
+    setLoading(false)
+  }, [query, status, verdict])
+
+  React.useEffect(() => {
+    void loadWhitepapers()
+  }, [loadWhitepapers])
+
+  const submitQuery = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setQuery(queryInput.trim())
+  }
+
+  return (
+    <div className="h-full w-full overflow-auto">
+      <div className="mx-auto w-full max-w-7xl p-6">
+        <div className="mb-6 flex flex-col gap-1">
+          <h1 className="text-lg font-semibold tracking-tight">Library</h1>
+          <p className="text-sm text-muted-foreground">
+            Browse whitepapers processed by Torghut. Open any run to read the source PDF and AgentRun analysis side by
+            side.
+          </p>
+        </div>
+
+        <Card className="mb-4">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm">Filters</CardTitle>
+            <CardDescription>Search by title, run id, or source identifier.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={submitQuery} className="grid gap-3 md:grid-cols-[1fr_200px_200px_auto]">
+              <Input
+                value={queryInput}
+                onChange={(event) => setQueryInput(event.target.value)}
+                placeholder="Search whitepapers"
+                className="w-full"
+              />
+              <Select
+                value={status}
+                onValueChange={(value) => setStatus(value as (typeof STATUS_OPTIONS)[number]['value'])}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {STATUS_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select
+                value={verdict}
+                onValueChange={(value) => setVerdict(value as (typeof VERDICT_OPTIONS)[number]['value'])}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {VERDICT_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button type="submit">Apply</Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="mb-3 text-xs text-muted-foreground">{loading ? 'Loading...' : `${total} result(s)`}</div>
+
+        {loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Card key={String(index)}>
+                <CardHeader className="gap-2">
+                  <Skeleton className="h-4 w-1/2" />
+                  <Skeleton className="h-3 w-1/3" />
+                </CardHeader>
+                <CardContent>
+                  <Skeleton className="h-3 w-full" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : null}
+
+        {error ? (
+          <Card className="border-rose-300 bg-rose-50">
+            <CardHeader>
+              <CardTitle className="text-sm text-rose-950">Library request failed</CardTitle>
+              <CardDescription className="text-rose-900">{error}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button variant="outline" onClick={() => void loadWhitepapers()}>
+                Retry
+              </Button>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {!loading && !error && items.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">No whitepapers found</CardTitle>
+              <CardDescription>Try broadening filters or clear the search query.</CardDescription>
+            </CardHeader>
+          </Card>
+        ) : null}
+
+        {!loading && !error && items.length > 0 ? (
+          <div className="space-y-3">
+            {items.map((item) => (
+              <WhitepaperListCard key={item.runId} item={item} />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function WhitepaperListCard({ item }: { item: WhitepaperListItem }) {
+  const verdictValue = item.verdict?.verdict ?? null
+
+  return (
+    <Card>
+      <CardHeader className="gap-2 pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle className="text-base">{item.document.title ?? item.runId}</CardTitle>
+          <div className="flex items-center gap-2">
+            <Badge variant="outline" className={cn('font-mono text-[0.65rem] px-2 py-0.5', statusTone(item.status))}>
+              {item.status}
+            </Badge>
+            {verdictValue ? (
+              <Badge
+                variant="outline"
+                className={cn('font-mono text-[0.65rem] px-2 py-0.5', verdictTone(verdictValue))}
+              >
+                {verdictValue}
+              </Badge>
+            ) : null}
+          </div>
+        </div>
+        <CardDescription className="font-mono text-[0.7rem]">
+          {item.runId}
+          {item.document.sourceIdentifier ? ` • ${item.document.sourceIdentifier}` : ''}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-2 text-xs text-muted-foreground md:grid-cols-2">
+        <div>
+          <span className="font-medium text-foreground">Created:</span> {formatDate(item.createdAt)}
+        </div>
+        <div>
+          <span className="font-medium text-foreground">Parse:</span> {item.version.parseStatus ?? 'n/a'}
+        </div>
+        <div>
+          <span className="font-medium text-foreground">AgentRun:</span> {item.latestAgentrun?.status ?? 'n/a'}
+        </div>
+        <div>
+          <span className="font-medium text-foreground">File size:</span> {formatFileSize(item.version.fileSizeBytes)}
+        </div>
+        <div className="md:col-span-2">
+          <span className="font-medium text-foreground">Failure reason:</span> {item.failureReason ?? 'n/a'}
+        </div>
+        <div className="md:col-span-2 flex justify-end">
+          <Button asChild>
+            <Link to="/library/whitepapers/$runId" params={{ runId: item.runId }}>
+              Open split view
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary

- Add Torghut trigger-path support for whitepaper research workflows from GitHub issue comments and Kafka events.
- Add idempotent whitepaper run creation/requeue handling keyed for duplicate-safe processing.
- Add a new `Library` entry in Jangar with whitepaper list and split-view detail pages (PDF reader + formatted agent analysis).
- Add Jangar whitepaper APIs for list/detail/pdf backed by Torghut whitepaper tables and object storage streaming.
- Promote Jangar production manifests to image `registry.ide-newton.ts.net/lab/jangar:4ab30a2e@sha256:ae3beabc37faadda33f80ac6ea8e21447f50bb633f2520cdd7a75808d114caf6`.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/routes/api/whitepapers/-index.test.ts src/routes/api/whitepapers/\$runId/-index.test.ts src/routes/api/whitepapers/\$runId/-pdf.test.ts` (from `services/jangar`)
- `bun run tsc && bun run build` (from `services/jangar`)
- `bun run packages/scripts/src/jangar/build-image.ts`
- `bun run packages/scripts/src/jangar/update-manifests.ts --tag 4ab30a2e --digest sha256:ae3beabc37faadda33f80ac6ea8e21447f50bb633f2520cdd7a75808d114caf6`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
