### PR TITLE
fix(torghut-ws): restore stable ws subscriptions after 29-symbol trial

### DIFF
--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -10,9 +10,9 @@ data:
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
   ALPACA_TRADE_STREAM_URL: "wss://paper-api.alpaca.markets/stream"
   ALPACA_BASE_URL: "https://data.alpaca.markets"
-  # Dynamic desired-symbol feed from Jangar (now constrained to 29 enabled symbols).
-  JANGAR_SYMBOLS_URL: "http://jangar.jangar.svc.cluster.local/api/torghut/symbols?assetClass=equity&format=compact"
-  # Static curated fallback universe used if desired-symbol fetch fails.
+  # Dynamic desired-symbol feed disabled: Alpaca account currently rejects 29-symbol subscription requests.
+  JANGAR_SYMBOLS_URL: ""
+  # Static curated universe kept within known provider subscription limits.
   SYMBOLS: "ARM,CRWD,GOOG,LRCX,MSFT,MU,NVDA,SNDK,TSM"
   SYMBOLS_POLL_INTERVAL_MS: "30000"
   SUBSCRIBE_BATCH_SIZE: "200"


### PR DESCRIPTION
## Summary

- Restored `torghut-ws` to static symbol sourcing by disabling dynamic `JANGAR_SYMBOLS_URL`.
- Preserved existing static curated symbol fallback set for stable readiness.
- Documents the observed runtime constraint: Alpaca still returns `405 symbol limit exceeded` at 29 symbols for this account.

## Related Issues

None

## Testing

- `kubectl -n torghut logs deployment/torghut-ws --tail=220` (verified failure with dynamic 29: `alpaca error code=405 msg=symbol limit exceeded`)
- `kustomize build argocd/applications/torghut/ws >/tmp/torghut-ws-kustomize-recover.out`
- `head -n 40 /tmp/torghut-ws-kustomize-recover.out` (verified rendered `JANGAR_SYMBOLS_URL: ""` + static `SYMBOLS`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
