### PR TITLE
feat(torghut): enforce profitability replay contract checks

### DIFF
--- a/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
+++ b/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
@@ -99,6 +99,7 @@ data:
       "promotion_min_janus_event_count": 1,
       "promotion_min_janus_reward_count": 1,
       "promotion_require_profitability_stage_manifest": true,
+      "promotion_require_profitability_stage_replay_contract": true,
       "promotion_profitability_stage_manifest_artifact": "profitability/profitability-stage-manifest-v1.json",
       "rollback_required_checks": [
         "killSwitchDryRunPassed",

--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -96,7 +96,7 @@ Make profitability a hard system contract across research, validation, execution
 1. Enforce `profitability-stage-manifest-v1` generation and validation for all promotion targets.
 2. Require stage-level pass/fail checks and artifact hashes in promotion prerequisites.
 3. Implement contamination and leakage registry checks in promotion gate path.
-4. Add replay determinism checks for stage manifests.
+4. Add replay determinism checks for stage manifests. (Completed `2026-03-03`)
 
 ### Primary files
 
@@ -339,3 +339,4 @@ Program is complete only when all are true:
 3. Enable profitability-stage manifest enforcement in runtime policy.
 4. Add contamination registry checks to promotion prerequisites. (Completed `2026-03-03`)
 5. Publish rollout dashboard for Wave 0 and Wave 1 gates.
+6. Enforce profitability stage-manifest replay-hash contract checks. (Completed `2026-03-03`)

--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -842,6 +842,21 @@ def _build_profitability_stage_manifest(
     ) else "fail"
     failure_reasons = [item["check"] for stage in stage_payloads.values()
                        for item in stage["checks"] if item.get("status") == "fail"]
+    replay_contract_artifact_hashes: dict[str, str] = {}
+    for stage_payload in stage_payloads.values():
+        if not isinstance(stage_payload, dict):
+            continue
+        artifacts_raw = stage_payload.get("artifacts")
+        if not isinstance(artifacts_raw, dict):
+            continue
+        for artifact_payload_raw in artifacts_raw.values():
+            if not isinstance(artifact_payload_raw, dict):
+                continue
+            artifact_ref = str(artifact_payload_raw.get("path", "")).strip()
+            artifact_sha = str(artifact_payload_raw.get("sha256", "")).strip()
+            if not artifact_ref or not artifact_sha:
+                continue
+            replay_contract_artifact_hashes[artifact_ref] = artifact_sha
     payload: dict[str, Any] = {
         "schema_version": _PROFITABILITY_STAGE_MANIFEST_SCHEMA_VERSION,
         "candidate_id": candidate_id,
@@ -860,6 +875,13 @@ def _build_profitability_stage_manifest(
         "stages": stage_payloads,
         "overall_status": overall_status,
         "failure_reasons": failure_reasons,
+        "replay_contract": {
+            "artifact_hashes": replay_contract_artifact_hashes,
+            "contract_hash": _stable_hash(
+                {"artifact_hashes": replay_contract_artifact_hashes}
+            ),
+            "hash_algorithm": "sha256",
+        },
         "rollback_contract_ref": _manifest_relative_path(
             output_dir, output_dir / "gates" / "rollback-readiness.json"
         ),

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -709,6 +709,19 @@ def _append_profitability_stage_manifest_reasons(
                             }
                         )
 
+    if bool(
+        policy_payload.get(
+            "promotion_require_profitability_stage_replay_contract", False
+        )
+    ):
+        _append_profitability_stage_manifest_replay_contract_reasons(
+            reasons=reasons,
+            reason_details=reason_details,
+            manifest_payload=manifest_payload,
+            manifest_path=manifest_path,
+            stages=stages,
+        )
+
     rollback_contract = manifest_payload.get("rollback_contract_ref")
     if not rollback_contract:
         reasons.append("profitability_stage_manifest_rollback_contract_ref_missing")
@@ -810,6 +823,99 @@ def _append_profitability_stage_manifest_reasons(
                 "failure_reasons": failure_reasons,
             }
         )
+
+
+def _append_profitability_stage_manifest_replay_contract_reasons(
+    *,
+    reasons: list[str],
+    reason_details: list[dict[str, object]],
+    manifest_payload: dict[str, Any],
+    manifest_path: Path,
+    stages: dict[str, Any],
+) -> None:
+    replay_contract = _as_dict(manifest_payload.get("replay_contract"))
+    if not replay_contract:
+        reasons.append("profitability_stage_manifest_replay_contract_missing")
+        reason_details.append(
+            {
+                "reason": "profitability_stage_manifest_replay_contract_missing",
+                "artifact_ref": str(manifest_path),
+            }
+        )
+        return
+
+    artifact_hashes_raw = _as_dict(replay_contract.get("artifact_hashes"))
+    artifact_hashes = {
+        str(key).strip(): str(value).strip()
+        for key, value in artifact_hashes_raw.items()
+        if str(key).strip() and str(value).strip()
+    }
+    if not artifact_hashes:
+        reasons.append("profitability_stage_manifest_replay_artifact_hashes_missing")
+        reason_details.append(
+            {
+                "reason": "profitability_stage_manifest_replay_artifact_hashes_missing",
+                "artifact_ref": str(manifest_path),
+            }
+        )
+
+    contract_hash = str(replay_contract.get("contract_hash", "")).strip()
+    if not contract_hash:
+        reasons.append("profitability_stage_manifest_replay_contract_hash_missing")
+        reason_details.append(
+            {
+                "reason": "profitability_stage_manifest_replay_contract_hash_missing",
+                "artifact_ref": str(manifest_path),
+            }
+        )
+    else:
+        expected_contract_hash = _sha256_json({"artifact_hashes": artifact_hashes})
+        if contract_hash != expected_contract_hash:
+            reasons.append("profitability_stage_manifest_replay_contract_hash_mismatch")
+            reason_details.append(
+                {
+                    "reason": "profitability_stage_manifest_replay_contract_hash_mismatch",
+                    "artifact_ref": str(manifest_path),
+                    "contract_hash": contract_hash,
+                    "expected_contract_hash": expected_contract_hash,
+                }
+            )
+
+    expected_stage_artifact_hashes: dict[str, str] = {}
+    for stage_name in _PROFITABILITY_STAGE_ORDER:
+        stage_payload = _as_dict(stages.get(stage_name))
+        stage_artifacts = _as_dict(stage_payload.get("artifacts"))
+        for artifact_payload_raw in stage_artifacts.values():
+            artifact_payload = _as_dict(artifact_payload_raw)
+            artifact_ref = str(artifact_payload.get("path", "")).strip()
+            expected_sha = str(artifact_payload.get("sha256", "")).strip()
+            if not artifact_ref or not expected_sha:
+                continue
+            expected_stage_artifact_hashes[artifact_ref] = expected_sha
+
+    for artifact_ref, expected_sha in sorted(expected_stage_artifact_hashes.items()):
+        replay_sha = artifact_hashes.get(artifact_ref, "")
+        if not replay_sha:
+            reasons.append("profitability_stage_manifest_replay_artifact_hash_missing")
+            reason_details.append(
+                {
+                    "reason": "profitability_stage_manifest_replay_artifact_hash_missing",
+                    "artifact_ref": str(manifest_path),
+                    "stage_artifact_ref": artifact_ref,
+                }
+            )
+            continue
+        if replay_sha != expected_sha:
+            reasons.append("profitability_stage_manifest_replay_artifact_hash_mismatch")
+            reason_details.append(
+                {
+                    "reason": "profitability_stage_manifest_replay_artifact_hash_mismatch",
+                    "artifact_ref": str(manifest_path),
+                    "stage_artifact_ref": artifact_ref,
+                    "replay_sha256": replay_sha,
+                    "expected_sha256": expected_sha,
+                }
+            )
 
 
 def _append_profitability_evidence_reasons(

--- a/services/torghut/app/trading/autonomy/policy_contract.py
+++ b/services/torghut/app/trading/autonomy/policy_contract.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 _REQUIRED_BOOL_KEYS: tuple[str, ...] = (
     "promotion_require_profitability_stage_manifest",
+    "promotion_require_profitability_stage_replay_contract",
     "promotion_require_benchmark_parity",
     "promotion_require_janus_evidence",
     "promotion_require_stress_evidence",

--- a/services/torghut/config/autonomous-gate-policy.json
+++ b/services/torghut/config/autonomous-gate-policy.json
@@ -88,6 +88,7 @@
   "promotion_min_janus_event_count": 1,
   "promotion_min_janus_reward_count": 1,
   "promotion_require_profitability_stage_manifest": true,
+  "promotion_require_profitability_stage_replay_contract": true,
   "promotion_profitability_stage_manifest_artifact": "profitability/profitability-stage-manifest-v1.json",
   "rollback_required_checks": ["killSwitchDryRunPassed", "gitopsRevertDryRunPassed", "strategyDisableDryRunPassed"],
   "rollback_dry_run_max_age_hours": 72,

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -88,6 +88,7 @@
   "promotion_min_janus_event_count": 1,
   "promotion_min_janus_reward_count": 1,
   "promotion_require_profitability_stage_manifest": true,
+  "promotion_require_profitability_stage_replay_contract": true,
   "promotion_profitability_stage_manifest_artifact": "profitability/profitability-stage-manifest-v1.json",
   "rollback_required_checks": ["killSwitchDryRunPassed", "gitopsRevertDryRunPassed", "strategyDisableDryRunPassed"],
   "rollback_dry_run_max_age_hours": 72,

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -131,6 +131,257 @@ class TestPolicyChecks(TestCase):
             promotion.reasons,
         )
 
+    def test_promotion_prerequisites_fail_when_profitability_stage_manifest_replay_contract_missing(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "profitability").mkdir(parents=True, exist_ok=True)
+
+            candidate_spec_path = root / "research" / "candidate-spec.json"
+            candidate_spec_path.write_text("{}", encoding="utf-8")
+            candidate_generation_manifest_path = (
+                root / "research" / "candidate-generation-manifest.json"
+            )
+            candidate_generation_manifest_path.write_text("{}", encoding="utf-8")
+            walkforward_results_path = root / "backtest" / "walkforward-results.json"
+            walkforward_results_path.write_text(
+                json.dumps({"status": "ok"}),
+                encoding="utf-8",
+            )
+            baseline_report_path = root / "backtest" / "baseline-evaluation-report.json"
+            baseline_report_path.write_text(
+                json.dumps({"status": "ok"}),
+                encoding="utf-8",
+            )
+            evaluation_report_path = root / "backtest" / "evaluation-report.json"
+            evaluation_report_path.write_text(
+                json.dumps({"status": "ok"}),
+                encoding="utf-8",
+            )
+            gate_report_path = root / "gates" / "gate-evaluation.json"
+            gate_report_path.write_text(json.dumps(_gate_report()), encoding="utf-8")
+            profitability_benchmark_path = root / "gates" / "profitability-benchmark-v4.json"
+            profitability_benchmark_path.write_text(
+                json.dumps(
+                    {"slices": [{"slice_type": "regime", "slice_key": "regime:neutral"}]}
+                ),
+                encoding="utf-8",
+            )
+            profitability_evidence_path = root / "gates" / "profitability-evidence-v4.json"
+            profitability_evidence_path.write_text(
+                json.dumps({"schema_version": "profitability-evidence-v4"}),
+                encoding="utf-8",
+            )
+            profitability_validation_path = root / "gates" / "profitability-evidence-validation.json"
+            profitability_validation_path.write_text(
+                json.dumps({"passed": True, "reasons": []}),
+                encoding="utf-8",
+            )
+            recalibration_report_path = root / "gates" / "recalibration-report.json"
+            recalibration_report_path.write_text(
+                json.dumps({"status": "not_required"}),
+                encoding="utf-8",
+            )
+            janus_event_car_path = root / "gates" / "janus-event-car-v1.json"
+            janus_event_car_path.write_text(
+                json.dumps(
+                    {"schema_version": "janus-event-car-v1", "summary": {"event_count": 1}}
+                ),
+                encoding="utf-8",
+            )
+            janus_hgrm_reward_path = root / "gates" / "janus-hgrm-reward-v1.json"
+            janus_hgrm_reward_path.write_text(
+                json.dumps(
+                    {"schema_version": "janus-hgrm-reward-v1", "summary": {"reward_count": 1}}
+                ),
+                encoding="utf-8",
+            )
+            rollback_readiness_path = root / "gates" / "rollback-readiness.json"
+            rollback_readiness_path.write_text(
+                json.dumps({"dryRunCompletedAt": datetime.now(timezone.utc).isoformat()}),
+                encoding="utf-8",
+            )
+
+            manifest_payload = _build_profitability_stage_manifest_payload(
+                root=root,
+                candidate_spec_path=candidate_spec_path,
+                candidate_generation_manifest_path=candidate_generation_manifest_path,
+                walkforward_results_path=walkforward_results_path,
+                baseline_evaluation_report_path=baseline_report_path,
+                evaluation_report_path=evaluation_report_path,
+                gate_report_path=gate_report_path,
+                profitability_benchmark_path=profitability_benchmark_path,
+                profitability_evidence_path=profitability_evidence_path,
+                profitability_validation_path=profitability_validation_path,
+                janus_event_car_path=janus_event_car_path,
+                janus_hgrm_reward_path=janus_hgrm_reward_path,
+                recalibration_report_path=recalibration_report_path,
+                rollback_readiness_path=rollback_readiness_path,
+            )
+            manifest_payload.pop("replay_contract", None)
+            manifest_payload["content_hash"] = _sha256_json(
+                {k: v for k, v in manifest_payload.items() if k != "content_hash"}
+            )
+            (root / "profitability" / "profitability-stage-manifest-v1.json").write_text(
+                json.dumps(manifest_payload),
+                encoding="utf-8",
+            )
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_profitability_stage_manifest": True,
+                    "promotion_require_profitability_stage_replay_contract": True,
+                    "gate6_require_profitability_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                },
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="shadow",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn(
+            "profitability_stage_manifest_replay_contract_missing",
+            promotion.reasons,
+        )
+
+    def test_promotion_prerequisites_fail_when_profitability_stage_manifest_replay_hash_mismatch(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "profitability").mkdir(parents=True, exist_ok=True)
+
+            candidate_spec_path = root / "research" / "candidate-spec.json"
+            candidate_spec_path.write_text("{}", encoding="utf-8")
+            candidate_generation_manifest_path = (
+                root / "research" / "candidate-generation-manifest.json"
+            )
+            candidate_generation_manifest_path.write_text("{}", encoding="utf-8")
+            walkforward_results_path = root / "backtest" / "walkforward-results.json"
+            walkforward_results_path.write_text(
+                json.dumps({"status": "ok"}),
+                encoding="utf-8",
+            )
+            baseline_report_path = root / "backtest" / "baseline-evaluation-report.json"
+            baseline_report_path.write_text(
+                json.dumps({"status": "ok"}),
+                encoding="utf-8",
+            )
+            evaluation_report_path = root / "backtest" / "evaluation-report.json"
+            evaluation_report_path.write_text(
+                json.dumps({"status": "ok"}),
+                encoding="utf-8",
+            )
+            gate_report_path = root / "gates" / "gate-evaluation.json"
+            gate_report_path.write_text(json.dumps(_gate_report()), encoding="utf-8")
+            profitability_benchmark_path = root / "gates" / "profitability-benchmark-v4.json"
+            profitability_benchmark_path.write_text(
+                json.dumps(
+                    {"slices": [{"slice_type": "regime", "slice_key": "regime:neutral"}]}
+                ),
+                encoding="utf-8",
+            )
+            profitability_evidence_path = root / "gates" / "profitability-evidence-v4.json"
+            profitability_evidence_path.write_text(
+                json.dumps({"schema_version": "profitability-evidence-v4"}),
+                encoding="utf-8",
+            )
+            profitability_validation_path = root / "gates" / "profitability-evidence-validation.json"
+            profitability_validation_path.write_text(
+                json.dumps({"passed": True, "reasons": []}),
+                encoding="utf-8",
+            )
+            recalibration_report_path = root / "gates" / "recalibration-report.json"
+            recalibration_report_path.write_text(
+                json.dumps({"status": "not_required"}),
+                encoding="utf-8",
+            )
+            janus_event_car_path = root / "gates" / "janus-event-car-v1.json"
+            janus_event_car_path.write_text(
+                json.dumps(
+                    {"schema_version": "janus-event-car-v1", "summary": {"event_count": 1}}
+                ),
+                encoding="utf-8",
+            )
+            janus_hgrm_reward_path = root / "gates" / "janus-hgrm-reward-v1.json"
+            janus_hgrm_reward_path.write_text(
+                json.dumps(
+                    {"schema_version": "janus-hgrm-reward-v1", "summary": {"reward_count": 1}}
+                ),
+                encoding="utf-8",
+            )
+            rollback_readiness_path = root / "gates" / "rollback-readiness.json"
+            rollback_readiness_path.write_text(
+                json.dumps({"dryRunCompletedAt": datetime.now(timezone.utc).isoformat()}),
+                encoding="utf-8",
+            )
+
+            manifest_payload = _build_profitability_stage_manifest_payload(
+                root=root,
+                candidate_spec_path=candidate_spec_path,
+                candidate_generation_manifest_path=candidate_generation_manifest_path,
+                walkforward_results_path=walkforward_results_path,
+                baseline_evaluation_report_path=baseline_report_path,
+                evaluation_report_path=evaluation_report_path,
+                gate_report_path=gate_report_path,
+                profitability_benchmark_path=profitability_benchmark_path,
+                profitability_evidence_path=profitability_evidence_path,
+                profitability_validation_path=profitability_validation_path,
+                janus_event_car_path=janus_event_car_path,
+                janus_hgrm_reward_path=janus_hgrm_reward_path,
+                recalibration_report_path=recalibration_report_path,
+                rollback_readiness_path=rollback_readiness_path,
+            )
+            replay_contract = manifest_payload.get("replay_contract")
+            if not isinstance(replay_contract, dict):
+                raise AssertionError("expected replay_contract in manifest payload")
+            replay_hashes = replay_contract.get("artifact_hashes")
+            if not isinstance(replay_hashes, dict):
+                raise AssertionError(
+                    "expected replay_contract.artifact_hashes in manifest payload"
+                )
+            replay_hashes["research/candidate-spec.json"] = "0" * 64
+            replay_contract["contract_hash"] = _sha256_json(
+                {"artifact_hashes": replay_hashes}
+            )
+            manifest_payload["content_hash"] = _sha256_json(
+                {k: v for k, v in manifest_payload.items() if k != "content_hash"}
+            )
+            (root / "profitability" / "profitability-stage-manifest-v1.json").write_text(
+                json.dumps(manifest_payload),
+                encoding="utf-8",
+            )
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_profitability_stage_manifest": True,
+                    "promotion_require_profitability_stage_replay_contract": True,
+                    "gate6_require_profitability_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                },
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="shadow",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn(
+            "profitability_stage_manifest_replay_artifact_hash_mismatch",
+            promotion.reasons,
+        )
+
     def test_promotion_prerequisites_fail_when_profitability_stage_manifest_artifact_hash_mismatch(
         self,
     ) -> None:
@@ -3538,6 +3789,22 @@ def _build_profitability_stage_manifest_payload(
             "owner": stage_owner[stage_name],
             "completed_at_utc": "2026-03-01T00:00:00+00:00",
         }
+    replay_artifact_hashes: dict[str, str] = {}
+    for stage_payload_raw in stages.values():
+        if not isinstance(stage_payload_raw, dict):
+            continue
+        stage_payload = stage_payload_raw
+        artifacts_raw = stage_payload.get("artifacts")
+        if not isinstance(artifacts_raw, dict):
+            continue
+        for artifact_payload_raw in artifacts_raw.values():
+            if not isinstance(artifact_payload_raw, dict):
+                continue
+            artifact_payload = artifact_payload_raw
+            artifact_ref = str(artifact_payload.get("path", "")).strip()
+            artifact_sha = str(artifact_payload.get("sha256", "")).strip()
+            if artifact_ref and artifact_sha:
+                replay_artifact_hashes[artifact_ref] = artifact_sha
     manifest = {
         "schema_version": "profitability-stage-manifest-v1",
         "candidate_id": "cand-test",
@@ -3554,6 +3821,11 @@ def _build_profitability_stage_manifest_payload(
         "stages": stages,
         "overall_status": "pass",
         "failure_reasons": [],
+        "replay_contract": {
+            "artifact_hashes": replay_artifact_hashes,
+            "contract_hash": _sha256_json({"artifact_hashes": replay_artifact_hashes}),
+            "hash_algorithm": "sha256",
+        },
         "rollback_contract_ref": "gates/rollback-readiness.json",
         "created_at_utc": "2026-03-01T00:00:00+00:00",
     }


### PR DESCRIPTION
## Summary

- enforce deterministic replay-contract validation for `profitability-stage-manifest-v1` in promotion prerequisite policy checks
- add replay contract generation to autonomous lane profitability manifest output (artifact hash map + contract hash)
- turn on strict runtime enforcement with `promotion_require_profitability_stage_replay_contract` in canonical Torghut policy + GitOps ConfigMap
- add regression tests for missing replay contract and replay hash mismatch, and update v6 master-plan execution backlog status

## Related Issues

- Related: `torghut-v6-gap-closure-loop10`

## Testing

- `cd /workspace/lab/services/torghut && export PATH=/root/.local/bin:$PATH && uv sync --frozen --extra dev --python 3.12`
- `cd /workspace/lab/services/torghut && export PATH=/root/.local/bin:$PATH && uv run --python 3.12 --frozen pyright --project pyrightconfig.json`
- `cd /workspace/lab/services/torghut && export PATH=/root/.local/bin:$PATH && uv run --python 3.12 --frozen pyright --project pyrightconfig.alpha.json`
- `cd /workspace/lab/services/torghut && export PATH=/root/.local/bin:$PATH && uv run --python 3.12 --frozen pyright --project pyrightconfig.scripts.json`
- `cd /workspace/lab/services/torghut && export PATH=/root/.local/bin:$PATH && uv run --python 3.12 --with pytest pytest`
- `cd /workspace/lab/services/torghut && export PATH=/root/.local/bin:$PATH && uv run --python 3.12 --frozen ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
