### PR TITLE
chore(jangar): promote image 1cb25322

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f22a8cbc
-  digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
+  tag: 1cb25322
+  digest: sha256:e4fb3d18570906f2b7f8ce02d369c4333f37f64b73025a1411b4cb4558cfaad6
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f22a8cbc
-    digest: sha256:3ed8e2ca010bce0cc4c4f220c213b67679d4972a1edc903ba91972ddf6627f72
+    tag: 1cb25322
+    digest: sha256:e62b4263ddca2b17c5d27599e3f72b25830559816f63bfd73c754f4d259ebec3
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f22a8cbc
-    digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
+    tag: 1cb25322
+    digest: sha256:e4fb3d18570906f2b7f8ce02d369c4333f37f64b73025a1411b4cb4558cfaad6
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T00:50:09Z"
+    deploy.knative.dev/rollout: "2026-03-02T00:50:52Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T00:50:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T00:50:52Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f22a8cbc"
-    digest: sha256:a3e375592fc49a6877e16b0493e050df347e6db6cc631f6e3094fb8595526b74
+    newTag: "1cb25322"
+    digest: sha256:e4fb3d18570906f2b7f8ce02d369c4333f37f64b73025a1411b4cb4558cfaad6


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `1cb2532206e0abf4d4668ff77286475c45788ef1`
- Image tag: `1cb25322`
- Image digest: `sha256:e4fb3d18570906f2b7f8ce02d369c4333f37f64b73025a1411b4cb4558cfaad6`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`