### PR TITLE
fix(jangar): harden torghut market-context ingest reliability

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -300,10 +300,16 @@ spec:
               value: torghut-market-context-fundamentals-v1
             - name: JANGAR_MARKET_CONTEXT_NEWS_IMPLEMENTATION_SPEC
               value: torghut-market-context-news-v1
+            - name: JANGAR_MARKET_CONTEXT_AGENT_SERVICE_ACCOUNT
+              value: agents-sa
             - name: JANGAR_MARKET_CONTEXT_FUNDAMENTALS_DISPATCH_COOLDOWN_SECONDS
               value: "1800"
             - name: JANGAR_MARKET_CONTEXT_NEWS_DISPATCH_COOLDOWN_SECONDS
               value: "120"
+            - name: JANGAR_MARKET_CONTEXT_FUNDAMENTALS_DISPATCH_STUCK_SECONDS
+              value: "2700"
+            - name: JANGAR_MARKET_CONTEXT_NEWS_DISPATCH_STUCK_SECONDS
+              value: "600"
             - name: JANGAR_MARKET_CONTEXT_AGENT_CALLBACK_BASE_URL
               value: http://jangar.jangar.svc.cluster.local
             - name: JANGAR_MARKET_CONTEXT_AGENT_TTL_SECONDS
@@ -311,13 +317,7 @@ spec:
             - name: JANGAR_MARKET_CONTEXT_INGEST_ALLOW_SERVICE_ACCOUNT_TOKEN
               value: "true"
             - name: JANGAR_MARKET_CONTEXT_INGEST_ALLOWED_SERVICE_ACCOUNT_PREFIXES
-              value: system:serviceaccount:agents:default,system:serviceaccount:agents:agents-sa
-            - name: JANGAR_MARKET_CONTEXT_INGEST_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: jangar-market-context-providers
-                  key: ingest_token
-                  optional: true
+              value: system:serviceaccount:agents:agents-sa
             - name: JANGAR_TORGHUT_DECISION_ENGINE_ENABLED
               value: "true"
             - name: JANGAR_TORGHUT_DECISION_ENGINE_ENABLED_FLAG_KEY

--- a/argocd/applications/jangar/market-context-providers-secret.yaml
+++ b/argocd/applications/jangar/market-context-providers-secret.yaml
@@ -7,4 +7,3 @@ type: Opaque
 stringData:
   fundamentals_url: http://jangar.jangar.svc.cluster.local/api/torghut/market-context/providers/fundamentals
   news_url: http://jangar.jangar.svc.cluster.local/api/torghut/market-context/providers/news
-  ingest_token: ''

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -1260,3 +1260,58 @@ data:
                 Quant frames are being computed but are stale according to the configured max staleness threshold.
                 This typically indicates upstream Torghut decisions/executions are not updating.
               runbook_url: docs/runbooks/torghut-quant-control-plane.md
+      - name: torghut-market-context.rules
+        rules:
+          - alert: JangarTorghutMarketContextIngestUnauthorized
+            expr: |
+              sum(increase(jangar_torghut_market_context_ingest_requests_total{outcome="unauthorized"}[10m])) > 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: Jangar market-context ingest is rejecting callbacks (401)
+              description: |
+                Market-context provider callbacks are failing authorization. This blocks fundamentals/news snapshots
+                and can force Torghut into low-quality market context mode.
+              runbook_url: docs/runbooks/torghut-market-context-ingest.md
+          - alert: JangarTorghutMarketContextIngestSuccessRateLow
+            expr: |
+              (
+                sum(rate(jangar_torghut_market_context_ingest_requests_total{outcome="accepted"}[15m]))
+                /
+                clamp_min(sum(rate(jangar_torghut_market_context_ingest_requests_total[15m])), 0.001)
+              ) < 0.6
+              and sum(rate(jangar_torghut_market_context_ingest_requests_total[15m])) > 0.01
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Jangar market-context callback success rate is degraded
+              description: |
+                Accepted market-context ingest callbacks are below 60% of total callbacks over 15 minutes.
+                Provider snapshots may stop refreshing and Torghut market-context quality can drop below gate thresholds.
+              runbook_url: docs/runbooks/torghut-market-context-ingest.md
+          - alert: JangarTorghutMarketContextDispatchErrors
+            expr: |
+              sum(increase(jangar_torghut_market_context_dispatch_attempts_total{outcome="dispatch_error"}[15m])) > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Jangar market-context dispatch errors detected
+              description: |
+                Jangar failed to submit one or more market-context AgentRuns in the last 15 minutes.
+                Fundamentals/news backfill can stall until dispatch recovers.
+              runbook_url: docs/runbooks/torghut-market-context-ingest.md
+          - alert: JangarTorghutMarketContextDispatchStuck
+            expr: |
+              sum(increase(jangar_torghut_market_context_dispatch_stuck_total[15m])) > 0
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              summary: Jangar market-context dispatch is stuck in submitted state
+              description: |
+                Market-context dispatch state has remained submitted past configured stuck thresholds.
+                This indicates callback ingest and/or runner completion handoff is blocked.
+              runbook_url: docs/runbooks/torghut-market-context-ingest.md

