### PR TITLE
feat(torghut): implement janus-q m1 runtime and fail-closed gates

### DIFF
--- a/docs/whitepapers/wp-d72cb1a5c1febdcfbd9dae71/engineering-implementation-plan.md
+++ b/docs/whitepapers/wp-d72cb1a5c1febdcfbd9dae71/engineering-implementation-plan.md
@@ -4,6 +4,10 @@
 - Milestone: `M1` (event schema/CAR + HGRM scaffold + fail-closed promotion gating)
 - Last updated (UTC): `2026-02-26`
 
+## Production Planning
+
+- Production plan (phased M0-M5): `docs/whitepapers/wp-d72cb1a5c1febdcfbd9dae71/production-engineering-plan.md`
+
 ## M1 Scope Status
 
 | Item | Status | Evidence |
@@ -29,4 +33,3 @@
   - Result: pass
 
 - Targeted runtime tests added but full execution is currently blocked in this environment by missing Python dependencies/tooling (`sqlalchemy`, `pytest`, `uv`, and `python` alias in subprocess harnesses).
-

--- a/docs/whitepapers/wp-d72cb1a5c1febdcfbd9dae71/engineering-implementation-plan.md
+++ b/docs/whitepapers/wp-d72cb1a5c1febdcfbd9dae71/engineering-implementation-plan.md
@@ -1,0 +1,32 @@
+# Janus-Q Engineering Implementation Plan
+
+- Run ID: `wp-d72cb1a5c1febdcfbd9dae71`
+- Milestone: `M1` (event schema/CAR + HGRM scaffold + fail-closed promotion gating)
+- Last updated (UTC): `2026-02-26`
+
+## M1 Scope Status
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Implement deterministic event-centric schema + CAR scaffold artifact | ✅ Completed | `services/torghut/app/trading/autonomy/janus_q.py` (`build_janus_event_car_artifact_v1`) and lane emission to `gates/janus-event-car-v1.json` |
+| Implement deterministic HGRM reward scaffold artifact | ✅ Completed | `services/torghut/app/trading/autonomy/janus_q.py` (`build_janus_hgrm_reward_artifact_v1`) and lane emission to `gates/janus-hgrm-reward-v1.json` |
+| Wire Janus-Q evidence into runtime profitability/gate payloads | ✅ Completed | `services/torghut/app/trading/autonomy/lane.py` (`janus_q` evidence in profitability payload, gate payload, promotion evidence/provenance) |
+| Enforce fail-closed gate behavior for incomplete Janus evidence | ✅ Completed | `services/torghut/app/trading/autonomy/gates.py` (`gate6_require_janus_evidence`, schema/count checks) |
+| Enforce fail-closed promotion prerequisite checks for missing Janus artifacts | ✅ Completed | `services/torghut/app/trading/autonomy/policy_checks.py` (required artifacts + artifact schema/count checks + promotion evidence checks) |
+| Update policy defaults to require Janus evidence for paper/live progression | ✅ Completed | `services/torghut/config/autonomy-gates-v3.json`, `services/torghut/config/autonomous-gate-policy.json` |
+| Add deterministic regression tests for Janus scaffold + gate/policy integration | ✅ Completed | `services/torghut/tests/test_janus_q_scaffold.py` + updates to `test_autonomy_gates.py`, `test_policy_checks.py`, `test_autonomous_lane.py`, `test_governance_policy_dry_run.py` |
+
+## Determinism and Safety Constraints
+
+- Live trading remains disabled by policy (`gate5_live_enabled: false` in default configs).
+- Promotion remains fail-closed when required Janus artifacts/evidence are missing or incomplete.
+- Janus artifacts include deterministic manifest hashes and explicit schema versions for auditability.
+
+## Validation Evidence
+
+- Syntax validation completed:
+  - `python3 -m py_compile services/torghut/app/trading/autonomy/janus_q.py services/torghut/app/trading/autonomy/lane.py services/torghut/app/trading/autonomy/gates.py services/torghut/app/trading/autonomy/policy_checks.py services/torghut/scripts/run_governance_policy_dry_run.py services/torghut/scripts/run_autonomous_lane.py services/torghut/tests/test_janus_q_scaffold.py services/torghut/tests/test_autonomy_gates.py services/torghut/tests/test_policy_checks.py services/torghut/tests/test_autonomous_lane.py services/torghut/tests/test_governance_policy_dry_run.py`
+  - Result: pass
+
+- Targeted runtime tests added but full execution is currently blocked in this environment by missing Python dependencies/tooling (`sqlalchemy`, `pytest`, `uv`, and `python` alias in subprocess harnesses).
+

