### PR TITLE
feat(torghut): add DSPy cutover migration guard

### DIFF
--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -124,7 +124,7 @@ Complete DSPy-only production decisioning path with explicit decommissioning of 
 1. Remove legacy runtime LLM call path from decision codepath.
 2. Enforce DSPy artifact/version locks for all live advisory decisions.
 3. Ensure committee/veto telemetry and promotion lineage coverage are complete.
-4. Add migration guard that blocks rollout if legacy toggles are still enabled.
+4. Add migration guard that blocks rollout if legacy toggles are still enabled. (Completed `2026-03-03`)
 
 ### Primary files
 

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -2259,6 +2259,35 @@ class Settings(BaseSettings):
         ):
             reasons.append("llm_committee_mandatory_roles_invalid")
 
+        migration_allowed, migration_reasons = self.llm_dspy_cutover_migration_guard()
+        if not migration_allowed:
+            reasons.extend(migration_reasons)
+
+        return (not reasons, tuple(reasons))
+
+    def llm_dspy_cutover_migration_guard(self) -> tuple[bool, tuple[str, ...]]:
+        """Reject mixed legacy/DSPy posture when active cutover mode is requested."""
+
+        if self.llm_dspy_runtime_mode != "active":
+            return True, ()
+
+        reasons: list[str] = []
+        if self.llm_fail_mode_enforcement != "strict_veto":
+            reasons.append("dspy_cutover_requires_strict_veto_enforcement")
+        if self.llm_fail_mode != "veto":
+            reasons.append("dspy_cutover_requires_veto_fail_mode")
+        if self.llm_abstain_fail_mode != "veto":
+            reasons.append("dspy_cutover_requires_veto_abstain_fail_mode")
+        if self.llm_escalate_fail_mode != "veto":
+            reasons.append("dspy_cutover_requires_veto_escalate_fail_mode")
+        if self.llm_quality_fail_mode != "veto":
+            reasons.append("dspy_cutover_requires_veto_quality_fail_mode")
+        if self.llm_shadow_mode:
+            reasons.append("dspy_cutover_requires_shadow_mode_disabled")
+
+        for exception in self.llm_policy_exceptions:
+            reasons.append(f"dspy_cutover_policy_exception_{exception}")
+
         return (not reasons, tuple(reasons))
 
     @property

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -94,6 +94,14 @@ def _env_or_none(name: str) -> str | None:
     return value or None
 
 
+def _assert_dspy_cutover_migration_guard() -> None:
+    allowed, reasons = settings.llm_dspy_cutover_migration_guard()
+    if allowed:
+        return
+    reason_summary = "|".join(reasons) if reasons else "unknown"
+    raise RuntimeError(f"dspy_cutover_migration_guard_failed:{reason_summary}")
+
+
 def _register_whitepaper_inngest_routes(app: FastAPI) -> inngest.Inngest | None:
     if not whitepaper_workflow_enabled() or not whitepaper_inngest_enabled():
         app.state.whitepaper_inngest_registered = False
@@ -210,6 +218,7 @@ async def lifespan(app: FastAPI):
         assert_runtime_gate_policy_contract(settings.trading_autonomy_gate_policy_path)
 
     if settings.trading_enabled:
+        _assert_dspy_cutover_migration_guard()
         await scheduler.start()
     if whitepaper_workflow_enabled():
         await whitepaper_worker.start()

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -284,6 +284,7 @@ class TestConfig(TestCase):
             LLM_EFFECTIVE_CHALLENGE_ID="challenge-1",
             LLM_SHADOW_COMPLETED_AT="2026-03-01T00:00:00Z",
             LLM_MODEL_VERSION_LOCK="codex-5.3-spark@v1",
+            LLM_ABSTAIN_FAIL_MODE="veto",
             DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
         allowed, reasons = settings.llm_dspy_live_runtime_gate()
@@ -304,11 +305,60 @@ class TestConfig(TestCase):
             LLM_EFFECTIVE_CHALLENGE_ID="challenge-1",
             LLM_SHADOW_COMPLETED_AT="2026-03-01T00:00:00Z",
             LLM_MODEL_VERSION_LOCK="codex-5.3-spark@v1",
