### PR TITLE
fix(jangar): throttle swarm status-only reconciles

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -297,6 +297,31 @@ describe('supporting primitives controller', () => {
     expect(__test__.resolveWatchedResourceForKind('ConfigMap')).toBeNull()
   })
 
+  it('identifies swarm status-only modified events', () => {
+    const swarm = {
+      kind: 'Swarm',
+      metadata: { generation: 7 },
+      status: { observedGeneration: 7 },
+    }
+
+    expect(__test__.isSwarmStatusOnlyEvent('MODIFIED', swarm)).toBe(true)
+    expect(__test__.isSwarmStatusOnlyEvent('ADDED', swarm)).toBe(false)
+    expect(__test__.isSwarmStatusOnlyEvent('MODIFIED', { ...swarm, status: { observedGeneration: 6 } })).toBe(false)
+  })
+
+  it('throttles swarm status-only reconciles within the guard interval', () => {
+    const key = 'agents/Swarm/jangar-control-plane'
+    const startMs = 1_000
+
+    expect(__test__.shouldThrottleSwarmStatusReconcile(key, startMs)).toBe(false)
+    expect(
+      __test__.shouldThrottleSwarmStatusReconcile(key, startMs + __test__.SWARM_STATUS_ONLY_RECONCILE_INTERVAL_MS - 1),
+    ).toBe(true)
+    expect(
+      __test__.shouldThrottleSwarmStatusReconcile(key, startMs + __test__.SWARM_STATUS_ONLY_RECONCILE_INTERVAL_MS),
+    ).toBe(false)
+  })
+
   it('resolves startup gate from feature flags with env fallback default', async () => {
     const previousNodeEnv = process.env.NODE_ENV
     try {

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -67,6 +67,9 @@ const namespaceQueues = new Map<string, Promise<void>>()
 const queuedResourceKeysByNamespace = new Map<string, Map<string, { rerun: boolean }>>()
 const optionalCrdsReady = new Set<string>()
 const swarmUnfreezeTimers = new Map<string, NodeJS.Timeout>()
+const swarmStatusReconcileThrottleByKey = new Map<string, number>()
+
+const SWARM_STATUS_ONLY_RECONCILE_INTERVAL_MS = 30_000
 
 const nowIso = () => new Date().toISOString()
 
@@ -550,6 +553,28 @@ const resolveWatchedResourceForKind = (kind: string) => {
   if (kind === 'Workspace') return RESOURCE_MAP.Workspace
   if (kind === 'Artifact') return RESOURCE_MAP.Artifact
   return null
+}
+
+const asNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  return null
+}
+
+const isSwarmStatusOnlyEvent = (eventType: string | undefined, resource: Record<string, unknown>) => {
+  if (eventType !== 'MODIFIED') return false
+  if (asString(resource.kind) !== 'Swarm') return false
+  const generation = asNumber(readNested(resource, ['metadata', 'generation']))
+  const observedGeneration = asNumber(readNested(resource, ['status', 'observedGeneration']))
+  return generation !== null && observedGeneration !== null && generation === observedGeneration
+}
+
+const shouldThrottleSwarmStatusReconcile = (resourceKey: string, nowMs = Date.now()) => {
+  const last = swarmStatusReconcileThrottleByKey.get(resourceKey)
+  if (last !== undefined && nowMs - last < SWARM_STATUS_ONLY_RECONCILE_INTERVAL_MS) {
+    return true
+  }
+  swarmStatusReconcileThrottleByKey.set(resourceKey, nowMs)
+  return false
 }
 
 const applyResourceIfChanged = async (
@@ -2227,6 +2252,9 @@ const handleResourceEvent = (
   const resourceKind = asString(resource.kind) ?? 'Unknown'
   const resourceName = asString(readNested(resource, ['metadata', 'name'])) ?? 'unknown'
   const queueKey = `${resourceNamespace}/${resourceKind}/${resourceName}`
+  if (isSwarmStatusOnlyEvent(event.type, resource) && shouldThrottleSwarmStatusReconcile(queueKey)) {
+    return
+  }
   queueResourceTask(resourceNamespace, queueKey, async () => {
     const watchedResource = resolveWatchedResourceForKind(resourceKind)
     if (!watchedResource || !resourceName || resourceName === 'unknown') {
@@ -2453,6 +2481,7 @@ export const stopSupportingPrimitivesController = () => {
   watchHandles = []
   namespaceQueues.clear()
   queuedResourceKeysByNamespace.clear()
+  swarmStatusReconcileThrottleByKey.clear()
   started = false
   controllerState.started = false
 }
@@ -2460,9 +2489,12 @@ export const stopSupportingPrimitivesController = () => {
 export const __test__ = {
   applyResourceIfChanged,
   buildScheduleRunnerCommand,
+  isSwarmStatusOnlyEvent,
   reconcileTool,
   reconcileSwarm,
   resolveWatchedResourceForKind,
+  shouldThrottleSwarmStatusReconcile,
   shouldStartWithFeatureFlag,
+  SWARM_STATUS_ONLY_RECONCILE_INTERVAL_MS,
   SWARM_CRD_REFRESH_INTERVAL_MS,
 }


### PR DESCRIPTION
## Summary

- Added `Swarm` status-only event detection for `MODIFIED` events where `metadata.generation == status.observedGeneration`.
- Added a bounded reconcile throttle (`30s`) for these status-only `Swarm` events to prevent high-frequency full swarm reconciles.
- Added regression coverage for status-only event detection and throttle interval behavior in supporting controller tests.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/src/server/supporting-primitives-controller.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bunx vitest run src/server/__tests__/supporting-primitives-controller.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. Behavior change is internal reconcile throttling only.
