### PR TITLE
fix(torghut-ws): enable full channels with 12-symbol fallback

### DIFF
--- a/argocd/applications/torghut/ws/configmap.yaml
+++ b/argocd/applications/torghut/ws/configmap.yaml
@@ -10,13 +10,13 @@ data:
   ALPACA_STREAM_URL: "wss://stream.data.alpaca.markets"
   ALPACA_TRADE_STREAM_URL: "wss://paper-api.alpaca.markets/stream"
   ALPACA_BASE_URL: "https://data.alpaca.markets"
-  # Alpaca enforces 30 real-time trade/quote subscriptions on this account.
-  # We ingest trades + bars + updatedBars (quotes disabled) so a 20-symbol universe stays under limit.
-  ALPACA_MARKET_DATA_CHANNELS: "trades,bars,updatedBars"
+  # Full market-data mode (quotes enabled) must stay within account subscription constraints.
+  # Keep universe size capped at 12 to preserve headroom and avoid 405 symbol-limit failures.
+  ALPACA_MARKET_DATA_CHANNELS: "trades,quotes,bars,updatedBars"
   # Dynamic desired-symbol feed sourced from Jangar universe manager.
   JANGAR_SYMBOLS_URL: "http://jangar.jangar.svc.cluster.local/api/torghut/symbols?assetClass=equity&format=compact"
   # Startup fallback if Jangar is temporarily unavailable.
-  SYMBOLS: "AAPL,ADBE,ADI,AMAT,AMD,APP,ASML,AVGO,CDNS,CRWD,GOOGL,INTC,INTU,KLAC,LRCX,META,MRVL,MSFT,MU,NVDA"
+  SYMBOLS: "AAPL,MSFT,GOOG,META,PLTR,SHOP,NVDA,AVGO,MU,AMD,AMAT,INTC"
   SYMBOLS_POLL_INTERVAL_MS: "30000"
   SUBSCRIBE_BATCH_SIZE: "200"
   SHARD_COUNT: "1"


### PR DESCRIPTION
## Summary

- enable full Alpaca market-data channels in torghut-ws (`trades,quotes,bars,updatedBars`)
- cap ws startup fallback symbols to 12 to match full-channel subscription headroom
- align fallback universe with current Jangar equity selection to avoid startup drift

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `curl -sS 'http://jangar/api/torghut/symbols?includeDisabled=true&format=full&assetClass=equity' | jq '.items | length'` (expects 12)
- `kubectl -n torghut patch configmap torghut-ws-config --type merge -p '{"data":{"ALPACA_MARKET_DATA_CHANNELS":"trades,quotes,bars,updatedBars","SYMBOLS":"AAPL,MSFT,GOOG,META,PLTR,SHOP,NVDA,AVGO,MU,AMD,AMAT,INTC"}}'`
- `kubectl -n torghut rollout restart deployment/torghut-ws`
- `kubectl -n torghut rollout status deployment/torghut-ws --timeout=180s`
- `kubectl -n torghut logs deploy/torghut-ws --since=5m | rg -n "channels=|initial symbols=|405|limit" -i`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
