### PR TITLE
fix(ci): include tsconfig base in jangar prebuild tree

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -81,6 +81,9 @@ jobs:
           if [ -f "$PRUNE_DIR/bun.lock" ]; then
             cp "$PRUNE_DIR/bun.lock" "$PRUNE_DIR/full/bun.lock"
           fi
+          if [ -f "$PRUNE_DIR/tsconfig.base.json" ]; then
+            cp "$PRUNE_DIR/tsconfig.base.json" "$PRUNE_DIR/full/tsconfig.base.json"
+          fi
           bun install --cwd "$PRUNE_DIR/full" --ignore-scripts --filter @proompteng/otel --filter @proompteng/temporal-bun-sdk --filter @proompteng/jangar
           timeout 20m bun --cwd "$PRUNE_DIR/full/services/jangar" --bun vite build --logLevel warn
           bun --cwd "$PRUNE_DIR/full/services/jangar" run copy:grpc-proto


### PR DESCRIPTION
## Summary

- Fix `jangar-build-push` prebuild context by copying `tsconfig.base.json` into the pruned `full/` tree.
- Keep prebuild install/build in `full/` so `services/jangar/tsconfig.json` can resolve `../../tsconfig.base.json`.
- Prevent the `vite` prebuild failure observed on `main` after PR #3729 merge.

## Related Issues

None

## Testing

- Reviewed failing main run `22516239670` (`Prebuild jangar output`) and reproduced missing `tsconfig.base.json` path in logs.
- Verified workflow step now stages `tsconfig.base.json` to `$PRUNE_DIR/full/tsconfig.base.json` before `vite build`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
