### PR TITLE
chore(jangar): promote image 251bf56f

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f22a8cbc
-  digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
+  tag: 251bf56f
+  digest: sha256:473e53286be883d361af8ae5a1d6ca7c15377f91472ca1445c0faed422c1dc34
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f22a8cbc
-    digest: sha256:3ed8e2ca010bce0cc4c4f220c213b67679d4972a1edc903ba91972ddf6627f72
+    tag: 251bf56f
+    digest: sha256:47b2e87a3bd2760acbef42236a9c1f34f46c317956f020505c9850752458d5a2
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f22a8cbc
-    digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
+    tag: 251bf56f
+    digest: sha256:473e53286be883d361af8ae5a1d6ca7c15377f91472ca1445c0faed422c1dc34
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-01T20:00:58Z"
+    deploy.knative.dev/rollout: "2026-03-02T00:37:26Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-01T20:00:58Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T00:37:26Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f22a8cbc"
-    digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
+    newTag: "251bf56f"
+    digest: sha256:473e53286be883d361af8ae5a1d6ca7c15377f91472ca1445c0faed422c1dc34


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `251bf56ff1c0084aeeb76a6d87b33be0e2eb872c`
- Image tag: `251bf56f`
- Image digest: `sha256:473e53286be883d361af8ae5a1d6ca7c15377f91472ca1445c0faed422c1dc34`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`