### PR TITLE
feat(agents): enforce dynamic huly channel collaboration

### DIFF
--- a/argocd/applications/agents/swarm-implspecs.yaml
+++ b/argocd/applications/agents/swarm-implspecs.yaml
@@ -28,6 +28,7 @@ spec:
     - hulyProject (optional, default DefaultProject)
     - hulyChannelName (optional, default general)
     - hulyChannelUrl (optional, default https://huly.proompteng.ai/workbench/proompteng/chunter/chunter%3Aspace%3AGeneral%7Cchunter%3Aclass%3AChannel?message)
+    - swarmRequirementChannel (optional, huly://<workspace>/channels/<name>)
     - hulyTeamspaceName (optional, default PROOMPTENG)
     - hulyTrackerUrl (optional, default https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues)
     - hulyRequireDedicatedAccount (optional, default false)
@@ -39,17 +40,21 @@ spec:
     - Use internet research when stage needs fresh external facts.
     - Use the Huly skill at ${hulySkillRef} for owner updates and cross-swarm communication.
     - Operate as a human coworker for ${swarmTeamName}; write in natural first-person language as ${swarmHumanName}.
-    - When posting to Huly, include concrete status, decisions, blockers, and explicit asks instead of robotic status-only text.
+    - Resolve an active Huly channel in this order: swarmRequirementChannel, hulyChannelName, then hulyChannelUrl.
+    - Read recent teammate context from that active channel before taking action:
+      `python3 skills/huly-api/scripts/huly-api.py --operation list-channel-messages --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --require-worker-token --channel "${activeHulyChannel}" --limit 30`
+    - React to relevant teammate messages by posting at least one explicit reply that references message IDs and your decision.
+    - Write worker-authored channel messages from live context and decisions; do not rely on canned text.
     - If hulyRequireDedicatedAccount is true, call
       `python3 skills/huly-api/scripts/huly-api.py --operation account-info --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --require-worker-token`
       and include `--expected-actor-id` only when hulyExpectedActorId is provided.
       and fail the run if account identity validation fails.
     - Verify chat posting access for this worker account via
-      `python3 skills/huly-api/scripts/huly-api.py --operation verify-chat-access --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --require-worker-token --channel "${hulyChannelName}"`
+      `python3 skills/huly-api/scripts/huly-api.py --operation verify-chat-access --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --require-worker-token --channel "${activeHulyChannel}" --message "${chatAccessMessage}"`
       and reference ${hulyChannelUrl} in the owner update.
     - Publish mission artifacts through all Huly collaboration modules (tasks board, channel message, mission document).
     - Use
-      `python3 skills/huly-api/scripts/huly-api.py --operation upsert-mission --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --project "${hulyProject}" --teamspace "${hulyTeamspaceName}" --channel "${hulyChannelName}" ...`
+      `python3 skills/huly-api/scripts/huly-api.py --operation upsert-mission --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --project "${hulyProject}" --teamspace "${hulyTeamspaceName}" --channel "${activeHulyChannel}" --message "${ownerUpdateMessage}" ...`
       to write those artifacts.
     - Ensure issue artifacts are written to ${hulyProject} and reference ${hulyTrackerUrl} when provided.
     - Sign communications with ${swarmHumanName} (${swarmTeamName}) and worker identity ${swarmAgentWorkerId}/${swarmAgentIdentity}.
@@ -116,6 +121,10 @@ spec:
     1) If swarmRequirementChannel exists and points to Huly, treat this run as a cross-swarm requirement from
        swarmRequirementSource -> swarmRequirementTarget and use the requirement description/payload as the primary scope.
     1a) Operate as a human coworker for ${swarmTeamName}; write in natural first-person language as ${swarmHumanName}.
+    1b) Resolve an active Huly channel in this order: swarmRequirementChannel, hulyChannelName, then hulyChannelUrl.
+    1c) Read recent messages on the active channel before implementation to pick up teammate requirements and blockers:
+       `python3 skills/huly-api/scripts/huly-api.py --operation list-channel-messages --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --require-worker-token --channel "${activeHulyChannel}" --limit 30`
+    1d) React to at least one relevant teammate message with a direct reply that references the message id.
     2) Implement minimal, production-quality code and config changes in ${repository}.
     3) Run targeted validation for touched areas (lint/type-check/tests as applicable).
     4) If hulyRequireDedicatedAccount is true, call
