### PR TITLE
chore(jangar): promote image 973770cd

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 322973b8
-  digest: sha256:8de6c65256bea4f888017b6ce316d60c1ffad22a7ad8a5d8c1c5806b93ee1244
+  tag: 973770cd
+  digest: sha256:8b433c2973517cae64c891f7fc5c2359694188e5b24433d9c4128ae5443cd90c
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 322973b8
-    digest: sha256:4e8ec8971f0b7372b3619cd497f673d51c8ca3394c0768568fc56a1cd20ee87e
+    tag: 973770cd
+    digest: sha256:572af335a98e06d047c20301f08ca4e2f265bdabdd1d0c476aeee0982103e201
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 322973b8
-    digest: sha256:8de6c65256bea4f888017b6ce316d60c1ffad22a7ad8a5d8c1c5806b93ee1244
+    tag: 973770cd
+    digest: sha256:8b433c2973517cae64c891f7fc5c2359694188e5b24433d9c4128ae5443cd90c
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-27T22:09:44Z"
+    deploy.knative.dev/rollout: "2026-02-28T08:10:44Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-27T22:09:44Z"
+        kubectl.kubernetes.io/restartedAt: "2026-02-28T08:10:44Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "322973b8"
-    digest: sha256:8de6c65256bea4f888017b6ce316d60c1ffad22a7ad8a5d8c1c5806b93ee1244
+    newTag: "973770cd"
+    digest: sha256:8b433c2973517cae64c891f7fc5c2359694188e5b24433d9c4128ae5443cd90c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `973770cdb8c9e019da2e0a3c41f9f9e6af6670d9`
- Image tag: `973770cd`
- Image digest: `sha256:8b433c2973517cae64c891f7fc5c2359694188e5b24433d9c4128ae5443cd90c`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`