### PR TITLE
chore(torghut): promote image 177f1652

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7e098c1dd72fa773fd110530aad9a5a4533867938cc1eae61a5228f80019dd25
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e86761867a4d20e34205124737bab4c8a439ca675d20a26c2f1797f74b8a614e
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T11:44:05Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T11:58:40Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7e098c1dd72fa773fd110530aad9a5a4533867938cc1eae61a5228f80019dd25
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e86761867a4d20e34205124737bab4c8a439ca675d20a26c2f1797f74b8a614e
           ports:
             - name: http1
               containerPort: 8181
@@ -386,9 +386,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-166-gd0ad58d5
+              value: v0.562.0-168-g177f1652
             - name: TORGHUT_COMMIT
-              value: d0ad58d5ab4ea354ec8fb88be670967f17350881
+              value: 177f16528f37244153a836ddb942c3cc576dbd1a
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `177f16528f37244153a836ddb942c3cc576dbd1a`
- Image tag: `177f1652`
- Image digest: `sha256:e86761867a4d20e34205124737bab4c8a439ca675d20a26c2f1797f74b8a614e`