@@ -123,10 +132,10 @@ spec:
        and include `--expected-actor-id` only when hulyExpectedActorId is provided,
        and fail the mission if validation fails.
     5) Verify chat posting access for this worker via
-       `python3 skills/huly-api/scripts/huly-api.py --operation verify-chat-access --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --require-worker-token --channel "${hulyChannelName}"`
+       `python3 skills/huly-api/scripts/huly-api.py --operation verify-chat-access --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --require-worker-token --channel "${activeHulyChannel}" --message "${chatAccessMessage}"`
        and include ${hulyChannelUrl} in the status update.
     6) Use the Huly skill at ${hulySkillRef} and call
-       `python3 skills/huly-api/scripts/huly-api.py --operation upsert-mission --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --project "${hulyProject}" --teamspace "${hulyTeamspaceName}" --channel "${hulyChannelName}" ...`
+       `python3 skills/huly-api/scripts/huly-api.py --operation upsert-mission --worker-id "${swarmAgentWorkerId}" --worker-identity "${swarmAgentIdentity}" --project "${hulyProject}" --teamspace "${hulyTeamspaceName}" --channel "${activeHulyChannel}" --message "${ownerUpdateMessage}" ...`
        so this mission always updates all three Huly modules:
        - tasks board issue
        - channel status message

--- a/docs/agents/designs/jangar-swarm-intelligence-owner-serving.md
+++ b/docs/agents/designs/jangar-swarm-intelligence-owner-serving.md
@@ -3,6 +3,7 @@
 Status: Proposed (2026-03-01)
 
 Docs index: [README](../README.md)
+Execution runbook: [swarm-end-to-end-runbook](../swarm-end-to-end-runbook.md)
 
 ## Objective
 

--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -9,6 +9,7 @@ See also:
 - `README.md` (docs index)
 - `designs/handoff-common.md` (GitOps render + live verification commands)
 - `ci-validation-plan.md` (what to run before/after rollout)
+- `swarm-end-to-end-runbook.md` (dual-swarm Huly communication + e2e validation flow)
 
 ## Install
 

