### PR TITLE
fix(kafka): set node pool storage to 20Gi

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -40,7 +40,7 @@ spec:
     - broker
   storage:
     type: persistent-claim
-    size: 8Gi
+    size: 20Gi
     deleteClaim: false
     class: rook-ceph-block
 ---


### PR DESCRIPTION
## Summary

- Change the Strimzi KafkaNodePool storage size in `argocd/applications/kafka/strimzi-kafka-cluster.yaml` from `8Gi` to `20Gi`.
- Align desired PVC size with the existing mounted brokers (`data-kafka-pool-a-*`), avoiding reconcile attempts to shrink PVCs below current capacity.
- This addresses the Kafka `NotReady`/`argocd` degradation path caused by Strimzi trying to resize `data-kafka-pool-a-*` from `20Gi` to `8Gi`.

## Related Issues

N/A

## Testing

- N/A (manifest-only change; behavior is validated through Argo CD sync + Kafka operator reconciliation after merge).

## Breaking Changes

None.
