### PR TITLE
feat(torghut): close Wave 2 lineage telemetry gap

### DIFF
--- a/docs/torghut/design-system/v6/03-dspy-llm-decision-layer-over-jangar.md
+++ b/docs/torghut/design-system/v6/03-dspy-llm-decision-layer-over-jangar.md
@@ -10,12 +10,14 @@
 - Evidence:
   - `services/torghut/app/trading/llm/dspy_programs/runtime.py`
   - `services/torghut/app/trading/llm/dspy_compile/workflow.py`
-  - `services/torghut/app/trading/llm/review_engine.py`
-  - `services/torghut/app/trading/llm/schema.py`
-  - `services/torghut/tests/test_llm_dspy_workflow.py`
-  - `services/torghut/tests/test_llm_review_engine.py`
-  - `argocd/applications/torghut/knative-service.yaml`
-- Rollout gap: full production-path cutover still needs legacy LLM route decommission and end-to-end artifact-driven promotion telemetry.
+- `services/torghut/app/trading/llm/review_engine.py`
+- `services/torghut/app/trading/llm/schema.py`
+- `services/torghut/app/trading/scheduler.py`
+- `services/torghut/tests/test_llm_dspy_workflow.py`
+- `services/torghut/tests/test_llm_review_engine.py`
+- `services/torghut/tests/test_trading_pipeline.py`
+- `argocd/applications/torghut/knative-service.yaml`
+- Rollout gap: full production-path cutover still needs explicit legacy fail-open posture sunset; decision-row DSPy lineage and committee/veto telemetry coverage are now persisted end-to-end.
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -123,7 +123,7 @@ Complete DSPy-only production decisioning path with explicit decommissioning of 
 
 1. Remove legacy runtime LLM call path from decision codepath.
 2. Enforce DSPy artifact/version locks for all live advisory decisions.
-3. Ensure committee/veto telemetry and promotion lineage coverage are complete.
+3. Ensure committee/veto telemetry and promotion lineage coverage are complete. (Completed `2026-03-03`)
 4. Add migration guard that blocks rollout if legacy toggles are still enabled. (Completed `2026-03-03`)
 
 ### Primary files

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -3305,6 +3305,17 @@ class TradingPipeline:
             response_json["mrm_guardrails"] = list(guardrails.reasons)
         response_json["policy_resolution"] = policy_resolution
         response_json["guardrail_controls"] = _llm_guardrail_controls_snapshot()
+        committee_veto = _committee_trace_has_veto(response_json)
+        response_json["committee_veto_alignment"] = (
+            _build_committee_veto_alignment_payload(
+                committee_veto=committee_veto,
+                deterministic_veto=policy_outcome.verdict == "veto",
+            )
+        )
+        _attach_dspy_lineage(
+            response_json,
+            artifact_source="runtime_review",
+        )
         return response_json
 
     def _record_llm_committee_metrics(self, response_json: Mapping[str, Any]) -> None:
@@ -3361,6 +3372,12 @@ class TradingPipeline:
         policy_outcome: Any,
         guardrails: Any,
     ) -> tuple[StrategyDecision, Optional[str]]:
+        committee_veto = _committee_trace_has_veto(outcome.response_json)
+        if committee_veto:
+            self.state.metrics.record_llm_committee_veto_alignment(
+                committee_veto=True,
+                deterministic_veto=policy_outcome.verdict == "veto",
+            )
         if guardrails.shadow_mode:
             self.state.metrics.llm_shadow_total += 1
             if not settings.llm_shadow_mode:
@@ -3368,10 +3385,6 @@ class TradingPipeline:
             return decision, None
         if policy_outcome.verdict != "veto":
             return policy_outcome.decision, None
-        self.state.metrics.record_llm_committee_veto_alignment(
-            committee_veto=bool(outcome.response.committee),
-            deterministic_veto=True,
-        )
         return decision, policy_outcome.reason or "llm_veto"
 
     def _handle_llm_review_error(
@@ -3701,7 +3714,19 @@ class TradingPipeline:
         tokens_completion: Optional[int],
     ) -> None:
         request_payload = coerce_json_payload(request_json)