--- a/docs/whitepapers/wp-d72cb1a5c1febdcfbd9dae71/production-engineering-plan.md
+++ b/docs/whitepapers/wp-d72cb1a5c1febdcfbd9dae71/production-engineering-plan.md
@@ -1,0 +1,272 @@
+# Janus-Q Production Engineering Plan
+
+- Run ID: `wp-d72cb1a5c1febdcfbd9dae71`
+- Whitepaper: `arXiv:2602.19919`
+- Repository: `proompteng/lab`
+- Baseline commit: `51810e18` (branch `codex/whitepaper-b1-c1febdcfbd9dae71-plan-20260226`)
+- Last updated (UTC): `2026-02-26`
+
+## 1) Objective
+
+Implement Janus-Q in Torghut as a production-safe, reproducible, and auditable capability that can be promoted from research to paper trading and then to controlled live canary only after statistically defensible performance and operational reliability gates are met.
+
+## 2) Current Baseline (What Exists Today)
+
+M1 scaffolding already exists in code:
+
+1. Deterministic event/CAR artifact generation and HGRM reward scaffold:
+   - `services/torghut/app/trading/autonomy/janus_q.py`
+2. Lane integration and artifact emission:
+   - `services/torghut/app/trading/autonomy/lane.py`
+3. Gate6 fail-closed checks for Janus evidence:
+   - `services/torghut/app/trading/autonomy/gates.py`
+4. Promotion prerequisite checks for Janus artifacts/evidence:
+   - `services/torghut/app/trading/autonomy/policy_checks.py`
+5. Policy defaults requiring Janus evidence:
+   - `services/torghut/config/autonomy-gates-v3.json`
+   - `services/torghut/config/autonomous-gate-policy.json`
+6. Regression tests:
+   - `services/torghut/tests/test_janus_q_scaffold.py`
+   - `services/torghut/tests/test_autonomy_gates.py`
+   - `services/torghut/tests/test_policy_checks.py`
+   - `services/torghut/tests/test_autonomous_lane.py`
+   - `services/torghut/tests/test_governance_policy_dry_run.py`
+
+## 3) Production Scope
+
+In scope:
+
+1. Replace M1 proxy logic with paper-aligned event/CAR and HGRM semantics.
+2. Add reproducible SFT -> GRPO training pipeline and model registry lineage.
+3. Add statistically rigorous multi-window evaluation and promotion evidence.
+4. Integrate inference into autonomy lane with deterministic fallbacks.
+5. Add operational controls: observability, drift monitors, kill-switches, rollback runbooks.
+6. Controlled deployment path: research -> paper -> canary live.
+
+Out of scope (this plan):
+
+1. Full market-universe expansion beyond agreed pilot scope.
+2. Unbounded autonomous live rollout without explicit human approval gates.
+3. Removing existing deterministic fallback strategy.
+
+## 4) Milestones and Exit Criteria
+
+## M0 - Safety and Contract Alignment (1 week)
+
+Deliverables:
+
+1. Resolve policy inconsistency so Janus evidence checks and Janus artifact requirements are controlled by the same gate switches.
+2. Formalize v1 JSON contracts for:
+   - `janus-event-car-v1`
+   - `janus-hgrm-reward-v1`
+   - `janus-q-evidence-v1`
+3. Add compatibility tests for policy toggle combinations.
+
+Exit criteria:
+
+1. All policy toggle matrices pass in CI.
+2. No contradiction between required artifacts and evidence checks.
+3. Backward-compatible behavior documented for older artifacts.
+
+## M1 - Data and Labeling Fidelity Upgrade (2 weeks)
+
+Deliverables:
+
+1. Upgrade event/CAR generation from proxy to paper-aligned specification:
+   - explicit abnormal return model
+   - factor-neutralized return path
+   - deterministic event window policy
+2. Event taxonomy normalizer and validation (unknown event handling).
+3. Data lineage manifest:
+   - dataset snapshot hash
+   - schema hash
+   - generation code hash
+   - run configuration hash
+
+Exit criteria:
+
+1. Determinism replay test: identical inputs yield identical manifests.
+2. Event coverage and schema validity thresholds pass.
+3. Lineage manifest generated for every run.
+
+## M2 - HGRM Reward Semantics (2 weeks)
+
+Deliverables:
+
+1. Implement configurable reward components aligned to paper equations:
+   - direction gate
+   - event-type gate
+   - cost-aware PnL
+   - magnitude shaping
+   - process reward
+2. Reward decomposition logs per sample.
+3. Sanity-check simulation suite for reward monotonicity and clipping boundaries.
+
+Exit criteria:
+
+1. Reward decomposition trace available for audit on every training run.
+2. Property tests for gate sign behavior and clipping pass.
+3. No undefined/NaN reward values in training traces.
+
+## M3 - Training and Evaluation Platform (3 weeks)
+
+Deliverables:
+
+1. Reproducible SFT pipeline:
+   - frozen prompt templates
+   - exact training config and seeds
+2. Reproducible GRPO pipeline with checkpoint lineage.
+3. Evaluation package:
+   - rolling walk-forward windows
+   - regime-sliced metrics
+   - bootstrap confidence intervals for SR/DA/ETA deltas
+4. Candidate report extension with significance evidence.
+
+Exit criteria:
+
+1. Re-run reproducibility within tolerance across two independent executions.
+2. Candidate reports include confidence intervals and significance metadata.
+3. Baseline-vs-candidate comparison reproducibly generated from manifests.
+
+## M4 - Runtime Integration and Paper Trading Pilot (2 weeks)
+
+Deliverables:
+
+1. Janus-aware decision service integration into autonomy lane.
+2. Runtime controls:
+   - timeout budgets
+   - deterministic fallback route
+   - stale-event suppression
+3. Operational metrics and alerts:
+   - janus evidence completeness
+   - fallback ratio
+   - inference latency
+   - gate fail reasons
+
+Exit criteria:
+
+1. Paper-trading dry run completes without safety violations.
+2. Fallback behavior is deterministic and audited.
+3. On-call runbook validated in simulation drills.
+
+## M5 - Controlled Live Canary (2 weeks minimum observation)
+
+Deliverables:
+
+1. Limited-scope canary configuration:
+   - symbol allowlist
+   - notional caps
+   - strict kill-switch and rollback
+2. Daily governance review artifact with:
+   - performance drift
+   - risk breaches
+   - gate pass/fail trends
+
+Exit criteria:
+
+1. Canary SLOs satisfied for required observation window.
+2. No unresolved severity-1 or severity-2 incidents.
+3. Explicit human approval for broader rollout.
+
+## 5) Engineering Workstreams
+
+| Workstream | Primary Files/Systems | Owner Role | Output |
+| --- | --- | --- | --- |
+| Policy and gates | `autonomy/gates.py`, `autonomy/policy_checks.py`, gate policy JSON | Trading Platform | Consistent fail-closed governance |
+| Janus data pipeline | `autonomy/janus_q.py`, artifact manifests | Research Eng | Deterministic event/CAR + reward artifacts |
+| Training stack | training jobs, model registry, run manifests | ML Platform | Reproducible SFT/GRPO candidates |
+| Evaluation rigor | report generation, significance tooling | Quant Research | Promotion-grade evidence package |
+| Runtime serving | lane runtime, inference path, fallback policies | Runtime Eng | Reliable paper/live execution path |
+| Observability and ops | metrics, alerts, runbooks, on-call drills | SRE/On-call | Operable production system |
+
+## 6) Quality Gates (Promotion Requirements)
+
+Mandatory for `shadow -> paper`:
+
+1. Gate0/1/2/6/7 pass with Janus evidence complete.
+2. Reproducibility manifests present and hash-consistent.
+3. Statistical evidence attached (confidence intervals and baseline delta significance).
+
+Mandatory for `paper -> live-canary`:
+
+1. Paper-trading stability window completed.
+2. Latency/error/fallback SLOs within threshold.
+3. Human approval token with rollback drill completion proof.
+
+## 7) SLOs and Operational Metrics
+
+Core SLOs:
+
+1. Inference timeout rate < 0.5% (5-minute windows).
+2. Deterministic fallback activation < 5% during normal market hours.
+3. Janus evidence completeness = 100% for promotable runs.
+4. Zero unreviewed gate bypasses in production.
+
+Core dashboards:
+
+1. `janus_event_count`, `janus_reward_count`, `janus_evidence_complete`.
+2. `autonomy_gate_fail_total{gate_id,reason}`.
+3. `autonomy_fallback_ratio`, `autonomy_inference_latency_ms_p95`.
+4. `promotion_attempt_total{target,status,reason}`.
+
+## 8) Test Strategy
+
+1. Unit tests:
+   - reward component correctness
+   - schema/version guards
+   - policy toggle matrix behavior
+2. Property tests:
+   - determinism and hash stability
+   - reward gate monotonicity under sign flips
+3. Integration tests:
+   - end-to-end lane artifact generation
+   - promotion checks with synthetic and real fixtures
+4. Replay tests:
+   - exact output reproducibility from archived snapshots
+5. Failure injection:
+   - missing artifacts
+   - malformed schema
+   - inference timeout and fallback takeover
+
+## 9) Rollback and Incident Plan
+
+1. Immediate mitigation:
+   - set `TRADING_ENABLED=false` for Torghut if safety breach.
+2. Strategy rollback:
+   - revert candidate patch via GitOps.
+3. Janus pathway disable:
+   - force deterministic fallback by policy toggle.
+4. Post-incident requirements:
+   - root-cause report
+   - replay proof
+   - gate/policy regression test addition before re-enable.
+
+## 10) Key Risks and Mitigations
+
+1. External validity risk:
+   - Mitigation: multi-window, regime-segmented evaluation before promotion.
+2. Reward overfitting risk:
+   - Mitigation: strict holdout periods, ablations, and drift monitors.
+3. Operational fragility risk:
+   - Mitigation: fallback-first runtime design and on-call drills.
+4. Reproducibility drift risk:
+   - Mitigation: immutable manifests and hash-locked artifacts.
+
+## 11) Timeline (Target)
+
+1. Week 1: M0
+2. Weeks 2-3: M1
+3. Weeks 4-5: M2
+4. Weeks 6-8: M3
+5. Weeks 9-10: M4
+6. Weeks 11-12+: M5 observation and go/no-go
+
+## 12) Go/No-Go Checklist
+
+Go only if all are true:
+
+1. All required gates pass with no manual bypass.
+2. Reproducibility package validated.
+3. Statistical evidence meets policy thresholds.
+4. Rollback drill passed within last 72 hours.
+5. On-call acknowledges live canary readiness.

