### PR TITLE
fix(torghut-ws): roll out f766131 websocket image digest

### DIFF
--- a/argocd/applications/torghut/ws/deployment.yaml
+++ b/argocd/applications/torghut/ws/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: torghut-ws
       annotations:
-        kubectl.kubernetes.io/restartedAt: 2026-03-02T08:35:04Z
+        kubectl.kubernetes.io/restartedAt: 2026-03-03T08:05:00Z
     spec:
       serviceAccountName: torghut-runtime
       securityContext:
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:3643ed1cd724435024c86f6d90ef471d42df85df46a8d8c29ee9602533413e04
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7a29c76d66903727fac3e0c469cbb09df3b2370e90edad30eaf9f2cbfa80d64b
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -53,9 +53,9 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: codex-202603020832
+              value: main-202603030801
             - name: TORGHUT_WS_COMMIT
-              value: d50e5bbfe2737ece253f41f47d4cf281dc17d9c7
+              value: f76613179921b29c7ee20ce487557742ae0c33cc
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary

- update `torghut-ws` deployment image digest to the CI-built websocket image for main commit `f766131`
- align deployment metadata env vars (`TORGHUT_WS_VERSION`, `TORGHUT_WS_COMMIT`) with the pinned image
- refresh deployment restart annotation to trigger rollout of the new image

## Related Issues

None

## Testing

- `kustomize build argocd/applications/torghut/ws`
- validated CI run `Torghut WS Docker Build and Push` for `f766131` succeeded and published digest `sha256:7a29c76d66903727fac3e0c469cbb09df3b2370e90edad30eaf9f2cbfa80d64b`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
