### PR TITLE
fix(jangar): include codex nats helpers in runtime image

### DIFF
--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -581,11 +581,13 @@ WORKDIR /app/services/jangar
 RUN mkdir -p /root/.codex
 COPY --from=jangar-build /app/services/jangar/scripts/codex-config-container.toml /root/.codex/config.toml
 COPY --from=jangar-build /app/services/jangar/scripts/agent-runner.ts /usr/local/bin/agent-runner
+COPY --from=jangar-build /app/services/jangar/scripts/codex-nats-publish.ts /usr/local/bin/codex-nats-publish
+COPY --from=jangar-build /app/services/jangar/scripts/codex-nats-soak.ts /usr/local/bin/codex-nats-soak
 COPY --from=jangar-build /app/services/jangar/scripts/codex ./scripts/codex
 COPY --from=jangar-build /app/services/jangar/scripts/agent-providers /etc/agent-providers
 COPY skills/ /root/.codex/skills/
 RUN ln -sf /app/services/jangar/scripts/codex/codex-implement.ts /usr/local/bin/codex-implement \
-  && chmod +x /usr/local/bin/agent-runner /app/services/jangar/scripts/codex/codex-implement.ts
+  && chmod +x /usr/local/bin/agent-runner /usr/local/bin/codex-nats-publish /usr/local/bin/codex-nats-soak /app/services/jangar/scripts/codex/codex-implement.ts
 
 # Start the compiled Nitro server produced by `bun --bun vite build`
 CMD ["bun", "run", ".output/server/index.mjs"]


### PR DESCRIPTION
## Summary

- Include `codex-nats-publish` and `codex-nats-soak` in the Jangar runtime image at `/usr/local/bin`.
- Mark both helper scripts executable in the runtime image so `codex-implement.ts` can invoke them by command name.
- Preserve existing `codex-implement` wiring while restoring runtime parity with expected Codex helper tools.

## Related Issues

None

## Testing

- Reproduced failing AgentRun in cluster before this change: `torghut-v5-doc12-dspy-adoption-run-20260225e` failed with `Executable not found in $PATH: \"codex-nats-soak\"`.
- Verified Dockerfile changes are in runtime stage and executable bits are set for both helper scripts.
- CI image build and deploy checks will validate runtime image assembly end-to-end.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
