### PR TITLE
fix(torghut-ws): restore stable ws symbol subscriptions

### DIFF
--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -10,9 +10,9 @@ data:
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
   ALPACA_TRADE_STREAM_URL: "wss://paper-api.alpaca.markets/stream"
   ALPACA_BASE_URL: "https://data.alpaca.markets"
-  # Dynamic desired-symbol feed from Jangar (enabled symbols only).
-  JANGAR_SYMBOLS_URL: "http://jangar.jangar.svc.cluster.local/api/torghut/symbols?assetClass=equity&format=compact"
-  # Bootstrap fallback universe used only if Jangar fetch fails at startup.
+  # Dynamic desired-symbol feed disabled: Alpaca market-data plan rejects current full universe size.
+  JANGAR_SYMBOLS_URL: ""
+  # Static curated universe kept within known provider subscription limits.
   SYMBOLS: "ARM,CRWD,GOOG,LRCX,MSFT,MU,NVDA,SNDK,TSM"
   SYMBOLS_POLL_INTERVAL_MS: "30000"
   SUBSCRIBE_BATCH_SIZE: "200"


### PR DESCRIPTION
## Summary

- Reverted `torghut-ws` dynamic Jangar symbol feed in production config.
- Set `JANGAR_SYMBOLS_URL` back to empty so WS uses the known-safe static symbol universe.
- Updated comments to document root cause: provider symbol-limit rejection on the full dynamic universe.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/torghut/ws >/tmp/torghut-ws-kustomize-hotfix.out`
- `rg -n "JANGAR_SYMBOLS_URL|SYMBOLS:" /tmp/torghut-ws-kustomize-hotfix.out`
- `kubectl -n torghut logs deployment/torghut-ws --tail=200` (confirmed current failure mode before hotfix: `alpaca error code=405 msg=symbol limit exceeded`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
