### PR TITLE
docs(whitepapers): refresh blocked analysis for wp-d3cdc094c8e3184af629999a

### DIFF
--- a/docs/whitepapers/wp-d3cdc094c8e3184af629999a/design.md
+++ b/docs/whitepapers/wp-d3cdc094c8e3184af629999a/design.md
@@ -2,55 +2,55 @@
 
 - Run ID: `wp-d3cdc094c8e3184af629999a`
 - Repository: `proompteng/lab`
+- Base branch: `main`
 - Issue URL: `https://github.com/proompteng/lab/issues/42`
 - Primary PDF URL: `https://github.com/user-attachments/files/12345/sample-paper.pdf`
 - Ceph Object URI: `s3://torghut-whitepapers/raw/checksum/b5/b5d4c2daa152f53c02621a70601b11dc5b4aecbda1cc3f5962bc5f7f491bad40/source.pdf`
-- Evaluation timestamp (UTC): `2026-02-27T08:32:14Z`
+- Evaluation timestamp (UTC): `2026-03-02T00:55:57Z`
 
 ## Decision
 
 `blocked` at stage `source_acquisition`.
 
-The whitepaper source could not be retrieved, so full end-to-end paper reading is impossible. Because requirement (1) is unmet, no evidence-backed implementation analysis can be produced.
+The whitepaper cannot be read end-to-end from the provided sources. Requirement (1) is therefore unmet, so an evidence-backed implementation analysis is not possible for this run.
 
-## Evidence Log
+## Evidence
 
-1. Primary PDF URL is not retrievable:
-   - Command: `curl -L --fail --silent --show-error "https://github.com/user-attachments/files/12345/sample-paper.pdf" -o /tmp/.../source-primary.pdf`
+1. Primary source URL is invalid for retrieval.
+   - Command: `curl -L --fail --silent --show-error "https://github.com/user-attachments/files/12345/sample-paper.pdf" -o /tmp/wp-d3cdc094.pdf`
    - Result: `curl: (22) The requested URL returned error: 404`
-2. Ceph object retrieval is not possible in this workspace:
-   - `aws s3 cp` is unavailable.
-   - No whitepaper Ceph credentials are present in environment variables (`WHITEPAPER_CEPH_*`, `AWS_*`, `MINIO_*` not set).
-   - Kubernetes RBAC for this pod (`system:serviceaccount:agents:default`) cannot read `torghut` namespace secrets/configmaps needed to resolve object store host/keys.
-3. Run lookup does not resolve:
-   - `GET http://torghut.torghut.svc.cluster.local/whitepapers/runs/wp-d3cdc094c8e3184af629999a` returns `{"detail":"whitepaper_run_not_found"}`.
-   - `GET http://jangar.jangar.svc.cluster.local/api/whitepapers/wp-d3cdc094c8e3184af629999a` returns `404` with `{"ok":false,"message":"whitepaper run not found"}`.
-4. Issue context does not contain analyzable paper metadata:
-   - `gh issue view 42 -R proompteng/lab` resolves to merged PR metadata (`✨ Update targetRevision to 'main' in argo-cd.yaml`) with empty body.
 
-## Assumptions
+2. Issue context is not a whitepaper issue payload.
+   - Command: `gh issue view 42 -R proompteng/lab --json number,title,body,url,state,closedAt`
+   - Result: `{"number":42,"state":"MERGED","title":"Update targetRevision to 'main' in argo-cd.yaml","url":"https://github.com/proompteng/lab/pull/42","body":""}`
 
-1. The provided PDF URL (`sample-paper.pdf`) and issue reference are placeholders or stale.
-2. The run may not have been ingested into Torghut, or it was never persisted in the currently reachable environment.
+3. Run ID matches deterministic hash from known test fixtures.
+   - `build_whitepaper_run_id` implementation: `services/torghut/app/whitepapers/workflow.py` (`run_id = sha256(source_identifier|attachment_url)[:24]`).
+   - Command seed: `proompteng/lab#42|https://github.com/user-attachments/files/12345/sample-paper.pdf`
+   - Derived run ID: `wp-d3cdc094c8e3184af629999a` (exact match).
+   - Test fixture path using same placeholder URL: `services/torghut/tests/test_whitepaper_workflow.py`.
 
