### PR TITLE
fix(torghut): use POST for clickhouse simulation ddl

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -635,8 +635,7 @@ def _http_clickhouse_query(
     config: ClickHouseRuntimeConfig,
     query: str,
 ) -> tuple[int, str]:
-    query_param = quote_plus(query)
-    request_url = f'{config.http_url}/?query={query_param}'
+    request_url = config.http_url
     parsed = urlsplit(request_url)
     scheme = parsed.scheme.lower()
     if scheme not in {'http', 'https'}:
@@ -656,7 +655,7 @@ def _http_clickhouse_query(
     connection_class = HTTPSConnection if scheme == 'https' else HTTPConnection
     connection = connection_class(parsed.hostname, parsed.port)
     try:
-        connection.request('GET', path, headers=headers)
+        connection.request('POST', path, body=query.encode('utf-8'), headers=headers)
         response = connection.getresponse()
         body = response.read().decode('utf-8', errors='replace').strip()
         return response.status, body


### PR DESCRIPTION
## Summary

- switch simulation ClickHouse HTTP query execution from `GET` to `POST` so DDL statements are accepted by ClickHouse.
- keep query behavior unchanged for reads while eliminating readonly-mode failures on `CREATE DATABASE IF NOT EXISTS`.
- add a regression test that asserts `_http_clickhouse_query` issues `POST` and sends the SQL text as request body.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check scripts/start_historical_simulation.py tests/test_start_historical_simulation.py`

## Screenshots (if applicable)

N/A (backend/script behavior)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
