### PR TITLE
chore(jangar): promote image f652ff3a

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: cee7ebef
-  digest: sha256:86729ac78a84c67f270889af5ff80ae13e4dc4f0a5e010c7f8964ddd87b65771
+  tag: f652ff3a
+  digest: sha256:906f0479b27318ff3cd915b2ca2fae4d2ea5395efd729d59c9d0f40d5ecdf310
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: cee7ebef
-    digest: sha256:8f8d98be8ec1f16eddff1fe29ede7a9b0975a5559bbe6edf68bc5c26d936b26c
+    tag: f652ff3a
+    digest: sha256:f4e26b596f8bf7aa184c761a9e34989aa6ea8720c250789346e16d30f7f6eedd
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: cee7ebef
-    digest: sha256:86729ac78a84c67f270889af5ff80ae13e4dc4f0a5e010c7f8964ddd87b65771
+    tag: f652ff3a
+    digest: sha256:906f0479b27318ff3cd915b2ca2fae4d2ea5395efd729d59c9d0f40d5ecdf310
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-03T07:30:54Z"
+    deploy.knative.dev/rollout: "2026-03-03T08:32:19Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-03T07:30:54Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-03T08:32:19Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "cee7ebef"
-    digest: sha256:86729ac78a84c67f270889af5ff80ae13e4dc4f0a5e010c7f8964ddd87b65771
+    newTag: "f652ff3a"
+    digest: sha256:906f0479b27318ff3cd915b2ca2fae4d2ea5395efd729d59c9d0f40d5ecdf310


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f652ff3a8e33069a4e0498e780f0d35ce1dcc9db`
- Image tag: `f652ff3a`
- Image digest: `sha256:906f0479b27318ff3cd915b2ca2fae4d2ea5395efd729d59c9d0f40d5ecdf310`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`