--- a/docs/runbooks/torghut-market-context-ingest.md
+++ b/docs/runbooks/torghut-market-context-ingest.md
@@ -1,0 +1,92 @@
+# Torghut Market-Context Ingest Runbook
+
+## Scope
+
+Use this runbook for alerts:
+
+- `JangarTorghutMarketContextIngestUnauthorized`
+- `JangarTorghutMarketContextIngestSuccessRateLow`
+- `JangarTorghutMarketContextDispatchErrors`
+- `JangarTorghutMarketContextDispatchStuck`
+
+These failures block fundamentals/news snapshot persistence and can keep Torghut market context below the trading quality gate.
+
+## Quick Checks
+
+1. Confirm Jangar revision includes market-context agents codepath:
+
+```bash
+kubectl exec -n jangar deploy/jangar -c app -- sh -c 'cd /workspace/lab/services/jangar && ls src/server | rg "torghut-market-context-agents" -n'
+```
+
+2. Check Jangar runtime auth config (SA-only expected):
+
+```bash
+kubectl exec -n jangar deploy/jangar -c app -- sh -c 'env | grep JANGAR_MARKET_CONTEXT_INGEST'
+```
+
+Expected:
+
+- `JANGAR_MARKET_CONTEXT_INGEST_ALLOW_SERVICE_ACCOUNT_TOKEN=true`
+- `JANGAR_MARKET_CONTEXT_INGEST_ALLOWED_SERVICE_ACCOUNT_PREFIXES=system:serviceaccount:agents:agents-sa`
+- `JANGAR_MARKET_CONTEXT_INGEST_TOKEN` unset/empty
+
+3. Confirm market-context jobs run with explicit `agents-sa`:
+
+```bash
+kubectl get pods -n agents -o custom-columns=NAME:.metadata.name,SA:.spec.serviceAccountName \
+  --no-headers | rg 'torghut-market-context-(fundamentals|news)-'
+```
+
+4. Confirm callback failures are not 401:
+
+```bash
+kubectl logs -n agents job/<latest-market-context-job> --tail=200
+```
+
+Search for callback `curl` failures and HTTP codes.
+
+## Data Plane Verification
+
+1. Trigger providers via Jangar (example symbol):
+
+```bash
+kubectl exec -n jangar deploy/jangar -c app -- sh -c 'curl -sS "http://127.0.0.1:8080/api/torghut/market-context/providers/news?symbol=NVDA" | jq'
+kubectl exec -n jangar deploy/jangar -c app -- sh -c 'curl -sS "http://127.0.0.1:8080/api/torghut/market-context/providers/fundamentals?symbol=NVDA" | jq'
+```
+
+2. Validate snapshots are persisted:
+
+```bash
+kubectl exec -n jangar deploy/jangar -c app -- sh -c 'cd /workspace/lab/services/jangar && node -e "\
+const { Client } = require(\"pg\"); \
+(async () => { \
+  const c = new Client({ connectionString: process.env.DATABASE_URL }); \
+  await c.connect(); \
+  const q = await c.query(\"select symbol,domain,as_of,updated_at,quality_score from torghut_market_context_snapshots where symbol=$1 order by updated_at desc\", [\"NVDA\"]); \
+  console.log(q.rows); \
+  await c.end(); \
+})();"'
+```
+
+3. Validate bundle quality recovers:
+
+```bash
+kubectl exec -n torghut deploy/torghut -- sh -c 'curl -sS "http://jangar.jangar.svc.cluster.local/api/torghut/market-context/?symbol=NVDA" | jq ".qualityScore,.riskFlags"'
+```
+
+## Remediation
+
+1. If callbacks are `401`:
+
+- Verify Jangar allowlist prefix matches runtime service account.
+- Verify AgentRun runtime service account is `agents-sa`.
+
+2. If dispatch is stuck in `submitted`:
+
+- Check job logs for callback failures and rerun failing AgentRuns.
+- Validate ingest endpoint authorization by posting from inside an `agents-sa` pod token.
+
+3. If Jangar revision is missing `torghut-market-context-agents`:
+
+- Roll out a newer Jangar image/revision containing market-context agent ingest code before further debugging.

