### PR TITLE
chore(torghut): promote image 44b85258

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1c0337b6fa797ce2baa231d75fe7b24805f0a08d82522dad3faf32c9d16897e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88477a11fbc07c4250aca5447323161de2e5a2647a8f37db366ea40fd5d9b9bd
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-26T06:15:08Z"
+        client.knative.dev/updateTimestamp: "2026-02-26T08:40:56Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1c0337b6fa797ce2baa231d75fe7b24805f0a08d82522dad3faf32c9d16897e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88477a11fbc07c4250aca5447323161de2e5a2647a8f37db366ea40fd5d9b9bd
           ports:
             - name: http1
               containerPort: 8181
@@ -366,9 +366,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-61-g8c6d1373
+              value: v0.561.0-73-g44b85258
             - name: TORGHUT_COMMIT
-              value: 8c6d137352c5cfddb8eb9271c5ea074f5237d6c8
+              value: 44b85258404ea89c933507906d4617c9cebbee11
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `44b85258404ea89c933507906d4617c9cebbee11`
- Image tag: `44b85258`
- Image digest: `sha256:88477a11fbc07c4250aca5447323161de2e5a2647a8f37db366ea40fd5d9b9bd`
- Migration change detected under `services/torghut/migrations/**`
- Added `do-not-automerge`; manual DB migration approval required before merge