### PR TITLE
feat(torghut): converge autonomy runtime gate policy contract

### DIFF
--- a/argocd/applications/torghut/autonomous-configmap.yaml
+++ b/argocd/applications/torghut/autonomous-configmap.yaml
@@ -39,22 +39,3 @@ data:
           next_on_fail: rollback_incident_workflow
         - id: rollback_incident_workflow
           next_on_pass: research_intake
-  autonomous-gate-policy.json: |
-    {
-      "policy_version": "v3-gates-1",
-      "required_feature_schema_version": "3.0.0",
-      "gate0_max_null_rate": "0.01",
-      "gate0_max_staleness_ms": 120000,
-      "gate0_min_symbol_coverage": 1,
-      "gate1_min_decision_count": 1,
-      "gate1_min_trade_count": 1,
-      "gate1_min_net_pnl": "0",
-      "gate1_max_negative_fold_ratio": "0.50",
-      "gate1_max_net_pnl_cv": "2.0",
-      "gate2_max_drawdown": "250",
-      "gate2_max_turnover_ratio": "8.0",
-      "gate2_max_cost_bps": "35",
-      "gate3_max_llm_error_ratio": "0.10",
-      "gate5_live_enabled": false,
-      "gate5_require_approval_token": true
-    }

--- a/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
+++ b/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
@@ -23,10 +23,27 @@ data:
       "gate2_max_drawdown": "250",
       "gate2_max_turnover_ratio": "8.0",
       "gate2_max_cost_bps": "35",
+      "gate2_max_fragility_score": "0.85",
+      "gate2_max_fragility_state_rank": 2,
+      "gate2_require_stability_mode_under_stress": true,
       "gate3_max_llm_error_ratio": "0.10",
       "gate3_max_forecast_fallback_rate": "0.05",
       "gate3_max_forecast_latency_ms_p95": 200,
       "gate3_min_forecast_calibration_score": "0.85",
+      "gate6_require_janus_evidence": true,
+      "gate6_min_janus_event_count": 1,
+      "gate6_min_janus_reward_count": 1,
+      "gate6_max_calibration_error": "0.45",
+      "gate7_target_coverage": "0.90",
+      "gate7_max_coverage_error_pass": "0.03",
+      "gate7_max_coverage_error_degrade": "0.05",
+      "gate7_max_coverage_error_abstain": "0.08",
+      "gate7_shift_score_degrade": "0.60",
+      "gate7_shift_score_abstain": "0.80",
+      "gate7_shift_score_fail": "0.95",
+      "gate7_max_interval_width_pass": "1.25",
+      "gate7_max_interval_width_degrade": "1.75",
+      "promotion_uncertainty_max_coverage_error": "0.03",
       "gate5_live_enabled": false,
       "gate5_require_approval_token": true,
       "promotion_required_artifacts": [
@@ -34,10 +51,43 @@ data:
         "backtest/evaluation-report.json",
         "gates/gate-evaluation.json"
       ],
