### PR TITLE
feat(torghut): complete doc14 dspy-only runtime rollout

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -310,8 +310,6 @@ spec:
               value: "0.25"
             - name: TRADING_ROLLBACK_MAX_DRAWDOWN_LIMIT
               value: "0.08"
-            - name: LLM_PROVIDER
-              value: jangar
             - name: LLM_MODEL
               value: gpt-5.3-codex-spark
             - name: LLM_MODEL_VERSION_LOCK
@@ -320,8 +318,6 @@ spec:
               value: gpt-5.3-codex-spark
             - name: LLM_ALLOWED_PROMPT_VERSIONS
               value: v1
-            - name: LLM_ENABLED
-              value: "true"
             - name: LLM_ROLLOUT_STAGE
               value: stage1
             - name: LLM_SHADOW_MODE
@@ -342,8 +338,6 @@ spec:
               value: "1200"
             - name: LLM_TIMEOUT_SECONDS
               value: "20"
-            - name: LLM_DSPY_RUNTIME_MODE
-              value: active
             - name: LLM_DSPY_ARTIFACT_HASH
               value: df087a5e643d6478b1ebe51bf44ad2d0e2228825c1c0a8e9dc345729d6a3bbff
             - name: LLM_DSPY_PROGRAM_NAME
@@ -366,10 +360,6 @@ spec:
               value: "600"
             - name: LLM_ADJUSTMENT_APPROVED
               value: "false"
-            - name: LLM_SELF_HOSTED_BASE_URL
-              value: http://saigak.saigak.svc.cluster.local:11434/v1
-            - name: LLM_SELF_HOSTED_MODEL
-              value: qwen3-coder-saigak:30b
             - name: TA_CLICKHOUSE_URL
               value: http://torghut-clickhouse.torghut.svc.cluster.local:8123
             - name: TA_CLICKHOUSE_USERNAME

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -73,8 +73,7 @@ Endpoints:
   - `app/trading/llm/dspy_programs/` (typed signatures/modules/adapters)
   - `app/trading/llm/dspy_compile/` (compile/eval/promotion artifacts + AgentRun payload builder)
 - Runtime gates:
-  - `LLM_DSPY_RUNTIME_MODE=disabled|shadow|active` (default `disabled`)
-  - `LLM_DSPY_ARTIFACT_HASH=<sha256>` required when mode is `shadow` or `active`
+  - `LLM_DSPY_ARTIFACT_HASH=<sha256>` (required for active DSPy runtime)
   - `LLM_DSPY_PROGRAM_NAME`, `LLM_DSPY_SIGNATURE_VERSION`, `LLM_DSPY_TIMEOUT_SECONDS`
 
 AgentRun payload builder (`build_dspy_agentrun_payload`) enforces:

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1102,19 +1102,23 @@ class Settings(BaseSettings):
     jangar_base_url: Optional[str] = Field(default=None, alias="JANGAR_BASE_URL")
     jangar_api_key: Optional[str] = Field(default=None, alias="JANGAR_API_KEY")
 
-    llm_enabled: bool = Field(default=False, alias="LLM_ENABLED")
+    llm_enabled: bool = Field(default=True, alias="LLM_ENABLED")
+    # Deprecated in the DSPy-only decision path. Kept for backward-compatible tooling.
     llm_provider: Literal["jangar", "openai"] = Field(
         default="openai", alias="LLM_PROVIDER"
     )
     llm_model: str = Field(default="gpt-5.3-codex-spark", alias="LLM_MODEL")
     # Used only when `LLM_PROVIDER=jangar` and the Jangar request fails.
     # This should point at an OpenAI-compatible endpoint (e.g. vLLM, Ollama, llama.cpp server).
+    # Deprecated in the DSPy-only decision path. Kept for backward-compatible tooling.
     llm_self_hosted_base_url: Optional[str] = Field(
         default=None, alias="LLM_SELF_HOSTED_BASE_URL"
     )
+    # Deprecated in the DSPy-only decision path. Kept for backward-compatible tooling.
     llm_self_hosted_api_key: Optional[str] = Field(
         default=None, alias="LLM_SELF_HOSTED_API_KEY"
     )
+    # Deprecated in the DSPy-only decision path. Kept for backward-compatible tooling.
     llm_self_hosted_model: Optional[str] = Field(
         default=None, alias="LLM_SELF_HOSTED_MODEL"
     )
@@ -1221,6 +1225,7 @@ class Settings(BaseSettings):
         default="veto",
         alias="LLM_COMMITTEE_FAIL_CLOSED_VERDICT",
     )
