### PR TITLE
chore(jangar): promote image a5d12678

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-26T19:34:17Z"
+    deploy.knative.dev/rollout: "2026-02-26T19:52:31.032Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-26T19:34:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-26T19:52:31.032Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "9009e162"
-    digest: sha256:bfaf86fa3313272a487cfc7537ad2fcad7edc74ce2a8c5aef38fc600e3009806
+    newTag: "a5d12678"
+    digest: sha256:8ac964d3f2cd84a18982ba3734be4fa0cb289c73a1d8ecc09c5d3cdfa36357a4


### PR DESCRIPTION
## Summary

- promote Jangar image in `argocd/applications/jangar/kustomization.yaml` from `9009e162@sha256:bfaf...` to `a5d12678@sha256:8ac964...`.
- update Jangar app deployment rollout annotation timestamp so the app deployment restarts onto the promoted digest.
- update Jangar worker deployment restart annotation timestamp to roll worker pod onto the same promoted digest.

## Related Issues

None

## Testing

- `skopeo inspect --override-os linux --override-arch arm64 --format '{{.Digest}}' docker://registry.ide-newton.ts.net/lab/jangar:a5d12678`
- `bun run packages/scripts/src/jangar/update-manifests.ts --tag a5d12678 --digest sha256:8ac964d3f2cd84a18982ba3734be4fa0cb289c73a1d8ecc09c5d3cdfa36357a4`
- `mise exec helm@3 -- kubectl kustomize argocd/applications/jangar --enable-helm >/tmp/jangar-kustomize-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
