### PR TITLE
chore(torghut): promote image 48504ed3

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8de7683c55c08bc1eba57f75cbffc090698e3601c2dab20e355406976e4f3b4f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:993202fd854d43bcd529c5de88f3d105fd79ff6ad4a9550c86b34113242f03ad
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-24T07:08:11Z"
+        client.knative.dev/updateTimestamp: "2026-02-24T08:27:17Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8de7683c55c08bc1eba57f75cbffc090698e3601c2dab20e355406976e4f3b4f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:993202fd854d43bcd529c5de88f3d105fd79ff6ad4a9550c86b34113242f03ad
           ports:
             - name: http1
               containerPort: 8181
@@ -330,9 +330,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0
+              value: v0.561.0-13-g48504ed3
             - name: TORGHUT_COMMIT
-              value: 626a4415809e6916ea23afb56dee19a6cb363f00
+              value: 48504ed3082620a22847c2aba43fb955702633e3
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `48504ed3082620a22847c2aba43fb955702633e3`
- Image tag: `48504ed3`
- Image digest: `sha256:993202fd854d43bcd529c5de88f3d105fd79ff6ad4a9550c86b34113242f03ad`