### PR TITLE
chore(jangar): promote image 6aa4edc7

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: d455ba84
-  digest: sha256:e30bb558b726988f17f7a4f0ff73f64a6a0d938060e180c82998f07ab7cb82d5
+  tag: 6aa4edc7
+  digest: sha256:824e5db0fa0f3958806330fff64a2ebfcc0196effa3a8f29151c5dda4c9809f5
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: d455ba84
-    digest: sha256:8d813d0e55f503542e9dbde7f7e6f578fe9650ccf0b8e23c03ea5f4c387c7bac
+    tag: 6aa4edc7
+    digest: sha256:517d2c392ae788a820ff71b1be9f8736ac08f64ca7f8cdc5b8e8f4fe269e6a52
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: d455ba84
-    digest: sha256:e30bb558b726988f17f7a4f0ff73f64a6a0d938060e180c82998f07ab7cb82d5
+    tag: 6aa4edc7
+    digest: sha256:824e5db0fa0f3958806330fff64a2ebfcc0196effa3a8f29151c5dda4c9809f5
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-02T08:52:21Z"
+    deploy.knative.dev/rollout: "2026-03-03T03:30:46Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-02T08:52:21Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-03T03:30:46Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "d455ba84"
-    digest: sha256:e30bb558b726988f17f7a4f0ff73f64a6a0d938060e180c82998f07ab7cb82d5
+    newTag: "6aa4edc7"
+    digest: sha256:824e5db0fa0f3958806330fff64a2ebfcc0196effa3a8f29151c5dda4c9809f5


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `6aa4edc78510558b028d762b6c92141e5f8778bc`
- Image tag: `6aa4edc7`
- Image digest: `sha256:824e5db0fa0f3958806330fff64a2ebfcc0196effa3a8f29151c5dda4c9809f5`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`