### PR TITLE
chore(jangar): promote image 5d29e81a

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c5ef6a3e
-  digest: sha256:9bb3a98ceec0c058d3abcf98c3317a3475db47f24e4d2064158869d0709f47ee
+  tag: 5d29e81a
+  digest: sha256:574fb186d099258ba656503081d70b67966e9a48071b61b389271ac7de6a47d6
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c5ef6a3e
-    digest: sha256:65502ec9c7790c485365c237b59a8768b56a3b77eec876bd277662c5e5488c1f
+    tag: 5d29e81a
+    digest: sha256:4a3a450662f09b35c797994b6f245fdfd8b14d02188eee41e115478d084165fd
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c5ef6a3e
-    digest: sha256:9bb3a98ceec0c058d3abcf98c3317a3475db47f24e4d2064158869d0709f47ee
+    tag: 5d29e81a
+    digest: sha256:574fb186d099258ba656503081d70b67966e9a48071b61b389271ac7de6a47d6
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T08:05:12.566Z"
+    deploy.knative.dev/rollout: "2026-03-02T08:08:51Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T08:05:12.566Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T08:08:51Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "5d29e81ab"
-    digest: sha256:e46388bc57da2a6d920cdeccebdb6fc79820a3e1e2fe7c8693584d97310d11b7
+    newTag: "5d29e81a"
+    digest: sha256:574fb186d099258ba656503081d70b67966e9a48071b61b389271ac7de6a47d6


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `5d29e81abbc9582cd1f95f397021b80191b52583`
- Image tag: `5d29e81a`
- Image digest: `sha256:574fb186d099258ba656503081d70b67966e9a48071b61b389271ac7de6a47d6`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`