-## Impact
+4. Ceph object URI is not directly retrievable in this workspace.
+   - `aws` CLI is unavailable (`aws_cli_missing`).
+   - No signed HTTPS URL or object-store credentials were provided with this run request.
 
-1. Full-paper review cannot be completed.
-2. Section/claim-level citations from the whitepaper cannot be produced.
-3. Any implementation recommendation would be speculative and non-auditable.
+## Assumptions And Risks
+
+1. The provided issue/PDF metadata is synthetic, stale, or misrouted from test-like inputs.
+2. A real source PDF may exist in upstream storage, but it is not accessible from current inputs.
+3. Without source bytes, any section-level citation or technical claim extraction would be non-auditable.
 
 ## Smallest Unblocker
 
-Provide one valid, accessible source artifact:
+Provide one valid, downloadable source for this run:
 
-1. A working PDF URL for this run, or
-2. A temporary signed HTTPS URL for the Ceph object key `raw/checksum/b5/b5d4c2daa152f53c02621a70601b11dc5b4aecbda1cc3f5962bc5f7f491bad40/source.pdf`, or
-3. A reachable Torghut/Jangar run record (`wp-d3cdc094c8e3184af629999a`) whose `/pdf` endpoint streams the source.
+1. A working PDF URL, or
+2. A presigned HTTPS URL for `raw/checksum/b5/b5d4c2daa152f53c02621a70601b11dc5b4aecbda1cc3f5962bc5f7f491bad40/source.pdf`, or
+3. A reachable Torghut/Jangar run record for `wp-d3cdc094c8e3184af629999a` with a streaming PDF endpoint.
 
-## Resume Plan Once Unblocked
+## Resume Procedure After Unblock
 
-1. Download and checksum-verify the exact PDF bytes.
-2. Read the full paper end-to-end (including appendices/references in scope).
-3. Rebuild `synthesis.json` with section/claim citations grounded in the source.
-4. Recompute `verdict.json` from evidence-backed feasibility and repository constraints.
-5. Update this design doc with concrete implementation decisions.
+1. Download source and verify SHA-256.
+2. Read full paper including appendices/references in scope.
+3. Rebuild `synthesis.json` with section/claim citations from the paper text.
+4. Recompute `verdict.json` against repository constraints.

