### PR TITLE
chore(jangar): promote image a9721f83

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 3eafcaf8
-  digest: sha256:a579124ac26c2fa155c0625d571d8d2751761f2fc209f1aa0415b79834cf2c92
+  tag: a9721f83
+  digest: sha256:9e85441420fac8e81957889c08faa202bc4382b406b7997ada1da04f4288a610
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 3eafcaf8
-    digest: sha256:55b167f7045b052013e108e90c0b0ca53767cf6a9c666c5cde1517d76f269387
+    tag: a9721f83
+    digest: sha256:fb78ca725b160578363dce9a16e8f25236114dcd0bf33f8615f97b9bda393358
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 3eafcaf8
-    digest: sha256:a579124ac26c2fa155c0625d571d8d2751761f2fc209f1aa0415b79834cf2c92
+    tag: a9721f83
+    digest: sha256:9e85441420fac8e81957889c08faa202bc4382b406b7997ada1da04f4288a610
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-24T08:13:51Z"
+    deploy.knative.dev/rollout: "2026-02-24T08:40:55Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-24T08:13:51Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-24T08:40:55Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "3eafcaf8"
-    digest: sha256:a579124ac26c2fa155c0625d571d8d2751761f2fc209f1aa0415b79834cf2c92
+    newTag: "a9721f83"
+    digest: sha256:9e85441420fac8e81957889c08faa202bc4382b406b7997ada1da04f4288a610


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a9721f837f5a05787535c10ffa49904689a8f961`
- Image tag: `a9721f83`
- Image digest: `sha256:9e85441420fac8e81957889c08faa202bc4382b406b7997ada1da04f4288a610`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`