+            LLM_ABSTAIN_FAIL_MODE="veto",
             DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
         allowed, reasons = settings.llm_dspy_live_runtime_gate()
         self.assertTrue(allowed)
         self.assertNotIn("dspy_jangar_base_url_invalid", reasons)
+
+    def test_live_dspy_runtime_gate_blocks_legacy_fail_open_cutover_toggles(self) -> None:
+        settings = Settings(
+            TRADING_MODE="live",
+            TRADING_LIVE_ENABLED=True,
+            TRADING_UNIVERSE_SOURCE="jangar",
+            LLM_DSPY_RUNTIME_MODE="active",
+            LLM_DSPY_ARTIFACT_HASH="a" * 64,
+            JANGAR_BASE_URL="https://jangar.example/openai/v1",
+            LLM_ALLOWED_MODELS="codex-5.3-spark",
+            LLM_MODEL="codex-5.3-spark",
+            LLM_ROLLOUT_STAGE="stage3",
+            LLM_EVALUATION_REPORT="ok",
+            LLM_EFFECTIVE_CHALLENGE_ID="challenge-1",
+            LLM_SHADOW_COMPLETED_AT="2026-03-01T00:00:00Z",
+            LLM_MODEL_VERSION_LOCK="codex-5.3-spark@v1",
+            LLM_FAIL_MODE_ENFORCEMENT="configured",
+            LLM_FAIL_OPEN_LIVE_APPROVED=True,
+            DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+        )
+        allowed, reasons = settings.llm_dspy_live_runtime_gate()
+        self.assertFalse(allowed)
+        self.assertIn("dspy_cutover_requires_strict_veto_enforcement", reasons)
+        self.assertIn(
+            "dspy_cutover_policy_exception_configured_fail_mode_enabled",
+            reasons,
+        )
+
+    def test_dspy_cutover_migration_guard_passes_with_strict_controls(self) -> None:
+        settings = Settings(
+            TRADING_MODE="live",
+            TRADING_LIVE_ENABLED=True,
+            TRADING_UNIVERSE_SOURCE="jangar",
+            LLM_DSPY_RUNTIME_MODE="active",
+            LLM_DSPY_ARTIFACT_HASH="a" * 64,
+            LLM_FAIL_MODE_ENFORCEMENT="strict_veto",
+            LLM_FAIL_MODE="veto",
+            LLM_ABSTAIN_FAIL_MODE="veto",
+            LLM_ESCALATE_FAIL_MODE="veto",
+            LLM_QUALITY_FAIL_MODE="veto",
+            LLM_SHADOW_MODE=False,
+            DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+        )
+
+        allowed, reasons = settings.llm_dspy_cutover_migration_guard()
+
+        self.assertTrue(allowed)
+        self.assertEqual(reasons, ())
 
     def test_strategy_runtime_defaults_move_to_scheduler_v3(self) -> None:
         settings = Settings(

--- a/services/torghut/tests/test_llm_dspy_runtime.py
+++ b/services/torghut/tests/test_llm_dspy_runtime.py
@@ -43,6 +43,12 @@ class TestLLMDSPyRuntime(TestCase):
             "llm_effective_challenge_id": settings.llm_effective_challenge_id,
             "llm_shadow_completed_at": settings.llm_shadow_completed_at,
             "llm_model_version_lock": settings.llm_model_version_lock,
+            "llm_fail_mode_enforcement": settings.llm_fail_mode_enforcement,
+            "llm_fail_mode": settings.llm_fail_mode,
+            "llm_abstain_fail_mode": settings.llm_abstain_fail_mode,
+            "llm_escalate_fail_mode": settings.llm_escalate_fail_mode,
+            "llm_quality_fail_mode": settings.llm_quality_fail_mode,
+            "llm_shadow_mode": settings.llm_shadow_mode,
         }
         settings.llm_allowed_models_raw = settings.llm_model
         settings.llm_rollout_stage = "stage3"
@@ -50,6 +56,12 @@ class TestLLMDSPyRuntime(TestCase):
         settings.llm_effective_challenge_id = "dspy-runtime-challenge"
         settings.llm_shadow_completed_at = "2026-03-01T00:00:00Z"
         settings.llm_model_version_lock = settings.llm_model
