### PR TITLE
fix(jangar): restore canonical codex runtime for agent runs

### DIFF
--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -581,10 +581,11 @@ WORKDIR /app/services/jangar
 RUN mkdir -p /root/.codex
 COPY --from=jangar-build /app/services/jangar/scripts/codex-config-container.toml /root/.codex/config.toml
 COPY --from=jangar-build /app/services/jangar/scripts/agent-runner.ts /usr/local/bin/agent-runner
-COPY --from=jangar-build /app/services/jangar/scripts/codex-implement.ts /usr/local/bin/codex-implement
+COPY --from=jangar-build /app/services/jangar/scripts/codex ./scripts/codex
 COPY --from=jangar-build /app/services/jangar/scripts/agent-providers /etc/agent-providers
 COPY skills/ /root/.codex/skills/
-RUN chmod +x /usr/local/bin/agent-runner /usr/local/bin/codex-implement
+RUN ln -sf /app/services/jangar/scripts/codex/codex-implement.ts /usr/local/bin/codex-implement \
+  && chmod +x /usr/local/bin/agent-runner /app/services/jangar/scripts/codex/codex-implement.ts
 
 # Start the compiled Nitro server produced by `bun --bun vite build`
 CMD ["bun", "run", ".output/server/index.mjs"]

--- a/services/jangar/scripts/codex/lib/codex-runner.ts
+++ b/services/jangar/scripts/codex/lib/codex-runner.ts
@@ -24,6 +24,8 @@ export interface RunCodexSessionOptions {
 export interface RunCodexSessionResult {
   agentMessages: string[]
   sessionId?: string
+  exitCode?: number
+  forcedTermination?: boolean
 }
 
 export interface PushCodexEventsToLokiOptions {
@@ -650,7 +652,12 @@ export const runCodexSession = async ({
     }
   }
 
-  return { agentMessages, sessionId }
+  return {
+    agentMessages,
+    sessionId,
+    exitCode: runResult.exitCode,
+    forcedTermination: runResult.forcedTermination,
+  }
 }
 
 export const pushCodexEventsToLoki = async ({


### PR DESCRIPTION
## Summary

- Switch the runtime `codex-implement` entrypoint to the canonical `services/jangar/scripts/codex/codex-implement.ts` flow instead of the legacy wrapper path.
- Propagate Codex session termination metadata (`exitCode`, `forcedTermination`) through `codex-runner` and use it in implementation orchestration.
- Add bounded resume behavior for incomplete/truncated Codex sessions so the same agent session can continue and complete its end-to-end contract.
- Add regression coverage for the incomplete-session resume path in `codex-implement` tests.

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts --maxWorkers=1 scripts/codex/__tests__/codex-implement.test.ts`
- `cd services/jangar && bunx vitest run --config vitest.config.ts --maxWorkers=1 scripts/codex/lib/__tests__/codex-runner.test.ts scripts/__tests__/codex-implement-legacy.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
