### PR TITLE
feat(huly): harden cockroach tls

### DIFF
--- a/argocd/applications/huly/account/account-deployment.yaml
+++ b/argocd/applications/huly/account/account-deployment.yaml
@@ -37,11 +37,13 @@ spec:
                   key: STORAGE_CONFIG
             - name: MODEL_ENABLED
               value: '*'
-            - name: DB_URL
+            - name: COCKROACH_DB_URL
               valueFrom:
                 secretKeyRef:
                   name: huly-secret
                   key: CR_DB_URL
+            - name: DB_URL
+              value: "$(COCKROACH_DB_URL)?sslmode=require"
             - name: MONGO_URL
               valueFrom:
                 configMapKeyRef:

--- a/argocd/applications/huly/cockroach/cockroach-deployment.yaml
+++ b/argocd/applications/huly/cockroach/cockroach-deployment.yaml
@@ -12,19 +12,52 @@
           labels:
             app: cockroach
         spec:
-          # initContainers:
-          # - name: init-certs-dir
-          #   image: busybox
-          #   command: ['sh', '-c', 'mkdir -p /cockroach/cockroach-certs && chmod -R 700 /cockroach']
-          #   volumeMounts:
-          #   - name: certs
-          #     mountPath: /cockroach/certs
+          initContainers:
+            - name: init-certs
+              image: cockroachdb/cockroach:latest-v24.2
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  mkdir -p /cockroach/certs
+                  if [ ! -f /cockroach/certs/ca.crt ] || \
+                     [ ! -f /cockroach/certs/node.crt ] || \
+                     [ ! -f /cockroach/certs/node.key ] || \
+                     [ ! -f /cockroach/certs/root.key ] || \
+                     [ ! -f /cockroach/certs/root.crt ]; then
+                    cockroach cert create-ca \
+                      --certs-dir=/cockroach/certs \
+                      --ca-key=/cockroach/certs/ca.key
+                    cockroach cert create-node \
+                      --certs-dir=/cockroach/certs \
+                      --ca-key=/cockroach/certs/ca.key \
+                      --overwrite \
+                      cockroach \
+                      cockroach.huly \
+                      cockroach.huly.svc \
+                      cockroach.huly.svc.cluster.local \
+                      localhost \
+                      127.0.0.1 \
+                      $(hostname -i)
+                    cockroach cert create-client \
+                      --certs-dir=/cockroach/certs \
+                      --ca-key=/cockroach/certs/ca.key \
+                      --overwrite \
+                      root
+                  fi
+                  chmod -R 700 /cockroach/certs
+              volumeMounts:
+                - name: cockroachdb-certs
+                  mountPath: /cockroach/certs
           containers:
           - name: cockroachdb
             image: cockroachdb/cockroach:latest-v24.2
             args:
               - start-single-node
-              - --accept-sql-without-tls
+              - --certs-dir=/cockroach/certs
+              - --listen-addr=0.0.0.0:26257
+              - --http-addr=0.0.0.0:8080
             env:
               - name: COCKROACH_DATABASE
                 value: "defaultdb"

--- a/argocd/applications/huly/fulltext/fulltext-deployment.yaml
+++ b/argocd/applications/huly/fulltext/fulltext-deployment.yaml
@@ -21,11 +21,13 @@ spec:
                 secretKeyRef:
                   name: huly-secret
                   key: SERVER_SECRET
-            - name: DB_URL
+            - name: COCKROACH_DB_URL
               valueFrom:
                 secretKeyRef:
                   name: huly-secret
                   key: CR_DB_URL
+            - name: DB_URL
+              value: "$(COCKROACH_DB_URL)?sslmode=require"
             - name: FULLTEXT_DB_URL
               valueFrom:
                 configMapKeyRef:
@@ -53,7 +55,6 @@ spec:
           name: fulltext
           ports:
             - containerPort: 4700
-              hostPort: 4700
               protocol: TCP
           resources:
             limits:

--- a/argocd/applications/huly/transactor/transactor-deployment.yaml
+++ b/argocd/applications/huly/transactor/transactor-deployment.yaml
@@ -37,11 +37,13 @@ spec:
                 configMapKeyRef:
                   name: huly-config
                   key: MONGO_URL
-            - name: DB_URL
+            - name: COCKROACH_DB_URL
               valueFrom:
                 secretKeyRef:
                   name: huly-secret
                   key: CR_DB_URL
+            - name: DB_URL
+              value: "$(COCKROACH_DB_URL)?sslmode=require"
             - name: SERVER_CURSOR_MAXTIMEMS
               value: "30000"
             - name: SERVER_PORT
@@ -57,6 +59,5 @@ spec:
           name: transactor
           ports:
             - containerPort: 3333
-              hostPort: 3333
               protocol: TCP
       restartPolicy: Always

--- a/argocd/applications/huly/workspace/workspace-deployment.yaml
+++ b/argocd/applications/huly/workspace/workspace-deployment.yaml
@@ -32,11 +32,15 @@ spec:
                   key: STORAGE_CONFIG
             - name: MODEL_ENABLED
               value: '*'
-            - name: DB_URL
+            - name: COCKROACH_DB_URL
               valueFrom:
                 secretKeyRef:
                   name: huly-secret
                   key: CR_DB_URL
+            - name: ACCOUNTS_DB_URL
+              value: "$(COCKROACH_DB_URL)?sslmode=require"
+            - name: DB_URL
+              value: "$(COCKROACH_DB_URL)?sslmode=require"
             - name: MONGO_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Summary

- Remove CockroachDB insecure mode by introducing certificate-based startup arguments.
- Add an init container to generate and persist cluster certificates in the existing certs PVC.
- Ensure Huly services build DB URLs with `sslmode=require` via env var composition.
- Keep Cockroach database secret usage unchanged while switching clients to TLS-aware connection strings.

## Related Issues

None

## Testing

- N/A: not run (not requested).

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
