### PR TITLE
chore(jangar): promote image 675afb73

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 5d29e81a
-  digest: sha256:574fb186d099258ba656503081d70b67966e9a48071b61b389271ac7de6a47d6
+  tag: 675afb73
+  digest: sha256:20477d7f41587bab150723e84e500725c6fd80a9f77432c6d510a7ff9a92535e
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 5d29e81a
-    digest: sha256:4a3a450662f09b35c797994b6f245fdfd8b14d02188eee41e115478d084165fd
+    tag: 675afb73
+    digest: sha256:9f08147abbc2caa7f9219282180ba549d006d699fb6a682be7c58e5c88266b02
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 5d29e81a
-    digest: sha256:574fb186d099258ba656503081d70b67966e9a48071b61b389271ac7de6a47d6
+    tag: 675afb73
+    digest: sha256:20477d7f41587bab150723e84e500725c6fd80a9f77432c6d510a7ff9a92535e
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T08:20:33.021Z"
+    deploy.knative.dev/rollout: "2026-03-02T08:37:23Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T08:20:33.021Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T08:37:23Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "2bbf6f10b"
-    digest: sha256:d212d678638b1377c357f5e501e75f70ecdd31ee4949cbeecac092e95c4c192d
+    newTag: "675afb73"
+    digest: sha256:20477d7f41587bab150723e84e500725c6fd80a9f77432c6d510a7ff9a92535e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `675afb734efef884fc9ad17b010abe84bd21a284`
- Image tag: `675afb73`
- Image digest: `sha256:20477d7f41587bab150723e84e500725c6fd80a9f77432c6d510a7ff9a92535e`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`