### PR TITLE
fix(jangar): fix schedule delivery-id runtime substitution

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -131,6 +131,14 @@ describe('supporting primitives controller', () => {
     expect(degraded?.status).toBe('True')
   })
 
+  it('builds schedule runner command with runtime delivery id substitution', () => {
+    const command = __test__.buildScheduleRunnerCommand()
+
+    expect(command).toContain('DELIVERY_ID=$(cat /proc/sys/kernel/random/uuid);')
+    expect(command).toContain('s/__JANGAR_DELIVERY_ID__/${DELIVERY_ID}/g')
+    expect(command).not.toContain('\\${DELIVERY_ID}')
+  })
+
   it('resolves startup gate from feature flags with env fallback default', async () => {
     const previousNodeEnv = process.env.NODE_ENV
     try {

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -909,6 +909,12 @@ const resolveScheduleTarget = async (
   throw new Error(`unsupported schedule target kind: ${targetKind}`)
 }
 
+const buildScheduleRunnerCommand = (): string =>
+  [
+    'DELIVERY_ID=$(cat /proc/sys/kernel/random/uuid);',
+    'sed "s/__JANGAR_DELIVERY_ID__/${DELIVERY_ID}/g" /config/run.json | kubectl create -f -',
+  ].join(' ')
+
 const reconcileSchedule = async (
   kube: ReturnType<typeof createKubernetesClient>,
   schedule: Record<string, unknown>,
@@ -990,14 +996,7 @@ const reconcileSchedule = async (
                   {
                     name: 'schedule-runner',
                     image,
-                    command: [
-                      '/bin/sh',
-                      '-ec',
-                      [
-                        'DELIVERY_ID=$(cat /proc/sys/kernel/random/uuid);',
-                        `sed "s/__JANGAR_DELIVERY_ID__/\\$${'{DELIVERY_ID}'}/g" /config/run.json | kubectl create -f -`,
-                      ].join(' '),
-                    ],
+                    command: ['/bin/sh', '-ec', buildScheduleRunnerCommand()],
                     volumeMounts: [{ name: 'schedule-template', mountPath: '/config' }],
                   },
                 ],
@@ -1770,6 +1769,7 @@ export const stopSupportingPrimitivesController = () => {
 }
 
 export const __test__ = {
+  buildScheduleRunnerCommand,
   reconcileTool,
   reconcileSwarm,
   shouldStartWithFeatureFlag,


### PR DESCRIPTION
## Summary

- Fix schedule-runner command generation to substitute `__JANGAR_DELIVERY_ID__` with the runtime `DELIVERY_ID` value (instead of a literal `${DELIVERY_ID}` string).
- Extract command construction into `buildScheduleRunnerCommand()` to keep command semantics explicit and testable.
- Add regression coverage in `supporting-primitives-controller.test.ts` that asserts runtime substitution format and guards against escaped `${DELIVERY_ID}`.

## Related Issues

None

## Testing

- `cd services/jangar && bun run test src/server/__tests__/supporting-primitives-controller.test.ts`
- `cd services/jangar && bunx tsc --noEmit --project tsconfig.paths.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
