### PR TITLE
docs(torghut): add v6 beyond-tsmom intraday design pack

### DIFF
--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -54,6 +54,10 @@ The v1 documents are written to stay consistent with:
   with comprehensive design docs and per-paper technique synthesis.
   - Entry point: `docs/torghut/design-system/v5/index.md`
 
+- `v6/` - beyond-TSMOM intraday autonomy pack translating fresh multi-agent, regime-routing, and contamination-safe
+  evaluation research into production implementation and rollout docs (2026-02-27).
+  - Entry point: `docs/torghut/design-system/v6/index.md`
+
 - `v1/` - first cohesive design-system pass aligned to production reality as of **2026-02-08**.
 
 ### v1 Index

--- a/docs/torghut/design-system/v6/01-beyond-tsmom-system-architecture-and-latency-model.md
+++ b/docs/torghut/design-system/v6/01-beyond-tsmom-system-architecture-and-latency-model.md
@@ -1,0 +1,135 @@
+# Beyond TSMOM System Architecture and Latency Model
+
+## Status
+
+- Doc: `v6/01`
+- Date: `2026-02-27`
+- Maturity: `production design`
+- Scope: replace static intraday TSMOM loop with a layered regime-adaptive system plus fast/slow decision routing
+
+## Objective
+
+Define a production architecture that keeps the strengths of TSMOM while addressing known intraday failure modes:
+
+- regime blindness during reversals,
+- static position scaling under microstructure shifts,
+- no integration of unstructured context,
+- delayed reaction to momentum crashes.
+
+## Current Baseline and Gaps
+
+Baseline components in Torghut are strong on deterministic safety and execution policy, but alpha generation is still narrow relative to current research.
+
+Primary gaps:
+
+1. Single dominant trend signal family in stressed regimes.
+2. Limited dynamic strategy weighting by detected market state.
+3. LLM reasoning exists but is not yet fully unified under one production program runtime and artifact lifecycle.
+4. Limited formal contamination controls across all strategy and LLM eval surfaces.
+
+## Target Layered Architecture
+
+### Layer A: Enhanced Momentum Core
+
+Replace static trend estimators with a learned momentum core inspired by DMN + MTL-TSMOM + MTDP:
+
+- learned trend state encoder,
+- joint sizing head optimized on risk-adjusted objective,
+- changepoint feature channel for abrupt regime transition detection,
+- auxiliary tasks (volatility and drawdown forecasting) to improve generalization.
+
+### Layer B: Regime-Adaptive Expert Router
+
+Wrap momentum as one expert among multiple experts:
+
+- trend expert,
+- mean-reversion expert,
+- breakout/volatility-expansion expert,
+- defensive/static allocation expert.
+
+A router produces dynamic weights per symbol and time bucket.
+
+### Layer C: LLM Reasoning Overlay
+
+Use DSPy multi-agent reasoning only when needed:
+
+- ambiguous or conflicting expert outputs,
+- elevated uncertainty,
+- high-impact event windows (news, macro, earnings).
+
+### Layer D: Deterministic Decision and Execution
+
+All model outputs are advisory inputs to deterministic controls:
+
+- policy gates,
+- risk limits,
+- execution limits,
+- kill switches.
+
+## Fast/Slow Inference Model
+
+### Fast path (routine)
+
+- latency budget: `< 100ms`
+- inputs: market microstructure + expert outputs + router weights
+- behavior: deterministic scoring + action if confidence and risk gates pass
+
+### Slow path (reasoning)
+
+- latency budget: `1s` to `5s`
+- inputs: fast-path bundle plus fundamentals/news and LLM committee context
+- behavior: DSPy committee produces structured advisory critique and confidence
+
+### Slow path trigger conditions
+
+At least one must be true:
+
+1. Router entropy exceeds configured threshold.
+2. Expert disagreement exceeds configured spread.
+3. Regime transition probability exceeds configured threshold.
+4. News/fundamental freshness is recent and relevance score is high.
+5. Position/risk impact of the proposed trade is above critical notional.
+
+## Data and Interface Contracts
+
+### Symbol-state contract (runtime)
+
+- `symbol`
+- `asOfUtc`
+- `regimeLabel`
+- `regimeProbabilities`
+- `expertScores`
+- `routerWeights`
+- `uncertaintyScore`
+- `contextFreshness`
+
+### Decision-intent contract (pre-execution)
+
+- `intent` (`buy|sell|hold|abstain`)
+- `confidence`
+- `positionDelta`
+- `riskBudgetRef`
+- `llmAdvisoryRef` (optional)
+- `gateInputsHash`
+
+## Engineering Deliverables
+
+1. Feature contract update for regime and uncertainty fields.
+2. Router integration in strategy decision loop.
+3. Slow-path trigger evaluator with deterministic criteria.
+4. End-to-end telemetry on path selection (`fast|slow`) and outcomes.
+
+## Acceptance Criteria
+
+1. Fast-path p95 latency stays within budget during market hours.
+2. Slow-path invocation stays within configured rate cap and does not degrade scheduler health.
+3. Regime-aware routing reduces drawdown in known reversal windows versus static TSMOM baseline.
+4. All new decision fields are represented in audit artifacts and replay tooling.
+
+## Research Inputs
+
+- Deep Momentum Networks (Lim et al.)
+- MTL-TSMOM
+- MTDP changepoint-augmented momentum designs
+- MM-DREX regime-adaptive routing
+- FPX fast/slow model selection findings

