### PR TITLE
fix(torghut): require observed dspy metrics and fail closed refs

### DIFF
--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -109,7 +109,12 @@ uv run python scripts/compile_dspy_program.py \
   --artifact-path artifacts/dspy/run-1/compile \
   --dataset-ref artifacts/dspy/run-1/dataset-build/dspy-dataset.json \
   --metric-policy-ref config/trading/llm/dspy-metrics.yaml \
-  --optimizer miprov2
+  --optimizer miprov2 \
+  --schema-valid-rate 0.998 \
+  --veto-alignment-rate 0.81 \
+  --false-veto-rate 0.02 \
+  --fallback-rate 0.02 \
+  --latency-p95-ms 1200
 ```
 
 Eval helper (matches `torghut-dspy-eval-v1` contract):

--- a/services/torghut/app/trading/llm/dspy_compile/dataset.py
+++ b/services/torghut/app/trading/llm/dspy_compile/dataset.py
@@ -203,7 +203,7 @@ def _resolve_symbol_filter(*, session: Session, universe_ref: str) -> _UniverseF
             symbols=_load_enabled_equity_universe_symbols(session),
         )
 
-    return _UniverseFilter(mode="unrecognized_ref", symbols=None)
+    raise ValueError("universe_ref_unrecognized")
 
 
 def _query_dataset_source_rows(

--- a/services/torghut/app/trading/llm/dspy_compile/evaluator.py
+++ b/services/torghut/app/trading/llm/dspy_compile/evaluator.py
@@ -80,6 +80,7 @@ def evaluate_dspy_compile_artifact(
     policy = cast(dict[str, Any], gate_policy_payload.get("policy") or {})
 
     observed = _extract_observed_metrics(compile_result.metric_bundle)
+    _require_observed_metrics(observed)
     threshold_checks, threshold_snapshot, threshold_failures = _evaluate_threshold_checks(
         policy=policy,
         observed=observed,
@@ -246,6 +247,13 @@ def _extract_observed_metrics(metric_bundle: Mapping[str, Any]) -> _ObservedMetr
         fallback_rate=fallback_rate,
         missing_metric_keys=tuple(sorted(set(missing_metric_keys))),
     )
+
+
+def _require_observed_metrics(observed: _ObservedMetrics) -> None:
+    if not observed.missing_metric_keys:
+        return
+    missing_keys = ",".join(observed.missing_metric_keys)
+    raise ValueError(f"compile_result_missing_observed_metrics:{missing_keys}")
 
 
 def _evaluate_threshold_checks(

--- a/services/torghut/scripts/compile_dspy_program.py
+++ b/services/torghut/scripts/compile_dspy_program.py
@@ -53,6 +53,36 @@ def parse_args() -> argparse.Namespace:
         default="torghut-dspy-compile-seed-v1",
         help="Deterministic compile seed.",
     )
+    parser.add_argument(
+        "--schema-valid-rate",
+        type=float,
+        default=None,
+        help="Optional observed schema validity rate [0,1] for eval gating.",
+    )
+    parser.add_argument(
+        "--veto-alignment-rate",
+        type=float,
+        default=None,
+        help="Optional observed veto alignment rate [0,1] for eval gating.",
+    )
+    parser.add_argument(
+        "--false-veto-rate",
+        type=float,
+        default=None,
+        help="Optional observed false veto rate [0,1] for eval gating.",
+    )
+    parser.add_argument(
+        "--fallback-rate",
+        type=float,
+        default=None,
+        help="Optional observed fallback rate [0,1] for eval gating.",
+    )
+    parser.add_argument(
+        "--latency-p95-ms",
+        type=int,
+        default=None,
+        help="Optional observed p95 latency in milliseconds for eval gating.",
+    )
     return parser.parse_args()
 
 
@@ -69,6 +99,11 @@ def main() -> int:
         program_name=args.program_name,
         signature_version=args.signature_version,
         seed=args.seed,
+        schema_valid_rate=args.schema_valid_rate,
+        veto_alignment_rate=args.veto_alignment_rate,
+        false_veto_rate=args.false_veto_rate,
+        fallback_rate=args.fallback_rate,
+        latency_p95_ms=args.latency_p95_ms,
     )
     payload = {
         "ok": True,

--- a/services/torghut/tests/test_llm_dspy_dataset.py
+++ b/services/torghut/tests/test_llm_dspy_dataset.py
@@ -236,6 +236,32 @@ class TestLLMDSPyDatasetBuilder(TestCase):
                         window_end=now,
                     )
 
+    def test_build_dataset_artifacts_rejects_unknown_universe_ref(self) -> None:
+        now = datetime(2026, 2, 27, 9, 30, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            strategy = self._create_strategy(session)
+            self._insert_reviewed_decision(
+                session=session,
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                created_at=now - timedelta(hours=1),
+                verdict="approve",
+                include_market_context=True,
+            )
+
+            with TemporaryDirectory() as tmp:
+                with self.assertRaisesRegex(ValueError, "universe_ref_unrecognized"):
+                    build_dspy_dataset_artifacts(
+                        session,
+                        repository="proompteng/lab",
+                        base="main",
+                        head="codex/dspy-dataset",
+                        artifact_path=tmp,
+                        dataset_window="P10D",
+                        universe_ref="torghut:equity:typo",
+                        window_end=now,
+                    )
+
     def _create_strategy(
         self,
         session: Session,


### PR DESCRIPTION
## Summary

- Require observed DSPy quality metrics before eval gating so gate decisions are not computed from implicit fallback defaults.
- Add compile-helper support for passing observed metrics (`--schema-valid-rate`, `--veto-alignment-rate`, `--false-veto-rate`, `--fallback-rate`, `--latency-p95-ms`) and wire these into `dspy-compile-result.json`.
- Fail dataset builds closed on unknown `universe_ref` values instead of silently widening symbol scope.
- Add regression tests for missing observed metrics, unknown universe refs, and compile observed-metrics validation; update Torghut README compile/eval helper example.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_llm_dspy_dataset.py tests/test_llm_dspy_compiler.py tests/test_llm_dspy_eval.py`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
