### PR TITLE
chore(jangar): promote image f12b6082

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-25T08:38:07Z"
+    deploy.knative.dev/rollout: "2026-02-25T08:39:08Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-25T08:38:07Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-25T08:39:08Z"
     spec:
       initContainers:
         - name: bootstrap-workspace


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f12b608286f50851a4a68bddfd87bcac55854f4a`
- Image tag: `f12b6082`
- Image digest: `sha256:ad8e5038c955b357298557853c8b806fed387d6501776588f3fa82eb8ea6bbc4`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`