### PR TITLE
fix(jangar): use correct swarm schedule api group

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -224,7 +224,7 @@ describe('supporting primitives controller', () => {
     for (const call of apply.mock.calls) {
       const payload = call[0] as Record<string, unknown>
       expect(payload.kind).toBe('Schedule')
-      expect(payload.apiVersion).toBe('schedules.schedules.proompteng.ai/v1alpha1')
+      expect(payload.apiVersion).toBe('schedules.proompteng.ai/v1alpha1')
       const labels =
         payload?.metadata && typeof payload.metadata === 'object'
           ? (payload.metadata as Record<string, unknown>).labels

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -1224,7 +1224,7 @@ const reconcileSwarm = async (
 
     const stageLabel = normalizeLabelValue(stageConfig.stage)
     const schedule = {
-      apiVersion: 'schedules.schedules.proompteng.ai/v1alpha1',
+      apiVersion: 'schedules.proompteng.ai/v1alpha1',
       kind: 'Schedule',
       metadata: {
         name: stageConfig.scheduleName,


### PR DESCRIPTION
## Summary

- Fix Swarm stage schedule manifests to use the correct API group `schedules.proompteng.ai/v1alpha1`.
- Remove the incorrect `schedules.schedules.proompteng.ai/v1alpha1` value that caused live reconcile failures.
- Update swarm reconciliation test expectation to assert the corrected API version.

## Related Issues

None

## Testing

- `cd services/jangar && bun run test src/server/__tests__/supporting-primitives-controller.test.ts && bunx tsc --noEmit --project tsconfig.paths.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
