### PR TITLE
chore(jangar): promote image c5ef6a3e

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 9a5f8042
-  digest: sha256:83afb0951b80ab59b903e700b7cadc5533aefeedfc63b49ca3552d3b6bea3790
+  tag: c5ef6a3e
+  digest: sha256:9bb3a98ceec0c058d3abcf98c3317a3475db47f24e4d2064158869d0709f47ee
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 9a5f8042
-    digest: sha256:0946653d3dd633a8a2c0e032ce5c2080dc0e7233c471d675079ac39b7f8775be
+    tag: c5ef6a3e
+    digest: sha256:65502ec9c7790c485365c237b59a8768b56a3b77eec876bd277662c5e5488c1f
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 9a5f8042
-    digest: sha256:83afb0951b80ab59b903e700b7cadc5533aefeedfc63b49ca3552d3b6bea3790
+    tag: c5ef6a3e
+    digest: sha256:9bb3a98ceec0c058d3abcf98c3317a3475db47f24e4d2064158869d0709f47ee
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T06:29:57Z"
+    deploy.knative.dev/rollout: "2026-03-02T07:02:08Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T06:29:57Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T07:02:08Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "9a5f8042"
-    digest: sha256:83afb0951b80ab59b903e700b7cadc5533aefeedfc63b49ca3552d3b6bea3790
+    newTag: "c5ef6a3e"
+    digest: sha256:9bb3a98ceec0c058d3abcf98c3317a3475db47f24e4d2064158869d0709f47ee


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c5ef6a3e2467a34187f68eb08f92ff4277abd3b6`
- Image tag: `c5ef6a3e`
- Image digest: `sha256:9bb3a98ceec0c058d3abcf98c3317a3475db47f24e4d2064158869d0709f47ee`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`