### PR TITLE
chore(torghut): promote image 4370c92e

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9b049167339395506e6f85eaeb052da55f8246ff6883306bd6062647fa319cc0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ea09348776ecccb740ea5656ccce96abd0ec94b5d933fb0963e02f635e837008
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-28T00:17:06Z"
+        client.knative.dev/updateTimestamp: "2026-02-28T00:36:21Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9b049167339395506e6f85eaeb052da55f8246ff6883306bd6062647fa319cc0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ea09348776ecccb740ea5656ccce96abd0ec94b5d933fb0963e02f635e837008
           ports:
             - name: http1
               containerPort: 8181
@@ -372,9 +372,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-113-g1e2c97fd
+              value: v0.561.0-115-g4370c92e
             - name: TORGHUT_COMMIT
-              value: 1e2c97fd49856bedf0ae1ae9ae182497d765ddd5
+              value: 4370c92edde3de7462221e53dc73399e56abaede
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `4370c92edde3de7462221e53dc73399e56abaede`
- Image tag: `4370c92e`
- Image digest: `sha256:ea09348776ecccb740ea5656ccce96abd0ec94b5d933fb0963e02f635e837008`