+    # Deprecated runtime toggle; DSPy runtime path is always used by review engine.
     llm_dspy_runtime_mode: Literal["disabled", "shadow", "active"] = Field(
         default="disabled",
         alias="LLM_DSPY_RUNTIME_MODE",
@@ -1640,7 +1645,10 @@ class Settings(BaseSettings):
             raise ValueError("LLM_DSPY_TIMEOUT_SECONDS must be > 0")
         if self.llm_dspy_agentrun_ttl_seconds < 0:
             raise ValueError("LLM_DSPY_AGENTRUN_TTL_SECONDS must be >= 0")
-        if self.llm_dspy_runtime_mode in {"shadow", "active"} and not self.llm_dspy_artifact_hash:
+        if (
+            self.llm_dspy_runtime_mode in {"shadow", "active"}
+            and not self.llm_dspy_artifact_hash
+        ):
             raise ValueError(
                 "LLM_DSPY_ARTIFACT_HASH is required when LLM_DSPY_RUNTIME_MODE is shadow or active"
             )

--- a/services/torghut/app/trading/llm/review_engine.py
+++ b/services/torghut/app/trading/llm/review_engine.py
@@ -2,21 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
-import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
-import hashlib
-from pathlib import Path
 from typing import Any, Optional, cast
-
-from openai.types.chat import ChatCompletionMessageParam
-from pydantic import ValidationError
 
 from ...config import settings
 from ..models import StrategyDecision
-from .client import LLMClient
 from .circuit import LLMCircuitBreaker
 from .dspy_programs import DSPyReviewRuntime, DSPyRuntimeError
 from .policy import allowed_order_types
@@ -24,25 +18,11 @@ from .schema import (
     LLMDecisionContext,
     LLMPolicyContext,
     LLMReviewRequest,
+    LLMReviewResponse,
     MarketContextBundle,
     MarketSnapshot,
     PortfolioSnapshot,
     RecentDecisionSummary,
-    LLMCommitteeMemberResponse,
-    LLMCommitteeTrace,
-    LLMReviewResponse,
-)
-
-_SYSTEM_PROMPT = (
-    "You are an automated trading review agent. "
-    "Respond ONLY with a JSON object matching the required schema. "
-    "Decide whether to approve, veto, adjust, abstain, or escalate the decision. "
-    "Always provide calibrated per-verdict probabilities that sum to 1.0. "
-    "Always provide confidence and uncertainty bands. "
-    "If adjusting, propose qty and optionally order_type within policy bounds. "
-    "If adjusting order_type to limit or stop_limit, include limit_price. "
-    "Provide a concise rationale (<= 280 chars). "
-    "Do not include chain-of-thought or extra keys."
 )
 
 _ALLOWED_DECISION_PARAMS = {
@@ -71,13 +51,8 @@ _ALLOWED_POSITION_KEYS = {
     "unrealized_plpc",
     "cost_basis",
 }
-_COMMITTEE_ROLES = {
-    "researcher",
-    "risk_critic",
-    "execution_critic",
-    "policy_judge",
-}
-_MANDATORY_COMMITTEE_ROLES = {"risk_critic", "execution_critic", "policy_judge"}
+
+_SAFE_FALLBACK_CHECKS = ["execution_policy", "order_firewall", "risk_engine"]
 
 
 @dataclass
@@ -94,26 +69,21 @@ class LLMReviewOutcome:
 
 
 class LLMReviewEngine:
-    """Build the LLM prompt, call the client, and validate the response."""
+    """Build review payloads, execute DSPy runtime, and persist auditable outcomes."""
 
     def __init__(
         self,
-        client: Optional[LLMClient] = None,
         model: Optional[str] = None,
         prompt_version: Optional[str] = None,
-        temperature: Optional[float] = None,
-        max_tokens: Optional[int] = None,
         circuit_breaker: Optional[LLMCircuitBreaker] = None,
         dspy_runtime: Optional[DSPyReviewRuntime] = None,
     ) -> None:
-        self.model = model or settings.llm_model
-        self.prompt_version = prompt_version or settings.llm_prompt_version
-        self.temperature = temperature if temperature is not None else settings.llm_temperature
-        self.max_tokens = max_tokens if max_tokens is not None else settings.llm_max_tokens
-        self.client = client or LLMClient(self.model, settings.llm_timeout_seconds)
+        self.model = model or f"dspy:{settings.llm_dspy_program_name}"
+        self.prompt_version = (
+            prompt_version or f"dspy:{settings.llm_dspy_signature_version}"
+        )
         self.circuit_breaker = circuit_breaker or LLMCircuitBreaker.from_settings()
         self.dspy_runtime = dspy_runtime or DSPyReviewRuntime.from_settings()
-        self.system_prompt = load_prompt_template(self.prompt_version)
 
     def review(
         self,
@@ -140,66 +110,26 @@ class LLMReviewEngine:
                 market_context,
                 recent_decisions,
             )
+
         request_json = request.model_dump(mode="json")
-        dspy_error: str | None = None
-        dspy_shadow_payload: dict[str, Any] | None = None
         used_model = self.model
         used_prompt_version = self.prompt_version
-        response: LLMReviewResponse | None = None
-        response_json: dict[str, Any] | None = None
-        tokens_prompt: Optional[int] = None
-        tokens_completion: Optional[int] = None
 
-        if self.dspy_runtime.is_enabled():
-            try:
-                dspy_response, dspy_metadata = self.dspy_runtime.review(request)
-                dspy_payload = dspy_response.model_dump(mode="json")
-                dspy_payload["dspy"] = dspy_metadata.to_payload()
-                if self.dspy_runtime.mode == "active":
-                    response = dspy_response
-                    response_json = dspy_payload
-                    used_model = f"dspy:{dspy_metadata.program_name}"
-                    used_prompt_version = f"dspy:{dspy_metadata.signature_version}"
-                else:
-                    dspy_shadow_payload = dspy_payload
-                    raise DSPyRuntimeError("dspy_shadow_mode_fallback_to_legacy_llm")
-            except DSPyRuntimeError as exc:
-                dspy_error = str(exc)
-
-        if (
-            response_json is None
-            and dspy_shadow_payload is None
-            and dspy_error is None
-            and self.dspy_runtime.is_enabled()
-        ):
-            # defensive branch: if DSPy was enabled but produced neither output nor error,
-            # force deterministic fallback to legacy path.
-            dspy_error = "dspy_runtime_missing_result_fallback_to_legacy_llm"
-
-        if response_json is None or response is None:
-            if settings.llm_committee_enabled:
-                response, tokens_prompt, tokens_completion = self._review_with_committee(
-                    request_json
-                )
-            else:
-                response, tokens_prompt, tokens_completion = self._review_single(
-                    request_json
-                )
+        try:
+            response, metadata = self.dspy_runtime.review(request)
             response_json = response.model_dump(mode="json")
-            if dspy_shadow_payload is not None:
-                response_json["dspy_shadow"] = dspy_shadow_payload
-            if dspy_error is not None:
-                response_json["dspy"] = {
-                    "mode": self.dspy_runtime.mode,
-                    "program_name": self.dspy_runtime.program_name,
-                    "signature_version": self.dspy_runtime.signature_version,
-                    "artifact_hash": self.dspy_runtime.artifact_hash,
-                    "fallback_to_legacy": True,
-                    "error": dspy_error,
-                    "advisory_only": True,
-                }
-        assert response is not None
-        assert response_json is not None
+            response_json["dspy"] = metadata.to_payload()
+            used_model = f"dspy:{metadata.program_name}"
+            used_prompt_version = f"dspy:{metadata.signature_version}"
+        except DSPyRuntimeError as exc:
+            response, dspy_payload = _deterministic_fallback_response(
+                runtime=self.dspy_runtime,
+                error=str(exc),
+            )
+            response_json = response.model_dump(mode="json")
+            response_json["dspy"] = dspy_payload
+            used_model = f"dspy:{self.dspy_runtime.program_name}"
+            used_prompt_version = f"dspy:{self.dspy_runtime.signature_version}"
 
         request_hash = _hash_payload(request_json)
         response_hash = _hash_payload(response_json)
@@ -210,135 +140,11 @@ class LLMReviewEngine:
             response=response,
             model=used_model,
             prompt_version=used_prompt_version,
-            tokens_prompt=tokens_prompt,
-            tokens_completion=tokens_completion,
+            tokens_prompt=None,
+            tokens_completion=None,
             request_hash=request_hash,
             response_hash=response_hash,
         )
-
-    def _review_single(
-        self, request_json: dict[str, Any]
-    ) -> tuple[LLMReviewResponse, Optional[int], Optional[int]]:
-        messages: list[ChatCompletionMessageParam] = [
-            {"role": "system", "content": self.system_prompt},
-            {
-                "role": "user",
-                "content": (
-                    "Review the following trade decision and respond with JSON "
-                    "matching the schema described.\n\n" + json.dumps(request_json, separators=(",", ":"))
-                ),
-            },
-        ]
-
-        raw = self.client.request_review(
-            messages=messages,
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-        )
-
-        content = raw.content or ""
-        try:
-            parsed = _parse_json_object(content)
-        except json.JSONDecodeError as exc:
-            raise ValueError("llm_response_not_json") from exc
-
-        try:
-            response = LLMReviewResponse.model_validate(parsed)
-        except ValidationError as exc:
-            raise ValueError("llm_response_invalid") from exc
-
-        usage = raw.usage or {}
-        tokens_prompt = _coerce_int(usage.get("prompt_tokens"))
-        tokens_completion = _coerce_int(usage.get("completion_tokens"))
-        return response, tokens_prompt, tokens_completion
-
-    def _review_with_committee(
-        self, request_json: dict[str, Any]
-    ) -> tuple[LLMReviewResponse, Optional[int], Optional[int]]:
-        role_outputs: dict[str, LLMCommitteeMemberResponse] = {}
-        schema_error_count = 0
-        tokens_prompt_total = 0
-        tokens_completion_total = 0
-
-        configured_roles = [
-            role
-            for role in settings.llm_committee_roles
-            if role in _COMMITTEE_ROLES
-        ]
-        roles = configured_roles or [
-            "researcher",
-            "risk_critic",
-            "execution_critic",
-            "policy_judge",
-        ]
-
-        mandatory_roles = [
-            role
-            for role in settings.llm_committee_mandatory_roles
-            if role in _MANDATORY_COMMITTEE_ROLES
-        ]
-        if not mandatory_roles:
-            mandatory_roles = ["risk_critic", "execution_critic", "policy_judge"]
-
-        for role in roles:
-            started = time.monotonic()
-            try:
-                raw = self.client.request_review(
-                    messages=[
-                        {"role": "system", "content": _committee_system_prompt(role)},
-                        {
-                            "role": "user",
-                            "content": (
-                                "Review the following trade decision and respond with JSON "
-                                "matching the schema described.\n\n"
-                                + json.dumps(request_json, separators=(",", ":"))
-                            ),
-                        },
-                    ],
-                    temperature=self.temperature,
-                    max_tokens=self.max_tokens,
-                )
-                parsed = _parse_json_object(raw.content or "")
-                parsed["role"] = role
-                member = LLMCommitteeMemberResponse.model_validate(parsed)
-                member.latency_ms = int((time.monotonic() - started) * 1000)
-                role_outputs[role] = member
-                usage = raw.usage or {}
-                tokens_prompt_total += _coerce_int(usage.get("prompt_tokens")) or 0
-                tokens_completion_total += (
-                    _coerce_int(usage.get("completion_tokens")) or 0
-                )
-            except Exception:
-                schema_error_count += 1
-                role_outputs[role] = LLMCommitteeMemberResponse(
-                    role=cast(
-                        Any,
-                        role,
-                    ),
-                    verdict=settings.llm_committee_fail_closed_verdict,
-                    confidence=0.0,
-                    uncertainty="high",
-                    rationale_short="committee_role_schema_error",
-                    required_checks=[],
-                    latency_ms=int((time.monotonic() - started) * 1000),
-                    schema_error=True,
-                )
-
-        committee_trace = LLMCommitteeTrace(
-            roles=cast(dict[Any, LLMCommitteeMemberResponse], role_outputs),
-            mandatory_roles=cast(list[Any], mandatory_roles),
-            fail_closed_verdict=settings.llm_committee_fail_closed_verdict,
-            schema_error_count=schema_error_count,
-        )
-
-        aggregate = _aggregate_committee(
-            role_outputs=role_outputs,
-            mandatory_roles=mandatory_roles,
-            fail_closed_verdict=settings.llm_committee_fail_closed_verdict,
-        )
-        aggregate["committee"] = committee_trace.model_dump(mode="json")
-        response = LLMReviewResponse.model_validate(aggregate)
-        return response, tokens_prompt_total, tokens_completion_total
 
     def build_request(
         self,
@@ -352,7 +158,9 @@ class LLMReviewEngine:
         adjustment_allowed: Optional[bool] = None,
     ) -> LLMReviewRequest:
         effective_adjustment_allowed = (
-            settings.llm_adjustment_allowed if adjustment_allowed is None else adjustment_allowed
+            settings.llm_adjustment_allowed
+            if adjustment_allowed is None
+            else adjustment_allowed
         )
         sanitized_account = _sanitize_account(account)
         sanitized_positions = _sanitize_positions(positions)
@@ -387,451 +195,54 @@ class LLMReviewEngine:
         )
 
 