--- a/docs/agents/swarm-end-to-end-runbook.md
+++ b/docs/agents/swarm-end-to-end-runbook.md
@@ -1,0 +1,173 @@
+# Swarm End-To-End Runbook
+
+Status: Current (2026-03-02)
+
+This runbook documents how dual swarms run continuously, how they communicate through Huly, and how to verify the
+full loop from requirement signal to implementation execution.
+
+## System Topology
+
+```mermaid
+flowchart LR
+  T["Torghut Swarm (trading)"] -->|Signal requirement| S["Signal CRD (agents ns)"]
+  S --> J["Jangar Swarm (engineering)"]
+  T --> H["Huly (Tracker + Chat + Docs)"]
+  J --> H
+  T --> AR["AgentRun Scheduler"]
+  J --> AR
+  AR --> C["codex-spark-agent"]
+  C --> G["GitHub PR + CI"]
+  G --> A["Argo CD"]
+  A --> K["Kubernetes Runtime"]
+  K --> H
+```
+
+## Channel Communication Contract
+
+All workers use the Huly skill and must do three actions per stage:
+
+1. Read recent channel history (`list-channel-messages`).
+2. React to relevant teammate messages (post explicit replies referencing message ids).
+3. Publish a worker-authored mission update (`upsert-mission --message ...`).
+
+Channel selection is dynamic at runtime:
+
+1. `swarmRequirementChannel` from signal (if present).
+2. `hulyChannelName`.
+3. `hulyChannelUrl`.
+
+## Execution Loop
+
+```mermaid
+sequenceDiagram
+  participant T as Torghut Swarm
+  participant H as Huly Channel
+  participant S as Signal CRD
+  participant J as Jangar Swarm
+  participant R as AgentRun
+  participant C as codex-spark-agent
+  participant G as GitHub/CI
+  participant A as Argo CD
+
+  T->>H: Read latest teammate messages
+  T->>H: React with requirement context
+  T->>S: Create requirement signal (huly://.../channels/<name>)
+  S->>J: Dispatch requirement context
+  J->>R: Create requirement-driven implement run
+  C->>H: Read channel history before acting
+  C->>H: Post worker-authored access and mission updates
+  C->>G: Commit / PR / CI
+  G->>A: Green checks and merge
+  A->>H: Deployment outcome posted by worker
+```
+
+## Live Verification Procedure
+
+Run these checks in order.
+
+### 1. Branch and merge safety
+
+```bash
+git status --porcelain=v1 -b
+rg -n "^<<<<<<<|^=======|^>>>>>>>" -g'!*node_modules/*'
+```
+
+Expected:
+
+- Clean working tree.
+- No conflict markers.
+
+### 2. GitOps health
+
+```bash
+kubectl -n argocd get application agents -o json | jq '{sync:.status.sync.status,health:.status.health.status,revision:.status.sync.revision}'
+kubectl -n agents get swarm
+kubectl -n agents get schedules.schedules.proompteng.ai
+```
+
+Expected:
+
+- `agents` app is `Synced` and `Healthy`.
+- `jangar-control-plane` and `torghut-quant` swarms are `Active` and `Ready=True`.
+- All stage schedules are `Active`.
+
+### 3. Cross-swarm handoff proof
+
+Create a live Torghut -> Jangar requirement signal:
+
+```bash
+TS=$(date +%s)
+NAME="torghut-to-jangar-e2e-$TS"
+cat <<EOF | kubectl apply -f -
+apiVersion: signals.proompteng.ai/v1alpha1
+kind: Signal
+metadata:
+  name: $NAME
+  namespace: agents
+  labels:
+    swarm.proompteng.ai/from: torghut-quant
+    swarm.proompteng.ai/to: jangar-control-plane
+    swarm.proompteng.ai/type: requirement
+spec:
+  channel: huly://virtual-workers/channels/general
+  description: "Live e2e validation from Torghut to Jangar"
+  payload:
+    mission: $NAME
+    priority: high
+    acceptance: "publish issue/document/channel artifacts and complete handoff"
+EOF
+```
+
+Confirm Jangar created a requirement-driven run:
+
+```bash
+kubectl -n agents get agentrun -o json | jq -r --arg n "$NAME" '.items[] | select(.spec.parameters.swarmRequirementSignal == $n) | .metadata.name'
+```
+
+Then follow to terminal phase:
+
+```bash
+RUN="<name-from-previous-command>"
+kubectl -n agents get agentrun "$RUN" -w
+```
+
+### 4. Huly read/reply/post evidence
+
+Inspect the run job logs and confirm all three behaviors:
+
+```bash
+JOB=$(kubectl -n agents get job -l agents.proompteng.ai/agent-run="$RUN" -o jsonpath='{.items[0].metadata.name}')
+kubectl -n agents logs job/"$JOB" --tail=400 | rg -n "list-channel-messages|verify-chat-access|upsert-mission|messageId|issueId|documentId"
+```
+
+Expected evidence:
+
+- `list-channel-messages` called before mission action.
+- `verify-chat-access` called with explicit `--message`.
+- `upsert-mission` called with explicit `--message`.
+- Returned Huly artifact ids (`issueId`, `documentId`, `messageId`).
+
+## Current Known State (2026-03-02)
+
+- `agents` Argo CD app: `Synced` + `Healthy`.
+- Both swarms: `Active` + `Ready=True`.
+- Live cross-swarm run observed: `jangar-control-plane-torghut-quant-req-00gbjlqs-1-n2l4r` (running during latest validation).
+- Last completed cross-swarm requirement example: `jangar-control-plane-torghut-quant-req-00gc1i45-1-hv7qz` (`Succeeded`).
+
+## Failure Criteria
+
+Treat loop as failed if any of these occur:
+
+- Signal exists but no requirement-driven Jangar run is created.
+- Jangar run reaches `Failed` or stays non-terminal past runtime SLO.
+- Run does not show `list-channel-messages`, `verify-chat-access --message`, and `upsert-mission --message`.
+- Huly artifacts are missing issue/doc/channel ids.
+
+## Recovery Actions
+
+1. Force swarm reconcile:
+   `kubectl -n agents annotate swarm jangar-control-plane swarm.proompteng.ai/reconcile-now="$(date +%s)" --overwrite`
+2. Inspect failed run status and runtime job logs.
+3. Re-submit requirement signal with a new mission id.
+4. If Argo sync is stuck on terminating template runs, clear stale `runtime-cleanup` finalizers on terminating template
+   `AgentRun` objects and re-sync.

