### PR TITLE
chore(argocd): bump cert-manager to 1.19.4

### DIFF
--- a/argocd/applications/cert-manager/kustomization.yaml
+++ b/argocd/applications/cert-manager/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 helmCharts:
   - name: cert-manager
     repo: https://charts.jetstack.io
-    version: 1.17.2
+    version: 1.19.4
     releaseName: cert-manager
     namespace: cert-manager
     includeCRDs: true


### PR DESCRIPTION
## Summary
- Bump the Argo CD cert-manager chart version from 1.17.2 to 1.19.4.
- Keep all cert-manager values and related manifests unchanged.
- Ensure GitOps installs use the newer cert-manager release for better DNS-01 + Cloudflare behavior.

## Related Issues
None.

## Testing
- Manual verification pending: Argo CD will re-render and sync `cert-manager` from the updated chart version.

## Screenshots
N/A

## Breaking Changes
None.

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
