### PR TITLE
docs(runbooks): fix mermaid syntax in mimir discord design

### DIFF
--- a/docs/runbooks/mimir-discord-alerting.md
+++ b/docs/runbooks/mimir-discord-alerting.md
@@ -57,12 +57,12 @@ This design is intentionally **generic to Mimir** and is not coupled to any spec
 
 ```mermaid
 flowchart LR
-  A[PrometheusRule resources in observability app] -->|rule labels| B[Mimir Ruler]
-  B -->|alerts| C[Mimir Alertmanager StatefulSet]
-  C -->|route/group/group intervals| D[alertmanager.fallbackConfig]
-  D -->|HTTP POST| E[Discord relay (internal namespace service)]
-  E -->|validated payload| F[Discord incoming webhook endpoint]
-  C -->|no match / disabled route| G[default-receiver/no-op]
+  A["PrometheusRule resources in observability app"] -->|rule labels| B["Mimir Ruler"]
+  B -->|alerts| C["Mimir Alertmanager StatefulSet"]
+  C -->|route/group/group intervals| D["alertmanager.fallbackConfig"]
+  D -->|HTTP POST| E["Discord relay (internal namespace service)"]
+  E -->|validated payload| F["Discord incoming webhook endpoint"]
+  C -->|no match / disabled route| G["default-receiver/no-op"]
 ```
 
 ## Target alert model


### PR DESCRIPTION
## Summary

- Fix Mermaid rendering in `docs/runbooks/mimir-discord-alerting.md` by switching flowchart node labels to quoted strings to satisfy GitHub Mermaid parser.

## Related Issues

None

## Testing

- N/A

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [ ] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.
