### PR TITLE
chore(jangar): promote image 03e35a22

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a66a03b1
-  digest: sha256:4bc310c3576f6d3056365bbf84bd325dbe1fc8d5ce3087668d5a06379fe16b52
+  tag: 03e35a22
+  digest: sha256:7175dc6a94aa207d796a66eecec395f14a127c1c839a7115b1c3e0df74731265
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a66a03b1
-    digest: sha256:f8bd42257a41fe4ead707094434573db31d00c9c188dbcc4c45c1dd98fc2506c
+    tag: 03e35a22
+    digest: sha256:1d5793dd74fd87202792061ba936b01e814161e03fc1f50be444e22b2a8ac3e0
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a66a03b1
-    digest: sha256:4bc310c3576f6d3056365bbf84bd325dbe1fc8d5ce3087668d5a06379fe16b52
+    tag: 03e35a22
+    digest: sha256:7175dc6a94aa207d796a66eecec395f14a127c1c839a7115b1c3e0df74731265
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-03T04:35:13Z"
+    deploy.knative.dev/rollout: "2026-03-03T06:21:37Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-03T04:35:13Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-03T06:21:37Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a66a03b1"
-    digest: sha256:4bc310c3576f6d3056365bbf84bd325dbe1fc8d5ce3087668d5a06379fe16b52
+    newTag: "03e35a22"
+    digest: sha256:7175dc6a94aa207d796a66eecec395f14a127c1c839a7115b1c3e0df74731265


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `03e35a22401e46938e7c1666d7140eba35f6ca23`
- Image tag: `03e35a22`
- Image digest: `sha256:7175dc6a94aa207d796a66eecec395f14a127c1c839a7115b1c3e0df74731265`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`