### PR TITLE
chore(torghut): promote image 3f5991a8

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d53f091b1cc1f493eed39b2842e5654f59f2e063d97e669a8f9ca794d68a94e8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4f40e1bb8f72f03581bab06a1baedb7f30e8eb7680d7188601435fcbfad32faf
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-02-28T23:13:38Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T05:51:35Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d53f091b1cc1f493eed39b2842e5654f59f2e063d97e669a8f9ca794d68a94e8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4f40e1bb8f72f03581bab06a1baedb7f30e8eb7680d7188601435fcbfad32faf
           ports:
             - name: http1
               containerPort: 8181
@@ -378,9 +378,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.561.0-145-g1ec3e141
+              value: v0.562.0-127-g3f5991a8
             - name: TORGHUT_COMMIT
-              value: 1ec3e141bd7dce53f8e00952520669a0735eec1f
+              value: 3f5991a8799f84fbf4ec64540d17635639c4b7a5
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `3f5991a8799f84fbf4ec64540d17635639c4b7a5`
- Image tag: `3f5991a8`
- Image digest: `sha256:4f40e1bb8f72f03581bab06a1baedb7f30e8eb7680d7188601435fcbfad32faf`