### PR TITLE
fix(kafka): increase node pool storage to 30Gi

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -40,7 +40,7 @@ spec:
     - broker
   storage:
     type: persistent-claim
-    size: 20Gi
+    size: 30Gi
     deleteClaim: false
     class: rook-ceph-block
 ---


### PR DESCRIPTION
## Summary

- Increase Kafka node pool storage size in `argocd/applications/kafka/strimzi-kafka-cluster.yaml` from `20Gi` to `30Gi`.
- Align storage intent with expected growth and avoid future PVC shrink reconciliation failures.
- This change is a follow-up to the prior 20Gi rollback fix after the PVC size drift incident.

## Related Issues

N/A

## Testing

- N/A (manifest-only change). Validation will be completed after Argo CD sync via Kafka operator PVC expansion reconciliation.

## Breaking Changes

None.
