### PR TITLE
fix(torghut): disable runtime flag overrides for dspy cutover

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -78,7 +78,7 @@ spec:
             - name: TRADING_KILL_SWITCH_ENABLED
               value: "false"
             - name: TRADING_FEATURE_FLAGS_ENABLED
-              value: "true"
+              value: "false"
             - name: TRADING_FEATURE_FLAGS_URL
               value: http://feature-flags.feature-flags.svc.cluster.local:8013
             - name: TRADING_FEATURE_FLAGS_TIMEOUT_MS

--- a/docs/torghut/design-system/v6/03-dspy-llm-decision-layer-over-jangar.md
+++ b/docs/torghut/design-system/v6/03-dspy-llm-decision-layer-over-jangar.md
@@ -18,7 +18,7 @@
 - `services/torghut/tests/test_trading_pipeline.py`
 - `argocd/applications/torghut/knative-service.yaml`
 - `argocd/applications/feature-flags/gitops/default/features.yaml`
-- Cutover status: live runtime now enforces stage3 DSPy active posture with strict-veto fail-closed controls and feature-flag parity.
+- Cutover status: live runtime now enforces stage3 DSPy active posture with strict-veto fail-closed controls; runtime feature-flag overrides are disabled to prevent `feature-flags-state` drift from reintroducing legacy posture.
 
 ## Objective
 

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -103,10 +103,10 @@ def _load_torghut_feature_flags() -> dict[str, object]:
 class TestLiveConfigManifestContract(TestCase):
     def test_knative_env_wiring_is_safe_live_defaults(self) -> None:
         env = _load_torghut_knative_env()
-        env["TRADING_FEATURE_FLAGS_ENABLED"] = "false"
         settings = Settings(**env)
 
         self.assertEqual(settings.trading_mode, "live")
+        self.assertFalse(settings.trading_feature_flags_enabled)
         self.assertEqual(settings.llm_rollout_stage, "stage3_controlled_live")
         self.assertEqual(settings.llm_dspy_runtime_mode, "active")
         self.assertEqual(settings.llm_fail_mode, "veto")
@@ -152,7 +152,6 @@ class TestLiveConfigManifestContract(TestCase):
 
     def test_live_pass_through_with_strict_veto_profile_is_rejected(self) -> None:
         env = _load_torghut_knative_env()
-        env["TRADING_FEATURE_FLAGS_ENABLED"] = "false"
         env["TRADING_MODE"] = "live"
         fail_open_env = dict(env)
         fail_open_env["LLM_ROLLOUT_STAGE"] = "stage3"


### PR DESCRIPTION
## Summary

- Disables Torghut runtime feature-flag overrides in Knative env (`TRADING_FEATURE_FLAGS_ENABLED=false`) to keep DSPy cutover posture deterministic at startup.
- Prevents `feature-flags-state` drift from forcing `llm_shadow_mode=true`, which was crash-looping revision `00019` under the strict cutover migration guard.
- Updates manifest contract tests to assert runtime flag overrides are disabled in live defaults.
- Updates v6/03 design doc cutover evidence with the feature-flag drift mitigation.

## Related Issues

None (workflow run: `torghut-v6-gap-closure-loop10`)

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev --python 3.12`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --with pytest pytest`
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