--- a/docs/torghut/design-system/v6/02-regime-adaptive-expert-router-design.md
+++ b/docs/torghut/design-system/v6/02-regime-adaptive-expert-router-design.md
@@ -1,0 +1,113 @@
+# Regime-Adaptive Expert Router Design
+
+## Status
+
+- Doc: `v6/02`
+- Date: `2026-02-27`
+- Maturity: `production design`
+- Scope: implement MM-DREX-style expert routing in Torghut with deterministic guardrails
+
+## Objective
+
+Implement a regime-aware routing layer that dynamically allocates weight across heterogeneous strategy experts and explicitly replaces static single-strategy capital assignment.
+
+## Expert Set
+
+1. `trend`: momentum and continuation behavior.
+2. `reversal`: mean-reversion in over-extended conditions.
+3. `breakout`: volatility expansion and range escape behavior.
+4. `defensive`: low-risk static or reduced-exposure posture.
+
+## Router Inputs
+
+- time-series features (returns, volatility, realized correlation, drawdown state),
+- microstructure features (spread, imbalance proxy, liquidity stress),
+- event-context features (news density and freshness),
+- changepoint probability.
+
+## Router Output Contract
+
+```json
+{
+  "symbol": "NVDA",
+  "asOfUtc": "2026-02-27T15:31:00Z",
+  "regimeLabel": "trend_up",
+  "regimeConfidence": 0.78,
+  "weights": {
+    "trend": 0.62,
+    "reversal": 0.14,
+    "breakout": 0.20,
+    "defensive": 0.04
+  },
+  "entropy": 0.41,
+  "routerVersion": "router-v1"
+}
+```
+
+Rules:
+
+- all weights are in `[0,1]`,
+- weight sum must equal `1.0` after normalization,
+- invalid output fails closed to defensive posture.
+
+## Decision Aggregation
+
+Per symbol/time bucket:
+
+1. score each expert independently,
+2. apply router weights,
+3. compute weighted intent,
+4. pass result through deterministic risk/policy gates.
+
+If router confidence is low or entropy is high, invoke slow-path DSPy committee before final intent.
+
+## Training and Refresh Policy
+
+### Offline training
+
+- rolling window with strict forward splits,
+- regime-balanced sampling,
+- objective includes return quality and drawdown penalty.
+
+### Online refresh
+
+- periodic retraining cadence,
+- drift triggers from distribution and performance monitors,
+- promotion only through artifact registry and gate evidence.
+
+## Failure Modes and Fallbacks
+
+1. Router unavailable: use last known good router artifact; if unavailable, force defensive weights.
+2. Router schema error: reject output and open severity alert.
+3. Feature freshness breach: disable non-defensive experts for affected symbols.
+
+## Observability
+
+Required runtime metrics:
+
+- `router_inference_latency_ms`
+- `router_confidence`
+- `router_entropy`
+- `expert_weight_distribution`
+- `regime_transition_rate`
+- `router_fallback_count`
+
+Required alerts:
+
+- high fallback rate,
+- prolonged high-entropy regime,
+- abnormal concentration in one expert,
+- stale features feeding router.
+
+## Validation Plan
+
+1. Replay tests across crisis/reversal windows.
+2. Walk-forward evaluation by market regime.
+3. Comparison against static TSMOM and static best-expert baselines.
+4. Outage simulation verifying defensive fallback behavior.
+
+## Exit Criteria
+
+1. Router output contract is stable and versioned.
+2. Weighted strategy outperforms static baseline on risk-adjusted metrics across forward windows.
+3. Fallback and fail-closed behavior verified in integration tests and staged runtime drills.

