### PR TITLE
fix(agents): harden codex-spark provider auth for agentruns

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -13,7 +13,7 @@ spec:
     - path: /root/.codex/config.toml
       content: |-
         model = "gpt-5.3-codex-spark"
-        model_reasoning_summary = "detailed"
+        model_reasoning_summary = "none"
         model_reasoning_effort = "high"
         model_verbosity = "medium"
         preferred_auth_method = "apikey"
@@ -48,7 +48,7 @@ spec:
           "binary": "/bin/bash",
           "argsTemplate": [
             "-lc",
-            "PROMPT_PATH='{{payloads.promptPath}}'; cat \"$PROMPT_PATH\" | /usr/local/bin/codex exec --skip-git-repo-check --cd /tmp -"
+            "PROMPT_PATH='{{payloads.promptPath}}'; if [ -f \"$CODEX_AUTH\" ]; then AUTH_TMP=\"/tmp/codex-auth-apikey.json\"; jq -c 'if (.OPENAI_API_KEY // \"\") != \"\" then .auth_mode = \"apikey\" | del(.tokens, .last_refresh) else . end' \"$CODEX_AUTH\" > \"$AUTH_TMP\" && export CODEX_AUTH=\"$AUTH_TMP\"; fi; cat \"$PROMPT_PATH\" | /usr/local/bin/codex exec --skip-git-repo-check --cd /tmp -"
           ]
         }
   outputArtifacts:


### PR DESCRIPTION
## Summary

- Update `codex-spark` provider config to set `model_reasoning_summary = "none"` for `gpt-5.3-codex-spark`, avoiding unsupported `reasoning.summary` request parameters.
- Normalize mounted Codex auth to API-key mode at runtime (`auth_mode=apikey`, drop `tokens`/`last_refresh`) before `codex exec`, preventing refresh-token reuse failures in AgentRun jobs.
- Keep provider behavior otherwise unchanged; this targets torghut market-context fundamentals/news AgentRun reliability.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Live failure evidence before change: `torghut-market-context-news-bqbwn-job` and `torghut-market-context-fundamentals-g4gzz-job` failed with `refresh_token_reused` and `Unsupported parameter: 'reasoning.summary'` in pod logs.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
