### PR TITLE
fix(torghut): harden short eligibility and sizing reject taxonomy

### DIFF
--- a/argocd/applications/feature-flags/gitops/default/features.yaml
+++ b/argocd/applications/feature-flags/gitops/default/features.yaml
@@ -164,7 +164,7 @@ flags:
     name: Torghut Trading Allow Shorts
     description: Allows short-side trading intents.
     type: BOOLEAN_FLAG_TYPE
-    enabled: false
+    enabled: true
   - key: torghut_trading_fractional_equities_enabled
     name: Torghut Trading Fractional Equities Enabled
     description: Enables fractional equity quantities for long-side orders.

--- a/docs/runbooks/torghut-shorts-and-sizer-remediation-2026-03-03.md
+++ b/docs/runbooks/torghut-shorts-and-sizer-remediation-2026-03-03.md
@@ -1,0 +1,136 @@
+# Torghut Shorts + Sizing Remediation (2026-03-03)
+
+## Objective
+
+Reduce non-kill-switch rejections by:
+
+1. Enabling short intents safely with Alpaca-compatible prechecks.
+2. Eliminating misleading `qty_below_min` rejects when symbol capacity is already exhausted.
+
+## Root Cause Summary
+
+### Shorts
+
+- `shorts_not_allowed` rejects were deterministic local policy rejects when short-increasing sells were evaluated with `TRADING_ALLOW_SHORTS=false`.
+- This did not validate Alpaca short prerequisites (`account shorting enabled`, `shortable`, `easy_to_borrow`) because shorts were disabled before broker capability checks were needed.
+
+### `qty_below_min`
+
+- Rejects labeled `qty_below_min` were primarily not quantity-step defects.
+- The portfolio sizing audit showed `cap_per_symbol_zero` and `final_qty=0`, then downstream minimum-qty validation labeled the rejection as `qty_below_min`.
+- For March 2 examples, this happened when the symbol already exceeded configured per-symbol capacity, so adding exposure was impossible.
+
+## Implemented Changes
+
+### 1) Alpaca-aligned short prechecks
+
+Files:
+
+- `services/torghut/app/trading/execution.py`
+- `services/torghut/app/alpaca_client.py`
+
+Behavior:
+
+- For short-increasing sells, local pre-submit checks now enforce:
+  - account has `shorting_enabled=true` (when available),
+  - asset is `tradable=true` (when available),
+  - asset is `shortable=true` (when available),
+  - asset is `easy_to_borrow=true` (when available).
+- Rejects now return explicit local codes:
+  - `local_account_shorting_disabled`
+  - `local_symbol_not_tradable`
+  - `local_symbol_not_shortable`
+  - `local_symbol_not_easy_to_borrow`
+
+Notes:
+
+- In `TRADING_MODE=live`, account/asset eligibility metadata must be available; unknown metadata is fail-closed with explicit local codes.
+- In `TRADING_MODE=paper`, metadata lookup failures remain fail-open so local/testing execution is not blocked.
+
+### 2) Capacity-exhaustion reason fix in portfolio sizing
+
+File:
+
+- `services/torghut/app/trading/portfolio.py`
+
+Behavior:
+
+- Zero-cap sizing methods now produce explicit capacity reasons instead of falling through to `qty_below_min`:
+  - `cap_per_symbol_zero` -> `symbol_capacity_exhausted`
+  - `cap_gross_exposure_zero` -> `gross_exposure_capacity_exhausted`
+  - `cap_net_exposure_zero` -> `net_exposure_capacity_exhausted`
+  - `cap_sell_inventory_zero` -> `sell_inventory_unavailable`
+
+### 3) Shorts enabled in feature flags
+
+File:
+
+- `argocd/applications/feature-flags/gitops/default/features.yaml`
+
+Change:
+
+- `torghut_trading_allow_shorts` set to `enabled: true`.
+
+## Validation Plan
+
+### 1. Unit tests
+
+Run:
+
+```bash
+uv run --frozen pytest services/torghut/tests/test_order_idempotency.py services/torghut/tests/test_portfolio_sizing.py
+```
+
+Expected:
+
+- New short precheck tests pass.
+- Capacity-exhaustion reason test passes.
+
+### 2. Runtime validation (post-deploy)
+
+### Rejection taxonomy
+
+```sql
+WITH reasons AS (
+  SELECT jsonb_array_elements_text(COALESCE(td.decision_json::jsonb->'risk_reasons','[]'::jsonb)) AS reason
+  FROM trade_decisions td
+  WHERE td.created_at >= now() - interval '24 hours'
+    AND td.status='rejected'
+)
+SELECT reason, count(*) FROM reasons GROUP BY reason ORDER BY count(*) DESC;
+```
+
+Acceptance:
+
+- `shorts_not_allowed` trends to near-zero.
+- `qty_below_min` materially drops.
+- If exposure limits bind, rejections appear as explicit capacity reasons.
+
+### Short capability rejects
+
+Monitor for:
+
+- `local_pre_submit_rejected code=local_account_shorting_disabled`
+- `local_pre_submit_rejected code=local_symbol_not_shortable`
+- `local_pre_submit_rejected code=local_symbol_not_easy_to_borrow`
+- `local_pre_submit_rejected code=local_account_metadata_unavailable`
+- `local_pre_submit_rejected code=local_account_shorting_status_unknown`
+- `local_pre_submit_rejected code=local_symbol_metadata_unavailable`
+- `local_pre_submit_rejected code=local_symbol_tradability_unknown`
+- `local_pre_submit_rejected code=local_symbol_shortability_unknown`
+- `local_pre_submit_rejected code=local_symbol_borrow_status_unknown`
+
+These are expected safety rejects for symbols/accounts that cannot short or for live lanes that cannot verify required short-eligibility metadata.
+
+### 3. Rollback
+
+Immediate rollback if:
+
+- Broker reject rate spikes materially after enabling shorts.
+- Unexpected short inventory behavior appears.
+
+Rollback actions:
+
+1. Set `torghut_trading_allow_shorts` to `false`.
+2. Redeploy/reconcile.
+3. Confirm rejection mix returns to baseline.

