### PR TITLE
docs(agents): default AgentRun loops to controller-managed image

### DIFF
--- a/charts/agents/examples/agentrun-workflow-loop-conditional.yaml
+++ b/charts/agents/examples/agentrun-workflow-loop-conditional.yaml
@@ -33,7 +33,7 @@ spec:
             volumeNames:
               - workspace
   workload:
-    image: registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl
+    # Intentionally omit workload.image by default so the controller-managed runner image is used.
     resources:
       requests:
         cpu: 250m

--- a/charts/agents/examples/agentrun-workflow-loop-fixed.yaml
+++ b/charts/agents/examples/agentrun-workflow-loop-fixed.yaml
@@ -25,7 +25,7 @@ spec:
             volumeNames:
               - workspace
   workload:
-    image: registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl
+    # Intentionally omit workload.image by default so the controller-managed runner image is used.
     resources:
       requests:
         cpu: 250m

--- a/docs/agents/agentrun-creation-guide.md
+++ b/docs/agents/agentrun-creation-guide.md
@@ -85,6 +85,24 @@ Notes:
   Do not put TTL under `spec.runtime.config` unless a specific runtime explicitly documents it.
 - Keep `metadata.name` short enough for label propagation. The controller writes
   `agents.proompteng.ai/agent-run=<run-name>` labels, so names longer than 63 characters can fail reconciliation.
+- Prefer omitting `spec.workload.image` unless you intentionally pin a known-good runner image.
+
+## Runner Image Selection (Avoid Accidental Overrides)
+
+Image resolution order (highest first):
+
+1. `AgentRun.spec.workload.image`
+2. `JANGAR_AGENT_RUNNER_IMAGE`
+3. `JANGAR_AGENT_IMAGE`
+
+Safe default for normal runs:
+
+- Do not set `spec.workload.image`; let the controller-provided default image drive execution.
+
+Use per-run image pinning only when:
+
+- you are running a controlled canary/debug experiment, and
+- you have verified the exact image is compatible with the configured agent provider/runtime.
 
 ## Verify The Run Is Using The Spec Text
 
@@ -198,6 +216,7 @@ Do not use system prompt customization to compensate for an incorrect user promp
 - You assumed `${parameter}` placeholders were auto-expanded in prompt text without verifying `run.json.prompt`.
 - You used a head branch that conflicts with another active run (see `docs/agents/version-control-provider-design.md`).
 - Your `AgentRun.metadata.name` exceeded 63 chars and failed when propagated into Kubernetes label values.
+- You set `spec.workload.image` to a stale/incompatible image instead of inheriting controller defaults.
 - Required secrets were not allowlisted or not included in `spec.secrets`.
 - The repo is not in the allowlist configured for the controllers deployment.
 - You expected “followers not-ready” behavior without having implemented leader election in code and chart.


### PR DESCRIPTION
## Summary

- Clarify AgentRun docs to default to omitting `spec.workload.image` so runs inherit the controller-managed runner image.
- Add explicit runner image resolution precedence and guidance for when per-run image pinning is appropriate.
- Remove hardcoded `workload.image` from loop example manifests and annotate that image override is intentionally omitted by default.

## Related Issues

None

## Testing

- `kubectl -n agents apply --dry-run=server -f charts/agents/examples/agentrun-workflow-loop-fixed.yaml`
- `kubectl -n agents apply --dry-run=server -f charts/agents/examples/agentrun-workflow-loop-conditional.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
