### PR TITLE
fix(torghut): unblock historical simulation decisions and executions

### DIFF
--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -193,6 +193,10 @@ uv run python scripts/start_historical_simulation.py \
   --confirm START_HISTORICAL_SIMULATION
 ```
 
+For historical windows, the starter auto-derives
+`TRADING_FEATURE_MAX_STALENESS_MS` from `window.start` when no explicit override is supplied.
+Set `torghut_env_overrides.TRADING_FEATURE_MAX_STALENESS_MS` only when you want a custom budget.
+
 Teardown restores previously captured TA + Torghut runtime config:
 
 ```bash

--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -102,8 +102,11 @@ class ClickHouseSignalIngestor:
         self.initial_lookback_minutes = initial_lookback_minutes or settings.trading_signal_lookback_minutes
         self.schema = schema or settings.trading_signal_schema
         self.account_label = account_label or settings.trading_account_label
-        self.fast_forward_stale_cursor = fast_forward_stale_cursor
-        self.empty_batch_advance_seconds = max(0, settings.trading_signal_empty_batch_advance_seconds)
+        simulation_mode = bool(settings.trading_simulation_enabled)
+        self.fast_forward_stale_cursor = False if simulation_mode else fast_forward_stale_cursor
+        self.empty_batch_advance_seconds = (
+            0 if simulation_mode else max(0, settings.trading_signal_empty_batch_advance_seconds)
+        )
         self._columns: Optional[set[str]] = None
         self._time_column: Optional[str] = None
         self._latest_signal_ts_cache: Optional[datetime] = None

--- a/services/torghut/config/simulation/example-dataset.yaml
+++ b/services/torghut/config/simulation/example-dataset.yaml
@@ -36,3 +36,10 @@ replay:
   acceleration: 60
   max_sleep_seconds: 5
   auto_offset_reset: earliest
+
+# Optional Torghut runtime overrides applied only during simulation `apply` and restored on `teardown`.
+# If omitted, TRADING_FEATURE_MAX_STALENESS_MS is auto-derived from window.start.
+# Keep explicit values when you need a custom staleness policy for the run.
+torghut_env_overrides:
+  TRADING_FEATURE_QUALITY_ENABLED: 'true'
+  TRADING_FEATURE_MAX_STALENESS_MS: '43200000'


### PR DESCRIPTION
## Summary

- fixed historical simulation runs that produced zero decisions/executions by auto-deriving `TRADING_FEATURE_MAX_STALENESS_MS` from `window.start` when no explicit override is provided.
- added guarded manifest override support (`torghut_env_overrides`) for simulation-only Torghut runtime knobs and persisted those overrides into plan/apply reports.
- fixed simulation ingest behavior so cursor stale fast-forward and empty-batch cursor advance are disabled when `TRADING_SIMULATION_ENABLED=true`, preserving historical replay cursor semantics.
- added regression tests for override validation/merging and simulation ingest cursor behavior, and updated simulation docs/playbook and example manifest.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_signal_ingest.py tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`
- Manual runtime validation on 2026-02-28: confirmed simulation staleness p95 rejection signature and cursor fast-forward/rewind signature in cluster logs; restored Torghut runtime and Argo automation to live/auto after validation.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