--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -93,6 +93,21 @@ class TorghutAlpacaClient:
         account = self._trading.get_account()
         return self._model_to_dict(account)
 
+    def get_asset(self, symbol_or_asset_id: str) -> Dict[str, Any] | None:
+        getter = cast(Callable[[str], Any] | None, getattr(self._trading, "get_asset", None))
+        if getter is None:
+            return None
+        try:
+            asset = getter(symbol_or_asset_id)
+        except APIError as exc:
+            status_code = getattr(exc, "status_code", None)
+            if isinstance(status_code, int) and status_code == 404:
+                return None
+            raise
+        if asset is None:
+            return None
+        return self._model_to_dict(asset)
+
     def list_positions(self) -> List[Dict[str, Any]]:
         positions = self._trading.get_all_positions()
         return [self._model_to_dict(pos) for pos in positions]

--- a/services/torghut/app/trading/execution.py
+++ b/services/torghut/app/trading/execution.py
@@ -167,6 +167,12 @@ class OrderExecutor:
         )
         if pre_submit_error is not None:
             raise RuntimeError(json.dumps(pre_submit_error))
+        short_precheck_error = self._validate_short_sell_constraints(
+            execution_client,
+            request,
+        )
+        if short_precheck_error is not None:
+            raise RuntimeError(json.dumps(short_precheck_error))
 
         if retry_delays is None:
             retry_delays = []
@@ -550,6 +556,146 @@ class OrderExecutor:
             requested_qty=request.qty,
         )
 
