### PR TITLE
chore(torghut): promote image d78f4092

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:11cf4759d5dfe89aa2f355c0800a9b1a376df19c77216cc756ee955d23b23807
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7c1b90e721a2b708ded82a77d2ce9c118d396ee93949b4d3387e1f34ce9fae2
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-28T08:58:58Z"
+        client.knative.dev/updateTimestamp: "2026-02-28T09:29:06Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:11cf4759d5dfe89aa2f355c0800a9b1a376df19c77216cc756ee955d23b23807
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7c1b90e721a2b708ded82a77d2ce9c118d396ee93949b4d3387e1f34ce9fae2
           ports:
             - name: http1
               containerPort: 8181
@@ -372,9 +372,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-137-gf6fd9a77
+              value: v0.561.0-139-gd78f4092
             - name: TORGHUT_COMMIT
-              value: f6fd9a7727843f1a4d4a1d7c77301db53ca2ea1b
+              value: d78f4092b0c2c9e76900ecd48d8a704fc5b38466
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `d78f4092b0c2c9e76900ecd48d8a704fc5b38466`
- Image tag: `d78f4092`
- Image digest: `sha256:e7c1b90e721a2b708ded82a77d2ce9c118d396ee93949b4d3387e1f34ce9fae2`