### PR TITLE
chore(torghut): promote image 16001333

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ed61396a29e6c001fc786159b98c2190021c14672fc14f78a39d346eccc7dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a240188672e81ce9549b6e9e70cf67a5155e72dd85071d97673051151c145aa9
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T08:55:52Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T09:09:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ed61396a29e6c001fc786159b98c2190021c14672fc14f78a39d346eccc7dbb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a240188672e81ce9549b6e9e70cf67a5155e72dd85071d97673051151c145aa9
           ports:
             - name: http1
               containerPort: 8181
@@ -378,9 +378,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-153-g78204ed1
+              value: v0.562.0-156-g16001333
             - name: TORGHUT_COMMIT
-              value: 78204ed1a05272618548359f523abcf2f078edaf
+              value: 16001333e49aaefbaddd696270923fac0fc8a563
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `16001333e49aaefbaddd696270923fac0fc8a563`
- Image tag: `16001333`
- Image digest: `sha256:a240188672e81ce9549b6e9e70cf67a5155e72dd85071d97673051151c145aa9`