### PR TITLE
feat(jangar): persist market-context lifecycle and agent callbacks

### DIFF
--- a/argocd/applications/agents/torghut-agentruns.yaml
+++ b/argocd/applications/agents/torghut-agentruns.yaml
@@ -225,18 +225,21 @@ spec:
     }
 
     Steps:
-    1) Research current fundamentals for `${symbol}` (valuation, growth, profitability, balance-sheet/capital structure, near-term catalysts).
-    2) Write the payload to `/tmp/market-context-fundamentals.json` using Python `json` serialization (do not handcraft shell-escaped JSON).
-    3) Validate payload before submit:
+    1) Start lifecycle tracking (required before research) using repo scripts:
+       - `python3 /workspace/lab/skills/market-context/scripts/market_context_run_api.py start --callback-url "${callbackUrl}" --request-id "${requestId}" --symbol "${symbol}" --domain fundamentals --reason "${reason}" --provider codex-spark --expect-status 200`
+       - `python3 /workspace/lab/skills/market-context/scripts/market_context_run_api.py progress --callback-url "${callbackUrl}" --request-id "${requestId}" --seq 1 --status running --message fundamentals_collection_started --expect-status 200`
+    2) Research current fundamentals for `${symbol}` (valuation, growth, profitability, balance-sheet/capital structure, near-term catalysts).
+    3) Write the payload to `/tmp/market-context-fundamentals.json` using Python `json` serialization (do not handcraft shell-escaped JSON).
+    4) Validate payload before submit:
        - `python3 -m json.tool /tmp/market-context-fundamentals.json >/dev/null`
-       - `jq -e '.symbol and .domain == "fundamentals" and (.qualityScore | type == "number")' /tmp/market-context-fundamentals.json >/dev/null`
-    4) Submit the payload:
-       - AUTH=()
-       - TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
-       - if [ -r "${TOKEN_PATH}" ]; then TOKEN="$(tr -d '\n' < "${TOKEN_PATH}")"; fi
-       - if [ -n "${TOKEN:-}" ]; then AUTH=(-H "authorization: Bearer ${TOKEN}"); fi
-       - Capture HTTP status and response body; require HTTP 200 and response contains `"ok": true`.
-    5) If callback fails on first attempt, print response body, repair payload, retry once; if second attempt fails, exit non-zero.
+       - `python3 /workspace/lab/skills/market-context/scripts/validate_market_context_payload.py --domain fundamentals --file /tmp/market-context-fundamentals.json`
+    5) Build citation evidence array in `/tmp/market-context-fundamentals-evidence.json` from the same sources you used for the payload.
+       - Evidence items must include at least `source`; include `publishedAt`, `url`, `headline`, and `summary` when available.
+       - Submit evidence:
+         `python3 /workspace/lab/skills/market-context/scripts/market_context_run_api.py evidence --callback-url "${callbackUrl}" --request-id "${requestId}" --symbol "${symbol}" --domain fundamentals --seq 2 --evidence-file /tmp/market-context-fundamentals-evidence.json --expect-status 200`
+    6) Finalize and persist via lifecycle finalize endpoint:
+       - `python3 /workspace/lab/skills/market-context/scripts/market_context_run_api.py finalize --callback-url "${callbackUrl}" --request-id "${requestId}" --payload-file /tmp/market-context-fundamentals.json --expect-status 200 --retries 1`
+       - Require response JSON to include `"ok": true`.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec
@@ -296,18 +299,21 @@ spec:
     }
 
     Steps:
-    1) Gather recent high-signal company/sector/macro news relevant to `${symbol}`.
-    2) Write the payload to `/tmp/market-context-news.json` using Python `json` serialization (do not handcraft shell-escaped JSON).
-    3) Validate payload before submit:
+    1) Start lifecycle tracking (required before research) using repo scripts:
+       - `python3 /workspace/lab/skills/market-context/scripts/market_context_run_api.py start --callback-url "${callbackUrl}" --request-id "${requestId}" --symbol "${symbol}" --domain news --reason "${reason}" --provider codex-spark --expect-status 200`
+       - `python3 /workspace/lab/skills/market-context/scripts/market_context_run_api.py progress --callback-url "${callbackUrl}" --request-id "${requestId}" --seq 1 --status running --message news_collection_started --expect-status 200`
+    2) Gather recent high-signal company/sector/macro news relevant to `${symbol}`.
+    3) Write the payload to `/tmp/market-context-news.json` using Python `json` serialization (do not handcraft shell-escaped JSON).
+    4) Validate payload before submit:
        - `python3 -m json.tool /tmp/market-context-news.json >/dev/null`
-       - `jq -e '.symbol and .domain == "news" and (.qualityScore | type == "number") and (.payload.headlines | type == "array")' /tmp/market-context-news.json >/dev/null`
-    4) Submit the payload:
-       - AUTH=()
-       - TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
-       - if [ -r "${TOKEN_PATH}" ]; then TOKEN="$(tr -d '\n' < "${TOKEN_PATH}")"; fi
-       - if [ -n "${TOKEN:-}" ]; then AUTH=(-H "authorization: Bearer ${TOKEN}"); fi
-       - Capture HTTP status and response body; require HTTP 200 and response contains `"ok": true`.
-    5) If callback fails on first attempt, print response body, repair payload, retry once; if second attempt fails, exit non-zero.
+       - `python3 /workspace/lab/skills/market-context/scripts/validate_market_context_payload.py --domain news --file /tmp/market-context-news.json`
+    5) Build citation evidence array in `/tmp/market-context-news-evidence.json` from the same sources you used for the payload.
+       - Evidence items must include at least `source`; include `publishedAt`, `url`, `headline`, and `summary` when available.
+       - Submit evidence:
+         `python3 /workspace/lab/skills/market-context/scripts/market_context_run_api.py evidence --callback-url "${callbackUrl}" --request-id "${requestId}" --symbol "${symbol}" --domain news --seq 2 --evidence-file /tmp/market-context-news-evidence.json --expect-status 200`
+    6) Finalize and persist via lifecycle finalize endpoint:
+       - `python3 /workspace/lab/skills/market-context/scripts/market_context_run_api.py finalize --callback-url "${callbackUrl}" --request-id "${requestId}" --payload-file /tmp/market-context-news.json --expect-status 200 --retries 1`
+       - Require response JSON to include `"ok": true`.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -302,6 +302,18 @@ spec:
               value: torghut-market-context-news-v1
             - name: JANGAR_MARKET_CONTEXT_AGENT_SERVICE_ACCOUNT
               value: agents-sa
+            - name: JANGAR_MARKET_CONTEXT_AGENT_VCS_MODE
+              value: read-only
+            - name: JANGAR_MARKET_CONTEXT_AGENT_VCS_REQUIRED
+              value: "true"
+            - name: JANGAR_MARKET_CONTEXT_AGENT_VCS_REF_NAME
+              value: github
+            - name: JANGAR_MARKET_CONTEXT_AGENT_REPOSITORY
+              value: proompteng/lab
+            - name: JANGAR_MARKET_CONTEXT_AGENT_VCS_BASE_REF
+              value: main
+            - name: JANGAR_MARKET_CONTEXT_AGENT_VCS_HEAD_PREFIX
+              value: codex/torghut-market-context
             - name: JANGAR_MARKET_CONTEXT_FUNDAMENTALS_DISPATCH_COOLDOWN_SECONDS
               value: "1800"
             - name: JANGAR_MARKET_CONTEXT_NEWS_DISPATCH_COOLDOWN_SECONDS

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -149,6 +149,11 @@ import { Route as ApiAgentsControlPlaneResourceRouteImport } from './routes/api/
 import { Route as ApiAgentsControlPlaneLogsRouteImport } from './routes/api/agents/control-plane/logs'
 import { Route as ApiAgentsControlPlaneEventsRouteImport } from './routes/api/agents/control-plane/events'
 import { Route as GithubPullsOwnerRepoNumberRouteImport } from './routes/github/pulls/$owner/$repo/$number'