--- a/docs/torghut/design-system/v6/03-dspy-llm-decision-layer-over-jangar.md
+++ b/docs/torghut/design-system/v6/03-dspy-llm-decision-layer-over-jangar.md
@@ -1,0 +1,123 @@
+# DSPy LLM Decision Layer over Jangar
+
+## Status
+
+- Doc: `v6/03`
+- Date: `2026-02-27`
+- Maturity: `production design`
+- Scope: production LLM decision architecture using DSPy programs, Jangar OpenAI-compatible inference, and deterministic safety integration
+
+## Objective
+
+Standardize all live Torghut LLM decision reasoning on:
+
+1. DSPy program runtime with versioned artifacts,
+2. Jangar OpenAI-compatible endpoint transport,
+3. spark model pinning for live inference,
+4. deterministic fallback when DSPy runtime fails.
+
+## Non-Negotiable Rules
+
+- No legacy runtime network LLM path remains in the final decision flow.
+- No feature-flag branch that can bypass DSPy in normal operation.
+- DSPy output is advisory only and must pass deterministic controls.
+- Every LLM decision row must carry program/artifact lineage.
+
+## Serving Path
+
+```mermaid
+flowchart TD
+  A["Decision request"] --> B["DSPy runtime"]
+  B --> C["Artifact validation"]
+  C --> D["Jangar /openai/v1/chat/completions"]
+  D --> E["Schema validation"]
+  E --> F["Deterministic policy and risk gates"]
+  F --> G["Execution or abstain"]
+  B --> H["Deterministic fallback"]
+  H --> F
+```
+
+## Program Topology
+
+Suggested DSPy modules:
+
+1. `SignalSynthesisModule`
+2. `CounterThesisModule`
+3. `RiskCriticModule`
+4. `DecisionSchemaModule`
+
+Final output schema (simplified):
+
+- `intent`
+- `confidence`
+- `rationale`
+- `riskFlags`
+- `abstainReason`
+- `citations`
+
+## Runtime Triggering
+
+DSPy advisory is called when:
+
+1. slow-path trigger conditions are met, or
+2. configured policy requires LLM critique for specific strategy classes.
+
+For fast-path-only decisions, the system may skip LLM invocation but still emits explicit metadata (`llmSkipped=true`, reason).
+
+## Configuration Contract
+
+Required runtime env:
+
+- `JANGAR_BASE_URL`
+- `LLM_MODEL=gpt-5.3-codex-spark`
+- `LLM_DSPY_ARTIFACT_HASH`
+- `LLM_DSPY_PROGRAM_NAME`
+- `LLM_DSPY_SIGNATURE_VERSION`
+- `LLM_DSPY_TIMEOUT_SECONDS`
+- `LLM_DSPY_COMPILE_METRICS_POLICY_REF`
+- `LLM_DSPY_SECRET_BINDING_REF`
+- `LLM_DSPY_AGENTRUN_TTL_SECONDS`
+
+`JANGAR_API_KEY` stays optional and is not a required production contract item.
+
+## Compile/Eval/Promote Lifecycle
+
+Required lanes:
+
+1. `torghut-dspy-dataset-build-v1`
+2. `torghut-dspy-compile-mipro-v1`
+3. `torghut-dspy-eval-v1`
+4. `torghut-dspy-promote-artifact-v1`
+
+Optional lane:
+
+- `torghut-dspy-gepa-experiment-v1`
+
+Promotion criteria minimums:
+
+1. schema validity `>= 99.5%`
+2. reproducible artifact hash
+3. deterministic compatibility `pass`
+4. timeout plus fallback rate within target budget
+
+## Required Code Integration Anchors
+
+- `services/torghut/app/trading/llm/dspy_programs/runtime.py`
+- `services/torghut/app/trading/llm/review_engine.py`
+- `services/torghut/app/trading/llm/dspy_compile/workflow.py`
+- `argocd/applications/torghut/knative-service.yaml`
+- `argocd/applications/agents/torghut-agentruns.yaml`
+
+## Test Plan
+
+1. Unit tests for artifact and schema validation failure paths.
+2. Integration tests for Jangar OpenAI request/response compatibility.
+3. Runtime fallback tests for timeout, parsing, and invalid output.
+4. End-to-end workflow test from dataset build to promote.
+
+## Exit Criteria
+
+1. Live runtime uses DSPy and Jangar endpoint for all LLM decision calls.
+2. No legacy runtime network LLM call path remains reachable.
+3. At least one successful compile/eval/promote cycle is persisted with lineage.
+4. Fallback safety is proven and alerting is active.

