### PR TITLE
fix(jangar): bootstrap quant runtime and correct market context health default

### DIFF
--- a/services/jangar/nitro.config.ts
+++ b/services/jangar/nitro.config.ts
@@ -8,6 +8,7 @@ const agentctlPlugin = resolve(rootDir, 'server/plugins/agentctl-grpc')
 const controlPlaneCachePlugin = resolve(rootDir, 'server/plugins/control-plane-cache')
 const h3AppAliasPlugin = resolve(rootDir, 'server/plugins/h3-app-alias')
 const websocketResolverPlugin = resolve(rootDir, 'server/plugins/websocket-resolver')
+const torghutQuantRuntimePlugin = resolve(rootDir, 'server/plugins/torghut-quant-runtime')
 const buildSourceMap = (() => {
   const value = process.env.JANGAR_BUILD_SOURCEMAP?.trim().toLowerCase()
   if (value === '0' || value === 'false') return false
@@ -30,5 +31,12 @@ export default defineNitroConfig({
   experimental: {
     websocket: true,
   },
-  plugins: [agentsRuntimePlugin, agentctlPlugin, controlPlaneCachePlugin, h3AppAliasPlugin, websocketResolverPlugin],
+  plugins: [
+    agentsRuntimePlugin,
+    agentctlPlugin,
+    controlPlaneCachePlugin,
+    h3AppAliasPlugin,
+    websocketResolverPlugin,
+    torghutQuantRuntimePlugin,
+  ],
 })

--- a/services/jangar/src/routes/api/torghut/market-context/health.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/health.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { getTorghutMarketContextHealth } from '~/server/torghut-market-context'
+import { normalizeTorghutSymbol } from '~/server/torghut-symbols'
 
 export const Route = createFileRoute('/api/torghut/market-context/health')({
   server: {
@@ -20,9 +21,16 @@ const jsonResponse = (payload: unknown, status = 200) => {
   })
 }
 
+const resolveDefaultHealthSymbol = () => {
+  const configured = process.env.JANGAR_MARKET_CONTEXT_HEALTH_DEFAULT_SYMBOL?.trim()
+  if (configured && configured.length > 0) return normalizeTorghutSymbol(configured)
+  return 'AAPL'
+}
+
 export const getMarketContextHealthHandler = async (request: Request) => {
   const url = new URL(request.url)
-  const symbol = url.searchParams.get('symbol')?.trim() || 'SPY'
+  const rawSymbol = url.searchParams.get('symbol')?.trim()
+  const symbol = rawSymbol && rawSymbol.length > 0 ? normalizeTorghutSymbol(rawSymbol) : resolveDefaultHealthSymbol()
 
   try {
     const health = await getTorghutMarketContextHealth(symbol)

--- a/services/jangar/src/server/__tests__/nitro-config.test.ts
+++ b/services/jangar/src/server/__tests__/nitro-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 
 import nitroConfig from '../../../nitro.config'
 
@@ -13,5 +13,18 @@ describe('nitro config', () => {
 
   test('disables nf3 node_modules tracing for container builds', () => {
     expect(nitroConfig.externals?.noTrace).toBe(true)
+  })
+
+  it('registers torghut quant runtime bootstrap plugin', () => {
+    const plugins = Array.isArray((nitroConfig as { plugins?: unknown }).plugins)
+      ? ((nitroConfig as { plugins: unknown[] }).plugins as unknown[])
+      : []
+
+    const hasQuantRuntimePlugin = plugins.some(
+      (plugin): plugin is string =>
+        typeof plugin === 'string' && plugin.includes('server/plugins/torghut-quant-runtime'),
+    )
+
+    expect(hasQuantRuntimePlugin).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- register `server/plugins/torghut-quant-runtime` in `services/jangar/nitro.config.ts` so quant metrics runtime starts in production boot path.
- add regression coverage in `services/jangar/src/server/__tests__/nitro-config.test.ts` to ensure the quant runtime plugin remains wired.
- update `/api/torghut/market-context/health` default symbol behavior to use normalized `JANGAR_MARKET_CONTEXT_HEALTH_DEFAULT_SYMBOL` when set and fallback to `AAPL` instead of `SPY`.
- add route tests in `services/jangar/src/routes/api/torghut/market-context/-health.test.ts` for configured default and fallback default symbol behavior.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/nitro.config.ts services/jangar/src/routes/api/torghut/market-context/health.ts services/jangar/src/routes/api/torghut/market-context/-health.test.ts services/jangar/src/server/__tests__/nitro-config.test.ts`
- `bunx vitest run --config vitest.config.ts src/routes/api/torghut/market-context/-health.test.ts src/server/__tests__/nitro-config.test.ts` (run in `services/jangar`)
- `bun run --filter @proompteng/jangar tsc`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