+    def _validate_short_sell_constraints(
+        self,
+        execution_client: Any,
+        request: ExecutionRequest,
+    ) -> dict[str, Any] | None:
+        if request.side.strip().lower() != "sell":
+            return None
+        symbol = request.symbol.strip().upper()
+        if not symbol:
+            return None
+
+        position_qty = self._position_qty_for_symbol(execution_client, symbol)
+        if not self._is_short_increasing_sell(position_qty, request.qty):
+            return None
+
+        if not settings.trading_allow_shorts:
+            return {
+                "source": "local_pre_submit",
+                "code": "local_shorts_not_allowed",
+                "reject_reason": "short selling disabled by runtime policy",
+                "symbol": symbol,
+                "qty": str(request.qty),
+            }
+
+        strict_short_precheck = settings.trading_mode == "live"
+        account = self._get_account(execution_client)
+        if account is None:
+            if strict_short_precheck:
+                return {
+                    "source": "local_pre_submit",
+                    "code": "local_account_metadata_unavailable",
+                    "reject_reason": "account shorting eligibility metadata unavailable in live mode",
+                    "symbol": symbol,
+                    "qty": str(request.qty),
+                }
+        else:
+            shorting_enabled = account.get("shorting_enabled")
+            if isinstance(shorting_enabled, bool):
+                if not shorting_enabled:
+                    return {
+                        "source": "local_pre_submit",
+                        "code": "local_account_shorting_disabled",
+                        "reject_reason": "account shorting is disabled",
+                        "symbol": symbol,
+                        "qty": str(request.qty),
+                    }
+            elif strict_short_precheck:
+                return {
+                    "source": "local_pre_submit",
+                    "code": "local_account_shorting_status_unknown",
+                    "reject_reason": "account shorting eligibility unknown in live mode",
+                    "symbol": symbol,
+                    "qty": str(request.qty),
+                }
+
+        asset = self._get_asset(execution_client, symbol)
+        if asset is None:
+            if strict_short_precheck:
+                return {
+                    "source": "local_pre_submit",
+                    "code": "local_symbol_metadata_unavailable",
+                    "reject_reason": "asset shortability metadata unavailable in live mode",
+                    "symbol": symbol,
+                    "qty": str(request.qty),
+                }
+            return None
+
+        tradable = asset.get("tradable")
+        if isinstance(tradable, bool):
+            if not tradable:
+                return {
+                    "source": "local_pre_submit",
+                    "code": "local_symbol_not_tradable",
+                    "reject_reason": "symbol is not tradable",
+                    "symbol": symbol,
+                    "qty": str(request.qty),
+                }
+        elif strict_short_precheck:
+            return {
+                "source": "local_pre_submit",
+                "code": "local_symbol_tradability_unknown",
+                "reject_reason": "symbol tradability unknown in live mode",
+                "symbol": symbol,
+                "qty": str(request.qty),
+            }
+
+        shortable = asset.get("shortable")
+        if isinstance(shortable, bool):
+            if not shortable:
+                return {
+                    "source": "local_pre_submit",
+                    "code": "local_symbol_not_shortable",
+                    "reject_reason": "symbol is not shortable",
+                    "symbol": symbol,
+                    "qty": str(request.qty),
+                }
+        elif strict_short_precheck:
+            return {
+                "source": "local_pre_submit",
+                "code": "local_symbol_shortability_unknown",
+                "reject_reason": "symbol shortability unknown in live mode",
+                "symbol": symbol,
+                "qty": str(request.qty),
+            }
+
+        easy_to_borrow = asset.get("easy_to_borrow")
+        if isinstance(easy_to_borrow, bool):
+            if not easy_to_borrow:
+                return {
+                    "source": "local_pre_submit",
+                    "code": "local_symbol_not_easy_to_borrow",
+                    "reject_reason": "symbol is not easy-to-borrow",
+                    "symbol": symbol,
+                    "qty": str(request.qty),
+                }
+        elif strict_short_precheck:
+            return {
+                "source": "local_pre_submit",
+                "code": "local_symbol_borrow_status_unknown",
+                "reject_reason": "easy-to-borrow status unknown in live mode",
+                "symbol": symbol,
+                "qty": str(request.qty),
+            }
+
+        return None
+
+    @staticmethod
+    def _is_short_increasing_sell(
+        position_qty: Decimal | None,
+        request_qty: Decimal,
+    ) -> bool:
+        if request_qty <= 0:
+            return False
+        if position_qty is None:
+            # Position lookup can fail transiently; avoid false local rejects.
+            return False
+        if position_qty <= 0:
+            return True
+        return request_qty > position_qty
+
     @classmethod
     def _position_qty_for_symbol(
         cls,
@@ -627,6 +773,43 @@ class OrderExecutor:
             mapped = cast(Mapping[object, Any], position)
             normalized.append({str(key): value for key, value in mapped.items()})
         return normalized
+
+    @staticmethod
+    def _get_account(execution_client: Any) -> dict[str, Any] | None:
+        getter = getattr(execution_client, "get_account", None)
+        if not callable(getter):
+            return None
+        try:
+            account = getter()
+        except Exception as exc:
+            logger.warning("Failed to fetch account for short precheck: %s", exc)
+            return None
+        if not isinstance(account, Mapping):
+            return None
+        payload = cast(Mapping[object, Any], account)
+        return {str(key): value for key, value in payload.items()}
+
+    @staticmethod
+    def _get_asset(
+        execution_client: Any,
+        symbol: str,
+    ) -> dict[str, Any] | None:
+        getter = getattr(execution_client, "get_asset", None)
+        if not callable(getter):
+            return None
+        try:
+            asset = getter(symbol)
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch asset metadata for short precheck symbol=%s: %s",
+                symbol,
+                exc,
+            )
+            return None
+        if not isinstance(asset, Mapping):
+            return None
+        payload = cast(Mapping[object, Any], asset)
+        return {str(key): value for key, value in payload.items()}
 
 
 def _coerce_json(value: Any) -> dict[str, Any]:

