### PR TITLE
fix(huly): use kafka brokers service for queue bootstrap

### DIFF
--- a/argocd/applications/huly/account/account-deployment.yaml
+++ b/argocd/applications/huly/account/account-deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   name: huly-config
                   key: TRANSACTOR_URL
             - name: QUEUE_CONFIG
-              value: kafka-kafka-bootstrap.kafka:9093
+              value: kafka-kafka-brokers.kafka.svc.cluster.local:9093
           image: hardcoreeng/account:v0.7.375
           name: account
           ports:

--- a/argocd/applications/huly/fulltext/fulltext-deployment.yaml
+++ b/argocd/applications/huly/fulltext/fulltext-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: STATS_URL
               value: http://stats
             - name: QUEUE_CONFIG
-              value: kafka-kafka-bootstrap.kafka:9093
+              value: kafka-kafka-brokers.kafka.svc.cluster.local:9093
           image: hardcoreeng/fulltext:v0.7.375
           name: fulltext
           ports:

--- a/argocd/applications/huly/transactor/transactor-deployment.yaml
+++ b/argocd/applications/huly/transactor/transactor-deployment.yaml
@@ -56,7 +56,7 @@ spec:
                   name: huly-secret
                   key: SERVER_SECRET
             - name: QUEUE_CONFIG
-              value: kafka-kafka-bootstrap.kafka:9093
+              value: kafka-kafka-brokers.kafka.svc.cluster.local:9093
           image: hardcoreeng/transactor:v0.7.375
           name: transactor
           ports:

--- a/argocd/applications/huly/workspace/workspace-deployment.yaml
+++ b/argocd/applications/huly/workspace/workspace-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                   name: huly-secret
                   key: SERVER_SECRET
             - name: QUEUE_CONFIG
-              value: kafka-kafka-bootstrap.kafka:9093
+              value: kafka-kafka-brokers.kafka.svc.cluster.local:9093
           image: hardcoreeng/workspace:v0.7.375
           name: workspace
           resources:


### PR DESCRIPTION
## Summary

- Update Huly queue bootstrap configuration for account, fulltext, transactor, and workspace services to use the Kafka brokers service hostname.
- Replace `kafka-kafka-bootstrap.kafka:9093` with `kafka-kafka-brokers.kafka.svc.cluster.local:9093` to avoid bootstrap-service resolution/connectivity issues.
- Preserve the same plaintext listener/port and avoid other Kafka/listener behavior changes.

## Related Issues

None

## Testing

- Not run in this step (GitOps validation is performed via ArgoCD sync in the deployment environment).

## Breaking Changes

None.
