### PR TITLE
fix(torghut): harden dspy idempotency and secret binding defaults

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -355,7 +355,7 @@ spec:
             - name: LLM_DSPY_COMPILE_METRICS_POLICY_REF
               value: config/trading/llm/dspy-metrics.yaml
             - name: LLM_DSPY_SECRET_BINDING_REF
-              value: codex-whitepaper-github-token
+              value: codex-github-token
             - name: LLM_DSPY_AGENTRUN_TTL_SECONDS
               value: "14400"
             - name: LLM_CIRCUIT_MAX_ERRORS

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1246,7 +1246,7 @@ class Settings(BaseSettings):
         alias="LLM_DSPY_COMPILE_METRICS_POLICY_REF",
     )
     llm_dspy_secret_binding_ref: str = Field(
-        default="codex-whitepaper-github-token",
+        default="codex-github-token",
         alias="LLM_DSPY_SECRET_BINDING_REF",
     )
     llm_dspy_agentrun_ttl_seconds: int = Field(


### PR DESCRIPTION
## Summary

- Fix DSPy workflow AgentRun idempotency keys to be Kubernetes-label-safe by sanitizing invalid characters and enforcing length bounds.
- Prevent idempotency key collisions on long run prefixes by adding deterministic hash-based shortening rather than naive truncation.
- Align DSPy orchestration defaults to the `codex-agent` SecretBinding path by defaulting `LLM_DSPY_SECRET_BINDING_REF` to `codex-github-token` in Torghut config and GitOps Knative env.
- Add regression coverage for sanitized keys, long-prefix uniqueness, colon-containing run prefixes, and persisted workflow idempotency metadata.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_llm_dspy_workflow.py tests/test_llm_dspy_runtime.py tests/test_llm_review_engine.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
