### PR TITLE
chore(jangar): promote image b80c0a01

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "8fe286aa"
-  digest: sha256:ea933e8c55c46b4de59d286b9206762e8a1f46d5af177ce748e9d87ace9e6602
+  tag: b80c0a01
+  digest: sha256:4bf571fea50ecf0dd9fe00d06e9d5c4cccd9a946fefe334c1d7bd9d6447d200f
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: "8fe286aa"
-    digest: sha256:0bfa67715120e1ef300598f059f60bf6ca892553f12d53ef0ee28da25969786d
+    tag: b80c0a01
+    digest: sha256:e1af131fb2df506799b3c9c5fb216f5996c181e773285351af528202197294e2
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: "8fe286aa"
-    digest: sha256:ea933e8c55c46b4de59d286b9206762e8a1f46d5af177ce748e9d87ace9e6602
+    tag: b80c0a01
+    digest: sha256:4bf571fea50ecf0dd9fe00d06e9d5c4cccd9a946fefe334c1d7bd9d6447d200f
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-25T03:05:13Z"
+    deploy.knative.dev/rollout: "2026-02-25T06:48:50Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-25T03:05:13Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-25T06:48:50Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "700e2436"
-    digest: sha256:cead7a3f6e27d667bc167b2c4640a7eb01e7e10e488a13ca05e94ce5c9e7d40c
+    newTag: "b80c0a01"
+    digest: sha256:4bf571fea50ecf0dd9fe00d06e9d5c4cccd9a946fefe334c1d7bd9d6447d200f


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b80c0a010e7538b1df3e23468399e2408488974b`
- Image tag: `b80c0a01`
- Image digest: `sha256:4bf571fea50ecf0dd9fe00d06e9d5c4cccd9a946fefe334c1d7bd9d6447d200f`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`