### PR TITLE
fix( torghut): harden historical simulation workflow and container config

### DIFF
--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -26,10 +26,6 @@ spec:
         value: 'false'
       - name: outputRoot
         value: /tmp/torghut-simulations
-      - name: gitRepo
-        value: https://github.com/proompteng/lab.git
-      - name: gitRef
-        value: main
   templates:
     - name: run
       inputs:
@@ -42,10 +38,8 @@ spec:
           - name: forceDump
           - name: allowMissingState
           - name: outputRoot
-          - name: gitRepo
-          - name: gitRef
       container:
-        image: python:3.11-slim
+        image: registry.ide-newton.ts.net/lab/torghut:latest
         command:
           - /bin/bash
           - -lc
@@ -60,43 +54,12 @@ spec:
           - |
             set -euo pipefail
 
-            WORK_ROOT=/workspace/lab
             WORKFLOW_DIR=/tmp/torghut-historical-simulation
             MANIFEST_PATH="${WORKFLOW_DIR}/dataset-manifest.yaml"
             OUTPUT_ROOT="{{inputs.parameters.outputRoot}}"
             export MANIFEST_PATH OUTPUT_ROOT
 
-            if command -v apt-get >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y --no-install-recommends git curl ca-certificates
-              rm -rf /var/lib/apt/lists/*
-            fi
-
-            pip install --no-cache-dir --upgrade pip
-            pip install --no-cache-dir kafka-python "psycopg[binary]" pyyaml alembic uv
-
-            if [ ! -f /usr/local/bin/kubectl ]; then
-              K8S_STABLE="$(curl -fsSL https://dl.k8s.io/release/stable.txt | tr -d '[:space:]')"
-              if [ -z "$K8S_STABLE" ]; then
-                K8S_STABLE="v1.30.0"
-              fi
-              curl -fsSL "https://dl.k8s.io/release/${K8S_STABLE}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
-              chmod +x /usr/local/bin/kubectl
-            fi
-
-            if ! command -v git >/dev/null 2>&1; then
-              echo "git is required to fetch services/torghut/scripts/start_historical_simulation.py" >&2
-              exit 1
-            fi
-
             mkdir -p "${WORKFLOW_DIR}"
-            if [ -d "${WORK_ROOT}/.git" ]; then
-              git -C "${WORK_ROOT}" fetch --depth 1 origin "{{inputs.parameters.gitRef}}"
-              git -C "${WORK_ROOT}" reset --hard "origin/{{inputs.parameters.gitRef}}"
-            else
-              rm -rf "${WORK_ROOT}"
-              git clone --depth 1 --branch "{{inputs.parameters.gitRef}}" "{{inputs.parameters.gitRepo}}" "${WORK_ROOT}"
-            fi
 
             if [ -z "{{inputs.parameters.datasetManifestB64}}" ]; then
               echo "datasetManifestB64 must be supplied" >&2
@@ -126,7 +89,6 @@ spec:
                 yaml.safe_dump(payload, handle, default_flow_style=False, sort_keys=False)
             PY
 
-            chmod +x "${WORK_ROOT}/services/torghut/scripts/start_historical_simulation.py"
             RUN_ID='{{inputs.parameters.runId}}'
             MODE='{{inputs.parameters.mode}}'
             if [ -z "$RUN_ID" ]; then
@@ -134,7 +96,7 @@ spec:
             fi
 
             case "$MODE" in
-              plan|apply|teardown) ;;
+              plan|apply|run|report|teardown) ;;
               *)
                 echo "invalid mode: $MODE" >&2
                 exit 1
@@ -142,7 +104,7 @@ spec:
             esac
 
             SCRIPT_ARGS=(--mode "$MODE" --run-id "$RUN_ID" --dataset-manifest "$MANIFEST_PATH" --json)
-            if [ "$MODE" = "apply" ]; then
+            if [ "$MODE" = "apply" ] || [ "$MODE" = "run" ]; then
               SCRIPT_ARGS+=(--confirm '{{inputs.parameters.confirmPhrase}}')
             fi
             if [ '{{inputs.parameters.forceReplay}}' = 'true' ]; then
@@ -156,7 +118,7 @@ spec:
             fi
 
             mkdir -p "$OUTPUT_ROOT"
-            python3 "${WORK_ROOT}/services/torghut/scripts/start_historical_simulation.py" "${SCRIPT_ARGS[@]}"
+            python3 /app/scripts/start_historical_simulation.py "${SCRIPT_ARGS[@]}"
       outputs:
         artifacts:
           - name: simulation-output

--- a/services/torghut/Dockerfile
+++ b/services/torghut/Dockerfile
@@ -34,15 +34,22 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PATH="/opt/venv/bin:${PATH}"
 
 WORKDIR /app
+ARG KUBECTL_VERSION=v1.30.0
 
 RUN apt-get update \
- && apt-get install --no-install-recommends -y libpq5 \
+ && apt-get install --no-install-recommends -y \
+      ca-certificates \
+      curl \
+      libpq5 \
+ && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+ && chmod +x /usr/local/bin/kubectl \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/venv /opt/venv
 COPY alembic.ini ./
 COPY app ./app
 COPY migrations ./migrations
+COPY scripts ./scripts
 COPY README.md .
 
 RUN groupadd --system torghut && useradd --system --create-home --gid torghut torghut

--- a/services/torghut/config/simulation/example-dataset.yaml
+++ b/services/torghut/config/simulation/example-dataset.yaml
@@ -26,7 +26,9 @@ kafka:
 clickhouse:
   http_url: http://torghut-clickhouse.torghut.svc.cluster.local:8123
   username: torghut
-  password: ''
+  password_secret_name: torghut-clickhouse-auth
+  password_secret_key: torghut_password
+  secret_namespace: torghut
   simulation_database: torghut_sim_sim_2026_02_27_01
 
 postgres:
@@ -47,6 +49,8 @@ replay:
   acceleration: 60
   max_sleep_seconds: 5
   auto_offset_reset: earliest
+  status_update_every_records: 25000
+  status_update_every_seconds: 30
 
 monitor:
   timeout_seconds: 1200


### PR DESCRIPTION
## Summary

- Add cluster-safe Torghut historical simulation runtime to the Python image by installing kubectl in `services/torghut/Dockerfile`, and include `scripts/` so `start_historical_simulation.py` runs directly from the workflow image.
- Update `argocd/applications/torghut/historical-simulation-workflowtemplate.yaml` to use the Torghut image directly (no in-container apt/pip/git/bootstrap), remove repo fetch parameters, support `run`/`report` mode dispatch, and execute the bundled `/app/scripts/start_historical_simulation.py`.
- Make `services/torghut/config/simulation/example-dataset.yaml` production-safe by switching clickhouse credentials to Kubernetes secret references and adding replay heartbeat controls.
- Persist earlier script-level fixes already merged in this cycle, including clickhouse secret resolution for password/username and heartbeat updates during dump/replay/monitor phases.

## Related Issues

None

## Testing

- `argo terminate -n argo-workflows ...` and related workflow checks performed to confirm running jobs were stopped (operational verification).
- No full integration test run for the updated workflow/image path was executed in this request.

## Breaking Changes

None
