### PR TITLE
fix(torghut): normalize paper mode live flag from feature flags

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1366,6 +1366,11 @@ class Settings(BaseSettings):
             return
         if not self.trading_feature_flags_url:
             return
+
+        trading_live_explicitly_set = (
+            "trading_live_enabled" in self.__pydantic_fields_set__
+        )
+
         endpoint = self.trading_feature_flags_url.strip().rstrip("/")
         if not endpoint:
             return
@@ -1396,6 +1401,17 @@ class Settings(BaseSettings):
                     flag_key,
                 )
                 break
+
+        if (
+            self.trading_mode == "paper"
+            and self.trading_live_enabled
+            and not trading_live_explicitly_set
+        ):
+            logger.warning(
+                "Feature flag override enabled trading live mode while TRADING_MODE=paper. "
+                "Normalizing TRADING_LIVE_ENABLED to false."
+            )
+            self.trading_live_enabled = False
 
     @staticmethod
     def _normalize_csv_setting(raw: str) -> str:


### PR DESCRIPTION
## Summary

- Prevented feature flag and environment override logic from forcing `trading_live_enabled=true` when `trading_mode=paper` in torghut startup.
- Ensured paper-mode validation remains intact when `trading_live_enabled` is explicitly configured by the operator.
- Added a regression test in `services/torghut/tests/test_config.py` to verify feature-flag overrides cannot enable live mode in paper mode.

## Related Issues

None

## Testing

- Added regression test: `services/torghut/tests/test_config.py::test_feature_flags_cannot_enable_live_in_paper_mode`.
- Local full-test execution was not run for this PR.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
