### PR TITLE
fix(jangar): stop injecting legacy huly-api secret in swarm runs

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -687,7 +687,8 @@ describe('supporting primitives controller', () => {
     expect(parameters.hulyApiBaseUrl).toBe('https://huly.proompteng.ai')
     expect(parameters.hulySkillRef).toBe('skills/huly-api/SKILL.md')
     const runSecrets = Array.isArray(requirementRun.spec.secrets) ? (requirementRun.spec.secrets as string[]) : []
-    expect(runSecrets).toContain('huly-api')
+    expect(runSecrets).not.toContain('huly-api')
+    expect(runSecrets).toHaveLength(0)
 
     const statusCall = applyStatus.mock.calls.at(-1)
     const status = (statusCall?.[0] as { status?: Record<string, unknown> } | undefined)?.status ?? {}

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -729,7 +729,7 @@ const SWARM_DEFAULT_HULY_BASE_URL = (() => {
 })()
 const SWARM_DEFAULT_HULY_SECRET_NAME = (() => {
   const value = asString(process.env.JANGAR_SWARM_HULY_SECRET_NAME)?.trim()
-  return value && value.length > 0 ? value : 'huly-api'
+  return value && value.length > 0 ? value : ''
 })()
 const SWARM_DEFAULT_HULY_SKILL_REF = (() => {
   const value = asString(process.env.JANGAR_SWARM_HULY_SKILL_REF)?.trim()


### PR DESCRIPTION
## Summary

- Stop injecting legacy `huly-api` secret by default in swarm runtime secret resolution.
- Keep swarm runs dependent only on explicitly declared run/template secrets unless `JANGAR_SWARM_HULY_SECRET_NAME` is intentionally set.
- Add regression coverage to ensure requirement-dispatch runs do not auto-include `huly-api` when no explicit swarm Huly secret is configured.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/supporting-primitives-controller.test.ts`
- `bunx oxfmt --check services/jangar/src/server/supporting-primitives-controller.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
