### PR TITLE
fix(jangar): route internal and trade-execution calls statelessly

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-decision-engine.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-decision-engine.test.ts
@@ -153,7 +153,11 @@ describe('torghut decision engine', () => {
 
   it('forwards llm review temperature and max_tokens to chat completion payload', async () => {
     let seenBody: unknown = null
+    let seenClientKindHeader: string | null = null
+    let hasOpenWebuiChatIdHeader = false
     vi.spyOn(chatServer, 'handleChatCompletion').mockImplementation(async (request: Request) => {
+      seenClientKindHeader = request.headers.get('x-jangar-client-kind')
+      hasOpenWebuiChatIdHeader = request.headers.has('x-openwebui-chat-id')
       seenBody = await request.json()
       const payload = [
         'data: {"choices":[{"delta":{"content":"{\\"verdict\\":\\"approve\\"}"}}]}',
@@ -187,5 +191,7 @@ describe('torghut decision engine', () => {
       temperature: 0.2,
       max_tokens: 321,
     })
+    expect(seenClientKindHeader).toBe('internal')
+    expect(hasOpenWebuiChatIdHeader).toBe(false)
   })
 })

--- a/services/jangar/src/server/torghut-decision-engine.ts
+++ b/services/jangar/src/server/torghut-decision-engine.ts
@@ -531,7 +531,10 @@ const runDefaultDecisionExecutor = async (input: DecisionExecutorInput): Promise
 
   const request = new Request('http://localhost/openai/v1/chat/completions', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      'content-type': 'application/json',
+      'x-jangar-client-kind': 'internal',
+    },
     body: safeJsonStringify(payload),
     signal: input.signal,
   })


### PR DESCRIPTION
## Summary

- classify chat completion callers by explicit client kind header instead of always treating every `x-openwebui-chat-id` request as OpenWebUI stateful
- skip thread/worktree/transcript state tracking for `internal` and `trade-execution` requests while preserving it for OpenWebUI/Discord flows
- route torghut decision-engine calls through `x-jangar-client-kind: internal` and add regression coverage to lock header semantics
- keep existing `x-trade-execution: torghut` compatibility and reject legacy `x-jangar-client-kind: trade-execution`

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/chat-completions.test.ts src/server/__tests__/torghut-decision-engine.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
