### PR TITLE
chore(jangar): promote image fa09da44

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 1cb25322
-  digest: sha256:e4fb3d18570906f2b7f8ce02d369c4333f37f64b73025a1411b4cb4558cfaad6
+  tag: fa09da44
+  digest: sha256:d7121dc9683acedc8bbae878059174ba2b8bcfb79aaa0fef2124f402a8251d3d
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 1cb25322
-    digest: sha256:e62b4263ddca2b17c5d27599e3f72b25830559816f63bfd73c754f4d259ebec3
+    tag: fa09da44
+    digest: sha256:b7617eae9912e6b2ce0bc445e4fb3d16c5cbc832dd6e4157515cf065b251a65b
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 1cb25322
-    digest: sha256:e4fb3d18570906f2b7f8ce02d369c4333f37f64b73025a1411b4cb4558cfaad6
+    tag: fa09da44
+    digest: sha256:d7121dc9683acedc8bbae878059174ba2b8bcfb79aaa0fef2124f402a8251d3d
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T00:50:52Z"
+    deploy.knative.dev/rollout: "2026-03-02T01:24:52Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T00:50:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T01:24:52Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "1cb25322"
-    digest: sha256:e4fb3d18570906f2b7f8ce02d369c4333f37f64b73025a1411b4cb4558cfaad6
+    newTag: "fa09da44"
+    digest: sha256:d7121dc9683acedc8bbae878059174ba2b8bcfb79aaa0fef2124f402a8251d3d


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `fa09da447fdc78b9696f4c7b598f073f580ae5a2`
- Image tag: `fa09da44`
- Image digest: `sha256:d7121dc9683acedc8bbae878059174ba2b8bcfb79aaa0fef2124f402a8251d3d`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`