### PR TITLE
feat(trading): enforce strict runtime uncertainty gate fail-closed

### DIFF
--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -972,6 +972,261 @@ class TestTradingPipeline(TestCase):
             self.assertEqual(gate.action, "fail")
             self.assertEqual(gate.source, "autonomy_gate_report")
 
+    def test_runtime_uncertainty_gate_resolves_invalid_action_to_abstain(self) -> None:
+        pipeline = TradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        decision = StrategyDecision(
+            strategy_id="strategy",
+            symbol="AAPL",
+            event_ts=datetime.now(timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            params={
+                "uncertainty_gate_action": "invalid",
+            },
+        )
+
+        gate = pipeline._resolve_runtime_uncertainty_gate(decision)
+
+        self.assertEqual(gate.action, "abstain")
+        self.assertEqual(gate.source, "decision_params_invalid_action")
+
+    def test_pipeline_runtime_uncertainty_invalid_action_report_abstains(self) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_kill_switch_enabled": config.settings.trading_kill_switch_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_kill_switch_enabled = False
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with self.session_local() as session:
+                    strategy = Strategy(
+                        name="demo",
+                        description="runtime-gate-invalid-action-report",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=["AAPL"],
+                        max_notional_per_trade=Decimal("1000"),
+                    )
+                    session.add(strategy)
+                    session.commit()
+
+                gate_path = Path(tmpdir) / "gate-report.json"
+                gate_path.write_text(
+                    '{"uncertainty_gate_action":"bogus"}',
+                    encoding="utf-8",
+                )
+                signal = SignalEnvelope(
+                    event_ts=datetime.now(timezone.utc),
+                    symbol="AAPL",
+                    payload={
+                        "macd": {"macd": 1.2, "signal": 0.5},
+                        "rsi14": 25,
+                        "price": 100,
+                    },
+                    timeframe="1Min",
+                )
+                state = TradingState(last_autonomy_gates=str(gate_path))
+                alpaca_client = FakeAlpacaClient()
+                pipeline = TradingPipeline(
+                    alpaca_client=alpaca_client,
+                    order_firewall=OrderFirewall(alpaca_client),
+                    ingestor=FakeIngestor([signal]),
+                    decision_engine=DecisionEngine(),
+                    risk_engine=RiskEngine(),
+                    executor=OrderExecutor(),
+                    execution_adapter=alpaca_client,
+                    reconciler=Reconciler(),
+                    universe_resolver=UniverseResolver(),
+                    state=state,
+                    account_label="paper",
+                    session_factory=self.session_local,
+                )
+
+                pipeline.run_once()
+
+                with self.session_local() as session:
+                    decisions = session.execute(select(TradeDecision)).scalars().all()
+                    self.assertEqual(len(decisions), 1)
+                    self.assertEqual(decisions[0].status, "rejected")
+                    decision_json = decisions[0].decision_json
+                    assert isinstance(decision_json, dict)
+                    self.assertIn(
+                        "runtime_uncertainty_gate_abstain_block_risk_increasing_entries",
+                        decision_json.get("risk_reasons", []),
+                    )
+                    params = decision_json.get("params")
+                    assert isinstance(params, dict)
+                    gate_payload = params.get("runtime_uncertainty_gate")
+                    assert isinstance(gate_payload, dict)
+                    self.assertEqual(gate_payload.get("action"), "abstain")
+                    self.assertEqual(
+                        gate_payload.get("source"),
+                        "autonomy_gate_report_invalid_action",
+                    )
+                    self.assertTrue(gate_payload.get("entry_blocked"))
+
+                self.assertEqual(alpaca_client.submitted, [])
+                self.assertEqual(
+                    state.metrics.runtime_uncertainty_gate_action_total.get("abstain"),
+                    1,
+                )
+                self.assertEqual(
+                    state.metrics.runtime_uncertainty_gate_blocked_total.get("abstain"),
+                    1,
+                )
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_kill_switch_enabled = original[
+                "trading_kill_switch_enabled"
+            ]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+
+    def test_pipeline_runtime_uncertainty_pass_action_with_invalid_payload_fails_closed(
+        self,
+    ) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_kill_switch_enabled": config.settings.trading_kill_switch_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_kill_switch_enabled = False
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with self.session_local() as session:
+                    strategy = Strategy(
+                        name="demo",
+                        description="runtime-gate-pass-metric-invalid",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=["AAPL"],
+                        max_notional_per_trade=Decimal("1000"),
+                    )
+                    session.add(strategy)
+                    session.commit()
+
+                gate_path = Path(tmpdir) / "gate-report.json"
+                gate_path.write_text(
+                    '{"uncertainty_gate_action":"pass","coverage_error":"0.5","shift_score":"not-a-number","conformal_interval_width":"0.10"}',
+                    encoding="utf-8",
+                )
+                signal = SignalEnvelope(
+                    event_ts=datetime.now(timezone.utc),
+                    symbol="AAPL",
+                    payload={
+                        "macd": {"macd": 1.2, "signal": 0.5},
+                        "rsi14": 25,
+                        "price": 100,
+                    },
+                    timeframe="1Min",
+                )
+                state = TradingState(last_autonomy_gates=str(gate_path))
+                alpaca_client = FakeAlpacaClient()
+                pipeline = TradingPipeline(
+                    alpaca_client=alpaca_client,
+                    order_firewall=OrderFirewall(alpaca_client),
+                    ingestor=FakeIngestor([signal]),
+                    decision_engine=DecisionEngine(),
+                    risk_engine=RiskEngine(),
+                    executor=OrderExecutor(),
+                    execution_adapter=alpaca_client,
+                    reconciler=Reconciler(),
+                    universe_resolver=UniverseResolver(),
+                    state=state,
+                    account_label="paper",
+                    session_factory=self.session_local,
+                )
+
+                pipeline.run_once()
+
+                with self.session_local() as session:
+                    decisions = session.execute(select(TradeDecision)).scalars().all()
+                    self.assertEqual(len(decisions), 1)
+                    self.assertEqual(decisions[0].status, "rejected")
+                    decision_json = decisions[0].decision_json
+                    assert isinstance(decision_json, dict)
+                    self.assertIn(
+                        "runtime_uncertainty_gate_abstain_block_risk_increasing_entries",
+                        decision_json.get("risk_reasons", []),
+                    )
+                    params = decision_json.get("params")
+                    assert isinstance(params, dict)
+                    gate_payload = params.get("runtime_uncertainty_gate")
+                    assert isinstance(gate_payload, dict)
+                    self.assertEqual(gate_payload.get("action"), "abstain")
+                    self.assertEqual(
+                        gate_payload.get("source"),
+                        "autonomy_gate_report_invalid_payload",
+                    )
+
+                self.assertEqual(alpaca_client.submitted, [])
+                self.assertEqual(
+                    state.metrics.runtime_uncertainty_gate_action_total.get("abstain"),
+                    1,
+                )
+                self.assertEqual(
+                    state.metrics.runtime_uncertainty_gate_blocked_total.get("abstain"),
+                    1,
+                )
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_kill_switch_enabled = original[
+                "trading_kill_switch_enabled"
+            ]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+
     def test_pipeline_runtime_uncertainty_gate_report_parse_error_fails_closed(self) -> None:
         from app import config
 
@@ -1261,7 +1516,7 @@ class TestTradingPipeline(TestCase):
                 pipeline.run_once()
 
                 self.assertEqual(len(alpaca_client.submitted), 1)
-                self.assertEqual(alpaca_client.submitted[0]["qty"], "5.0")
+                submitted_qty = float(alpaca_client.submitted[0]["qty"])
                 with self.session_local() as session:
                     decisions = session.execute(select(TradeDecision)).scalars().all()
                     self.assertEqual(len(decisions), 1)
@@ -1274,12 +1529,18 @@ class TestTradingPipeline(TestCase):
                     assert isinstance(gate_payload, dict)
                     self.assertEqual(gate_payload.get("action"), "degrade")
                     self.assertEqual(gate_payload.get("degrade_qty_multiplier"), "0.50")
+                    self.assertEqual(
+                        float(gate_payload["adjusted_qty"]),
+                        submitted_qty,
+                    )
                     allocator = params.get("allocator")
                     assert isinstance(allocator, dict)
                     self.assertEqual(
                         allocator.get("max_participation_rate_override"), "0.05"
                     )
                     self.assertEqual(params.get("execution_seconds"), 120)
+                    initial_qty = float(decision_json.get("qty", 0))
+                    self.assertLess(submitted_qty, initial_qty)
 
                 self.assertEqual(
                     state.metrics.runtime_uncertainty_gate_action_total.get("degrade"),
@@ -1559,6 +1820,151 @@ class TestTradingPipeline(TestCase):
                 self.assertEqual(
                     state.metrics.runtime_uncertainty_gate_blocked_total.get("fail"),
                     1,
+                )
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_kill_switch_enabled = original[
+                "trading_kill_switch_enabled"
+            ]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+            config.settings.llm_enabled = original["llm_enabled"]
+            config.settings.llm_min_confidence = original["llm_min_confidence"]
+            config.settings.llm_adjustment_allowed = original["llm_adjustment_allowed"]
+            config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
+            config.settings.llm_evaluation_report = original["llm_evaluation_report"]
+            config.settings.llm_effective_challenge_id = original[
+                "llm_effective_challenge_id"
+            ]
+            config.settings.llm_shadow_completed_at = original[
+                "llm_shadow_completed_at"
+            ]
+            config.settings.llm_adjustment_approved = original[
+                "llm_adjustment_approved"
+            ]
+
+    def test_pipeline_runtime_uncertainty_recheck_after_llm_does_not_bypass_degrade(self) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_kill_switch_enabled": config.settings.trading_kill_switch_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+            "llm_enabled": config.settings.llm_enabled,
+            "llm_min_confidence": config.settings.llm_min_confidence,
+            "llm_adjustment_allowed": config.settings.llm_adjustment_allowed,
+            "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
+            "llm_evaluation_report": config.settings.llm_evaluation_report,
+            "llm_effective_challenge_id": config.settings.llm_effective_challenge_id,
+            "llm_shadow_completed_at": config.settings.llm_shadow_completed_at,
+            "llm_adjustment_approved": config.settings.llm_adjustment_approved,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_kill_switch_enabled = False
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.llm_enabled = True
+        config.settings.llm_min_confidence = 0.0
+        config.settings.llm_adjustment_allowed = True
+        _set_llm_guardrails(config, adjustment_approved=True)
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with self.session_local() as session:
+                    strategy = Strategy(
+                        name="demo",
+                        description="runtime-gate-post-llm-degrade-preserved",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=["AAPL"],
+                        max_notional_per_trade=Decimal("1000"),
+                    )
+                    session.add(strategy)
+                    session.commit()
+
+                gate_path = Path(tmpdir) / "gate-report.json"
+                gate_path.write_text(
+                    '{"uncertainty_gate_action":"degrade"}',
+                    encoding="utf-8",
+                )
+                signal = SignalEnvelope(
+                    event_ts=datetime.now(timezone.utc),
+                    symbol="AAPL",
+                    payload={
+                        "macd": {"macd": 1.2, "signal": 0.5},
+                        "rsi14": 25,
+                        "price": 100,
+                    },
+                    timeframe="1Min",
+                )
+                state = TradingState(last_autonomy_gates=str(gate_path))
+                alpaca_client = FakeAlpacaClient()
+                pipeline = TradingPipeline(
+                    alpaca_client=alpaca_client,
+                    order_firewall=OrderFirewall(alpaca_client),
+                    ingestor=FakeIngestor([signal]),
+                    decision_engine=DecisionEngine(),
+                    risk_engine=RiskEngine(),
+                    executor=OrderExecutor(),
+                    execution_adapter=alpaca_client,
+                    reconciler=Reconciler(),
+                    universe_resolver=UniverseResolver(),
+                    state=state,
+                    account_label="paper",
+                    session_factory=self.session_local,
+                    llm_review_engine=FakeLLMReviewEngine(
+                        verdict="adjust",
+                        adjusted_qty=Decimal("20"),
+                        adjusted_order_type="market",
+                    ),
+                )
+
+                pipeline.run_once()
+
+                self.assertEqual(len(alpaca_client.submitted), 1)
+                submitted_qty = float(alpaca_client.submitted[0]["qty"])
+                with self.session_local() as session:
+                    decisions = session.execute(select(TradeDecision)).scalars().all()
+                    self.assertEqual(len(decisions), 1)
+                    self.assertEqual(decisions[0].status, "submitted")
+                    decision_json = decisions[0].decision_json
+                    assert isinstance(decision_json, dict)
+                    params = decision_json.get("params")
+                    assert isinstance(params, dict)
+                    gate_payload = params.get("runtime_uncertainty_gate")
+                    assert isinstance(gate_payload, dict)
+                    self.assertEqual(gate_payload.get("action"), "degrade")
+                    self.assertIsNotNone(gate_payload.get("adjusted_qty"))
+                    self.assertLess(
+                        float(gate_payload["adjusted_qty"]),
+                        float(decision_json.get("qty", 0)),
+                    )
+                    self.assertEqual(
+                        float(gate_payload["adjusted_qty"]),
+                        submitted_qty,
+                    )
+                    allocator = params.get("allocator")
+                    assert isinstance(allocator, dict)
+                    self.assertEqual(
+                        allocator.get("max_participation_rate_override"), "0.05"
+                    )
+                    self.assertEqual(params.get("execution_seconds"), 120)
+
+                self.assertEqual(
+                    state.metrics.runtime_uncertainty_gate_blocked_total.get("degrade", 0),
+                    0,
                 )
         finally:
             config.settings.trading_enabled = original["trading_enabled"]


### PR DESCRIPTION
## Summary

- Implemented strict runtime uncertainty gate fail-closed parsing in `services/torghut/app/trading/scheduler.py` by treating invalid/missing certainty and action signals as `abstain` or strict missing-artifact fallback (`runtime_uncertainty_gate_missing`) and by validating autonomy gate payload fields for pass-path metrics.
- Made runtime uncertainty enforcement deterministic across advisory flow by re-running the same gate after LLM review (`_recheck_runtime_uncertainty_gate_after_llm`) using a tuple return of updated decision, gate payload, and rejection state.
- Added/updated regression coverage in `services/torghut/tests/test_trading_pipeline.py` for: invalid direct `uncertainty_gate_action`, invalid autonomy gate action/payload fail-closed behavior, and post-LLM gate recheck non-bypass behavior.
- Scoped references used in this work: `docs/torghut/design-system/v5/02-conformal-uncertainty-and-regime-gates.md` for priority/objectives and `docs/torghut/design-system/implementation-status-matrix-2026-02-21.md` for v5/02 status context.

## Related Issues

- None.

## Testing

- `cd /workspace/proompteng-lab/services/torghut && . .venv/bin/activate && python -m pytest tests/test_trading_pipeline.py -k "runtime_uncertainty"` -> 12 passed, 26 deselected.
- `cd /workspace/proompteng-lab/services/torghut && . .venv/bin/activate && python -m pytest tests/test_trading_pipeline.py` -> 38 passed.

## Screenshots

- Not applicable.

## Breaking Changes

- None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
