### PR TITLE
fix(pgadmin): ensure server list repopulates on startup

### DIFF
--- a/argocd/applications/pgadmin/values.yaml
+++ b/argocd/applications/pgadmin/values.yaml
@@ -42,6 +42,8 @@ persistentVolume:
 envVarsExtra:
   - name: PGADMIN_SERVER_JSON_FILE
     value: /var/lib/pgadmin/servers/servers.json
+  - name: PGADMIN_REPLACE_SERVERS_ON_STARTUP
+    value: "True"
   - name: PGADMIN_CONFIG_ENABLE_SERVER_PASS_EXEC_CMD
     value: "True"
 
@@ -163,18 +165,24 @@ extraInitContainers: |
                 value = f'pga_user_{value}'
             return value.replace('@', '_').replace('/', 'slash').replace('\\', 'slash')
 
-        clusters = [
-            {'secret': 'keycloak-db-app', 'name': 'keycloak-db'},
-            {'secret': 'coder-cluster-app', 'name': 'coder-cluster'},
-            {'secret': 'convex-db-app', 'name': 'convex-db'},
-            {'secret': 'cms-db-app', 'name': 'cms-db'},
-            {'secret': 'app-db-app', 'name': 'app-db'},
-            {'secret': 'jangar-db-app', 'name': 'jangar-db'},
-            {'secret': 'golink-db-app', 'name': 'golink-db'},
-            {'secret': 'facteur-vector-cluster-app', 'name': 'facteur-vector-cluster'},
-            {'secret': 'dernier-db-app', 'name': 'dernier-db'},
-            {'secret': 'torghut-db-app', 'name': 'torghut-db'},
-        ]
+        def normalize_name(secret_name: str) -> str:
+            if secret_name.endswith('-app'):
+                return secret_name[:-4]
+            return secret_name
+
+        def discover_clusters(secrets_root: Path) -> list[dict[str, str]]:
+            clusters = []
+            if not secrets_root.exists():
+                return clusters
+
+            for secret_dir in sorted((p for p in secrets_root.iterdir() if p.is_dir()), key=lambda p: p.name):
+                uri_path = secret_dir / 'uri'
+                if not uri_path.exists():
+                    continue
+                clusters.append({'secret': secret_dir.name, 'name': normalize_name(secret_dir.name)})
+            return clusters
+
+        clusters = discover_clusters(Path('/etc/pgadmin/secrets'))
 
         servers = {}
         index = 1


### PR DESCRIPTION
## Summary

- Add `PGADMIN_REPLACE_SERVERS_ON_STARTUP=True` to force pgAdmin to re-import `servers.json` on pod restarts.
- Keep server import path configurable by generating `/var/lib/pgadmin/servers/servers.json` from discovered `/etc/pgadmin/secrets/*/uri` entries instead of a fixed secret list.
- Normalize discovered secret names to cleanly display server names in pgAdmin (`-app` suffix removed).

## Related Issues

None

## Testing

- Verified locally by rendering Argo Helm values with `helm@3 kustomize build --enable-helm argocd/applications/pgadmin`.
- Applied updated manifest with `kubectl apply` and confirmed deployment rollout in `pgadmin` namespace.
- Confirmed pgAdmin container environment includes `PGADMIN_REPLACE_SERVERS_ON_STARTUP=True`.
- Confirmed `/var/lib/pgadmin/pgadmin4.db` contains discovered server entries after startup.

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
- [x] PR title and scope match the actual change.
