### PR TITLE
chore(jangar): promote image 1cc0ecd2

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-25T09:32:52Z"
+    deploy.knative.dev/rollout: "2026-02-25T09:34:11Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-25T09:32:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-25T09:34:11Z"
     spec:
       initContainers:
         - name: bootstrap-workspace


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `1cc0ecd2b6b1aba50ad174b722257fa4816a7549`
- Image tag: `1cc0ecd2`
- Image digest: `sha256:83dec83515fa25c70d7bcb4bef1f4642f5f27b973652a3aed87c1572a2a0a3d2`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`