### PR TITLE
chore(jangar): promote image 700e2436

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 1da4adc0
-  digest: sha256:056b2ec2a8e6b09786d4f9a29592542acd003f1db303d1f0e4c000bb00d9812c
+  tag: "700e2436"
+  digest: sha256:cead7a3f6e27d667bc167b2c4640a7eb01e7e10e488a13ca05e94ce5c9e7d40c
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 1da4adc0
-    digest: sha256:186358d1073546b50ba7746aec39250473d2d0387f20d2ad864fc6b9be2256a0
+    tag: "700e2436"
+    digest: sha256:d859aab09267b9b289b86dec80200452231d684ae66df0039cbb38accb91b3b2
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 1da4adc0
-    digest: sha256:056b2ec2a8e6b09786d4f9a29592542acd003f1db303d1f0e4c000bb00d9812c
+    tag: "700e2436"
+    digest: sha256:cead7a3f6e27d667bc167b2c4640a7eb01e7e10e488a13ca05e94ce5c9e7d40c
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-24T08:40:55Z"
+    deploy.knative.dev/rollout: "2026-02-25T03:05:13Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-24T08:40:55Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-25T03:05:13Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a9721f83"
-    digest: sha256:9e85441420fac8e81957889c08faa202bc4382b406b7997ada1da04f4288a610
+    newTag: "700e2436"
+    digest: sha256:cead7a3f6e27d667bc167b2c4640a7eb01e7e10e488a13ca05e94ce5c9e7d40c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `700e24364a62a35961d8713c4ded79b02fbe72da`
- Image tag: `700e2436`
- Image digest: `sha256:cead7a3f6e27d667bc167b2c4640a7eb01e7e10e488a13ca05e94ce5c9e7d40c`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`