### PR TITLE
chore(torghut): promote image 2eec8e5d

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a240188672e81ce9549b6e9e70cf67a5155e72dd85071d97673051151c145aa9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:025b4259472728ebc2bdbd7a1b7818590a1987fccd72b78542c88eea2c840a31
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T09:09:24Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T09:55:20Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a240188672e81ce9549b6e9e70cf67a5155e72dd85071d97673051151c145aa9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:025b4259472728ebc2bdbd7a1b7818590a1987fccd72b78542c88eea2c840a31
           ports:
             - name: http1
               containerPort: 8181
@@ -378,9 +378,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-156-g16001333
+              value: v0.562.0-158-g2eec8e5d
             - name: TORGHUT_COMMIT
-              value: 16001333e49aaefbaddd696270923fac0fc8a563
+              value: 2eec8e5de339eb27e72010b77b5fa0b1660c692e
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2eec8e5de339eb27e72010b77b5fa0b1660c692e`
- Image tag: `2eec8e5d`
- Image digest: `sha256:025b4259472728ebc2bdbd7a1b7818590a1987fccd72b78542c88eea2c840a31`