### PR TITLE
chore(jangar): promote image 09867cb7

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: fa09da44
-  digest: sha256:d7121dc9683acedc8bbae878059174ba2b8bcfb79aaa0fef2124f402a8251d3d
+  tag: 09867cb7
+  digest: sha256:9000780a23744b61ee33e724d30415b2eb8d0a48fb7883d3bc999400cdb71e72
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: fa09da44
-    digest: sha256:b7617eae9912e6b2ce0bc445e4fb3d16c5cbc832dd6e4157515cf065b251a65b
+    tag: 09867cb7
+    digest: sha256:b2ca9cdbb67e14f0e99130d7b92c25296ea70f68add82d3eb53478e91e8d2457
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: fa09da44
-    digest: sha256:d7121dc9683acedc8bbae878059174ba2b8bcfb79aaa0fef2124f402a8251d3d
+    tag: 09867cb7
+    digest: sha256:9000780a23744b61ee33e724d30415b2eb8d0a48fb7883d3bc999400cdb71e72
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T01:24:52Z"
+    deploy.knative.dev/rollout: "2026-03-02T01:48:44Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T01:24:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T01:48:44Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "fa09da44"
-    digest: sha256:d7121dc9683acedc8bbae878059174ba2b8bcfb79aaa0fef2124f402a8251d3d
+    newTag: "09867cb7"
+    digest: sha256:9000780a23744b61ee33e724d30415b2eb8d0a48fb7883d3bc999400cdb71e72


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `09867cb719ed5c99bdd79b4cf2287990c4981589`
- Image tag: `09867cb7`
- Image digest: `sha256:9000780a23744b61ee33e724d30415b2eb8d0a48fb7883d3bc999400cdb71e72`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`