--- a/skills/huly-api/SKILL.md
+++ b/skills/huly-api/SKILL.md
@@ -39,6 +39,46 @@ Load credentials from the `huly-api` Kubernetes secret via AgentRun `spec.secret
 
 Use `scripts/huly-api.py`.
 
+### Mandatory channel interaction loop
+
+For every mission stage, run this in order:
+
+1. Read recent channel history:
+
+```bash
+python3 skills/huly-api/scripts/huly-api.py \
+  --operation list-channel-messages \
+  --worker-id "${SWARM_AGENT_WORKER_ID}" \
+  --worker-identity "${SWARM_AGENT_IDENTITY}" \
+  --require-worker-token \
+  --channel "${ACTIVE_HULY_CHANNEL}" \
+  --limit 30
+```
+
+2. React to at least one relevant teammate message by posting a direct reply that references the message ID and decision impact:
+
+```bash
+python3 skills/huly-api/scripts/huly-api.py \
+  --operation post-channel-message \
+  --worker-id "${SWARM_AGENT_WORKER_ID}" \
+  --worker-identity "${SWARM_AGENT_IDENTITY}" \
+  --require-worker-token \
+  --channel "${ACTIVE_HULY_CHANNEL}" \
+  --message "Replying to message <messageId>: I picked up this requirement and I will implement X next."
+```
+
+3. Post a worker-authored stage update after completing the mission action:
+
+```bash
+python3 skills/huly-api/scripts/huly-api.py \
+  --operation post-channel-message \
+  --worker-id "${SWARM_AGENT_WORKER_ID}" \
+  --worker-identity "${SWARM_AGENT_IDENTITY}" \
+  --require-worker-token \
+  --channel "${ACTIVE_HULY_CHANNEL}" \
+  --message "${OWNER_UPDATE_MESSAGE}"
+```
+
 ### Mission-level sync (recommended)
 
 ```bash
@@ -52,6 +92,7 @@ python3 skills/huly-api/scripts/huly-api.py \
   --details "Includes evidence, risk deltas, and PR links" \
   --stage discover \
   --status running \
+  --message "${OWNER_UPDATE_MESSAGE}" \
   --project "DefaultProject" \
   --teamspace "PROOMPTENG" \
   --channel "general"
@@ -69,8 +110,9 @@ This creates/updates:
 python3 skills/huly-api/scripts/huly-api.py --operation create-issue --title "..." --mission-id "..."
 python3 skills/huly-api/scripts/huly-api.py --operation create-document --title "..." --mission-id "..."
 python3 skills/huly-api/scripts/huly-api.py --operation post-channel-message --message "..."
+python3 skills/huly-api/scripts/huly-api.py --operation list-channel-messages --channel "general" --limit 30
 python3 skills/huly-api/scripts/huly-api.py --operation account-info --worker-id "${SWARM_AGENT_WORKER_ID}" --require-worker-token