+import { Route as ApiTorghutMarketContextRunsStartRouteImport } from './routes/api/torghut/market-context/runs/start'
+import { Route as ApiTorghutMarketContextRunsProgressRouteImport } from './routes/api/torghut/market-context/runs/progress'
+import { Route as ApiTorghutMarketContextRunsFinalizeRouteImport } from './routes/api/torghut/market-context/runs/finalize'
+import { Route as ApiTorghutMarketContextRunsEvidenceRouteImport } from './routes/api/torghut/market-context/runs/evidence'
+import { Route as ApiTorghutMarketContextRunsRequestIdRouteImport } from './routes/api/torghut/market-context/runs/$requestId'
 import { Route as ApiTorghutMarketContextProvidersNewsRouteImport } from './routes/api/torghut/market-context/providers/news'
 import { Route as ApiTorghutMarketContextProvidersFundamentalsRouteImport } from './routes/api/torghut/market-context/providers/fundamentals'
 import { Route as ApiTorghutDecisionEngineRunsIdRouteImport } from './routes/api/torghut/decision-engine/runs/$id'
@@ -926,6 +931,36 @@ const GithubPullsOwnerRepoNumberRoute =
     path: '/$owner/$repo/$number',
     getParentRoute: () => GithubPullsRoute,
   } as any)
