### PR TITLE
chore(jangar): pin rollout manifests to image 5d29e81ab

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T07:50:53.242Z"
+    deploy.knative.dev/rollout: "2026-03-02T08:05:12.566Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T07:50:53.242Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T08:05:12.566Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "3a8ba1608"
-    digest: sha256:a637f227e4dda8deb7511da39690b1f48a05ce347bec7135ceef1e01f8a9164a
+    newTag: "5d29e81ab"
+    digest: sha256:e46388bc57da2a6d920cdeccebdb6fc79820a3e1e2fe7c8693584d97310d11b7


### PR DESCRIPTION
## Summary

- Pin Jangar GitOps manifests to image `5d29e81ab@sha256:e46388bc57da2a6d920cdeccebdb6fc79820a3e1e2fe7c8693584d97310d11b7`.
- Refresh rollout annotations for `jangar` and `jangar-worker` so the new pod templates are applied.
- Align Argo desired state with the merged Swarm status-only throttle fix now on `main`.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/jangar/deploy-service.ts`
- `kubectl -n jangar rollout status deployment/jangar --timeout=120s`
- `kubectl -n jangar rollout status deployment/jangar-worker --timeout=120s`
- `kubectl -n jangar get deploy jangar jangar-worker -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.template.spec.containers[*]}{.name}={.image}{" "}{end}{"\n"}{end}'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