-python3 skills/huly-api/scripts/huly-api.py --operation verify-chat-access --worker-id "${SWARM_AGENT_WORKER_ID}" --worker-identity "${SWARM_AGENT_IDENTITY}" --require-worker-token --channel "general"
+python3 skills/huly-api/scripts/huly-api.py --operation verify-chat-access --worker-id "${SWARM_AGENT_WORKER_ID}" --worker-identity "${SWARM_AGENT_IDENTITY}" --require-worker-token --channel "general" --message "Hi team, I can post in this channel and I am starting this stage now."
 ```
 
 ### Raw HTTP mode (debug)
@@ -84,9 +126,11 @@ python3 skills/huly-api/scripts/huly-api.py --operation http --method GET --path
 - Every mission stage must publish artifacts to all three Huly modules: tasks, channels, and docs.
 - Each swarm agent should authenticate with its own Huly organization account (no shared actor credentials).
 - Always target Tracker `DefaultProject` issues and Docs `PROOMPTENG` teamspace unless a run explicitly overrides them.
+- Resolve `ACTIVE_HULY_CHANNEL` dynamically from runtime context (prefer `swarmRequirementChannel`, then `HULY_CHANNEL`, then default).
+- Read channel history before taking action, then react to relevant teammate messages with explicit follow-up replies.
 - Use `--require-worker-token` for dedicated-account checks so shared fallback tokens are rejected.
 - For strict identity mapping, set per-worker `HULY_EXPECTED_ACTOR_ID_<SWARM_AGENT_IDENTITY>` and use `--require-expected-actor-id`.
-- Run `verify-chat-access` before autonomous delivery stages to prove the worker account can write to `#general`.
+- Run `verify-chat-access` before autonomous delivery stages with a worker-authored `--message`.
 - Include `swarmAgentWorkerId` and `swarmAgentIdentity` in the issue/document/message body.
-- Keep channel updates concise and link issue/doc/PR/deploy evidence.
+- Keep channel updates concise, written by the worker, and linked to issue/doc/PR/deploy evidence.
 - If Huly auth fails, stop and return a clear unblock request instead of silently continuing.

--- a/skills/huly-api/scripts/huly-api.py
+++ b/skills/huly-api/scripts/huly-api.py
@@ -391,8 +391,26 @@ def resolve_teamspace(context: HulyContext, teamspace_ref: str) -> dict[str, Any
     return spaces[0]
 
 
+def normalize_channel_ref(channel_ref: str) -> str:
+    value = channel_ref.strip()
+    if not value:
+        return ''
+    if value.startswith('huly://'):
+        parsed = urllib.parse.urlparse(value)
+        segments = [segment for segment in parsed.path.split('/') if segment]
+        if len(segments) >= 2 and segments[0] == 'channels':
+            return urllib.parse.unquote(segments[1]).strip()
+        return urllib.parse.unquote(parsed.path.strip('/')).strip()
+    if value.startswith('http://') or value.startswith('https://'):
+        decoded = urllib.parse.unquote(urllib.parse.urlparse(value).path)
+        marker = 'chunter:space:'
+        if marker in decoded:
+            return decoded.split(marker, 1)[1].split('|', 1)[0].strip().lower()
+    return value
+
+
 def resolve_channel(context: HulyContext, channel_ref: str) -> dict[str, Any]:
-    channel_ref = channel_ref.strip()
+    channel_ref = normalize_channel_ref(channel_ref)
     if channel_ref:
         for query in ({'_id': channel_ref}, {'name': channel_ref}):
             channels = find_all(context=context, class_name=CHANNEL_CLASS, query=query, options={'limit': 1})
@@ -650,6 +668,43 @@ def post_channel_message(
     }
 
 
+def list_channel_messages(
+    *,
+    context: HulyContext,
+    channel_ref: str,
+    limit: int,
+) -> dict[str, Any]:
+    channel = resolve_channel(context, channel_ref)
+    channel_id = str(channel.get('_id') or '')
+    channel_name = str(channel.get('name') or '')
+    if not channel_id:
+        raise RuntimeError('resolved channel is missing _id')
+
+    safe_limit = max(1, min(limit, 200))
+    messages = find_all(
+        context=context,
+        class_name=CHAT_MESSAGE_CLASS,
+        query={'space': channel_id},
+        options={'limit': safe_limit, 'sort': {'modifiedOn': -1}},
+    )
+    normalized: list[dict[str, Any]] = []
+    for message in messages:
+        normalized.append(
+            {
+                'messageId': message.get('_id'),
+                'message': message.get('message', ''),
+                'createdBy': message.get('createdBy'),
+                'modifiedOn': message.get('modifiedOn'),
+            }
+        )
+    return {
+        'channelId': channel_id,
+        'channelName': channel_name,
+        'count': len(normalized),
+        'messages': normalized,
+    }
+
+
 def build_context(args: argparse.Namespace, *, for_platform_api: bool) -> HulyContext:
     base_url_raw = args.base_url.strip() or env_first('HULY_API_BASE_URL', 'HULY_BASE_URL')
     if not base_url_raw:
@@ -759,6 +814,11 @@ def run_account_info(args: argparse.Namespace) -> int:
 
 
 def run_verify_chat_access(args: argparse.Namespace) -> int:
+    chat_message = args.message.strip()
+    if not chat_message:
+        print('--message is required for verify-chat-access', file=sys.stderr)
+        return 2
+
     context = build_context(args, for_platform_api=True)
     account = fetch_account_info(context)
     actor_id = str(account.get('primarySocialId') or '').strip()
@@ -792,15 +852,6 @@ def run_verify_chat_access(args: argparse.Namespace) -> int:
         )
         return 1
 
