### PR TITLE
fix(jangar): accept runtime service account aliases

### DIFF
--- a/services/jangar/src/server/__tests__/agents-controller-job-runtime.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller-job-runtime.test.ts
@@ -27,9 +27,10 @@ describe('agents controller job-runtime module', () => {
     expect(normalizeLabelValue('___')).toBe('unknown')
   })
 
-  it('resolves runner service account from runtime config or env default', () => {
+  it('resolves runner service account from runtime config aliases or env default', () => {
     process.env.JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT = 'runner-default'
     expect(resolveRunnerServiceAccount({ serviceAccount: 'runtime-sa' })).toBe('runtime-sa')
+    expect(resolveRunnerServiceAccount({ serviceAccountName: 'runtime-sa-name' })).toBe('runtime-sa-name')
     expect(resolveRunnerServiceAccount({})).toBe('runner-default')
   })
 

--- a/services/jangar/src/server/__tests__/primitives-policy.test.ts
+++ b/services/jangar/src/server/__tests__/primitives-policy.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { KubernetesClient } from '~/server/primitives-kube'
-import { validateApprovalPolicies, validateBudget, validateSecretBinding } from '~/server/primitives-policy'
+import {
+  extractRuntimeServiceAccount,
+  validateApprovalPolicies,
+  validateBudget,
+  validateSecretBinding,
+} from '~/server/primitives-policy'
 
 const createKubeMock = (resources: Record<string, Record<string, unknown> | null>): KubernetesClient => ({
   apply: vi.fn(async (resource) => resource),
@@ -93,5 +98,12 @@ describe('primitives policy', () => {
         kube,
       ),
     ).rejects.toThrow('missing secrets')
+  })
+
+  it('extracts runtime service account from either legacy or canonical config keys', () => {
+    expect(extractRuntimeServiceAccount({ runtime: { config: { serviceAccount: 'legacy-sa' } } })).toBe('legacy-sa')
+    expect(extractRuntimeServiceAccount({ runtime: { config: { serviceAccountName: 'canonical-sa' } } })).toBe(
+      'canonical-sa',
+    )
   })
 })

--- a/services/jangar/src/server/agents-controller/job-runtime.ts
+++ b/services/jangar/src/server/agents-controller/job-runtime.ts
@@ -110,7 +110,9 @@ const buildRunSpecContext = (
 }
 
 export const resolveRunnerServiceAccount = (runtimeConfig: Record<string, unknown>) =>
-  asString(runtimeConfig.serviceAccount) ?? asString(process.env.JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT)
+  asString(runtimeConfig.serviceAccount) ??
+  asString(runtimeConfig.serviceAccountName) ??
+  asString(process.env.JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT)
 
 const buildJobResources = (workload: Record<string, unknown>) => {
   const resources = asRecord(workload.resources) ?? {}

--- a/services/jangar/src/server/primitives-policy.ts
+++ b/services/jangar/src/server/primitives-policy.ts
@@ -215,5 +215,5 @@ export const extractAllowedServiceAccounts = (spec: Record<string, unknown>) => 
 export const extractRuntimeServiceAccount = (spec: Record<string, unknown>) => {
   const runtime = (spec.runtime ?? {}) as Record<string, unknown>
   const config = (runtime.config ?? {}) as Record<string, unknown>
-  return asString(config.serviceAccount)
+  return asString(config.serviceAccount) ?? asString(config.serviceAccountName)
 }


### PR DESCRIPTION
## Summary

- Accept both `spec.runtime.config.serviceAccount` and `spec.runtime.config.serviceAccountName` when resolving AgentRun runner service account in job runtime.
- Update primitives policy extraction to read both service-account keys so admission/policy checks reflect the same effective runtime identity.
- Add regression tests covering both aliases in `agents-controller-job-runtime.test.ts` and `primitives-policy.test.ts`.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/src/server/agents-controller/job-runtime.ts services/jangar/src/server/primitives-policy.ts services/jangar/src/server/__tests__/agents-controller-job-runtime.test.ts services/jangar/src/server/__tests__/primitives-policy.test.ts`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/agents-controller-job-runtime.test.ts src/server/__tests__/primitives-policy.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
