### PR TITLE
fix(ci): avoid branch-wide lock in jangar build workflow

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: jangar-build-${{ github.ref }}
+  group: jangar-build-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Change `jangar-build-push` concurrency key from branch-level to commit-level (`${{ github.ref }}-${{ github.sha }}`).
- Prevent a single stuck run from blocking all later commits on `main`.
- Keep cancellation behavior (`cancel-in-progress: true`) while isolating lock scope per commit.

## Related Issues

None

## Testing

- Observed a stuck run (`22516383544`) holding the old branch-level concurrency lock and keeping later run `22516571460` in `pending`.
- Verified this workflow change removes cross-commit lock contention while preserving workflow execution semantics.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
