### PR TITLE
fix(jangar): avoid false swarm freeze on timed-out workflows

### DIFF
--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -3343,6 +3343,76 @@ describe('agents controller reconcileAgentRun', () => {
     expect(steps[0]?.message).toBe('Step timed out')
   })
 
+  it('does not fail timed out workflow step when runtime job already completed', async () => {
+    const apply = vi.fn(async (resource: Record<string, unknown>) => {
+      const metadata = (resource.metadata ?? {}) as Record<string, unknown>
+      const uid = metadata.uid ?? `uid-${String(resource.kind ?? 'resource').toLowerCase()}`
+      return { ...resource, metadata: { ...metadata, uid } }
+    })
+    const kube = buildKube({
+      apply,
+      get: vi.fn(async (resource: string, name: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        if (resource === 'job') {
+          return {
+            metadata: { name },
+            status: {
+              succeeded: 1,
+              startTime: '2026-03-02T20:01:25Z',
+              completionTime: '2026-03-02T20:20:00Z',
+            },
+          }
+        }
+        return null
+      }),
+    })
+
+    const startedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    const agentRun = buildAgentRun({
+      spec: {
+        agentRef: { name: 'agent-1' },
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'workflow', config: {} },
+        workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
+        workflow: {
+          steps: [{ name: 'timeout-step', timeoutSeconds: 60 }],
+        },
+      },
+      status: {
+        phase: 'Running',
+        workflow: {
+          phase: 'Running',
+          steps: [
+            {
+              name: 'timeout-step',
+              phase: 'Running',
+              attempt: 1,
+              startedAt,
+              jobRef: { name: 'timeout-job', namespace: 'agents' },
+            },
+          ],
+        },
+      },
+    })
+
+    await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
+
+    const status = getLastStatus(kube)
+    const workflow = status.workflow as Record<string, unknown>
+    const steps = (workflow.steps as Record<string, unknown>[]) ?? []
+    expect(status.phase).toBe('Succeeded')
+    expect(workflow.phase).toBe('Succeeded')
+    expect(steps[0]?.phase).toBe('Succeeded')
+  })
+
   it('deletes completed AgentRun after retention window', async () => {
     const deleteMock = vi.fn(async () => ({}))
     const kube = buildKube({ delete: deleteMock })

--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -1600,6 +1600,104 @@ describe('supporting primitives controller', () => {
     expect(status.freeze).toBeTruthy()
   })
 
+  it('does not freeze when timed-out implement runs have successful runtime jobs', async () => {
+    const applyStatus = vi.fn().mockResolvedValue({})
+    const apply = vi.fn().mockResolvedValue({})
+    const get = vi.fn(async (resource: string, name: string) => {
+      if (resource === 'job' && (name === 'timeout-job-1' || name === 'timeout-job-2')) {
+        return {
+          metadata: { name, namespace: 'agents' },
+          status: {
+            succeeded: 1,
+            startTime: '2026-01-20T00:00:00Z',
+            completionTime: '2026-01-20T00:10:00Z',
+          },
+        }
+      }
+      return null
+    })
+    const list = vi.fn(async (resource: string) => {
+      if (resource === RESOURCE_MAP.AgentRun) {
+        return {
+          items: [
+            {
+              metadata: {
+                name: 'run-2',
+                creationTimestamp: '2026-01-20T00:01:00Z',
+                labels: {
+                  'swarm.proompteng.ai/name': 'torghut-quant',
+                  'swarm.proompteng.ai/stage': 'implement',
+                },
+              },
+              status: {
+                phase: 'Failed',
+                runtimeRef: { type: 'workflow', name: 'timeout-job-2', namespace: 'agents' },
+                conditions: [{ type: 'Failed', status: 'True', reason: 'WorkflowStepTimedOut' }],
+              },
+            },
+            {
+              metadata: {
+                name: 'run-1',
+                creationTimestamp: '2026-01-20T00:00:00Z',
+                labels: {
+                  'swarm.proompteng.ai/name': 'torghut-quant',
+                  'swarm.proompteng.ai/stage': 'implement',
+                },
+              },
+              status: {
+                phase: 'Failed',
+                runtimeRef: { type: 'workflow', name: 'timeout-job-1', namespace: 'agents' },
+                conditions: [{ type: 'Failed', status: 'True', reason: 'WorkflowStepTimedOut' }],
+              },
+            },
+          ],
+        }
+      }
+      if (resource === RESOURCE_MAP.OrchestrationRun) {
+        return { items: [] }
+      }
+      return { items: [] }
+    })
+    const deleteFn = vi.fn().mockResolvedValue(null)
+    const kube = { applyStatus, apply, get, list, delete: deleteFn } as unknown as KubernetesClient
+
+    const swarm = {
+      apiVersion: 'swarm.proompteng.ai/v1alpha1',
+      kind: 'Swarm',
+      metadata: { name: 'torghut-quant', namespace: 'agents', generation: 1, uid: 'swarm-uid' },
+      spec: {
+        owner: { id: 'trading-owner', channel: 'swarm://owner/trading' },
+        domains: ['autonomous-trading'],
+        objectives: ['improve risk-adjusted return'],
+        mode: 'lights-out',
+        cadence: {
+          discoverEvery: '1m',
+          planEvery: '5m',
+          implementEvery: '15m',
+          verifyEvery: '1m',
+        },
+        discovery: { sources: [{ name: 'market-feed' }] },
+        delivery: { deploymentTargets: ['torghut'] },
+        risk: { freezeAfterFailures: 2, freezeDuration: '60m' },
+        execution: {
+          discover: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          plan: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          implement: { targetRef: { kind: 'OrchestrationRun', name: 'orchestrationrun-sample' } },
+          verify: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+        },
+      },
+    }
+
+    await __test__.reconcileSwarm(kube, swarm, 'agents')
+
+    expect(apply).toHaveBeenCalledTimes(4)
+    expect(deleteFn).not.toHaveBeenCalled()
+    const firstStatusCall = applyStatus.mock.calls[0]
+    const status = (firstStatusCall?.[0] as { status?: Record<string, unknown> } | undefined)?.status ?? {}
+    expect(status.phase).toBe('Active')
+    expect(status.freeze).toBeUndefined()
+  })
+
   it('counts implement failures from configured target namespaces when deciding freeze', async () => {
     const applyStatus = vi.fn().mockResolvedValue({})
     const apply = vi.fn().mockResolvedValue({})

--- a/services/jangar/src/server/agents-controller/workflow-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/workflow-reconciler.ts
@@ -710,51 +710,70 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         const iterationIndex = loopStatus
           ? Math.max(1, loopStatus.currentIteration || loopStatus.completedIterations + 1)
           : 0
+        const jobName = asString(stepStatus.jobRef?.name) ?? ''
+        const jobNamespace = asString(stepStatus.jobRef?.namespace) ?? namespace
+        let prefetchedJobForTimeout: Record<string, unknown> | null = null
+        const applyTimeoutOutcome = () => {
+          if (stepStatus.attempt < maxAttempts) {
+            setWorkflowStepPhase(stepStatus, 'Retrying', 'Step timed out; retrying')
+            stepStatus.finishedAt = deps.nowIso()
+            stepStatus.nextRetryAt =
+              stepSpec.retryBackoffSeconds > 0
+                ? new Date(now + stepSpec.retryBackoffSeconds * 1000).toISOString()
+                : deps.nowIso()
+            if (loopStatus) {
+              upsertWorkflowLoopIteration(loopStatus, iterationIndex, {
+                phase: 'Running',
+                attempts: stepStatus.attempt,
+                startedAt: stepStatus.startedAt,
+                finishedAt: stepStatus.finishedAt,
+                message: 'Step timed out; retrying',
+                jobRef: stepStatus.jobRef,
+              })
+            }
+            workflowRunning = true
+            return
+          }
+          setWorkflowStepPhase(stepStatus, 'Failed', 'Step timed out')
+          stepStatus.finishedAt = deps.nowIso()
+          if (loopStatus) {
+            upsertWorkflowLoopIteration(loopStatus, iterationIndex, {
+              phase: 'Failed',
+              attempts: stepStatus.attempt,
+              startedAt: stepStatus.startedAt,
+              finishedAt: stepStatus.finishedAt,
+              message: 'Step timed out',
+              jobRef: stepStatus.jobRef,
+            })
+            loopStatus.stopReason = 'LoopIterationFailed'
+          }
+          workflowFailure = {
+            reason: 'WorkflowStepTimedOut',
+            message: `workflow step ${stepSpec.name} timed out`,
+          }
+        }
         if (stepSpec.timeoutSeconds > 0) {
           const startedAt = stepStatus.startedAt
           const startTime = startedAt ? Date.parse(startedAt) : Number.NaN
           if (Number.isFinite(startTime) && now >= startTime + stepSpec.timeoutSeconds * 1000) {
-            if (stepStatus.attempt < maxAttempts) {
-              setWorkflowStepPhase(stepStatus, 'Retrying', 'Step timed out; retrying')
-              stepStatus.finishedAt = deps.nowIso()
-              stepStatus.nextRetryAt =
-                stepSpec.retryBackoffSeconds > 0
-                  ? new Date(now + stepSpec.retryBackoffSeconds * 1000).toISOString()
-                  : deps.nowIso()
-              if (loopStatus) {
-                upsertWorkflowLoopIteration(loopStatus, iterationIndex, {
-                  phase: 'Running',
-                  attempts: stepStatus.attempt,
-                  startedAt: stepStatus.startedAt,
-                  finishedAt: stepStatus.finishedAt,
-                  message: 'Step timed out; retrying',
-                  jobRef: stepStatus.jobRef,
-                })
+            let terminalJobStateObserved = false
+            if (jobName) {
+              prefetchedJobForTimeout = await kube.get('job', jobName, jobNamespace)
+              if (prefetchedJobForTimeout) {
+                const prefetchedStatus = asRecord(prefetchedJobForTimeout.status) ?? {}
+                const prefetchedSucceeded = Number(prefetchedStatus.succeeded ?? 0)
+                const prefetchedFailed = Number(prefetchedStatus.failed ?? 0)
+                const terminalSuccess = prefetchedSucceeded > 0 || deps.isJobComplete(prefetchedJobForTimeout)
+                const terminalFailure = prefetchedFailed > 0 && deps.isJobFailed(prefetchedJobForTimeout)
+                terminalJobStateObserved = terminalSuccess || terminalFailure
               }
-              workflowRunning = true
+            }
+            if (!terminalJobStateObserved) {
+              applyTimeoutOutcome()
               break
             }
-            setWorkflowStepPhase(stepStatus, 'Failed', 'Step timed out')
-            stepStatus.finishedAt = deps.nowIso()
-            if (loopStatus) {
-              upsertWorkflowLoopIteration(loopStatus, iterationIndex, {
-                phase: 'Failed',
-                attempts: stepStatus.attempt,
-                startedAt: stepStatus.startedAt,
-                finishedAt: stepStatus.finishedAt,
-                message: 'Step timed out',
-                jobRef: stepStatus.jobRef,
-              })
-              loopStatus.stopReason = 'LoopIterationFailed'
-            }
-            workflowFailure = {
-              reason: 'WorkflowStepTimedOut',
-              message: `workflow step ${stepSpec.name} timed out`,
-            }
-            break
           }
         }
-        const jobName = asString(stepStatus.jobRef?.name) ?? ''
         if (!jobName) {
           setWorkflowStepPhase(stepStatus, 'Failed', 'Job reference missing')
           stepStatus.finishedAt = deps.nowIso()
@@ -775,8 +794,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
           }
           break
         }
-        const jobNamespace = asString(stepStatus.jobRef?.namespace) ?? namespace
-        const job = await kube.get('job', jobName, jobNamespace)
+        const job = prefetchedJobForTimeout ?? (await kube.get('job', jobName, jobNamespace))
         if (!job) {
           if (!stepStatus.jobObservedAt) {
             setWorkflowStepPhase(stepStatus, 'Running', 'Waiting for job to be created')

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -1050,13 +1050,68 @@ const sortByMostRecentRun = (resources: Record<string, unknown>[]) => {
   })
 }
 
-const countConsecutiveFailures = (resources: Record<string, unknown>[]) => {
+const getFailedConditionReason = (resource: Record<string, unknown>) => {
+  const conditions = normalizeConditions(readNested(resource, ['status', 'conditions']))
+  const failedCondition = conditions.find((condition) => condition.type === 'Failed' && condition.status === 'True')
+  return failedCondition?.reason ?? null
+}
+
+const didTimedOutWorkflowRunSucceed = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  resource: Record<string, unknown>,
+  defaultNamespace: string,
+) => {
+  const phase = (asString(readNested(resource, ['status', 'phase'])) ?? '').toLowerCase()
+  if (!TERMINAL_FAILURE_PHASES.has(phase)) return false
+  if (getFailedConditionReason(resource) !== 'WorkflowStepTimedOut') return false
+
+  const runtimeRef = asRecord(readNested(resource, ['status', 'runtimeRef'])) ?? {}
+  const runtimeType = (asString(runtimeRef.type) ?? '').toLowerCase()
+  if (runtimeType && runtimeType !== 'workflow') return false
+
+  const runtimeName = asString(runtimeRef.name)
+  if (!runtimeName) return false
+  const runtimeNamespace = asString(runtimeRef.namespace) ?? defaultNamespace
+
+  let job: Record<string, unknown> | null
+  try {
+    job = await kube.get('job', runtimeName, runtimeNamespace)
+  } catch (error) {
+    console.warn('[jangar] failed to inspect timed-out workflow runtime job', {
+      run: asString(readNested(resource, ['metadata', 'name'])) ?? 'unknown',
+      namespace: runtimeNamespace,
+      job: runtimeName,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+  if (!job) return false
+
+  const jobStatus = asRecord(readNested(job, ['status'])) ?? {}
+  const succeeded = Number(jobStatus.succeeded ?? 0)
+  const failed = Number(jobStatus.failed ?? 0)
+  if (succeeded > 0 && failed <= 0) return true
+
+  const jobConditions = normalizeConditions(jobStatus.conditions)
+  const completeCondition = jobConditions.find((condition) => condition.type === 'Complete')
+  const failedCondition = jobConditions.find((condition) => condition.type === 'Failed')
+  return completeCondition?.status === 'True' && failedCondition?.status !== 'True'
+}
+
+const countConsecutiveFailures = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  resources: Record<string, unknown>[],
+  defaultNamespace: string,
+) => {
   const sorted = sortByMostRecentRun(resources)
   let failures = 0
   for (const resource of sorted) {
     const phase = (asString(readNested(resource, ['status', 'phase'])) ?? '').toLowerCase()
     if (!phase) continue
     if (TERMINAL_FAILURE_PHASES.has(phase)) {
+      if (await didTimedOutWorkflowRunSucceed(kube, resource, defaultNamespace)) {
+        break
+      }
       failures += 1
       continue
     }
@@ -1758,7 +1813,7 @@ const reconcileSwarm = async (
 
   if (!freezeActive) {
     const recentImplementRuns = filterRunsAfterTime(implementRuns, failureWindowStartMs)
-    const consecutiveFailures = countConsecutiveFailures(recentImplementRuns)
+    const consecutiveFailures = await countConsecutiveFailures(kube, recentImplementRuns, swarmNamespace)
     if (consecutiveFailures >= freezeAfterFailures) {
       freezeActive = true
       freezeReason = 'ConsecutiveFailures'


### PR DESCRIPTION
## Summary

- Guarded workflow timeout handling so a step is not marked timed out when its runtime Job is already terminal.
- Updated swarm freeze failure counting to ignore `WorkflowStepTimedOut` implement runs whose runtime workflow Job actually succeeded.
- Added regression tests in agents-controller and supporting-primitives-controller suites for the timeout/job-complete race and freeze behavior.

## Related Issues

None.

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/agents-controller.test.ts src/server/__tests__/supporting-primitives-controller.test.ts -t "timeout|timed out|freeze"` (from `services/jangar`)
- `bun run --filter @proompteng/jangar tsc`
- `bunx oxfmt --check services/jangar/src/server/agents-controller/workflow-reconciler.ts services/jangar/src/server/supporting-primitives-controller.ts services/jangar/src/server/__tests__/agents-controller.test.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
