### PR TITLE
chore(jangar): promote image 9a5f8042

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: d481ef0d
-  digest: sha256:bcac6a1783be8b41ceac6e2eff304204d6866adc34c861d5166ea1434d39559f
+  tag: 9a5f8042
+  digest: sha256:83afb0951b80ab59b903e700b7cadc5533aefeedfc63b49ca3552d3b6bea3790
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: d481ef0d
-    digest: sha256:cedc77099ed11495b3384f4d7c300423cd560abc006c350aed60ba6af2463dfe
+    tag: 9a5f8042
+    digest: sha256:0946653d3dd633a8a2c0e032ce5c2080dc0e7233c471d675079ac39b7f8775be
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: d481ef0d
-    digest: sha256:bcac6a1783be8b41ceac6e2eff304204d6866adc34c861d5166ea1434d39559f
+    tag: 9a5f8042
+    digest: sha256:83afb0951b80ab59b903e700b7cadc5533aefeedfc63b49ca3552d3b6bea3790
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T04:28:36Z"
+    deploy.knative.dev/rollout: "2026-03-02T06:29:57Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T04:28:36Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T06:29:57Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "d481ef0d"
-    digest: sha256:bcac6a1783be8b41ceac6e2eff304204d6866adc34c861d5166ea1434d39559f
+    newTag: "9a5f8042"
+    digest: sha256:83afb0951b80ab59b903e700b7cadc5533aefeedfc63b49ca3552d3b6bea3790


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `9a5f8042eb6783ef3fca858194566e38b7011ab5`
- Image tag: `9a5f8042`
- Image digest: `sha256:83afb0951b80ab59b903e700b7cadc5533aefeedfc63b49ca3552d3b6bea3790`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`