### PR TITLE
chore(jangar): promote image 2ce2f33f

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "331868e5"
-  digest: sha256:874517caa3f8cec396dbe80bd1e28e331f2c1f9497841417a700c0d37b70aac4
+  tag: 2ce2f33f
+  digest: sha256:83b64d0ee556e05467b4a26e854e74238b195b6bd87698c13d9bcea2a2f0e650
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: "331868e5"
-    digest: sha256:423659cfe2a6728318dcf48e4cb8c12298f53856f3532cf2e174ab9b20fb89b8
+    tag: 2ce2f33f
+    digest: sha256:b5cb7cfef7b2b86c30eabd0985c05c7b2281b105124f84c8c2fef1923081b313
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: "331868e5"
-    digest: sha256:874517caa3f8cec396dbe80bd1e28e331f2c1f9497841417a700c0d37b70aac4
+    tag: 2ce2f33f
+    digest: sha256:83b64d0ee556e05467b4a26e854e74238b195b6bd87698c13d9bcea2a2f0e650
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-01T19:03:07Z"
+    deploy.knative.dev/rollout: "2026-03-01T19:24:01Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-01T19:03:07Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-01T19:24:01Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "331868e5"
-    digest: sha256:874517caa3f8cec396dbe80bd1e28e331f2c1f9497841417a700c0d37b70aac4
+    newTag: "2ce2f33f"
+    digest: sha256:83b64d0ee556e05467b4a26e854e74238b195b6bd87698c13d9bcea2a2f0e650


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `2ce2f33fc379bd071ab3bcb4d1f802ad472669fa`
- Image tag: `2ce2f33f`
- Image digest: `sha256:83b64d0ee556e05467b4a26e854e74238b195b6bd87698c13d9bcea2a2f0e650`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`