-def _coerce_int(value: Any) -> Optional[int]:
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
 __all__ = ["LLMReviewEngine", "LLMReviewOutcome"]
 
 
-def _parse_json_object(content: str) -> dict[str, Any]:
-    """Parse the first JSON object from an LLM response.
-
-    Jangar streams may include gateway-injected preambles (e.g. rate limit notes)
-    before the JSON payload. We accept that and decode the first `{...}` block.
-    """
-
-    content = content.strip()
-    if not content:
-        raise json.JSONDecodeError("empty", content, 0)
-
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError:
-        decoder = json.JSONDecoder()
-        start = content.find("{")
-        if start < 0:
-            raise
-        parsed, _ = decoder.raw_decode(content[start:])
-
-    if not isinstance(parsed, dict):
-        raise json.JSONDecodeError("expected_object", content, 0)
-
-    return _normalize_llm_response_payload(cast(dict[str, Any], parsed))
-
-
-def _normalize_llm_response_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Normalize common model mistakes into the expected response shape."""
-
-    normalized = _normalize_response_verdict(payload)
-    confidence = _clamp01(normalized.get("confidence"))
-    normalized = _ensure_confidence_fields(normalized, confidence)
-    confidence_band = _normalize_confidence_band(
-        normalized.get("confidence_band"), confidence
-    )
-    normalized = _set_payload_value(normalized, "confidence_band", confidence_band)
-    normalized = _ensure_uncertainty_fields(
-        normalized,
-        confidence=confidence,
-        confidence_band=confidence_band,
-    )
-    normalized = _ensure_calibration_fields(normalized, confidence=confidence)
-    normalized = _normalize_escalation_fields(normalized)
-    normalized = _set_default_risk_flags(normalized)
-    return _normalize_rationale_fields(normalized)
-
-
-def _normalize_response_verdict(payload: dict[str, Any]) -> dict[str, Any]:
-    normalized = payload
-    if "verdict" not in normalized and "decision" in normalized:
-        moved = dict(normalized)
-        moved["verdict"] = moved.pop("decision")
-        normalized = moved
-    if "verdict" not in normalized:
-        return normalized
-    verdict = str(normalized["verdict"]).strip().lower()
-    aliases = {
-        "escalate_to_human": "escalate",
-        "escalate_human": "escalate",
-        "defer": "abstain",
-        "hold": "abstain",
-    }
-    return _set_payload_value(normalized, "verdict", aliases.get(verdict, verdict))
-
-
-def _ensure_confidence_fields(payload: dict[str, Any], confidence: float) -> dict[str, Any]:
-    normalized = payload
-    if "confidence" not in normalized:
-        normalized = _set_payload_value(normalized, "confidence", 0.5)
-    if "confidence_band" not in normalized:
-        normalized = _set_payload_value(
-            normalized,
-            "confidence_band",
-            _confidence_band_from_score(confidence),
-        )
-    return normalized
-
-
-def _ensure_uncertainty_fields(
-    payload: dict[str, Any],
-    *,
-    confidence: float,
-    confidence_band: str,
-) -> dict[str, Any]:
-    if "uncertainty" in payload:
-        return payload
-    return _set_payload_value(
-        payload,
-        "uncertainty",
+def _deterministic_fallback_response(
+    *, runtime: DSPyReviewRuntime, error: str
+) -> tuple[LLMReviewResponse, dict[str, Any]]:
+    response = LLMReviewResponse.model_validate(
         {
-            "score": round(1.0 - confidence, 4),
-            "band": _uncertainty_band_from_confidence_band(confidence_band),
-        },
-    )
-
-
-def _ensure_calibration_fields(payload: dict[str, Any], *, confidence: float) -> dict[str, Any]:
-    normalized = payload
-    if "calibrated_probabilities" not in normalized:
-        normalized = _set_payload_value(
-            normalized,
-            "calibrated_probabilities",
-            _default_calibrated_probabilities(
-                str(normalized.get("verdict") or ""),
-                confidence,
-            ),
-        )
-    if "calibration_metadata" not in normalized:
-        normalized = _set_payload_value(normalized, "calibration_metadata", {})
-    return normalized
-
-
-def _normalize_escalation_fields(payload: dict[str, Any]) -> dict[str, Any]:
-    if "escalate_reason" in payload or "escalation_reason" not in payload:
-        return payload
-    return _set_payload_value(
-        payload,
-        "escalate_reason",
-        payload.get("escalation_reason"),
-    )
-
-
-def _set_default_risk_flags(payload: dict[str, Any]) -> dict[str, Any]:
-    if "risk_flags" in payload:
-        return payload
-    return _set_payload_value(payload, "risk_flags", [])
-
-
-def _normalize_rationale_fields(payload: dict[str, Any]) -> dict[str, Any]:
-    rationale = payload.get("rationale")
-    rationale_short = payload.get("rationale_short")
-    normalized = payload
-    if not rationale and isinstance(rationale_short, str):
-        normalized = _set_payload_value(normalized, "rationale", rationale_short)
-    if not rationale_short and isinstance(rationale, str):
-        normalized = _set_payload_value(normalized, "rationale_short", rationale)
-    return normalized
-
-
-def _set_payload_value(payload: dict[str, Any], key: str, value: Any) -> dict[str, Any]:
-    if payload.get(key) == value:
-        return payload
-    updated = dict(payload)
-    updated[key] = value
-    return updated
-
-
-def _committee_system_prompt(role: str) -> str:
-    role_instructions: dict[str, str] = {
-        "researcher": "Explain thesis quality and expected edge.",
-        "risk_critic": "Stress-test downside and risk/policy violations.",
-        "execution_critic": "Check feasibility under market microstructure and execution constraints.",
-        "policy_judge": "Validate schema, confidence calibration, and required deterministic checks.",
-    }
-    role_instruction = role_instructions.get(role, "Provide bounded committee review.")
-    return (
-        "You are an automated trading committee member. "
-        f"Role: {role}. {role_instruction} "
-        "Output must be advisory-only and cannot directly execute trades. "
-        "Respond ONLY with a JSON object containing exactly these keys: "
-        "verdict, confidence, uncertainty, rationale_short, required_checks, adjusted_qty, adjusted_order_type, "
-        "limit_price, risk_flags. "
-        "verdict must be one of approve|adjust|veto|abstain|escalate. "
-        "confidence must be between 0 and 1. uncertainty must be low|medium|high. "
-        "rationale_short must be <= 280 chars. required_checks must list deterministic policy check IDs. "
-        "Do not include chain-of-thought or extra keys."
-    )
-
-
-def _aggregate_committee(
-    *,
-    role_outputs: dict[str, LLMCommitteeMemberResponse],
-    mandatory_roles: list[str],
-    fail_closed_verdict: str,
-) -> dict[str, Any]:
-    aggregated_checks = _aggregate_committee_checks(role_outputs)
-    aggregated_risk_flags = _aggregate_committee_risk_flags(role_outputs)
-    if _committee_has_mandatory_veto(role_outputs, mandatory_roles):
-        return _mandatory_committee_veto_payload(
-            required_checks=aggregated_checks,
-            risk_flags=aggregated_risk_flags,
-        )
-
-    verdict = _committee_verdict(role_outputs, fail_closed_verdict=fail_closed_verdict)
-    confidence = _committee_confidence(role_outputs)
-    uncertainty_band = _committee_uncertainty_band(role_outputs)
-    adjusted_qty, adjusted_order_type, limit_price = _committee_adjustment_fields(
-        role_outputs
-    )
-    verdict, adjusted_qty, adjusted_order_type, limit_price = _validate_adjustment_payload(
-        verdict=verdict,
-        adjusted_qty=adjusted_qty,
-        adjusted_order_type=adjusted_order_type,
-        limit_price=limit_price,
-        fail_closed_verdict=fail_closed_verdict,
-    )
-    return _committee_payload(
-        verdict=verdict,
-        confidence=confidence,
-        uncertainty_band=uncertainty_band,
-        adjusted_qty=adjusted_qty,
-        adjusted_order_type=adjusted_order_type,
-        limit_price=limit_price,
-        required_checks=aggregated_checks,
-        risk_flags=aggregated_risk_flags,
-    )
-
-
-def _aggregate_committee_checks(
-    role_outputs: dict[str, LLMCommitteeMemberResponse],
-) -> list[str]:
-    return sorted(
-        {
-            check
-            for item in role_outputs.values()
-            for check in item.required_checks
+            "verdict": "veto",
+            "confidence": 1.0,
+            "confidence_band": "high",
+            "calibrated_probabilities": {
+                "approve": 0.0,
+                "veto": 1.0,
+                "adjust": 0.0,
+                "abstain": 0.0,
+                "escalate": 0.0,
+            },
+            "uncertainty": {"score": 0.0, "band": "low"},
+            "calibration_metadata": {
+                "fallback": "deterministic",
+                "reason": "dspy_runtime_error",
+                "error": error,
+            },
+            "rationale": "dspy_runtime_fallback_veto",
+            "rationale_short": "dspy_runtime_fallback_veto",
+            "required_checks": list(_SAFE_FALLBACK_CHECKS),
+            "risk_flags": ["dspy_runtime_fallback", error],
         }
     )
-
-
-def _aggregate_committee_risk_flags(
-    role_outputs: dict[str, LLMCommitteeMemberResponse],
-) -> list[str]:
-    return sorted(
-        {
-            flag
-            for item in role_outputs.values()
-            for flag in item.risk_flags
-        }
-    )
-
-
-def _committee_has_mandatory_veto(
-    role_outputs: dict[str, LLMCommitteeMemberResponse],
-    mandatory_roles: list[str],
-) -> bool:
-    return any(
-        role_outputs.get(role) is None or role_outputs[role].verdict == "veto"
-        for role in mandatory_roles
-    )
-
-
-def _mandatory_committee_veto_payload(
-    *,
-    required_checks: list[str],
-    risk_flags: list[str],
-) -> dict[str, Any]:
-    verdict = "veto"
-    confidence = 1.0
-    rationale = "mandatory_committee_veto"
-    return {
-        "verdict": verdict,
-        "confidence": confidence,
-        "confidence_band": "high",
-        "calibrated_probabilities": _default_calibrated_probabilities(verdict, confidence),
-        "uncertainty": {"score": 0.0, "band": "low"},
-        "calibration_metadata": {},
-        "rationale_short": rationale,
-        "required_checks": required_checks,
-        "rationale": rationale,
-        "risk_flags": sorted([*risk_flags, "mandatory_committee_veto"]),
+    dspy_payload: dict[str, Any] = {
+        "mode": "active",
+        "program_name": runtime.program_name,
+        "signature_version": runtime.signature_version,
+        "artifact_hash": runtime.artifact_hash,
+        "artifact_source": "runtime_fallback",
+        "executor": "heuristic",
+        "latency_ms": 0,
+        "advisory_only": True,
+        "fallback": True,
+        "error": error,
     }
-
-
-def _committee_verdict(
-    role_outputs: dict[str, LLMCommitteeMemberResponse],
-    *,
-    fail_closed_verdict: str,
-) -> str:
-    votes = [member.verdict for member in role_outputs.values()]
-    if any(vote == "escalate" for vote in votes):
-        return "escalate"
-    if any(vote == "abstain" for vote in votes):
-        return fail_closed_verdict
-    if any(vote == "adjust" for vote in votes):
-        return "adjust"
-    if any(vote == "approve" for vote in votes):
-        return "approve"
-    return fail_closed_verdict
-
-
-def _committee_confidence(role_outputs: dict[str, LLMCommitteeMemberResponse]) -> float:
-    confidence_values = [member.confidence for member in role_outputs.values()]
-    if not confidence_values:
-        return 0.0
-    return round(sum(confidence_values) / len(confidence_values), 4)
-
-
-def _committee_uncertainty_band(
-    role_outputs: dict[str, LLMCommitteeMemberResponse],
-) -> str:
-    uncertainty_rank = {"low": 1, "medium": 2, "high": 3}
-    uncertainty = "low"
-    for member in role_outputs.values():
-        if uncertainty_rank[member.uncertainty] > uncertainty_rank[uncertainty]:
-            uncertainty = member.uncertainty
-    return uncertainty
-
-
-def _committee_adjustment_fields(
-    role_outputs: dict[str, LLMCommitteeMemberResponse],
-) -> tuple[Decimal | None, str | None, Decimal | None]:
-    adjusted_source = next(
-        (member for member in role_outputs.values() if member.verdict == "adjust"),
-        None,
-    )
-    if adjusted_source is None:
-        return None, None, None
-    return (
-        adjusted_source.adjusted_qty,
-        adjusted_source.adjusted_order_type,
-        adjusted_source.limit_price,
-    )
-
-
-def _validate_adjustment_payload(
-    *,
-    verdict: str,
-    adjusted_qty: Decimal | None,
-    adjusted_order_type: str | None,
-    limit_price: Decimal | None,
-    fail_closed_verdict: str,
-) -> tuple[str, Decimal | None, str | None, Decimal | None]:
-    if verdict != "adjust":
-        return verdict, adjusted_qty, adjusted_order_type, limit_price
-    if adjusted_qty is None:
-        return fail_closed_verdict, None, None, None
-    if adjusted_order_type in {"limit", "stop_limit"} and limit_price is None:
-        return fail_closed_verdict, None, None, None
-    return verdict, adjusted_qty, adjusted_order_type, limit_price
-
-
-def _committee_payload(
-    *,
-    verdict: str,
-    confidence: float,
-    uncertainty_band: str,
-    adjusted_qty: Decimal | None,
-    adjusted_order_type: str | None,
-    limit_price: Decimal | None,
-    required_checks: list[str],
-    risk_flags: list[str],
-) -> dict[str, Any]:
-    rationale = f"committee_aggregate_{verdict}"
-    payload: dict[str, Any] = {
-        "verdict": verdict,
-        "confidence": confidence,
-        "confidence_band": _confidence_band_from_score(confidence),
-        "calibrated_probabilities": _default_calibrated_probabilities(verdict, confidence),
-        "uncertainty": {"score": round(1.0 - confidence, 4), "band": uncertainty_band},
-        "calibration_metadata": {},
-        "rationale_short": rationale,
-        "required_checks": required_checks,
-        "adjusted_qty": adjusted_qty,
-        "adjusted_order_type": adjusted_order_type,
-        "limit_price": limit_price,
-        "rationale": rationale,
-        "risk_flags": risk_flags,
-    }
-    if verdict == "escalate":
-        payload["escalate_reason"] = "committee_requested_escalation"
-    return payload
-
-
-def _clamp01(value: Any) -> float:
-    try:
-        score = float(value)
-    except (TypeError, ValueError):
-        return 0.5
-    return min(1.0, max(0.0, score))
-
-
-def _confidence_band_from_score(confidence: float) -> str:
-    if confidence >= 0.75:
-        return "high"
-    if confidence >= 0.5:
-        return "medium"
-    return "low"
-
-
-def _normalize_confidence_band(confidence_band: Any, confidence: float) -> str:
-    aliases = {
-        "l": "low",
-        "low-confidence": "low",
-        "low_confidence": "low",
-        "m": "medium",
-        "med": "medium",
-        "mid": "medium",
-        "moderate": "medium",
-        "medium-confidence": "medium",
-        "medium_confidence": "medium",
-        "h": "high",
-        "high-confidence": "high",
-        "high_confidence": "high",
-    }
-    normalized = aliases.get(str(confidence_band or "").strip().lower(), str(confidence_band or "").strip().lower())
-    if normalized in {"low", "medium", "high"}:
-        return normalized
-    return _confidence_band_from_score(confidence)
-
-
-def _uncertainty_band_from_confidence_band(confidence_band: str) -> str:
-    if confidence_band == "high":
-        return "low"
-    if confidence_band == "medium":
-        return "medium"
-    return "high"
-
-
-def _default_calibrated_probabilities(verdict: str, confidence: float) -> dict[str, float]:
-    labels = ["approve", "veto", "adjust", "abstain", "escalate"]
-    picked = verdict if verdict in labels else "abstain"
-    remainder = max(0.0, 1.0 - confidence)
-    background = remainder / 4.0
-    probabilities = {label: background for label in labels}
-    probabilities[picked] = confidence
-    total = sum(probabilities.values())
-    if total <= 0:
-        return {label: 0.2 for label in labels}
-    return {label: round(score / total, 6) for label, score in probabilities.items()}
+    return response, dspy_payload
 
 
 def _hash_payload(payload: dict[str, Any]) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
-
-
-def load_prompt_template(version: str) -> str:
-    templates_dir = Path(__file__).resolve().parent / "prompt_templates"
-    candidate = templates_dir / f"system_{version}.txt"
-    if candidate.exists():
-        return candidate.read_text(encoding="utf-8")
-    return _SYSTEM_PROMPT
 
 
 def _sanitize_account(account: dict[str, Any]) -> dict[str, str]:
@@ -870,15 +281,30 @@ def _sanitize_decision_params(params: dict[str, Any]) -> dict[str, Any]:
         if value is None:
             continue
         if key == "price_snapshot" and isinstance(value, Mapping):
-            sanitized[key] = _sanitize_nested(cast(Mapping[str, Any], value), _ALLOWED_PRICE_SNAPSHOT_KEYS)
+            sanitized[key] = _sanitize_nested(
+                cast(Mapping[str, Any], value),
+                _ALLOWED_PRICE_SNAPSHOT_KEYS,
+            )
         elif key == "imbalance" and isinstance(value, Mapping):
-            sanitized[key] = _sanitize_nested(cast(Mapping[str, Any], value), _ALLOWED_IMBALANCE_KEYS)
+            sanitized[key] = _sanitize_nested(
+                cast(Mapping[str, Any], value),
+                _ALLOWED_IMBALANCE_KEYS,
+            )
         elif key == "sizing" and isinstance(value, Mapping):
-            sanitized[key] = _sanitize_nested(cast(Mapping[str, Any], value), _ALLOWED_SIZING_KEYS)
+            sanitized[key] = _sanitize_nested(
+                cast(Mapping[str, Any], value),
+                _ALLOWED_SIZING_KEYS,
+            )
         else:
             sanitized[key] = value
     return sanitized
 
 
-def _sanitize_nested(payload: Mapping[str, Any], allowed_keys: set[str]) -> dict[str, Any]:
-    return {key: payload[key] for key in allowed_keys if key in payload and payload[key] is not None}
+def _sanitize_nested(
+    payload: Mapping[str, Any], allowed_keys: set[str]
+) -> dict[str, Any]:
+    return {
+        key: payload[key]
+        for key in allowed_keys
+        if key in payload and payload[key] is not None
+    }

--- a/services/torghut/scripts/run_dspy_workflow.py
+++ b/services/torghut/scripts/run_dspy_workflow.py
@@ -47,6 +47,12 @@ def _build_lane_overrides(args: argparse.Namespace) -> dict[str, dict[str, str]]
             "artifactHash": artifact_hash,
             "promotionTarget": args.promotion_target,
             "approvalRef": args.approval_ref,
+            "gateCompatibility": args.eval_gate_compatibility,
+            "schemaValidRate": f"{args.eval_schema_valid_rate:.6f}",
+            "deterministicCompatibility": (
+                "pass" if args.eval_deterministic_compatibility else "fail"
+            ),
+            "fallbackRate": f"{args.eval_fallback_rate:.6f}",
         },
     }
 
@@ -130,6 +136,30 @@ def parse_args() -> argparse.Namespace:
         choices=["paper", "shadow", "constrained_live", "scaled_live"],
     )
     parser.add_argument("--approval-ref", default="risk-committee")
+    parser.add_argument(
+        "--eval-gate-compatibility",
+        default="pass",
+        choices=["pass", "fail"],
+        help="Eval gate compatibility evidence passed into promote lane.",
+    )
+    parser.add_argument(
+        "--eval-schema-valid-rate",
+        type=float,
+        default=0.995,
+        help="Eval schema valid rate evidence used for promotion gate enforcement.",
+    )
+    parser.add_argument(
+        "--eval-deterministic-compatibility",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Eval deterministic compatibility evidence used for promotion gate enforcement.",
+    )
+    parser.add_argument(
+        "--eval-fallback-rate",
+        type=float,
+        default=0.05,
+        help="Observed fallback rate evidence used for promotion gate enforcement.",
+    )
 
     parser.add_argument("--include-gepa-experiment", action="store_true")
     parser.add_argument("--gepa-baseline-ref", default="")

--- a/services/torghut/tests/test_llm_dspy_runtime.py
+++ b/services/torghut/tests/test_llm_dspy_runtime.py
@@ -54,7 +54,6 @@ class TestLLMDSPyRuntime(TestCase):
 
     def test_bootstrap_artifact_executes_and_emits_metadata(self) -> None:
         runtime = DSPyReviewRuntime(
-            mode="active",
             artifact_hash=DSPyReviewRuntime.bootstrap_artifact_hash(),
             program_name="trade-review-committee-v1",
             signature_version="v1",
@@ -71,7 +70,6 @@ class TestLLMDSPyRuntime(TestCase):
 
     def test_program_name_mismatch_is_blocking(self) -> None:
         runtime = DSPyReviewRuntime(
-            mode="active",
             artifact_hash=DSPyReviewRuntime.bootstrap_artifact_hash(),
             program_name="trade-review-committee-v2",
             signature_version="v1",
@@ -85,7 +83,6 @@ class TestLLMDSPyRuntime(TestCase):
 
     def test_unknown_artifact_hash_is_rejected(self) -> None:
         runtime = DSPyReviewRuntime(
-            mode="active",
             artifact_hash="a" * 64,
             program_name="trade-review-committee-v1",
             signature_version="v1",
@@ -97,3 +94,16 @@ class TestLLMDSPyRuntime(TestCase):
                 runtime.review(self._request())
 
         self.assertIn("dspy_artifact_manifest_not_found", str(exc.exception))
+
+    def test_runtime_requires_artifact_hash(self) -> None:
+        runtime = DSPyReviewRuntime(
+            artifact_hash=None,
+            program_name="trade-review-committee-v1",
+            signature_version="v1",
+            timeout_seconds=8,
+        )
+
+        with self.assertRaises(DSPyRuntimeError) as exc:
+            runtime.review(self._request())
+
+        self.assertIn("dspy_artifact_hash_missing", str(exc.exception))


### PR DESCRIPTION
## Summary

- Refactored Torghut review execution to DSPy-only runtime, removing legacy `LLMClient` fallback serving behavior from `LLMReviewEngine` and keeping deterministic fail-closed fallback on DSPy runtime errors.
- Routed DSPy live transport through Jangar OpenAI-compatible contract (`JANGAR_BASE_URL` + spark model) and aligned persisted error/unavailable review records to DSPy lineage identifiers.
- Hardened DSPy lifecycle orchestration with explicit promote-lane gate enforcement (schema validity, deterministic compatibility, gate status, fallback threshold) and persisted per-lane lineage metadata in `llm_dspy_workflow_artifacts`.
- Cleaned Torghut Knative runtime contract in GitOps by removing deprecated legacy decision-path env knobs (`LLM_PROVIDER`, `LLM_ENABLED`, `LLM_DSPY_RUNTIME_MODE`, `LLM_SELF_HOSTED_*`) while keeping explicit Jangar endpoint and spark model pinning.

## Related Issues

None

## Testing

- `cd services/torghut && /tmp/codex-uv/bin/uv sync --frozen --extra dev`
- `cd services/torghut && .venv/bin/ruff check app/config.py app/trading/llm/review_engine.py app/trading/llm/dspy_programs/runtime.py app/trading/llm/dspy_compile/workflow.py app/trading/scheduler.py scripts/run_dspy_workflow.py tests/test_llm_review_engine.py tests/test_llm_dspy_runtime.py tests/test_llm_dspy_workflow.py`
- `cd services/torghut && .venv/bin/python -m unittest tests.test_llm_review_engine tests.test_llm_dspy_runtime tests.test_llm_dspy_workflow tests.test_config tests.test_trading_pipeline tests.test_trading_api`
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd /workspace/lab && PATH="/tmp:$PATH" bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

- Legacy runtime decision-path env knobs were removed from Torghut Knative manifest (`LLM_PROVIDER`, `LLM_ENABLED`, `LLM_DSPY_RUNTIME_MODE`, `LLM_SELF_HOSTED_BASE_URL`, `LLM_SELF_HOSTED_MODEL`).
- `LLMReviewEngine` no longer executes legacy direct network completion flow; DSPy runtime is now the only review execution path.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
