### PR TITLE
fix(huly): correct transactor websocket endpoint scheme

### DIFF
--- a/argocd/applications/huly/config/config.yaml
+++ b/argocd/applications/huly/config/config.yaml
@@ -8,7 +8,7 @@ data:
   FRONT_URL: 'https://huly.proompteng.ai'
   REKONI_URL: 'https://rekoni.huly.proompteng.ai/'
   STATS_URL: 'https://stats.huly.proompteng.ai/'
-  TRANSACTOR_URL: 'wss://transactor;wss://transactor.huly.proompteng.ai/'
+  TRANSACTOR_URL: 'ws://transactor;wss://transactor.huly.proompteng.ai/'
   MINIO_ENDPOINT: 'rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80'
   MONGO_URL: 'mongodb://mongodb:27017'
   ELASTIC_URL: 'http://elastic:9200'


### PR DESCRIPTION
## Summary
- Fix Huly `TRANSACTOR_URL` to preserve internal plaintext websocket traffic for service-to-service calls.
- Keep external/public websocket endpoint on TLS through the ingress domain.
- Align URL list format with Huly expected multi-target pattern (`internal;public`).

## Related Issues
None

## Testing
- N/A (config-only change; validation via ArgoCD rollout and in-cluster WS checks is pending).

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (or removed).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
