### PR TITLE
fix(agents): copy run payload before codex preflight

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -48,7 +48,7 @@ spec:
           "binary": "/bin/bash",
           "argsTemplate": [
             "-lc",
-            "python3 /root/.codex/ensure-market-context-issue-number.py \"$1\" && exec /usr/local/bin/codex-implement \"$1\"",
+            "EVENT_FILE=$(mktemp /tmp/codex-event.XXXXXX.json) && cp \"$1\" \"$EVENT_FILE\" && python3 /root/.codex/ensure-market-context-issue-number.py \"$EVENT_FILE\" && exec /usr/local/bin/codex-implement \"$EVENT_FILE\"",
             "--",
             "{{payloads.eventFilePath}}"
           ],


### PR DESCRIPTION
## Summary

- Fix `codex-spark` preflight wrapper to avoid mutating `/workspace/run.json` in place.
- Copy the event payload to a writable temp file before running preflight normalization/interpolation.
- Pass the writable temp payload path to `codex-implement` so market-context runs no longer fail with read-only filesystem errors.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applications/agents/codex-spark-agentprovider.yaml`
- Live validation in `agents` namespace before this patch showed: `OSError: [Errno 30] Read-only file system: '/workspace/run.json'` in both news/fundamentals jobs.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
