### PR TITLE
chore(jangar): promote image 9009e162

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 477487a4
-  digest: sha256:e1ee9a1fb175d57141e474ba7526423e049451f97922b6c34a4d232ee0a0b0b6
+  tag: "9009e162"
+  digest: sha256:bfaf86fa3313272a487cfc7537ad2fcad7edc74ce2a8c5aef38fc600e3009806
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 477487a4
-    digest: sha256:01e35162aa6c7efdd8192010c0853cf82f8988a0eb4d89519e61b5bed43da6a8
+    tag: "9009e162"
+    digest: sha256:a87d1ac84c4865fc9771ab04076eb748d6920b16667b7f984215201ca01b6ee2
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 477487a4
-    digest: sha256:e1ee9a1fb175d57141e474ba7526423e049451f97922b6c34a4d232ee0a0b0b6
+    tag: "9009e162"
+    digest: sha256:bfaf86fa3313272a487cfc7537ad2fcad7edc74ce2a8c5aef38fc600e3009806
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-25T16:31:54Z"
+    deploy.knative.dev/rollout: "2026-02-26T19:34:17Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-25T16:31:54Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-26T19:34:17Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "477487a4"
-    digest: sha256:e1ee9a1fb175d57141e474ba7526423e049451f97922b6c34a4d232ee0a0b0b6
+    newTag: "9009e162"
+    digest: sha256:bfaf86fa3313272a487cfc7537ad2fcad7edc74ce2a8c5aef38fc600e3009806


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `9009e162419304b2e533002c03d6b86536d6d3d6`
- Image tag: `9009e162`
- Image digest: `sha256:bfaf86fa3313272a487cfc7537ad2fcad7edc74ce2a8c5aef38fc600e3009806`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`