### PR TITLE
feat(torghut): implement hmm regime control-plane path

### DIFF
--- a/services/torghut/app/metrics.py
+++ b/services/torghut/app/metrics.py
@@ -248,6 +248,20 @@ _SIMPLE_MAP_METRICS: dict[str, tuple[str, str, str, str, str]] = {
         "fragility_state",
         "int",
     ),
+    "decision_regime_resolution_source_total": (
+        "torghut_trading_decision_regime_resolution_source_total",
+        "Decision regime source resolution by signal source.",
+        "counter",
+        "source",
+        "int",
+    ),
+    "decision_regime_resolution_fallback_total": (
+        "torghut_trading_decision_regime_resolution_fallback_total",
+        "Decision regime fallback reason counts.",
+        "counter",
+        "reason",
+        "int",
+    ),
 }
 
 _STRATEGY_RUNTIME_METRICS: dict[str, tuple[str, str]] = {

--- a/services/torghut/app/trading/forecasting.py
+++ b/services/torghut/app/trading/forecasting.py
@@ -199,7 +199,10 @@ class ForecastRouterPolicyEntry:
         return (
             fnmatch.fnmatch(symbol, self.symbol_glob)
             and (self.horizon == '*' or self.horizon == horizon)
-            and (self.regime == '*' or self.regime == regime)
+            and (
+                self.regime == '*'
+                or self.regime.lower() == regime.lower()
+            )
         )
 
 

--- a/services/torghut/app/trading/llm/schema.py
+++ b/services/torghut/app/trading/llm/schema.py
@@ -25,6 +25,18 @@ def _market_context_citations_default() -> list["MarketContextCitation"]:
     return []
 
 
+class LLMRegimeHMMContext(BaseModel):
+    """Compact HMM regime context provided to LLM review."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    regime_id: str
+    entropy_band: Literal["low", "medium", "high"]
+    predicted_next: str
+    artifact_version: str
+    guardrail_reason: str | None = None
+
+
 class LLMDecisionContext(BaseModel):
     """Minimal decision context passed to the LLM reviewer."""
 
@@ -39,6 +51,7 @@ class LLMDecisionContext(BaseModel):
     event_ts: datetime
     timeframe: str
     rationale: Optional[str] = None
+    regime_hmm: Optional[LLMRegimeHMMContext] = None
     params: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -324,6 +337,7 @@ class LLMCommitteeTrace(BaseModel):
 
 
 __all__ = [
+    "LLMRegimeHMMContext",
     "LLMDecisionContext",
     "PortfolioSnapshot",
     "MarketSnapshot",

--- a/services/torghut/app/trading/regime_hmm.py
+++ b/services/torghut/app/trading/regime_hmm.py
@@ -247,7 +247,9 @@ def _parse_context_map(payload: Mapping[str, Any]) -> HMMRegimeContext:
     predicted_next = _normalize_predicted_next(
         payload.get("predicted_next") or payload.get("predictedNext")
     )
-    transition_shock = bool(payload.get("transition_shock") or payload.get("transitionShock"))
+    transition_shock = _coerce_bool(
+        payload.get("transition_shock") or payload.get("transitionShock")
+    )
     duration_ms = _coerce_int(payload.get("duration_ms") or payload.get("durationMs"))
     artifact = _coerce_artifact(payload.get("artifact"))
     guardrail = _coerce_guardrail(

--- a/services/torghut/app/trading/regime_hmm.py
+++ b/services/torghut/app/trading/regime_hmm.py
@@ -1,0 +1,435 @@
+"""Shared HMM regime-context parsing and normalization helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Mapping, cast
+
+
+HMM_CONTEXT_SCHEMA_VERSION = "hmm_regime_context_v1"
+HMM_UNKNOWN_SCHEMA_VERSION = "unknown"
+HMM_UNKNOWN_REGIME_ID = "unknown"
+HMM_DEFAULT_ENTROPY = "0"
+HMM_UNKNOWN_POSTERIOR: dict[str, str] = {}
+HMM_ENTROPY_BANDS = {"low", "medium", "high"}
+HMM_ENTROPY_MEDIUM_THRESHOLD = Decimal("0.90")
+HMM_ENTROPY_HIGH_THRESHOLD = Decimal("1.35")
+_REGIME_ID_RE = re.compile(r"^[Rr]\d+$")
+
+
+@dataclass(frozen=True)
+class HMMGuardrail:
+    stale: bool
+    fallback_to_defensive: bool
+    reason: str | None
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "stale": self.stale,
+            "fallback_to_defensive": self.fallback_to_defensive,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class HMMArtifact:
+    model_id: str
+    feature_schema: str
+    training_run_id: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "model_id": self.model_id,
+            "feature_schema": self.feature_schema,
+            "training_run_id": self.training_run_id,
+        }
+
+
+@dataclass(frozen=True)
+class HMMRegimeContext:
+    schema_version: str
+    regime_id: str
+    posterior: dict[str, str]
+    entropy: str
+    entropy_band: str
+    predicted_next: str
+    transition_shock: bool
+    duration_ms: int
+    artifact: HMMArtifact
+    guardrail: HMMGuardrail
+
+    @property
+    def artifact_model_id(self) -> str:
+        return self.artifact.model_id
+
+    @property
+    def guardrail_reason(self) -> str | None:
+        return self.guardrail.reason
+
+    @property
+    def has_regime(self) -> bool:
+        return self.regime_id != HMM_UNKNOWN_REGIME_ID
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "regime_id": self.regime_id,
+            "posterior": self.posterior,
+            "entropy": self.entropy,
+            "entropy_band": self.entropy_band,
+            "predicted_next": self.predicted_next,
+            "transition_shock": self.transition_shock,
+            "duration_ms": self.duration_ms,
+            "artifact": self.artifact.to_payload(),
+            "guardrail": self.guardrail.to_payload(),
+        }
+
+    @classmethod
+    def unknown(cls) -> "HMMRegimeContext":
+        return cls(
+            schema_version=HMM_UNKNOWN_SCHEMA_VERSION,
+            regime_id=HMM_UNKNOWN_REGIME_ID,
+            posterior=HMM_UNKNOWN_POSTERIOR,
+            entropy=HMM_DEFAULT_ENTROPY,
+            entropy_band="low",
+            predicted_next=HMM_UNKNOWN_REGIME_ID,
+            transition_shock=False,
+            duration_ms=0,
+            artifact=HMMArtifact(
+                model_id=HMM_UNKNOWN_REGIME_ID,
+                feature_schema=HMM_UNKNOWN_REGIME_ID,
+                training_run_id=HMM_UNKNOWN_REGIME_ID,
+            ),
+            guardrail=HMMGuardrail(
+                stale=False,
+                fallback_to_defensive=False,
+                reason=None,
+            ),
+        )
+
+
+def resolve_hmm_context(raw_payload: Mapping[str, Any] | None) -> HMMRegimeContext:
+    if raw_payload is None:
+        return HMMRegimeContext.unknown()
+
+    payload = dict(cast(dict[str, Any], raw_payload))
+    direct_payload = _extract_context_payload(payload)
+    if direct_payload is None:
+        if not _has_hmm_split_fields(payload):
+            return HMMRegimeContext.unknown()
+        return _parse_context_map(payload)
+
+    return _parse_context_map(direct_payload)
+
+
+def resolve_regime_route_label(
+    payload: Mapping[str, Any],
+    *,
+    macd: Decimal | None,
+    macd_signal: Decimal | None,
+) -> str:
+    context = resolve_hmm_context(payload)
+    if context.has_regime:
+        return context.regime_id
+
+    explicit = payload.get("regime_label")
+    if isinstance(explicit, str):
+        explicit_value = explicit.strip()
+        if explicit_value:
+            return explicit_value.lower()
+
+    if macd is None or macd_signal is None:
+        return "unknown"
+    spread = macd - macd_signal
+    if spread >= Decimal("0.02"):
+        return "trend"
+    if spread <= Decimal("-0.02"):
+        return "mean_revert"
+    return "range"
+
+
+def resolve_legacy_regime_label(payload: Mapping[str, Any]) -> str | None:
+    direct = payload.get("regime_label")
+    if isinstance(direct, str):
+        direct_value = direct.strip()
+        if direct_value:
+            return direct_value.lower()
+    regime = payload.get("regime")
+    if isinstance(regime, Mapping):
+        regime_map = cast(Mapping[str, Any], regime)
+        label = regime_map.get("label")
+        if isinstance(label, str):
+            label_value = label.strip()
+            if label_value:
+                return label_value.lower()
+    return None
+
+
+def _extract_context_payload(payload: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    candidate_keys = (
+        "regime_hmm",
+        "hmm_regime_context",
+        "hmm_context",
+        "regime_context",
+    )
+    for key in candidate_keys:
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            context_payload = cast(Mapping[str, Any], value)
+            return {str(k): v for k, v in context_payload.items()}
+
+    regime_payload = payload
+    if "posterior" in regime_payload and isinstance(regime_payload.get("posterior"), Mapping):
+        if _has_any_context_field(regime_payload):
+            return {str(k): v for k, v in regime_payload.items()}
+    if _has_hmm_split_fields(regime_payload):
+        return {
+            "regime_id": regime_payload.get("hmm_regime_id"),
+            "posterior": regime_payload.get("hmm_state_posterior"),
+            "entropy": regime_payload.get("hmm_entropy"),
+            "entropy_band": regime_payload.get("hmm_entropy_band"),
+            "predicted_next": regime_payload.get("hmm_predicted_next"),
+            "transition_shock": regime_payload.get("hmm_transition_shock"),
+            "duration_ms": regime_payload.get("hmm_duration_ms"),
+            "artifact": regime_payload.get("hmm_artifact"),
+            "guardrail": regime_payload.get("hmm_guardrail"),
+        }
+    return None
+
+
+def _has_any_context_field(payload: Mapping[str, Any]) -> bool:
+    return any(
+        isinstance(payload.get(field), Mapping)
+        or field in payload
+        for field in (
+            "schema_version",
+            "regime_id",
+            "posterior",
+            "entropy",
+            "entropy_band",
+            "predicted_next",
+            "transition_shock",
+            "duration_ms",
+            "artifact",
+            "guardrail",
+        )
+    )
+
+
+def _has_hmm_split_fields(payload: Mapping[str, Any]) -> bool:
+    split_keys = {
+        "hmm_state_posterior",
+        "hmm_entropy",
+        "hmm_entropy_band",
+        "hmm_regime_id",
+        "hmm_predicted_next",
+        "hmm_transition_shock",
+        "hmm_duration_ms",
+        "hmm_artifact",
+        "hmm_guardrail",
+    }
+    return any(key in payload for key in split_keys)
+
+
+def _parse_context_map(payload: Mapping[str, Any]) -> HMMRegimeContext:
+    schema_version = _coerce_string(payload.get("schema_version") or payload.get("schemaVersion"))
+    if not schema_version:
+        schema_version = HMM_UNKNOWN_SCHEMA_VERSION
+
+    regime_id = _normalize_regime_id(payload.get("regime_id") or payload.get("regimeId"))
+    posterior_raw = payload.get("posterior")
+    posterior = _coerce_posterior(posterior_raw)
+    entropy = _coerce_decimal_str(payload.get("entropy"))
+    entropy_band_raw = payload.get("entropy_band") or payload.get("entropyBand")
+    entropy_band = _coerce_entropy_band(entropy_band_raw, entropy)
+    predicted_next = _normalize_predicted_next(
+        payload.get("predicted_next") or payload.get("predictedNext")
+    )
+    transition_shock = bool(payload.get("transition_shock") or payload.get("transitionShock"))
+    duration_ms = _coerce_int(payload.get("duration_ms") or payload.get("durationMs"))
+    artifact = _coerce_artifact(payload.get("artifact"))
+    guardrail = _coerce_guardrail(
+        payload.get("guardrail"),
+        fallback_to_defensive=_coerce_bool(
+            payload.get("fallback_to_defensive") or payload.get("fallbackToDefensive")
+        ),
+    )
+
+    return HMMRegimeContext(
+        schema_version=schema_version,
+        regime_id=regime_id,
+        posterior=posterior,
+        entropy=entropy,
+        entropy_band=entropy_band,
+        predicted_next=predicted_next,
+        transition_shock=transition_shock,
+        duration_ms=duration_ms,
+        artifact=artifact,
+        guardrail=guardrail,
+    )
+
+
+def _coerce_string(raw: Any) -> str:
+    if raw is None:
+        return ""
+    text = str(raw).strip()
+    return text
+
+
+def _normalize_regime_id(raw: Any) -> str:
+    text = _coerce_string(raw)
+    if not text:
+        return HMM_UNKNOWN_REGIME_ID
+    return text
+
+
+def _coerce_posterior(raw: Any) -> dict[str, str]:
+    if not isinstance(raw, Mapping):
+        return {}
+
+    payload = cast(Mapping[str, Any], raw)
+    posterior: dict[str, str] = {}
+    for key, value in payload.items():
+        key_value = _coerce_string(key)
+        if not _REGIME_ID_RE.match(key_value):
+            continue
+        if not key_value:
+            continue
+        posterior[key_value] = _coerce_decimal_str(value)
+    return posterior
+
+
+def _coerce_decimal_str(raw: Any) -> str:
+    if raw is None:
+        return HMM_DEFAULT_ENTROPY
+    if isinstance(raw, Decimal):
+        return str(raw)
+    try:
+        decimal_value = Decimal(str(raw))
+    except (ArithmeticError, ValueError, TypeError):
+        return HMM_DEFAULT_ENTROPY
+    return str(decimal_value)
+
+
+def _coerce_entropy_band(raw: Any, entropy: str) -> str:
+    band = _coerce_string(raw).lower()
+    if band in HMM_ENTROPY_BANDS:
+        return band
+
+    entropy_value = _coerce_entropy_value(entropy)
+    if entropy_value <= HMM_ENTROPY_MEDIUM_THRESHOLD:
+        return "low"
+    if entropy_value <= HMM_ENTROPY_HIGH_THRESHOLD:
+        return "medium"
+    return "high"
+
+
+def _coerce_entropy_value(raw: str) -> Decimal:
+    try:
+        return Decimal(raw)
+    except (ValueError, ArithmeticError):
+        return Decimal("0")
+
+
+def _normalize_predicted_next(raw: Any) -> str:
+    text = _coerce_string(raw)
+    if not text:
+        return HMM_UNKNOWN_REGIME_ID
+    return text
+
+
+def _coerce_int(raw: Any) -> int:
+    if raw is None:
+        return 0
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_bool(raw: Any) -> bool:
+    if isinstance(raw, bool):
+        return raw
+    if raw is None:
+        return False
+    if isinstance(raw, (int, float)):
+        return raw != 0
+    text = str(raw).strip().lower()
+    return text in {"1", "true", "yes", "on"}
+
+
+def _coerce_artifact(raw: Any) -> HMMArtifact:
+    if isinstance(raw, Mapping):
+        artifact_map = cast(Mapping[str, Any], raw)
+        model_id = _coerce_string(
+            artifact_map.get("model_id")
+            or artifact_map.get("modelId")
+            or artifact_map.get("artifact_model_id")
+            or artifact_map.get("artifactModelId")
+            or HMM_UNKNOWN_REGIME_ID
+        )
+        feature_schema = _coerce_string(
+            artifact_map.get("feature_schema")
+            or artifact_map.get("featureSchema")
+            or artifact_map.get("artifact_feature_schema")
+            or artifact_map.get("featureSchemaVersion")
+            or HMM_UNKNOWN_REGIME_ID
+        )
+        training_run_id = _coerce_string(
+            artifact_map.get("training_run_id")
+            or artifact_map.get("trainingRunId")
+            or HMM_UNKNOWN_REGIME_ID
+        )
+    else:
+        model_id = HMM_UNKNOWN_REGIME_ID
+        feature_schema = HMM_UNKNOWN_REGIME_ID
+        training_run_id = HMM_UNKNOWN_REGIME_ID
+    return HMMArtifact(
+        model_id=model_id,
+        feature_schema=feature_schema,
+        training_run_id=training_run_id,
+    )
+
+
+def _coerce_guardrail(raw: Any, *, fallback_to_defensive: bool = False) -> HMMGuardrail:
+    if isinstance(raw, Mapping):
+        guardrail_map = cast(Mapping[str, Any], raw)
+        stale = _coerce_bool(
+            guardrail_map.get("stale")
+            or guardrail_map.get("isStale")
+            or guardrail_map.get("is_stale")
+        )
+        if not fallback_to_defensive:
+            fallback_to_defensive = _coerce_bool(
+                guardrail_map.get("fallback_to_defensive")
+                or guardrail_map.get("fallbackToDefensive")
+            )
+        reason = _coerce_string(
+            guardrail_map.get("reason")
+        )
+    else:
+        stale = False
+        reason = ""
+    if fallback_to_defensive and not reason:
+        reason = "fallback_to_defensive"
+    return HMMGuardrail(
+        stale=stale,
+        fallback_to_defensive=fallback_to_defensive,
+        reason=reason or None,
+    )
+
+
+__all__ = [
+    "HMMArtifact",
+    "HMMGuardrail",
+    "HMMRegimeContext",
+    "HMMRegimeContext",
+    "HMM_CONTEXT_SCHEMA_VERSION",
+    "HMM_UNKNOWN_REGIME_ID",
+    "HMM_UNKNOWN_SCHEMA_VERSION",
+    "resolve_hmm_context",
+    "resolve_legacy_regime_label",
+    "resolve_regime_route_label",
+]

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -3267,9 +3267,12 @@ def _resolve_signal_regime(signal: SignalEnvelope) -> Optional[str]:
     resolved = resolve_regime_route_label(
         payload_map, macd=macd, macd_signal=macd_signal
     )
-    if resolved == "unknown":
-        return None
-    return resolved
+    if resolved != "unknown":
+        return resolved
+    regime_label = resolve_legacy_regime_label(payload_map)
+    if regime_label is not None:
+        return regime_label
+    return None
 
 
 def _resolve_decision_regime_label_with_source(
@@ -3297,14 +3300,11 @@ def _resolve_decision_regime_label_with_source(
         return None, "none", "hmm_unknown"
 
     direct = params.get("regime_label")
-    legacy_label = direct if isinstance(direct, str) else None
-    if legacy_label is None:
-        legacy_label = resolve_legacy_regime_label(params)
-    regime_label = (
-        legacy_label.strip().lower()
-        if isinstance(legacy_label, str) and legacy_label.strip()
-        else None
-    )
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip().lower(), "legacy", None
+
+    legacy_label = resolve_legacy_regime_label(params)
+    regime_label = legacy_label if legacy_label is not None else None
     return regime_label, "legacy", None if regime_label is not None else "missing"
 
 

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -55,6 +55,11 @@ from .order_feed import OrderFeedIngestor
 from .reconcile import Reconciler
 from .risk import RiskEngine
 from .tca import AdaptiveExecutionPolicyDecision, derive_adaptive_execution_policy
+from .regime_hmm import (
+    resolve_hmm_context,
+    resolve_legacy_regime_label,
+    resolve_regime_route_label,
+)
 from .autonomy import (
     DriftThresholds,
     DriftTriggerPolicy,
@@ -447,6 +452,12 @@ class TradingMetrics:
     allocator_regime_total: dict[str, int] = field(
         default_factory=lambda: cast(dict[str, int], {})
     )
+    decision_regime_resolution_source_total: dict[str, int] = field(
+        default_factory=lambda: cast(dict[str, int], {})
+    )
+    decision_regime_resolution_fallback_total: dict[str, int] = field(
+        default_factory=lambda: cast(dict[str, int], {})
+    )
     allocator_fragility_state_total: dict[str, int] = field(
         default_factory=lambda: cast(dict[str, int], {})
     )
@@ -785,6 +796,20 @@ class TradingMetrics:
         if calibration_error is not None:
             key = f"{family}|{symbol}|{horizon}"
             self.forecast_calibration_error[key] = str(calibration_error)
+
+    def record_decision_regime_resolution(
+        self, *, source: str, fallback_reason: str | None
+    ) -> None:
+        normalized_source = source.strip() or "unknown"
+        self.decision_regime_resolution_source_total[normalized_source] = (
+            self.decision_regime_resolution_source_total.get(normalized_source, 0) + 1
+        )
+        if fallback_reason is None:
+            return
+        normalized_reason = fallback_reason.strip() or "unknown"
+        self.decision_regime_resolution_fallback_total[normalized_reason] = (
+            self.decision_regime_resolution_fallback_total.get(normalized_reason, 0) + 1
+        )
 
     def record_adaptive_policy_result(
         self,
@@ -1790,10 +1815,17 @@ class TradingPipeline:
         positions: list[dict[str, Any]],
         snapshot: Optional[MarketSnapshot],
     ) -> tuple[StrategyDecision, Any] | None:
+        regime_label, regime_source, regime_fallback = _resolve_decision_regime_label_with_source(
+            decision
+        )
+        self.state.metrics.record_decision_regime_resolution(
+            source=regime_source,
+            fallback_reason=regime_fallback,
+        )
         adaptive_policy = derive_adaptive_execution_policy(
             session,
             symbol=decision.symbol,
-            regime_label=_resolve_decision_regime_label(decision),
+            regime_label=regime_label,
         )
         policy_outcome = self.execution_policy.evaluate(
             decision,
@@ -3224,36 +3256,72 @@ def _load_recent_decisions(
 def _resolve_signal_regime(signal: SignalEnvelope) -> Optional[str]:
     payload = signal.payload
     payload_map = cast(Mapping[str, Any], payload)
-    direct = payload_map.get("regime_label")
-    if isinstance(direct, str) and direct.strip():
-        return direct.strip().lower()
-    regime = payload_map.get("regime")
-    if isinstance(regime, Mapping):
-        regime_map = cast(Mapping[str, Any], regime)
-        label = regime_map.get("label")
-        if isinstance(label, str) and label.strip():
-            return label.strip().lower()
-    return None
+    macd = _optional_decimal(payload_map.get("macd"))
+    if macd is None and isinstance(payload_map.get("macd"), Mapping):
+        macd_block = cast(Mapping[str, Any], payload_map.get("macd"))
+        macd = _optional_decimal(macd_block.get("macd"))
+    macd_signal = _optional_decimal(payload_map.get("macd_signal"))
+    if macd_signal is None and isinstance(payload_map.get("macd"), Mapping):
+        macd_block = cast(Mapping[str, Any], payload_map.get("macd"))
+        macd_signal = _optional_decimal(macd_block.get("signal"))
+    resolved = resolve_regime_route_label(
+        payload_map, macd=macd, macd_signal=macd_signal
+    )
+    if resolved == "unknown":
+        return None
+    return resolved
 
 
-def _resolve_decision_regime_label(decision: StrategyDecision) -> Optional[str]:
-    params = decision.params
+def _resolve_decision_regime_label_with_source(
+    decision: StrategyDecision,
+) -> tuple[Optional[str], str, str | None]:
+    params = cast(Mapping[str, Any], decision.params)
     allocator = params.get("allocator")
     if isinstance(allocator, Mapping):
         allocator_map = cast(Mapping[str, Any], allocator)
         allocator_regime = allocator_map.get("regime_label")
         if isinstance(allocator_regime, str) and allocator_regime.strip():
-            return allocator_regime.strip().lower()
+            return allocator_regime.strip().lower(), "allocator", None
+
+    raw_regime_hmm = params.get("regime_hmm")
+    if isinstance(raw_regime_hmm, Mapping):
+        regime_id = _resolve_regime_hmm_id(cast(Mapping[str, Any], raw_regime_hmm))
+        if regime_id is not None and regime_id.lower() != "unknown":
+            return regime_id.lower(), "hmm", None
+        regime_context = resolve_hmm_context(cast(Mapping[str, Any], raw_regime_hmm))
+        if regime_context.has_regime:
+            return regime_context.regime_id.lower(), "hmm", None
+        regime_label = resolve_legacy_regime_label(params)
+        if regime_label is not None:
+            return regime_label, "legacy", "hmm_unknown"
+        return None, "none", "hmm_unknown"
+
     direct = params.get("regime_label")
-    if isinstance(direct, str) and direct.strip():
-        return direct.strip().lower()
-    regime = params.get("regime")
-    if isinstance(regime, Mapping):
-        regime_map = cast(Mapping[str, Any], regime)
-        label = regime_map.get("label")
-        if isinstance(label, str) and label.strip():
-            return label.strip().lower()
-    return None
+    legacy_label = direct if isinstance(direct, str) else None
+    if legacy_label is None:
+        legacy_label = resolve_legacy_regime_label(params)
+    regime_label = (
+        legacy_label.strip().lower()
+        if isinstance(legacy_label, str) and legacy_label.strip()
+        else None
+    )
+    return regime_label, "legacy", None if regime_label is not None else "missing"
+
+
+def _resolve_decision_regime_label(decision: StrategyDecision) -> Optional[str]:  # pyright: ignore[reportUnusedFunction]
+    # kept for backwards compatibility with existing tests and callers
+    regime_label, _, _ = _resolve_decision_regime_label_with_source(decision)
+    return regime_label
+
+
+def _resolve_regime_hmm_id(raw_regime_hmm: Mapping[str, Any]) -> str | None:
+    raw_value = raw_regime_hmm.get("regime_id") or raw_regime_hmm.get("regimeId")
+    if not isinstance(raw_value, str):
+        return None
+    text = raw_value.strip()
+    if not text:
+        return None
+    return text
 
 
 def _allocator_rejection_reasons(decision: StrategyDecision) -> list[str]:

--- a/services/torghut/tests/test_metrics.py
+++ b/services/torghut/tests/test_metrics.py
@@ -489,3 +489,24 @@ class TestTradingMetrics(TestCase):
             'torghut_trading_recalibration_runs_total{status="queued"} 1',
             payload,
         )
+
+    def test_regime_resolution_metrics_are_exported(self) -> None:
+        metrics = TradingMetrics()
+        metrics.decision_regime_resolution_source_total["allocator"] = 3
+        metrics.decision_regime_resolution_source_total["hmm"] = 1
+        metrics.decision_regime_resolution_fallback_total["hmm_unknown"] = 2
+
+        payload = render_trading_metrics(metrics.__dict__)
+
+        self.assertIn(
+            'torghut_trading_decision_regime_resolution_source_total{source="allocator"} 3',
+            payload,
+        )
+        self.assertIn(
+            'torghut_trading_decision_regime_resolution_source_total{source="hmm"} 1',
+            payload,
+        )
+        self.assertIn(
+            'torghut_trading_decision_regime_resolution_fallback_total{reason="hmm_unknown"} 2',
+            payload,
+        )

--- a/services/torghut/tests/test_scheduler_regime_resolution.py
+++ b/services/torghut/tests/test_scheduler_regime_resolution.py
@@ -5,7 +5,10 @@ from decimal import Decimal
 from unittest import TestCase
 
 from app.trading.models import StrategyDecision
-from app.trading.scheduler import _resolve_decision_regime_label
+from app.trading.scheduler import (
+    _resolve_decision_regime_label,
+    _resolve_decision_regime_label_with_source,
+)
 
 
 class TestSchedulerRegimeResolution(TestCase):
@@ -41,3 +44,50 @@ class TestSchedulerRegimeResolution(TestCase):
         regime_label = _resolve_decision_regime_label(decision)
 
         self.assertEqual(regime_label, 'vol=mid|trend=up|liq=liquid')
+
+    def test_regime_resolution_prefers_hmm_when_allocator_missing(self) -> None:
+        decision = StrategyDecision(
+            strategy_id='strategy-1',
+            symbol='AAPL',
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            timeframe='1Min',
+            action='buy',
+            qty=Decimal('1'),
+            params={
+                'regime': {'label': 'Vol=Mid|Trend=Up|Liq=Liquid'},
+                'regime_hmm': {
+                    'regime_id': 'R2',
+                    'artifact': {'model_id': 'hmm-regime-v1.2.0'},
+                    'guardrail': {'reason': 'stable'},
+                },
+            },
+        )
+
+        source_regime_label = _resolve_decision_regime_label_with_source(decision)
+
+        self.assertEqual(source_regime_label, ('r2', 'hmm', None))
+
+    def test_regime_resolution_falls_back_to_legacy_when_hmm_unknown(self) -> None:
+        decision = StrategyDecision(
+            strategy_id='strategy-1',
+            symbol='AAPL',
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            timeframe='1Min',
+            action='buy',
+            qty=Decimal('1'),
+            params={
+                'regime_label': 'Vol=Mid|Trend=Up|Liq=Liquid',
+                'regime_hmm': {
+                    'regime_id': 'unknown',
+                    'artifact': {'model_id': 'hmm-regime-v1.2.0'},
+                    'guardrail': {'reason': 'stable'},
+                },
+            },
+        )
+
+        source_regime_label = _resolve_decision_regime_label_with_source(decision)
+
+        self.assertEqual(
+            source_regime_label,
+            ('vol=mid|trend=up|liq=liquid', 'legacy', 'hmm_unknown'),
+        )

--- a/services/torghut/tests/test_scheduler_regime_resolution.py
+++ b/services/torghut/tests/test_scheduler_regime_resolution.py
@@ -4,10 +4,11 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from unittest import TestCase
 
-from app.trading.models import StrategyDecision
+from app.trading.models import SignalEnvelope, StrategyDecision
 from app.trading.scheduler import (
     _resolve_decision_regime_label,
     _resolve_decision_regime_label_with_source,
+    _resolve_signal_regime,
 )
 
 
@@ -90,4 +91,36 @@ class TestSchedulerRegimeResolution(TestCase):
         self.assertEqual(
             source_regime_label,
             ('vol=mid|trend=up|liq=liquid', 'legacy', 'hmm_unknown'),
+        )
+
+    def test_signal_regime_resolution_falls_back_to_legacy_regime(self) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            symbol='AAPL',
+            payload={'regime': {'label': 'Vol=Mid|Trend=Up|Liq=Liquid'}},
+        )
+
+        regime_label = _resolve_signal_regime(signal)
+
+        self.assertEqual(regime_label, 'vol=mid|trend=up|liq=liquid')
+
+    def test_decision_regime_resolution_uses_legacy_when_blank_regime_label(self) -> None:
+        decision = StrategyDecision(
+            strategy_id='strategy-1',
+            symbol='AAPL',
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            timeframe='1Min',
+            action='buy',
+            qty=Decimal('1'),
+            params={
+                'regime_label': '   ',
+                'regime': {'label': 'Vol=Mid|Trend=Up|Liq=Liquid'},
+            },
+        )
+
+        source_regime_label = _resolve_decision_regime_label_with_source(decision)
+
+        self.assertEqual(
+            source_regime_label,
+            ('vol=mid|trend=up|liq=liquid', 'legacy', None),
         )


### PR DESCRIPTION
## Summary

- Implemented HMM-aware regime resolution and routing for Torghut trading decisions, including precedence logic for allocator-provided, HMM-derived, and legacy regime labels.
- Added compact `regime_hmm` context propagation into LLM review request payloads and strict schema validation for entropy band and HMM metadata.
- Introduced forecasting route-key normalization for HMM regime IDs and HMM-aware metrics/decision tracing hooks for observability.
- Added/updated tests covering scheduler resolution source precedence, forecasting preference behavior, LLM request schema behavior, and metrics/decision updates.

## Related Issues

None

## Testing

- `python -m pytest -q tests/test_scheduler_regime_resolution.py tests/test_llm_review_engine.py tests/test_decisions.py tests/test_metrics.py tests/test_forecasting.py tests/test_llm_schema.py`
- `uv run --with pytest python -m pytest -q` (services/torghut)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app/trading tests`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
- [x] No screenshot section is needed for this backend-only change.
