### PR TITLE
feat(torghut): add codex-spark fundamentals/news market-context pipeline

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -1,0 +1,58 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentProvider
+metadata:
+  name: codex-spark
+spec:
+  binary: /usr/local/bin/agent-runner
+  argsTemplate: []
+  envTemplate:
+    CODEX_LOG_LEVEL: info
+    NATS_URL: nats://nats.nats.svc.cluster.local:4222
+    AGENT_PROVIDER_PATH: /root/.codex/provider-codex-spark.json
+  inputFiles:
+    - path: /root/.codex/config.toml
+      content: |-
+        model = "gpt-5.3-codex-spark"
+        model_reasoning_summary = "detailed"
+        model_reasoning_effort = "high"
+        model_verbosity = "medium"
+        preferred_auth_method = "apikey"
+        approval_policy = "never"
+        sandbox_mode = "danger-full-access"
+        web_search = "live"
+
+        [features]
+        undo = true
+        enable_request_compression = true
+        apply_patch_freeform = true
+        unified_exec = true
+        shell_snapshot = true
+        steer = true
+        multi_agent = true
+        child_agents_md = true
+        collaboration_modes = true
+        responses_websockets = false
+
+        [shell_environment_policy]
+        ignore_default_excludes = true
+
+        [projects."/workspace/lab"]
+        trust_level = "trusted"
+
+        [projects."/root"]
+        trust_level = "trusted"
+    - path: /root/.codex/provider-codex-spark.json
+      content: |-
+        {
+          "name": "codex-spark",
+          "binary": "/bin/bash",
+          "argsTemplate": [
+            "-lc",
+            "PROMPT_PATH='{{payloads.promptPath}}'; cat \"$PROMPT_PATH\" | /usr/local/bin/codex exec --skip-git-repo-check --cd /tmp -"
+          ]
+        }
+  outputArtifacts:
+    - name: runner-log
+      path: /workspace/.agent/runner.log
+    - name: runner-status
+      path: /workspace/.agent/status.json

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
   - codex-whitepaper-secretbinding.yaml
   - codex-whitepaper-agent.yaml
   - codex-agentprovider.yaml
+  - codex-spark-agentprovider.yaml
+  - torghut-fundamentals-agent.yaml
+  - torghut-news-agent.yaml
   - codex-agent-system-prompt-configmap.yaml
   - codex-whitepaper-agent-system-prompt-configmap.yaml
   - codex-research-secretbinding.yaml

--- a/argocd/applications/agents/torghut-agentruns.yaml
+++ b/argocd/applications/agents/torghut-agentruns.yaml
@@ -172,3 +172,131 @@ spec:
        - resume-ta: set spec.job.state: running and bump spec.restartNonce if needed.
     4) Open a PR against ${repository} with base ${base} and head ${head}.
     5) Output PR URL and clear rollback instructions.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: torghut-market-context-fundamentals-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - symbol
+      - domain
+      - asOfUtc
+      - reason
+      - callbackUrl
+      - requestId
+  text: |
+    Objective: Build a fundamentals market-context snapshot for `${symbol}` and publish it to `${callbackUrl}`.
+
+    Guardrails:
+    - Read-only research task; do not mutate cluster state.
+    - Use at least 2 independent citations.
+    - All timestamps must be UTC ISO-8601 strings.
+    - Keep qualityScore in [0, 1].
+
+    Inputs:
+    - symbol, domain, asOfUtc, reason
+    - callbackUrl, requestId
+    - callbackToken (optional bearer token)
+
+    Required output payload shape:
+    {
+      "symbol": "<symbol>",
+      "domain": "fundamentals",
+      "asOfUtc": "<ISO timestamp>",
+      "sourceCount": <integer>,
+      "qualityScore": <number 0..1>,
+      "payload": {
+        "thesis": "<short summary>",
+        "valuation": { ... },
+        "growth": { ... },
+        "profitability": { ... },
+        "balanceSheet": { ... },
+        "upcomingCatalysts": [ ... ]
+      },
+      "citations": [
+        { "source": "<publisher>", "publishedAt": "<ISO timestamp>", "url": "<https url or null>" }
+      ],
+      "riskFlags": [ ... ],
+      "provider": "codex-spark",
+      "runStatus": "succeeded",
+      "requestId": "<requestId>"
+    }
+
+    Steps:
+    1) Research current fundamentals for `${symbol}` (valuation, growth, profitability, balance-sheet/capital structure, near-term catalysts).
+    2) Write the JSON payload to `/tmp/market-context-fundamentals.json`.
+    3) Submit the payload:
+       - AUTH=()
+       - if [ -n "${callbackToken}" ]; then AUTH=(-H "authorization: Bearer ${callbackToken}"); fi
+       - curl -fsS -X POST "${callbackUrl}" -H "content-type: application/json" "${AUTH[@]}" --data-binary @/tmp/market-context-fundamentals.json
+    4) Ensure callback response contains `"ok": true`. If it fails, retry once; if still failing, exit non-zero.
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: torghut-market-context-news-v1
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - symbol
+      - domain
+      - asOfUtc
+      - reason
+      - callbackUrl
+      - requestId
+  text: |
+    Objective: Build a news market-context snapshot for `${symbol}` and publish it to `${callbackUrl}`.
+
+    Guardrails:
+    - Read-only research task; do not mutate cluster state.
+    - Prioritize the most recent high-signal news (last 24h, then 7d if sparse).
+    - Use at least 3 citations.
+    - All timestamps must be UTC ISO-8601 strings.
+    - Keep qualityScore in [0, 1].
+
+    Inputs:
+    - symbol, domain, asOfUtc, reason
+    - callbackUrl, requestId
+    - callbackToken (optional bearer token)
+
+    Required output payload shape:
+    {
+      "symbol": "<symbol>",
+      "domain": "news",
+      "asOfUtc": "<ISO timestamp>",
+      "sourceCount": <integer>,
+      "qualityScore": <number 0..1>,
+      "payload": {
+        "summary": "<short summary>",
+        "headlines": [
+          {
+            "headline": "<title>",
+            "publisher": "<publisher>",
+            "publishedAt": "<ISO timestamp>",
+            "url": "<https url or null>",
+            "marketImpact": "positive|negative|mixed|neutral"
+          }
+        ],
+        "eventRisk": "low|medium|high"
+      },
+      "citations": [
+        { "source": "<publisher>", "publishedAt": "<ISO timestamp>", "url": "<https url or null>" }
+      ],
+      "riskFlags": [ ... ],
+      "provider": "codex-spark",
+      "runStatus": "succeeded",
+      "requestId": "<requestId>"
+    }
+
+    Steps:
+    1) Gather recent high-signal company/sector/macro news relevant to `${symbol}`.
+    2) Write the JSON payload to `/tmp/market-context-news.json`.
+    3) Submit the payload:
+       - AUTH=()
+       - if [ -n "${callbackToken}" ]; then AUTH=(-H "authorization: Bearer ${callbackToken}"); fi
+       - curl -fsS -X POST "${callbackUrl}" -H "content-type: application/json" "${AUTH[@]}" --data-binary @/tmp/market-context-news.json
+    4) Ensure callback response contains `"ok": true`. If it fails, retry once; if still failing, exit non-zero.

--- a/argocd/applications/agents/torghut-agentruns.yaml
+++ b/argocd/applications/agents/torghut-agentruns.yaml
@@ -199,7 +199,6 @@ spec:
     Inputs:
     - symbol, domain, asOfUtc, reason
     - callbackUrl, requestId
-    - callbackToken (optional bearer token)
 
     Required output payload shape:
     {
@@ -230,7 +229,9 @@ spec:
     2) Write the JSON payload to `/tmp/market-context-fundamentals.json`.
     3) Submit the payload:
        - AUTH=()
-       - if [ -n "${callbackToken}" ]; then AUTH=(-H "authorization: Bearer ${callbackToken}"); fi
+       - TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
+       - if [ -r "${TOKEN_PATH}" ]; then TOKEN="$(tr -d '\n' < "${TOKEN_PATH}")"; fi
+       - if [ -n "${TOKEN:-}" ]; then AUTH=(-H "authorization: Bearer ${TOKEN}"); fi
        - curl -fsS -X POST "${callbackUrl}" -H "content-type: application/json" "${AUTH[@]}" --data-binary @/tmp/market-context-fundamentals.json
     4) Ensure callback response contains `"ok": true`. If it fails, retry once; if still failing, exit non-zero.
 ---
@@ -261,7 +262,6 @@ spec:
     Inputs:
     - symbol, domain, asOfUtc, reason
     - callbackUrl, requestId
-    - callbackToken (optional bearer token)
 
     Required output payload shape:
     {
@@ -297,6 +297,8 @@ spec:
     2) Write the JSON payload to `/tmp/market-context-news.json`.
     3) Submit the payload:
        - AUTH=()
-       - if [ -n "${callbackToken}" ]; then AUTH=(-H "authorization: Bearer ${callbackToken}"); fi
+       - TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
+       - if [ -r "${TOKEN_PATH}" ]; then TOKEN="$(tr -d '\n' < "${TOKEN_PATH}")"; fi
+       - if [ -n "${TOKEN:-}" ]; then AUTH=(-H "authorization: Bearer ${TOKEN}"); fi
        - curl -fsS -X POST "${callbackUrl}" -H "content-type: application/json" "${AUTH[@]}" --data-binary @/tmp/market-context-news.json
     4) Ensure callback response contains `"ok": true`. If it fails, retry once; if still failing, exit non-zero.

--- a/argocd/applications/agents/torghut-fundamentals-agent.yaml
+++ b/argocd/applications/agents/torghut-fundamentals-agent.yaml
@@ -1,0 +1,7 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: Agent
+metadata:
+  name: torghut-fundamentals-agent
+spec:
+  providerRef:
+    name: codex-spark

--- a/argocd/applications/agents/torghut-news-agent.yaml
+++ b/argocd/applications/agents/torghut-news-agent.yaml
@@ -1,0 +1,7 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: Agent
+metadata:
+  name: torghut-news-agent
+spec:
+  providerRef:
+    name: codex-spark

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-26T19:53:36Z"
+    deploy.knative.dev/rollout: "2026-02-26T21:16:24.147Z"
 spec:
   replicas: 1
   strategy:
@@ -285,16 +285,36 @@ spec:
             - name: JANGAR_MARKET_CONTEXT_REGIME_MAX_FRESHNESS_SECONDS
               value: "120"
             - name: JANGAR_MARKET_CONTEXT_FUNDAMENTALS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: jangar-market-context-providers
-                  key: fundamentals_url
-                  optional: true
+              value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context/providers/fundamentals
+              valueFrom: null
             - name: JANGAR_MARKET_CONTEXT_NEWS_URL
+              value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context/providers/news
+              valueFrom: null
+            - name: JANGAR_MARKET_CONTEXT_AGENT_DISPATCH_ENABLED
+              value: "true"
+            - name: JANGAR_MARKET_CONTEXT_AGENT_NAMESPACE
+              value: agents
+            - name: JANGAR_MARKET_CONTEXT_FUNDAMENTALS_AGENT_NAME
+              value: torghut-fundamentals-agent
+            - name: JANGAR_MARKET_CONTEXT_NEWS_AGENT_NAME
+              value: torghut-news-agent
+            - name: JANGAR_MARKET_CONTEXT_FUNDAMENTALS_IMPLEMENTATION_SPEC
+              value: torghut-market-context-fundamentals-v1
+            - name: JANGAR_MARKET_CONTEXT_NEWS_IMPLEMENTATION_SPEC
+              value: torghut-market-context-news-v1
+            - name: JANGAR_MARKET_CONTEXT_FUNDAMENTALS_DISPATCH_COOLDOWN_SECONDS
+              value: "1800"
+            - name: JANGAR_MARKET_CONTEXT_NEWS_DISPATCH_COOLDOWN_SECONDS
+              value: "120"
+            - name: JANGAR_MARKET_CONTEXT_AGENT_CALLBACK_BASE_URL
+              value: http://jangar.jangar.svc.cluster.local
+            - name: JANGAR_MARKET_CONTEXT_AGENT_TTL_SECONDS
+              value: "1800"
+            - name: JANGAR_MARKET_CONTEXT_INGEST_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: jangar-market-context-providers
-                  key: news_url
+                  key: ingest_token
                   optional: true
             - name: JANGAR_TORGHUT_DECISION_ENGINE_ENABLED
               value: "true"

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-26T19:53:36Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-26T21:16:24.147Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "249893c7"
-    digest: sha256:9c69a1aa6513cdd4b256f80adfeb1761c2426f0d693b4b032eb3a8f72f6e0de1
+    newTag: "477487a4"
+    digest: sha256:e1ee9a1fb175d57141e474ba7526423e049451f97922b6c34a4d232ee0a0b0b6

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a5d12678"
-    digest: sha256:8ac964d3f2cd84a18982ba3734be4fa0cb289c73a1d8ecc09c5d3cdfa36357a4
+    newTag: "249893c7"
+    digest: sha256:9c69a1aa6513cdd4b256f80adfeb1761c2426f0d693b4b032eb3a8f72f6e0de1