--- a/services/torghut/app/trading/autonomy/janus_q.py
+++ b/services/torghut/app/trading/autonomy/janus_q.py
@@ -1,0 +1,517 @@
+"""Deterministic Janus-Q M1 scaffolding for event/CAR and HGRM reward evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from ..evaluation import WalkForwardDecision
+from ..features import extract_price
+from ..models import SignalEnvelope
+
+def _to_utc_iso(ts: datetime) -> str:
+    resolved = ts if ts.tzinfo is not None else ts.replace(tzinfo=timezone.utc)
+    return resolved.astimezone(timezone.utc).isoformat()
+
+
+def _decimal_str(value: Decimal) -> str:
+    return str(value.normalize()) if value != 0 else "0"
+
+
+def _hash_payload(payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _safe_decimal(value: object) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (ArithmeticError, TypeError, ValueError):
+        return Decimal("0")
+
+
+def _event_type(payload: dict[str, Any]) -> str:
+    for key in (
+        "event_type",
+        "eventType",
+        "news_event_type",
+        "taxonomy",
+        "signal_type",
+    ):
+        raw = payload.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip().lower()
+    if "macd" in payload or "rsi14" in payload or "rsi" in payload:
+        return "technical_indicator"
+    return "unclassified_event"
+
+
+def _car_direction(car: Decimal) -> str:
+    if car > 0:
+        return "long"
+    if car < 0:
+        return "short"
+    return "neutral"
+
+
+def _strength_label(car: Decimal, *, threshold: Decimal) -> str:
+    if abs(car) >= threshold:
+        return "strong"
+    return "weak"
+
+
+@dataclass(frozen=True)
+class JanusEventCarRecordV1:
+    event_id: str
+    event_ts: datetime
+    symbol: str
+    seq: int
+    event_type: str
+    semantic_direction: str
+    strength_label: str
+    price_t: str
+    price_t_plus_1: str
+    raw_return: str
+    abnormal_return: str
+    risk_neutralized_return: str
+    car: str
+    payload_hash: str
+    source: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "event_id": self.event_id,
+            "event_ts": _to_utc_iso(self.event_ts),
+            "symbol": self.symbol,
+            "seq": self.seq,
+            "event_type": self.event_type,
+            "semantic_direction": self.semantic_direction,
+            "strength_label": self.strength_label,
+            "price_t": self.price_t,
+            "price_t_plus_1": self.price_t_plus_1,
+            "raw_return": self.raw_return,
+            "abnormal_return": self.abnormal_return,
+            "risk_neutralized_return": self.risk_neutralized_return,
+            "car": self.car,
+            "payload_hash": self.payload_hash,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
+class JanusEventCarArtifactV1:
+    schema_version: str
+    run_id: str
+    generated_at: datetime
+    methodology: dict[str, object]
+    records: list[JanusEventCarRecordV1]
+    summary: dict[str, object]
+    manifest_hash: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "generated_at": _to_utc_iso(self.generated_at),
+            "methodology": dict(self.methodology),
+            "records": [item.to_payload() for item in self.records],
+            "summary": dict(self.summary),
+            "manifest_hash": self.manifest_hash,
+        }
+
+
+@dataclass(frozen=True)
+class JanusHgrmRewardRecordV1:
+    reward_id: str
+    event_id: str
+    event_ts: datetime
+    symbol: str
+    strategy_id: str
+    action: str
+    expected_direction: str
+    event_type: str
+    predicted_event_type: str | None
+    direction_gate: str
+    event_type_gate: str
+    pnl_reward: str
+    magnitude_reward: str
+    process_reward: str
+    final_reward: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "reward_id": self.reward_id,
+            "event_id": self.event_id,
+            "event_ts": _to_utc_iso(self.event_ts),
+            "symbol": self.symbol,
+            "strategy_id": self.strategy_id,
+            "action": self.action,
+            "expected_direction": self.expected_direction,
+            "event_type": self.event_type,
+            "predicted_event_type": self.predicted_event_type,
+            "direction_gate": self.direction_gate,
+            "event_type_gate": self.event_type_gate,
+            "pnl_reward": self.pnl_reward,
+            "magnitude_reward": self.magnitude_reward,
+            "process_reward": self.process_reward,
+            "final_reward": self.final_reward,
+        }
+
+
+@dataclass(frozen=True)
+class JanusHgrmRewardArtifactV1:
+    schema_version: str
+    run_id: str
+    candidate_id: str
+    generated_at: datetime
+    reward_version: str
+    rewards: list[JanusHgrmRewardRecordV1]
+    summary: dict[str, object]
+    manifest_hash: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "candidate_id": self.candidate_id,
+            "generated_at": _to_utc_iso(self.generated_at),
+            "reward_version": self.reward_version,
+            "rewards": [item.to_payload() for item in self.rewards],
+            "summary": dict(self.summary),
+            "manifest_hash": self.manifest_hash,
+        }
+
+
+def build_janus_event_car_artifact_v1(
+    *,
+    run_id: str,
+    signals: list[SignalEnvelope],
+    generated_at: datetime | None = None,
+    strong_threshold: Decimal = Decimal("0.0025"),
+) -> JanusEventCarArtifactV1:
+    ordered = sorted(signals, key=lambda item: (item.event_ts, item.symbol, item.seq or 0))
+    if not ordered:
+        raise ValueError("janus_event_car_requires_signals")
+
+    next_price_by_index: dict[int, Decimal] = {}
+    prices_by_index: dict[int, Decimal] = {}
+    indices_by_symbol: dict[str, list[int]] = {}
+    for index, signal in enumerate(ordered):
+        indices_by_symbol.setdefault(signal.symbol, []).append(index)
+        prices_by_index[index] = extract_price(signal.payload or {}) or Decimal("0")
+
+    for indexes in indices_by_symbol.values():
+        for offset, current_index in enumerate(indexes):
+            current_price = prices_by_index.get(current_index, Decimal("0"))
+            if offset + 1 >= len(indexes):
+                next_price_by_index[current_index] = current_price
+                continue
+            next_index = indexes[offset + 1]
+            next_price = prices_by_index.get(next_index, current_price)
+            next_price_by_index[current_index] = next_price
+
+    raw_returns_by_index: dict[int, Decimal] = {}
+    raw_returns_by_ts: dict[str, list[Decimal]] = {}
+    for index, signal in enumerate(ordered):
+        price_t = prices_by_index.get(index, Decimal("0"))
+        price_t1 = next_price_by_index.get(index, price_t)
+        raw_return = Decimal("0")
+        if price_t > 0:
+            raw_return = (price_t1 - price_t) / price_t
+        raw_returns_by_index[index] = raw_return
+        ts_key = _to_utc_iso(signal.event_ts)
+        raw_returns_by_ts.setdefault(ts_key, []).append(raw_return)
+
+    market_mean_by_ts = {
+        key: (sum(values, Decimal("0")) / Decimal(len(values)) if values else Decimal("0"))
+        for key, values in raw_returns_by_ts.items()
+    }
+
+    records: list[JanusEventCarRecordV1] = []
+    positive = 0
+    negative = 0
+    neutral = 0
+    strong = 0
+    abs_car_total = Decimal("0")
+    for index, signal in enumerate(ordered):
+        payload = signal.payload or {}
+        ts_key = _to_utc_iso(signal.event_ts)
+        raw_return = raw_returns_by_index.get(index, Decimal("0"))
+        market_return = market_mean_by_ts.get(ts_key, Decimal("0"))
+        abnormal = raw_return - market_return
+        car = abnormal
+        direction = _car_direction(car)
+        strength = _strength_label(car, threshold=strong_threshold)
+        if direction == "long":
+            positive += 1
+        elif direction == "short":
+            negative += 1
+        else:
+            neutral += 1
+        if strength == "strong":
+            strong += 1
+        abs_car_total += abs(car)
+        seq = int(signal.seq or 0)
+        event_payload = {
+            "event_ts": ts_key,
+            "symbol": signal.symbol,
+            "seq": seq,
+            "source": signal.source,
+            "payload": payload,
+        }
+        event_id = hashlib.sha256(
+            json.dumps(event_payload, sort_keys=True, separators=(",", ":"), default=str).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        records.append(
+            JanusEventCarRecordV1(
+                event_id=event_id,
+                event_ts=signal.event_ts,
+                symbol=signal.symbol,
+                seq=seq,
+                event_type=_event_type(payload),
+                semantic_direction=direction,
+                strength_label=strength,
+                price_t=_decimal_str(prices_by_index.get(index, Decimal("0"))),
+                price_t_plus_1=_decimal_str(next_price_by_index.get(index, Decimal("0"))),
+                raw_return=_decimal_str(raw_return),
+                abnormal_return=_decimal_str(abnormal),
+                risk_neutralized_return=_decimal_str(abnormal),
+                car=_decimal_str(car),
+                payload_hash=_hash_payload(payload),
+                source=str(signal.source or "unknown"),
+            )
+        )
+
+    summary = {
+        "event_count": len(records),
+        "positive_direction_count": positive,
+        "negative_direction_count": negative,
+        "neutral_direction_count": neutral,
+        "strong_event_count": strong,
+        "mean_abs_car": _decimal_str(
+            abs_car_total / Decimal(len(records)) if records else Decimal("0")
+        ),
+    }
+    methodology = {
+        "stage": "m1_scaffold",
+        "event_window": "t_plus_1_signal",
+        "market_model": "cross_sectional_mean_proxy",
+        "risk_neutralization": "identity_proxy",
+        "paper_alignment": {
+            "car_reference": "janus_q_sec_3_1_eq_1_to_5",
+            "label_reference": "janus_q_sec_3_1_2",
+        },
+    }
+    manifest = _hash_payload([item.to_payload() for item in records])
+    return JanusEventCarArtifactV1(
+        schema_version="janus-event-car-v1",
+        run_id=run_id,
+        generated_at=generated_at or datetime.now(timezone.utc),
+        methodology=methodology,
+        records=records,
+        summary=summary,
+        manifest_hash=manifest,
+    )
+
+
+def build_janus_hgrm_reward_artifact_v1(
+    *,
+    run_id: str,
+    candidate_id: str,
+    event_car: JanusEventCarArtifactV1,
+    walk_decisions: list[WalkForwardDecision],
+    generated_at: datetime | None = None,
+) -> JanusHgrmRewardArtifactV1:
+    event_lookup = {
+        (_to_utc_iso(item.event_ts), item.symbol): item for item in event_car.records
+    }
+    rewards: list[JanusHgrmRewardRecordV1] = []
+    mapped_count = 0
+    direction_pass = 0
+    event_type_match = 0
+    hard_gate_fail = 0
+    sum_final = Decimal("0")
+    sum_pnl = Decimal("0")
+    for item in sorted(
+        walk_decisions,
+        key=lambda entry: (
+            entry.decision.event_ts,
+            entry.decision.symbol,
+            entry.decision.strategy_id,
+        ),
+    ):
+        decision = item.decision
+        lookup_key = (_to_utc_iso(decision.event_ts), decision.symbol)
+        event = event_lookup.get(lookup_key)
+        expected_direction = "neutral"
+        event_type = "unclassified_event"
+        car = Decimal("0")
+        event_id = "unmapped"
+        if event is not None:
+            mapped_count += 1
+            expected_direction = event.semantic_direction
+            event_type = event.event_type
+            car = _safe_decimal(event.car)
+            event_id = event.event_id
+
+        action_direction = "long" if decision.action == "buy" else "short"
+        if expected_direction == "neutral":
+            direction_gate = Decimal("-0.50")
+        elif action_direction == expected_direction:
+            direction_gate = Decimal("1")
+            direction_pass += 1
+        else:
+            direction_gate = Decimal("-1")
+            hard_gate_fail += 1
+
+        predicted_event_type_raw = decision.params.get("event_type")
+        predicted_event_type = (
+            str(predicted_event_type_raw).strip().lower()
+            if isinstance(predicted_event_type_raw, str) and predicted_event_type_raw.strip()
+            else None
+        )
+        if predicted_event_type is None:
+            event_type_gate = Decimal("0.70")
+        elif predicted_event_type == event_type:
+            event_type_gate = Decimal("1")
+            event_type_match += 1
+        else:
+            event_type_gate = Decimal("0.40")
+
+        position_sign = Decimal("1") if decision.action == "buy" else Decimal("-1")
+        pnl_reward = (car * position_sign) - Decimal("0.0005")
+        magnitude_reward = abs(car) if action_direction == expected_direction else -abs(car)
+        process_reward = (
+            Decimal("0.10")
+            if (decision.rationale or str(decision.params.get("rationale", "")).strip())
+            else Decimal("0")
+        )
+        final_reward = (direction_gate * event_type_gate * pnl_reward) + magnitude_reward + process_reward
+        sum_final += final_reward
+        sum_pnl += pnl_reward
+
+        reward_payload = {
+            "event_id": event_id,
+            "strategy_id": decision.strategy_id,
+            "symbol": decision.symbol,
+            "event_ts": _to_utc_iso(decision.event_ts),
+            "action": decision.action,
+            "direction_gate": _decimal_str(direction_gate),
+            "event_type_gate": _decimal_str(event_type_gate),
+            "pnl_reward": _decimal_str(pnl_reward),
+            "magnitude_reward": _decimal_str(magnitude_reward),
+            "process_reward": _decimal_str(process_reward),
+            "final_reward": _decimal_str(final_reward),
+        }
+        rewards.append(
+            JanusHgrmRewardRecordV1(
+                reward_id=hashlib.sha256(
+                    json.dumps(reward_payload, sort_keys=True, separators=(",", ":")).encode(
+                        "utf-8"
+                    )
+                ).hexdigest()[:24],
+                event_id=event_id,
+                event_ts=decision.event_ts,
+                symbol=decision.symbol,
+                strategy_id=decision.strategy_id,
+                action=decision.action,
+                expected_direction=expected_direction,
+                event_type=event_type,
+                predicted_event_type=predicted_event_type,
+                direction_gate=_decimal_str(direction_gate),
+                event_type_gate=_decimal_str(event_type_gate),
+                pnl_reward=_decimal_str(pnl_reward),
+                magnitude_reward=_decimal_str(magnitude_reward),
+                process_reward=_decimal_str(process_reward),
+                final_reward=_decimal_str(final_reward),
+            )
+        )
+
+    reward_count = len(rewards)
+    summary = {
+        "reward_count": reward_count,
+        "event_mapped_count": mapped_count,
+        "hard_gate_fail_count": hard_gate_fail,
+        "direction_gate_pass_ratio": _decimal_str(
+            Decimal(direction_pass) / Decimal(reward_count) if reward_count else Decimal("0")
+        ),
+        "event_type_match_ratio": _decimal_str(
+            Decimal(event_type_match) / Decimal(reward_count) if reward_count else Decimal("0")
+        ),
+        "mean_final_reward": _decimal_str(
+            sum_final / Decimal(reward_count) if reward_count else Decimal("0")
+        ),
+        "mean_pnl_reward": _decimal_str(
+            sum_pnl / Decimal(reward_count) if reward_count else Decimal("0")
+        ),
+    }
+    manifest = _hash_payload([item.to_payload() for item in rewards])
+    return JanusHgrmRewardArtifactV1(
+        schema_version="janus-hgrm-reward-v1",
+        run_id=run_id,
+        candidate_id=candidate_id,
+        generated_at=generated_at or datetime.now(timezone.utc),
+        reward_version="janus-hgrm-scaffold-v1",
+        rewards=rewards,
+        summary=summary,
+        manifest_hash=manifest,
+    )
+
+
+def build_janus_q_evidence_summary_v1(
+    *,
+    event_car: JanusEventCarArtifactV1,
+    hgrm_reward: JanusHgrmRewardArtifactV1,
+    event_car_artifact_ref: str,
+    hgrm_reward_artifact_ref: str,
+) -> dict[str, object]:
+    event_count = int(event_car.summary.get("event_count", 0))
+    reward_count = int(hgrm_reward.summary.get("reward_count", 0))
+    mapped_count = int(hgrm_reward.summary.get("event_mapped_count", 0))
+    reasons: list[str] = []
+    if event_count <= 0:
+        reasons.append("janus_event_count_missing")
+    if reward_count <= 0:
+        reasons.append("janus_reward_count_missing")
+    if reward_count > 0 and mapped_count < reward_count:
+        reasons.append("janus_reward_event_mapping_incomplete")
+    return {
+        "schema_version": "janus-q-evidence-v1",
+        "evidence_complete": not reasons,
+        "reasons": reasons,
+        "event_car": {
+            "schema_version": event_car.schema_version,
+            "event_count": event_count,
+            "manifest_hash": event_car.manifest_hash,
+            "artifact_ref": event_car_artifact_ref,
+        },
+        "hgrm_reward": {
+            "schema_version": hgrm_reward.schema_version,
+            "reward_count": reward_count,
+            "event_mapped_count": mapped_count,
+            "direction_gate_pass_ratio": str(
+                hgrm_reward.summary.get("direction_gate_pass_ratio", "0")
+            ),
+            "manifest_hash": hgrm_reward.manifest_hash,
+            "artifact_ref": hgrm_reward_artifact_ref,
+        },
+    }
+
+
+__all__ = [
+    "JanusEventCarArtifactV1",
+    "JanusEventCarRecordV1",
+    "JanusHgrmRewardArtifactV1",
+    "JanusHgrmRewardRecordV1",
+    "build_janus_event_car_artifact_v1",
+    "build_janus_hgrm_reward_artifact_v1",
+    "build_janus_q_evidence_summary_v1",
+]

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -727,6 +727,7 @@ def _evaluate_promotion_evidence(
 
     janus_reasons, janus_details, janus_refs = _evaluate_janus_evidence(
         policy_payload=policy_payload,
+        promotion_target=promotion_target,
         evidence=evidence,
     )
     reasons.extend(janus_reasons)
@@ -748,8 +749,14 @@ def _evaluate_promotion_evidence(
 def _evaluate_janus_evidence(
     *,
     policy_payload: dict[str, Any],
+    promotion_target: str,
     evidence: dict[str, Any],
 ) -> tuple[list[str], list[dict[str, object]], list[str]]:
+    if not _requires_janus_evidence(
+        policy_payload=policy_payload,
+        promotion_target=promotion_target,
+    ):
+        return [], [], []
     if not bool(policy_payload.get("promotion_require_janus_evidence", True)):
         return [], [], []
     reasons: list[str] = []

--- a/services/torghut/config/autonomous-gate-policy.json
+++ b/services/torghut/config/autonomous-gate-policy.json
@@ -19,6 +19,9 @@
   "gate3_max_forecast_fallback_rate": "0.05",
   "gate3_max_forecast_latency_ms_p95": 200,
   "gate3_min_forecast_calibration_score": "0.85",
+  "gate6_require_janus_evidence": true,
+  "gate6_min_janus_event_count": 1,
+  "gate6_min_janus_reward_count": 1,
   "gate5_live_enabled": false,
   "gate5_require_approval_token": true,
   "promotion_required_artifacts": [
@@ -27,6 +30,16 @@
     "gates/gate-evaluation.json"
   ],
   "promotion_require_patch_targets": ["paper", "live"],
+  "promotion_janus_required_targets": ["paper", "live"],
+  "promotion_janus_required_artifacts": [
+    "gates/janus-event-car-v1.json",
+    "gates/janus-hgrm-reward-v1.json"
+  ],
+  "promotion_require_janus_evidence": true,
+  "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
+  "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",
+  "promotion_min_janus_event_count": 1,
+  "promotion_min_janus_reward_count": 1,
   "rollback_required_checks": ["killSwitchDryRunPassed", "gitopsRevertDryRunPassed", "strategyDisableDryRunPassed"],
   "rollback_dry_run_max_age_hours": 72,
   "rollback_require_human_approval": true

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -19,6 +19,9 @@
   "gate3_max_forecast_fallback_rate": "0.05",
   "gate3_max_forecast_latency_ms_p95": 200,
   "gate3_min_forecast_calibration_score": "0.85",
+  "gate6_require_janus_evidence": true,
+  "gate6_min_janus_event_count": 1,
+  "gate6_min_janus_reward_count": 1,
   "gate6_max_calibration_error": "0.45",
   "gate7_target_coverage": "0.90",
   "gate7_max_coverage_error_pass": "0.03",
@@ -44,6 +47,16 @@
     "gates/profitability-evidence-validation.json",
     "gates/recalibration-report.json"
   ],
+  "promotion_janus_required_targets": ["paper", "live"],
+  "promotion_janus_required_artifacts": [
+    "gates/janus-event-car-v1.json",
+    "gates/janus-hgrm-reward-v1.json"
+  ],
+  "promotion_require_janus_evidence": true,
+  "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
+  "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",
+  "promotion_min_janus_event_count": 1,
+  "promotion_min_janus_reward_count": 1,
   "rollback_required_checks": ["killSwitchDryRunPassed", "gitopsRevertDryRunPassed", "strategyDisableDryRunPassed"],
   "rollback_dry_run_max_age_hours": 72,
   "rollback_require_human_approval": true

--- a/services/torghut/scripts/run_autonomous_lane.py
+++ b/services/torghut/scripts/run_autonomous_lane.py
@@ -107,6 +107,12 @@ def main() -> int:
         "profitability_validation_path": str(
             result.output_dir / "gates" / "profitability-evidence-validation.json"
         ),
+        "janus_event_car_path": str(
+            result.output_dir / "gates" / "janus-event-car-v1.json"
+        ),
+        "janus_hgrm_reward_path": str(
+            result.output_dir / "gates" / "janus-hgrm-reward-v1.json"
+        ),
         "promotion_gate_path": str(
             result.output_dir / "gates" / "promotion-evidence-gate.json"
         ),

--- a/services/torghut/scripts/run_governance_policy_dry_run.py
+++ b/services/torghut/scripts/run_governance_policy_dry_run.py
@@ -94,6 +94,26 @@ def main() -> int:
             '{"schema_version":"recalibration_report_v1","status":"not_required","recalibration_run_id":null}\n',
             encoding="utf-8",
         )
+        (root / "gates" / "janus-event-car-v1.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "janus-event-car-v1",
+                    "summary": {"event_count": 2},
+                    "records": [{"event_id": "evt-1"}, {"event_id": "evt-2"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (root / "gates" / "janus-hgrm-reward-v1.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "janus-hgrm-reward-v1",
+                    "summary": {"reward_count": 2},
+                    "rewards": [{"reward_id": "rwd-1"}, {"reward_id": "rwd-2"}],
+                }
+            ),
+            encoding="utf-8",
+        )
         (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
             "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: dry-run\n",
             encoding="utf-8",

--- a/services/torghut/tests/test_autonomous_lane.py
+++ b/services/torghut/tests/test_autonomous_lane.py
@@ -149,6 +149,9 @@ class TestAutonomousLane(TestCase):
             evidence = gate_payload["promotion_evidence"]
             self.assertEqual(evidence["fold_metrics"]["count"], 1)
             self.assertEqual(evidence["stress_metrics"]["count"], 4)
+            self.assertIn("janus_q", evidence)
+            self.assertEqual(evidence["janus_q"]["event_car"]["count"], 3)
+            self.assertEqual(evidence["janus_q"]["hgrm_reward"]["count"], 3)
             self.assertTrue(
                 bool(evidence["promotion_rationale"].get("recommendation_trace_id"))
             )
@@ -162,6 +165,10 @@ class TestAutonomousLane(TestCase):
                 (
                     output_dir / "gates" / "profitability-evidence-validation.json"
                 ).exists()
+            )
+            self.assertTrue((output_dir / "gates" / "janus-event-car-v1.json").exists())
+            self.assertTrue(
+                (output_dir / "gates" / "janus-hgrm-reward-v1.json").exists()
             )
             self.assertTrue(
                 (output_dir / "gates" / "promotion-evidence-gate.json").exists()

--- a/services/torghut/tests/test_governance_policy_dry_run.py
+++ b/services/torghut/tests/test_governance_policy_dry_run.py
@@ -63,6 +63,18 @@ class TestGovernancePolicyDryRun(TestCase):
                     ],
                     'artifact_ref': 'db:research_stress_metrics',
                 },
+                'janus_q': {
+                    'event_car': {
+                        'count': 2,
+                        'artifact_ref': 'gates/janus-event-car-v1.json',
+                    },
+                    'hgrm_reward': {
+                        'count': 2,
+                        'artifact_ref': 'gates/janus-hgrm-reward-v1.json',
+                    },
+                    'evidence_complete': True,
+                    'reasons': [],
+                },
                 'promotion_rationale': {
                     'requested_target': 'paper',
                     'gate_recommended_mode': 'paper',
@@ -80,7 +92,7 @@ class TestGovernancePolicyDryRun(TestCase):
             gate_report_path.write_text(json.dumps(gate_report, indent=2), encoding='utf-8')
 
             cmd = [
-                'python',
+                'python3',
                 str(script),
                 '--policy',
                 str(policy),

--- a/services/torghut/tests/test_janus_q_scaffold.py
+++ b/services/torghut/tests/test_janus_q_scaffold.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.autonomy.janus_q import (
+    build_janus_event_car_artifact_v1,
+    build_janus_hgrm_reward_artifact_v1,
+    build_janus_q_evidence_summary_v1,
+)
+from app.trading.evaluation import WalkForwardDecision
+from app.trading.features import SignalFeatures
+from app.trading.models import SignalEnvelope, StrategyDecision
+
+
+class TestJanusQScaffold(TestCase):
+    def test_event_car_artifact_is_deterministic(self) -> None:
+        signals = _signals_fixture()
+        generated_at = datetime(2026, 2, 25, tzinfo=timezone.utc)
+
+        first = build_janus_event_car_artifact_v1(
+            run_id="run-janus",
+            signals=signals,
+            generated_at=generated_at,
+        )
+        second = build_janus_event_car_artifact_v1(
+            run_id="run-janus",
+            signals=signals,
+            generated_at=generated_at,
+        )
+
+        self.assertEqual(first.schema_version, "janus-event-car-v1")
+        self.assertEqual(first.summary["event_count"], 4)
+        self.assertEqual(first.manifest_hash, second.manifest_hash)
+        self.assertNotEqual(first.records[0].car, "0")
+
+    def test_hgrm_reward_scaffold_and_summary_contract(self) -> None:
+        signals = _signals_fixture()
+        walk_decisions = _decisions_fixture()
+        generated_at = datetime(2026, 2, 25, tzinfo=timezone.utc)
+
+        event_car = build_janus_event_car_artifact_v1(
+            run_id="run-janus",
+            signals=signals,
+            generated_at=generated_at,
+        )
+        hgrm = build_janus_hgrm_reward_artifact_v1(
+            run_id="run-janus",
+            candidate_id="cand-janus",
+            event_car=event_car,
+            walk_decisions=walk_decisions,
+            generated_at=generated_at,
+        )
+        summary = build_janus_q_evidence_summary_v1(
+            event_car=event_car,
+            hgrm_reward=hgrm,
+            event_car_artifact_ref="/tmp/janus-event-car-v1.json",
+            hgrm_reward_artifact_ref="/tmp/janus-hgrm-reward-v1.json",
+        )
+
+        self.assertEqual(hgrm.schema_version, "janus-hgrm-reward-v1")
+        self.assertEqual(hgrm.summary["reward_count"], 2)
+        self.assertEqual(hgrm.summary["event_mapped_count"], 2)
+        self.assertTrue(summary["evidence_complete"])
+        self.assertEqual(summary["schema_version"], "janus-q-evidence-v1")
+
+
+def _signals_fixture() -> list[SignalEnvelope]:
+    return [
+        SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            payload={"price": "100", "event_type": "earnings"},
+            seq=1,
+            source="fixture",
+        ),
+        SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+            symbol="MSFT",
+            timeframe="1Min",
+            payload={"price": "200", "event_type": "guidance"},
+            seq=1,
+            source="fixture",
+        ),
+        SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 0, 2, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            payload={"price": "102", "event_type": "earnings"},
+            seq=2,
+            source="fixture",
+        ),
+        SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 0, 2, tzinfo=timezone.utc),
+            symbol="MSFT",
+            timeframe="1Min",
+            payload={"price": "198", "event_type": "guidance"},
+            seq=2,
+            source="fixture",
+        ),
+    ]
+
+
+def _decisions_fixture() -> list[WalkForwardDecision]:
+    return [
+        WalkForwardDecision(
+            decision=StrategyDecision(
+                strategy_id="s-1",
+                symbol="AAPL",
+                event_ts=datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                params={"event_type": "earnings"},
+            ),
+            features=SignalFeatures(
+                macd=Decimal("0.5"),
+                macd_signal=Decimal("0.2"),
+                rsi=Decimal("60"),
+                price=Decimal("100"),
+                volatility=Decimal("0.1"),
+            ),
+        ),
+        WalkForwardDecision(
+            decision=StrategyDecision(
+                strategy_id="s-1",
+                symbol="MSFT",
+                event_ts=datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"event_type": "guidance"},
+            ),
+            features=SignalFeatures(
+                macd=Decimal("-0.5"),
+                macd_signal=Decimal("-0.2"),
+                rsi=Decimal("40"),
+                price=Decimal("200"),
+                volatility=Decimal("0.1"),
+            ),
+        ),
+    ]

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -70,6 +70,58 @@ class TestPolicyChecks(TestCase):
         self.assertFalse(result.ready)
         self.assertIn("rollback_dry_run_stale", result.reasons)
 
+    def test_promotion_prerequisites_fail_when_janus_artifacts_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "paper-candidate").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "gates" / "gate-evaluation.json").write_text("{}", encoding="utf-8")
+            (root / "gates" / "profitability-evidence-v4.json").write_text(
+                json.dumps({"schema_version": "profitability-evidence-v4"}),
+                encoding="utf-8",
+            )
+            (root / "gates" / "profitability-benchmark-v4.json").write_text(
+                json.dumps(
+                    {
+                        "slices": [
+                            {"slice_type": "regime", "slice_key": "regime:neutral"}
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "gates" / "profitability-evidence-validation.json").write_text(
+                json.dumps({"passed": True, "reasons": []}),
+                encoding="utf-8",
+            )
+            (root / "gates" / "recalibration-report.json").write_text(
+                json.dumps({"status": "not_required"}),
+                encoding="utf-8",
+            )
+            (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
+                "kind: ConfigMap", encoding="utf-8"
+            )
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={},
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn("janus_event_car_artifact_missing", promotion.reasons)
+        self.assertIn("janus_hgrm_reward_artifact_missing", promotion.reasons)
+
     def test_allows_progression_when_artifacts_and_rollback_are_ready(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -106,6 +158,7 @@ class TestPolicyChecks(TestCase):
                 json.dumps({"status": "not_required"}),
                 encoding="utf-8",
             )
+            _write_janus_artifacts(root)
             (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
                 "kind: ConfigMap", encoding="utf-8"
             )
@@ -171,6 +224,7 @@ class TestPolicyChecks(TestCase):
                 json.dumps({"status": "queued", "recalibration_run_id": "recal-1"}),
                 encoding="utf-8",
             )
+            _write_janus_artifacts(root)
             (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
                 "kind: ConfigMap", encoding="utf-8"
             )
@@ -473,6 +527,7 @@ class TestPolicyChecks(TestCase):
                 json.dumps({"status": "queued", "recalibration_run_id": "recal-1"}),
                 encoding="utf-8",
             )
+            _write_janus_artifacts(root)
             (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
                 "kind: ConfigMap", encoding="utf-8"
             )
@@ -529,6 +584,7 @@ class TestPolicyChecks(TestCase):
                 json.dumps({"status": "not_required"}),
                 encoding="utf-8",
             )
+            _write_janus_artifacts(root)
             (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
                 "kind: ConfigMap", encoding="utf-8"
             )
@@ -583,6 +639,7 @@ class TestPolicyChecks(TestCase):
                 json.dumps({"status": "not_required"}),
                 encoding="utf-8",
             )
+            _write_janus_artifacts(root)
             (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
                 "kind: ConfigMap", encoding="utf-8"
             )
@@ -622,6 +679,29 @@ def _candidate_state() -> dict[str, object]:
     }
 
 
+def _write_janus_artifacts(root: Path) -> None:
+    (root / "gates" / "janus-event-car-v1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "janus-event-car-v1",
+                "summary": {"event_count": 2},
+                "records": [{"event_id": "evt-1"}, {"event_id": "evt-2"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "gates" / "janus-hgrm-reward-v1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "janus-hgrm-reward-v1",
+                "summary": {"reward_count": 2},
+                "rewards": [{"reward_id": "rwd-1"}, {"reward_id": "rwd-2"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def _gate_report() -> dict[str, object]:
     return {
         "run_id": "run-test",
@@ -655,6 +735,18 @@ def _gate_report() -> dict[str, object]:
                     {"case": "halt"},
                 ],
                 "artifact_ref": "db:research_stress_metrics",
+            },
+            "janus_q": {
+                "event_car": {
+                    "count": 2,
+                    "artifact_ref": "gates/janus-event-car-v1.json",
+                },
+                "hgrm_reward": {
+                    "count": 2,
+                    "artifact_ref": "gates/janus-hgrm-reward-v1.json",
+                },
+                "evidence_complete": True,
+                "reasons": [],
             },
             "promotion_rationale": {
                 "requested_target": "paper",


### PR DESCRIPTION
## Summary

- Implemented Janus-Q M1 deterministic scaffolding in Torghut autonomy runtime with new event-centric CAR artifacts and HGRM reward artifacts.
- Wired Janus evidence into autonomous lane runtime outputs, profitability evidence payloads, promotion evidence payloads, and artifact provenance references.
- Added fail-closed enforcement for incomplete/missing Janus evidence in both gate evaluation (`gate6`) and promotion prerequisite policy checks.
- Updated default autonomy policy JSONs and governance dry-run helpers/fixtures to require Janus evidence for paper/live progression.
- Added/updated deterministic tests and created `docs/whitepapers/wp-d72cb1a5c1febdcfbd9dae71/engineering-implementation-plan.md` with concrete M1 completion status.

## Related Issues

Related to #3589

## Testing

- `python3 -m py_compile services/torghut/app/trading/autonomy/janus_q.py services/torghut/app/trading/autonomy/lane.py services/torghut/app/trading/autonomy/gates.py services/torghut/app/trading/autonomy/policy_checks.py services/torghut/scripts/run_governance_policy_dry_run.py services/torghut/scripts/run_autonomous_lane.py services/torghut/tests/test_janus_q_scaffold.py services/torghut/tests/test_autonomy_gates.py services/torghut/tests/test_policy_checks.py services/torghut/tests/test_autonomous_lane.py services/torghut/tests/test_governance_policy_dry_run.py` (pass)
- `python3 -m unittest services.torghut.tests.test_janus_q_scaffold services.torghut.tests.test_autonomy_gates services.torghut.tests.test_policy_checks services.torghut.tests.test_autonomous_lane services.torghut.tests.test_governance_policy_dry_run` (fails in this container due missing runtime dependencies/tooling: `sqlalchemy`, `pytest`, `uv`, and preexisting `python` alias assumptions)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
