### PR TITLE
fix(torghut): use venv python in historical simulation workflow

### DIFF
--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -67,7 +67,7 @@ spec:
             fi
 
             printf '%s' "{{inputs.parameters.datasetManifestB64}}" | base64 -d > "${MANIFEST_PATH}"
-            python3 - <<'PY'
+            /opt/venv/bin/python - <<'PY'
             import os
             import yaml
 
@@ -118,7 +118,7 @@ spec:
             fi
 
             mkdir -p "$OUTPUT_ROOT"
-            python3 /app/scripts/start_historical_simulation.py "${SCRIPT_ARGS[@]}"
+            /opt/venv/bin/python /app/scripts/start_historical_simulation.py "${SCRIPT_ARGS[@]}"
       outputs:
         artifacts:
           - name: simulation-output


### PR DESCRIPTION
## Summary

- Update the Torghut historical simulation WorkflowTemplate to use the image virtualenv Python interpreter (`/opt/venv/bin/python`) for both manifest preprocessing and script execution.
- Resolve `ModuleNotFoundError: No module named 'yaml'` in Argo workflow pods by avoiding the system Python interpreter lacking dependencies.
- Ensure workflow output artifact staging continues to succeed with the corrected runtime environment.

## Related Issues

None

## Testing

- `argo submit --from workflowtemplate/torghut-historical-simulation -n argo-workflows --parameter runId="sim-clean-$(date -u +%Y%m%dT%H%M%SZ)" --parameter mode=plan --parameter datasetManifestB64="$(base64 < services/torghut/config/simulation/example-dataset.yaml | tr -d '\n')"`
- `argo get <workflow-name> -n argo-workflows` (verified `Status: Succeeded`)
- `argo logs <workflow-name> -n argo-workflows` (verified no `ModuleNotFoundError` and successful JSON output)

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
