### PR TITLE
chore(jangar): promote image b907c2f0

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 6aa4edc7
-  digest: sha256:824e5db0fa0f3958806330fff64a2ebfcc0196effa3a8f29151c5dda4c9809f5
+  tag: b907c2f0
+  digest: sha256:5727025e0d5412b5dd432ddd26649f606fc46e0b2b2bbcdd5881711a8bcbc99c
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 6aa4edc7
-    digest: sha256:517d2c392ae788a820ff71b1be9f8736ac08f64ca7f8cdc5b8e8f4fe269e6a52
+    tag: b907c2f0
+    digest: sha256:1678999f9810954b064da0baa80541a8bb659e74d55d7ca46e731faa051d58f6
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 6aa4edc7
-    digest: sha256:824e5db0fa0f3958806330fff64a2ebfcc0196effa3a8f29151c5dda4c9809f5
+    tag: b907c2f0
+    digest: sha256:5727025e0d5412b5dd432ddd26649f606fc46e0b2b2bbcdd5881711a8bcbc99c
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-03T03:30:46Z"
+    deploy.knative.dev/rollout: "2026-03-03T03:40:16Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-03T03:30:46Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-03T03:40:16Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "6aa4edc7"
-    digest: sha256:824e5db0fa0f3958806330fff64a2ebfcc0196effa3a8f29151c5dda4c9809f5
+    newTag: "b907c2f0"
+    digest: sha256:5727025e0d5412b5dd432ddd26649f606fc46e0b2b2bbcdd5881711a8bcbc99c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b907c2f0b450c18761509b73e70c07009e6ea46b`
- Image tag: `b907c2f0`
- Image digest: `sha256:5727025e0d5412b5dd432ddd26649f606fc46e0b2b2bbcdd5881711a8bcbc99c`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`