### PR TITLE
fix(agents): harden torghut market-context prompt execution

### DIFF
--- a/argocd/applications/agents/torghut-agentruns.yaml
+++ b/argocd/applications/agents/torghut-agentruns.yaml
@@ -226,14 +226,17 @@ spec:
 
     Steps:
     1) Research current fundamentals for `${symbol}` (valuation, growth, profitability, balance-sheet/capital structure, near-term catalysts).
-    2) Write the JSON payload to `/tmp/market-context-fundamentals.json`.
-    3) Submit the payload:
+    2) Write the payload to `/tmp/market-context-fundamentals.json` using Python `json` serialization (do not handcraft shell-escaped JSON).
+    3) Validate payload before submit:
+       - `python3 -m json.tool /tmp/market-context-fundamentals.json >/dev/null`
+       - `jq -e '.symbol and .domain == "fundamentals" and (.qualityScore | type == "number")' /tmp/market-context-fundamentals.json >/dev/null`
+    4) Submit the payload:
        - AUTH=()
        - TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
        - if [ -r "${TOKEN_PATH}" ]; then TOKEN="$(tr -d '\n' < "${TOKEN_PATH}")"; fi
        - if [ -n "${TOKEN:-}" ]; then AUTH=(-H "authorization: Bearer ${TOKEN}"); fi
-       - curl -fsS -X POST "${callbackUrl}" -H "content-type: application/json" "${AUTH[@]}" --data-binary @/tmp/market-context-fundamentals.json
-    4) Ensure callback response contains `"ok": true`. If it fails, retry once; if still failing, exit non-zero.
+       - Capture HTTP status and response body; require HTTP 200 and response contains `"ok": true`.
+    5) If callback fails on first attempt, print response body, repair payload, retry once; if second attempt fails, exit non-zero.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec
@@ -294,14 +297,17 @@ spec:
 
     Steps:
     1) Gather recent high-signal company/sector/macro news relevant to `${symbol}`.
-    2) Write the JSON payload to `/tmp/market-context-news.json`.
-    3) Submit the payload:
+    2) Write the payload to `/tmp/market-context-news.json` using Python `json` serialization (do not handcraft shell-escaped JSON).
+    3) Validate payload before submit:
+       - `python3 -m json.tool /tmp/market-context-news.json >/dev/null`
+       - `jq -e '.symbol and .domain == "news" and (.qualityScore | type == "number") and (.payload.headlines | type == "array")' /tmp/market-context-news.json >/dev/null`
+    4) Submit the payload:
        - AUTH=()
        - TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
        - if [ -r "${TOKEN_PATH}" ]; then TOKEN="$(tr -d '\n' < "${TOKEN_PATH}")"; fi
        - if [ -n "${TOKEN:-}" ]; then AUTH=(-H "authorization: Bearer ${TOKEN}"); fi
-       - curl -fsS -X POST "${callbackUrl}" -H "content-type: application/json" "${AUTH[@]}" --data-binary @/tmp/market-context-news.json
-    4) Ensure callback response contains `"ok": true`. If it fails, retry once; if still failing, exit non-zero.
+       - Capture HTTP status and response body; require HTTP 200 and response contains `"ok": true`.
+    5) If callback fails on first attempt, print response body, repair payload, retry once; if second attempt fails, exit non-zero.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec


### PR DESCRIPTION
## Summary

- Harden `torghut-market-context-fundamentals-v1` and `torghut-market-context-news-v1` implementation prompts to require Python JSON serialization (instead of hand-escaped shell JSON).
- Add explicit payload validation steps (`python3 -m json.tool` and `jq -e` checks) before callback submission.
- Require explicit HTTP status/body checks on callback responses and clarify retry/repair behavior on first failure.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Live failure evidence before this prompt hardening: fundamentals callback from `torghut-market-context-fundamentals-6f4vh-job` returned HTTP 400 after malformed payload generation, despite run completion.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
