### PR TITLE
chore(torghut): promote image 2dd1ac11

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2c1981a01b32f2bf0cbd8781f874d1876225fa18dd7f8ff0490f3145f77abce3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ad19a56c214cf45b16dd1844b6ec188a94bf347c32a9f8570b978616ef2b8a9f
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T06:26:54Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T06:39:25Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2c1981a01b32f2bf0cbd8781f874d1876225fa18dd7f8ff0490f3145f77abce3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ad19a56c214cf45b16dd1844b6ec188a94bf347c32a9f8570b978616ef2b8a9f
           ports:
             - name: http1
               containerPort: 8181
@@ -372,9 +372,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-130-g3d1eda64
+              value: v0.562.0-133-g2dd1ac11
             - name: TORGHUT_COMMIT
-              value: 3d1eda6449299e6e7ebb320c5ee6ddc3c0054df9
+              value: 2dd1ac119352754c59e28b1036a98fc177057b77
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2dd1ac119352754c59e28b1036a98fc177057b77`
- Image tag: `2dd1ac11`
- Image digest: `sha256:ad19a56c214cf45b16dd1844b6ec188a94bf347c32a9f8570b978616ef2b8a9f`