### PR TITLE
fix(jangar): reconcile latest resources from watch events

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -290,6 +290,13 @@ describe('supporting primitives controller', () => {
     expect(apply).toHaveBeenCalledTimes(1)
   })
 
+  it('resolves watched resources only for controller-managed kinds', () => {
+    expect(__test__.resolveWatchedResourceForKind('Swarm')).toBe(RESOURCE_MAP.Swarm)
+    expect(__test__.resolveWatchedResourceForKind('Schedule')).toBe(RESOURCE_MAP.Schedule)
+    expect(__test__.resolveWatchedResourceForKind('Artifact')).toBe(RESOURCE_MAP.Artifact)
+    expect(__test__.resolveWatchedResourceForKind('ConfigMap')).toBeNull()
+  })
+
   it('resolves startup gate from feature flags with env fallback default', async () => {
     const previousNodeEnv = process.env.NODE_ENV
     try {

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -538,6 +538,20 @@ const resolveComparableResource = (kind: string) => {
   return null
 }
 
+const resolveWatchedResourceForKind = (kind: string) => {
+  if (kind === 'Tool') return RESOURCE_MAP.Tool
+  if (kind === 'ApprovalPolicy') return RESOURCE_MAP.ApprovalPolicy
+  if (kind === 'Budget') return RESOURCE_MAP.Budget
+  if (kind === 'SecretBinding') return RESOURCE_MAP.SecretBinding
+  if (kind === 'Signal') return RESOURCE_MAP.Signal
+  if (kind === 'SignalDelivery') return RESOURCE_MAP.SignalDelivery
+  if (kind === 'Schedule') return RESOURCE_MAP.Schedule
+  if (kind === 'Swarm') return RESOURCE_MAP.Swarm
+  if (kind === 'Workspace') return RESOURCE_MAP.Workspace
+  if (kind === 'Artifact') return RESOURCE_MAP.Artifact
+  return null
+}
+
 const applyResourceIfChanged = async (
   kube: ReturnType<typeof createKubernetesClient>,
   resource: Record<string, unknown>,
@@ -2213,7 +2227,16 @@ const handleResourceEvent = (
   const resourceKind = asString(resource.kind) ?? 'Unknown'
   const resourceName = asString(readNested(resource, ['metadata', 'name'])) ?? 'unknown'
   const queueKey = `${resourceNamespace}/${resourceKind}/${resourceName}`
-  queueResourceTask(resourceNamespace, queueKey, () => reconcileResource(kube, resource, resourceNamespace))
+  queueResourceTask(resourceNamespace, queueKey, async () => {
+    const watchedResource = resolveWatchedResourceForKind(resourceKind)
+    if (!watchedResource || !resourceName || resourceName === 'unknown') {
+      await reconcileResource(kube, resource, resourceNamespace)
+      return
+    }
+    const latestResource = await kube.get(watchedResource, resourceName, resourceNamespace)
+    if (!latestResource) return
+    await reconcileResource(kube, latestResource, resourceNamespace)
+  })
 }
 
 const handleScheduleRunnerEvent = async (
@@ -2439,6 +2462,7 @@ export const __test__ = {
   buildScheduleRunnerCommand,
   reconcileTool,
   reconcileSwarm,
+  resolveWatchedResourceForKind,
   shouldStartWithFeatureFlag,
   SWARM_CRD_REFRESH_INTERVAL_MS,
 }


### PR DESCRIPTION
## Summary

- Updated watch-event reconciliation to fetch the latest live object (`kube.get`) for controller-managed kinds before reconciling, preventing stale watch snapshots from retriggering redundant status writes.
- Kept per-resource queue coalescing semantics and fallback behavior for unsupported/unknown kinds.
- Added regression coverage for watched-kind resource mapping in supporting controller tests.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/src/server/supporting-primitives-controller.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bunx vitest run src/server/__tests__/supporting-primitives-controller.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No user-facing API or config behavior changed.
