### PR TITLE
chore(jangar): promote image 322973b8

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 4089ae59
-  digest: sha256:95b6b75007f5e8054b969234b2059c88373ffe746909f223d61e81149d5b20fe
+  tag: 322973b8
+  digest: sha256:8de6c65256bea4f888017b6ce316d60c1ffad22a7ad8a5d8c1c5806b93ee1244
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 4089ae59
-    digest: sha256:c5f8dc39e2d37a3deabf1f36b257d8050cc682aee304de34cc22b5b051e59e4f
+    tag: 322973b8
+    digest: sha256:4e8ec8971f0b7372b3619cd497f673d51c8ca3394c0768568fc56a1cd20ee87e
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 4089ae59
-    digest: sha256:95b6b75007f5e8054b969234b2059c88373ffe746909f223d61e81149d5b20fe
+    tag: 322973b8
+    digest: sha256:8de6c65256bea4f888017b6ce316d60c1ffad22a7ad8a5d8c1c5806b93ee1244
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-27T20:55:59Z"
+    deploy.knative.dev/rollout: "2026-02-27T22:09:44Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-27T20:55:59Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-27T22:09:44Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "4089ae59"
-    digest: sha256:95b6b75007f5e8054b969234b2059c88373ffe746909f223d61e81149d5b20fe
+    newTag: "322973b8"
+    digest: sha256:8de6c65256bea4f888017b6ce316d60c1ffad22a7ad8a5d8c1c5806b93ee1244


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `322973b80cb2368a1fd5059d2e81d8f0c86693c7`
- Image tag: `322973b8`
- Image digest: `sha256:8de6c65256bea4f888017b6ce316d60c1ffad22a7ad8a5d8c1c5806b93ee1244`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`