### PR TITLE
chore(torghut): promote image 8c6d1373

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2ec0b94beac6d48a37a0302e27363a7bea3fcc21b90ab8dd6ada4eb22b841f7c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7d9ad18a205404f2811df77bd0aab687ab6e1805be0dbef796ec227019afdad2
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-26T05:06:36Z"
+        client.knative.dev/updateTimestamp: "2026-02-26T06:13:09Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2ec0b94beac6d48a37a0302e27363a7bea3fcc21b90ab8dd6ada4eb22b841f7c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7d9ad18a205404f2811df77bd0aab687ab6e1805be0dbef796ec227019afdad2
           ports:
             - name: http1
               containerPort: 8181
@@ -342,9 +342,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-59-ga96e9200
+              value: v0.561.0-61-g8c6d1373
             - name: TORGHUT_COMMIT
-              value: a96e9200f8b1bdda2d04ca59b92682a49ea6670d
+              value: 8c6d137352c5cfddb8eb9271c5ea074f5237d6c8
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary

- Promote Torghut runtime and migration job images to the build produced from merged `main` commit `8c6d137352c5cfddb8eb9271c5ea074f5237d6c8`.
- Update `TORGHUT_VERSION`/`TORGHUT_COMMIT` envs in the Knative service to match the promoted image.
- Refresh Knative update timestamp to force a new rollout revision under Argo.

## Related Issues

None

## Testing

- `docker buildx build --platform linux/arm64 -f services/torghut/Dockerfile -t registry.ide-newton.ts.net/lab/torghut:latest --push services/torghut`
- `git diff -- argocd/applications/torghut/knative-service.yaml argocd/applications/torghut/db-migrations-job.yaml`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
