### PR TITLE
chore(torghut): promote image 3bdd6231

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec53c6bbec3e6b0649a932f08ccf497768645a07056f8c7de42dc7cad9ad1410
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:373adf3b8147868aaad6628c253ccab0cf6f3231ee8a65649e9dcb115a8e3169
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-27T07:11:04Z"
+        client.knative.dev/updateTimestamp: "2026-02-27T07:40:49Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec53c6bbec3e6b0649a932f08ccf497768645a07056f8c7de42dc7cad9ad1410
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:373adf3b8147868aaad6628c253ccab0cf6f3231ee8a65649e9dcb115a8e3169
           ports:
             - name: http1
               containerPort: 8181
@@ -382,9 +382,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-87-ga07a4e18
+              value: v0.561.0-89-g3bdd6231
             - name: TORGHUT_COMMIT
-              value: a07a4e18261a527603421d024f63701b9702a081
+              value: 3bdd6231641653953e90a65715e534eb7518d779
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `3bdd6231641653953e90a65715e534eb7518d779`
- Image tag: `3bdd6231`
- Image digest: `sha256:373adf3b8147868aaad6628c253ccab0cf6f3231ee8a65649e9dcb115a8e3169`