### PR TITLE
chore(jangar): promote image 4089ae59

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: eebf1d3e
-  digest: sha256:2fa7247737a63cd2596783c0d9c2868fbed784df326132b1a69dc5762a2ff31a
+  tag: 4089ae59
+  digest: sha256:95b6b75007f5e8054b969234b2059c88373ffe746909f223d61e81149d5b20fe
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: eebf1d3e
-    digest: sha256:c7eebf16ca4c119a636310dc973d8e383a27d62c2135e7bb7acc6ee95594d7bd
+    tag: 4089ae59
+    digest: sha256:c5f8dc39e2d37a3deabf1f36b257d8050cc682aee304de34cc22b5b051e59e4f
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: eebf1d3e
-    digest: sha256:2fa7247737a63cd2596783c0d9c2868fbed784df326132b1a69dc5762a2ff31a
+    tag: 4089ae59
+    digest: sha256:95b6b75007f5e8054b969234b2059c88373ffe746909f223d61e81149d5b20fe
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-27T20:33:51Z"
+    deploy.knative.dev/rollout: "2026-02-27T20:55:59Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-27T20:33:51Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-27T20:55:59Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "eebf1d3e"
-    digest: sha256:2fa7247737a63cd2596783c0d9c2868fbed784df326132b1a69dc5762a2ff31a
+    newTag: "4089ae59"
+    digest: sha256:95b6b75007f5e8054b969234b2059c88373ffe746909f223d61e81149d5b20fe


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `4089ae59ee2e97532d25e7e0f92dc5cd49ebbfb8`
- Image tag: `4089ae59`
- Image digest: `sha256:95b6b75007f5e8054b969234b2059c88373ffe746909f223d61e81149d5b20fe`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`