--- a/docs/torghut/design-system/v5/13-fundamentals-news-codex-spark-agent-pipeline-2026-02-26.md
+++ b/docs/torghut/design-system/v5/13-fundamentals-news-codex-spark-agent-pipeline-2026-02-26.md
@@ -1,0 +1,389 @@
+# Torghut Fundamentals + News via Codex Agent Provider (`gpt-5.3-codex-spark`)
+
+## Status
+
+- Date: `2026-02-26`
+- Maturity: `production design + rollout plan`
+- Scope: replace unconfigured fundamentals/news providers with in-cluster Codex AgentRuns using `gpt-5.3-codex-spark`, with a core HTTP integration path first and optional streaming/analytics expansion
+
+## Objective
+
+Deliver production-grade fundamentals and news context for Torghut by:
+
+1. generating domain context with Codex agents (Spark model),
+2. materializing authoritative latest-state in Jangar Postgres for deterministic reads,
+3. preserving the existing Torghut consumption contract (`GET /api/torghut/market-context` via Jangar),
+4. optionally adding Kafka/Flink/ClickHouse for replay, scale, and analytics after v1 stability.
+
+## Verified Current State (Live Audit, 2026-02-26)
+
+### 1. Torghut consumes Jangar market context, not direct fundamentals/news services
+
+- Torghut runtime points to:
+  - `TRADING_MARKET_CONTEXT_URL=http://jangar.jangar.svc.cluster.local/api/torghut/market-context/`
+  - `TRADING_MARKET_CONTEXT_REQUIRED=true`
+  - `TRADING_MARKET_CONTEXT_FAIL_MODE=shadow_only`
+  - `LLM_MODEL=gpt-5.3-codex-spark`
+- Verified from live `ksvc/torghut` env.
+
+### 2. Jangar market-context is currently degraded due missing fundamentals/news configuration
+
+- `GET /api/torghut/market-context/health?symbol=NVDA` from the live Jangar pod reports:
+  - `overallState: degraded`
+  - `providerHealth[].configured=false` for `fundamentals` and `news`
+  - `technicals` and `regime` state `ok` (ClickHouse ingest healthy)
+- Current URL env vars are optional secret refs:
+  - `JANGAR_MARKET_CONTEXT_FUNDAMENTALS_URL` <- `secret/jangar-market-context-providers:fundamentals_url`
+  - `JANGAR_MARKET_CONTEXT_NEWS_URL` <- `secret/jangar-market-context-providers:news_url`
+
+### 3. Agent provider exists, but default model is not Spark
+
+- Live `AgentProvider/codex` writes `/root/.codex/config.toml` with:
+  - `model = "gpt-5.3-codex"`
+- Therefore fundamentals/news AgentRuns need a new provider (or equivalent model override path) to guarantee Spark.
+
+### 4. ClickHouse dataplane is healthy and fresh for TA, but has no fundamentals/news tables
+
+- `torghut.ta_signals` latest lag observed: ~`2s` (healthy).
+- Existing user tables in DB `torghut`: `ta_microbars`, `ta_signals`.
+- No dedicated fundamentals/news context tables currently exist.
+
+### 5. Kafka and Flink are healthy and ready for extension
+
+- Kafka (Strimzi) topics are healthy for Torghut TA/trading pipelines.
+- No existing `torghut.fundamentals.*` or `torghut.news.*` topics.
+- Flink `torghut-ta` is `RUNNING`; checkpoints are completing and externalized to S3.
+- Flink can be extended via a separate low-risk job instead of modifying TA core path first.
+
+### 6. Postgres has no current fundamentals/news market-context state store
+
+- `torghut` Postgres has trading/whitepaper tables; no fundamentals/news context tables.
+- `jangar` Postgres has control-plane schemas and `torghut_symbols`, but no context-domain tables.
+
+## Non-Negotiable Invariants
+
+- Paper/shadow-first; deterministic gates remain final authority.
+- Market-context contract version remains `torghut.market-context.v1`.
+- Fundamentals/news generation failures must degrade context, not silently pass as healthy.
+- No direct, ad-hoc cluster mutations in steady-state operation; GitOps is primary path.
+- Agent model for fundamentals/news must be pinned to `gpt-5.3-codex-spark`.
+
+## Implementation Profiles
+
+### Core v1 (required)
+
+- Torghut <-> Jangar remains HTTP (`TRADING_MARKET_CONTEXT_URL`).
+- Jangar orchestrates Codex AgentRuns and stores latest fundamentals/news in Postgres.
+- No Kafka/Flink/ClickHouse dependency for correctness.
+
+### Stream v2 (optional)
+
+- Add Kafka event streams, Flink stateful assembly, and ClickHouse analytical materialization.
+- Use only after Core v1 is stable and SLO-compliant.
+
+## Target Architecture
+
+```mermaid
+flowchart LR
+  SYM["Jangar symbols (torghut_symbols)"] --> ORCH["Jangar context orchestrator"]
+  ORCH --> AR1["AgentRun: fundamentals (codex-spark)"]
+  ORCH --> AR2["AgentRun: news (codex-spark)"]
+  AR1 --> PG["Postgres (jangar.market_context_*)"]
+  AR2 --> PG
+  PG --> API["Jangar /api/torghut/market-context"]
+  API --> TOR["Torghut trading scheduler"]
+  AR1 -. optional v2 .-> KAF["Kafka topic: torghut.fundamentals.v1"]
+  AR2 -. optional v2 .-> KAF2["Kafka topic: torghut.news.v1"]
+  KAF -. optional v2 .-> FLINK["Flink market-context assembler"]
+  KAF2 -. optional v2 .-> FLINK
+  TA["Kafka: torghut.ta.signals.v1"] -. optional v2 .-> FLINK
+  FLINK -. optional v2 .-> CH["ClickHouse market_context tables"]
+  CH -. optional enrichment .-> API
+```
+
+## Integration Design by System
+
+### Kubernetes (`kubectl` / GitOps)
+
+Add resources under `argocd/applications/agents` and `argocd/applications/torghut`:
+
+1. `AgentProvider/codex-spark`
+   - clone of current `codex` provider with `model = "gpt-5.3-codex-spark"`.
+2. `Agent/codex-fundamentals-agent` and `Agent/codex-news-agent`
+   - `providerRef.name: codex-spark`
+   - dedicated system prompts and secret bindings.
+3. `ImplementationSpec` pair:
+   - `torghut-fundamentals-context-v1`
+   - `torghut-news-context-v1`
+4. Jangar deployment env extensions:
+   - scheduler cadence knobs
+   - control-plane feature flag `JANGAR_MARKET_CONTEXT_AGENTS_ENABLED`.
+5. Optional Stream v2 env (disabled by default):
+   - Kafka producer settings (bootstrap, auth secret refs, topic names)
+   - stream publish toggle and batch/timeout controls.
+
+### Postgres
+
+Use `jangar` DB for operational truth and idempotency:
+
+1. `torghut_control_plane.market_context_domain_runs`
+   - run lifecycle, agentrun name/uid, symbol, domain, status, timing, failure reason.
+2. `torghut_control_plane.market_context_domain_latest`
+   - one latest row per (`symbol`, `domain`) with normalized payload and quality/freshness fields.
+3. Optional Stream v2: `torghut_control_plane.market_context_publish_offsets`
+   - exactly-once Kafka publish checkpointing/idempotency keys.
+
+Why Jangar DB:
+
+- aligns with existing agent/control-plane ownership,
+- gives deterministic low-latency reads for the market-context API,
+- keeps Torghut integration independent of stream processors.
+
+### Kafka
+
+Not required for Core v1.
+
+Optional Stream v2 topics in `argocd/applications/kafka/torghut-topics.yaml`:
+
+1. `torghut.fundamentals.v1`
+2. `torghut.news.v1`
+3. `torghut.market-context.status.v1` (optional compacted status stream)
+
+Suggested config:
+
+- `partitions: 3` (match symbol parallelism)
+- `replicas: 3`
+- `compression.type: lz4`
+- `cleanup.policy: delete` for domain event topics
+- `cleanup.policy: compact,delete` for status topic
+
+Create a dedicated `KafkaUser` (least privilege), for example `jangar-market-context`.
+
+### Flink
+
+Not required for Core v1.
+
+Optional Stream v2 introduces a separate job (`torghut-market-context-flink`) rather than changing `torghut-ta`:
+
+Inputs:
+
+- `torghut.fundamentals.v1`
+- `torghut.news.v1`
+- `torghut.ta.signals.v1` (optional join for technical/regime coherence signal)
+
+Responsibilities:
+
+- event-time freshness computation,
+- latest-by-symbol/domain consolidation,
+- optional quality smoothing and missing-data alarms,
+- sink to ClickHouse `market_context_*` tables with exactly-once semantics.
+
+This keeps TA job blast radius low while allowing stateful stream assembly when needed.
+
+### ClickHouse
+
+Not required for Core v1.
+
+Optional Stream v2 adds tables in `torghut` DB:
+
+1. `market_context_domain_events`
+   - append log of normalized fundamentals/news events.
+2. `market_context_latest`
+   - replacing table keyed by (`symbol`, `domain`) with latest enriched view.
+
+Jangar endpoint read path:
+
+- primary: Postgres `market_context_domain_latest` (authoritative control-plane state),
+- optional enrichment: ClickHouse `market_context_latest` for analytics/freshness overlays.
+
+## Contract Design
+
+### Agent output artifact (both domains)
+
+Each run must emit JSON:
+
+```json
+{
+  "contextVersion": "torghut.market-context.v1",
+  "domain": "fundamentals",
+  "symbol": "NVDA",
+  "asOfUtc": "2026-02-26T19:40:00Z",
+  "sourceCount": 6,
+  "qualityScore": 0.82,
+  "payload": {},
+  "citations": [
+    { "source": "sec", "publishedAt": "2026-02-25T21:00:00Z", "url": "https://..." }
+  ],
+  "riskFlags": []
+}
+```
+
+Notes:
+
+- `domain` is `fundamentals` or `news`.
+- `qualityScore` must be clamped to `[0,1]`.
+- invalid/missing timestamps are rejected as failed runs.
+
+### AgentRun parameter contract
+
+Required keys:
+
+- `symbol`
+- `asOfUtc`
+- `domain`
+- `artifactPath`
+- `qualityPolicyRef`
+- `citationPolicyRef`
+
+### Jangar market-context endpoint compatibility
+
+No contract break for Torghut:
+
+- keep `GET /api/torghut/market-context/` response shape unchanged,
+- keep `GET /api/torghut/market-context/health` semantics unchanged (`ok|degraded|down`),
+- map missing domains to existing `*_missing` risk flags.
+
+## Operational Flow
+
+1. Scheduler picks active symbols from `torghut_symbols` (equity/crypto class aware).
+2. Jangar submits two AgentRuns per symbol cadence:
+   - fundamentals (slower cadence, e.g. 15m-60m),
+   - news (faster cadence, e.g. 30s-120s).
+3. On completion, Jangar validates artifact JSON and upserts Postgres latest rows.
+4. Jangar serves fundamentals/news domains directly from Postgres in `/api/torghut/market-context`.
+5. Torghut continues to consume that API without contract change.
+6. Optional Stream v2: publish to Kafka -> process in Flink -> materialize to ClickHouse.
+
+## Observability, SLOs, and Alerts
+
+### SLOs
+
+- `fundamentals` freshness p95 <= `24h` (or filing-event aware equivalent).
+- `news` freshness p95 <= `300s`.
+- AgentRun success rate >= `99%` per rolling hour.
+- Optional Stream v2: end-to-end publish lag (AgentRun completion -> Kafka -> ClickHouse latest) p95 <= `30s`.
+
+### Metrics to add
+
+- Jangar:
+  - `jangar_market_context_agentrun_submitted_total{domain}`
+  - `jangar_market_context_agentrun_failed_total{domain,reason}`
+  - `jangar_market_context_domain_freshness_seconds{domain,symbol}`
+- Optional Stream v2:
+  - `jangar_market_context_kafka_publish_latency_seconds`
+  - Flink watermark lag / checkpoint failure counters
+  - ClickHouse lag for `market_context_domain_events` and `market_context_latest`.
+
+### Alert examples
+
+- `news` stale > `600s` for > `5m` -> warning.
+- `fundamentals` stale > `36h` -> warning.
+- any domain `error` state ratio > `10%` over `10m` -> critical.
+
+## Security and Policy
+
+- Use dedicated SecretBinding for new agents (`codex-fundamentals-secrets`, `codex-news-secrets`).
+- Restrict allowed secrets to minimal set (`codex-auth`, optional provider/API keys).
+- Add explicit approval policy labels for any write-capable AgentRun flows.
+- Keep `vcsPolicy.mode=none` for pure data-context runs (no PR needed).
+
+## Rollout Plan (Production Quality)
+
+### Phase 0: Bootstrap (no traffic impact)
+
+1. Add `codex-spark` AgentProvider and new agents/specs.
+2. Add Postgres schema + migrations.
+3. Deploy Jangar scheduler code behind disabled feature flag.
+
+Exit gates:
+
+- CRDs Ready in `agents` namespace.
+- Migration applied cleanly.
+
+### Phase 1: Core v1 canary and cutover
+
+1. Enable AgentRuns for a 3-symbol canary (`NVDA`, `MSFT`, `AAPL`).
+2. Keep legacy URL provider mode as fallback for one release.
+3. Compare quality/freshness against manual samples.
+4. Validate Torghut market-context behavior in shadow mode.
+
+Exit gates:
+
+- >= `99%` successful runs for 24h.
+- No malformed artifacts.
+- Jangar health `overallState=ok` for active symbols,
+- no increase in `market_context_domain_error`.
+
+### Phase 2: Scale-out
+
+1. Expand to full symbol universe.
+2. Tune cadence and concurrency.
+3. Remove legacy external URL configuration once stable.
+
+### Phase 3 (Optional): Stream v2 integration
+
+1. Add Kafka topics and KafkaUser.
+2. Enable Kafka publish for canary symbols.
+3. Enable `torghut-market-context-flink` canary job.
+4. Add ClickHouse materialized/latest tables for analytics.
+
+Exit gates:
+
+- checkpoint health stable,
+- no sustained consumer lag alarms,
+- ClickHouse freshness meets Stream v2 SLO.
+
+## Rollback Plan
+
+- Toggle `JANGAR_MARKET_CONTEXT_AGENTS_ENABLED=false`.
+- Re-enable legacy URL provider mode (`JANGAR_MARKET_CONTEXT_FUNDAMENTALS_URL`, `...NEWS_URL`) if required.
+- Optional Stream v2 rollback: pause Flink context job and disable Kafka publish.
+- Maintain Torghut deterministic trading path unchanged.
+
+## Validation Commands (Runbook Snippets)
+
+Kubernetes:
+
+```bash
+kubectl -n agents get agentprovider,agent,implementationspec
+kubectl -n jangar get deploy jangar -o yaml | rg JANGAR_MARKET_CONTEXT
+kubectl -n torghut get ksvc torghut -o yaml | rg TRADING_MARKET_CONTEXT
+```
+
+Postgres:
+
+```bash
+kubectl cnpg psql -n jangar jangar-db -- jangar -c \
+  "select table_schema, table_name from information_schema.tables where table_schema='torghut_control_plane';"
+```
+
+Optional Stream v2 only - Kafka:
+
+```bash
+kubectl -n kafka get kafkatopic | rg 'torghut.(fundamentals|news|market-context)'
+kubectl -n kafka get kafkauser jangar-market-context -o yaml
+```
+
+Optional Stream v2 only - Flink:
+
+```bash
+kubectl -n torghut get flinkdeployment
+kubectl -n torghut port-forward svc/torghut-market-context-rest 18082:8081
+curl -s http://127.0.0.1:18082/jobs/overview
+```
+
+Optional Stream v2 only - ClickHouse:
+
+```bash
+# Use torghut-clickhouse auth secret + clickhouse-client in pod
+SELECT max(event_ts), count() FROM torghut.market_context_domain_events;
+SELECT symbol, domain, asOfUtc FROM torghut.market_context_latest ORDER BY asOfUtc DESC LIMIT 50;
+```
+
+## Acceptance Criteria
+
+- Torghut market-context no longer reports `fundamentals_missing`/`news_missing` due unconfigured providers for active symbols.
+- Agent model pin for fundamentals/news is provably `gpt-5.3-codex-spark`.
+- Core v1 pipeline (AgentRun -> Postgres -> Jangar API -> Torghut) is observable and meets SLOs.
+- Optional Stream v2, if enabled, meets stream SLOs and does not regress Core v1 behavior.
+- Runbooks and rollback are validated in staging before production promotion.

