### PR TITLE
fix(torghut-ws): use 29-symbol dynamic equity universe

### DIFF
--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -10,9 +10,9 @@ data:
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
   ALPACA_TRADE_STREAM_URL: "wss://paper-api.alpaca.markets/stream"
   ALPACA_BASE_URL: "https://data.alpaca.markets"
-  # Dynamic desired-symbol feed disabled: Alpaca market-data plan rejects current full universe size.
-  JANGAR_SYMBOLS_URL: ""
-  # Static curated universe kept within known provider subscription limits.
+  # Dynamic desired-symbol feed from Jangar (now constrained to 29 enabled symbols).
+  JANGAR_SYMBOLS_URL: "http://jangar.jangar.svc.cluster.local/api/torghut/symbols?assetClass=equity&format=compact"
+  # Static curated fallback universe used if desired-symbol fetch fails.
   SYMBOLS: "ARM,CRWD,GOOG,LRCX,MSFT,MU,NVDA,SNDK,TSM"
   SYMBOLS_POLL_INTERVAL_MS: "30000"
   SUBSCRIBE_BATCH_SIZE: "200"


### PR DESCRIPTION
## Summary

- Re-enabled `torghut-ws` dynamic desired-symbol sourcing from Jangar.
- Kept static `SYMBOLS` fallback for startup/fetch-failure resilience.
- Dynamic source is now effectively capped to 29 symbols after removing `DASH` from Jangar equity universe.

## Related Issues

None

## Testing

- `curl -sS "http://jangar/api/torghut/symbols?assetClass=equity&format=compact" | jq -r '.symbols | "count=\(length)\n\(.)"'` (verified `count=29`, no `DASH`)
- `kustomize build argocd/applications/torghut/ws >/tmp/torghut-ws-kustomize-dynamic29.out`
- `head -n 45 /tmp/torghut-ws-kustomize-dynamic29.out` (verified rendered `JANGAR_SYMBOLS_URL` points to compact equity endpoint)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
