### PR TITLE
chore(jangar): promote image f22a8cbc

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 2ce2f33f
-  digest: sha256:83b64d0ee556e05467b4a26e854e74238b195b6bd87698c13d9bcea2a2f0e650
+  tag: f22a8cbc
+  digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 2ce2f33f
-    digest: sha256:b5cb7cfef7b2b86c30eabd0985c05c7b2281b105124f84c8c2fef1923081b313
+    tag: f22a8cbc
+    digest: sha256:3ed8e2ca010bce0cc4c4f220c213b67679d4972a1edc903ba91972ddf6627f72
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 2ce2f33f
-    digest: sha256:83b64d0ee556e05467b4a26e854e74238b195b6bd87698c13d9bcea2a2f0e650
+    tag: f22a8cbc
+    digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-01T19:24:01Z"
+    deploy.knative.dev/rollout: "2026-03-01T20:00:58Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-01T19:24:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-01T20:00:58Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "2ce2f33f"
-    digest: sha256:83b64d0ee556e05467b4a26e854e74238b195b6bd87698c13d9bcea2a2f0e650
+    newTag: "f22a8cbc"
+    digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f22a8cbc91f8462d5e375e7684a38b03af271dde`
- Image tag: `f22a8cbc`
- Image digest: `sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`