### PR TITLE
chore(jangar): promote image eebf1d3e

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a524ca44
-  digest: sha256:d07559486bd59e978622c2059bb20d3596de9baf3b220c183c4dd52cf8d33b5c
+  tag: eebf1d3e
+  digest: sha256:2fa7247737a63cd2596783c0d9c2868fbed784df326132b1a69dc5762a2ff31a
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a524ca44
-    digest: sha256:8ca929d46cf51c4b84dbb934b3e2b2971251b0ca155290e08d2060450031092c
+    tag: eebf1d3e
+    digest: sha256:c7eebf16ca4c119a636310dc973d8e383a27d62c2135e7bb7acc6ee95594d7bd
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a524ca44
-    digest: sha256:d07559486bd59e978622c2059bb20d3596de9baf3b220c183c4dd52cf8d33b5c
+    tag: eebf1d3e
+    digest: sha256:2fa7247737a63cd2596783c0d9c2868fbed784df326132b1a69dc5762a2ff31a
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-27T02:05:26Z"
+    deploy.knative.dev/rollout: "2026-02-27T20:33:51Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-27T02:05:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-27T20:33:51Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a524ca44"
-    digest: sha256:d07559486bd59e978622c2059bb20d3596de9baf3b220c183c4dd52cf8d33b5c
+    newTag: "eebf1d3e"
+    digest: sha256:2fa7247737a63cd2596783c0d9c2868fbed784df326132b1a69dc5762a2ff31a


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `eebf1d3ea32652fb3545b475e0dcaf28d613c241`
- Image tag: `eebf1d3e`
- Image digest: `sha256:2fa7247737a63cd2596783c0d9c2868fbed784df326132b1a69dc5762a2ff31a`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`