--- a/services/torghut/app/trading/portfolio.py
+++ b/services/torghut/app/trading/portfolio.py
@@ -36,6 +36,13 @@ ALLOCATOR_CLIP_STRATEGY_BUDGET = "allocator_clip_strategy_budget"
 ALLOCATOR_CLIP_SYMBOL_BUDGET = "allocator_clip_symbol_budget"
 ALLOCATOR_CLIP_CORRELATION_CAPACITY = "allocator_clip_correlation_capacity"
 
+_SIZING_CAP_ZERO_REASON_BY_METHOD: dict[str, str] = {
+    "cap_per_symbol_zero": "symbol_capacity_exhausted",
+    "cap_gross_exposure_zero": "gross_exposure_capacity_exhausted",
+    "cap_net_exposure_zero": "net_exposure_capacity_exhausted",
+    "cap_sell_inventory_zero": "sell_inventory_unavailable",
+}
+
 
 @dataclass(frozen=True)
 class AggregatedIntent:
@@ -180,6 +187,7 @@ class PortfolioSizer:
             price=price,
             notional=notional,
             current_qty=current_qty,
+            applied_methods=applied_methods,
             reasons=reasons,
         )
 
@@ -309,8 +317,23 @@ class PortfolioSizer:
         price: Decimal,
         notional: Decimal,
         current_qty: Decimal,
+        applied_methods: list[str],
         reasons: list[str],
     ) -> tuple[Decimal, Decimal, bool, list[str]]:
+        for method in applied_methods:
+            mapped_reason = _SIZING_CAP_ZERO_REASON_BY_METHOD.get(method)
+            if mapped_reason is None:
+                continue
+            if (
+                mapped_reason == "sell_inventory_unavailable"
+                and "shorts_not_allowed" in reasons
+            ):
+                continue
+            if mapped_reason not in reasons:
+                reasons.append(mapped_reason)
+        if reasons:
+            return Decimal("0"), Decimal("0"), False, reasons
+
         target_qty = notional / price
         fractional_equities_enabled = fractional_equities_enabled_for_trade(
             action=decision.action,

--- a/services/torghut/tests/test_order_idempotency.py
+++ b/services/torghut/tests/test_order_idempotency.py
@@ -146,6 +146,76 @@ class PositionLookupUnavailableHeldInventoryClient(PositionLookupUnavailableClie
         ]
 
 
+class AccountShortingDisabledClient(FakeAlpacaClient):
+    def get_account(self) -> dict[str, bool]:
+        return {"shorting_enabled": False}
+
+
+class SymbolNotShortableClient(FakeAlpacaClient):
+    def get_account(self) -> dict[str, bool]:
+        return {"shorting_enabled": True}
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, str | bool]:
+        return {
+            "symbol": symbol_or_asset_id,
+            "tradable": True,
+            "shortable": False,
+            "easy_to_borrow": False,
+        }
+
+
+class SymbolNotEasyToBorrowClient(FakeAlpacaClient):
+    def get_account(self) -> dict[str, bool]:
+        return {"shorting_enabled": True}
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, str | bool]:
+        return {
+            "symbol": symbol_or_asset_id,
+            "tradable": True,
+            "shortable": True,
+            "easy_to_borrow": False,
+        }
+
+
+class AccountMetadataUnavailableClient(FakeAlpacaClient):
+    def get_account(self) -> dict[str, bool]:
+        raise RuntimeError("account lookup unavailable")
+
+
+class AccountShortingUnknownClient(FakeAlpacaClient):
+    def get_account(self) -> dict[str, str]:
+        return {"status": "active"}
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, str | bool]:
+        return {
+            "symbol": symbol_or_asset_id,
+            "tradable": True,
+            "shortable": True,
+            "easy_to_borrow": True,
+        }
+
+
+class AssetMetadataUnavailableClient(FakeAlpacaClient):
+    def get_account(self) -> dict[str, bool]:
+        return {"shorting_enabled": True}
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, bool]:
+        _ = symbol_or_asset_id
+        raise RuntimeError("asset lookup unavailable")
+
+
+class AssetShortabilityUnknownClient(FakeAlpacaClient):
+    def get_account(self) -> dict[str, bool]:
+        return {"shorting_enabled": True}
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, str | bool]:
+        return {
+            "symbol": symbol_or_asset_id,
+            "tradable": True,
+            "easy_to_borrow": True,
+        }
+
+
 class TestOrderIdempotency(TestCase):
     def setUp(self) -> None:
         engine = create_engine('sqlite+pysqlite:///:memory:', future=True)