-        response_payload = coerce_json_payload(response_json)
+        response_payload_json = dict(response_json)
+        _attach_dspy_lineage(
+            response_payload_json,
+            artifact_source="runtime_persisted_review",
+        )
+        if not isinstance(response_payload_json.get("committee_veto_alignment"), Mapping):
+            response_payload_json["committee_veto_alignment"] = (
+                _build_committee_veto_alignment_payload(
+                    committee_veto=_committee_trace_has_veto(response_payload_json),
+                    deterministic_veto=verdict == "veto",
+                )
+            )
+        response_payload = coerce_json_payload(response_payload_json)
         risk_payload = coerce_json_payload(risk_flags)
         review = LLMDecisionReview(
             trade_decision_id=decision_row.id,
@@ -4146,6 +4171,104 @@ def _is_runtime_risk_increasing_entry(
 def _hash_payload(payload: dict[str, Any]) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _normalize_optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized or None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _runtime_dspy_metadata(
+    *, artifact_source: str, error: str | None = None
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "mode": settings.llm_dspy_runtime_mode,
+        "program_name": settings.llm_dspy_program_name,
+        "signature_version": settings.llm_dspy_signature_version,
+        "artifact_hash": _normalize_optional_text(settings.llm_dspy_artifact_hash),
+        "artifact_source": artifact_source,
+    }
+    if error is not None and error.strip():
+        payload["error"] = error.strip()
+    return payload
+
+
+def _build_dspy_lineage(response_json: Mapping[str, Any]) -> dict[str, Any]:
+    payload = response_json.get("dspy")
+    dspy_payload: dict[str, Any] = {}
+    if isinstance(payload, Mapping):
+        dspy_payload = {
+            str(key): value for key, value in cast(Mapping[str, Any], payload).items()
+        }
+    mode = _normalize_optional_text(dspy_payload.get("mode")) or settings.llm_dspy_runtime_mode
+    program_name = _normalize_optional_text(dspy_payload.get("program_name")) or settings.llm_dspy_program_name
+    signature_version = _normalize_optional_text(dspy_payload.get("signature_version")) or settings.llm_dspy_signature_version
+    artifact_hash = _normalize_optional_text(dspy_payload.get("artifact_hash")) or _normalize_optional_text(
+        settings.llm_dspy_artifact_hash
+    )
+    artifact_source = _normalize_optional_text(dspy_payload.get("artifact_source")) or "runtime"
+    return {
+        "mode": mode,
+        "program_name": program_name,
+        "signature_version": signature_version,
+        "artifact_hash": artifact_hash,
+        "artifact_source": artifact_source,
+    }
+
+
+def _attach_dspy_lineage(
+    response_json: dict[str, Any],
+    *,
+    artifact_source: str,
+    error: str | None = None,
+) -> None:
+    payload = response_json.get("dspy")
+    if isinstance(payload, Mapping):
+        dspy_payload = {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+        if _normalize_optional_text(dspy_payload.get("artifact_source")) is None:
+            dspy_payload["artifact_source"] = artifact_source
+        if error is not None and error.strip() and "error" not in dspy_payload:
+            dspy_payload["error"] = error.strip()
+        response_json["dspy"] = dspy_payload
+    else:
+        response_json["dspy"] = _runtime_dspy_metadata(
+            artifact_source=artifact_source,
+            error=error,
+        )
+    response_json["dspy_lineage"] = _build_dspy_lineage(response_json)
+
+
+def _committee_trace_has_veto(response_json: Mapping[str, Any]) -> bool:
+    committee_payload = response_json.get("committee")
+    if not isinstance(committee_payload, Mapping):
+        return False
+    committee_roles = cast(Mapping[str, Any], committee_payload).get("roles")
+    if not isinstance(committee_roles, Mapping):
+        return False
+    for role_payload in cast(Mapping[str, Any], committee_roles).values():
+        if not isinstance(role_payload, Mapping):
+            continue
+        verdict = _normalize_optional_text(cast(Mapping[str, Any], role_payload).get("verdict"))
+        if verdict == "veto":
+            return True
+    return False
+
+
+def _build_committee_veto_alignment_payload(
+    *,
+    committee_veto: bool,
+    deterministic_veto: bool,
+) -> dict[str, bool]:
+    return {
+        "committee_veto": committee_veto,
+        "deterministic_veto": deterministic_veto,
+        "aligned": (not committee_veto) or deterministic_veto,
+    }
 
 
 def _is_llm_stage_policy_violation(rollout_stage: str) -> bool:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -40,6 +40,8 @@ from app.trading.scheduler import (
     TradingPipeline,
     TradingState,
     _apply_projected_position_decision,
+    _build_dspy_lineage,
+    _committee_trace_has_veto,
 )
 from app.trading.tca import AdaptiveExecutionPolicyDecision
 from app.trading.universe import UniverseResolver
@@ -4038,6 +4040,30 @@ class TestTradingPipeline(TestCase):
                 assert isinstance(policy_resolution, dict)
                 self.assertIn("effective_fail_mode", policy_resolution)
                 self.assertIn("reasoning", policy_resolution)
+                lineage = reviews[0].response_json.get("dspy_lineage")
+                self.assertIsInstance(lineage, dict)
+                assert isinstance(lineage, dict)
+                self.assertEqual(
+                    lineage.get("program_name"),
+                    config.settings.llm_dspy_program_name,
+                )
+                self.assertEqual(
+                    lineage.get("signature_version"),
+                    config.settings.llm_dspy_signature_version,
+                )
+                configured_artifact_hash = config.settings.llm_dspy_artifact_hash
+                if isinstance(configured_artifact_hash, str):
+                    expected_artifact_hash = configured_artifact_hash.strip() or None
+                else:
+                    expected_artifact_hash = None
+                self.assertEqual(lineage.get("artifact_hash"), expected_artifact_hash)
+                committee_veto_alignment = reviews[0].response_json.get(
+                    "committee_veto_alignment"
+                )
+                self.assertIsInstance(committee_veto_alignment, dict)
+                assert isinstance(committee_veto_alignment, dict)
+                self.assertFalse(committee_veto_alignment.get("committee_veto", True))
+                self.assertFalse(committee_veto_alignment.get("deterministic_veto", True))
 
             config.settings.trading_mode = "live"
             config.settings.trading_live_enabled = True
@@ -4102,6 +4128,47 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_adjustment_approved = original[
                 "llm_adjustment_approved"
             ]
+
+    def test_committee_veto_detection_helper(self) -> None:
+        with_veto = {
+            "committee": {
+                "roles": {
+                    "risk_critic": {"verdict": "veto"},
+                    "execution_critic": {"verdict": "approve"},
+                }
+            }
+        }
+        without_veto = {
+            "committee": {
+                "roles": {
+                    "risk_critic": {"verdict": "approve"},
+                    "execution_critic": {"verdict": "adjust"},
+                }
+            }
+        }
+
+        self.assertTrue(_committee_trace_has_veto(with_veto))
+        self.assertFalse(_committee_trace_has_veto(without_veto))
+        self.assertFalse(_committee_trace_has_veto({}))
+
+    def test_dspy_lineage_helper_uses_response_payload(self) -> None:
+        response_json = {
+            "dspy": {
+                "mode": "active",
+                "program_name": "trade-review-committee-v9",
+                "signature_version": "2026-03-03.v9",
+                "artifact_hash": "f" * 64,
+                "artifact_source": "runtime_fallback",
+            }
+        }
+
+        lineage = _build_dspy_lineage(response_json)
+
+        self.assertEqual(lineage["mode"], "active")
+        self.assertEqual(lineage["program_name"], "trade-review-committee-v9")
+        self.assertEqual(lineage["signature_version"], "2026-03-03.v9")
+        self.assertEqual(lineage["artifact_hash"], "f" * 64)
+        self.assertEqual(lineage["artifact_source"], "runtime_fallback")
 
     def test_pipeline_llm_unsupported_runtime_state_vetoes_decision(self) -> None:
         from app import config


### PR DESCRIPTION
## Summary

- Persisted DSPy lineage metadata (`mode`, `program`, `signature`, `artifact hash/source`) on every persisted `llm_decision_reviews.response_json`, including error/unavailable paths.
- Added explicit `committee_veto_alignment` payloads and corrected alignment metric semantics to key off actual committee veto verdicts instead of committee presence.
- Added regression coverage in `test_trading_pipeline.py` for persisted lineage payloads and helper behavior.
- Updated v6 docs/master plan evidence to record Wave 2 committee/veto telemetry + lineage closure progress.

## Related Issues

Resolves torghut-v6-gap-closure-loop10.

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev --python 3.12`
- `cd services/torghut && /root/.local/bin/uv run --python 3.12 --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --python 3.12 --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --python 3.12 --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --python 3.12 --with pytest pytest`
- `cd services/torghut && /root/.local/bin/uv run --python 3.12 --frozen ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
