### PR TITLE
chore(jangar): promote image cee7ebef

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 03e35a22
-  digest: sha256:7175dc6a94aa207d796a66eecec395f14a127c1c839a7115b1c3e0df74731265
+  tag: cee7ebef
+  digest: sha256:86729ac78a84c67f270889af5ff80ae13e4dc4f0a5e010c7f8964ddd87b65771
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 03e35a22
-    digest: sha256:1d5793dd74fd87202792061ba936b01e814161e03fc1f50be444e22b2a8ac3e0
+    tag: cee7ebef
+    digest: sha256:8f8d98be8ec1f16eddff1fe29ede7a9b0975a5559bbe6edf68bc5c26d936b26c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 03e35a22
-    digest: sha256:7175dc6a94aa207d796a66eecec395f14a127c1c839a7115b1c3e0df74731265
+    tag: cee7ebef
+    digest: sha256:86729ac78a84c67f270889af5ff80ae13e4dc4f0a5e010c7f8964ddd87b65771
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-03T06:21:37Z"
+    deploy.knative.dev/rollout: "2026-03-03T07:30:54Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-03T06:21:37Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-03T07:30:54Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "03e35a22"
-    digest: sha256:7175dc6a94aa207d796a66eecec395f14a127c1c839a7115b1c3e0df74731265
+    newTag: "cee7ebef"
+    digest: sha256:86729ac78a84c67f270889af5ff80ae13e4dc4f0a5e010c7f8964ddd87b65771


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `cee7ebef3d27bced7940a99e84e5632f43bd3485`
- Image tag: `cee7ebef`
- Image digest: `sha256:86729ac78a84c67f270889af5ff80ae13e4dc4f0a5e010c7f8964ddd87b65771`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`