### PR TITLE
fix(ci): make torghut latest-tag alias best-effort

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -82,7 +82,9 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
-      - name: Update latest tag
+      - name: Update latest tag (best effort)
+        id: latest_tag
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -91,3 +93,18 @@ jobs:
           docker buildx imagetools create -t "${IMAGE}:latest" "${IMAGE}:${TAG}"
           docker buildx imagetools inspect "${IMAGE}:${TAG}"
           docker buildx imagetools inspect "${IMAGE}:latest"
+
+      - name: Warn on latest tag update failure
+        if: steps.latest_tag.outcome == 'failure'
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE='registry.ide-newton.ts.net/lab/torghut'
+          echo "::warning::Non-blocking failure updating ${IMAGE}:latest; digest-tagged image and release artifact are still valid."
+          {
+            echo "### Latest tag update failed (non-blocking)"
+            echo ""
+            echo "- Registry alias update failed for \`registry.ide-newton.ts.net/lab/torghut:latest\`."
+            echo "- Immutable release contract artifact was already produced and uploaded."
+            echo "- \`torghut-release\` can proceed using the digest from the contract."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Make Torghut `latest` alias publication best-effort in `.github/workflows/torghut-build-push.yaml`.
- Prevent registry alias errors (like `400` on `manifests/latest`) from failing the whole build workflow.
- Add explicit warning + job summary output when the alias update fails, while keeping digest-based release contract flow intact.

## Related Issues

None

## Testing

- `python - <<'PY'\nimport yaml\nfrom pathlib import Path\nyaml.safe_load(Path('.github/workflows/torghut-build-push.yaml').read_text())\nprint('YAML parse ok')\nPY`
- Reviewed generated diff to verify only the `latest` alias step behavior changed and release contract steps remain blocking.
- End-to-end execution of GitHub Actions is not locally reproducible in this environment; validation will occur via PR checks.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
