### PR TITLE
fix(jangar): decouple codex runner from discord workspace import

### DIFF
--- a/services/jangar/scripts/codex/lib/codex-runner.ts
+++ b/services/jangar/scripts/codex/lib/codex-runner.ts
@@ -1,8 +1,10 @@
 import { stat } from 'node:fs/promises'
 import process from 'node:process'
 import { CodexRunner } from '@proompteng/codex'
-import { DISCORD_MESSAGE_SEPARATOR } from '@proompteng/discord'
 import { type CodexLogger, consoleLogger } from './logger'
+
+// Keep the codex runtime self-contained: Discord channel frames are NUL-delimited.
+const DISCORD_MESSAGE_SEPARATOR = '\u0000'
 
 export interface DiscordChannelOptions {
   command: string[]


### PR DESCRIPTION
## Summary

- Remove `@proompteng/discord` workspace import from `services/jangar/scripts/codex/lib/codex-runner.ts`.
- Inline the Discord frame separator constant (`\u0000`) in the codex runner so the runtime stays self-contained.
- Fix AgentRun job startup failures caused by missing `/app/packages/discord` in runtime images when executing canonical `codex-implement`.

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts --maxWorkers=1 scripts/codex/lib/__tests__/codex-runner.test.ts`
- `cd services/jangar && bunx vitest run --config vitest.config.ts --maxWorkers=1 scripts/codex/__tests__/codex-implement.test.ts` (hangs in this environment; relied on targeted runner suite + CI for full validation)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
