### PR TITLE
chore(jangar): promote image 3eafcaf8

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 42ddd627
-  digest: sha256:55a126d1348427d358b8df5b68afe7bf053535b92cedad6a3d212a7b4238f8f6
+  tag: 3eafcaf8
+  digest: sha256:a579124ac26c2fa155c0625d571d8d2751761f2fc209f1aa0415b79834cf2c92
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 42ddd627
-    digest: sha256:b5edd9818465bb1131d3b9173bea87d50829289f02a34308e0edca4351d77567
+    tag: 3eafcaf8
+    digest: sha256:55b167f7045b052013e108e90c0b0ca53767cf6a9c666c5cde1517d76f269387
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 42ddd627
-    digest: sha256:55a126d1348427d358b8df5b68afe7bf053535b92cedad6a3d212a7b4238f8f6
+    tag: 3eafcaf8
+    digest: sha256:a579124ac26c2fa155c0625d571d8d2751761f2fc209f1aa0415b79834cf2c92
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-24T07:32:35Z"
+    deploy.knative.dev/rollout: "2026-02-24T08:13:51Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-24T07:32:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-24T08:13:51Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "42ddd627"
-    digest: sha256:55a126d1348427d358b8df5b68afe7bf053535b92cedad6a3d212a7b4238f8f6
+    newTag: "3eafcaf8"
+    digest: sha256:a579124ac26c2fa155c0625d571d8d2751761f2fc209f1aa0415b79834cf2c92


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `3eafcaf838f9004b47929c03520cf666498aea12`
- Image tag: `3eafcaf8`
- Image digest: `sha256:a579124ac26c2fa155c0625d571d8d2751761f2fc209f1aa0415b79834cf2c92`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`