### PR TITLE
chore(agents): set controller per-agent concurrency to 10

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -37,6 +37,8 @@ resources:
 controller:
   namespaces:
     - agents
+  concurrency:
+    perAgent: 10
   jobTtlSeconds: 86400
   jobTtlSecondsAfterFinished: 86400
   logRetentionSeconds: 604800


### PR DESCRIPTION
## Summary

- set `controller.concurrency.perAgent` to `10` in agents GitOps values
- keep namespace concurrency unchanged at `10`
- enable Argo CD to reconcile `agents-controllers` with per-agent concurrency `10` from `main`

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents | rg 'JANGAR_AGENTS_CONTROLLER_CONCURRENCY_(NAMESPACE|AGENT|CLUSTER)' -n -A1 -B1`
- `kubectl -n agents get deployment agents-controllers -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' | rg 'JANGAR_AGENTS_CONTROLLER_CONCURRENCY_(AGENT|NAMESPACE|CLUSTER)'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
