### PR TITLE
chore(torghut): promote image ae9b774e

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1cf426e2d68af60915cac8cd1175c04eebb999500d634e3e30566c8bdc559f6b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:13c0c62f6f738d05e2b15dbd54c29c887152c95d0cff2afbfce3062b6c42d11a
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-25T16:26:50Z"
+        client.knative.dev/updateTimestamp: "2026-02-25T17:17:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1cf426e2d68af60915cac8cd1175c04eebb999500d634e3e30566c8bdc559f6b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:13c0c62f6f738d05e2b15dbd54c29c887152c95d0cff2afbfce3062b6c42d11a
           ports:
             - name: http1
               containerPort: 8181
@@ -340,9 +340,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-49-g477487a4
+              value: v0.561.0-53-gae9b774e
             - name: TORGHUT_COMMIT
-              value: 477487a45cd0842b69732ac574cf5f0f726af8fa
+              value: ae9b774e96a6f0547cf4eb70b841f1398234f3d0
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `ae9b774e96a6f0547cf4eb70b841f1398234f3d0`
- Image tag: `ae9b774e`
- Image digest: `sha256:13c0c62f6f738d05e2b15dbd54c29c887152c95d0cff2afbfce3062b6c42d11a`