--- a/docs/whitepapers/wp-d3cdc094c8e3184af629999a/synthesis.json
+++ b/docs/whitepapers/wp-d3cdc094c8e3184af629999a/synthesis.json
@@ -1,82 +1,97 @@
 {
   "run_id": "wp-d3cdc094c8e3184af629999a",
-  "generated_at_utc": "2026-02-27T08:32:14Z",
-  "executive_summary": "Blocked: the whitepaper source PDF is not accessible from the provided GitHub attachment URL or the Ceph object path in this execution environment. Requirement to read the full paper end-to-end cannot be satisfied, so no evidence-backed technical synthesis of paper claims is possible.",
-  "problem_statement": "Assess implementation viability of the whitepaper for repository proompteng/lab, grounded in full-paper evidence and current codebase constraints.",
-  "methodology_summary": "Attempted deterministic source acquisition from the primary PDF URL, Ceph object URI, Torghut run endpoint, and Jangar whitepaper endpoints. Source retrieval failed (404 / run-not-found / unavailable credentials), preventing full-text review and section-level claim extraction.",
+  "generated_at_utc": "2026-03-02T00:55:57Z",
+  "executive_summary": "Blocked at source acquisition. The provided primary PDF URL returns HTTP 404, the referenced issue is a historical merged PR entry with no whitepaper body, and the run id deterministically maps to known test fixture inputs. Without retrievable source bytes, full-paper reading and section-level synthesis are impossible.",
+  "problem_statement": "Determine implementation viability for whitepaper run wp-d3cdc094c8e3184af629999a in proompteng/lab, grounded in full-document evidence and current repository constraints.",
+  "methodology_summary": "Validated source accessibility, issue metadata, and deterministic run-id provenance. Checked whitepaper workflow code paths to verify run-id derivation and compared provided inputs against known test fixtures. Because no source PDF was obtainable, synthesis is limited to blockage diagnosis.",
   "key_findings": [
     {
       "id": "KF-1",
       "finding": "Primary PDF URL is inaccessible.",
       "evidence": [
-        "HTTP 404 from GitHub user-attachments URL"
+        "curl -L --fail --silent --show-error https://github.com/user-attachments/files/12345/sample-paper.pdf",
+        "Exit signal: curl_exit:22",
+        "HTTP status: 404"
       ]
     },
     {
       "id": "KF-2",
-      "finding": "Ceph object cannot be fetched in the current workspace due missing credentials and RBAC limits.",
+      "finding": "Issue reference does not provide whitepaper context.",
       "evidence": [
-        "No WHITEPAPER_CEPH_*/AWS_*/MINIO_* env vars present",
-        "Forbidden when attempting to read torghut namespace secrets/configmaps"
+        "gh issue view 42 -R proompteng/lab --json number,title,body,url,state,closedAt",
+        "Resolved object is merged PR #42 with empty body and title 'Update targetRevision to main in argo-cd.yaml'"
       ]
     },
     {
       "id": "KF-3",
-      "finding": "Run ID does not exist in reachable Torghut/Jangar APIs.",
+      "finding": "Run id aligns exactly with deterministic hash of test placeholder inputs.",
       "evidence": [
-        "torghut /whitepapers/runs/{run_id} => whitepaper_run_not_found",
-        "jangar /api/whitepapers/{run_id} => 404 whitepaper run not found"
+        "build_whitepaper_run_id in services/torghut/app/whitepapers/workflow.py computes sha256(source_identifier|attachment_url)[:24]",
+        "Computed seed: proompteng/lab#42|https://github.com/user-attachments/files/12345/sample-paper.pdf",
+        "Computed run id: wp-d3cdc094c8e3184af629999a (exact match)",
+        "services/torghut/tests/test_whitepaper_workflow.py uses the same attachment URL placeholder"
       ]
     },
     {
       "id": "KF-4",
-      "finding": "No whitepaper sections/claims can be cited because the source document was not obtained.",
+      "finding": "Ceph object URI is not directly retrievable from supplied inputs.",
       "evidence": [
-        "No readable PDF bytes available in workspace"
+        "No signed HTTPS URL provided for object key",
+        "aws CLI unavailable in workspace (aws_cli_missing)"
       ]
     }
   ],
   "novelty_claims": [
     {
-      "claim": "Not assessable",
+      "claim": "Paper novelty and technical claims are not assessable",
       "assessment": "blocked",
-      "notes": "Novelty analysis requires full-paper reading; source unavailable."
+      "notes": "No whitepaper content was retrieved, so section/appendix claim extraction cannot be performed."
     }
   ],
   "risk_assessment": [
     {
       "risk": "evidence_insufficiency",
       "severity": "critical",
-      "detail": "Without full source access, any implementation recommendation would be speculative and non-auditable."
+      "detail": "Implementation guidance without full paper text would be speculative and violate deterministic evidence requirements."
     },
     {
-      "risk": "workflow_input_integrity",
+      "risk": "input_integrity_mismatch",
       "severity": "high",
-      "detail": "Issue URL and attachment appear non-actionable for this run, indicating stale or placeholder workflow inputs."
+      "detail": "Run metadata appears derived from test fixtures, creating high risk of analyzing the wrong artifact."
     }
   ],
   "citations": [
     {
-      "type": "source_access_attempt",
+      "id": "CIT-1",
+      "kind": "source_access_attempt",
       "target": "https://github.com/user-attachments/files/12345/sample-paper.pdf",
       "result": "http_404"
     },
     {
-      "type": "source_access_attempt",
+      "id": "CIT-2",
+      "kind": "issue_metadata",
+      "target": "https://github.com/proompteng/lab/issues/42",
+      "result": "resolves_to_merged_pr_with_empty_body"
+    },
+    {
+      "id": "CIT-3",
+      "kind": "repo_code_reference",
+      "target": "services/torghut/app/whitepapers/workflow.py::build_whitepaper_run_id",
+      "result": "run_id_deterministic_hash_definition"
+    },
+    {
+      "id": "CIT-4",
+      "kind": "repo_test_reference",
+      "target": "services/torghut/tests/test_whitepaper_workflow.py",
+      "result": "uses_sample_paper_placeholder_url"
+    },
+    {
+      "id": "CIT-5",
+      "kind": "source_access_attempt",
       "target": "s3://torghut-whitepapers/raw/checksum/b5/b5d4c2daa152f53c02621a70601b11dc5b4aecbda1cc3f5962bc5f7f491bad40/source.pdf",
-      "result": "not_retrievable_without_ceph_credentials"
-    },
-    {
-      "type": "run_lookup",
-      "target": "http://torghut.torghut.svc.cluster.local/whitepapers/runs/wp-d3cdc094c8e3184af629999a",
-      "result": "whitepaper_run_not_found"
-    },
-    {
-      "type": "run_lookup",
-      "target": "http://jangar.jangar.svc.cluster.local/api/whitepapers/wp-d3cdc094c8e3184af629999a",
-      "result": "404_whitepaper_run_not_found"
+      "result": "not_retrievable_from_provided_inputs"
     }
   ],
-  "implementation_plan_md": "Blocked until source access is restored.\\n\\n1. Provide a valid downloadable PDF URL or presigned Ceph URL for the exact checksum object.\\n2. Re-run full paper reading and section/claim extraction.\\n3. Recompute viability using repository constraints and produce non-blocked synthesis/verdict artifacts.\\n4. Update design.md with concrete, evidence-backed implementation decisions.",
-  "confidence": 0.08
+  "implementation_plan_md": "Blocked until source access is restored.\\n\\n1. Provide one valid downloadable source for this run (direct PDF URL, presigned HTTPS Ceph URL, or reachable run PDF endpoint).\\n2. Verify downloaded bytes against expected SHA-256 before analysis.\\n3. Read the full paper including appendices/references and extract section-level claims with citations.\\n4. Recompute implementation viability against repository constraints and update design/verdict artifacts.",
+  "confidence": 0.1
 }

