### PR TITLE
chore(argocd): fix posthog pooler + init image source

### DIFF
--- a/argocd/applications/posthog/deployment-posthog-events.yaml
+++ b/argocd/applications/posthog/deployment-posthog-events.yaml
@@ -155,7 +155,7 @@ spec:
             {}
       initContainers:        
         - name: wait-for-service-dependencies
-          image: busybox:1.34
+          image: ghcr.io/cloudnative-pg/postgresql:17.0
           env:
             - name: CLICKHOUSE_HOST
               value: "posthog-clickhouse.posthog.svc.cluster.local"
@@ -178,16 +178,11 @@ spec:
             - /bin/sh
             - -c
             - >
-                
-        
-                until (nc -vz "posthog-db-pooler.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" 5432);
+                until pg_isready -q -h "posthog-db-pooler.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" -p 5432;
                 do
-                    echo "waiting for Postgres pooler"; sleep 1;
+                  echo "waiting for Postgres pooler";
+                  sleep 1;
                 done
-        
-                
-        
-                
         
                         
         - name: wait-for-migrations

--- a/argocd/applications/posthog/deployment-posthog-plugins.yaml
+++ b/argocd/applications/posthog/deployment-posthog-plugins.yaml
@@ -131,7 +131,7 @@ spec:
             {}
       initContainers:        
         - name: wait-for-service-dependencies
-          image: busybox:1.34
+          image: ghcr.io/cloudnative-pg/postgresql:17.0
           env:
             - name: CLICKHOUSE_HOST
               value: "posthog-clickhouse.posthog.svc.cluster.local"
@@ -154,16 +154,11 @@ spec:
             - /bin/sh
             - -c
             - >
-                
-        
-                until (nc -vz "posthog-db-pooler.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" 5432);
+                until pg_isready -q -h "posthog-db-pooler.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" -p 5432;
                 do
-                    echo "waiting for Postgres pooler"; sleep 1;
+                  echo "waiting for Postgres pooler";
+                  sleep 1;
                 done
-        
-                
-        
-                
         
                         
         - name: wait-for-migrations

--- a/argocd/applications/posthog/deployment-posthog-web.yaml
+++ b/argocd/applications/posthog/deployment-posthog-web.yaml
@@ -169,7 +169,7 @@ spec:
             {}
       initContainers:        
         - name: wait-for-service-dependencies
-          image: busybox:1.34
+          image: ghcr.io/cloudnative-pg/postgresql:17.0
           env:
             - name: CLICKHOUSE_HOST
               value: "posthog-clickhouse.posthog.svc.cluster.local"
@@ -192,16 +192,11 @@ spec:
             - /bin/sh
             - -c
             - >
-                
-        
-                until (nc -vz "posthog-db-pooler.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" 5432);
+                until pg_isready -q -h "posthog-db-pooler.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" -p 5432;
                 do
-                    echo "waiting for Postgres pooler"; sleep 1;
+                  echo "waiting for Postgres pooler";
+                  sleep 1;
                 done
-        
-                
-        
-                
         
                         
         - name: wait-for-migrations

--- a/argocd/applications/posthog/deployment-posthog-worker.yaml
+++ b/argocd/applications/posthog/deployment-posthog-worker.yaml
@@ -125,7 +125,7 @@ spec:
             {}
       initContainers:        
         - name: wait-for-service-dependencies
-          image: busybox:1.34
+          image: ghcr.io/cloudnative-pg/postgresql:17.0
           env:
             - name: CLICKHOUSE_HOST
               value: "posthog-clickhouse.posthog.svc.cluster.local"
@@ -148,16 +148,11 @@ spec:
             - /bin/sh
             - -c
             - >
-                
-        
-                until (nc -vz "posthog-db-pooler.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" 5432);
+                until pg_isready -q -h "posthog-db-pooler.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" -p 5432;
                 do
-                    echo "waiting for Postgres pooler"; sleep 1;
+                  echo "waiting for Postgres pooler";
+                  sleep 1;
                 done
-        
-                
-        
-                
         
                         
         - name: wait-for-migrations

--- a/argocd/applications/posthog/job-posthog-migrate.yaml
+++ b/argocd/applications/posthog/job-posthog-migrate.yaml
@@ -121,7 +121,7 @@ spec:
           {}
       initContainers:        
         - name: wait-for-service-dependencies
-          image: busybox:1.34
+          image: ghcr.io/cloudnative-pg/postgresql:17.0
           env:
             - name: CLICKHOUSE_HOST
               value: "posthog-clickhouse.posthog.svc.cluster.local"
@@ -144,9 +144,8 @@ spec:
             - /bin/sh
             - -c
             - >
-                
-        
-                until (nc -vz "posthog-db-rw.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" 5432);
+                until pg_isready -q -h "posthog-db-rw.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local" -p 5432;
                 do
-                    echo "waiting for Postgres"; sleep 1;
+                  echo "waiting for Postgres";
+                  sleep 1;
                 done

--- a/argocd/applications/posthog/pooler-posthog-db.yaml
+++ b/argocd/applications/posthog/pooler-posthog-db.yaml
@@ -9,7 +9,7 @@ spec:
   instances: 1
   type: rw
   pgbouncer:
+    poolMode: transaction
     parameters:
-      pool_mode: transaction
       default_pool_size: "20"
       max_client_conn: "1000"


### PR DESCRIPTION
## Summary
- Fixes `Pooler` configuration for PostHog PostgreSQL integration by using `pgbouncer.poolMode` and removing `pgbouncer.parameters.pool_mode`, which is rejected by CNPG as reserved.
- Removes Docker Hub `busybox:1.34` dependency from PostHog init containers by switching them to `ghcr.io/cloudnative-pg/postgresql:17.0` with `pg_isready` checks, preventing unauthenticated Docker Hub pull rate-limit failures during startup.

## Testing
- Not run (GitOps change only): updated manifests and reviewed generated application resources.

## Security
- No new secrets added.
- No privilege escalation or credential changes.

## Notes
- This addresses the current Argo CD sync failure and image pull blocker seen during deployment hardening.
