### PR TITLE
fix(jangar): restore codex-spark agentrun payload compatibility

### DIFF
--- a/docs/agents/jangar-controller-design.md
+++ b/docs/agents/jangar-controller-design.md
@@ -142,6 +142,9 @@ AgentProvider defines how to invoke `/usr/local/bin/agent-runner`:
 - Render `argsTemplate` and `envTemplate` against resolved AgentRun + ImplementationSpec data.
 - Materialize `inputFiles` into the runtime workspace.
 - Collect `outputArtifacts` paths.
+- Payload key compatibility:
+  - prefer `payloads.eventFilePath` in provider `argsTemplate`,
+  - `payloads.eventBodyPath` is emitted as a compatibility alias to the same `/workspace/run.json` payload.
 
 Agent-runner spec (contract):
 

--- a/services/jangar/scripts/__tests__/agent-runner.test.ts
+++ b/services/jangar/scripts/__tests__/agent-runner.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { resolveSpecPath } from '../agent-runner'
+
+describe('agent-runner spec path resolution', () => {
+  const envKeys = ['AGENT_RUNNER_SPEC_PATH', 'AGENT_RUN_SPEC', 'AGENT_SPEC_PATH'] as const
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      delete process.env[key]
+    }
+  })
+
+  it('prefers explicit --spec path over env vars', () => {
+    process.env.AGENT_RUNNER_SPEC_PATH = '/workspace/agent-runner.json'
+    process.env.AGENT_RUN_SPEC = '/workspace/run.json'
+
+    expect(resolveSpecPath({ specPath: '/tmp/override.json' })).toBe('/tmp/override.json')
+  })
+
+  it('prefers AGENT_RUNNER_SPEC_PATH over AGENT_RUN_SPEC', () => {
+    process.env.AGENT_RUNNER_SPEC_PATH = '/workspace/agent-runner.json'
+    process.env.AGENT_RUN_SPEC = '/workspace/run.json'
+
+    expect(resolveSpecPath({})).toBe('/workspace/agent-runner.json')
+  })
+
+  it('falls back to AGENT_RUN_SPEC and AGENT_SPEC_PATH', () => {
+    process.env.AGENT_RUN_SPEC = '/workspace/run.json'
+    process.env.AGENT_SPEC_PATH = '/workspace/legacy-spec.json'
+
+    expect(resolveSpecPath({})).toBe('/workspace/run.json')
+
+    delete process.env.AGENT_RUN_SPEC
+    expect(resolveSpecPath({})).toBe('/workspace/legacy-spec.json')
+  })
+})

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -1075,9 +1075,20 @@ describe('agents controller reconcileAgentRun', () => {
     const appliedResources = apply.mock.calls.map((call) => call[0]) as Record<string, unknown>[]
     const job = appliedResources.find((resource) => resource.kind === 'Job')
     const configMaps = appliedResources.filter((resource) => resource.kind === 'ConfigMap')
+    const specConfigMap = configMaps.find((resource) =>
+      Boolean((resource.data as Record<string, unknown> | undefined)?.['agent-runner.json']),
+    )
 
     expect(job).toBeTruthy()
     expect(configMaps).toHaveLength(2)
+    expect(specConfigMap).toBeTruthy()
+
+    const agentRunnerSpec = JSON.parse(
+      String((specConfigMap?.data as Record<string, unknown> | undefined)?.['agent-runner.json'] ?? '{}'),
+    ) as Record<string, unknown>
+    const payloads = (agentRunnerSpec.payloads ?? {}) as Record<string, unknown>
+    expect(payloads.eventFilePath).toBe('/workspace/run.json')
+    expect(payloads.eventBodyPath).toBe('/workspace/run.json')
 
     const jobLabels = (job?.metadata as Record<string, unknown> | undefined)?.labels as
       | Record<string, string>

--- a/services/jangar/src/server/agents-controller/job-runtime.ts
+++ b/services/jangar/src/server/agents-controller/job-runtime.ts
@@ -297,6 +297,8 @@ const buildAgentRunnerSpec = (
   inputs: parameters,
   payloads: {
     eventFilePath: '/workspace/run.json',
+    // Keep legacy key as an alias so older provider templates keep working.
+    eventBodyPath: '/workspace/run.json',
   },
   artifacts: {
     statusPath: '/workspace/.agent/status.json',


### PR DESCRIPTION
## Summary

- Restored `codex-spark` AgentRun compatibility by fixing runner spec-path precedence so `/workspace/agent-runner.json` is honored via `AGENT_RUNNER_SPEC_PATH`.
- Added backward-compatible payload aliasing in controller-generated `agent-runner.json` so both `payloads.eventFilePath` and `payloads.eventBodyPath` resolve to `/workspace/run.json`.
- Added regression tests for spec-path resolution and payload key emission to prevent `codex-implement` no-argument failures.
- Documented provider payload key compatibility in the Jangar controller design doc.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts scripts/__tests__/agent-runner.test.ts src/server/__tests__/agents-controller.test.ts -t "agent-runner spec path resolution|creates job and configmaps for job runtime"`
- `bunx oxfmt --check services/jangar/scripts/agent-runner.ts services/jangar/src/server/agents-controller/job-runtime.ts services/jangar/src/server/__tests__/agents-controller.test.ts services/jangar/scripts/__tests__/agent-runner.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