-    worker_id = args.worker_id.strip() or env_if_set('SWARM_AGENT_WORKER_ID') or 'unknown-worker'
-    worker_identity = args.worker_identity.strip() or env_if_set('SWARM_AGENT_IDENTITY') or 'unknown-identity'
-    chat_message = args.message.strip() or (
-        '[swarm-chat-access-ok] '
-        f'worker={worker_id} '
-        f'identity={worker_identity} '
-        f'actorId={actor_id} '
-        f'tokenSource={context.token_source}'
-    )
     channel_result = post_channel_message(
         context=context,
         channel_ref=args.channel,
@@ -915,9 +966,18 @@ def run_post_channel_message(args: argparse.Namespace) -> int:
     return 0
 
 
-def run_upsert_mission(args: argparse.Namespace) -> int:
+def run_list_channel_messages(args: argparse.Namespace) -> int:
     context = build_context(args, for_platform_api=True)
+    result = list_channel_messages(
+        context=context,
+        channel_ref=args.channel,
+        limit=args.limit,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
 
+
+def run_upsert_mission(args: argparse.Namespace) -> int:
     mission_id = args.mission_id.strip()
     if not mission_id:
         print('--mission-id is required for upsert-mission', file=sys.stderr)
@@ -932,6 +992,12 @@ def run_upsert_mission(args: argparse.Namespace) -> int:
     if not summary:
         print('--summary is required for upsert-mission', file=sys.stderr)
         return 2
+    channel_message = args.message.strip()
+    if not channel_message:
+        print('--message is required for upsert-mission (worker-authored channel update)', file=sys.stderr)
+        return 2
+
+    context = build_context(args, for_platform_api=True)
 
     stage = args.stage.strip() or 'unknown'
     status = args.status.strip() or 'in-progress'
@@ -969,13 +1035,6 @@ def run_upsert_mission(args: argparse.Namespace) -> int:
         mission_id=mission_id,
     )
 
-    channel_message = (
-        f'[{stage}] [{status}] mission={mission_id}\\n'
-        f'title={title}\\n'
-        f'summary={summary}\\n'
-        f'issueId={issue_result.get("issueId", "")} '
-        f'documentId={document_result.get("documentId", "")}'
-    )
     channel_result = post_channel_message(
         context=context,
         channel_ref=args.channel,
@@ -1006,6 +1065,7 @@ def build_parser() -> argparse.ArgumentParser:
             'create-issue',
             'create-document',
             'post-channel-message',
+            'list-channel-messages',
             'upsert-mission',
             'account-info',
             'verify-chat-access',
@@ -1062,6 +1122,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--status', default='', help='Mission status label for upsert-mission')
     parser.add_argument('--issue-status', default=DEFAULT_ISSUE_STATUS, help='Issue status id for task artifacts')
     parser.add_argument('--priority', type=int, default=0, help='Issue priority for task artifacts')
+    parser.add_argument('--limit', type=int, default=20, help='Result limit for list-channel-messages')
     parser.add_argument(
         '--expected-actor-id',
         default='',
@@ -1094,6 +1155,8 @@ def main() -> int:
             return run_create_document(args)
         if args.operation == 'post-channel-message':
             return run_post_channel_message(args)
+        if args.operation == 'list-channel-messages':
+            return run_list_channel_messages(args)
         if args.operation == 'upsert-mission':
             return run_upsert_mission(args)
         if args.operation == 'account-info':

--- a/skills/huly-api/scripts/test_huly_api.py
+++ b/skills/huly-api/scripts/test_huly_api.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+def load_module():
+    module_path = pathlib.Path(__file__).with_name('huly-api.py')
+    spec = importlib.util.spec_from_file_location('huly_api_script', module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError('unable to load huly-api.py')
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class HulyApiFormattingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_module()
+
+    def test_normalize_channel_ref_huly_uri(self):
+        channel = self.module.normalize_channel_ref('huly://virtual-workers/channels/general')
+        self.assertEqual(channel, 'general')
+
+    def test_normalize_channel_ref_workbench_url(self):
+        channel = self.module.normalize_channel_ref(
+            'https://huly.proompteng.ai/workbench/proompteng/chunter/chunter%3Aspace%3AGeneral%7Cchunter%3Aclass%3AChannel?message'
+        )
+        self.assertEqual(channel, 'general')
+
+    def test_parser_includes_list_channel_messages_operation(self):
+        parser = self.module.build_parser()
+        operation = parser._option_string_actions['--operation']
+        self.assertIn('list-channel-messages', operation.choices)
+
+    def test_verify_chat_access_requires_message(self):
+        parser = self.module.build_parser()
+        args = parser.parse_args(['--operation', 'verify-chat-access'])
+        result = self.module.run_verify_chat_access(args)
+        self.assertEqual(result, 2)
+
+    def test_upsert_mission_requires_message(self):
+        parser = self.module.build_parser()
+        args = parser.parse_args(
+            [
+                '--operation',
+                'upsert-mission',
+                '--mission-id',
+                'swarm-jangar-control-plane-plan',
+                '--title',
+                'Jangar plan mission',
+                '--summary',
+                'Plan the next delivery lane.',
+            ]
+        )
+        result = self.module.run_upsert_mission(args)
+        self.assertEqual(result, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Removed canned/default chat text generation from `huly-api.py` so worker channel messages must be authored by the executing worker.
- Added dynamic Huly channel resolution (`huly://...`, workbench URL, or channel name) and a new `list-channel-messages` operation for reading history.
- Updated swarm ImplementationSpecs to require read -> react -> post behavior on the active channel, including explicit `--message` for chat verification and mission upserts.
- Expanded the Huly skill documentation with a mandatory channel interaction loop and dynamic channel routing rules.
- Added a full dual-swarm end-to-end runbook with architecture and sequence diagrams plus concrete validation commands.

## Related Issues

None

## Testing

- `python3 -m py_compile skills/huly-api/scripts/huly-api.py skills/huly-api/scripts/test_huly_api.py`
- `python3 -m unittest skills/huly-api/scripts/test_huly_api.py`
- `kubectl -n argocd get application agents -o json | jq '{sync:.status.sync.status,health:.status.health.status,revision:.status.sync.revision}'`
- `kubectl -n agents get swarm`
- `kubectl -n agents get agentrun jangar-control-plane-torghut-quant-req-00gbjlqs-1-n2l4r -o wide`

## Screenshots (if applicable)

N/A

## Breaking Changes

- `skills/huly-api/scripts/huly-api.py --operation verify-chat-access` now requires explicit `--message`.
- `skills/huly-api/scripts/huly-api.py --operation upsert-mission` now requires explicit `--message` for channel posting.
- Existing callers that relied on autogenerated status text must provide worker-authored message content.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
