### PR TITLE
chore(torghut): promote image 1e2c97fd

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:94cec22fe5674f7ffc42475cd07578d71ed82d2355e7da71d4fc645ee5dcacdd
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9b049167339395506e6f85eaeb052da55f8246ff6883306bd6062647fa319cc0
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-27T23:30:20Z"
+        client.knative.dev/updateTimestamp: "2026-02-28T00:17:06Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:94cec22fe5674f7ffc42475cd07578d71ed82d2355e7da71d4fc645ee5dcacdd
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9b049167339395506e6f85eaeb052da55f8246ff6883306bd6062647fa319cc0
           ports:
             - name: http1
               containerPort: 8181
@@ -372,9 +372,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-111-g849e3798
+              value: v0.561.0-113-g1e2c97fd
             - name: TORGHUT_COMMIT
-              value: 849e37980a1cd52239010a0644dbf9675d3a10b6
+              value: 1e2c97fd49856bedf0ae1ae9ae182497d765ddd5
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `1e2c97fd49856bedf0ae1ae9ae182497d765ddd5`
- Image tag: `1e2c97fd`
- Image digest: `sha256:9b049167339395506e6f85eaeb052da55f8246ff6883306bd6062647fa319cc0`