--- a/docs/torghut/design-system/v6/04-alpha-discovery-and-autonomous-improvement-pipeline.md
+++ b/docs/torghut/design-system/v6/04-alpha-discovery-and-autonomous-improvement-pipeline.md
@@ -1,0 +1,92 @@
+# Alpha Discovery and Autonomous Improvement Pipeline
+
+## Status
+
+- Doc: `v6/04`
+- Date: `2026-02-27`
+- Maturity: `production design`
+- Scope: offline strategy and factor discovery pipeline that continuously improves live expert stack without unsafe online mutation
+
+## Objective
+
+Operationalize strategy discovery methods inspired by QuantEvolve, AlphaQuanter, and automated factor mining research while preserving strict promotion controls.
+
+## Pipeline Overview
+
+### Stage A: Hypothesis generation
+
+- Generate candidate alpha factors and strategy variants from multimodal datasets.
+- Enforce strategy template constraints to avoid invalid or unexecutable proposals.
+
+### Stage B: Candidate evaluation
+
+- Run contamination-safe backtests and walk-forward tests.
+- Score candidates by return quality, drawdown, turnover, slippage realism, and stability.
+
+### Stage C: Candidate promotion
+
+- Persist candidate artifacts and lineage.
+- Promote only through deterministic gates and staged rollout policies.
+
+### Stage D: Live feedback learning
+
+- Collect post-trade diagnostics, attribution, and regret signals.
+- Feed learnings into next offline generation cycle.
+
+## Artifact Model
+
+Each candidate must persist:
+
+- `candidateId`
+- `strategyDefinition`
+- `featureSetVersion`
+- `trainingWindow`
+- `evalWindow`
+- `performanceMetrics`
+- `riskMetrics`
+- `artifactHash`
+- `parentCandidates`
+
+## AgentRun Lane Extensions
+
+In addition to DSPy lanes, add strategy-discovery lanes:
+
+1. `torghut-alpha-generate-v1`
+2. `torghut-alpha-eval-v1`
+3. `torghut-alpha-risk-audit-v1`
+4. `torghut-alpha-promote-v1`
+
+These lanes must emit machine-readable artifacts that link back to DSPy and router artifact versions when relevant.
+
+## Governance Constraints
+
+- No direct auto-deploy from generation output.
+- Every candidate must pass deterministic risk audit before paper stage.
+- Live ramps require staged notional caps and rollback rehearsal evidence.
+
+## Integration with Router and LLM Layers
+
+- New factors can be assigned to existing experts or create new expert variants.
+- Router feature schema versions must be updated transactionally with promoted candidates.
+- LLM reasoning prompts/signatures can be tuned from evaluated candidate diagnostics, but runtime promotion remains evidence-gated.
+
+## Key Metrics
+
+- Candidate pass-through rate by stage.
+- Median and p95 time from generation to paper deployment.
+- Promotion acceptance rate.
+- Live degradation rate after promotion.
+- Rollback frequency and mean time to recovery.
+
+## Validation and Safety Tests
+
+1. Reproducibility tests for candidate regeneration from fixed seed and data snapshot.
+2. Cross-regime robustness tests.
+3. Capacity and slippage sensitivity tests.
+4. Failure injection tests for candidate registry and promotion chain.
+
+## Exit Criteria
+
+1. End-to-end candidate lifecycle is fully automated through AgentRuns.
+2. All promoted strategies have immutable lineage and replayable evidence.
+3. Unsafe candidates are blocked before paper stage with explicit failure reasons.