-      "promotion_require_patch_targets": [
-        "paper",
-        "live"
+      "promotion_require_patch_targets": ["paper", "live"],
+      "promotion_profitability_required_artifacts": [
+        "gates/profitability-evidence-v4.json",
+        "gates/profitability-benchmark-v4.json",
+        "gates/profitability-evidence-validation.json",
+        "gates/recalibration-report.json"
       ],
+      "promotion_janus_required_targets": ["paper", "live"],
+      "promotion_janus_required_artifacts": [
+        "gates/janus-event-car-v1.json",
+        "gates/janus-hgrm-reward-v1.json"
+      ],
+      "promotion_require_benchmark_parity": true,
+      "promotion_benchmark_parity_required_targets": ["paper", "live"],
+      "promotion_benchmark_required_artifacts": [
+        "benchmarks/benchmark-parity-report-v1.json"
+      ],
+      "promotion_benchmark_parity_min_advisory_output_rate": "0.995",
+      "promotion_benchmark_parity_max_policy_violation_rate_degradation": "0.05",
+      "promotion_benchmark_parity_max_fallback_rate": "0.01",
+      "promotion_benchmark_parity_max_timeout_rate": "0.005",
+      "promotion_benchmark_parity_max_adverse_regime_decision_quality_degradation": "0.01",
+      "promotion_benchmark_parity_max_risk_veto_alignment_degradation": "0.01",
+      "promotion_benchmark_parity_max_confidence_calibration_error_degradation": "0.01",
+      "promotion_require_stress_evidence": true,
+      "promotion_stress_required_targets": ["paper", "live"],
+      "promotion_stress_required_artifacts": [
+        "gates/stress-metrics-v1.json"
+      ],
+      "promotion_stress_max_age_hours": 24,
+      "promotion_require_janus_evidence": true,
+      "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
+      "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",
+      "promotion_min_janus_event_count": 1,
+      "promotion_min_janus_reward_count": 1,
+      "promotion_require_profitability_stage_manifest": true,
+      "promotion_profitability_stage_manifest_artifact": "profitability/profitability-stage-manifest-v1.json",
       "rollback_required_checks": [
         "killSwitchDryRunPassed",
         "gitopsRevertDryRunPassed",

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -38,7 +38,10 @@ from .models import (
     WhitepaperRolloutTransition,
 )
 from .trading import TradingScheduler
-from .trading.autonomy import evaluate_evidence_continuity
+from .trading.autonomy import (
+    assert_runtime_gate_policy_contract,
+    evaluate_evidence_continuity,
+)
 from .trading.lean_lanes import LeanLaneManager
 from .trading.llm.evaluation import build_llm_evaluation_metrics
 from .trading.tca import build_tca_gate_inputs
@@ -202,6 +205,9 @@ async def lifespan(app: FastAPI):
         ensure_schema()
     except SQLAlchemyError as exc:  # pragma: no cover - defensive for startup only
         logger.warning("Database not reachable during startup: %s", exc)
+
+    if settings.trading_autonomy_enabled:
+        assert_runtime_gate_policy_contract(settings.trading_autonomy_gate_policy_path)
 
     if settings.trading_enabled:
         await scheduler.start()

--- a/services/torghut/app/trading/autonomy/__init__.py
+++ b/services/torghut/app/trading/autonomy/__init__.py
@@ -19,6 +19,12 @@ from .policy_checks import (
     evaluate_promotion_prerequisites,
     evaluate_rollback_readiness,
 )
+from .policy_contract import (
+    REQUIRED_RUNTIME_GATE_POLICY_KEYS,
+    assert_runtime_gate_policy_contract,
+    load_runtime_gate_policy,
+    required_key_errors,
+)
 from .evidence import EvidenceContinuityCheckReport, evaluate_evidence_continuity
 from .drift import (
     DriftActionDecision,
@@ -51,6 +57,7 @@ __all__ = [
     "LegacyMacdRsiPlugin",
     "PromotionTarget",
     "PromotionPrerequisiteResult",
+    "REQUIRED_RUNTIME_GATE_POLICY_KEYS",
     "RuntimeEvaluationResult",
     "RollbackReadinessResult",
     "StrategyContext",
@@ -72,9 +79,12 @@ __all__ = [
     "evaluate_live_promotion_evidence",
     "evaluate_gate_matrix",
     "evaluate_evidence_continuity",
+    "assert_runtime_gate_policy_contract",
     "load_runtime_strategy_config",
+    "load_runtime_gate_policy",
     "evaluate_promotion_prerequisites",
     "evaluate_rollback_readiness",
+    "required_key_errors",
     "upsert_autonomy_no_signal_run",
     "run_autonomous_lane",
 ]

--- a/services/torghut/app/trading/autonomy/policy_contract.py
+++ b/services/torghut/app/trading/autonomy/policy_contract.py
@@ -1,0 +1,104 @@
+"""Runtime gate-policy contract checks for startup and CI parity enforcement."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+_REQUIRED_BOOL_KEYS: tuple[str, ...] = (
+    "promotion_require_profitability_stage_manifest",
+    "promotion_require_benchmark_parity",
+    "promotion_require_janus_evidence",
+    "promotion_require_stress_evidence",
+)
+
+_REQUIRED_STRING_KEYS: tuple[str, ...] = (
+    "promotion_profitability_stage_manifest_artifact",
+)
+
+_REQUIRED_LIST_KEYS: tuple[str, ...] = (
+    "promotion_benchmark_required_artifacts",
+    "promotion_janus_required_artifacts",
+    "promotion_stress_required_artifacts",
+)
+
+REQUIRED_RUNTIME_GATE_POLICY_KEYS: tuple[str, ...] = (
+    *_REQUIRED_BOOL_KEYS,
+    *_REQUIRED_STRING_KEYS,
+    *_REQUIRED_LIST_KEYS,
+)
+
+
+def load_runtime_gate_policy(policy_path: Path) -> dict[str, Any]:
+    raw_payload = json.loads(policy_path.read_text(encoding="utf-8"))
+    if not isinstance(raw_payload, dict):
+        raise ValueError("policy payload must be a JSON object")
+    return cast(dict[str, Any], raw_payload)
+
+
+def required_key_errors(policy_payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    for key in REQUIRED_RUNTIME_GATE_POLICY_KEYS:
+        if key not in policy_payload:
+            errors.append(f"missing:{key}")
+
+    for key in _REQUIRED_BOOL_KEYS:
+        if key not in policy_payload:
+            continue
+        if not isinstance(policy_payload.get(key), bool):
+            errors.append(f"invalid_type:{key}:bool")
+
+    for key in _REQUIRED_STRING_KEYS:
+        if key not in policy_payload:
+            continue
+        value = policy_payload.get(key)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"invalid_type:{key}:non_empty_string")
+
+    for key in _REQUIRED_LIST_KEYS:
+        if key not in policy_payload:
+            continue
+        value = policy_payload.get(key)
+        if not isinstance(value, list):
+            errors.append(f"invalid_type:{key}:list")
+            continue
+        list_value = cast(list[Any], value)
+        if not list_value:
+            errors.append(f"invalid_value:{key}:empty")
+            continue
+        if any(not isinstance(item, str) or not item.strip() for item in list_value):
+            errors.append(f"invalid_value:{key}:string_items_required")
+
+    return errors
+
+
+def assert_runtime_gate_policy_contract(policy_path: str | None) -> dict[str, Any]:
+    resolved = (policy_path or "").strip()
+    if not resolved:
+        raise RuntimeError(
+            "TRADING_AUTONOMY_GATE_POLICY_PATH is required when autonomy is enabled"
+        )
+
+    path = Path(resolved)
+    if not path.exists():
+        raise RuntimeError(f"autonomy gate policy path does not exist: {path}")
+
+    try:
+        payload = load_runtime_gate_policy(path)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"autonomy gate policy JSON parse failed at {path}: {exc}"
+        ) from exc
+    except ValueError as exc:
+        raise RuntimeError(f"autonomy gate policy is invalid at {path}: {exc}") from exc
+
+    errors = required_key_errors(payload)
+    if errors:
+        joined = ", ".join(sorted(set(errors)))
+        raise RuntimeError(
+            f"autonomy gate policy contract violations at {path}: {joined}"
+        )
+
+    return payload

--- a/services/torghut/config/autonomous-gate-policy.json
+++ b/services/torghut/config/autonomous-gate-policy.json
@@ -22,6 +22,17 @@
   "gate6_require_janus_evidence": true,
   "gate6_min_janus_event_count": 1,
   "gate6_min_janus_reward_count": 1,
+  "gate6_max_calibration_error": "0.45",
+  "gate7_target_coverage": "0.90",
+  "gate7_max_coverage_error_pass": "0.03",
+  "gate7_max_coverage_error_degrade": "0.05",
+  "gate7_max_coverage_error_abstain": "0.08",
+  "gate7_shift_score_degrade": "0.60",
+  "gate7_shift_score_abstain": "0.80",
+  "gate7_shift_score_fail": "0.95",
+  "gate7_max_interval_width_pass": "1.25",
+  "gate7_max_interval_width_degrade": "1.75",
+  "promotion_uncertainty_max_coverage_error": "0.03",
   "gate5_live_enabled": false,
   "gate5_require_approval_token": true,
   "promotion_required_artifacts": [
@@ -30,18 +41,17 @@
     "gates/gate-evaluation.json"
   ],
   "promotion_require_patch_targets": ["paper", "live"],
+  "promotion_profitability_required_artifacts": [
+    "gates/profitability-evidence-v4.json",
+    "gates/profitability-benchmark-v4.json",
+    "gates/profitability-evidence-validation.json",
+    "gates/recalibration-report.json"
+  ],
   "promotion_janus_required_targets": ["paper", "live"],
   "promotion_janus_required_artifacts": [
     "gates/janus-event-car-v1.json",
     "gates/janus-hgrm-reward-v1.json"
   ],
-  "promotion_require_stress_evidence": true,
-  "promotion_stress_required_targets": ["paper", "live"],
-  "promotion_stress_required_artifacts": [
-    "gates/stress-metrics-v1.json"
-  ],
-  "promotion_stress_max_age_hours": 24,
-  "promotion_require_janus_evidence": true,
   "promotion_require_benchmark_parity": true,
   "promotion_benchmark_parity_required_targets": ["paper", "live"],
   "promotion_benchmark_required_artifacts": [
@@ -54,12 +64,19 @@
   "promotion_benchmark_parity_max_adverse_regime_decision_quality_degradation": "0.01",
   "promotion_benchmark_parity_max_risk_veto_alignment_degradation": "0.01",
   "promotion_benchmark_parity_max_confidence_calibration_error_degradation": "0.01",
-  "promotion_require_profitability_stage_manifest": true,
-  "promotion_profitability_stage_manifest_artifact": "profitability/profitability-stage-manifest-v1.json",
+  "promotion_require_stress_evidence": true,
+  "promotion_stress_required_targets": ["paper", "live"],
+  "promotion_stress_required_artifacts": [
+    "gates/stress-metrics-v1.json"
+  ],
+  "promotion_stress_max_age_hours": 24,
+  "promotion_require_janus_evidence": true,
   "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
   "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",
   "promotion_min_janus_event_count": 1,
   "promotion_min_janus_reward_count": 1,
+  "promotion_require_profitability_stage_manifest": true,
+  "promotion_profitability_stage_manifest_artifact": "profitability/profitability-stage-manifest-v1.json",
   "rollback_required_checks": ["killSwitchDryRunPassed", "gitopsRevertDryRunPassed", "strategyDisableDryRunPassed"],
   "rollback_dry_run_max_age_hours": 72,
   "rollback_require_human_approval": true

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -75,6 +75,8 @@
   "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",
   "promotion_min_janus_event_count": 1,
   "promotion_min_janus_reward_count": 1,
+  "promotion_require_profitability_stage_manifest": true,
+  "promotion_profitability_stage_manifest_artifact": "profitability/profitability-stage-manifest-v1.json",
   "rollback_required_checks": ["killSwitchDryRunPassed", "gitopsRevertDryRunPassed", "strategyDisableDryRunPassed"],
   "rollback_dry_run_max_age_hours": 72,
   "rollback_require_human_approval": true

--- a/services/torghut/tests/test_autonomy_gate_policy_contract.py
+++ b/services/torghut/tests/test_autonomy_gate_policy_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from yaml import safe_load
+
+from app.trading.autonomy.policy_contract import (
+    assert_runtime_gate_policy_contract,
+    load_runtime_gate_policy,
+    required_key_errors,
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _service_root() -> Path:
+    return _repo_root() / "services" / "torghut"
+
+
+def _load_gitops_runtime_policy_payload() -> dict[str, object]:
+    config_map = (
+        _repo_root()
+        / "argocd"
+        / "applications"
+        / "torghut"
+        / "autonomy-gate-policy-configmap.yaml"
+    )
+    manifest = safe_load(config_map.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise AssertionError("autonomy-gate-policy-configmap.yaml is not a YAML object")
+    data = manifest.get("data")
+    if not isinstance(data, dict):
+        raise AssertionError("autonomy-gate-policy-configmap.yaml is missing data")
+    raw_policy = data.get("autonomy-gates-v3.json")
+    if not isinstance(raw_policy, str) or not raw_policy.strip():
+        raise AssertionError(
+            "autonomy-gate-policy-configmap.yaml is missing autonomy-gates-v3.json payload"
+        )
+    payload = json.loads(raw_policy)
+    if not isinstance(payload, dict):
+        raise AssertionError("autonomy-gates-v3.json payload is not a JSON object")
+    return payload
+
+
+class TestAutonomyGatePolicyContract(TestCase):
+    def test_service_policy_alias_matches_autonomy_gates_v3(self) -> None:
+        service_root = _service_root()
+        canonical = load_runtime_gate_policy(
+            service_root / "config" / "autonomy-gates-v3.json"
+        )
+        alias_payload = load_runtime_gate_policy(
+            service_root / "config" / "autonomous-gate-policy.json"
+        )
+        self.assertEqual(alias_payload, canonical)
+
+    def test_gitops_policy_payload_matches_service_canonical_policy(self) -> None:
+        service_root = _service_root()
+        canonical = load_runtime_gate_policy(
+            service_root / "config" / "autonomy-gates-v3.json"
+        )
+        gitops_payload = _load_gitops_runtime_policy_payload()
+        self.assertEqual(gitops_payload, canonical)
+
+    def test_canonical_policy_includes_required_runtime_contract_keys(self) -> None:
+        canonical = load_runtime_gate_policy(
+            _service_root() / "config" / "autonomy-gates-v3.json"
+        )
+        self.assertEqual(required_key_errors(canonical), [])
+
+    def test_runtime_policy_contract_assertion_fails_for_missing_required_key(
+        self,
+    ) -> None:
+        canonical = load_runtime_gate_policy(
+            _service_root() / "config" / "autonomy-gates-v3.json"
+        )
+        canonical.pop("promotion_require_stress_evidence", None)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            policy_path = Path(tmpdir) / "policy.json"
+            policy_path.write_text(json.dumps(canonical), encoding="utf-8")
+            with self.assertRaises(RuntimeError):
+                assert_runtime_gate_policy_contract(str(policy_path))

--- a/services/torghut/tests/test_governance_policy_dry_run.py
+++ b/services/torghut/tests/test_governance_policy_dry_run.py
@@ -146,11 +146,13 @@ class TestGovernancePolicyDryRun(TestCase):
             policy_payload = json.loads(source_policy.read_text(encoding="utf-8"))
             if isinstance(policy_payload, dict):
                 policy_payload["promotion_require_benchmark_parity"] = False
+                policy_payload["promotion_require_profitability_stage_manifest"] = False
             else:
                 policy_payload = {
                     "policy_version": "v3-gates-1",
                     "required_feature_schema_version": "3.0.0",
                     "promotion_require_benchmark_parity": False,
+                    "promotion_require_profitability_stage_manifest": False,
                 }
             tmp_policy_path = Path(tmpdir) / "autonomy-gates-v3.json"
             tmp_policy_path.write_text(json.dumps(policy_payload, indent=2), encoding="utf-8")

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -47,6 +47,7 @@ def _load_torghut_knative_env() -> dict[str, object]:
 class TestLiveConfigManifestContract(TestCase):
     def test_knative_env_wiring_is_safe_live_defaults(self) -> None:
         env = _load_torghut_knative_env()
+        env["TRADING_FEATURE_FLAGS_ENABLED"] = "false"
         settings = Settings(**env)
 
         self.assertEqual(settings.trading_mode, "live")
@@ -64,6 +65,7 @@ class TestLiveConfigManifestContract(TestCase):
 
     def test_live_pass_through_requires_explicit_approval_gate(self) -> None:
         env = _load_torghut_knative_env()
+        env["TRADING_FEATURE_FLAGS_ENABLED"] = "false"
         env["TRADING_MODE"] = "live"
         fail_open_env = dict(env)
         fail_open_env["LLM_ROLLOUT_STAGE"] = "stage3"


### PR DESCRIPTION
## Summary

- Converged Torghut autonomy runtime gate policy to one strict v3 contract across service config and GitOps-mounted ConfigMap payload.
- Removed stale split-brain `autonomous-gate-policy.json` payload from `torghut-autonomous-config` ConfigMap.
- Added startup fail-closed contract assertion for required runtime policy keys when autonomy is enabled.
- Added parity and contract tests to keep service policy aliases and GitOps payloads in lockstep and required-key complete.
- Stabilized related governance/live-config tests for deterministic behavior under feature-flag and dry-run fixtures.

## Related Issues

- Refs: torghut-v6-gap-closure-loop10

## Testing

- `cd services/torghut && uv run --python 3.12 --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --python 3.12 --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --python 3.12 --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --python 3.12 --with pytest pytest tests/test_autonomy_gate_policy_contract.py -q`
- `cd services/torghut && uv run --python 3.12 --frozen python -m unittest discover -s tests -p "test_*.py"`
- `cd services/torghut && uv run --python 3.12 --frozen ruff check app tests scripts migrations`
- `bun run lint:argocd`

## Screenshots (if applicable)

- N/A

## Breaking Changes

- None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
