### PR TITLE
chore(jangar): bump OpenWebUI to v0.8.5

### DIFF
--- a/argocd/applications/jangar/openwebui-values.yaml
+++ b/argocd/applications/jangar/openwebui-values.yaml
@@ -18,7 +18,7 @@ websocket:
     enabled: false
 
 image:
-  tag: v0.7.2
+  tag: v0.8.5
 
 openaiApiKey: ""
 

--- a/docs/jangar/openwebui.md
+++ b/docs/jangar/openwebui.md
@@ -1,6 +1,6 @@
 # OpenWebUI deployment (separate host)
 
-OpenWebUI is installed via the upstream Helm chart (`open-webui` v8.19.0, app v0.7.2) in the `jangar` namespace. The chart creates a StatefulSet and `open-webui` ClusterIP Service; a dedicated Tailscale LoadBalancer `openwebui-tailscale` (hostname `openwebui`) fronts it. Websocket support is enabled and backed by a Redis instance `jangar-openwebui-redis` managed by the OTCK Redis operator. Postgres comes from the existing CNPG cluster `jangar-db` (`jangar-db-app` + `jangar-db-ca`). Jangar no longer proxies or iframes OpenWebUI; users open the Tailscale host directly.
+OpenWebUI is installed via the upstream Helm chart (`open-webui` v8.19.0, app v0.8.5) in the `jangar` namespace. The chart creates a StatefulSet and `open-webui` ClusterIP Service; a dedicated Tailscale LoadBalancer `openwebui-tailscale` (hostname `openwebui`) fronts it. Websocket support is enabled and backed by a Redis instance `jangar-openwebui-redis` managed by the OTCK Redis operator. Postgres comes from the existing CNPG cluster `jangar-db` (`jangar-db-app` + `jangar-db-ca`). Jangar no longer proxies or iframes OpenWebUI; users open the Tailscale host directly.
 
 OpenWebUI forwards the chat identifier in the `x-openwebui-chat-id` header (enabled via the chart values). Jangar consumes this header to map conversations to Codex thread ids and to increment turn numbers, persisting the mapping in Redis (`redis://jangar-openwebui-redis:6379/1`) with a 7-day TTL so subsequent turns stay on the same thread.
 
@@ -26,7 +26,7 @@ OpenWebUI forwards the chat identifier in the `x-openwebui-chat-id` header (enab
 
 ## Image pin
 
-- `ghcr.io/open-webui/open-webui:v0.7.2` (managed by the Helm chart)
+- `ghcr.io/open-webui/open-webui:v0.8.5` (managed by the Helm chart)
 
 ## Dev notes
 

--- a/services/jangar/docker-compose.yml
+++ b/services/jangar/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped
 
   openwebui:
-    image: ghcr.io/open-webui/open-webui:v0.7.2
+    image: ghcr.io/open-webui/open-webui:v0.8.5
     container_name: jangar-openwebui
     ports:
       - '${OPENWEBUI_PORT:-8080}:8080'


### PR DESCRIPTION
## Summary

- Bumped OpenWebUI Helm chart image tag from `v0.7.2` to `v0.8.5` in the Jangar ArgoCD values.
- Updated local `services/jangar/docker-compose.yml` OpenWebUI image to `ghcr.io/open-webui/open-webui:v0.8.5`.
- Updated OpenWebUI documentation to reflect the new app image version `v0.8.5`.

## Related Issues

None

## Testing

- Verified all direct version references for OpenWebUI app image in target files were updated to `v0.8.5` via grep checks.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