@@ -156,9 +226,11 @@ class TestOrderIdempotency(TestCase):
         self._orig_fractional_equities_enabled = (
             settings.trading_fractional_equities_enabled
         )
+        self._orig_trading_mode = settings.trading_mode
         settings.trading_multi_account_enabled = False
         settings.trading_allow_shorts = False
         settings.trading_fractional_equities_enabled = False
+        settings.trading_mode = "paper"
 
     def tearDown(self) -> None:
         settings.trading_multi_account_enabled = self._orig_multi_account_enabled
@@ -166,6 +238,7 @@ class TestOrderIdempotency(TestCase):
         settings.trading_fractional_equities_enabled = (
             self._orig_fractional_equities_enabled
         )
+        settings.trading_mode = self._orig_trading_mode
 
     def test_decision_hash_stable_for_same_intent(self) -> None:
         event_ts = datetime(2026, 2, 10, tzinfo=timezone.utc)
@@ -919,6 +992,336 @@ class TestOrderIdempotency(TestCase):
             payload = json.loads(str(context.exception))
             self.assertEqual(payload.get("source"), "local_pre_submit")
             self.assertEqual(payload.get("code"), "local_qty_below_min")
+
+    def test_submit_order_precheck_blocks_short_when_account_shorting_disabled(self) -> None:
+        settings.trading_allow_shorts = True
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    AccountShortingDisabledClient(),
+                    decision,
+                    decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "local_pre_submit")
+            self.assertEqual(payload.get("code"), "local_account_shorting_disabled")
+
+    def test_submit_order_precheck_blocks_short_when_symbol_not_shortable(self) -> None:
+        settings.trading_allow_shorts = True
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    SymbolNotShortableClient(),
+                    decision,
+                    decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "local_pre_submit")
+            self.assertEqual(payload.get("code"), "local_symbol_not_shortable")
+
+    def test_submit_order_precheck_blocks_short_when_symbol_not_easy_to_borrow(self) -> None:
+        settings.trading_allow_shorts = True
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    SymbolNotEasyToBorrowClient(),
+                    decision,
+                    decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "local_pre_submit")
+            self.assertEqual(payload.get("code"), "local_symbol_not_easy_to_borrow")
+
+    def test_submit_order_precheck_blocks_short_when_account_metadata_unavailable_live(self) -> None:
+        settings.trading_allow_shorts = True
+        settings.trading_mode = "live"
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    AccountMetadataUnavailableClient(),
+                    decision,
+                    decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "local_pre_submit")
+            self.assertEqual(payload.get("code"), "local_account_metadata_unavailable")
+
+    def test_submit_order_precheck_blocks_short_when_account_shorting_status_unknown_live(
+        self,
+    ) -> None:
+        settings.trading_allow_shorts = True
+        settings.trading_mode = "live"
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    AccountShortingUnknownClient(),
+                    decision,
+                    decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "local_pre_submit")
+            self.assertEqual(payload.get("code"), "local_account_shorting_status_unknown")
+
+    def test_submit_order_precheck_blocks_short_when_asset_metadata_unavailable_live(
+        self,
+    ) -> None:
+        settings.trading_allow_shorts = True
+        settings.trading_mode = "live"
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    AssetMetadataUnavailableClient(),
+                    decision,
+                    decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "local_pre_submit")
+            self.assertEqual(payload.get("code"), "local_symbol_metadata_unavailable")
+
+    def test_submit_order_precheck_blocks_short_when_asset_shortability_unknown_live(
+        self,
+    ) -> None:
+        settings.trading_allow_shorts = True
+        settings.trading_mode = "live"
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    AssetShortabilityUnknownClient(),
+                    decision,
+                    decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "local_pre_submit")
+            self.assertEqual(payload.get("code"), "local_symbol_shortability_unknown")
+
+    def test_submit_order_precheck_allows_short_when_asset_metadata_unavailable_paper(
+        self,
+    ) -> None:
+        settings.trading_allow_shorts = True
+        settings.trading_mode = "paper"
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            execution = executor.submit_order(
+                session,
+                AssetMetadataUnavailableClient(),
+                decision,
+                decision_row,
+                "paper",
+            )
+
+            self.assertIsNotNone(execution)
 
     def test_submit_order_precheck_allows_fractional_sell_when_position_lookup_unavailable(
         self,

--- a/services/torghut/tests/test_portfolio_sizing.py
+++ b/services/torghut/tests/test_portfolio_sizing.py
@@ -602,6 +602,41 @@ class TestPortfolioSizing(TestCase):
         self.assertTrue(result.approved)
         self.assertEqual(result.decision.qty, Decimal("5"))
 
+    def test_symbol_capacity_exhaustion_reports_capacity_reason_not_qty_min(self) -> None:
+        sizer = PortfolioSizer(
+            PortfolioSizingConfig(
+                notional_per_position=None,
+                volatility_target=None,
+                volatility_floor=Decimal("0"),
+                max_positions=None,
+                max_notional_per_symbol=Decimal("1000"),
+                max_position_pct_equity=Decimal("0.10"),
+                max_gross_exposure=None,
+                max_net_exposure=None,
+            )
+        )
+        decision = StrategyDecision(
+            strategy_id="s1",
+            symbol="NVDA",
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            order_type="market",
+            time_in_force="day",
+            params={"price": Decimal("100")},
+        )
+        positions = [{"symbol": "NVDA", "qty": "15", "market_value": "1500"}]
+
+        result = sizer.size(decision, account={"equity": "10000"}, positions=positions)
+
+        self.assertFalse(result.approved)
+        self.assertIn("symbol_capacity_exhausted", result.reasons)
+        self.assertNotIn("qty_below_min", result.reasons)
+        portfolio_output = result.audit.get("output", {})
+        self.assertEqual(portfolio_output.get("status"), "rejected")
+        self.assertIn("cap_per_symbol_zero", portfolio_output.get("methods", []))
+
     def test_allocator_clips_fractional_crypto_qty(self) -> None:
         allocator = PortfolioAllocator(
             AllocationConfig(


### PR DESCRIPTION
## Summary

- Enable Torghut short-side intents via GitOps feature flag (`torghut_trading_allow_shorts=true`).
- Add Alpaca-aligned short pre-submit checks in execution flow (account shorting eligibility plus asset tradable/shortable/easy-to-borrow) with explicit local rejection codes.
- Harden live trading behavior to fail closed when required short-eligibility metadata is missing/unknown, while preserving paper-mode fail-open for local/testing workflows.
- Fix portfolio sizing reject taxonomy by mapping zero-capacity methods to explicit capacity reasons instead of mislabeling as `qty_below_min`.
- Add regression coverage and a runbook for rollout, monitoring, and rollback.

## Related Issues

None

## Testing

- `uv run --frozen pytest services/torghut/tests/test_order_idempotency.py services/torghut/tests/test_portfolio_sizing.py`
- `uv run --frozen pytest services/torghut/tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app/alpaca_client.py app/trading/execution.py app/trading/portfolio.py tests/test_order_idempotency.py tests/test_portfolio_sizing.py`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
