### PR TITLE
chore(jangar): promote image 338312f4

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f12b6082
-  digest: sha256:ad8e5038c955b357298557853c8b806fed387d6501776588f3fa82eb8ea6bbc4
+  tag: 338312f4
+  digest: sha256:491f70cfd27eb5acc46ac549fddbd4f0e562d18301f267eb09eca0425b0f620e
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f12b6082
-    digest: sha256:9fd1a7c3b6e6dfcb7d121d4393fb61a40dd91c7a1af1477d37915727e88e730a
+    tag: 338312f4
+    digest: sha256:2730550247bfa7e4e18515e6dcbe605601e0ad5f871e34a6367198ad43cf3c4d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f12b6082
-    digest: sha256:ad8e5038c955b357298557853c8b806fed387d6501776588f3fa82eb8ea6bbc4
+    tag: 338312f4
+    digest: sha256:491f70cfd27eb5acc46ac549fddbd4f0e562d18301f267eb09eca0425b0f620e
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-25T08:39:08Z"
+    deploy.knative.dev/rollout: "2026-02-25T09:11:43Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-25T08:39:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-25T09:11:43Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f12b6082"
-    digest: sha256:ad8e5038c955b357298557853c8b806fed387d6501776588f3fa82eb8ea6bbc4
+    newTag: "338312f4"
+    digest: sha256:491f70cfd27eb5acc46ac549fddbd4f0e562d18301f267eb09eca0425b0f620e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `338312f4605c4d5b686430941c087c78855cb440`
- Image tag: `338312f4`
- Image digest: `sha256:491f70cfd27eb5acc46ac549fddbd4f0e562d18301f267eb09eca0425b0f620e`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`