### PR TITLE
chore(torghut): promote image d0ad58d5

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2bea11d35a15ea237f61fde26f2106086c991a4a994911a2b68e032182b93de7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7e098c1dd72fa773fd110530aad9a5a4533867938cc1eae61a5228f80019dd25
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T11:20:44Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T11:44:05Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2bea11d35a15ea237f61fde26f2106086c991a4a994911a2b68e032182b93de7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7e098c1dd72fa773fd110530aad9a5a4533867938cc1eae61a5228f80019dd25
           ports:
             - name: http1
               containerPort: 8181
@@ -386,9 +386,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-164-ge3369286
+              value: v0.562.0-166-gd0ad58d5
             - name: TORGHUT_COMMIT
-              value: e33692866709bdf21ad4b3e0f740e91c3d8b3579
+              value: d0ad58d5ab4ea354ec8fb88be670967f17350881
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `d0ad58d5ab4ea354ec8fb88be670967f17350881`
- Image tag: `d0ad58d5`
- Image digest: `sha256:7e098c1dd72fa773fd110530aad9a5a4533867938cc1eae61a5228f80019dd25`