### PR TITLE
chore(jangar): promote image 42ddd627

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 9ce84b30
-  digest: sha256:cdc55eed51cc8fe7eed9fdb80a35418f6f03c80cf824ba52603cba26432593d0
+  tag: 42ddd627
+  digest: sha256:55a126d1348427d358b8df5b68afe7bf053535b92cedad6a3d212a7b4238f8f6
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 9ce84b30
-    digest: sha256:ee1cdde7425bbb0b58f9e825988b3dae908238703740daba3a07816b22daa645
+    tag: 42ddd627
+    digest: sha256:b5edd9818465bb1131d3b9173bea87d50829289f02a34308e0edca4351d77567
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 9ce84b30
-    digest: sha256:cdc55eed51cc8fe7eed9fdb80a35418f6f03c80cf824ba52603cba26432593d0
+    tag: 42ddd627
+    digest: sha256:55a126d1348427d358b8df5b68afe7bf053535b92cedad6a3d212a7b4238f8f6
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-24T07:11:43.496Z"
+    deploy.knative.dev/rollout: "2026-02-24T07:32:35Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-24T07:11:43.496Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-24T07:32:35Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "4ab30a2e"
-    digest: sha256:ae3beabc37faadda33f80ac6ea8e21447f50bb633f2520cdd7a75808d114caf6
+    newTag: "42ddd627"
+    digest: sha256:55a126d1348427d358b8df5b68afe7bf053535b92cedad6a3d212a7b4238f8f6


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `42ddd627460b8e9498dd7f305caa7e331527d9ac`
- Image tag: `42ddd627`
- Image digest: `sha256:55a126d1348427d358b8df5b68afe7bf053535b92cedad6a3d212a7b4238f8f6`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`