### PR TITLE
chore(torghut): promote image 3491f2b1

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1c0337b6fa797ce2baa231d75fe7b24805f0a08d82522dad3faf32c9d16897e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2298b65c827ef72d75fab59301c7df69426150d0e45bacb8d6babb9f13091e6
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-26T06:15:08Z"
+        client.knative.dev/updateTimestamp: "2026-02-26T08:43:49Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1c0337b6fa797ce2baa231d75fe7b24805f0a08d82522dad3faf32c9d16897e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2298b65c827ef72d75fab59301c7df69426150d0e45bacb8d6babb9f13091e6
           ports:
             - name: http1
               containerPort: 8181
@@ -366,9 +366,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-61-g8c6d1373
+              value: v0.561.0-74-g3491f2b1
             - name: TORGHUT_COMMIT
-              value: 8c6d137352c5cfddb8eb9271c5ea074f5237d6c8
+              value: 3491f2b11249026a801018868593af4532141273
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `3491f2b11249026a801018868593af4532141273`
- Image tag: `3491f2b1`
- Image digest: `sha256:f2298b65c827ef72d75fab59301c7df69426150d0e45bacb8d6babb9f13091e6`