--- a/docs/torghut/design-system/v5/index.md
+++ b/docs/torghut/design-system/v5/index.md
@@ -5,7 +5,7 @@
 - Version: `v5`
 - Date: `2026-02-26`
 - Maturity: `production-quality design pack`
-- Scope: 5 prioritized new-feature strategy builds plus whitepaper synthesis plus crypto pipeline migration design plus multi-account execution migration design
+- Scope: 5 prioritized new-feature strategy builds plus whitepaper synthesis plus crypto pipeline migration design plus multi-account execution migration design plus fundamentals/news Codex-spark context pipeline design
 
 ## Purpose
 
@@ -38,6 +38,7 @@ This pack expands the top 5 strategy priorities into implementation-grade design
 10. `10-crypto-market-data-pipeline-production-design-2026-02-22.md`
 11. `11-multi-account-trading-architecture-and-rollout-2026-02-22.md`
 12. `12-dspy-framework-adoption-for-quant-llm-autonomous-trading-2026-02-25.md`
+13. `13-fundamentals-news-codex-spark-agent-pipeline-2026-02-26.md`
 
 ## Source-Verified Implementation Snapshot (2026-02-26 audit refresh)
 
@@ -58,7 +59,8 @@ This pack expands the top 5 strategy priorities into implementation-grade design
 5. `04-llm-multi-agent-committee-with-deterministic-veto.md`
 6. `07-autonomous-research-to-engineering-pipeline.md`
 7. `12-dspy-framework-adoption-for-quant-llm-autonomous-trading-2026-02-25.md`
-8. `09-fully-autonomous-quant-llm-torghut-novel-alpha-system.md`
+8. `13-fundamentals-news-codex-spark-agent-pipeline-2026-02-26.md`
+9. `09-fully-autonomous-quant-llm-torghut-novel-alpha-system.md`
 
 ## Runtime Profitability Surface (2026-02-26)
 

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -129,6 +129,7 @@ import { Route as ApiTorghutTaSignalsRouteImport } from './routes/api/torghut/ta
 import { Route as ApiTorghutTaLatestRouteImport } from './routes/api/torghut/ta/latest'
 import { Route as ApiTorghutTaBarsRouteImport } from './routes/api/torghut/ta/bars'
 import { Route as ApiTorghutSymbolsSymbolRouteImport } from './routes/api/torghut/symbols/$symbol'
+import { Route as ApiTorghutMarketContextIngestRouteImport } from './routes/api/torghut/market-context/ingest'
 import { Route as ApiTorghutMarketContextHealthRouteImport } from './routes/api/torghut/market-context/health'
 import { Route as ApiTorghutDecisionEngineStreamRouteImport } from './routes/api/torghut/decision-engine/stream'
 import { Route as ApiTorghutDecisionEngineRunsRouteImport } from './routes/api/torghut/decision-engine/runs'
@@ -148,6 +149,8 @@ import { Route as ApiAgentsControlPlaneResourceRouteImport } from './routes/api/
 import { Route as ApiAgentsControlPlaneLogsRouteImport } from './routes/api/agents/control-plane/logs'
 import { Route as ApiAgentsControlPlaneEventsRouteImport } from './routes/api/agents/control-plane/events'
 import { Route as GithubPullsOwnerRepoNumberRouteImport } from './routes/github/pulls/$owner/$repo/$number'
+import { Route as ApiTorghutMarketContextProvidersNewsRouteImport } from './routes/api/torghut/market-context/providers/news'
+import { Route as ApiTorghutMarketContextProvidersFundamentalsRouteImport } from './routes/api/torghut/market-context/providers/fundamentals'
 import { Route as ApiTorghutDecisionEngineRunsIdRouteImport } from './routes/api/torghut/decision-engine/runs/$id'
 import { Route as ApiAgentsImplementationSourcesWebhooksProviderRouteImport } from './routes/api/agents/implementation-sources/webhooks/$provider'
 import { Route as ApiTorghutTradingControlPlaneQuantStreamRouteImport } from './routes/api/torghut/trading/control-plane/quant/stream'
@@ -806,6 +809,12 @@ const ApiTorghutSymbolsSymbolRoute = ApiTorghutSymbolsSymbolRouteImport.update({
   path: '/$symbol',
   getParentRoute: () => ApiTorghutSymbolsRoute,
 } as any)
