### PR TITLE
fix(ci): build workspace libs before jangar prebuild

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -85,6 +85,8 @@ jobs:
             cp "$PRUNE_DIR/tsconfig.base.json" "$PRUNE_DIR/full/tsconfig.base.json"
           fi
           bun install --cwd "$PRUNE_DIR/full" --ignore-scripts --filter @proompteng/otel --filter @proompteng/temporal-bun-sdk --filter @proompteng/jangar
+          bun run --cwd "$PRUNE_DIR/full" --filter @proompteng/otel build
+          bun run --cwd "$PRUNE_DIR/full" --filter @proompteng/temporal-bun-sdk build
           timeout 20m bun --cwd "$PRUNE_DIR/full/services/jangar" --bun vite build --logLevel warn
           bun --cwd "$PRUNE_DIR/full/services/jangar" run copy:grpc-proto
 


### PR DESCRIPTION
## Summary

- Update `jangar-build-push` prebuild flow to build workspace dependencies (`@proompteng/otel`, `@proompteng/temporal-bun-sdk`) before running `vite build` in the pruned `full/` tree.
- Preserve existing prune/install/prebuild steps while ensuring package exports are available during Vite resolution.
- Address the `Failed to resolve entry for package "@proompteng/temporal-bun-sdk"` failure seen on `main` run `22516278408`.

## Related Issues

None

## Testing

- Reviewed failed `jangar-build-push` main run `22516278408` logs to confirm unresolved workspace package exports during prebuild.
- Verified workflow now executes:
  - `bun run --cwd "$PRUNE_DIR/full" --filter @proompteng/otel build`
  - `bun run --cwd "$PRUNE_DIR/full" --filter @proompteng/temporal-bun-sdk build`
  before `vite build`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
