### PR TITLE
feat(autonomy): add timesfm forecast routing parity gate enforcement

### DIFF
--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -845,6 +845,18 @@ def _evaluate_promotion_evidence(
     reasons.extend(rationale_reasons)
     details.extend(rationale_details)
 
+    parity_reasons, parity_details, parity_refs = (
+        _evaluate_foundation_router_parity_evidence(
+            policy_payload=policy_payload,
+            gate_report_payload=gate_report_payload,
+            artifact_root=artifact_root,
+            promotion_target=promotion_target,
+        )
+    )
+    reasons.extend(parity_reasons)
+    details.extend(parity_details)
+    refs.extend(parity_refs)
+
     return sorted(set(reasons)), details, sorted(set(refs))
 
 

--- a/services/torghut/app/trading/forecasting.py
+++ b/services/torghut/app/trading/forecasting.py
@@ -45,6 +45,22 @@ def _coerce_horizon(value: str) -> str:
     return cleaned
 
 
+def _coerce_model_family(value: str) -> str:
+    normalized = value.strip().lower().replace('-', '_').replace(' ', '_')
+    aliases = {
+        'timesfm': 'financial_tsfm',
+        'financial_tsfm': 'financial_tsfm',
+        'financialtsfm': 'financial_tsfm',
+        'financial_tsfm_v1': 'financial_tsfm',
+        'financial-tsfm-v1': 'financial_tsfm',
+        'baseline': 'baseline',
+        'deterministic_baseline': 'baseline',
+        'moment': 'moment',
+        'chronos': 'chronos',
+    }
+    return aliases.get(normalized, normalized)
+
+
 @dataclass(frozen=True)
 class ForecastInterval:
     p05: Decimal


### PR DESCRIPTION
## Summary

- Added TimesFM-aware forecasting router lineage in `services/torghut/app/trading/autonomy/lane.py` with deterministic fallback behavior and foundation-router parity artifact emission (`foundation-router-parity-report-v1`) including per-symbol/horizon/regime slice metrics.
- Added calibration/parity-driven promotion gating in autonomy lane and policy checks so promotion and rollback readiness fails closed when stress evidence, forecast routing, or calibration inputs are missing/stale/untrusted.
- Added/updated torghut governance tests for adapter failure, deterministic fallback ordering, stress evidence fail-closed checks, and artifact path/reporting behavior.
- Fixed iteration note output location to `${artifactPath}/notes/iteration-<n>.md` with promotion/recommendation metadata included.

## Related Issues

- None

## Testing

- `cd /workspace/lab && bunx --yes pyright --project services/torghut/pyrightconfig.json`
- `cd /workspace/lab && bunx --yes pyright --project services/torghut/pyrightconfig.alpha.json`
- `cd /workspace/lab && bunx --yes pyright --project services/torghut/pyrightconfig.scripts.json`
- `python3 -m venv /tmp/torghut-test-env`
- `/tmp/torghut-test-env/bin/pip install pytest pyyaml sqlalchemy pydantic pydantic-settings fastapi alembic psycopg psycopg[binary] ruff`
- `cd /workspace/lab && PATH=/tmp/torghut-test-env/bin:$PATH PYTHONPATH=services/torghut pytest services/torghut/tests/test_autonomous_lane.py services/torghut/tests/test_policy_checks.py services/torghut/tests/test_governance_policy_dry_run.py`
- `cd /workspace/lab && PATH=/tmp/torghut-test-env/bin:$PATH PYTHONPATH=services/torghut /tmp/torghut-test-env/bin/ruff check app/trading/autonomy/lane.py tests/test_autonomous_lane.py tests/test_policy_checks.py tests/test_governance_policy_dry_run.py`

## Breaking Changes

- None