+const ApiTorghutMarketContextIngestRoute =
+  ApiTorghutMarketContextIngestRouteImport.update({
+    id: '/api/torghut/market-context/ingest',
+    path: '/api/torghut/market-context/ingest',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiTorghutMarketContextHealthRoute =
   ApiTorghutMarketContextHealthRouteImport.update({
     id: '/api/torghut/market-context/health',
@@ -916,6 +925,18 @@ const GithubPullsOwnerRepoNumberRoute =
     id: '/$owner/$repo/$number',
     path: '/$owner/$repo/$number',
     getParentRoute: () => GithubPullsRoute,
+  } as any)
+const ApiTorghutMarketContextProvidersNewsRoute =
+  ApiTorghutMarketContextProvidersNewsRouteImport.update({
+    id: '/api/torghut/market-context/providers/news',
+    path: '/api/torghut/market-context/providers/news',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTorghutMarketContextProvidersFundamentalsRoute =
+  ApiTorghutMarketContextProvidersFundamentalsRouteImport.update({
+    id: '/api/torghut/market-context/providers/fundamentals',
+    path: '/api/torghut/market-context/providers/fundamentals',
+    getParentRoute: () => rootRouteImport,
   } as any)
 const ApiTorghutDecisionEngineRunsIdRoute =
   ApiTorghutDecisionEngineRunsIdRouteImport.update({
@@ -1146,6 +1167,7 @@ export interface FileRoutesByFullPath {
   '/api/torghut/decision-engine/runs': typeof ApiTorghutDecisionEngineRunsRouteWithChildren
   '/api/torghut/decision-engine/stream': typeof ApiTorghutDecisionEngineStreamRoute
   '/api/torghut/market-context/health': typeof ApiTorghutMarketContextHealthRoute
+  '/api/torghut/market-context/ingest': typeof ApiTorghutMarketContextIngestRoute
   '/api/torghut/symbols/$symbol': typeof ApiTorghutSymbolsSymbolRoute
   '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
@@ -1161,6 +1183,8 @@ export interface FileRoutesByFullPath {
   '/control-plane/torghut/quant/': typeof ControlPlaneTorghutQuantIndexRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
+  '/api/torghut/market-context/providers/fundamentals': typeof ApiTorghutMarketContextProvidersFundamentalsRoute
+  '/api/torghut/market-context/providers/news': typeof ApiTorghutMarketContextProvidersNewsRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
@@ -1302,6 +1326,7 @@ export interface FileRoutesByTo {
   '/api/torghut/decision-engine/runs': typeof ApiTorghutDecisionEngineRunsRouteWithChildren
   '/api/torghut/decision-engine/stream': typeof ApiTorghutDecisionEngineStreamRoute
   '/api/torghut/market-context/health': typeof ApiTorghutMarketContextHealthRoute
+  '/api/torghut/market-context/ingest': typeof ApiTorghutMarketContextIngestRoute
   '/api/torghut/symbols/$symbol': typeof ApiTorghutSymbolsSymbolRoute
   '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
@@ -1317,6 +1342,8 @@ export interface FileRoutesByTo {
   '/control-plane/torghut/quant': typeof ControlPlaneTorghutQuantIndexRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
+  '/api/torghut/market-context/providers/fundamentals': typeof ApiTorghutMarketContextProvidersFundamentalsRoute
+  '/api/torghut/market-context/providers/news': typeof ApiTorghutMarketContextProvidersNewsRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
@@ -1461,6 +1488,7 @@ export interface FileRoutesById {
   '/api/torghut/decision-engine/runs': typeof ApiTorghutDecisionEngineRunsRouteWithChildren
   '/api/torghut/decision-engine/stream': typeof ApiTorghutDecisionEngineStreamRoute
   '/api/torghut/market-context/health': typeof ApiTorghutMarketContextHealthRoute
+  '/api/torghut/market-context/ingest': typeof ApiTorghutMarketContextIngestRoute
   '/api/torghut/symbols/$symbol': typeof ApiTorghutSymbolsSymbolRoute
   '/api/torghut/ta/bars': typeof ApiTorghutTaBarsRoute
   '/api/torghut/ta/latest': typeof ApiTorghutTaLatestRoute
@@ -1476,6 +1504,8 @@ export interface FileRoutesById {
   '/control-plane/torghut/quant/': typeof ControlPlaneTorghutQuantIndexRoute
   '/api/agents/implementation-sources/webhooks/$provider': typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
+  '/api/torghut/market-context/providers/fundamentals': typeof ApiTorghutMarketContextProvidersFundamentalsRoute
+  '/api/torghut/market-context/providers/news': typeof ApiTorghutMarketContextProvidersNewsRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
@@ -1621,6 +1651,7 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs'
     | '/api/torghut/decision-engine/stream'
     | '/api/torghut/market-context/health'
+    | '/api/torghut/market-context/ingest'
     | '/api/torghut/symbols/$symbol'
     | '/api/torghut/ta/bars'
     | '/api/torghut/ta/latest'
@@ -1636,6 +1667,8 @@ export interface FileRouteTypes {
     | '/control-plane/torghut/quant/'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/torghut/decision-engine/runs/$id'
+    | '/api/torghut/market-context/providers/fundamentals'
+    | '/api/torghut/market-context/providers/news'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
@@ -1777,6 +1810,7 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs'
     | '/api/torghut/decision-engine/stream'
     | '/api/torghut/market-context/health'
+    | '/api/torghut/market-context/ingest'
     | '/api/torghut/symbols/$symbol'
     | '/api/torghut/ta/bars'
     | '/api/torghut/ta/latest'
@@ -1792,6 +1826,8 @@ export interface FileRouteTypes {
     | '/control-plane/torghut/quant'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/torghut/decision-engine/runs/$id'
+    | '/api/torghut/market-context/providers/fundamentals'
+    | '/api/torghut/market-context/providers/news'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
@@ -1935,6 +1971,7 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs'
     | '/api/torghut/decision-engine/stream'
     | '/api/torghut/market-context/health'
+    | '/api/torghut/market-context/ingest'
     | '/api/torghut/symbols/$symbol'
     | '/api/torghut/ta/bars'
     | '/api/torghut/ta/latest'
@@ -1950,6 +1987,8 @@ export interface FileRouteTypes {
     | '/control-plane/torghut/quant/'
     | '/api/agents/implementation-sources/webhooks/$provider'
     | '/api/torghut/decision-engine/runs/$id'
+    | '/api/torghut/market-context/providers/fundamentals'
+    | '/api/torghut/market-context/providers/news'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
@@ -2075,6 +2114,7 @@ export interface RootRouteChildren {
   ApiTorghutDecisionEngineRunsRoute: typeof ApiTorghutDecisionEngineRunsRouteWithChildren
   ApiTorghutDecisionEngineStreamRoute: typeof ApiTorghutDecisionEngineStreamRoute
   ApiTorghutMarketContextHealthRoute: typeof ApiTorghutMarketContextHealthRoute
+  ApiTorghutMarketContextIngestRoute: typeof ApiTorghutMarketContextIngestRoute
   ApiTorghutTaBarsRoute: typeof ApiTorghutTaBarsRoute
   ApiTorghutTaLatestRoute: typeof ApiTorghutTaLatestRoute
   ApiTorghutTaSignalsRoute: typeof ApiTorghutTaSignalsRoute
@@ -2088,6 +2128,8 @@ export interface RootRouteChildren {
   ApiWhitepapersRunIdIndexRoute: typeof ApiWhitepapersRunIdIndexRoute
   ControlPlaneTorghutQuantIndexRoute: typeof ControlPlaneTorghutQuantIndexRoute
   ApiAgentsImplementationSourcesWebhooksProviderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
+  ApiTorghutMarketContextProvidersFundamentalsRoute: typeof ApiTorghutMarketContextProvidersFundamentalsRoute
+  ApiTorghutMarketContextProvidersNewsRoute: typeof ApiTorghutMarketContextProvidersNewsRoute
   ApiTorghutTradingControlPlaneLlmRolloutRoute: typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
   ApiTorghutTradingControlPlaneQuantAlertsRoute: typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   ApiTorghutTradingControlPlaneQuantHealthRoute: typeof ApiTorghutTradingControlPlaneQuantHealthRoute
@@ -2938,6 +2980,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiTorghutSymbolsSymbolRouteImport
       parentRoute: typeof ApiTorghutSymbolsRoute
     }
+    '/api/torghut/market-context/ingest': {
+      id: '/api/torghut/market-context/ingest'
+      path: '/api/torghut/market-context/ingest'
+      fullPath: '/api/torghut/market-context/ingest'
+      preLoaderRoute: typeof ApiTorghutMarketContextIngestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/torghut/market-context/health': {
       id: '/api/torghut/market-context/health'
       path: '/api/torghut/market-context/health'
@@ -3070,6 +3119,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/github/pulls/$owner/$repo/$number'
       preLoaderRoute: typeof GithubPullsOwnerRepoNumberRouteImport
       parentRoute: typeof GithubPullsRoute
+    }
+    '/api/torghut/market-context/providers/news': {
+      id: '/api/torghut/market-context/providers/news'
+      path: '/api/torghut/market-context/providers/news'
+      fullPath: '/api/torghut/market-context/providers/news'
+      preLoaderRoute: typeof ApiTorghutMarketContextProvidersNewsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/market-context/providers/fundamentals': {
+      id: '/api/torghut/market-context/providers/fundamentals'
+      path: '/api/torghut/market-context/providers/fundamentals'
+      fullPath: '/api/torghut/market-context/providers/fundamentals'
+      preLoaderRoute: typeof ApiTorghutMarketContextProvidersFundamentalsRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/torghut/decision-engine/runs/$id': {
       id: '/api/torghut/decision-engine/runs/$id'
@@ -3543,6 +3606,7 @@ const rootRouteChildren: RootRouteChildren = {
     ApiTorghutDecisionEngineRunsRouteWithChildren,
   ApiTorghutDecisionEngineStreamRoute: ApiTorghutDecisionEngineStreamRoute,
   ApiTorghutMarketContextHealthRoute: ApiTorghutMarketContextHealthRoute,
+  ApiTorghutMarketContextIngestRoute: ApiTorghutMarketContextIngestRoute,
   ApiTorghutTaBarsRoute: ApiTorghutTaBarsRoute,
   ApiTorghutTaLatestRoute: ApiTorghutTaLatestRoute,
   ApiTorghutTaSignalsRoute: ApiTorghutTaSignalsRoute,
@@ -3557,6 +3621,10 @@ const rootRouteChildren: RootRouteChildren = {
   ControlPlaneTorghutQuantIndexRoute: ControlPlaneTorghutQuantIndexRoute,
   ApiAgentsImplementationSourcesWebhooksProviderRoute:
     ApiAgentsImplementationSourcesWebhooksProviderRoute,
+  ApiTorghutMarketContextProvidersFundamentalsRoute:
+    ApiTorghutMarketContextProvidersFundamentalsRoute,
+  ApiTorghutMarketContextProvidersNewsRoute:
+    ApiTorghutMarketContextProvidersNewsRoute,
   ApiTorghutTradingControlPlaneLlmRolloutRoute:
     ApiTorghutTradingControlPlaneLlmRolloutRoute,
   ApiTorghutTradingControlPlaneQuantAlertsRoute:

--- a/services/jangar/src/routes/api/torghut/market-context/-ingest.test.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/-ingest.test.ts
@@ -8,15 +8,20 @@ vi.mock('~/server/torghut-market-context-agents', () => ({
 
 describe('POST /api/torghut/market-context/ingest', () => {
   const previousToken = process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN
+  const previousSaAuth = process.env.JANGAR_MARKET_CONTEXT_INGEST_ALLOW_SERVICE_ACCOUNT_TOKEN
 
   beforeEach(() => {
+    vi.resetModules()
     ingestMarketContextProviderResult.mockReset()
     delete process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN
+    delete process.env.JANGAR_MARKET_CONTEXT_INGEST_ALLOW_SERVICE_ACCOUNT_TOKEN
   })
 
   afterEach(() => {
     if (previousToken == null) delete process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN
     else process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN = previousToken
+    if (previousSaAuth == null) delete process.env.JANGAR_MARKET_CONTEXT_INGEST_ALLOW_SERVICE_ACCOUNT_TOKEN
+    else process.env.JANGAR_MARKET_CONTEXT_INGEST_ALLOW_SERVICE_ACCOUNT_TOKEN = previousSaAuth
   })
 
   it('returns 401 when ingest token is configured and auth header is missing', async () => {
@@ -37,11 +42,15 @@ describe('POST /api/torghut/market-context/ingest', () => {
   })
 
   it('returns 400 for invalid JSON payload', async () => {
+    process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN = 'secret-token'
     const { postMarketContextIngestHandler } = await import('./ingest')
     const response = await postMarketContextIngestHandler(
       new Request('http://localhost/api/torghut/market-context/ingest', {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer secret-token',
+        },
         body: 'not-json',
       }),
     )
@@ -52,7 +61,22 @@ describe('POST /api/torghut/market-context/ingest', () => {
     expect(ingestMarketContextProviderResult).not.toHaveBeenCalled()
   })
 
+  it('returns 401 when ingest token is not configured and auth header is missing', async () => {
+    const { postMarketContextIngestHandler } = await import('./ingest')
+    const response = await postMarketContextIngestHandler(
+      new Request('http://localhost/api/torghut/market-context/ingest', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ symbol: 'AAPL', domain: 'fundamentals' }),
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(ingestMarketContextProviderResult).not.toHaveBeenCalled()
+  })
+
   it('ingests payload and returns 202', async () => {
+    process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN = 'secret-token'
     ingestMarketContextProviderResult.mockResolvedValueOnce({
       ok: true,
       symbol: 'AAPL',
@@ -72,7 +96,10 @@ describe('POST /api/torghut/market-context/ingest', () => {
     const response = await postMarketContextIngestHandler(
       new Request('http://localhost/api/torghut/market-context/ingest', {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer secret-token',
+        },
         body: JSON.stringify({ symbol: 'AAPL', domain: 'fundamentals' }),
       }),
     )
@@ -81,5 +108,40 @@ describe('POST /api/torghut/market-context/ingest', () => {
     expect(response.status).toBe(202)
     expect(body.ok).toBe(true)
     expect(ingestMarketContextProviderResult).toHaveBeenCalledWith({ symbol: 'AAPL', domain: 'fundamentals' })
+  })
+
+  it('accepts a verified service-account bearer token when shared token is unset', async () => {
+    ingestMarketContextProviderResult.mockResolvedValueOnce({
+      ok: true,
+      symbol: 'AAPL',
+      domain: 'news',
+      runStatus: 'succeeded',
+      requestId: 'req-2',
+      context: {
+        asOfUtc: '2026-02-26T12:00:00.000Z',
+        sourceCount: 1,
+        qualityScore: 0.8,
+        payload: { headline: 'x' },
+        citations: [],
+        riskFlags: [],
+      },
+    })
+
+    const { __setIngestServiceAccountTokenVerifierForTests, postMarketContextIngestHandler } = await import('./ingest')
+    __setIngestServiceAccountTokenVerifierForTests(async () => true)
+
+    const response = await postMarketContextIngestHandler(
+      new Request('http://localhost/api/torghut/market-context/ingest', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer sa-token',
+        },
+        body: JSON.stringify({ symbol: 'AAPL', domain: 'news' }),
+      }),
+    )
+
+    expect(response.status).toBe(202)
+    expect(ingestMarketContextProviderResult).toHaveBeenCalledWith({ symbol: 'AAPL', domain: 'news' })
   })
 })

--- a/services/jangar/src/routes/api/torghut/market-context/-ingest.test.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/-ingest.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ingestMarketContextProviderResult = vi.fn()
+
+vi.mock('~/server/torghut-market-context-agents', () => ({
+  ingestMarketContextProviderResult,
+}))
+
+describe('POST /api/torghut/market-context/ingest', () => {
+  const previousToken = process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN
+
+  beforeEach(() => {
+    ingestMarketContextProviderResult.mockReset()
+    delete process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN
+  })
+
+  afterEach(() => {
+    if (previousToken == null) delete process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN
+    else process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN = previousToken
+  })
+
+  it('returns 401 when ingest token is configured and auth header is missing', async () => {
+    process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN = 'secret-token'
+    const { postMarketContextIngestHandler } = await import('./ingest')
+    const response = await postMarketContextIngestHandler(
+      new Request('http://localhost/api/torghut/market-context/ingest', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ symbol: 'AAPL', domain: 'news' }),
+      }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.ok).toBe(false)
+    expect(ingestMarketContextProviderResult).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid JSON payload', async () => {
+    const { postMarketContextIngestHandler } = await import('./ingest')
+    const response = await postMarketContextIngestHandler(
+      new Request('http://localhost/api/torghut/market-context/ingest', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: 'not-json',
+      }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(ingestMarketContextProviderResult).not.toHaveBeenCalled()
+  })
+
+  it('ingests payload and returns 202', async () => {
+    ingestMarketContextProviderResult.mockResolvedValueOnce({
+      ok: true,
+      symbol: 'AAPL',
+      domain: 'fundamentals',
+      runStatus: 'succeeded',
+      requestId: 'req-1',
+      context: {
+        asOfUtc: '2026-02-26T12:00:00.000Z',
+        sourceCount: 2,
+        qualityScore: 0.9,
+        payload: { marketCap: 1 },
+        citations: [],
+        riskFlags: [],
+      },
+    })
+    const { postMarketContextIngestHandler } = await import('./ingest')
+    const response = await postMarketContextIngestHandler(
+      new Request('http://localhost/api/torghut/market-context/ingest', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ symbol: 'AAPL', domain: 'fundamentals' }),
+      }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(202)
+    expect(body.ok).toBe(true)
+    expect(ingestMarketContextProviderResult).toHaveBeenCalledWith({ symbol: 'AAPL', domain: 'fundamentals' })
+  })
+})

--- a/services/jangar/src/routes/api/torghut/market-context/ingest.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/ingest.ts
@@ -1,3 +1,6 @@
+import { timingSafeEqual } from 'node:crypto'
+
+import { AuthenticationV1Api, KubeConfig } from '@kubernetes/client-node'
 import { createFileRoute } from '@tanstack/react-router'
 import { ingestMarketContextProviderResult } from '~/server/torghut-market-context-agents'
 
@@ -20,6 +23,102 @@ const jsonResponse = (payload: unknown, status = 200) => {
   })
 }
 
+const DEFAULT_ALLOWED_SERVICE_ACCOUNT_PREFIX = 'system:serviceaccount:agents:'
+
+type ServiceAccountTokenVerifier = (token: string) => Promise<boolean>
+
+let authApi: AuthenticationV1Api | null | undefined
+let serviceAccountTokenVerifierOverride: ServiceAccountTokenVerifier | null = null
+
+const parseBoolean = (value: string | undefined, fallback: boolean) => {
+  if (!value) return fallback
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on', 'enabled'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off', 'disabled'].includes(normalized)) return false
+  return fallback
+}
+
+const resolveAllowedServiceAccountPrefixes = () => {
+  const raw = process.env.JANGAR_MARKET_CONTEXT_INGEST_ALLOWED_SERVICE_ACCOUNT_PREFIXES?.trim()
+  if (!raw) return [DEFAULT_ALLOWED_SERVICE_ACCOUNT_PREFIX]
+  const prefixes = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+  return prefixes.length > 0 ? prefixes : [DEFAULT_ALLOWED_SERVICE_ACCOUNT_PREFIX]
+}
+
+const resolveAuthApi = () => {
+  if (authApi !== undefined) return authApi
+  try {
+    const kubeConfig = new KubeConfig()
+    kubeConfig.loadFromCluster()
+    authApi = kubeConfig.makeApiClient(AuthenticationV1Api)
+  } catch {
+    authApi = null
+  }
+  return authApi
+}
+
+const verifyServiceAccountTokenWithTokenReview = async (token: string) => {
+  const api = resolveAuthApi()
+  if (!api) return false
+
+  try {
+    const response = (await (
+      api as unknown as { createTokenReview: (body: unknown) => Promise<unknown> }
+    ).createTokenReview({
+      apiVersion: 'authentication.k8s.io/v1',
+      kind: 'TokenReview',
+      spec: { token },
+    })) as { body?: Record<string, unknown> } | Record<string, unknown>
+    const body =
+      response &&
+      typeof response === 'object' &&
+      'body' in response &&
+      response.body &&
+      typeof response.body === 'object'
+        ? response.body
+        : response
+    const status = body && typeof body === 'object' ? (body.status as Record<string, unknown> | undefined) : undefined
+    if (!status || status.authenticated !== true) return false
+
+    const user = status.user
+    if (!user || typeof user !== 'object') return false
+    const username =
+      typeof (user as Record<string, unknown>).username === 'string'
+        ? ((user as Record<string, unknown>).username as string)
+        : ''
+    if (!username) return false
+
+    const allowedPrefixes = resolveAllowedServiceAccountPrefixes()
+    return allowedPrefixes.some((prefix) => username.startsWith(prefix))
+  } catch {
+    return false
+  }
+}
+
+const verifyServiceAccountToken = async (token: string) => {
+  const override = serviceAccountTokenVerifierOverride
+  if (override) return override(token)
+  return verifyServiceAccountTokenWithTokenReview(token)
+}
+
+const resolveSharedIngestToken = () => {
+  const token = process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN?.trim()
+  return token && token.length > 0 ? token : null
+}
+
+const resolveServiceAccountTokenAuthEnabled = () =>
+  parseBoolean(process.env.JANGAR_MARKET_CONTEXT_INGEST_ALLOW_SERVICE_ACCOUNT_TOKEN, true)
+
+const safeEquals = (left: string, right: string) => {
+  const leftBuffer = Buffer.from(left)
+  const rightBuffer = Buffer.from(right)
+  if (leftBuffer.length !== rightBuffer.length) return false
+  return timingSafeEqual(leftBuffer, rightBuffer)
+}
+
 const resolveBearerToken = (request: Request) => {
   const raw = request.headers.get('authorization')?.trim()
   if (!raw) return null
@@ -29,15 +128,23 @@ const resolveBearerToken = (request: Request) => {
   return token.length > 0 ? token : null
 }
 
-const isIngestAuthorized = (request: Request) => {
-  const expected = process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN?.trim()
-  if (!expected) return true
+const isIngestAuthorized = async (request: Request) => {
   const actual = resolveBearerToken(request)
-  return actual === expected
+  if (!actual) return false
+
+  const expected = resolveSharedIngestToken()
+  if (expected && safeEquals(actual, expected)) return true
+  if (!resolveServiceAccountTokenAuthEnabled()) return false
+  return verifyServiceAccountToken(actual)
+}
+
+export const __setIngestServiceAccountTokenVerifierForTests = (verifier: ServiceAccountTokenVerifier | null) => {
+  serviceAccountTokenVerifierOverride = verifier
+  authApi = undefined
 }
 
 export const postMarketContextIngestHandler = async (request: Request) => {
-  if (!isIngestAuthorized(request)) {
+  if (!(await isIngestAuthorized(request))) {
     return jsonResponse({ ok: false, message: 'unauthorized' }, 401)
   }
 

--- a/services/jangar/src/routes/api/torghut/market-context/ingest.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/ingest.ts
@@ -80,7 +80,11 @@ const verifyServiceAccountTokenWithTokenReview = async (token: string) => {
       typeof response.body === 'object'
         ? response.body
         : response
-    const status = body && typeof body === 'object' ? (body.status as Record<string, unknown> | undefined) : undefined
+    const bodyRecord = body && typeof body === 'object' ? (body as Record<string, unknown>) : null
+    const status =
+      bodyRecord && bodyRecord.status && typeof bodyRecord.status === 'object'
+        ? (bodyRecord.status as Record<string, unknown>)
+        : null
     if (!status || status.authenticated !== true) return false
 
     const user = status.user

--- a/services/jangar/src/routes/api/torghut/market-context/ingest.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/ingest.ts
@@ -1,0 +1,56 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { ingestMarketContextProviderResult } from '~/server/torghut-market-context-agents'
+
+export const Route = createFileRoute('/api/torghut/market-context/ingest')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => postMarketContextIngestHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const resolveBearerToken = (request: Request) => {
+  const raw = request.headers.get('authorization')?.trim()
+  if (!raw) return null
+  const [scheme, ...rest] = raw.split(/\s+/g)
+  if (scheme.toLowerCase() !== 'bearer') return null
+  const token = rest.join(' ').trim()
+  return token.length > 0 ? token : null
+}
+
+const isIngestAuthorized = (request: Request) => {
+  const expected = process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN?.trim()
+  if (!expected) return true
+  const actual = resolveBearerToken(request)
+  return actual === expected
+}
+
+export const postMarketContextIngestHandler = async (request: Request) => {
+  if (!isIngestAuthorized(request)) {
+    return jsonResponse({ ok: false, message: 'unauthorized' }, 401)
+  }
+
+  const payload = (await request.json().catch(() => null)) as Record<string, unknown> | null
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return jsonResponse({ ok: false, message: 'invalid JSON payload' }, 400)
+  }
+
+  try {
+    const result = await ingestMarketContextProviderResult(payload)
+    return jsonResponse(result, 202)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'market context ingest failed'
+    return jsonResponse({ ok: false, message }, 400)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/market-context/ingest.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/ingest.ts
@@ -137,7 +137,7 @@ const isIngestAuthorized = async (request: Request) => {
   if (!actual) return false
 
   const expected = resolveSharedIngestToken()
-  if (expected && safeEquals(actual, expected)) return true
+  if (expected) return safeEquals(actual, expected)
   if (!resolveServiceAccountTokenAuthEnabled()) return false
   return verifyServiceAccountToken(actual)
 }

--- a/services/jangar/src/routes/api/torghut/market-context/providers/-fundamentals.test.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/providers/-fundamentals.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getMarketContextProviderResult = vi.fn()
+
+vi.mock('~/server/torghut-market-context-agents', () => ({
+  getMarketContextProviderResult,
+}))
+
+describe('GET /api/torghut/market-context/providers/fundamentals', () => {
+  beforeEach(() => {
+    getMarketContextProviderResult.mockReset()
+  })
+
+  it('returns 400 when symbol is missing', async () => {
+    const { getFundamentalsProviderHandler } = await import('./fundamentals')
+    const response = await getFundamentalsProviderHandler(
+      new Request('http://localhost/api/torghut/market-context/providers/fundamentals'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(getMarketContextProviderResult).not.toHaveBeenCalled()
+  })
+
+  it('returns provider payload for a symbol', async () => {
+    getMarketContextProviderResult.mockResolvedValueOnce({
+      symbol: 'AAPL',
+      domain: 'fundamentals',
+      snapshotState: 'fresh',
+      context: {
+        asOfUtc: '2026-02-26T12:00:00.000Z',
+        sourceCount: 3,
+        qualityScore: 0.9,
+        payload: { peRatio: 32.1 },
+        citations: [],
+        riskFlags: [],
+      },
+      dispatch: {
+        attempted: false,
+        dispatched: false,
+        reason: null,
+        runName: null,
+        error: null,
+      },
+    })
+    const { getFundamentalsProviderHandler } = await import('./fundamentals')
+    const response = await getFundamentalsProviderHandler(
+      new Request('http://localhost/api/torghut/market-context/providers/fundamentals?symbol=AAPL'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.domain).toBe('fundamentals')
+    expect(getMarketContextProviderResult).toHaveBeenCalledWith({ domain: 'fundamentals', symbolInput: 'AAPL' })
+  })
+})

--- a/services/jangar/src/routes/api/torghut/market-context/providers/-news.test.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/providers/-news.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getMarketContextProviderResult = vi.fn()
+
+vi.mock('~/server/torghut-market-context-agents', () => ({
+  getMarketContextProviderResult,
+}))
+
+describe('GET /api/torghut/market-context/providers/news', () => {
+  beforeEach(() => {
+    getMarketContextProviderResult.mockReset()
+  })
+
+  it('returns 400 when symbol is missing', async () => {
+    const { getNewsProviderHandler } = await import('./news')
+    const response = await getNewsProviderHandler(
+      new Request('http://localhost/api/torghut/market-context/providers/news'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(getMarketContextProviderResult).not.toHaveBeenCalled()
+  })
+
+  it('returns provider payload for a symbol', async () => {
+    getMarketContextProviderResult.mockResolvedValueOnce({
+      symbol: 'MSFT',
+      domain: 'news',
+      snapshotState: 'stale',
+      context: {
+        asOfUtc: '2026-02-26T12:00:00.000Z',
+        sourceCount: 5,
+        qualityScore: 0.7,
+        payload: { topHeadline: 'Sample headline' },
+        citations: [],
+        riskFlags: ['news_stale'],
+      },
+      dispatch: {
+        attempted: true,
+        dispatched: true,
+        reason: null,
+        runName: 'torghut-market-context-news-abcde',
+        error: null,
+      },
+    })
+    const { getNewsProviderHandler } = await import('./news')
+    const response = await getNewsProviderHandler(
+      new Request('http://localhost/api/torghut/market-context/providers/news?symbol=MSFT'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.domain).toBe('news')
+    expect(getMarketContextProviderResult).toHaveBeenCalledWith({ domain: 'news', symbolInput: 'MSFT' })
+  })
+})

--- a/services/jangar/src/routes/api/torghut/market-context/providers/fundamentals.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/providers/fundamentals.ts
@@ -1,0 +1,35 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getMarketContextProviderResult } from '~/server/torghut-market-context-agents'
+
+export const Route = createFileRoute('/api/torghut/market-context/providers/fundamentals')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getFundamentalsProviderHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getFundamentalsProviderHandler = async (request: Request) => {
+  const url = new URL(request.url)
+  const symbol = url.searchParams.get('symbol')?.trim() ?? ''
+  if (!symbol) return jsonResponse({ ok: false, message: 'symbol is required' }, 400)
+
+  try {
+    const result = await getMarketContextProviderResult({ domain: 'fundamentals', symbolInput: symbol })
+    return jsonResponse({ ok: true, ...result })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'fundamentals provider failed'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/market-context/providers/news.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/providers/news.ts
@@ -1,0 +1,35 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getMarketContextProviderResult } from '~/server/torghut-market-context-agents'
+
+export const Route = createFileRoute('/api/torghut/market-context/providers/news')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getNewsProviderHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getNewsProviderHandler = async (request: Request) => {
+  const url = new URL(request.url)
+  const symbol = url.searchParams.get('symbol')?.trim() ?? ''
+  if (!symbol) return jsonResponse({ ok: false, message: 'symbol is required' }, 400)
+
+  try {
+    const result = await getMarketContextProviderResult({ domain: 'news', symbolInput: symbol })
+    return jsonResponse({ ok: true, ...result })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'news provider failed'
+    return jsonResponse({ ok: false, message }, 500)
+  }
+}

--- a/services/jangar/src/server/__tests__/torghut-market-context-agents-ingest.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agents-ingest.test.ts
@@ -2,29 +2,53 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 type InsertTracker = {
   tableCalls: string[]
+  conflictWhereCalls: Array<{
+    table: string
+    args: unknown[]
+  }>
   db: {
-    insertInto: (table: string) => {
-      values: (value: unknown) => unknown
-      onConflict: (value: unknown) => unknown
-      execute: () => Promise<void>
-    }
+    insertInto: (table: string) => unknown
   }
 }
 
 const buildInsertTracker = (): InsertTracker => {
   const tableCalls: string[] = []
+  const conflictWhereCalls: Array<{
+    table: string
+    args: unknown[]
+  }> = []
   const db = {
     insertInto: (table: string) => {
       tableCalls.push(table)
       const chain = {
         values: () => chain,
-        onConflict: () => chain,
+        onConflict: (callback: unknown) => {
+          if (typeof callback === 'function') {
+            let whereArgs: unknown[] | null = null
+            const updateBuilder: { where: (...args: unknown[]) => unknown } = {
+              where: (...args: unknown[]) => {
+                whereArgs = args
+                return updateBuilder
+              },
+            }
+            const conflictBuilder: {
+              columns: (columns: unknown) => unknown
+              doUpdateSet: (values: unknown) => unknown
+            } = {
+              columns: () => conflictBuilder,
+              doUpdateSet: () => updateBuilder,
+            }
+            ;(callback as (builder: unknown) => unknown)(conflictBuilder)
+            if (whereArgs) conflictWhereCalls.push({ table, args: whereArgs })
+          }
+          return chain
+        },
         execute: async () => undefined,
       }
       return chain
     },
   }
-  return { tableCalls, db }
+  return { tableCalls, conflictWhereCalls, db }
 }
 
 describe('ingestMarketContextProviderResult', () => {
@@ -120,5 +144,34 @@ describe('ingestMarketContextProviderResult', () => {
 
     expect(tracker.tableCalls).toEqual(['torghut_market_context_snapshots', 'torghut_market_context_dispatch_state'])
     expect(clearMarketContextCache).toHaveBeenCalledOnce()
+  })
+
+  it('guards snapshot upsert against older as_of values', async () => {
+    const tracker = buildInsertTracker()
+    const clearMarketContextCache = vi.fn()
+
+    vi.doMock('~/server/db', () => ({
+      getDb: () => tracker.db,
+    }))
+    vi.doMock('~/server/kysely-migrations', () => ({
+      ensureMigrations: async () => undefined,
+    }))
+    vi.doMock('~/server/torghut-market-context', () => ({
+      clearMarketContextCache,
+    }))
+
+    const { ingestMarketContextProviderResult } = await import('../torghut-market-context-agents')
+    await ingestMarketContextProviderResult({
+      symbol: 'AAPL',
+      domain: 'fundamentals',
+      runStatus: 'succeeded',
+      asOfUtc: '2026-02-26T12:00:00.000Z',
+      payload: { peRatio: 21.4 },
+    })
+
+    expect(tracker.conflictWhereCalls).toContainEqual({
+      table: 'torghut_market_context_snapshots',
+      args: ['torghut_market_context_snapshots.as_of', '<=', new Date('2026-02-26T12:00:00.000Z')],
+    })
   })
 })

--- a/services/jangar/src/server/__tests__/torghut-market-context-agents-ingest.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agents-ingest.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type InsertTracker = {
+  tableCalls: string[]
+  db: {
+    insertInto: (table: string) => {
+      values: (value: unknown) => unknown
+      onConflict: (value: unknown) => unknown
+      execute: () => Promise<void>
+    }
+  }
+}
+
+const buildInsertTracker = (): InsertTracker => {
+  const tableCalls: string[] = []
+  const db = {
+    insertInto: (table: string) => {
+      tableCalls.push(table)
+      const chain = {
+        values: () => chain,
+        onConflict: () => chain,
+        execute: async () => undefined,
+      }
+      return chain
+    },
+  }
+  return { tableCalls, db }
+}
+
+describe('ingestMarketContextProviderResult', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('does not overwrite snapshots when runStatus is failed', async () => {
+    const tracker = buildInsertTracker()
+    const clearMarketContextCache = vi.fn()
+
+    vi.doMock('~/server/db', () => ({
+      getDb: () => tracker.db,
+    }))
+    vi.doMock('~/server/kysely-migrations', () => ({
+      ensureMigrations: async () => undefined,
+    }))
+    vi.doMock('~/server/torghut-market-context', () => ({
+      clearMarketContextCache,
+    }))
+
+    const { ingestMarketContextProviderResult } = await import('../torghut-market-context-agents')
+    await ingestMarketContextProviderResult({
+      symbol: 'AAPL',
+      domain: 'news',
+      runStatus: 'failed',
+      error: 'upstream timeout',
+    })
+
+    expect(tracker.tableCalls).toEqual(['torghut_market_context_dispatch_state'])
+    expect(clearMarketContextCache).not.toHaveBeenCalled()
+  })
+
+  it('persists snapshots when runStatus is succeeded', async () => {
+    const tracker = buildInsertTracker()
+    const clearMarketContextCache = vi.fn()
+
+    vi.doMock('~/server/db', () => ({
+      getDb: () => tracker.db,
+    }))
+    vi.doMock('~/server/kysely-migrations', () => ({
+      ensureMigrations: async () => undefined,
+    }))
+    vi.doMock('~/server/torghut-market-context', () => ({
+      clearMarketContextCache,
+    }))
+
+    const { ingestMarketContextProviderResult } = await import('../torghut-market-context-agents')
+    await ingestMarketContextProviderResult({
+      symbol: 'AAPL',
+      domain: 'fundamentals',
+      runStatus: 'succeeded',
+      sourceCount: 3,
+      qualityScore: 0.7,
+      payload: { peRatio: 21.4 },
+      citations: [{ source: 'sec', publishedAt: '2026-02-26T12:00:00Z', url: null }],
+      riskFlags: [],
+    })
+
+    expect(tracker.tableCalls).toEqual(['torghut_market_context_snapshots', 'torghut_market_context_dispatch_state'])
+    expect(clearMarketContextCache).toHaveBeenCalledOnce()
+  })
+})

--- a/services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/server/db', () => ({
+  getDb: () => null,
+}))
+
+describe('torghut market context agents', () => {
+  it('does not stamp missing provider context with current as-of', async () => {
+    const { getMarketContextProviderResult } = await import('../torghut-market-context-agents')
+
+    const result = await getMarketContextProviderResult({
+      domain: 'fundamentals',
+      symbolInput: 'AAPL',
+    })
+
+    expect(result.snapshotState).toBe('missing')
+    expect(result.context.asOfUtc).toBe('')
+    expect(result.dispatch.reason).toBe('database_unavailable')
+  })
+})

--- a/services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts
@@ -5,6 +5,14 @@ vi.mock('~/server/db', () => ({
 }))
 
 describe('torghut market context agents', () => {
+  it('sanitizes symbols for Kubernetes labels', async () => {
+    const { toKubernetesLabelValue } = await import('../torghut-market-context-agents')
+
+    expect(toKubernetesLabelValue('BTC/USD')).toBe('BTC-USD')
+    expect(toKubernetesLabelValue('..AAPL..')).toBe('AAPL')
+    expect(toKubernetesLabelValue('///')).toBe('unknown')
+  })
+
   it('does not stamp missing provider context with current as-of', async () => {
     const { getMarketContextProviderResult } = await import('../torghut-market-context-agents')
 

--- a/services/jangar/src/server/db.ts
+++ b/services/jangar/src/server/db.ts
@@ -614,6 +614,32 @@ type TorghutQuantPipelineHealth = {
   created_at: Generated<Timestamp>
 }
 
+type TorghutMarketContextSnapshots = {
+  id: Generated<string>
+  symbol: string
+  domain: string
+  as_of: Timestamp
+  source_count: number
+  quality_score: number
+  payload: JsonValue
+  citations: unknown
+  risk_flags: string[]
+  provider: string
+  run_name: string | null
+  created_at: Generated<Timestamp>
+  updated_at: Generated<Timestamp>
+}
+
+type TorghutMarketContextDispatchState = {
+  symbol: string
+  domain: string
+  last_dispatched_at: Timestamp | null
+  last_run_name: string | null
+  last_status: string
+  last_error: string | null
+  updated_at: Generated<Timestamp>
+}
+
 export type Database = {
   'atlas.repositories': AtlasRepositories
   'atlas.file_keys': AtlasFileKeys
@@ -653,6 +679,8 @@ export type Database = {
   'torghut_control_plane.quant_metrics_series': TorghutQuantMetricsSeries
   'torghut_control_plane.quant_alerts': TorghutQuantAlerts
   'torghut_control_plane.quant_pipeline_health': TorghutQuantPipelineHealth
+  torghut_market_context_snapshots: TorghutMarketContextSnapshots
+  torghut_market_context_dispatch_state: TorghutMarketContextDispatchState
   'codex_judge.runs': CodexJudgeRuns
   'codex_judge.artifacts': CodexJudgeArtifacts
   'codex_judge.evaluations': CodexJudgeEvaluations

--- a/services/jangar/src/server/kysely-migrations.ts
+++ b/services/jangar/src/server/kysely-migrations.ts
@@ -17,6 +17,7 @@ import * as jangarAgentRunIdempotencyMigration from '~/server/migrations/2026020
 import * as atlasChunkSearchMigration from '~/server/migrations/20260209_atlas_chunk_search'
 import * as torghutQuantControlPlaneMigration from '~/server/migrations/20260212_torghut_quant_control_plane'
 import * as removePromptTuningMigration from '~/server/migrations/20260220_remove_prompt_tuning'
+import * as torghutMarketContextAgentsMigration from '~/server/migrations/20260226_torghut_market_context_agents'
 
 type MigrationMap = Record<string, Migration>
 
@@ -47,6 +48,7 @@ const migrations: MigrationMap = {
   '20260209_atlas_chunk_search': atlasChunkSearchMigration,
   '20260212_torghut_quant_control_plane': torghutQuantControlPlaneMigration,
   '20260220_remove_prompt_tuning': removePromptTuningMigration,
+  '20260226_torghut_market_context_agents': torghutMarketContextAgentsMigration,
 }
 
 const migrationProvider = new StaticMigrationProvider(migrations)

--- a/services/jangar/src/server/migrations/20260226_torghut_market_context_agents.ts
+++ b/services/jangar/src/server/migrations/20260226_torghut_market_context_agents.ts
@@ -1,0 +1,56 @@
+import { type Kysely, sql } from 'kysely'
+
+import type { Database } from '../db'
+
+export const up = async (db: Kysely<Database>) => {
+  await sql`
+    CREATE TABLE IF NOT EXISTS torghut_market_context_snapshots (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      symbol TEXT NOT NULL,
+      domain TEXT NOT NULL CHECK (domain IN ('fundamentals', 'news')),
+      as_of TIMESTAMPTZ NOT NULL,
+      source_count INTEGER NOT NULL DEFAULT 0,
+      quality_score DOUBLE PRECISION NOT NULL DEFAULT 0,
+      payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+      citations JSONB NOT NULL DEFAULT '[]'::jsonb,
+      risk_flags TEXT[] NOT NULL DEFAULT '{}'::text[],
+      provider TEXT NOT NULL DEFAULT '',
+      run_name TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS torghut_market_context_snapshots_symbol_domain_idx
+    ON torghut_market_context_snapshots(symbol, domain);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS torghut_market_context_snapshots_domain_as_of_idx
+    ON torghut_market_context_snapshots(domain, as_of DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS torghut_market_context_snapshots_symbol_as_of_idx
+    ON torghut_market_context_snapshots(symbol, as_of DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS torghut_market_context_dispatch_state (
+      symbol TEXT NOT NULL,
+      domain TEXT NOT NULL CHECK (domain IN ('fundamentals', 'news')),
+      last_dispatched_at TIMESTAMPTZ,
+      last_run_name TEXT,
+      last_status TEXT NOT NULL DEFAULT 'idle',
+      last_error TEXT,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY(symbol, domain)
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS torghut_market_context_dispatch_state_dispatched_idx
+    ON torghut_market_context_dispatch_state(last_dispatched_at DESC);
+  `.execute(db)
+}

--- a/services/jangar/src/server/torghut-market-context-agents.ts
+++ b/services/jangar/src/server/torghut-market-context-agents.ts
@@ -83,6 +83,19 @@ const parseNumber = (value: unknown): number | null => {
 
 const clamp01 = (value: number) => Math.max(0, Math.min(1, value))
 const toIso = (value: Date) => value.toISOString()
+const KUBERNETES_LABEL_MAX_LENGTH = 63
+
+export const toKubernetesLabelValue = (raw: string, fallback = 'unknown') => {
+  const normalized = raw
+    .trim()
+    .replace(/[^A-Za-z0-9_.-]+/g, '-')
+    .replace(/^[^A-Za-z0-9]+/, '')
+    .replace(/[^A-Za-z0-9]+$/, '')
+
+  if (!normalized) return fallback
+  const truncated = normalized.slice(0, KUBERNETES_LABEL_MAX_LENGTH).replace(/[^A-Za-z0-9]+$/, '')
+  return truncated || fallback
+}
 
 const coerceRiskFlags = (value: unknown): string[] => {
   if (!Array.isArray(value)) return []
@@ -355,7 +368,7 @@ const dispatchDomainAgentRun = async (params: {
       generateName: `torghut-market-context-${params.domain}-`,
       namespace: settings.dispatchNamespace,
       labels: {
-        'torghut.proompteng.ai/symbol': params.symbol,
+        'torghut.proompteng.ai/symbol': toKubernetesLabelValue(params.symbol),
         'torghut.proompteng.ai/domain': params.domain,
         'jangar.proompteng.ai/source': 'torghut-market-context',
       },

--- a/services/jangar/src/server/torghut-market-context-agents.ts
+++ b/services/jangar/src/server/torghut-market-context-agents.ts
@@ -605,17 +605,20 @@ export const ingestMarketContextProviderResult = async (input: Record<string, un
         updated_at: now,
       })
       .onConflict((oc) =>
-        oc.columns(['symbol', 'domain']).doUpdateSet({
-          as_of: asOf,
-          source_count: sourceCount,
-          quality_score: qualityScore,
-          payload: payloadJson as unknown as Record<string, unknown>,
-          citations: citationsJson,
-          risk_flags: riskFlags,
-          provider,
-          run_name: runName,
-          updated_at: now,
-        }),
+        oc
+          .columns(['symbol', 'domain'])
+          .doUpdateSet({
+            as_of: asOf,
+            source_count: sourceCount,
+            quality_score: qualityScore,
+            payload: payloadJson as unknown as Record<string, unknown>,
+            citations: citationsJson,
+            risk_flags: riskFlags,
+            provider,
+            run_name: runName,
+            updated_at: now,
+          })
+          .where('torghut_market_context_snapshots.as_of', '<=', asOf),
       )
       .execute()
   }

--- a/services/jangar/src/server/torghut-market-context-agents.ts
+++ b/services/jangar/src/server/torghut-market-context-agents.ts
@@ -1,0 +1,648 @@
+import { randomUUID } from 'node:crypto'
+
+import { sql } from 'kysely'
+
+import { getDb } from '~/server/db'
+import { ensureMigrations } from '~/server/kysely-migrations'
+import { createKubernetesClient } from '~/server/primitives-kube'
+import { clearMarketContextCache } from '~/server/torghut-market-context'
+import { normalizeTorghutSymbol } from '~/server/torghut-symbols'
+
+export type MarketContextProviderDomain = 'fundamentals' | 'news'
+
+type ProviderCitation = {
+  source: string
+  publishedAt: string
+  url: string | null
+}
+
+export type MarketContextProviderContext = {
+  asOfUtc: string
+  sourceCount: number
+  qualityScore: number
+  payload: Record<string, unknown>
+  citations: ProviderCitation[]
+  riskFlags: string[]
+}
+
+export type MarketContextProviderResult = {
+  symbol: string
+  domain: MarketContextProviderDomain
+  snapshotState: 'fresh' | 'stale' | 'missing'
+  context: MarketContextProviderContext
+  dispatch: {
+    attempted: boolean
+    dispatched: boolean
+    reason: string | null
+    runName: string | null
+    error: string | null
+  }
+}
+
+const DEFAULT_FUNDAMENTALS_MAX_FRESHNESS_SECONDS = 24 * 60 * 60
+const DEFAULT_NEWS_MAX_FRESHNESS_SECONDS = 5 * 60
+const DEFAULT_FUNDAMENTALS_DISPATCH_COOLDOWN_SECONDS = 30 * 60
+const DEFAULT_NEWS_DISPATCH_COOLDOWN_SECONDS = 2 * 60
+const DEFAULT_AGENT_RUN_TTL_SECONDS = 30 * 60
+
+const parseBoolean = (value: string | undefined, fallback: boolean) => {
+  if (!value) return fallback
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on', 'enabled'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off', 'disabled'].includes(normalized)) return false
+  return fallback
+}
+
+const parsePositiveInt = (value: string | undefined, fallback: number) => {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+  return parsed
+}
+
+const parseTimestamp = (value: unknown): Date | null => {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const normalized = trimmed.includes('T') ? trimmed : trimmed.replace(' ', 'T')
+  const withZone = /[zZ]|[+-]\d{2}:?\d{2}$/.test(normalized) ? normalized : `${normalized}Z`
+  const parsed = new Date(withZone)
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed
+}
+
+const parseNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+const clamp01 = (value: number) => Math.max(0, Math.min(1, value))
+const toIso = (value: Date) => value.toISOString()
+
+const coerceRiskFlags = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item): item is string => item.length > 0)
+}
+
+const coercePayload = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+const coerceCitations = (value: unknown): ProviderCitation[] => {
+  if (!Array.isArray(value)) return []
+  const citations: ProviderCitation[] = []
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue
+    const row = item as Record<string, unknown>
+    const source = typeof row.source === 'string' ? row.source.trim() : ''
+    const publishedAt = parseTimestamp(row.publishedAt)
+    if (!source || !publishedAt) continue
+    citations.push({
+      source,
+      publishedAt: toIso(publishedAt),
+      url: typeof row.url === 'string' && row.url.trim().length > 0 ? row.url.trim() : null,
+    })
+  }
+  return citations
+}
+
+const resolveSettings = () => {
+  const callbackBaseUrl =
+    process.env.JANGAR_MARKET_CONTEXT_AGENT_CALLBACK_BASE_URL?.trim() || 'http://jangar.jangar.svc.cluster.local'
+  const callbackIngestUrl = `${callbackBaseUrl.replace(/\/+$/, '')}/api/torghut/market-context/ingest`
+  return {
+    dispatchEnabled: parseBoolean(process.env.JANGAR_MARKET_CONTEXT_AGENT_DISPATCH_ENABLED, true),
+    dispatchNamespace: process.env.JANGAR_MARKET_CONTEXT_AGENT_NAMESPACE?.trim() || 'agents',
+    fundamentalsAgentName:
+      process.env.JANGAR_MARKET_CONTEXT_FUNDAMENTALS_AGENT_NAME?.trim() || 'torghut-fundamentals-agent',
+    newsAgentName: process.env.JANGAR_MARKET_CONTEXT_NEWS_AGENT_NAME?.trim() || 'torghut-news-agent',
+    fundamentalsImplementationSpec:
+      process.env.JANGAR_MARKET_CONTEXT_FUNDAMENTALS_IMPLEMENTATION_SPEC?.trim() ||
+      'torghut-market-context-fundamentals-v1',
+    newsImplementationSpec:
+      process.env.JANGAR_MARKET_CONTEXT_NEWS_IMPLEMENTATION_SPEC?.trim() || 'torghut-market-context-news-v1',
+    runtimeType: process.env.JANGAR_MARKET_CONTEXT_AGENT_RUNTIME_TYPE?.trim() || 'job',
+    runtimeServiceAccount: process.env.JANGAR_MARKET_CONTEXT_AGENT_SERVICE_ACCOUNT?.trim() || '',
+    fundamentalsMaxFreshnessSeconds: parsePositiveInt(
+      process.env.JANGAR_MARKET_CONTEXT_FUNDAMENTALS_MAX_FRESHNESS_SECONDS,
+      DEFAULT_FUNDAMENTALS_MAX_FRESHNESS_SECONDS,
+    ),
+    newsMaxFreshnessSeconds: parsePositiveInt(
+      process.env.JANGAR_MARKET_CONTEXT_NEWS_MAX_FRESHNESS_SECONDS,
+      DEFAULT_NEWS_MAX_FRESHNESS_SECONDS,
+    ),
+    fundamentalsDispatchCooldownSeconds: parsePositiveInt(
+      process.env.JANGAR_MARKET_CONTEXT_FUNDAMENTALS_DISPATCH_COOLDOWN_SECONDS,
+      DEFAULT_FUNDAMENTALS_DISPATCH_COOLDOWN_SECONDS,
+    ),
+    newsDispatchCooldownSeconds: parsePositiveInt(
+      process.env.JANGAR_MARKET_CONTEXT_NEWS_DISPATCH_COOLDOWN_SECONDS,
+      DEFAULT_NEWS_DISPATCH_COOLDOWN_SECONDS,
+    ),
+    callbackIngestUrl,
+    ingestToken: process.env.JANGAR_MARKET_CONTEXT_INGEST_TOKEN?.trim() || '',
+    agentRunTtlSeconds: parsePositiveInt(
+      process.env.JANGAR_MARKET_CONTEXT_AGENT_TTL_SECONDS,
+      DEFAULT_AGENT_RUN_TTL_SECONDS,
+    ),
+  }
+}
+
+const resolveDomainMaxFreshness = (domain: MarketContextProviderDomain, settings: ReturnType<typeof resolveSettings>) =>
+  domain === 'fundamentals' ? settings.fundamentalsMaxFreshnessSeconds : settings.newsMaxFreshnessSeconds
+
+const resolveDomainCooldown = (domain: MarketContextProviderDomain, settings: ReturnType<typeof resolveSettings>) =>
+  domain === 'fundamentals' ? settings.fundamentalsDispatchCooldownSeconds : settings.newsDispatchCooldownSeconds
+
+const resolveAgentName = (domain: MarketContextProviderDomain, settings: ReturnType<typeof resolveSettings>) =>
+  domain === 'fundamentals' ? settings.fundamentalsAgentName : settings.newsAgentName
+
+const resolveImplementationSpec = (domain: MarketContextProviderDomain, settings: ReturnType<typeof resolveSettings>) =>
+  domain === 'fundamentals' ? settings.fundamentalsImplementationSpec : settings.newsImplementationSpec
+
+const resolveFreshnessSeconds = (now: Date, asOf: Date) =>
+  Math.max(0, Math.floor((now.getTime() - asOf.getTime()) / 1000))
+
+const buildMissingContext = (params: {
+  domain: MarketContextProviderDomain
+  symbol: string
+  now: Date
+  dispatchQueued: boolean
+  dispatchError: string | null
+}): MarketContextProviderContext => {
+  const riskFlags = [`${params.domain}_missing`]
+  if (params.dispatchQueued) riskFlags.push(`${params.domain}_dispatch_queued`)
+  if (params.dispatchError) riskFlags.push(`${params.domain}_dispatch_error`)
+
+  return {
+    asOfUtc: toIso(params.now),
+    sourceCount: 0,
+    qualityScore: 0,
+    payload: {
+      symbol: params.symbol,
+      domain: params.domain,
+      provider: 'codex-spark',
+      status: 'missing',
+    },
+    citations: [],
+    riskFlags,
+  }
+}
+
+const asDomain = (value: unknown): MarketContextProviderDomain | null => {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'fundamentals' || normalized === 'news') return normalized
+  return null
+}
+
+const resolveDbWithMigrations = async () => {
+  const db = getDb()
+  if (!db) return null
+  await ensureMigrations(db)
+  return db
+}
+
+type SnapshotRow = {
+  symbol: string
+  domain: string
+  as_of: string | Date
+  source_count: number
+  quality_score: number
+  payload: unknown
+  citations: unknown
+  risk_flags: string[] | null
+}
+
+const readLatestSnapshot = async (params: { symbol: string; domain: MarketContextProviderDomain }) => {
+  const db = await resolveDbWithMigrations()
+  if (!db) return null
+  const row = (await db
+    .selectFrom('torghut_market_context_snapshots')
+    .select(['symbol', 'domain', 'as_of', 'source_count', 'quality_score', 'payload', 'citations', 'risk_flags'])
+    .where('symbol', '=', params.symbol)
+    .where('domain', '=', params.domain)
+    .executeTakeFirst()) as SnapshotRow | undefined
+
+  if (!row) return null
+  const asOf = parseTimestamp(row.as_of)
+  if (!asOf) return null
+  return {
+    symbol: row.symbol,
+    domain: row.domain as MarketContextProviderDomain,
+    asOf,
+    sourceCount: Math.max(0, Math.trunc(parseNumber(row.source_count) ?? 0)),
+    qualityScore: clamp01(parseNumber(row.quality_score) ?? 0),
+    payload: coercePayload(row.payload),
+    citations: coerceCitations(row.citations),
+    riskFlags: coerceRiskFlags(row.risk_flags),
+  }
+}
+
+const reserveDispatchSlot = async (params: {
+  symbol: string
+  domain: MarketContextProviderDomain
+  now: Date
+  cooldownSeconds: number
+}) => {
+  const db = await resolveDbWithMigrations()
+  if (!db) return false
+
+  const threshold = new Date(params.now.getTime() - params.cooldownSeconds * 1000)
+  const result = await sql<{ symbol: string }>`
+    INSERT INTO torghut_market_context_dispatch_state (
+      symbol,
+      domain,
+      last_dispatched_at,
+      last_status,
+      last_error,
+      updated_at
+    )
+    VALUES (${params.symbol}, ${params.domain}, ${params.now}, 'queued', NULL, now())
+    ON CONFLICT (symbol, domain) DO UPDATE
+      SET
+        last_dispatched_at = EXCLUDED.last_dispatched_at,
+        last_status = 'queued',
+        last_error = NULL,
+        updated_at = now()
+    WHERE
+      torghut_market_context_dispatch_state.last_dispatched_at IS NULL OR
+      torghut_market_context_dispatch_state.last_dispatched_at < ${threshold}
+    RETURNING symbol;
+  `.execute(db)
+
+  return result.rows.length > 0
+}
+
+const updateDispatchState = async (params: {
+  symbol: string
+  domain: MarketContextProviderDomain
+  status: string
+  runName: string | null
+  error: string | null
+  now: Date
+}) => {
+  const db = await resolveDbWithMigrations()
+  if (!db) return
+  await db
+    .insertInto('torghut_market_context_dispatch_state')
+    .values({
+      symbol: params.symbol,
+      domain: params.domain,
+      last_dispatched_at: params.now,
+      last_run_name: params.runName,
+      last_status: params.status,
+      last_error: params.error,
+      updated_at: params.now,
+    })
+    .onConflict((oc) =>
+      oc.columns(['symbol', 'domain']).doUpdateSet({
+        last_dispatched_at: params.now,
+        last_run_name: params.runName,
+        last_status: params.status,
+        last_error: params.error,
+        updated_at: params.now,
+      }),
+    )
+    .execute()
+}
+
+const dispatchDomainAgentRun = async (params: {
+  domain: MarketContextProviderDomain
+  symbol: string
+  now: Date
+  reason: string
+}) => {
+  const settings = resolveSettings()
+  const cooldownSeconds = resolveDomainCooldown(params.domain, settings)
+  const reserved = await reserveDispatchSlot({
+    symbol: params.symbol,
+    domain: params.domain,
+    now: params.now,
+    cooldownSeconds,
+  })
+  if (!reserved) {
+    return {
+      attempted: true,
+      dispatched: false,
+      reason: 'dispatch_cooldown_active',
+      runName: null,
+      error: null,
+    }
+  }
+
+  const agentName = resolveAgentName(params.domain, settings)
+  const implementationSpec = resolveImplementationSpec(params.domain, settings)
+  const runtimeConfig: Record<string, unknown> = {}
+  if (settings.runtimeServiceAccount) {
+    runtimeConfig.serviceAccountName = settings.runtimeServiceAccount
+  }
+
+  const callbackToken = settings.ingestToken
+  const windowBucket = Math.floor(params.now.getTime() / (cooldownSeconds * 1000))
+  const idempotencyKey = `torghut-market-context:${params.domain}:${params.symbol}:${windowBucket}`
+
+  const resource: Record<string, unknown> = {
+    apiVersion: 'agents.proompteng.ai/v1alpha1',
+    kind: 'AgentRun',
+    metadata: {
+      generateName: `torghut-market-context-${params.domain}-`,
+      namespace: settings.dispatchNamespace,
+      labels: {
+        'torghut.proompteng.ai/symbol': params.symbol,
+        'torghut.proompteng.ai/domain': params.domain,
+        'jangar.proompteng.ai/source': 'torghut-market-context',
+      },
+    },
+    spec: {
+      agentRef: { name: agentName },
+      implementationSpecRef: { name: implementationSpec },
+      parameters: {
+        symbol: params.symbol,
+        domain: params.domain,
+        asOfUtc: toIso(params.now),
+        reason: params.reason,
+        callbackUrl: settings.callbackIngestUrl,
+        callbackToken,
+        requestId: randomUUID(),
+      },
+      runtime:
+        Object.keys(runtimeConfig).length > 0
+          ? { type: settings.runtimeType, config: runtimeConfig }
+          : { type: settings.runtimeType },
+      ttlSecondsAfterFinished: settings.agentRunTtlSeconds,
+      idempotencyKey,
+    },
+  }
+
+  try {
+    const kube = createKubernetesClient()
+    const applied = await kube.apply(resource)
+    const metadata =
+      applied.metadata && typeof applied.metadata === 'object'
+        ? (applied.metadata as Record<string, unknown>)
+        : ({} as Record<string, unknown>)
+    const runName = typeof metadata.name === 'string' ? metadata.name : null
+    await updateDispatchState({
+      symbol: params.symbol,
+      domain: params.domain,
+      status: 'submitted',
+      runName,
+      error: null,
+      now: params.now,
+    })
+    return {
+      attempted: true,
+      dispatched: true,
+      reason: null,
+      runName,
+      error: null,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    await updateDispatchState({
+      symbol: params.symbol,
+      domain: params.domain,
+      status: 'dispatch_error',
+      runName: null,
+      error: message.slice(0, 500),
+      now: params.now,
+    })
+    return {
+      attempted: true,
+      dispatched: false,
+      reason: 'dispatch_failed',
+      runName: null,
+      error: message,
+    }
+  }
+}
+
+export const getMarketContextProviderResult = async (params: {
+  domain: MarketContextProviderDomain
+  symbolInput: string
+}): Promise<MarketContextProviderResult> => {
+  const symbol = normalizeTorghutSymbol(params.symbolInput)
+  const now = new Date()
+  const settings = resolveSettings()
+  const maxFreshnessSeconds = resolveDomainMaxFreshness(params.domain, settings)
+  const db = await resolveDbWithMigrations()
+
+  if (!db) {
+    return {
+      symbol,
+      domain: params.domain,
+      snapshotState: 'missing',
+      context: {
+        ...buildMissingContext({
+          domain: params.domain,
+          symbol,
+          now,
+          dispatchQueued: false,
+          dispatchError: null,
+        }),
+        riskFlags: [`${params.domain}_missing`, `${params.domain}_database_unavailable`],
+      },
+      dispatch: {
+        attempted: false,
+        dispatched: false,
+        reason: 'database_unavailable',
+        runName: null,
+        error: null,
+      },
+    }
+  }
+
+  const snapshot = await readLatestSnapshot({ symbol, domain: params.domain })
+  if (!snapshot) {
+    const dispatch = settings.dispatchEnabled
+      ? await dispatchDomainAgentRun({
+          domain: params.domain,
+          symbol,
+          now,
+          reason: 'missing_snapshot',
+        })
+      : {
+          attempted: false,
+          dispatched: false,
+          reason: 'dispatch_disabled',
+          runName: null,
+          error: null,
+        }
+    return {
+      symbol,
+      domain: params.domain,
+      snapshotState: 'missing',
+      context: buildMissingContext({
+        domain: params.domain,
+        symbol,
+        now,
+        dispatchQueued: dispatch.dispatched,
+        dispatchError: dispatch.error,
+      }),
+      dispatch,
+    }
+  }
+
+  const freshnessSeconds = resolveFreshnessSeconds(now, snapshot.asOf)
+  const isStale = freshnessSeconds > maxFreshnessSeconds
+  const dispatch =
+    settings.dispatchEnabled && isStale
+      ? await dispatchDomainAgentRun({
+          domain: params.domain,
+          symbol,
+          now,
+          reason: 'stale_snapshot',
+        })
+      : {
+          attempted: false,
+          dispatched: false,
+          reason: isStale ? 'dispatch_disabled' : null,
+          runName: null,
+          error: null,
+        }
+
+  const riskFlags = new Set(snapshot.riskFlags)
+  if (isStale) riskFlags.add(`${params.domain}_stale`)
+  if (dispatch.dispatched) riskFlags.add(`${params.domain}_dispatch_queued`)
+  if (dispatch.error) riskFlags.add(`${params.domain}_dispatch_error`)
+
+  return {
+    symbol,
+    domain: params.domain,
+    snapshotState: isStale ? 'stale' : 'fresh',
+    context: {
+      asOfUtc: toIso(snapshot.asOf),
+      sourceCount: snapshot.sourceCount,
+      qualityScore: snapshot.qualityScore,
+      payload: snapshot.payload,
+      citations: snapshot.citations,
+      riskFlags: Array.from(riskFlags),
+    },
+    dispatch,
+  }
+}
+
+const coerceRunStatus = (value: unknown) => {
+  if (typeof value !== 'string') return 'succeeded'
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return 'succeeded'
+  if (normalized === 'failed' || normalized === 'error') return 'failed'
+  if (normalized === 'submitted' || normalized === 'queued') return 'submitted'
+  if (normalized === 'partial') return 'partial'
+  return 'succeeded'
+}
+
+const coerceSourceCount = (value: unknown) => Math.max(0, Math.trunc(parseNumber(value) ?? 0))
+
+const coerceQualityScore = (value: unknown) => clamp01(parseNumber(value) ?? 0)
+
+export const ingestMarketContextProviderResult = async (input: Record<string, unknown>) => {
+  const db = await resolveDbWithMigrations()
+  if (!db) {
+    throw new Error('DATABASE_URL is not configured')
+  }
+
+  const domain = asDomain(input.domain)
+  if (!domain) {
+    throw new Error('domain must be fundamentals or news')
+  }
+
+  const symbolRaw = typeof input.symbol === 'string' ? input.symbol.trim() : ''
+  if (!symbolRaw) {
+    throw new Error('symbol is required')
+  }
+  const symbol = normalizeTorghutSymbol(symbolRaw)
+
+  const asOf = parseTimestamp(input.asOfUtc ?? input.asOf ?? input.publishedAt) ?? new Date()
+  const sourceCount = coerceSourceCount(input.sourceCount ?? input.itemCount)
+  const qualityScore = coerceQualityScore(input.qualityScore)
+  const payload = coercePayload(input.payload ?? input.context)
+  const citations = coerceCitations(input.citations)
+  const riskFlags = coerceRiskFlags(input.riskFlags)
+  const provider = typeof input.provider === 'string' ? input.provider.trim() : 'codex-spark'
+  const runName = typeof input.runName === 'string' && input.runName.trim().length > 0 ? input.runName.trim() : null
+  const runStatus = coerceRunStatus(input.runStatus)
+  const runError = typeof input.error === 'string' && input.error.trim().length > 0 ? input.error.trim() : null
+  const payloadJson = JSON.stringify(payload)
+  const citationsJson = JSON.stringify(citations)
+  const now = new Date()
+
+  await db
+    .insertInto('torghut_market_context_snapshots')
+    .values({
+      symbol,
+      domain,
+      as_of: asOf,
+      source_count: sourceCount,
+      quality_score: qualityScore,
+      payload: payloadJson as unknown as Record<string, unknown>,
+      citations: citationsJson,
+      risk_flags: riskFlags,
+      provider,
+      run_name: runName,
+      updated_at: now,
+    })
+    .onConflict((oc) =>
+      oc.columns(['symbol', 'domain']).doUpdateSet({
+        as_of: asOf,
+        source_count: sourceCount,
+        quality_score: qualityScore,
+        payload: payloadJson as unknown as Record<string, unknown>,
+        citations: citationsJson,
+        risk_flags: riskFlags,
+        provider,
+        run_name: runName,
+        updated_at: now,
+      }),
+    )
+    .execute()
+
+  await db
+    .insertInto('torghut_market_context_dispatch_state')
+    .values({
+      symbol,
+      domain,
+      last_dispatched_at: now,
+      last_run_name: runName,
+      last_status: runStatus,
+      last_error: runError,
+      updated_at: now,
+    })
+    .onConflict((oc) =>
+      oc.columns(['symbol', 'domain']).doUpdateSet({
+        last_dispatched_at: now,
+        last_run_name: runName,
+        last_status: runStatus,
+        last_error: runError,
+        updated_at: now,
+      }),
+    )
+    .execute()
+
+  clearMarketContextCache()
+
+  return {
+    ok: true as const,
+    symbol,
+    domain,
+    runStatus,
+    requestId: typeof input.requestId === 'string' ? input.requestId : randomUUID(),
+    context: {
+      asOfUtc: toIso(asOf),
+      sourceCount,
+      qualityScore,
+      payload,
+      citations,
+      riskFlags,
+    } satisfies MarketContextProviderContext,
+  }
+}

--- a/services/jangar/src/server/torghut-market-context-agents.ts
+++ b/services/jangar/src/server/torghut-market-context-agents.ts
@@ -183,7 +183,7 @@ const buildMissingContext = (params: {
   if (params.dispatchError) riskFlags.push(`${params.domain}_dispatch_error`)
 
   return {
-    asOfUtc: toIso(params.now),
+    asOfUtc: '',
     sourceCount: 0,
     qualityScore: 0,
     payload: {

--- a/services/jangar/src/server/torghut-market-context-agents.ts
+++ b/services/jangar/src/server/torghut-market-context-agents.ts
@@ -529,13 +529,14 @@ export const getMarketContextProviderResult = async (params: {
 }
 
 const coerceRunStatus = (value: unknown) => {
-  if (typeof value !== 'string') return 'succeeded'
+  if (typeof value !== 'string') return 'failed'
   const normalized = value.trim().toLowerCase()
-  if (!normalized) return 'succeeded'
+  if (!normalized) return 'failed'
+  if (normalized === 'succeeded' || normalized === 'success' || normalized === 'ok') return 'succeeded'
   if (normalized === 'failed' || normalized === 'error') return 'failed'
   if (normalized === 'submitted' || normalized === 'queued') return 'submitted'
   if (normalized === 'partial') return 'partial'
-  return 'succeeded'
+  return 'failed'
 }
 
 const coerceSourceCount = (value: unknown) => Math.max(0, Math.trunc(parseNumber(value) ?? 0))


### PR DESCRIPTION
## Summary

- Add Jangar fundamentals/news provider and ingest endpoints for Torghut market-context, including route registration and route tests.
- Add Postgres persistence for market-context snapshots and dispatch state via migration `20260226_torghut_market_context_agents` and DB type wiring.
- Add agent dispatch/ingest service logic in Jangar with cooldown + idempotency handling, optional callback auth token, and cache invalidation.
- Add agents manifests for `codex-spark`, `torghut-fundamentals-agent`, and `torghut-news-agent`; update ImplementationSpecs and agents kustomization.
- Wire Jangar deployment env for fundamentals/news provider URLs and agent dispatch settings; update v5 design docs for the Torghut -> Jangar integration.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/src/server/torghut-market-context-agents.ts argocd/applications/agents/codex-spark-agentprovider.yaml argocd/applications/agents/torghut-agentruns.yaml`
- `bunx tsc --noEmit -p services/jangar/tsconfig.app.json`
- `bunx vitest run services/jangar/src/routes/api/torghut/market-context/-ingest.test.ts services/jangar/src/routes/api/torghut/market-context/providers/-fundamentals.test.ts services/jangar/src/routes/api/torghut/market-context/providers/-news.test.ts`
- `bun run packages/scripts/src/jangar/deploy-service.ts --tag marketctxfix2-$(date +%Y%m%d%H%M%S)`
- `kubectl apply -n agents -f argocd/applications/agents/torghut-agentruns.yaml`
- `kubectl apply -n agents -f argocd/applications/agents/codex-spark-agentprovider.yaml`
- `kubectl get deployment jangar -n jangar -o wide`
- `kubectl get agentprovider -n agents codex-spark -o yaml`
- `kubectl cnpg psql -n jangar jangar-db -- -d jangar -c '\dt torghut_market_context*'`
- Manual live validation: dispatched fundamentals/news provider runs for `INTC`, confirmed `AgentRun` completion, confirmed rows persisted in `torghut_market_context_snapshots` and `torghut_market_context_dispatch_state`, and confirmed provider endpoints return `snapshotState=fresh`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None (new DB tables and env wiring added for this flow; migration is included in this PR).

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
