### PR TITLE
chore(torghut): promote image f3fae4d4

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b9879ed2b3802020500fe40f8f1dfa983f23b43dd35d35acddceaa30512a26d5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6a825c7033f88205e8243491e7a66dae62ab991e1f07ac88a80b3d10a205a37e
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-27T08:55:25Z"
+        client.knative.dev/updateTimestamp: "2026-02-27T09:09:48Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b9879ed2b3802020500fe40f8f1dfa983f23b43dd35d35acddceaa30512a26d5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6a825c7033f88205e8243491e7a66dae62ab991e1f07ac88a80b3d10a205a37e
           ports:
             - name: http1
               containerPort: 8181
@@ -382,9 +382,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-94-g58cdcbaa
+              value: v0.561.0-96-gf3fae4d4
             - name: TORGHUT_COMMIT
-              value: 58cdcbaa1ddfb949dbe4a9eb442363c6ced41944
+              value: f3fae4d4751485d1b43d41c69d7d358e0617575c
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `f3fae4d4751485d1b43d41c69d7d358e0617575c`
- Image tag: `f3fae4d4`
- Image digest: `sha256:6a825c7033f88205e8243491e7a66dae62ab991e1f07ac88a80b3d10a205a37e`