### PR TITLE
fix(torghut): remove duplicate live approval env var

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -100,8 +100,6 @@ spec:
                 [{"label":"PA3SX7FYNUTF","mode":"live","enabled":true}]
             - name: TRADING_LIVE_ENABLED
               value: "true"
-            - name: LLM_FAIL_OPEN_LIVE_APPROVED
-              value: "true"
             - name: TRADING_SIGNAL_SOURCE
               value: clickhouse
             - name: TRADING_SIGNAL_TABLE


### PR DESCRIPTION
## Summary

- Remove duplicate `LLM_FAIL_OPEN_LIVE_APPROVED` environment variable from the Torghut Knative Service manifest so Argo CD can apply the updated pod spec.
- Keep Torghut trading in live mode by retaining the single live settings already present (`TRADING_MODE=live`, `TRADING_LIVE_ENABLED=true`, live `TRADING_ACCOUNTS_JSON`, and `LLM_FAIL_OPEN_LIVE_APPROVED=true`).
- Preserve existing LLM fail-open safety guard while avoiding the duplicate env entry that causes Kubernetes patch conflicts.

## Related Issues

None

## Testing

- `rg -n "LLM_FAIL_OPEN_LIVE_APPROVED|TRADING_MODE|TRADING_LIVE_ENABLED|TRADING_ACCOUNTS_JSON" argocd/applications/torghut/knative-service.yaml`
- Manual review of `argocd/applications/torghut/knative-service.yaml` diff to verify one remaining `LLM_FAIL_OPEN_LIVE_APPROVED` entry

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [ ] Documentation, release notes, and follow-ups are updated or tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a duplicate env var entry in a Knative Service manifest to avoid Argo CD/Kubernetes patch conflicts, without changing the remaining live-trading configuration values.
> 
> **Overview**
> Removes a duplicate `LLM_FAIL_OPEN_LIVE_APPROVED` environment variable entry from the Torghut Knative Service manifest so Argo CD can successfully apply the pod spec.
> 
> The single remaining `LLM_FAIL_OPEN_LIVE_APPROVED` setting (and existing live trading env vars like `TRADING_MODE=live` / `TRADING_LIVE_ENABLED=true`) is left intact, so runtime behavior should be unchanged aside from eliminating the deploy-time conflict.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4965a75625a7eced0ce49dd522dc666d5a925969. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->