### PR TITLE
fix(jangar): export codex event params for market-context lifecycle

### DIFF
--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -279,6 +279,39 @@ describe('runCodexImplementation', () => {
     expect(runCodexProgressCommentMock).not.toHaveBeenCalled()
   }, 40_000)
 
+  it('exports scalar event parameters as shell environment variables', async () => {
+    const payload = {
+      prompt: 'Implementation prompt',
+      repository: 'owner/repo',
+      issueNumber: 42,
+      base: 'main',
+      head: 'codex/issue-42',
+      symbol: 'NVDA',
+      domain: 'news',
+      asOfUtc: '2026-03-03T04:19:58.221Z',
+      reason: 'stale_snapshot',
+      callbackUrl: 'http://jangar.jangar.svc.cluster.local/api/torghut/market-context/ingest',
+      requestId: '6831f7d5-fef6-4eb5-b325-ad2d8eef56e9',
+    }
+    await writeFile(eventPath, JSON.stringify(payload), 'utf8')
+
+    await runCodexImplementation(eventPath)
+
+    expect(process.env.symbol).toBe('NVDA')
+    expect(process.env.SYMBOL).toBe('NVDA')
+    expect(process.env.CODEX_PARAM_SYMBOL).toBe('NVDA')
+    expect(process.env.domain).toBe('news')
+    expect(process.env.DOMAIN).toBe('news')
+    expect(process.env.asOfUtc).toBe('2026-03-03T04:19:58.221Z')
+    expect(process.env.AS_OF_UTC).toBe('2026-03-03T04:19:58.221Z')
+    expect(process.env.reason).toBe('stale_snapshot')
+    expect(process.env.REASON).toBe('stale_snapshot')
+    expect(process.env.callbackUrl).toBe('http://jangar.jangar.svc.cluster.local/api/torghut/market-context/ingest')
+    expect(process.env.CALLBACK_URL).toBe('http://jangar.jangar.svc.cluster.local/api/torghut/market-context/ingest')
+    expect(process.env.requestId).toBe('6831f7d5-fef6-4eb5-b325-ad2d8eef56e9')
+    expect(process.env.REQUEST_ID).toBe('6831f7d5-fef6-4eb5-b325-ad2d8eef56e9')
+  }, 40_000)
+
   it('bootstraps the worktree checkout when the repository is missing', async () => {
     const bootstrappedWorktree = join(workdir, 'fresh-worktree')
     process.env.WORKTREE = bootstrappedWorktree

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -409,6 +409,48 @@ const normalizeOptionalString = (value: string | null | undefined) => {
   return value
 }
 
+const EVENT_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+const eventKeyToEnvAlias = (key: string) =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^A-Za-z0-9_]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toUpperCase()
+
+const eventValueToEnvString = (value: unknown): string | null => {
+  if (value === null || value === undefined) {
+    return null
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value)
+  }
+  return null
+}
+
+const exportScalarEventParametersToEnv = (event: ImplementationEventPayload) => {
+  for (const [key, value] of Object.entries(event)) {
+    const envValue = eventValueToEnvString(value)
+    if (envValue === null) {
+      continue
+    }
+
+    if (EVENT_ENV_NAME_PATTERN.test(key)) {
+      process.env[key] = envValue
+    }
+
+    const envAlias = eventKeyToEnvAlias(key)
+    if (EVENT_ENV_NAME_PATTERN.test(envAlias)) {
+      process.env[envAlias] = envValue
+      process.env[`CODEX_PARAM_${envAlias}`] = envValue
+    }
+  }
+}
+
 const sha256Hex = (value: string) => createHash('sha256').update(value, 'utf8').digest('hex')
 
 const parseOptionalPrNumber = (value: string): number | null => {
@@ -1914,6 +1956,7 @@ export const runCodexImplementation = async (eventPath: string) => {
   process.env.COMMIT_SHA_PATH = commitShaPath
   process.env.PR_NUMBER_PATH = prNumberPath
   process.env.PR_URL_PATH = prUrlPath
+  exportScalarEventParametersToEnv(event)
 
   process.env.CODEX_STAGE = stage
   process.env.RUST_LOG = process.env.RUST_LOG ?? 'codex_core=info,codex_exec=info'


### PR DESCRIPTION
## Summary

- Export scalar AgentRun event payload fields (for example `symbol`, `callbackUrl`, `requestId`, `asOfUtc`, `reason`) into runtime shell environment variables in `codex-implement`.
- Add uppercase snake-case and `CODEX_PARAM_*` aliases so ImplementationSpec command snippets using shell interpolation can resolve required inputs reliably.
- Add regression coverage in `scripts/codex/__tests__/codex-implement.test.ts` to verify env export behavior.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/scripts/codex/codex-implement.ts services/jangar/scripts/codex/__tests__/codex-implement.test.ts`
- `bunx vitest run --config vitest.config.ts scripts/codex/__tests__/codex-implement.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
