### PR TITLE
fix(cert-manager): disable startup apicheck for sync stability

### DIFF
--- a/argocd/applications/cert-manager/README.md
+++ b/argocd/applications/cert-manager/README.md
@@ -14,4 +14,15 @@
 global:
   leaderElection:
     namespace: cert-manager
+
+### Startup API Check Hook Duplication
+
+**Issue:** ArgoCD sync loops can happen when the cert-manager `startupapicheck` Helm hook attempts to re-create RBAC resources that already exist with Argo hook finalizers.
+
+**Fix:** Disable the startup API check hook in this environment:
+
+```yaml
+startupapicheck:
+  enabled: false
+```
 ```

--- a/argocd/applications/cert-manager/kustomization.yaml
+++ b/argocd/applications/cert-manager/kustomization.yaml
@@ -13,6 +13,8 @@ helmCharts:
     includeCRDs: true
     valuesInline:
       installCRDs: true
+      startupapicheck:
+        enabled: false
       crds:
         enabled: true
         keep: false


### PR DESCRIPTION
## Summary
- Disabled the cert-manager `startupapicheck` Helm hook in the ArgoCD app manifest (`argocd/applications/cert-manager/kustomization.yaml`) to prevent repeated PostSync RBAC collisions.
- Kept `startupapicheck` configuration explicit and colocated with existing chart values (`installCRDs`, `crds`, `global.leaderElection`) for future clarity.
- Added a short README note in `argocd/applications/cert-manager/README.md` documenting the startup API check hook conflict and the applied fix.

## Related Issues
N/A

## Testing
- `helm show values jetstack/cert-manager --version 1.19.4 | sed -n '1288,1465p'` (verified `startupapicheck.enabled` is a supported key).
- `helm template cert-manager jetstack/cert-manager --version 1.19.4 --set startupapicheck.enabled=false --namespace cert-manager | rg -n "startupapicheck|cert-manager-startupapicheck|create-cert"` (verified startup API check resources are not rendered when explicitly disabled).

## Breaking Changes
None.
