### PR TITLE
chore(torghut): promote image 8c6d1373

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7d9ad18a205404f2811df77bd0aab687ab6e1805be0dbef796ec227019afdad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1c0337b6fa797ce2baa231d75fe7b24805f0a08d82522dad3faf32c9d16897e
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-26T06:13:09Z"
+        client.knative.dev/updateTimestamp: "2026-02-26T06:15:08Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7d9ad18a205404f2811df77bd0aab687ab6e1805be0dbef796ec227019afdad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1c0337b6fa797ce2baa231d75fe7b24805f0a08d82522dad3faf32c9d16897e
           ports:
             - name: http1
               containerPort: 8181


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `8c6d137352c5cfddb8eb9271c5ea074f5237d6c8`
- Image tag: `8c6d1373`
- Image digest: `sha256:a1c0337b6fa797ce2baa231d75fe7b24805f0a08d82522dad3faf32c9d16897e`