--- a/docs/torghut/design-system/v6/05-evaluation-benchmark-and-contamination-control-standard.md
+++ b/docs/torghut/design-system/v6/05-evaluation-benchmark-and-contamination-control-standard.md
@@ -1,0 +1,93 @@
+# Evaluation, Benchmark, and Contamination Control Standard
+
+## Status
+
+- Doc: `v6/05`
+- Date: `2026-02-27`
+- Maturity: `production design`
+- Scope: mandatory evaluation standard for all regime-router, DSPy, and alpha-discovery artifacts
+
+## Objective
+
+Define the evaluation framework that prevents false confidence from leakage or data contamination and enforces comparable, promotion-grade evidence.
+
+## Core Principle
+
+No model, prompt, or strategy artifact can be promoted without contamination-safe forward evaluation and reproducibility checks.
+
+## Evaluation Standard
+
+### Temporal integrity
+
+- Strict train/validation/test ordering.
+- No feature or textual source created after decision timestamp.
+- Explicit embargo windows around split boundaries.
+
+### Leakage controls
+
+- Timestamp normalization to UTC and event-time semantics.
+- Data-source lineage logged per feature and prompt context item.
+- Automatic rejection of artifacts that fail lineage completeness.
+
+### Regime-balanced coverage
+
+- Evaluate across trending, mean-reverting, high-volatility, and crisis regimes.
+- Require minimum decision counts per regime bucket.
+
+### Cost realism
+
+- Include slippage, spread, queue-position uncertainty, fees, and partial-fill behavior.
+- Compare simulated versus realized metrics continuously post-promotion.
+
+## Benchmark Set
+
+Required baselines for each strategy family:
+
+1. static TSMOM baseline,
+2. best-single-expert static baseline,
+3. regime-adaptive weighted baseline,
+4. deterministic no-LLM baseline for decision layer,
+5. current production artifact baseline.
+
+## Promotion Gate Metrics
+
+Minimum metrics for eligibility:
+
+- schema validity,
+- reproducibility hash match,
+- out-of-sample Sharpe and drawdown thresholds,
+- calibration and uncertainty metrics,
+- deterministic gate compatibility,
+- fallback and timeout rates within budget.
+
+## Required Artifacts per Eval Run
+
+- `dataset_manifest.json`
+- `split_manifest.json`
+- `metrics_report.json`
+- `failure_analysis.json`
+- `reproducibility_bundle.json`
+
+## CI and Enforcement
+
+- Eval schema checks are blocking in CI.
+- Promotion job fails closed on missing artifacts.
+- Pyright, unit tests, and integration tests remain mandatory for touched components.
+
+## Operational Monitoring
+
+Post-promotion monitors:
+
+- live-vs-backtest drift,
+- calibration drift,
+- fallback-rate drift,
+- regime-coverage drift,
+- realized slippage drift.
+
+If drift exceeds policy, auto-hold promotion queue and optionally auto-rollback current candidate.
+
+## Exit Criteria
+
+1. All promotion decisions reference full eval artifact bundle.
+2. No artifact can bypass temporal integrity checks.
+3. Drift monitors are active and tied to incident/runbook actions.

