### PR TITLE
chore(jangar): promote image c53e2c68

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 973770cd
-  digest: sha256:8b433c2973517cae64c891f7fc5c2359694188e5b24433d9c4128ae5443cd90c
+  tag: c53e2c68
+  digest: sha256:5b0a6f58dea92c6a40dbe3afd93d05004de34c351795a0bab6b3356e527707f8
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 973770cd
-    digest: sha256:572af335a98e06d047c20301f08ca4e2f265bdabdd1d0c476aeee0982103e201
+    tag: c53e2c68
+    digest: sha256:becd3535e2d3540bc056d09617afc9ac373008537aca136b0bd7d8b17760f2ed
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 973770cd
-    digest: sha256:8b433c2973517cae64c891f7fc5c2359694188e5b24433d9c4128ae5443cd90c
+    tag: c53e2c68
+    digest: sha256:5b0a6f58dea92c6a40dbe3afd93d05004de34c351795a0bab6b3356e527707f8
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-02-28T08:10:44Z"
+    deploy.knative.dev/rollout: "2026-03-01T05:47:49Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-28T08:10:44Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-01T05:47:49Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "973770cd"
-    digest: sha256:8b433c2973517cae64c891f7fc5c2359694188e5b24433d9c4128ae5443cd90c
+    newTag: "c53e2c68"
+    digest: sha256:5b0a6f58dea92c6a40dbe3afd93d05004de34c351795a0bab6b3356e527707f8


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c53e2c68567d9ee463bebee2e4780c7e377b800a`
- Image tag: `c53e2c68`
- Image digest: `sha256:5b0a6f58dea92c6a40dbe3afd93d05004de34c351795a0bab6b3356e527707f8`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`