### PR TITLE
chore(jangar): promote image 93eeaa3f

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c53e2c68
-  digest: sha256:5b0a6f58dea92c6a40dbe3afd93d05004de34c351795a0bab6b3356e527707f8
+  tag: 93eeaa3f
+  digest: sha256:3aa8685dbd6a8642dfe887c443727ac0c0e9b0bbc1c6080a55f225e068769b1a
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c53e2c68
-    digest: sha256:becd3535e2d3540bc056d09617afc9ac373008537aca136b0bd7d8b17760f2ed
+    tag: 93eeaa3f
+    digest: sha256:3e235465a645caeb785bdfad642628faf4704e45d237d0f2d189c5bc2d6843b3
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c53e2c68
-    digest: sha256:5b0a6f58dea92c6a40dbe3afd93d05004de34c351795a0bab6b3356e527707f8
+    tag: 93eeaa3f
+    digest: sha256:3aa8685dbd6a8642dfe887c443727ac0c0e9b0bbc1c6080a55f225e068769b1a
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-01T05:47:49Z"
+    deploy.knative.dev/rollout: "2026-03-01T06:48:14Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-01T05:47:49Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-01T06:48:14Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c53e2c68"
-    digest: sha256:5b0a6f58dea92c6a40dbe3afd93d05004de34c351795a0bab6b3356e527707f8
+    newTag: "93eeaa3f"
+    digest: sha256:3aa8685dbd6a8642dfe887c443727ac0c0e9b0bbc1c6080a55f225e068769b1a


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `93eeaa3fc5ba364e488851826d16a4dabcd0311a`
- Image tag: `93eeaa3f`
- Image digest: `sha256:3aa8685dbd6a8642dfe887c443727ac0c0e9b0bbc1c6080a55f225e068769b1a`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`