### PR TITLE
fix(agents): pass event body path to codex-spark provider

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -47,7 +47,7 @@ spec:
           "name": "codex-spark",
           "binary": "/usr/local/bin/codex-implement",
           "argsTemplate": [
-            "{{payloads.eventFilePath}}"
+            "{{payloads.eventBodyPath}}"
           ],
           "envTemplate": {
             "WORKFLOW_STAGE": "{{inputs.stage}}",


### PR DESCRIPTION
## Summary

- Fix `codex-spark` provider args template to pass `{{payloads.eventBodyPath}}` to `codex-implement`.
- This aligns provider input with `agent-runner` run-spec conversion behavior.
- Unblocks `codex-spark-agent` workflow loop jobs that were failing with `Usage: codex-implement.ts <event-json-path>`.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-kustomize-eventbodypath.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
