### PR TITLE
chore(torghut): promote image 915a3a98

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:025b4259472728ebc2bdbd7a1b7818590a1987fccd72b78542c88eea2c840a31
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:714770fbfab6462b8f05664f39b3da8a31eafe21dea8f7b616b8aa339c57e3ee
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T09:55:20Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T10:19:17Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:025b4259472728ebc2bdbd7a1b7818590a1987fccd72b78542c88eea2c840a31
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:714770fbfab6462b8f05664f39b3da8a31eafe21dea8f7b616b8aa339c57e3ee
           ports:
             - name: http1
               containerPort: 8181
@@ -378,9 +378,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-158-g2eec8e5d
+              value: v0.562.0-160-g915a3a98
             - name: TORGHUT_COMMIT
-              value: 2eec8e5de339eb27e72010b77b5fa0b1660c692e
+              value: 915a3a98b4e070a626b17553ba0a3d372d645710
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `915a3a98b4e070a626b17553ba0a3d372d645710`
- Image tag: `915a3a98`
- Image digest: `sha256:714770fbfab6462b8f05664f39b3da8a31eafe21dea8f7b616b8aa339c57e3ee`