--- a/docs/whitepapers/wp-d3cdc094c8e3184af629999a/verdict.json
+++ b/docs/whitepapers/wp-d3cdc094c8e3184af629999a/verdict.json
@@ -1,28 +1,40 @@
 {
   "run_id": "wp-d3cdc094c8e3184af629999a",
+  "generated_at_utc": "2026-03-02T00:55:57Z",
   "verdict": "reject",
   "score": 0.0,
-  "confidence": 0.97,
-  "decision_policy": "whitepaper_v1.blocked_on_source_access",
-  "rationale": "The required full-paper review could not be performed because the provided whitepaper sources were not accessible (primary URL 404, Ceph object not retrievable in this runtime, run not found in Torghut/Jangar). Any implementation decision beyond rejection would violate evidence requirements.",
+  "confidence": 0.98,
+  "decision_policy": "whitepaper_v1.require_full_source_read",
+  "rationale": "The run cannot satisfy the mandatory full-paper-read gate. The provided PDF URL returns HTTP 404, issue #42 does not contain whitepaper metadata, and the run id maps exactly to known test fixture inputs. Proceeding with implementation assessment would violate evidence and auditability requirements.",
   "rejection_reasons": [
-    "Requirement unmet: full whitepaper could not be read end-to-end.",
-    "No section/claim-level citations can be grounded in source text.",
-    "Run metadata appears inconsistent (issue URL does not contain whitepaper context; run not present in reachable control plane)."
+    "Full whitepaper was not retrievable, so requirement (1) failed.",
+    "No section-level citations can be produced without source text.",
+    "Input integrity risk: run metadata appears synthetic or misrouted from test-like fixtures."
   ],
   "recommendations": [
-    "Provide one valid source artifact for this run: accessible PDF URL, presigned Ceph URL, or reachable run PDF endpoint.",
-    "Re-run analysis after source retrieval and include section/claim citations from the complete paper.",
-    "Validate issue/run linkage in Torghut so run_id, issue metadata, and source artifact are consistent before dispatch."
+    "Provide a valid downloadable PDF source for run wp-d3cdc094c8e3184af629999a (direct or presigned HTTPS).",
+    "Confirm run metadata links to an actual whitepaper issue/body before dispatch.",
+    "Re-run implementation analysis only after successful source download and checksum verification."
   ],
   "requires_followup": true,
   "blocked_stage": "source_acquisition",
-  "block_reason": "whitepaper_source_unavailable",
+  "block_reason": "whitepaper_source_unavailable_or_invalid",
   "evidence": {
-    "primary_pdf_url_status": "404",
-    "ceph_retrieval": "blocked_missing_credentials_or_endpoint_visibility",
-    "torghut_run_lookup": "whitepaper_run_not_found",
-    "jangar_run_lookup": "404_whitepaper_run_not_found"
+    "primary_pdf_url": "https://github.com/user-attachments/files/12345/sample-paper.pdf",
+    "primary_pdf_status": "http_404",
+    "issue_lookup": {
+      "url": "https://github.com/proompteng/lab/issues/42",
+      "resolved_state": "MERGED",
+      "resolved_title": "Update targetRevision to 'main' in argo-cd.yaml",
+      "resolved_body": ""
+    },
+    "run_id_derivation": {
+      "seed": "proompteng/lab#42|https://github.com/user-attachments/files/12345/sample-paper.pdf",
+      "derived_run_id": "wp-d3cdc094c8e3184af629999a"
+    },
+    "ceph_object_uri": "s3://torghut-whitepapers/raw/checksum/b5/b5d4c2daa152f53c02621a70601b11dc5b4aecbda1cc3f5962bc5f7f491bad40/source.pdf",
+    "ceph_access": "no_presigned_url_or_object_credentials_provided",
+    "aws_cli": "missing"
   },
-  "smallest_unblocker": "Provide a working downloadable source PDF for run wp-d3cdc094c8e3184af629999a."
+  "smallest_unblocker": "Provide one working downloadable PDF artifact for this run and verify checksum before analysis."
 }


### PR DESCRIPTION
## Summary

- Refreshes `docs/whitepapers/wp-d3cdc094c8e3184af629999a/design.md` with current blocked-state evidence and deterministic unblock criteria.
- Rewrites `synthesis.json` with required keys, updated findings, and explicit citation objects tied to reproducible evidence.
- Rewrites `verdict.json` with a deterministic `reject` decision, policy rationale, and explicit block-stage metadata.

## Related Issues

None

## Testing

- `jq . docs/whitepapers/wp-d3cdc094c8e3184af629999a/synthesis.json >/dev/null`
- `jq . docs/whitepapers/wp-d3cdc094c8e3184af629999a/verdict.json >/dev/null`
- `curl -L --fail --silent --show-error "https://github.com/user-attachments/files/12345/sample-paper.pdf" -o /tmp/wp-d3cdc094.pdf` (expected failure, observed HTTP 404)
- `gh issue view 42 -R proompteng/lab --json number,title,body,url,state,closedAt`
- `python3 - <<'PY'` seed hash check for `build_whitepaper_run_id` equivalence to `wp-d3cdc094c8e3184af629999a`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
