### PR TITLE
chore(jangar): promote image a524ca44

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a5d12678
-  digest: sha256:8ac964d3f2cd84a18982ba3734be4fa0cb289c73a1d8ecc09c5d3cdfa36357a4
+  tag: a524ca44
+  digest: sha256:d07559486bd59e978622c2059bb20d3596de9baf3b220c183c4dd52cf8d33b5c
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a5d12678
-    digest: sha256:8942a51ec15b0cc4fe85557bf7e08a8ecefe04e4e2cce9fd40fcc9aa1e2fb6f4
+    tag: a524ca44
+    digest: sha256:8ca929d46cf51c4b84dbb934b3e2b2971251b0ca155290e08d2060450031092c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a5d12678
-    digest: sha256:8ac964d3f2cd84a18982ba3734be4fa0cb289c73a1d8ecc09c5d3cdfa36357a4
+    tag: a524ca44
+    digest: sha256:d07559486bd59e978622c2059bb20d3596de9baf3b220c183c4dd52cf8d33b5c
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-26T21:16:24.147Z"
+    deploy.knative.dev/rollout: "2026-02-27T02:05:26Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-26T21:16:24.147Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-27T02:05:26Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "477487a4"
-    digest: sha256:e1ee9a1fb175d57141e474ba7526423e049451f97922b6c34a4d232ee0a0b0b6
+    newTag: "a524ca44"
+    digest: sha256:d07559486bd59e978622c2059bb20d3596de9baf3b220c183c4dd52cf8d33b5c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a524ca442a675bfc75a6e2245503bd58c6ff01eb`
- Image tag: `a524ca44`
- Image digest: `sha256:d07559486bd59e978622c2059bb20d3596de9baf3b220c183c4dd52cf8d33b5c`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`