### PR TITLE
chore(jangar): promote image a66a03b1

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: b907c2f0
-  digest: sha256:5727025e0d5412b5dd432ddd26649f606fc46e0b2b2bbcdd5881711a8bcbc99c
+  tag: a66a03b1
+  digest: sha256:4bc310c3576f6d3056365bbf84bd325dbe1fc8d5ce3087668d5a06379fe16b52
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: b907c2f0
-    digest: sha256:1678999f9810954b064da0baa80541a8bb659e74d55d7ca46e731faa051d58f6
+    tag: a66a03b1
+    digest: sha256:f8bd42257a41fe4ead707094434573db31d00c9c188dbcc4c45c1dd98fc2506c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: b907c2f0
-    digest: sha256:5727025e0d5412b5dd432ddd26649f606fc46e0b2b2bbcdd5881711a8bcbc99c
+    tag: a66a03b1
+    digest: sha256:4bc310c3576f6d3056365bbf84bd325dbe1fc8d5ce3087668d5a06379fe16b52
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-03T03:40:16Z"
+    deploy.knative.dev/rollout: "2026-03-03T04:35:13Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-03T03:40:16Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-03T04:35:13Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "b907c2f0"
-    digest: sha256:5727025e0d5412b5dd432ddd26649f606fc46e0b2b2bbcdd5881711a8bcbc99c
+    newTag: "a66a03b1"
+    digest: sha256:4bc310c3576f6d3056365bbf84bd325dbe1fc8d5ce3087668d5a06379fe16b52


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a66a03b1a002875eb8116d00fa70bb9c58add1d5`
- Image tag: `a66a03b1`
- Image digest: `sha256:4bc310c3576f6d3056365bbf84bd325dbe1fc8d5ce3087668d5a06379fe16b52`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`