+const ApiTorghutMarketContextRunsStartRoute =
+  ApiTorghutMarketContextRunsStartRouteImport.update({
+    id: '/api/torghut/market-context/runs/start',
+    path: '/api/torghut/market-context/runs/start',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTorghutMarketContextRunsProgressRoute =
+  ApiTorghutMarketContextRunsProgressRouteImport.update({
+    id: '/api/torghut/market-context/runs/progress',
+    path: '/api/torghut/market-context/runs/progress',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTorghutMarketContextRunsFinalizeRoute =
+  ApiTorghutMarketContextRunsFinalizeRouteImport.update({
+    id: '/api/torghut/market-context/runs/finalize',
+    path: '/api/torghut/market-context/runs/finalize',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTorghutMarketContextRunsEvidenceRoute =
+  ApiTorghutMarketContextRunsEvidenceRouteImport.update({
+    id: '/api/torghut/market-context/runs/evidence',
+    path: '/api/torghut/market-context/runs/evidence',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiTorghutMarketContextRunsRequestIdRoute =
+  ApiTorghutMarketContextRunsRequestIdRouteImport.update({
+    id: '/api/torghut/market-context/runs/$requestId',
+    path: '/api/torghut/market-context/runs/$requestId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiTorghutMarketContextProvidersNewsRoute =
   ApiTorghutMarketContextProvidersNewsRouteImport.update({
     id: '/api/torghut/market-context/providers/news',
@@ -1185,6 +1220,11 @@ export interface FileRoutesByFullPath {
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
   '/api/torghut/market-context/providers/fundamentals': typeof ApiTorghutMarketContextProvidersFundamentalsRoute
   '/api/torghut/market-context/providers/news': typeof ApiTorghutMarketContextProvidersNewsRoute
+  '/api/torghut/market-context/runs/$requestId': typeof ApiTorghutMarketContextRunsRequestIdRoute
+  '/api/torghut/market-context/runs/evidence': typeof ApiTorghutMarketContextRunsEvidenceRoute
+  '/api/torghut/market-context/runs/finalize': typeof ApiTorghutMarketContextRunsFinalizeRoute
+  '/api/torghut/market-context/runs/progress': typeof ApiTorghutMarketContextRunsProgressRoute
+  '/api/torghut/market-context/runs/start': typeof ApiTorghutMarketContextRunsStartRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
@@ -1344,6 +1384,11 @@ export interface FileRoutesByTo {
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
   '/api/torghut/market-context/providers/fundamentals': typeof ApiTorghutMarketContextProvidersFundamentalsRoute
   '/api/torghut/market-context/providers/news': typeof ApiTorghutMarketContextProvidersNewsRoute
+  '/api/torghut/market-context/runs/$requestId': typeof ApiTorghutMarketContextRunsRequestIdRoute
+  '/api/torghut/market-context/runs/evidence': typeof ApiTorghutMarketContextRunsEvidenceRoute
+  '/api/torghut/market-context/runs/finalize': typeof ApiTorghutMarketContextRunsFinalizeRoute
+  '/api/torghut/market-context/runs/progress': typeof ApiTorghutMarketContextRunsProgressRoute
+  '/api/torghut/market-context/runs/start': typeof ApiTorghutMarketContextRunsStartRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
@@ -1506,6 +1551,11 @@ export interface FileRoutesById {
   '/api/torghut/decision-engine/runs/$id': typeof ApiTorghutDecisionEngineRunsIdRoute
   '/api/torghut/market-context/providers/fundamentals': typeof ApiTorghutMarketContextProvidersFundamentalsRoute
   '/api/torghut/market-context/providers/news': typeof ApiTorghutMarketContextProvidersNewsRoute
+  '/api/torghut/market-context/runs/$requestId': typeof ApiTorghutMarketContextRunsRequestIdRoute
+  '/api/torghut/market-context/runs/evidence': typeof ApiTorghutMarketContextRunsEvidenceRoute
+  '/api/torghut/market-context/runs/finalize': typeof ApiTorghutMarketContextRunsFinalizeRoute
+  '/api/torghut/market-context/runs/progress': typeof ApiTorghutMarketContextRunsProgressRoute
+  '/api/torghut/market-context/runs/start': typeof ApiTorghutMarketContextRunsStartRoute
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
@@ -1669,6 +1719,11 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs/$id'
     | '/api/torghut/market-context/providers/fundamentals'
     | '/api/torghut/market-context/providers/news'
+    | '/api/torghut/market-context/runs/$requestId'
+    | '/api/torghut/market-context/runs/evidence'
+    | '/api/torghut/market-context/runs/finalize'
+    | '/api/torghut/market-context/runs/progress'
+    | '/api/torghut/market-context/runs/start'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
@@ -1828,6 +1883,11 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs/$id'
     | '/api/torghut/market-context/providers/fundamentals'
     | '/api/torghut/market-context/providers/news'
+    | '/api/torghut/market-context/runs/$requestId'
+    | '/api/torghut/market-context/runs/evidence'
+    | '/api/torghut/market-context/runs/finalize'
+    | '/api/torghut/market-context/runs/progress'
+    | '/api/torghut/market-context/runs/start'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
@@ -1989,6 +2049,11 @@ export interface FileRouteTypes {
     | '/api/torghut/decision-engine/runs/$id'
     | '/api/torghut/market-context/providers/fundamentals'
     | '/api/torghut/market-context/providers/news'
+    | '/api/torghut/market-context/runs/$requestId'
+    | '/api/torghut/market-context/runs/evidence'
+    | '/api/torghut/market-context/runs/finalize'
+    | '/api/torghut/market-context/runs/progress'
+    | '/api/torghut/market-context/runs/start'
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
@@ -2130,6 +2195,11 @@ export interface RootRouteChildren {
   ApiAgentsImplementationSourcesWebhooksProviderRoute: typeof ApiAgentsImplementationSourcesWebhooksProviderRoute
   ApiTorghutMarketContextProvidersFundamentalsRoute: typeof ApiTorghutMarketContextProvidersFundamentalsRoute
   ApiTorghutMarketContextProvidersNewsRoute: typeof ApiTorghutMarketContextProvidersNewsRoute
+  ApiTorghutMarketContextRunsRequestIdRoute: typeof ApiTorghutMarketContextRunsRequestIdRoute
+  ApiTorghutMarketContextRunsEvidenceRoute: typeof ApiTorghutMarketContextRunsEvidenceRoute
+  ApiTorghutMarketContextRunsFinalizeRoute: typeof ApiTorghutMarketContextRunsFinalizeRoute
+  ApiTorghutMarketContextRunsProgressRoute: typeof ApiTorghutMarketContextRunsProgressRoute
+  ApiTorghutMarketContextRunsStartRoute: typeof ApiTorghutMarketContextRunsStartRoute
   ApiTorghutTradingControlPlaneLlmRolloutRoute: typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
   ApiTorghutTradingControlPlaneQuantAlertsRoute: typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   ApiTorghutTradingControlPlaneQuantHealthRoute: typeof ApiTorghutTradingControlPlaneQuantHealthRoute
@@ -3120,6 +3190,41 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GithubPullsOwnerRepoNumberRouteImport
       parentRoute: typeof GithubPullsRoute
     }
+    '/api/torghut/market-context/runs/start': {
+      id: '/api/torghut/market-context/runs/start'
+      path: '/api/torghut/market-context/runs/start'
+      fullPath: '/api/torghut/market-context/runs/start'
+      preLoaderRoute: typeof ApiTorghutMarketContextRunsStartRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/market-context/runs/progress': {
+      id: '/api/torghut/market-context/runs/progress'
+      path: '/api/torghut/market-context/runs/progress'
+      fullPath: '/api/torghut/market-context/runs/progress'
+      preLoaderRoute: typeof ApiTorghutMarketContextRunsProgressRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/market-context/runs/finalize': {
+      id: '/api/torghut/market-context/runs/finalize'
+      path: '/api/torghut/market-context/runs/finalize'
+      fullPath: '/api/torghut/market-context/runs/finalize'
+      preLoaderRoute: typeof ApiTorghutMarketContextRunsFinalizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/market-context/runs/evidence': {
+      id: '/api/torghut/market-context/runs/evidence'
+      path: '/api/torghut/market-context/runs/evidence'
+      fullPath: '/api/torghut/market-context/runs/evidence'
+      preLoaderRoute: typeof ApiTorghutMarketContextRunsEvidenceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/torghut/market-context/runs/$requestId': {
+      id: '/api/torghut/market-context/runs/$requestId'
+      path: '/api/torghut/market-context/runs/$requestId'
+      fullPath: '/api/torghut/market-context/runs/$requestId'
+      preLoaderRoute: typeof ApiTorghutMarketContextRunsRequestIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/torghut/market-context/providers/news': {
       id: '/api/torghut/market-context/providers/news'
       path: '/api/torghut/market-context/providers/news'
@@ -3625,6 +3730,15 @@ const rootRouteChildren: RootRouteChildren = {
     ApiTorghutMarketContextProvidersFundamentalsRoute,
   ApiTorghutMarketContextProvidersNewsRoute:
     ApiTorghutMarketContextProvidersNewsRoute,
+  ApiTorghutMarketContextRunsRequestIdRoute:
+    ApiTorghutMarketContextRunsRequestIdRoute,
+  ApiTorghutMarketContextRunsEvidenceRoute:
+    ApiTorghutMarketContextRunsEvidenceRoute,
+  ApiTorghutMarketContextRunsFinalizeRoute:
+    ApiTorghutMarketContextRunsFinalizeRoute,
+  ApiTorghutMarketContextRunsProgressRoute:
+    ApiTorghutMarketContextRunsProgressRoute,
+  ApiTorghutMarketContextRunsStartRoute: ApiTorghutMarketContextRunsStartRoute,
   ApiTorghutTradingControlPlaneLlmRolloutRoute:
     ApiTorghutTradingControlPlaneLlmRolloutRoute,
   ApiTorghutTradingControlPlaneQuantAlertsRoute:
@@ -3641,3 +3755,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/services/jangar/src/routes/api/torghut/market-context/runs/$requestId.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/runs/$requestId.ts
@@ -1,0 +1,47 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { recordTorghutMarketContextRunEvent } from '~/server/metrics'
+import {
+  getMarketContextProviderRunStatus,
+  isMarketContextIngestAuthorized,
+} from '~/server/torghut-market-context-agents'
+
+export const Route = createFileRoute('/api/torghut/market-context/runs/$requestId')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => getMarketContextRunStatusHandler(params.requestId, request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const getMarketContextRunStatusHandler = async (requestId: string, request: Request) => {
+  if (!(await isMarketContextIngestAuthorized(request))) {
+    recordTorghutMarketContextRunEvent({ endpoint: 'status', outcome: 'unauthorized' })
+    return jsonResponse({ ok: false, message: 'unauthorized' }, 401)
+  }
+
+  try {
+    const result = await getMarketContextProviderRunStatus(requestId)
+    recordTorghutMarketContextRunEvent({ endpoint: 'status', outcome: 'accepted', domain: result.domain })
+    return jsonResponse(result, 200)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'failed to read market-context run status'
+    if (message.includes('run not found')) {
+      recordTorghutMarketContextRunEvent({ endpoint: 'status', outcome: 'not_found' })
+      return jsonResponse({ ok: false, message }, 404)
+    }
+    recordTorghutMarketContextRunEvent({ endpoint: 'status', outcome: 'error' })
+    return jsonResponse({ ok: false, message }, 400)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/market-context/runs/-routes.test.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/runs/-routes.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isMarketContextIngestAuthorized = vi.fn()
+const startMarketContextProviderRun = vi.fn()
+const recordMarketContextProviderRunProgress = vi.fn()
+const recordMarketContextProviderEvidence = vi.fn()
+const ingestMarketContextProviderResult = vi.fn()
+const getMarketContextProviderRunStatus = vi.fn()
+const recordTorghutMarketContextRunEvent = vi.fn()
+
+vi.mock('~/server/torghut-market-context-agents', () => ({
+  isMarketContextIngestAuthorized,
+  startMarketContextProviderRun,
+  recordMarketContextProviderRunProgress,
+  recordMarketContextProviderEvidence,
+  ingestMarketContextProviderResult,
+  getMarketContextProviderRunStatus,
+}))
+
+vi.mock('~/server/metrics', () => ({
+  recordTorghutMarketContextRunEvent,
+}))
+
+describe('market-context run lifecycle routes', () => {
+  beforeEach(() => {
+    isMarketContextIngestAuthorized.mockReset()
+    startMarketContextProviderRun.mockReset()
+    recordMarketContextProviderRunProgress.mockReset()
+    recordMarketContextProviderEvidence.mockReset()
+    ingestMarketContextProviderResult.mockReset()
+    getMarketContextProviderRunStatus.mockReset()
+    recordTorghutMarketContextRunEvent.mockReset()
+  })
+
+  it('start returns 401 when unauthorized', async () => {
+    isMarketContextIngestAuthorized.mockResolvedValueOnce(false)
+
+    const { postMarketContextRunStartHandler } = await import('./start')
+    const response = await postMarketContextRunStartHandler(
+      new Request('http://localhost/api/torghut/market-context/runs/start', {
+        method: 'POST',
+        body: JSON.stringify({ symbol: 'AAPL', domain: 'news' }),
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(startMarketContextProviderRun).not.toHaveBeenCalled()
+    expect(recordTorghutMarketContextRunEvent).toHaveBeenCalledWith({ endpoint: 'start', outcome: 'unauthorized' })
+  })
+
+  it('start returns accepted response', async () => {
+    isMarketContextIngestAuthorized.mockResolvedValueOnce(true)
+    startMarketContextProviderRun.mockResolvedValueOnce({
+      ok: true,
+      requestId: 'req-1',
+      symbol: 'AAPL',
+      domain: 'fundamentals',
+      status: 'started',
+    })
+
+    const { postMarketContextRunStartHandler } = await import('./start')
+    const response = await postMarketContextRunStartHandler(
+      new Request('http://localhost/api/torghut/market-context/runs/start', {
+        method: 'POST',
+        body: JSON.stringify({ symbol: 'AAPL', domain: 'fundamentals' }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(recordTorghutMarketContextRunEvent).toHaveBeenCalledWith({
+      endpoint: 'start',
+      outcome: 'accepted',
+      domain: 'fundamentals',
+    })
+  })
+
+  it('progress returns 404 when run is not found', async () => {
+    isMarketContextIngestAuthorized.mockResolvedValueOnce(true)
+    recordMarketContextProviderRunProgress.mockRejectedValueOnce(new Error('run not found for requestId req-x'))
+
+    const { postMarketContextRunProgressHandler } = await import('./progress')
+    const response = await postMarketContextRunProgressHandler(
+      new Request('http://localhost/api/torghut/market-context/runs/progress', {
+        method: 'POST',
+        body: JSON.stringify({ requestId: 'req-x', seq: 1 }),
+      }),
+    )
+
+    expect(response.status).toBe(404)
+    expect(recordTorghutMarketContextRunEvent).toHaveBeenCalledWith({ endpoint: 'progress', outcome: 'not_found' })
+  })
+
+  it('evidence returns accepted response', async () => {
+    isMarketContextIngestAuthorized.mockResolvedValueOnce(true)
+    recordMarketContextProviderEvidence.mockResolvedValueOnce({
+      ok: true,
+      requestId: 'req-2',
+      symbol: 'NVDA',
+      domain: 'news',
+      evidenceCount: 2,
+      insertedEvidence: 2,
+      inserted: true,
+    })
+
+    const { postMarketContextRunEvidenceHandler } = await import('./evidence')
+    const response = await postMarketContextRunEvidenceHandler(
+      new Request('http://localhost/api/torghut/market-context/runs/evidence', {
+        method: 'POST',
+        body: JSON.stringify({ requestId: 'req-2', seq: 2, evidence: [{ source: 'x' }, { source: 'y' }] }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(recordTorghutMarketContextRunEvent).toHaveBeenCalledWith({
+      endpoint: 'evidence',
+      outcome: 'accepted',
+      domain: 'news',
+    })
+  })
+
+  it('finalize returns accepted response', async () => {
+    isMarketContextIngestAuthorized.mockResolvedValueOnce(true)
+    ingestMarketContextProviderResult.mockResolvedValueOnce({
+      ok: true,
+      symbol: 'AAPL',
+      domain: 'news',
+      runStatus: 'succeeded',
+      requestId: 'req-3',
+      context: {
+        asOfUtc: '2026-02-28T00:00:00.000Z',
+        sourceCount: 2,
+        qualityScore: 0.8,
+        payload: {},
+        citations: [],
+        riskFlags: [],
+      },
+    })
+
+    const { postMarketContextRunFinalizeHandler } = await import('./finalize')
+    const response = await postMarketContextRunFinalizeHandler(
+      new Request('http://localhost/api/torghut/market-context/runs/finalize', {
+        method: 'POST',
+        body: JSON.stringify({ symbol: 'AAPL', domain: 'news', runStatus: 'succeeded' }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(recordTorghutMarketContextRunEvent).toHaveBeenCalledWith({
+      endpoint: 'finalize',
+      outcome: 'accepted',
+      domain: 'news',
+    })
+  })
+
+  it('status returns 404 when run is not found', async () => {
+    isMarketContextIngestAuthorized.mockResolvedValueOnce(true)
+    getMarketContextProviderRunStatus.mockRejectedValueOnce(new Error('run not found for requestId req-missing'))
+
+    const { getMarketContextRunStatusHandler } = await import('./$requestId')
+    const response = await getMarketContextRunStatusHandler(
+      'req-missing',
+      new Request('http://localhost/api/torghut/market-context/runs/req-missing', {
+        method: 'GET',
+      }),
+    )
+
+    expect(response.status).toBe(404)
+    expect(recordTorghutMarketContextRunEvent).toHaveBeenCalledWith({ endpoint: 'status', outcome: 'not_found' })
+  })
+})

--- a/services/jangar/src/routes/api/torghut/market-context/runs/evidence.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/runs/evidence.ts
@@ -1,0 +1,53 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { recordTorghutMarketContextRunEvent } from '~/server/metrics'
+import {
+  isMarketContextIngestAuthorized,
+  recordMarketContextProviderEvidence,
+} from '~/server/torghut-market-context-agents'
+
+export const Route = createFileRoute('/api/torghut/market-context/runs/evidence')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => postMarketContextRunEvidenceHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const postMarketContextRunEvidenceHandler = async (request: Request) => {
+  if (!(await isMarketContextIngestAuthorized(request))) {
+    recordTorghutMarketContextRunEvent({ endpoint: 'evidence', outcome: 'unauthorized' })
+    return jsonResponse({ ok: false, message: 'unauthorized' }, 401)
+  }
+
+  const payload = await request.json().catch(() => null)
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    recordTorghutMarketContextRunEvent({ endpoint: 'evidence', outcome: 'invalid_payload' })
+    return jsonResponse({ ok: false, message: 'invalid JSON payload' }, 400)
+  }
+
+  try {
+    const result = await recordMarketContextProviderEvidence(payload)
+    recordTorghutMarketContextRunEvent({ endpoint: 'evidence', outcome: 'accepted', domain: result.domain })
+    return jsonResponse(result, 200)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'failed to record market-context evidence'
+    if (message.includes('run not found')) {
+      recordTorghutMarketContextRunEvent({ endpoint: 'evidence', outcome: 'not_found' })
+      return jsonResponse({ ok: false, message }, 404)
+    }
+    recordTorghutMarketContextRunEvent({ endpoint: 'evidence', outcome: 'error' })
+    return jsonResponse({ ok: false, message }, 400)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/market-context/runs/progress.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/runs/progress.ts
@@ -1,0 +1,53 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { recordTorghutMarketContextRunEvent } from '~/server/metrics'
+import {
+  isMarketContextIngestAuthorized,
+  recordMarketContextProviderRunProgress,
+} from '~/server/torghut-market-context-agents'
+
+export const Route = createFileRoute('/api/torghut/market-context/runs/progress')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => postMarketContextRunProgressHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const postMarketContextRunProgressHandler = async (request: Request) => {
+  if (!(await isMarketContextIngestAuthorized(request))) {
+    recordTorghutMarketContextRunEvent({ endpoint: 'progress', outcome: 'unauthorized' })
+    return jsonResponse({ ok: false, message: 'unauthorized' }, 401)
+  }
+
+  const payload = await request.json().catch(() => null)
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    recordTorghutMarketContextRunEvent({ endpoint: 'progress', outcome: 'invalid_payload' })
+    return jsonResponse({ ok: false, message: 'invalid JSON payload' }, 400)
+  }
+
+  try {
+    const result = await recordMarketContextProviderRunProgress(payload)
+    recordTorghutMarketContextRunEvent({ endpoint: 'progress', outcome: 'accepted', domain: result.domain })
+    return jsonResponse(result, 200)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'failed to record market-context progress'
+    if (message.includes('run not found')) {
+      recordTorghutMarketContextRunEvent({ endpoint: 'progress', outcome: 'not_found' })
+      return jsonResponse({ ok: false, message }, 404)
+    }
+    recordTorghutMarketContextRunEvent({ endpoint: 'progress', outcome: 'error' })
+    return jsonResponse({ ok: false, message }, 400)
+  }
+}

--- a/services/jangar/src/routes/api/torghut/market-context/runs/start.ts
+++ b/services/jangar/src/routes/api/torghut/market-context/runs/start.ts
@@ -1,0 +1,46 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { recordTorghutMarketContextRunEvent } from '~/server/metrics'
+import { isMarketContextIngestAuthorized, startMarketContextProviderRun } from '~/server/torghut-market-context-agents'
+
+export const Route = createFileRoute('/api/torghut/market-context/runs/start')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => postMarketContextRunStartHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const postMarketContextRunStartHandler = async (request: Request) => {
+  if (!(await isMarketContextIngestAuthorized(request))) {
+    recordTorghutMarketContextRunEvent({ endpoint: 'start', outcome: 'unauthorized' })
+    return jsonResponse({ ok: false, message: 'unauthorized' }, 401)
+  }
+
+  const payload = await request.json().catch(() => null)
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    recordTorghutMarketContextRunEvent({ endpoint: 'start', outcome: 'invalid_payload' })
+    return jsonResponse({ ok: false, message: 'invalid JSON payload' }, 400)
+  }
+
+  try {
+    const result = await startMarketContextProviderRun(payload)
+    recordTorghutMarketContextRunEvent({ endpoint: 'start', outcome: 'accepted', domain: result.domain })
+    return jsonResponse(result, 200)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'failed to start market-context run'
+    recordTorghutMarketContextRunEvent({ endpoint: 'start', outcome: 'error' })
+    return jsonResponse({ ok: false, message }, 400)
+  }
+}

--- a/services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agents.test.ts
@@ -344,4 +344,30 @@ describe('market context dispatch runtime', () => {
       type: 'job',
     })
   })
+
+  it('builds a sanitized git head ref for market-context runs', async () => {
+    const { buildMarketContextHeadRef } = await import('../torghut-market-context-agents')
+
+    const head = buildMarketContextHeadRef({
+      prefix: 'codex/torghut-market-context/',
+      domain: 'news',
+      symbol: 'BRK.B',
+      now: new Date('2026-02-28T06:00:00.000Z'),
+    })
+
+    expect(head).toMatch(/^codex\/torghut-market-context\/news-brk\.b-20260228060000-[0-9a-f]{8}$/)
+  })
+
+  it('falls back to default head prefix when prefix is blank', async () => {
+    const { buildMarketContextHeadRef } = await import('../torghut-market-context-agents')
+
+    const head = buildMarketContextHeadRef({
+      prefix: '   ',
+      domain: 'fundamentals',
+      symbol: 'AAPL',
+      now: new Date('2026-02-28T06:00:00.000Z'),
+    })
+
+    expect(head).toMatch(/^codex\/torghut-market-context\/fundamentals-aapl-20260228060000-[0-9a-f]{8}$/)
+  })
 })

--- a/services/jangar/src/server/db.ts
+++ b/services/jangar/src/server/db.ts
@@ -640,6 +640,50 @@ type TorghutMarketContextDispatchState = {
   updated_at: Generated<Timestamp>
 }
 
+type TorghutMarketContextRuns = {
+  request_id: string
+  symbol: string
+  domain: string
+  run_name: string | null
+  provider: string
+  reason: string | null
+  status: string
+  metadata: JsonValue
+  error: string | null
+  started_at: Generated<Timestamp>
+  last_heartbeat_at: Timestamp | null
+  finished_at: Timestamp | null
+  created_at: Generated<Timestamp>
+  updated_at: Generated<Timestamp>
+}
+
+type TorghutMarketContextRunEvents = {
+  id: Generated<string>
+  request_id: string
+  seq: number
+  event_type: string
+  payload: JsonValue
+  created_at: Generated<Timestamp>
+}
+
+type TorghutMarketContextEvidence = {
+  id: Generated<string>
+  request_id: string
+  symbol: string
+  domain: string
+  seq: number
+  source: string
+  published_at: Timestamp | null
+  url: string | null
+  headline: string | null
+  summary: string | null
+  sentiment: string | null
+  payload: JsonValue
+  digest: string
+  created_at: Generated<Timestamp>
+  updated_at: Generated<Timestamp>
+}
+
 export type Database = {
   'atlas.repositories': AtlasRepositories
   'atlas.file_keys': AtlasFileKeys
@@ -681,6 +725,9 @@ export type Database = {
   'torghut_control_plane.quant_pipeline_health': TorghutQuantPipelineHealth
   torghut_market_context_snapshots: TorghutMarketContextSnapshots
   torghut_market_context_dispatch_state: TorghutMarketContextDispatchState
+  torghut_market_context_runs: TorghutMarketContextRuns
+  torghut_market_context_run_events: TorghutMarketContextRunEvents
+  torghut_market_context_evidence: TorghutMarketContextEvidence
   'codex_judge.runs': CodexJudgeRuns
   'codex_judge.artifacts': CodexJudgeArtifacts
   'codex_judge.evaluations': CodexJudgeEvaluations

--- a/services/jangar/src/server/kysely-migrations.ts
+++ b/services/jangar/src/server/kysely-migrations.ts
@@ -18,6 +18,7 @@ import * as atlasChunkSearchMigration from '~/server/migrations/20260209_atlas_c
 import * as torghutQuantControlPlaneMigration from '~/server/migrations/20260212_torghut_quant_control_plane'
 import * as removePromptTuningMigration from '~/server/migrations/20260220_remove_prompt_tuning'
 import * as torghutMarketContextAgentsMigration from '~/server/migrations/20260226_torghut_market_context_agents'
+import * as torghutMarketContextRunLifecycleMigration from '~/server/migrations/20260228_torghut_market_context_run_lifecycle'
 
 type MigrationMap = Record<string, Migration>
 
@@ -49,6 +50,7 @@ const migrations: MigrationMap = {
   '20260212_torghut_quant_control_plane': torghutQuantControlPlaneMigration,
   '20260220_remove_prompt_tuning': removePromptTuningMigration,
   '20260226_torghut_market_context_agents': torghutMarketContextAgentsMigration,
+  '20260228_torghut_market_context_run_lifecycle': torghutMarketContextRunLifecycleMigration,
 }
 
 const migrationProvider = new StaticMigrationProvider(migrations)

--- a/services/jangar/src/server/metrics.ts
+++ b/services/jangar/src/server/metrics.ts
@@ -35,6 +35,7 @@ type JangarMetrics = {
   torghutQuantComputeErrors: Counter
   torghutQuantComputeDurationMs: Histogram
   torghutMarketContextIngestRequests: Counter
+  torghutMarketContextRunEvents: Counter
   torghutMarketContextDispatchAttempts: Counter
   torghutMarketContextDispatchStuck: Counter
 }
@@ -174,6 +175,19 @@ export const recordTorghutMarketContextIngestRequest = (params: {
     outcome: params.outcome,
     domain: params.domain?.trim() ? params.domain.trim() : 'unknown',
     run_status: params.runStatus?.trim() ? params.runStatus.trim() : 'unknown',
+  })
+}
+
+export const recordTorghutMarketContextRunEvent = (params: {
+  endpoint: 'start' | 'progress' | 'evidence' | 'finalize' | 'status'
+  outcome: 'accepted' | 'unauthorized' | 'invalid_payload' | 'not_found' | 'error'
+  domain?: string
+}) => {
+  if (!metricsState.enabled) return
+  recordCounter(metricsState.metrics?.torghutMarketContextRunEvents, 1, {
+    endpoint: params.endpoint,
+    outcome: params.outcome,
+    domain: params.domain?.trim() ? params.domain.trim() : 'unknown',
   })
 }
 
@@ -525,6 +539,9 @@ const createMetricsState = (): MetricsState => {
       }),
       torghutMarketContextIngestRequests: meter.createCounter('jangar_torghut_market_context_ingest_requests_total', {
         description: 'Count of market-context ingest callback requests by outcome/domain.',
+      }),
+      torghutMarketContextRunEvents: meter.createCounter('jangar_torghut_market_context_run_events_total', {
+        description: 'Count of market-context run lifecycle endpoint requests by endpoint/outcome/domain.',
       }),
       torghutMarketContextDispatchAttempts: meter.createCounter(
         'jangar_torghut_market_context_dispatch_attempts_total',

--- a/services/jangar/src/server/migrations/20260228_torghut_market_context_run_lifecycle.ts
+++ b/services/jangar/src/server/migrations/20260228_torghut_market_context_run_lifecycle.ts
@@ -1,0 +1,96 @@
+import { type Kysely, sql } from 'kysely'
+
+import type { Database } from '../db'
+
+export const up = async (db: Kysely<Database>) => {
+  await sql`
+    CREATE TABLE IF NOT EXISTS torghut_market_context_runs (
+      request_id TEXT PRIMARY KEY,
+      symbol TEXT NOT NULL,
+      domain TEXT NOT NULL,
+      run_name TEXT,
+      provider TEXT NOT NULL DEFAULT 'codex-spark',
+      reason TEXT,
+      status TEXT NOT NULL DEFAULT 'started',
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+      error TEXT,
+      started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      last_heartbeat_at TIMESTAMPTZ,
+      finished_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS torghut_market_context_runs_symbol_domain_status_idx
+    ON torghut_market_context_runs(symbol, domain, status);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS torghut_market_context_runs_updated_at_idx
+    ON torghut_market_context_runs(updated_at DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS torghut_market_context_run_events (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      request_id TEXT NOT NULL REFERENCES torghut_market_context_runs(request_id) ON DELETE CASCADE,
+      seq INTEGER NOT NULL,
+      event_type TEXT NOT NULL,
+      payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (request_id, seq)
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS torghut_market_context_run_events_request_created_idx
+    ON torghut_market_context_run_events(request_id, created_at DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS torghut_market_context_evidence (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      request_id TEXT NOT NULL REFERENCES torghut_market_context_runs(request_id) ON DELETE CASCADE,
+      symbol TEXT NOT NULL,
+      domain TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      source TEXT NOT NULL,
+      published_at TIMESTAMPTZ,
+      url TEXT,
+      headline TEXT,
+      summary TEXT,
+      sentiment TEXT,
+      payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+      digest TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (request_id, digest)
+    );
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS torghut_market_context_evidence_request_created_idx
+    ON torghut_market_context_evidence(request_id, created_at DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS torghut_market_context_evidence_symbol_domain_idx
+    ON torghut_market_context_evidence(symbol, domain, created_at DESC);
+  `.execute(db)
+}
+
+export const down = async (db: Kysely<Database>) => {
+  await sql`
+    DROP TABLE IF EXISTS torghut_market_context_evidence;
+  `.execute(db)
+
+  await sql`
+    DROP TABLE IF EXISTS torghut_market_context_run_events;
+  `.execute(db)
+
+  await sql`
+    DROP TABLE IF EXISTS torghut_market_context_runs;
+  `.execute(db)
+}

--- a/skills/fundamentals/SKILL.md
+++ b/skills/fundamentals/SKILL.md
@@ -7,6 +7,19 @@ description: Produce normalized fundamentals factors and deltas for one symbol.
 
 Produce normalized fundamentals factors and deltas for one symbol.
 
+## Scripted execution
+
+- Runner: `skills/fundamentals/scripts/fundamentals_run.py`
+- Shared lifecycle client: `skills/market-context/scripts/market_context_run_api.py`
+- Shared validator: `skills/market-context/scripts/validate_market_context_payload.py`
+
+Use `fundamentals_run.py` to:
+
+1. open run lifecycle (`start` + `progress`),
+2. validate payload contract,
+3. optionally submit parsed evidence rows,
+4. finalize to Jangar so DB persistence happens server-side.
+
 ## Output contract
 
 Return JSON keys:

--- a/skills/fundamentals/scripts/fundamentals_run.py
+++ b/skills/fundamentals/scripts/fundamentals_run.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Wrapper for fundamentals market-context run lifecycle calls."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_API = REPO_ROOT / 'skills/market-context/scripts/market_context_run_api.py'
+VALIDATE = REPO_ROOT / 'skills/market-context/scripts/validate_market_context_payload.py'
+
+
+def _run(*args: str) -> None:
+    command = ['python3', str(args[0]), *args[1:]]
+    completed = subprocess.run(command, check=False)
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Fundamentals market-context workflow helper')
+    parser.add_argument('--callback-url', required=True)
+    parser.add_argument('--request-id', required=True)
+    parser.add_argument('--symbol', required=True)
+    parser.add_argument('--reason', required=True)
+    parser.add_argument('--payload-file', required=True)
+    parser.add_argument('--evidence-file')
+    parser.add_argument('--run-name')
+    args = parser.parse_args()
+
+    _run(str(RUN_API), 'start', '--callback-url', args.callback_url, '--request-id', args.request_id, '--symbol', args.symbol, '--domain', 'fundamentals', '--reason', args.reason, '--provider', 'codex-spark', *(('--run-name', args.run_name) if args.run_name else ()))
+    _run(str(RUN_API), 'progress', '--callback-url', args.callback_url, '--request-id', args.request_id, '--seq', '1', '--status', 'running', '--message', 'fundamentals_collection_started')
+    _run(str(VALIDATE), '--domain', 'fundamentals', '--file', args.payload_file)
+
+    if args.evidence_file:
+        _run(str(RUN_API), 'evidence', '--callback-url', args.callback_url, '--request-id', args.request_id, '--symbol', args.symbol, '--domain', 'fundamentals', '--seq', '2', '--evidence-file', args.evidence_file)
+
+    _run(str(RUN_API), 'finalize', '--callback-url', args.callback_url, '--request-id', args.request_id, '--payload-file', args.payload_file, '--expect-status', '200')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/skills/market-context/SKILL.md
+++ b/skills/market-context/SKILL.md
@@ -7,6 +7,51 @@ description: Build a normalized market-context JSON bundle for a single symbol a
 
 Build a normalized market-context JSON bundle for a single symbol and timestamp.
 
+## Scripted workflow
+
+- Run lifecycle API client: `skills/market-context/scripts/market_context_run_api.py`
+- Finalize payload validator: `skills/market-context/scripts/validate_market_context_payload.py`
+- JSON Schemas:
+  - `skills/market-context/schemas/market-context-run-start.schema.json`
+  - `skills/market-context/schemas/market-context-run-progress.schema.json`
+  - `skills/market-context/schemas/market-context-run-evidence.schema.json`
+
+### Lifecycle endpoints
+
+- `POST /api/torghut/market-context/runs/start`
+- `POST /api/torghut/market-context/runs/progress`
+- `POST /api/torghut/market-context/runs/evidence`
+- `POST /api/torghut/market-context/runs/finalize`
+- `GET /api/torghut/market-context/runs/{requestId}`
+
+### Example sequence
+
+```bash
+python3 skills/market-context/scripts/market_context_run_api.py start \
+  --callback-url "<callbackUrl>" \
+  --request-id "<requestId>" \
+  --symbol "<symbol>" \
+  --domain "<fundamentals|news>" \
+  --reason "<reason>"
+
+python3 skills/market-context/scripts/market_context_run_api.py progress \
+  --callback-url "<callbackUrl>" \
+  --request-id "<requestId>" \
+  --seq 1 \
+  --status running \
+  --message "collection_started"
+
+python3 skills/market-context/scripts/validate_market_context_payload.py \
+  --domain "<fundamentals|news>" \
+  --file /tmp/market-context.json
+
+python3 skills/market-context/scripts/market_context_run_api.py finalize \
+  --callback-url "<callbackUrl>" \
+  --request-id "<requestId>" \
+  --payload-file /tmp/market-context.json \
+  --expect-status 200
+```
+
 ## Output contract
 
 Return JSON with keys:

--- a/skills/market-context/schemas/market-context-run-evidence.schema.json
+++ b/skills/market-context/schemas/market-context-run-evidence.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["requestId", "seq", "evidence"],
+  "properties": {
+    "requestId": { "type": "string", "minLength": 1 },
+    "symbol": { "type": "string" },
+    "domain": { "type": "string", "enum": ["fundamentals", "news"] },
+    "seq": { "type": "integer", "minimum": 0 },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["source"],
+        "properties": {
+          "source": { "type": "string", "minLength": 1 },
+          "publishedAt": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"] },
+          "headline": { "type": ["string", "null"] },
+          "summary": { "type": ["string", "null"] },
+          "sentiment": { "type": ["string", "null"] },
+          "payload": { "type": "object" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "metadata": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/skills/market-context/schemas/market-context-run-progress.schema.json
+++ b/skills/market-context/schemas/market-context-run-progress.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["requestId", "seq"],
+  "properties": {
+    "requestId": { "type": "string", "minLength": 1 },
+    "seq": { "type": "integer", "minimum": 0 },
+    "status": { "type": "string" },
+    "message": { "type": "string" },
+    "metadata": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/skills/market-context/schemas/market-context-run-start.schema.json
+++ b/skills/market-context/schemas/market-context-run-start.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["requestId", "symbol", "domain"],
+  "properties": {
+    "requestId": { "type": "string", "minLength": 1 },
+    "symbol": { "type": "string", "minLength": 1 },
+    "domain": { "type": "string", "enum": ["fundamentals", "news"] },
+    "runName": { "type": ["string", "null"] },
+    "reason": { "type": ["string", "null"] },
+    "provider": { "type": "string" },
+    "seq": { "type": "integer", "minimum": 0 },
+    "metadata": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/skills/market-context/scripts/market_context_run_api.py
+++ b/skills/market-context/scripts/market_context_run_api.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Market-context run lifecycle API helper for AgentRun skills.
+
+This script posts run lifecycle events (start/progress/evidence/finalize) to Jangar market-context endpoints
+using the in-cluster service-account token when available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except OSError as exc:
+        raise SystemExit(f'failed to read JSON file {path}: {exc}') from exc
+
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f'invalid JSON in {path}: {exc}') from exc
+
+    if not isinstance(value, dict):
+        raise SystemExit(f'JSON file must contain an object: {path}')
+    return value
+
+
+def _read_evidence(path: Path) -> list[dict[str, Any]]:
+    try:
+        raw = path.read_text(encoding='utf-8')
+    except OSError as exc:
+        raise SystemExit(f'failed to read evidence file {path}: {exc}') from exc
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f'invalid JSON in evidence file {path}: {exc}') from exc
+
+    if isinstance(parsed, dict):
+        candidate = parsed.get('evidence', parsed.get('items'))
+    else:
+        candidate = parsed
+
+    if not isinstance(candidate, list):
+        raise SystemExit('evidence file must contain an array or object with evidence/items array')
+
+    result: list[dict[str, Any]] = []
+    for item in candidate:
+        if isinstance(item, dict):
+            result.append(item)
+    if not result:
+        raise SystemExit('evidence file contains no valid object rows')
+    return result
+
+
+def _resolve_base_url(callback_url: str) -> str:
+    base = callback_url.strip().rstrip('/')
+    for suffix in ('/ingest', '/runs/finalize'):
+        if base.endswith(suffix):
+            base = base[: -len(suffix)]
+            break
+    if not base:
+        raise SystemExit('callback URL is empty')
+    return base
+
+
+def _resolve_endpoint(action: str, callback_url: str, request_id: str | None) -> str:
+    base = _resolve_base_url(callback_url)
+    if action == 'start':
+        return f'{base}/runs/start'
+    if action == 'progress':
+        return f'{base}/runs/progress'
+    if action == 'evidence':
+        return f'{base}/runs/evidence'
+    if action == 'finalize':
+        return f'{base}/runs/finalize'
+    if action == 'status':
+        if not request_id:
+            raise SystemExit('requestId is required for status calls')
+        return f'{base}/runs/{request_id}'
+    raise SystemExit(f'unsupported action: {action}')
+
+
+def _load_token(token_path: str) -> str | None:
+    path = Path(token_path)
+    if not path.exists() or not path.is_file():
+        return None
+    token = path.read_text(encoding='utf-8').strip()
+    return token or None
+
+
+def _request_json(
+    *,
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None,
+    timeout_seconds: float,
+    expected_statuses: set[int],
+    token: str | None,
+    retries: int,
+) -> dict[str, Any]:
+    body = None
+    headers: dict[str, str] = {'accept': 'application/json'}
+    if payload is not None:
+        body = json.dumps(payload, separators=(',', ':'), ensure_ascii=True).encode('utf-8')
+        headers['content-type'] = 'application/json'
+    if token:
+        headers['authorization'] = f'Bearer {token}'
+
+    attempt = 0
+    while True:
+        attempt += 1
+        req = urllib.request.Request(url=url, data=body, method=method.upper(), headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout_seconds) as response:
+                status = response.getcode()
+                raw = response.read().decode('utf-8')
+                if status not in expected_statuses:
+                    raise SystemExit(f'unexpected status {status}; body={raw}')
+                if not raw.strip():
+                    return {'ok': status in expected_statuses, 'status': status}
+                decoded = json.loads(raw)
+                if not isinstance(decoded, dict):
+                    raise SystemExit(f'endpoint returned non-object JSON: {decoded!r}')
+                return decoded
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode('utf-8', errors='replace')
+            if attempt > retries + 1:
+                raise SystemExit(f'HTTP {exc.code} calling {url}; body={raw}') from exc
+        except urllib.error.URLError as exc:
+            if attempt > retries + 1:
+                raise SystemExit(f'network error calling {url}: {exc}') from exc
+        except TimeoutError as exc:
+            if attempt > retries + 1:
+                raise SystemExit(f'timeout calling {url}: {exc}') from exc
+
+        time.sleep(min(1.0 * attempt, 5.0))
+
+
+def _parse_expected(values: list[int]) -> set[int]:
+    if not values:
+        return {200}
+    return {int(value) for value in values}
+
+
+def _build_payload(args: argparse.Namespace) -> dict[str, Any] | None:
+    metadata: dict[str, Any] = {}
+    if args.metadata_file:
+        metadata = _read_json(Path(args.metadata_file))
+
+    if args.action == 'status':
+        return None
+
+    payload: dict[str, Any] = {}
+    if args.request_id:
+        payload['requestId'] = args.request_id
+    if args.symbol:
+        payload['symbol'] = args.symbol
+    if args.domain:
+        payload['domain'] = args.domain
+
+    if args.action == 'start':
+        if args.run_name:
+            payload['runName'] = args.run_name
+        if args.reason:
+            payload['reason'] = args.reason
+        payload['provider'] = args.provider
+        if args.seq is not None:
+            payload['seq'] = args.seq
+        if metadata:
+            payload['metadata'] = metadata
+        return payload
+
+    if args.action == 'progress':
+        if args.seq is None:
+            raise SystemExit('--seq is required for progress')
+        payload['seq'] = args.seq
+        payload['status'] = args.status
+        if args.message:
+            payload['message'] = args.message
+        if metadata:
+            payload['metadata'] = metadata
+        return payload
+
+    if args.action == 'evidence':
+        if args.seq is None:
+            raise SystemExit('--seq is required for evidence')
+        if not args.evidence_file:
+            raise SystemExit('--evidence-file is required for evidence')
+        payload['seq'] = args.seq
+        payload['evidence'] = _read_evidence(Path(args.evidence_file))
+        if metadata:
+            payload['metadata'] = metadata
+        return payload
+
+    if args.action == 'finalize':
+        if not args.payload_file:
+            raise SystemExit('--payload-file is required for finalize')
+        payload = _read_json(Path(args.payload_file))
+        if args.request_id and not payload.get('requestId'):
+            payload['requestId'] = args.request_id
+        if metadata:
+            existing = payload.get('metadata')
+            if isinstance(existing, dict):
+                merged = dict(existing)
+                merged.update(metadata)
+                payload['metadata'] = merged
+            else:
+                payload['metadata'] = metadata
+        return payload
+
+    raise SystemExit(f'unsupported action: {args.action}')
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Market-context run lifecycle API helper')
+    parser.add_argument('action', choices=['start', 'progress', 'evidence', 'finalize', 'status'])
+    parser.add_argument('--callback-url', required=True)
+    parser.add_argument('--request-id')
+    parser.add_argument('--symbol')
+    parser.add_argument('--domain', choices=['fundamentals', 'news'])
+    parser.add_argument('--run-name')
+    parser.add_argument('--reason')
+    parser.add_argument('--provider', default='codex-spark')
+    parser.add_argument('--seq', type=int)
+    parser.add_argument('--status', default='running')
+    parser.add_argument('--message')
+    parser.add_argument('--payload-file')
+    parser.add_argument('--evidence-file')
+    parser.add_argument('--metadata-file')
+    parser.add_argument('--token-path', default=DEFAULT_TOKEN_PATH)
+    parser.add_argument('--timeout-seconds', type=float, default=20.0)
+    parser.add_argument('--expect-status', type=int, action='append', default=[])
+    parser.add_argument('--retries', type=int, default=1)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.action != 'status' and not args.request_id:
+        raise SystemExit('--request-id is required for start/progress/evidence/finalize')
+
+    payload = _build_payload(args)
+    endpoint = _resolve_endpoint(args.action, args.callback_url, args.request_id)
+    token = _load_token(args.token_path)
+    expected = _parse_expected(args.expect_status)
+    method = 'GET' if args.action == 'status' else 'POST'
+
+    response = _request_json(
+        method=method,
+        url=endpoint,
+        payload=payload,
+        timeout_seconds=args.timeout_seconds,
+        expected_statuses=expected,
+        token=token,
+        retries=max(0, args.retries),
+    )
+    sys.stdout.write(json.dumps(response, separators=(',', ':'), ensure_ascii=True))
+    sys.stdout.write('\n')
+
+    ok_value = response.get('ok')
+    if isinstance(ok_value, bool) and not ok_value:
+        raise SystemExit(f'endpoint returned ok=false: {response}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/skills/market-context/scripts/validate_market_context_payload.py
+++ b/skills/market-context/scripts/validate_market_context_payload.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Validate market-context finalize payloads before submission."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ALLOWED_RUN_STATUS = {'succeeded', 'partial', 'failed', 'submitted'}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding='utf-8')
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError('payload must be a JSON object')
+    return parsed
+
+
+def _expect_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f'{key} must be a non-empty string')
+    return value.strip()
+
+
+def _expect_number(payload: dict[str, Any], key: str) -> float:
+    value = payload.get(key)
+    if not isinstance(value, (int, float)):
+        raise ValueError(f'{key} must be a number')
+    return float(value)
+
+
+def _validate_citations(payload: dict[str, Any]) -> None:
+    citations = payload.get('citations')
+    if not isinstance(citations, list):
+        raise ValueError('citations must be an array')
+    for idx, citation in enumerate(citations):
+        if not isinstance(citation, dict):
+            raise ValueError(f'citations[{idx}] must be an object')
+        source = citation.get('source')
+        published_at = citation.get('publishedAt')
+        if not isinstance(source, str) or not source.strip():
+            raise ValueError(f'citations[{idx}].source must be a non-empty string')
+        if not isinstance(published_at, str) or not published_at.strip():
+            raise ValueError(f'citations[{idx}].publishedAt must be a non-empty string')
+
+
+def _validate_payload(domain: str, payload: dict[str, Any]) -> None:
+    symbol = _expect_string(payload, 'symbol')
+    payload_domain = _expect_string(payload, 'domain')
+    if payload_domain != domain:
+        raise ValueError(f'domain mismatch: expected {domain}, got {payload_domain}')
+
+    _expect_string(payload, 'asOfUtc')
+    request_id = _expect_string(payload, 'requestId')
+    run_status = _expect_string(payload, 'runStatus').lower()
+    if run_status not in ALLOWED_RUN_STATUS:
+        raise ValueError(f'runStatus must be one of {sorted(ALLOWED_RUN_STATUS)}')
+
+    quality_score = _expect_number(payload, 'qualityScore')
+    if quality_score < 0 or quality_score > 1:
+        raise ValueError('qualityScore must be in [0, 1]')
+
+    source_count = _expect_number(payload, 'sourceCount')
+    if source_count < 0:
+        raise ValueError('sourceCount must be >= 0')
+
+    body = payload.get('payload')
+    if not isinstance(body, dict):
+        raise ValueError('payload field must be an object')
+
+    risk_flags = payload.get('riskFlags')
+    if risk_flags is not None and not isinstance(risk_flags, list):
+        raise ValueError('riskFlags must be an array when provided')
+
+    _validate_citations(payload)
+
+    if domain == 'news':
+        headlines = body.get('headlines')
+        if not isinstance(headlines, list):
+            raise ValueError('news payload.headlines must be an array')
+    if domain == 'fundamentals':
+        for key in ('valuation', 'growth', 'profitability', 'balanceSheet'):
+            if key not in body:
+                raise ValueError(f'fundamentals payload must contain {key}')
+
+    _expect_string(payload, 'provider')
+
+    _ = symbol
+    _ = request_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Validate market-context payload JSON')
+    parser.add_argument('--domain', choices=['fundamentals', 'news'], required=True)
+    parser.add_argument('--file', required=True)
+    args = parser.parse_args()
+
+    payload = _load_json(Path(args.file))
+    _validate_payload(args.domain, payload)
+
+    print(json.dumps({'ok': True, 'domain': args.domain, 'file': args.file}, separators=(',', ':')))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/skills/news-sentiment/SKILL.md
+++ b/skills/news-sentiment/SKILL.md
@@ -7,6 +7,19 @@ description: Extract structured, source-attributed sentiment context for one sym
 
 Extract structured, source-attributed sentiment context for one symbol.
 
+## Scripted execution
+
+- Runner: `skills/news-sentiment/scripts/news_run.py`
+- Shared lifecycle client: `skills/market-context/scripts/market_context_run_api.py`
+- Shared validator: `skills/market-context/scripts/validate_market_context_payload.py`
+
+Use `news_run.py` to:
+
+1. open run lifecycle (`start` + `progress`),
+2. validate payload contract,
+3. optionally submit parsed evidence rows,
+4. finalize to Jangar so DB persistence happens server-side.
+
 ## Output contract
 
 Return JSON keys:

--- a/skills/news-sentiment/scripts/news_run.py
+++ b/skills/news-sentiment/scripts/news_run.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Wrapper for news market-context run lifecycle calls."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_API = REPO_ROOT / 'skills/market-context/scripts/market_context_run_api.py'
+VALIDATE = REPO_ROOT / 'skills/market-context/scripts/validate_market_context_payload.py'
+
+
+def _run(*args: str) -> None:
+    command = ['python3', str(args[0]), *args[1:]]
+    completed = subprocess.run(command, check=False)
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='News market-context workflow helper')
+    parser.add_argument('--callback-url', required=True)
+    parser.add_argument('--request-id', required=True)
+    parser.add_argument('--symbol', required=True)
+    parser.add_argument('--reason', required=True)
+    parser.add_argument('--payload-file', required=True)
+    parser.add_argument('--evidence-file')
+    parser.add_argument('--run-name')
+    args = parser.parse_args()
+
+    _run(str(RUN_API), 'start', '--callback-url', args.callback_url, '--request-id', args.request_id, '--symbol', args.symbol, '--domain', 'news', '--reason', args.reason, '--provider', 'codex-spark', *(('--run-name', args.run_name) if args.run_name else ()))
+    _run(str(RUN_API), 'progress', '--callback-url', args.callback_url, '--request-id', args.request_id, '--seq', '1', '--status', 'running', '--message', 'news_collection_started')
+    _run(str(VALIDATE), '--domain', 'news', '--file', args.payload_file)
+
+    if args.evidence_file:
+        _run(str(RUN_API), 'evidence', '--callback-url', args.callback_url, '--request-id', args.request_id, '--symbol', args.symbol, '--domain', 'news', '--seq', '2', '--evidence-file', args.evidence_file)
+
+    _run(str(RUN_API), 'finalize', '--callback-url', args.callback_url, '--request-id', args.request_id, '--payload-file', args.payload_file, '--expect-status', '200')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add authenticated market-context run lifecycle endpoints in Jangar (`start`, `progress`, `evidence`, `finalize`, `status`) and persist run/event/evidence records in Postgres.
- Add lifecycle persistence migration and ingest integration so successful finalize updates `torghut_market_context_snapshot` while preserving failed/partial-run traceability.
- Add reusable market-context skill scripts/schemas and update Torghut news/fundamentals ImplementationSpecs to call lifecycle endpoints during collection and finalize.
- Add Jangar AgentRun VCS dispatch support for market-context jobs and configure deployment env so dispatched agents have repo access to run lifecycle scripts.

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-market-context-agents-ingest.test.ts src/routes/api/torghut/market-context/-ingest.test.ts src/routes/api/torghut/market-context/runs/-routes.test.ts src/server/__tests__/torghut-market-context-agents.test.ts`
- `cd services/jangar && bunx tsc --noEmit --project tsconfig.paths.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

- Requires DB migration `20260228_torghut_market_context_run_lifecycle` before lifecycle endpoints are used in production.
- News/Fundamentals market-context agents now depend on callback lifecycle endpoints being reachable and authorized from the agents namespace.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