--- a/services/jangar/src/routes/api/torghut/market-context/ingest.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/ingest.ts
@@ -4,6 +4,7 @@ import {
   ingestMarketContextProviderResult,
   isMarketContextIngestAuthorized,
 } from '~/server/torghut-market-context-agents'
+import { recordTorghutMarketContextIngestRequest } from '~/server/metrics'
 
 export const Route = createFileRoute('/api/torghut/market-context/ingest')({
   server: {
@@ -26,18 +27,27 @@ const jsonResponse = (payload: unknown, status = 200) => {
 
 export const postMarketContextIngestHandler = async (request: Request) => {
   if (!(await isMarketContextIngestAuthorized(request))) {
+    recordTorghutMarketContextIngestRequest({ outcome: 'unauthorized' })
     return jsonResponse({ ok: false, message: 'unauthorized' }, 401)
   }
 
   const payload = await request.json().catch(() => null)
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    recordTorghutMarketContextIngestRequest({ outcome: 'invalid_payload' })
     return jsonResponse({ ok: false, message: 'invalid JSON payload' }, 400)
   }
 
   try {
     const result = await ingestMarketContextProviderResult(payload)
+    recordTorghutMarketContextIngestRequest({
+      outcome: 'accepted',
+      domain: result.domain,
+      runStatus: result.runStatus,
+    })
     return jsonResponse(result, 202)
   } catch (error) {
+    const domain = typeof payload.domain === 'string' ? payload.domain : undefined
+    recordTorghutMarketContextIngestRequest({ outcome: 'ingest_error', domain })
     const message = error instanceof Error ? error.message : 'market context ingest failed'
     return jsonResponse({ ok: false, message }, 400)
   }


### PR DESCRIPTION
## Summary

- Hardened market-context ingest auth in Jangar to support service-account TokenReview fallback on shared-token mismatch and to recover from transient auth API initialization failures.
- Added market-context ingest and dispatch observability metrics (`ingest_requests_total`, `dispatch_attempts_total`, `dispatch_stuck_total`) and wired instrumentation in ingest/dispatch paths.
- Added dispatch-state stuck detection and propagated dispatch context (`queued`/`error`/`stuck`) into provider responses and risk flags.
- Enforced explicit market-context AgentRun service account (`agents-sa`) and narrowed ingest allowlist to `system:serviceaccount:agents:agents-sa`; removed shared ingest-token wiring from Jangar deployment.
- Added new Mimir alert rules for market-context ingest/dispatch failure modes and created a dedicated runbook.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `bunx oxfmt --check services/jangar/src/server/metrics.ts services/jangar/src/server/torghut-market-context-agents.ts services/jangar/src/routes/api/torghut/market-context/ingest.ts services/jangar/src/routes/api/torghut/market-context/-ingest.test.ts services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts docs/runbooks/torghut-market-context-ingest.md`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/routes/api/torghut/market-context/-ingest.test.ts src/server/__tests__/torghut-market-context-agents.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
