### PR TITLE
chore(agents): promote jangar images for swarm rollout

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f22a8cbc
-  digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
+  tag: 251bf56f
+  digest: sha256:473e53286be883d361af8ae5a1d6ca7c15377f91472ca1445c0faed422c1dc34
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f22a8cbc
-    digest: sha256:3ed8e2ca010bce0cc4c4f220c213b67679d4972a1edc903ba91972ddf6627f72
+    tag: 251bf56f
+    digest: sha256:47b2e87a3bd2760acbef42236a9c1f34f46c317956f020505c9850752458d5a2
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f22a8cbc
-    digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
+    tag: 251bf56f
+    digest: sha256:473e53286be883d361af8ae5a1d6ca7c15377f91472ca1445c0faed422c1dc34
 controllers:
   enabled: true
   replicaCount: 2


### PR DESCRIPTION
## Summary

- Promote `argocd/applications/agents/values.yaml` image tags from `f22a8cbc` to `251bf56f`.
- Update `jangar` image digest to `sha256:473e53286be883d361af8ae5a1d6ca7c15377f91472ca1445c0faed422c1dc34`.
- Update `jangar-control-plane` image digest to `sha256:47b2e87a3bd2760acbef42236a9c1f34f46c317956f020505c9850752458d5a2` for GitOps rollout of merged swarm changes.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
