### PR TITLE
chore(jangar): promote image f12b6082

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 362b814d
-  digest: sha256:d676340ff9095e263e6cf6b925b1f690474729868e445c6feeb7491ff5cec255
+  tag: f12b6082
+  digest: sha256:ad8e5038c955b357298557853c8b806fed387d6501776588f3fa82eb8ea6bbc4
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 362b814d
-    digest: sha256:ef47f61c13b8640aed8f27a918fbecb48852051c76d61ae01e2fa0122c22ccf9
+    tag: f12b6082
+    digest: sha256:9fd1a7c3b6e6dfcb7d121d4393fb61a40dd91c7a1af1477d37915727e88e730a
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 362b814d
-    digest: sha256:d676340ff9095e263e6cf6b925b1f690474729868e445c6feeb7491ff5cec255
+    tag: f12b6082
+    digest: sha256:ad8e5038c955b357298557853c8b806fed387d6501776588f3fa82eb8ea6bbc4
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-25T08:02:09Z"
+    deploy.knative.dev/rollout: "2026-02-25T08:38:07Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-25T08:02:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-25T08:38:07Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "362b814d"
-    digest: sha256:d676340ff9095e263e6cf6b925b1f690474729868e445c6feeb7491ff5cec255
+    newTag: "f12b6082"
+    digest: sha256:ad8e5038c955b357298557853c8b806fed387d6501776588f3fa82eb8ea6bbc4


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f12b608286f50851a4a68bddfd87bcac55854f4a`
- Image tag: `f12b6082`
- Image digest: `sha256:ad8e5038c955b357298557853c8b806fed387d6501776588f3fa82eb8ea6bbc4`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`