### PR TITLE
chore(jangar): promote image 362b814d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: b80c0a01
-  digest: sha256:4bf571fea50ecf0dd9fe00d06e9d5c4cccd9a946fefe334c1d7bd9d6447d200f
+  tag: 362b814d
+  digest: sha256:d676340ff9095e263e6cf6b925b1f690474729868e445c6feeb7491ff5cec255
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: b80c0a01
-    digest: sha256:e1af131fb2df506799b3c9c5fb216f5996c181e773285351af528202197294e2
+    tag: 362b814d
+    digest: sha256:ef47f61c13b8640aed8f27a918fbecb48852051c76d61ae01e2fa0122c22ccf9
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: b80c0a01
-    digest: sha256:4bf571fea50ecf0dd9fe00d06e9d5c4cccd9a946fefe334c1d7bd9d6447d200f
+    tag: 362b814d
+    digest: sha256:d676340ff9095e263e6cf6b925b1f690474729868e445c6feeb7491ff5cec255
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-25T06:48:50Z"
+    deploy.knative.dev/rollout: "2026-02-25T08:02:09Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-25T06:48:50Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-25T08:02:09Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "b80c0a01"
-    digest: sha256:4bf571fea50ecf0dd9fe00d06e9d5c4cccd9a946fefe334c1d7bd9d6447d200f
+    newTag: "362b814d"
+    digest: sha256:d676340ff9095e263e6cf6b925b1f690474729868e445c6feeb7491ff5cec255


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `362b814dbca903328a2382d012fa59219f8a3fb8`
- Image tag: `362b814d`
- Image digest: `sha256:d676340ff9095e263e6cf6b925b1f690474729868e445c6feeb7491ff5cec255`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`