+        settings.llm_fail_mode_enforcement = "strict_veto"
+        settings.llm_fail_mode = "veto"
+        settings.llm_abstain_fail_mode = "veto"
+        settings.llm_escalate_fail_mode = "veto"
+        settings.llm_quality_fail_mode = "veto"
+        settings.llm_shadow_mode = False
         settings.llm_dspy_runtime_mode = "active"
         settings.llm_dspy_artifact_hash = "a" * 64
         if jangar_base_url is not None:
@@ -92,6 +104,15 @@ class TestLLMDSPyRuntime(TestCase):
             str | None,
             original["llm_model_version_lock"],
         )
+        settings.llm_fail_mode_enforcement = cast(
+            str,
+            original["llm_fail_mode_enforcement"],
+        )
+        settings.llm_fail_mode = cast(str, original["llm_fail_mode"])
+        settings.llm_abstain_fail_mode = cast(str, original["llm_abstain_fail_mode"])
+        settings.llm_escalate_fail_mode = cast(str, original["llm_escalate_fail_mode"])
+        settings.llm_quality_fail_mode = cast(str, original["llm_quality_fail_mode"])
+        settings.llm_shadow_mode = cast(bool, original["llm_shadow_mode"])
 
     def _request(self) -> LLMReviewRequest:
         return LLMReviewRequest(
@@ -631,7 +652,19 @@ class TestLLMDSPyRuntime(TestCase):
 
     def test_active_readiness_accepts_dspy_live_executor(self) -> None:
         original_base = settings.jangar_base_url
+        original_fail_mode_enforcement = settings.llm_fail_mode_enforcement
+        original_fail_mode = settings.llm_fail_mode
+        original_abstain_fail_mode = settings.llm_abstain_fail_mode
+        original_escalate_fail_mode = settings.llm_escalate_fail_mode
+        original_quality_fail_mode = settings.llm_quality_fail_mode
+        original_shadow_mode = settings.llm_shadow_mode
         settings.jangar_base_url = "https://jangar.local/"
+        settings.llm_fail_mode_enforcement = "strict_veto"
+        settings.llm_fail_mode = "veto"
+        settings.llm_abstain_fail_mode = "veto"
+        settings.llm_escalate_fail_mode = "veto"
+        settings.llm_quality_fail_mode = "veto"
+        settings.llm_shadow_mode = False
         runtime = DSPyReviewRuntime(
             mode="active",
             artifact_hash="a" * 64,
@@ -654,11 +687,29 @@ class TestLLMDSPyRuntime(TestCase):
         self.assertTrue(is_ready)
         self.assertEqual(reasons, ())
         settings.jangar_base_url = original_base
+        settings.llm_fail_mode_enforcement = original_fail_mode_enforcement
+        settings.llm_fail_mode = original_fail_mode
+        settings.llm_abstain_fail_mode = original_abstain_fail_mode
+        settings.llm_escalate_fail_mode = original_escalate_fail_mode
+        settings.llm_quality_fail_mode = original_quality_fail_mode
+        settings.llm_shadow_mode = original_shadow_mode
 
     def test_resolve_dspy_api_base_uses_jangar_openai_endpoint(self) -> None:
         original_base = settings.jangar_base_url
+        original_fail_mode_enforcement = settings.llm_fail_mode_enforcement
+        original_fail_mode = settings.llm_fail_mode
+        original_abstain_fail_mode = settings.llm_abstain_fail_mode
+        original_escalate_fail_mode = settings.llm_escalate_fail_mode
+        original_quality_fail_mode = settings.llm_quality_fail_mode
+        original_shadow_mode = settings.llm_shadow_mode
         try:
             settings.jangar_base_url = "https://jangar.example/"
+            settings.llm_fail_mode_enforcement = "strict_veto"
+            settings.llm_fail_mode = "veto"
+            settings.llm_abstain_fail_mode = "veto"
+            settings.llm_escalate_fail_mode = "veto"
+            settings.llm_quality_fail_mode = "veto"
+            settings.llm_shadow_mode = False
             runtime = DSPyReviewRuntime(
                 mode="active",
                 artifact_hash="a" * 64,
@@ -703,6 +754,12 @@ class TestLLMDSPyRuntime(TestCase):
             )
         finally:
             settings.jangar_base_url = original_base
+            settings.llm_fail_mode_enforcement = original_fail_mode_enforcement
+            settings.llm_fail_mode = original_fail_mode
+            settings.llm_abstain_fail_mode = original_abstain_fail_mode
+            settings.llm_escalate_fail_mode = original_escalate_fail_mode
+            settings.llm_quality_fail_mode = original_quality_fail_mode
+            settings.llm_shadow_mode = original_shadow_mode
 
     def test_evaluate_live_readiness_blocks_without_jangar_api_base(self) -> None:
         original_base = settings.jangar_base_url

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -15,7 +15,7 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.db import get_session
-from app.main import app
+from app.main import _assert_dspy_cutover_migration_guard, app
 from app.trading.scheduler import TradingScheduler
 from app.config import settings
 from app.models import (
@@ -145,6 +145,36 @@ class TestTradingApi(TestCase):
         payload = response.json()
         self.assertEqual(len(payload), 1)
         self.assertEqual(payload[0]["symbol"], "AAPL")
+
+    def test_dspy_cutover_migration_guard_assertion_raises_for_legacy_toggles(self) -> None:
+        original_runtime_mode = settings.llm_dspy_runtime_mode
+        original_fail_mode_enforcement = settings.llm_fail_mode_enforcement
+        original_fail_mode = settings.llm_fail_mode
+        original_abstain_fail_mode = settings.llm_abstain_fail_mode
+        original_escalate_fail_mode = settings.llm_escalate_fail_mode
+        original_quality_fail_mode = settings.llm_quality_fail_mode
+        original_shadow_mode = settings.llm_shadow_mode
+        settings.llm_dspy_runtime_mode = "active"
+        settings.llm_fail_mode_enforcement = "configured"
+        settings.llm_fail_mode = "veto"
+        settings.llm_abstain_fail_mode = "pass_through"
+        settings.llm_escalate_fail_mode = "veto"
+        settings.llm_quality_fail_mode = "veto"
+        settings.llm_shadow_mode = False
+        try:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "dspy_cutover_migration_guard_failed",
+            ):
+                _assert_dspy_cutover_migration_guard()
+        finally:
+            settings.llm_dspy_runtime_mode = original_runtime_mode
+            settings.llm_fail_mode_enforcement = original_fail_mode_enforcement
+            settings.llm_fail_mode = original_fail_mode
+            settings.llm_abstain_fail_mode = original_abstain_fail_mode
+            settings.llm_escalate_fail_mode = original_escalate_fail_mode
+            settings.llm_quality_fail_mode = original_quality_fail_mode
+            settings.llm_shadow_mode = original_shadow_mode
 
     @patch(
         "app.main.check_schema_current",

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3516,6 +3516,9 @@ class TestTradingPipeline(TestCase):
             "llm_enabled": config.settings.llm_enabled,
             "llm_fail_mode": config.settings.llm_fail_mode,
             "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
+            "llm_abstain_fail_mode": config.settings.llm_abstain_fail_mode,
+            "llm_escalate_fail_mode": config.settings.llm_escalate_fail_mode,
+            "llm_quality_fail_mode": config.settings.llm_quality_fail_mode,
             "llm_fail_open_live_approved": config.settings.llm_fail_open_live_approved,
             "llm_shadow_mode": config.settings.llm_shadow_mode,
             "llm_min_confidence": config.settings.llm_min_confidence,
@@ -3533,6 +3536,9 @@ class TestTradingPipeline(TestCase):
         config.settings.llm_enabled = True
         config.settings.llm_fail_mode = "veto"
         config.settings.llm_fail_mode_enforcement = "strict_veto"
+        config.settings.llm_abstain_fail_mode = "veto"
+        config.settings.llm_escalate_fail_mode = "veto"
+        config.settings.llm_quality_fail_mode = "veto"
         config.settings.llm_shadow_mode = False
         config.settings.llm_min_confidence = 0.0
         _set_llm_guardrails(config)
@@ -3602,6 +3608,9 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_fail_mode_enforcement = original[
                 "llm_fail_mode_enforcement"
             ]
+            config.settings.llm_abstain_fail_mode = original["llm_abstain_fail_mode"]
+            config.settings.llm_escalate_fail_mode = original["llm_escalate_fail_mode"]
+            config.settings.llm_quality_fail_mode = original["llm_quality_fail_mode"]
             config.settings.llm_shadow_mode = original["llm_shadow_mode"]
             config.settings.llm_min_confidence = original["llm_min_confidence"]
             config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
@@ -3946,6 +3955,9 @@ class TestTradingPipeline(TestCase):
             "llm_enabled": config.settings.llm_enabled,
             "llm_fail_mode": config.settings.llm_fail_mode,
             "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
+            "llm_abstain_fail_mode": config.settings.llm_abstain_fail_mode,
+            "llm_escalate_fail_mode": config.settings.llm_escalate_fail_mode,
+            "llm_quality_fail_mode": config.settings.llm_quality_fail_mode,
             "llm_fail_open_live_approved": config.settings.llm_fail_open_live_approved,
             "llm_shadow_mode": config.settings.llm_shadow_mode,
             "llm_min_confidence": config.settings.llm_min_confidence,
@@ -4103,6 +4115,9 @@ class TestTradingPipeline(TestCase):
             "llm_enabled": config.settings.llm_enabled,
             "llm_fail_mode": config.settings.llm_fail_mode,
             "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
+            "llm_abstain_fail_mode": config.settings.llm_abstain_fail_mode,
+            "llm_escalate_fail_mode": config.settings.llm_escalate_fail_mode,
+            "llm_quality_fail_mode": config.settings.llm_quality_fail_mode,
             "llm_fail_open_live_approved": config.settings.llm_fail_open_live_approved,
             "llm_shadow_mode": config.settings.llm_shadow_mode,
             "llm_min_confidence": config.settings.llm_min_confidence,
@@ -4375,6 +4390,9 @@ class TestTradingPipeline(TestCase):
             "llm_enabled": config.settings.llm_enabled,
             "llm_fail_mode": config.settings.llm_fail_mode,
             "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
+            "llm_abstain_fail_mode": config.settings.llm_abstain_fail_mode,
+            "llm_escalate_fail_mode": config.settings.llm_escalate_fail_mode,
+            "llm_quality_fail_mode": config.settings.llm_quality_fail_mode,
             "llm_fail_open_live_approved": config.settings.llm_fail_open_live_approved,
             "llm_shadow_mode": config.settings.llm_shadow_mode,
             "llm_min_confidence": config.settings.llm_min_confidence,
@@ -4399,6 +4417,9 @@ class TestTradingPipeline(TestCase):
         config.settings.llm_enabled = True
         config.settings.llm_fail_mode = "veto"
         config.settings.llm_fail_mode_enforcement = "strict_veto"
+        config.settings.llm_abstain_fail_mode = "veto"
+        config.settings.llm_escalate_fail_mode = "veto"
+        config.settings.llm_quality_fail_mode = "veto"
         config.settings.llm_shadow_mode = False
         config.settings.llm_min_confidence = 0.0
         config.settings.llm_dspy_runtime_mode = "active"
@@ -4476,6 +4497,9 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_fail_mode_enforcement = original[
                 "llm_fail_mode_enforcement"
             ]
+            config.settings.llm_abstain_fail_mode = original["llm_abstain_fail_mode"]
+            config.settings.llm_escalate_fail_mode = original["llm_escalate_fail_mode"]
+            config.settings.llm_quality_fail_mode = original["llm_quality_fail_mode"]
             config.settings.llm_shadow_mode = original["llm_shadow_mode"]
             config.settings.llm_min_confidence = original["llm_min_confidence"]
             config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]


### PR DESCRIPTION
## Summary

- Added a deterministic DSPy cutover migration guard in Torghut settings that fail-closes active DSPy live runtime when legacy fail-open toggles remain enabled.
- Enforced the migration guard during FastAPI startup for trading-enabled runtimes so mixed legacy/DSPy posture is blocked before scheduler start.
- Expanded regression coverage across config, DSPy runtime, trading API startup guard assertions, and trading pipeline fixtures for strict cutover controls.
- Updated the v6 production gap-closure master plan to mark the Wave 2 migration-guard deliverable complete.

## Related Issues

- Related to torghut-v6-gap-closure-loop10.

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev --python 3.12`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen --with pytest pytest`
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