--- a/docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md
+++ b/docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md
@@ -1,0 +1,93 @@
+# Production Rollout, Operations, and Governance
+
+## Status
+
+- Doc: `v6/06`
+- Date: `2026-02-27`
+- Maturity: `production design`
+- Scope: phased rollout plan for Beyond-TSMOM architecture with explicit SLO, rollback, and governance controls
+
+## Objective
+
+Provide a practical rollout plan from current live posture to fully operational intraday regime-adaptive and DSPy-governed decisioning.
+
+## Rollout Phases
+
+### Phase 0: Baseline capture
+
+- Snapshot current decision quality, drawdown profile, fallback rates, and market-context freshness.
+- Freeze baseline artifact references for comparison.
+
+### Phase 1: Evaluation and data integrity hardening
+
+- Enable contamination-safe eval pipeline as promotion prerequisite.
+- Validate benchmark reproducibility and lineage capture.
+
+### Phase 2: Regime router shadow mode
+
+- Deploy router and expert-weight outputs in shadow.
+- Record path decisions without altering execution.
+- Validate entropy triggers and defensive fallbacks.
+
+### Phase 3: DSPy serving cutover over Jangar
+
+- Run DSPy as active decision reasoning path using Jangar OpenAI endpoint.
+- Remove legacy runtime network LLM path.
+- Keep deterministic fallback and strict timeout budget.
+
+### Phase 4: Controlled live routing activation
+
+- Start with low notional impact and high oversight.
+- Increase exposure only on passing SLO windows.
+- Keep immediate rollback switches available.
+
+### Phase 5: Alpha-discovery loop activation
+
+- Start offline generation/eval/promote cadence.
+- Promote only candidates that pass all evidence gates.
+
+## Runtime SLO Targets
+
+- `>= 99.9%` decision-loop availability.
+- Fast-path p95 latency within configured budget.
+- DSPy timeout plus fallback rate within policy threshold.
+- Market-context freshness target by domain (news and fundamentals).
+- Router fallback rate below configured ceiling.
+
+## Alerting and Incident Response
+
+Required alert families:
+
+1. DSPy transport/auth/schema failures.
+2. Router feature staleness or high fallback state.
+3. Deterministic gate anomaly spikes.
+4. Eval drift and promotion-gate failures.
+5. Market-context freshness degradation.
+
+Every alert class must map to a runbook action and owner.
+
+## Rollback Controls
+
+Hard rollback switches:
+
+1. disable DSPy path and force deterministic-only advisory fallback,
+2. disable regime-adaptive routing and use defensive/static expert weights,
+3. revert to prior promoted artifacts for router and DSPy runtime,
+4. roll Knative traffic back to last stable revision.
+
+## Governance and Audit
+
+Each rollout stage must produce:
+
+- commit SHA and image digest map,
+- active artifact hashes,
+- SLO and gate compliance summary,
+- unresolved risks and owner assignments.
+
+## Full Operational Exit Criteria
+
+1. Regime-adaptive router is live with verified fallback safety.
+2. DSPy over Jangar is the active LLM decision path with lineage and fallback controls.
+3. Contamination-safe eval pipeline gates all promotions.
+4. Alpha-discovery loop is running through controlled AgentRun lanes.
+5. GitOps manifests and deployed state are converged with no unmanaged drift.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -1,0 +1,52 @@
+# Torghut Design System v6: Beyond TSMOM Intraday Autonomy Pack
+
+## Status
+
+- Version: `v6`
+- Date: `2026-02-27`
+- Maturity: `production-quality design pack`
+- Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM reasoning, contamination-safe evaluation, and production rollout controls
+
+## Purpose
+
+Translate the "Beyond TSMOM" research synthesis into implementation-grade Torghut designs that can be executed by engineers and AgentRuns with explicit contracts, safety gates, and rollout criteria.
+
+This pack is positioned as the next architecture layer above:
+
+- `docs/torghut/design-system/v5/12-dspy-framework-adoption-for-quant-llm-autonomous-trading-2026-02-25.md`
+- `docs/torghut/design-system/v5/13-fundamentals-news-codex-spark-agent-pipeline-2026-02-26.md`
+- `docs/torghut/design-system/v5/14-dspy-jangar-openai-full-rollout-2026-02-27.md`
+
+## Non-Negotiable Invariants
+
+- Deterministic risk and policy controls remain final authority.
+- DSPy review runtime uses Jangar OpenAI-compatible endpoints (`/openai/v1/chat/completions`) with spark model for live LLM inference.
+- Legacy runtime network LLM call paths are removed from the decision codepath once cutover is complete.
+- Contamination-aware, forward-only evaluation is mandatory before promotion.
+- Every promotion and rollback action must be evidence-backed and reproducible.
+
+## Document Set
+
+1. `01-beyond-tsmom-system-architecture-and-latency-model.md`
+2. `02-regime-adaptive-expert-router-design.md`
+3. `03-dspy-llm-decision-layer-over-jangar.md`
+4. `04-alpha-discovery-and-autonomous-improvement-pipeline.md`
+5. `05-evaluation-benchmark-and-contamination-control-standard.md`
+6. `06-production-rollout-operations-and-governance.md`
+
+## Recommended Build Order
+
+1. `05-evaluation-benchmark-and-contamination-control-standard.md`
+2. `01-beyond-tsmom-system-architecture-and-latency-model.md`
+3. `02-regime-adaptive-expert-router-design.md`
+4. `03-dspy-llm-decision-layer-over-jangar.md`
+5. `04-alpha-discovery-and-autonomous-improvement-pipeline.md`
+6. `06-production-rollout-operations-and-governance.md`
+
+## Why This Sequence
+
+- Evaluation correctness and contamination safety must be locked first to avoid optimizing to invalid signals.
+- System architecture and routing design define data contracts used by the LLM and alpha-evolution layers.
+- DSPy decision integration must be implemented on top of stable routing and deterministic gate interfaces.
+- Autonomous strategy evolution should only be promoted after evaluation and serving contracts are stable.
+- Production rollout and governance closes with explicit SLO, rollback, and incident controls.


### PR DESCRIPTION
## Summary

- Add a new Torghut design-system `v6` pack for Beyond-TSMOM intraday autonomy architecture.
- Introduce six production-quality design docs covering architecture, regime router, DSPy-over-Jangar decisioning, alpha discovery, evaluation standards, and rollout/governance.
- Register `v6` in the design-system hierarchy README with entrypoint and scope description.

## Related Issues

None

## Testing

- `find docs/torghut/design-system/v6 -maxdepth 1 -type f | sort`
- `rg -n "v6" docs/torghut/design-system/README.md`
- `git diff -- docs/torghut/design-system/README.md docs/torghut/design-system/v6`
- Manual validation: reviewed all new docs for hierarchy fit, contract clarity, and production rollout completeness.

## Screenshots (if applicable)

N/A (docs-only changes)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
