### PR TITLE
chore(jangar): promote image d455ba84

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 675afb73
-  digest: sha256:20477d7f41587bab150723e84e500725c6fd80a9f77432c6d510a7ff9a92535e
+  tag: d455ba84
+  digest: sha256:e30bb558b726988f17f7a4f0ff73f64a6a0d938060e180c82998f07ab7cb82d5
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 675afb73
-    digest: sha256:9f08147abbc2caa7f9219282180ba549d006d699fb6a682be7c58e5c88266b02
+    tag: d455ba84
+    digest: sha256:8d813d0e55f503542e9dbde7f7e6f578fe9650ccf0b8e23c03ea5f4c387c7bac
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 675afb73
-    digest: sha256:20477d7f41587bab150723e84e500725c6fd80a9f77432c6d510a7ff9a92535e
+    tag: d455ba84
+    digest: sha256:e30bb558b726988f17f7a4f0ff73f64a6a0d938060e180c82998f07ab7cb82d5
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T08:37:23Z"
+    deploy.knative.dev/rollout: "2026-03-02T08:52:21Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T08:37:23Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-02T08:52:21Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "675afb73"
-    digest: sha256:20477d7f41587bab150723e84e500725c6fd80a9f77432c6d510a7ff9a92535e
+    newTag: "d455ba84"
+    digest: sha256:e30bb558b726988f17f7a4f0ff73f64a6a0d938060e180c82998f07ab7cb82d5


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `d455ba84e1e80c3f04a4c7e736a5c26dc59018c1`
- Image tag: `d455ba84`
- Image digest: `sha256:e30bb558b726988f17f7a4f0ff73f64a6a0d938060e180c82998f07ab7cb82d5`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`