### PR TITLE
fix(torghut): send issue metadata in dspy agentrun workflow

### DIFF
--- a/services/torghut/app/trading/llm/dspy_compile/workflow.py
+++ b/services/torghut/app/trading/llm/dspy_compile/workflow.py
@@ -329,6 +329,7 @@ def build_dspy_agentrun_payload(
     head: str,
     artifact_path: str,
     parameter_overrides: Mapping[str, Any],
+    issue_number: str = "0",
     namespace: str = "agents",
     agent_name: str = "codex-agent",
     vcs_ref_name: str = "github",
@@ -345,6 +346,10 @@ def build_dspy_agentrun_payload(
         "base": base.strip(),
         "head": head.strip(),
         "artifactPath": artifact_path.strip(),
+        "issueNumber": _normalize_string_parameter(
+            key="issueNumber",
+            value=issue_number,
+        ),
     }
     for key, value in parameter_overrides.items():
         normalized_key = str(key).strip()
@@ -508,6 +513,7 @@ def orchestrate_dspy_agentrun_workflow(
     artifact_root: str,
     run_prefix: str,
     auth_token: str | None,
+    issue_number: str = "0",
     lane_parameter_overrides: Mapping[DSPyWorkflowLane, Mapping[str, Any]]
     | None = None,
     include_gepa_experiment: bool = False,
@@ -552,6 +558,7 @@ def orchestrate_dspy_agentrun_workflow(
             head=head,
             artifact_path=artifact_path,
             parameter_overrides=lane_overrides,
+            issue_number=issue_number,
             namespace=namespace,
             agent_name=agent_name,
             vcs_ref_name=vcs_ref_name,

--- a/services/torghut/scripts/run_dspy_workflow.py
+++ b/services/torghut/scripts/run_dspy_workflow.py
@@ -68,6 +68,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base", default="main", help="VCS base branch")
     parser.add_argument("--head", required=True, help="VCS head branch")
     parser.add_argument(
+        "--issue-number",
+        default="0",
+        help="Issue number metadata required by codex agent runner (default: 0)",
+    )
+    parser.add_argument(
         "--run-prefix", required=True, help="Stable run prefix for idempotency keys"
     )
     parser.add_argument(
@@ -158,6 +163,7 @@ def main() -> int:
             artifact_root=args.artifact_root,
             run_prefix=args.run_prefix,
             auth_token=(args.auth_token.strip() or None),
+            issue_number=args.issue_number,
             lane_parameter_overrides=lane_overrides,
             include_gepa_experiment=bool(args.include_gepa_experiment),
             namespace=args.namespace,


### PR DESCRIPTION
## Summary

- Fix DSPy AgentRun orchestration payloads to always include `issueNumber` metadata, defaulting to `0` when no issue context exists.
- Add an explicit `issue_number` argument to DSPy workflow payload builders and orchestration entrypoints to keep metadata flow deterministic.
- Extend the DSPy workflow CLI script with `--issue-number` and pass-through wiring into orchestration.
- Add regression tests for default and override `issueNumber` behavior and assert it is present in submitted AgentRun payloads.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_llm_dspy_workflow.py tests/test_llm_dspy_runtime.py tests/test_llm_review_engine.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
