### PR TITLE
chore(jangar): pin rollout manifests to image 3a8ba1608

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T07:02:08Z"
+    deploy.knative.dev/rollout: "2026-03-02T07:50:53.242Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T07:02:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T07:50:53.242Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c5ef6a3e"
-    digest: sha256:9bb3a98ceec0c058d3abcf98c3317a3475db47f24e4d2064158869d0709f47ee
+    newTag: "3a8ba1608"
+    digest: sha256:a637f227e4dda8deb7511da39690b1f48a05ce347bec7135ceef1e01f8a9164a


### PR DESCRIPTION
## Summary

- Updated `argocd/applications/jangar/kustomization.yaml` to pin `registry.ide-newton.ts.net/lab/jangar` to tag `3a8ba1608` and digest `sha256:a637f227e4dda8deb7511da39690b1f48a05ce347bec7135ceef1e01f8a9164a`.
- Bumped rollout annotations in `deployment.yaml` and `jangar-worker-deployment.yaml` so Kubernetes performs a fresh rollout.
- Aligns GitOps desired state with the emergency rollout image so Argo CD no longer reverts to the previous digest.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kubectl kustomize argocd/applications/jangar --enable-helm | rg -n "image: registry.ide-newton.ts.net/lab/jangar"`
- `kubectl -n jangar rollout status deployment/jangar --timeout=300s`
- `kubectl -n jangar rollout status deployment/jangar-worker --timeout=300s`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. GitOps manifests are intentionally updated for this rollout.
