### PR TITLE
chore(torghut): promote image a96e9200

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:607a685769d3475ce0dc591951c62a9debd8f9bc93e861e1645696e3e3a1216d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:2ec0b94beac6d48a37a0302e27363a7bea3fcc21b90ab8dd6ada4eb22b841f7c
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-26T03:18:22Z"
+        client.knative.dev/updateTimestamp: "2026-02-26T05:06:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:607a685769d3475ce0dc591951c62a9debd8f9bc93e861e1645696e3e3a1216d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:2ec0b94beac6d48a37a0302e27363a7bea3fcc21b90ab8dd6ada4eb22b841f7c
           ports:
             - name: http1
               containerPort: 8181
@@ -342,9 +342,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-57-g80ca4e78
+              value: v0.561.0-59-ga96e9200
             - name: TORGHUT_COMMIT
-              value: 80ca4e78f09309b9c12fa3b9c38bc3d62c70fa7c
+              value: a96e9200f8b1bdda2d04ca59b92682a49ea6670d
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary\n- build and push torghut image from main commit a96e9200\n- update torghut knative service image digest and version/commit metadata\n- update db migration job image digest to keep presync migrations aligned\n\n## Validation\n- bun run build:torghut