### PR TITLE
feat(torghut): persist hmm posterior lineage artifact for promotion gates

### DIFF
--- a/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
+++ b/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
@@ -93,6 +93,12 @@ data:
         "gates/stress-metrics-v1.json"
       ],
       "promotion_stress_max_age_hours": 24,
+      "promotion_require_hmm_state_posterior": true,
+      "promotion_hmm_required_targets": ["paper", "live"],
+      "promotion_hmm_required_artifacts": [
+        "gates/hmm-state-posterior-v1.json"
+      ],
+      "promotion_hmm_min_authoritative_sample_ratio": "0.0",
       "promotion_require_janus_evidence": true,
       "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
       "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",

--- a/docs/torghut/design-system/v6/07-hmm-regime-state-and-autonomous-llm-control-plane-2026-02-28.md
+++ b/docs/torghut/design-system/v6/07-hmm-regime-state-and-autonomous-llm-control-plane-2026-02-28.md
@@ -16,7 +16,7 @@
   - `services/torghut/app/trading/execution_policy.py`
   - `services/torghut/app/trading/tca.py`
   - `services/torghut/app/trading/regime.py`
-- Rollout gap: HMM posterior inference service and state artifact lineage persistence (`hmm_state_posterior`, entropy, transition shock) are still unimplemented in production runtime.
+- Rollout gap: HMM posterior inference service remains partial, but deterministic `hmm-state-posterior-v1` lineage artifact emission is implemented in the autonomous lane (`2026-03-03`).
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -148,7 +148,7 @@ Close architecture gaps for regime-adaptive routing with persisted HMM state lin
 
 ### Deliverables
 
-1. Implement HMM posterior state artifact (`hmm_state_posterior`) persistence and lineage references.
+1. Implement HMM posterior state artifact (`hmm_state_posterior`) persistence and lineage references. (Completed `2026-03-03`)
 2. Add expert-router artifact registry with concentration/fallback SLO feedback loop.
 3. Wire regime-state quality into promotion and drift governance decisions.
 

--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -50,6 +50,7 @@ from ..forecasting import build_default_forecast_router
 from ..llm.evaluation import build_llm_evaluation_metrics
 from ..models import SignalEnvelope
 from ..parity import build_benchmark_parity_report, write_benchmark_parity_report
+from ..regime_hmm import HMM_UNKNOWN_REGIME_ID, resolve_hmm_context
 from ..reporting import (
     EvaluationReport,
     EvaluationReportConfig,
@@ -100,6 +101,7 @@ _STAGE_EVALUATION = "evaluation"
 _STAGE_RECOMMENDATION = "promotion-recommendation"
 _STRESS_METRICS_ARTIFACT_PATH = "stress-metrics-v1.json"
 _CONTAMINATION_REGISTRY_ARTIFACT_PATH = "contamination-leakage-report-v1.json"
+_HMM_STATE_POSTERIOR_ARTIFACT_PATH = "gates/hmm-state-posterior-v1.json"
 _STRESS_METRICS_CASES = ("spread", "volatility", "liquidity", "halt")
 _BENCHMARK_PARITY_REPORT_PATH = "benchmarks/benchmark-parity-report-v1.json"
 _STAGE_PROFITABILITY = "profitability_stage_manifest"
@@ -560,6 +562,122 @@ def _build_contamination_registry_payload(
     return payload
 
 
+def _normalize_hmm_regime_id(value: object) -> str:
+    normalized = str(value).strip().lower()
+    return normalized or HMM_UNKNOWN_REGIME_ID
+
+
+def _build_hmm_state_posterior_payload(
+    *,
+    output_dir: Path,
+    run_id: str,
+    candidate_id: str,
+    now: datetime,
+    walk_decisions: Sequence[WalkForwardDecision],
+    walkforward_results_path: Path,
+    gate_policy_path: Path,
+) -> dict[str, Any]:
+    regime_counts: dict[str, int] = {}
+    entropy_band_counts: dict[str, int] = {}
+    guardrail_reason_counts: dict[str, int] = {}
+    posterior_mass: dict[str, Decimal] = {}
+    authoritative_samples = 0
+    transition_shock_samples = 0
+    stale_or_defensive_samples = 0
+
+    decision_timestamps = sorted(
+        {
+            item.decision.event_ts.isoformat()
+            for item in walk_decisions
+            if item.decision.event_ts.tzinfo is not None
+        }
+    )
+
+    for decision in walk_decisions:
+        context = resolve_hmm_context(decision.decision.params)
+        regime_id = _normalize_hmm_regime_id(context.regime_id)
+        entropy_band = str(context.entropy_band).strip().lower() or "unknown"
+        guardrail_reason = str(context.guardrail_reason or "").strip() or "none"
+
+        regime_counts[regime_id] = regime_counts.get(regime_id, 0) + 1
+        entropy_band_counts[entropy_band] = entropy_band_counts.get(entropy_band, 0) + 1
+        guardrail_reason_counts[guardrail_reason] = (
+            guardrail_reason_counts.get(guardrail_reason, 0) + 1
+        )
+
+        if context.is_authoritative:
+            authoritative_samples += 1
+        if context.transition_shock:
+            transition_shock_samples += 1
+        if context.guardrail.stale or context.guardrail.fallback_to_defensive:
+            stale_or_defensive_samples += 1
+
+        for posterior_regime, posterior_value in context.posterior.items():
+            try:
+                posterior_decimal = Decimal(str(posterior_value))
+            except Exception:
+                continue
+            if posterior_decimal.is_nan() or posterior_decimal.is_infinite():
+                continue
+            normalized_regime = _normalize_hmm_regime_id(posterior_regime)
+            posterior_mass[normalized_regime] = (
+                posterior_mass.get(normalized_regime, Decimal("0")) + posterior_decimal
+            )
+
+    sample_count = len(walk_decisions)
+    authoritative_ratio = (
+        Decimal(authoritative_samples) / Decimal(sample_count)
+        if sample_count > 0
+        else Decimal("0")
+    )
+    ordered_posterior_mass = {
+        regime: str(value)
+        for regime, value in sorted(
+            posterior_mass.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    }
+    top_regime = (
+        max(posterior_mass.items(), key=lambda item: item[1])[0]
+        if posterior_mass
+        else HMM_UNKNOWN_REGIME_ID
+    )
+
+    payload: dict[str, Any] = {
+        "schema_version": "hmm-state-posterior-v1",
+        "run_id": run_id,
+        "candidate_id": candidate_id,
+        "generated_at": now.isoformat(),
+        "samples_total": sample_count,
+        "authoritative_samples": authoritative_samples,
+        "authoritative_sample_ratio": str(authoritative_ratio),
+        "transition_shock_samples": transition_shock_samples,
+        "stale_or_defensive_samples": stale_or_defensive_samples,
+        "regime_counts": dict(sorted(regime_counts.items())),
+        "entropy_band_counts": dict(sorted(entropy_band_counts.items())),
+        "guardrail_reason_counts": dict(sorted(guardrail_reason_counts.items())),
+        "posterior_mass_by_regime": ordered_posterior_mass,
+        "top_regime_by_posterior_mass": top_regime,
+        "decision_window": {
+            "first_event_ts": decision_timestamps[0] if decision_timestamps else None,
+            "last_event_ts": decision_timestamps[-1] if decision_timestamps else None,
+        },
+        "source_lineage": {
+            "walkforward_results_artifact_ref": _manifest_relative_path(
+                output_dir, walkforward_results_path
+            ),
+            "gate_policy_artifact_ref": _manifest_relative_path(
+                output_dir, gate_policy_path
+            ),
+            "decision_source": "walkforward_results",
+        },
+    }
+    payload["artifact_hash"] = _stable_hash(
+        {key: value for key, value in payload.items() if key != "artifact_hash"}
+    )
+    return payload
+
+
 def _build_profitability_stage_manifest(
     *,
     output_dir: Path,
@@ -581,6 +699,7 @@ def _build_profitability_stage_manifest(
     benchmark_parity_path: Path,
     profitability_evidence_path: Path,
     profitability_validation_path: Path,
+    hmm_state_posterior_path: Path,
     janus_event_car_path: Path,
     janus_hgrm_reward_path: Path,
     recalibration_report_path: Path,
@@ -691,6 +810,11 @@ def _build_profitability_stage_manifest(
         ("evaluation_report_present", "evaluation_report", evaluation_report_path),
         ("gate_evaluation_present", "gate_evaluation", gate_report_path),
         ("benchmark_parity_present", "benchmark_parity", benchmark_parity_path),
+        (
+            "hmm_state_posterior_present",
+            "hmm_state_posterior",
+            hmm_state_posterior_path,
+        ),
         ("janus_event_car_present", "janus_event_car", janus_event_car_path),
         ("janus_hgrm_reward_present", "janus_hgrm_reward", janus_hgrm_reward_path),
         ("recalibration_report_present", "recalibration_report", recalibration_report_path),
@@ -863,6 +987,9 @@ def _build_profitability_stage_manifest(
         "strategy_family": strategy_family,
         "llm_artifact_ref": llm_artifact_ref,
         "router_artifact_ref": router_artifact_ref,
+        "hmm_state_posterior_artifact_ref": _manifest_relative_path(
+            output_dir, hmm_state_posterior_path
+        ),
         "run_context": {
             "repository": run_context.get("repository", "unknown"),
             "base": run_context.get("base", "main"),
@@ -1022,6 +1149,7 @@ def run_autonomous_lane(
     janus_event_car_path = gates_dir / "janus-event-car-v1.json"
     janus_hgrm_reward_path = gates_dir / "janus-hgrm-reward-v1.json"
     stress_metrics_path = gates_dir / _STRESS_METRICS_ARTIFACT_PATH
+    hmm_state_posterior_path = output_dir / _HMM_STATE_POSTERIOR_ARTIFACT_PATH
     benchmark_parity_path = output_dir / _BENCHMARK_PARITY_REPORT_PATH
     recalibration_report_path = gates_dir / "recalibration-report.json"
     promotion_gate_path = gates_dir / "promotion-evidence-gate.json"
@@ -1061,6 +1189,7 @@ def run_autonomous_lane(
     stage_records: list[_StageManifestRecord] = []
     manifest_paths: dict[str, Path] = {}
     stage_trace_ids: dict[str, str] = {}
+    hmm_state_posterior_payload: dict[str, Any] = {}
 
     factory = session_factory or SessionLocal
     if persist_results:
@@ -1130,6 +1259,20 @@ def run_autonomous_lane(
 
         walk_results_path = backtest_dir / "walkforward-results.json"
         write_walk_forward_results(walk_results, walk_results_path)
+        hmm_state_posterior_payload = _build_hmm_state_posterior_payload(
+            output_dir=output_dir,
+            run_id=run_id,
+            candidate_id=candidate_id,
+            now=now,
+            walk_decisions=walk_decisions,
+            walkforward_results_path=walk_results_path,
+            gate_policy_path=gate_policy_path,
+        )
+        hmm_state_posterior_path.parent.mkdir(parents=True, exist_ok=True)
+        hmm_state_posterior_path.write_text(
+            json.dumps(hmm_state_posterior_payload, indent=2),
+            encoding="utf-8",
+        )
 
         report_config = EvaluationReportConfig(
             evaluation_start=signals[0].event_ts,
@@ -1252,6 +1395,7 @@ def run_autonomous_lane(
             "strategy_config": _sha256_path(strategy_config_path),
             "gate_policy": _sha256_path(gate_policy_path),
             "walkforward_results": _sha256_path(walk_results_path),
+            "hmm_state_posterior": _sha256_path(hmm_state_posterior_path),
             "candidate_report": _sha256_path(evaluation_report_path),
             "baseline_report": _sha256_path(baseline_report_path),
             "janus_event_car": _sha256_path(janus_event_car_path),
@@ -1269,6 +1413,7 @@ def run_autonomous_lane(
                 str(evaluation_report_path),
                 str(baseline_report_path),
                 str(walk_results_path),
+                str(hmm_state_posterior_path),
                 str(signals_path),
                 str(strategy_config_path),
                 str(gate_policy_path),
@@ -1310,6 +1455,7 @@ def run_autonomous_lane(
                 profitability_validation_path,
                 profitability_benchmark_path,
                 benchmark_parity_path,
+                hmm_state_posterior_path,
             ],
         )
         contamination_registry_path.write_text(
@@ -1465,6 +1611,11 @@ def run_autonomous_lane(
             contamination_registry_artifact_ref = str(
                 contamination_registry_path.relative_to(output_dir)
             )
+        hmm_state_posterior_artifact_ref = str(hmm_state_posterior_path)
+        if not output_dir.is_absolute():
+            hmm_state_posterior_artifact_ref = str(
+                hmm_state_posterior_path.relative_to(output_dir)
+            )
         gate_report_payload = gate_report.to_payload()
         gate_report_payload["run_id"] = run_id
         gate_report_payload["throughput"] = {
@@ -1501,6 +1652,21 @@ def run_autonomous_lane(
             },
             "benchmark_parity": {
                 "artifact_ref": benchmark_parity_artifact_ref,
+            },
+            "hmm_state_posterior": {
+                "artifact_ref": hmm_state_posterior_artifact_ref,
+                "schema_version": hmm_state_posterior_payload.get("schema_version"),
+                "samples_total": hmm_state_posterior_payload.get("samples_total"),
+                "authoritative_samples": hmm_state_posterior_payload.get(
+                    "authoritative_samples"
+                ),
+                "authoritative_sample_ratio": hmm_state_posterior_payload.get(
+                    "authoritative_sample_ratio"
+                ),
+                "top_regime_by_posterior_mass": hmm_state_posterior_payload.get(
+                    "top_regime_by_posterior_mass"
+                ),
+                "artifact_hash": hmm_state_posterior_payload.get("artifact_hash"),
             },
             "contamination_registry": {
                 "artifact_ref": contamination_registry_artifact_ref,
@@ -1549,6 +1715,7 @@ def run_autonomous_lane(
                 "profitability_evidence": str(profitability_evidence_path),
                 "profitability_validation": str(profitability_validation_path),
                 "stress_metrics": str(stress_metrics_path),
+                "hmm_state_posterior": str(hmm_state_posterior_path),
                 "janus_event_car": str(janus_event_car_path),
                 "janus_hgrm_reward": str(janus_hgrm_reward_path),
                 "recalibration_report": str(recalibration_report_path),
@@ -1624,6 +1791,7 @@ def run_autonomous_lane(
                 contamination_registry_path=contamination_registry_path,
                 profitability_evidence_path=profitability_evidence_path,
                 profitability_validation_path=profitability_validation_path,
+                hmm_state_posterior_path=hmm_state_posterior_path,
                 benchmark_parity_path=benchmark_parity_path,
                 janus_event_car_path=janus_event_car_path,
                 janus_hgrm_reward_path=janus_hgrm_reward_path,
@@ -1727,6 +1895,7 @@ def run_autonomous_lane(
                         str(profitability_evidence_path),
                         str(profitability_validation_path),
                         str(stress_metrics_path),
+                        str(hmm_state_posterior_path),
                         str(janus_event_car_path),
                         str(janus_hgrm_reward_path),
                         str(recalibration_report_path),
@@ -1752,6 +1921,7 @@ def run_autonomous_lane(
                         str(profitability_evidence_path),
                         str(profitability_validation_path),
                         str(stress_metrics_path),
+                        str(hmm_state_posterior_path),
                         str(janus_event_car_path),
                         str(janus_hgrm_reward_path),
                         *[
@@ -1796,6 +1966,21 @@ def run_autonomous_lane(
             "benchmark_parity": {
                 "artifact_ref": benchmark_parity_artifact_ref,
             },
+            "hmm_state_posterior": {
+                "artifact_ref": hmm_state_posterior_artifact_ref,
+                "schema_version": hmm_state_posterior_payload.get("schema_version"),
+                "samples_total": hmm_state_posterior_payload.get("samples_total"),
+                "authoritative_samples": hmm_state_posterior_payload.get(
+                    "authoritative_samples"
+                ),
+                "authoritative_sample_ratio": hmm_state_posterior_payload.get(
+                    "authoritative_sample_ratio"
+                ),
+                "top_regime_by_posterior_mass": hmm_state_posterior_payload.get(
+                    "top_regime_by_posterior_mass"
+                ),
+                "artifact_hash": hmm_state_posterior_payload.get("artifact_hash"),
+            },
             "contamination_registry": {
                 "artifact_ref": contamination_registry_artifact_ref,
                 "status": contamination_registry_payload.get("status", "fail"),
@@ -1832,6 +2017,7 @@ def run_autonomous_lane(
             "profitability_benchmark_artifact": str(profitability_benchmark_path),
             "profitability_evidence_artifact": str(profitability_evidence_path),
             "profitability_validation_artifact": str(profitability_validation_path),
+            "hmm_state_posterior_artifact": str(hmm_state_posterior_path),
             "janus_event_car_artifact": str(janus_event_car_path),
             "janus_hgrm_reward_artifact": str(janus_hgrm_reward_path),
             "recalibration_artifact": str(recalibration_report_path),
@@ -1867,6 +2053,7 @@ def run_autonomous_lane(
                 "profitability_benchmark": profitability_benchmark_path,
                 "profitability_evidence": profitability_evidence_path,
                 "profitability_validation": profitability_validation_path,
+                "hmm_state_posterior": hmm_state_posterior_path,
                 "janus_event_car": janus_event_car_path,
                 "janus_hgrm_reward": janus_hgrm_reward_path,
                 "recalibration_report": recalibration_report_path,
@@ -1903,7 +2090,9 @@ def run_autonomous_lane(
                         str(benchmark_parity_path),
                         str(contamination_registry_path),
                         str(profitability_benchmark_path),
+                        str(profitability_evidence_path),
                         str(profitability_validation_path),
+                        str(hmm_state_posterior_path),
                         str(janus_event_car_path),
                         str(janus_hgrm_reward_path),
                         str(recalibration_report_path),

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -43,6 +43,7 @@ _PROFITABILITY_STAGE_REQUIRED_CHECKS: dict[str, tuple[str, ...]] = {
         "walkforward_results_present",
         "evaluation_report_present",
         "gate_evaluation_present",
+        "hmm_state_posterior_present",
         "janus_event_car_present",
         "janus_hgrm_reward_present",
         "recalibration_report_present",
@@ -135,6 +136,10 @@ def evaluate_promotion_prerequisites(
         policy_payload=policy_payload,
         promotion_target=promotion_target,
     )
+    hmm_state_posterior_required = _requires_hmm_state_posterior(
+        policy_payload=policy_payload,
+        promotion_target=promotion_target,
+    )
     required_artifacts = _required_artifacts_for_target(
         policy_payload,
         promotion_target,
@@ -143,6 +148,7 @@ def evaluate_promotion_prerequisites(
         include_benchmark_parity_artifacts=benchmark_parity_required,
         include_contamination_artifacts=contamination_registry_required,
         include_stress_artifacts=stress_required,
+        include_hmm_state_posterior_artifacts=hmm_state_posterior_required,
         require_profitability_manifest=require_profitability_manifest,
     )
     missing_artifacts = [
@@ -1207,6 +1213,7 @@ def _required_artifacts_for_target(
     include_benchmark_parity_artifacts: bool,
     include_contamination_artifacts: bool,
     include_stress_artifacts: bool,
+    include_hmm_state_posterior_artifacts: bool,
     require_profitability_manifest: bool,
 ) -> list[str]:
     base_raw = policy_payload.get(
@@ -1279,6 +1286,10 @@ def _required_artifacts_for_target(
         for artifact in stress_artifacts:
             if isinstance(artifact, str):
                 required.append(artifact)
+    if include_hmm_state_posterior_artifacts:
+        hmm_artifacts = _hmm_state_posterior_required_artifact_refs(policy_payload)
+        for artifact in hmm_artifacts:
+            required.append(artifact)
     return sorted(set(required))
 
 
@@ -1341,6 +1352,44 @@ def _contamination_registry_required_artifact_refs(
     if legacy_artifact:
         return [legacy_artifact]
     return ["gates/contamination-leakage-report-v1.json"]
+
+
+def _hmm_state_posterior_required_artifact_refs(
+    policy_payload: dict[str, Any],
+) -> list[str]:
+    artifacts_raw = policy_payload.get(
+        "promotion_hmm_required_artifacts",
+        ["gates/hmm-state-posterior-v1.json"],
+    )
+    artifacts = [
+        str(artifact).strip()
+        for artifact in _list_from_any(artifacts_raw)
+        if isinstance(artifact, str) and artifact.strip()
+    ]
+    if artifacts:
+        return artifacts
+    return ["gates/hmm-state-posterior-v1.json"]
+
+
+def _requires_hmm_state_posterior(
+    *, policy_payload: dict[str, Any], promotion_target: str
+) -> bool:
+    if promotion_target == "shadow":
+        return False
+    if not bool(policy_payload.get("promotion_require_hmm_state_posterior", False)):
+        return False
+    required_targets_raw = policy_payload.get(
+        "promotion_hmm_required_targets",
+        ["paper", "live"],
+    )
+    required_targets = [
+        str(target)
+        for target in _list_from_any(required_targets_raw)
+        if isinstance(target, str)
+    ]
+    if not required_targets:
+        return False
+    return promotion_target in required_targets
 
 
 def _requires_profitability_evidence(
@@ -1543,6 +1592,16 @@ def _evaluate_promotion_evidence(
     reasons.extend(contamination_reasons)
     details.extend(contamination_details)
     refs.extend(contamination_refs)
+
+    hmm_reasons, hmm_details, hmm_refs = _evaluate_hmm_state_posterior_evidence(
+        policy_payload=policy_payload,
+        gate_report_payload=gate_report_payload,
+        artifact_root=artifact_root,
+        promotion_target=promotion_target,
+    )
+    reasons.extend(hmm_reasons)
+    details.extend(hmm_details)
+    refs.extend(hmm_refs)
 
     rationale_reasons, rationale_details = _evaluate_rationale_evidence(
         policy_payload=policy_payload,
@@ -2466,6 +2525,196 @@ def _evaluate_contamination_registry_evidence(
             details.append(
                 {
                     "reason": "contamination_registry_artifact_hash_mismatch",
+                    "artifact_ref": str(artifact_path),
+                    "artifact_hash": artifact_hash,
+                    "expected_artifact_hash": expected_hash,
+                }
+            )
+
+    return reasons, details, refs
+
+
+def _evaluate_hmm_state_posterior_evidence(
+    *,
+    policy_payload: dict[str, Any],
+    gate_report_payload: dict[str, Any],
+    artifact_root: Path,
+    promotion_target: str,
+) -> tuple[list[str], list[dict[str, object]], list[str]]:
+    if not _requires_hmm_state_posterior(
+        policy_payload=policy_payload,
+        promotion_target=promotion_target,
+    ):
+        return [], [], []
+
+    reasons: list[str] = []
+    details: list[dict[str, object]] = []
+    refs: list[str] = []
+
+    evidence = _as_dict(gate_report_payload.get("promotion_evidence"))
+    hmm_posterior = _as_dict(evidence.get("hmm_state_posterior"))
+    evidence_ref = str(hmm_posterior.get("artifact_ref") or "").strip()
+    if not evidence_ref:
+        reasons.append("hmm_state_posterior_artifact_ref_missing")
+        details.append({"reason": "hmm_state_posterior_artifact_ref_missing"})
+
+    required_artifacts = _hmm_state_posterior_required_artifact_refs(policy_payload)
+    artifact_ref = (evidence_ref or required_artifacts[0]).strip()
+    artifact_path = _normalize_artifact_path(artifact_ref, artifact_root=artifact_root)
+    if artifact_path is None:
+        reasons.append("hmm_state_posterior_artifact_ref_invalid")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_artifact_ref_invalid",
+                "artifact_ref": artifact_ref,
+            }
+        )
+        return reasons, details, refs
+
+    refs.append(evidence_ref or str(artifact_path))
+    payload = _load_json_if_exists(artifact_path)
+    if payload is None:
+        reasons.append("hmm_state_posterior_artifact_invalid_json")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_artifact_invalid_json",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+        return reasons, details, refs
+
+    schema_version = str(payload.get("schema_version", "")).strip()
+    if schema_version != "hmm-state-posterior-v1":
+        reasons.append("hmm_state_posterior_schema_version_invalid")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_schema_version_invalid",
+                "artifact_ref": str(artifact_path),
+                "schema_version": schema_version,
+            }
+        )
+
+    run_id = str(payload.get("run_id", "")).strip()
+    if not run_id:
+        reasons.append("hmm_state_posterior_run_id_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_run_id_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+
+    candidate_id = str(payload.get("candidate_id", "")).strip()
+    if not candidate_id:
+        reasons.append("hmm_state_posterior_candidate_id_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_candidate_id_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+
+    samples_total = _int_or_default(payload.get("samples_total"), -1)
+    if samples_total < 0:
+        reasons.append("hmm_state_posterior_samples_total_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_samples_total_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+
+    authoritative_samples = _int_or_default(payload.get("authoritative_samples"), -1)
+    if authoritative_samples < 0:
+        reasons.append("hmm_state_posterior_authoritative_samples_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_authoritative_samples_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    elif samples_total >= 0 and authoritative_samples > samples_total:
+        reasons.append("hmm_state_posterior_authoritative_samples_invalid")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_authoritative_samples_invalid",
+                "artifact_ref": str(artifact_path),
+                "samples_total": samples_total,
+                "authoritative_samples": authoritative_samples,
+            }
+        )
+
+    authoritative_ratio = _float_or_none(payload.get("authoritative_sample_ratio"))
+    if authoritative_ratio is None:
+        reasons.append("hmm_state_posterior_authoritative_ratio_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_authoritative_ratio_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    else:
+        min_authoritative_ratio = _float_or_none(
+            policy_payload.get("promotion_hmm_min_authoritative_sample_ratio")
+        )
+        if (
+            min_authoritative_ratio is not None
+            and authoritative_ratio < min_authoritative_ratio
+        ):
+            reasons.append("hmm_state_posterior_authoritative_ratio_below_threshold")
+            details.append(
+                {
+                    "reason": "hmm_state_posterior_authoritative_ratio_below_threshold",
+                    "artifact_ref": str(artifact_path),
+                    "actual_ratio": authoritative_ratio,
+                    "minimum_ratio": min_authoritative_ratio,
+                }
+            )
+
+    source_lineage = _as_dict(payload.get("source_lineage"))
+    walkforward_ref = str(
+        source_lineage.get("walkforward_results_artifact_ref") or ""
+    ).strip()
+    gate_policy_ref = str(source_lineage.get("gate_policy_artifact_ref") or "").strip()
+    if not walkforward_ref or not gate_policy_ref:
+        reasons.append("hmm_state_posterior_source_lineage_incomplete")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_source_lineage_incomplete",
+                "artifact_ref": str(artifact_path),
+                "walkforward_results_artifact_ref": walkforward_ref,
+                "gate_policy_artifact_ref": gate_policy_ref,
+            }
+        )
+
+    posterior_mass = _as_dict(payload.get("posterior_mass_by_regime"))
+    if not posterior_mass:
+        reasons.append("hmm_state_posterior_distribution_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_distribution_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+
+    artifact_hash = str(payload.get("artifact_hash", "")).strip()
+    if not artifact_hash:
+        reasons.append("hmm_state_posterior_artifact_hash_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_artifact_hash_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    else:
+        expected_hash = _sha256_json(
+            {key: value for key, value in payload.items() if key != "artifact_hash"}
+        )
+        if artifact_hash != expected_hash:
+            reasons.append("hmm_state_posterior_artifact_hash_mismatch")
+            details.append(
+                {
+                    "reason": "hmm_state_posterior_artifact_hash_mismatch",
                     "artifact_ref": str(artifact_path),
                     "artifact_hash": artifact_hash,
                     "expected_artifact_hash": expected_hash,

--- a/services/torghut/app/trading/autonomy/policy_contract.py
+++ b/services/torghut/app/trading/autonomy/policy_contract.py
@@ -10,6 +10,7 @@ _REQUIRED_BOOL_KEYS: tuple[str, ...] = (
     "promotion_require_profitability_stage_manifest",
     "promotion_require_profitability_stage_replay_contract",
     "promotion_require_benchmark_parity",
+    "promotion_require_hmm_state_posterior",
     "promotion_require_janus_evidence",
     "promotion_require_stress_evidence",
 )
@@ -20,6 +21,7 @@ _REQUIRED_STRING_KEYS: tuple[str, ...] = (
 
 _REQUIRED_LIST_KEYS: tuple[str, ...] = (
     "promotion_benchmark_required_artifacts",
+    "promotion_hmm_required_artifacts",
     "promotion_janus_required_artifacts",
     "promotion_stress_required_artifacts",
 )

--- a/services/torghut/config/autonomous-gate-policy.json
+++ b/services/torghut/config/autonomous-gate-policy.json
@@ -82,6 +82,12 @@
     "gates/stress-metrics-v1.json"
   ],
   "promotion_stress_max_age_hours": 24,
+  "promotion_require_hmm_state_posterior": true,
+  "promotion_hmm_required_targets": ["paper", "live"],
+  "promotion_hmm_required_artifacts": [
+    "gates/hmm-state-posterior-v1.json"
+  ],
+  "promotion_hmm_min_authoritative_sample_ratio": "0.0",
   "promotion_require_janus_evidence": true,
   "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
   "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -82,6 +82,12 @@
     "gates/stress-metrics-v1.json"
   ],
   "promotion_stress_max_age_hours": 24,
+  "promotion_require_hmm_state_posterior": true,
+  "promotion_hmm_required_targets": ["paper", "live"],
+  "promotion_hmm_required_artifacts": [
+    "gates/hmm-state-posterior-v1.json"
+  ],
+  "promotion_hmm_min_authoritative_sample_ratio": "0.0",
   "promotion_require_janus_evidence": true,
   "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
   "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",

--- a/services/torghut/scripts/run_governance_policy_dry_run.py
+++ b/services/torghut/scripts/run_governance_policy_dry_run.py
@@ -160,6 +160,7 @@ def main() -> int:
             "run_id": str(gate_report.get("run_id", "run-dry-run")),
         }
         promotion_evidence = gate_report.get("promotion_evidence")
+        hmm_posterior_payload: dict[str, Any] = {}
         if isinstance(promotion_evidence, dict):
             stress_metrics = promotion_evidence.get("stress_metrics")
             if isinstance(stress_metrics, dict):
@@ -181,6 +182,18 @@ def main() -> int:
                 contamination_registry = {}
                 promotion_evidence["contamination_registry"] = contamination_registry
             contamination_registry["artifact_ref"] = "gates/contamination-leakage-report-v1.json"
+            hmm_posterior = promotion_evidence.get("hmm_state_posterior")
+            if isinstance(hmm_posterior, dict):
+                hmm_posterior_payload = {
+                    str(key): value for key, value in hmm_posterior.items()
+                }
+            else:
+                promotion_evidence["hmm_state_posterior"] = {
+                    "artifact_ref": "gates/hmm-state-posterior-v1.json"
+                }
+            promotion_evidence["hmm_state_posterior"]["artifact_ref"] = (
+                "gates/hmm-state-posterior-v1.json"
+            )
         if "generated_at" not in stress_artifact:
             stress_artifact["generated_at"] = datetime.now(timezone.utc).isoformat()
         (root / "gates" / "stress-metrics-v1.json").write_text(
@@ -247,6 +260,38 @@ def main() -> int:
             contamination_path = root / "gates" / "contamination-leakage-report-v1.json"
             if contamination_path.exists():
                 contamination_path.unlink()
+
+        hmm_artifact: dict[str, Any] = {
+            "schema_version": "hmm-state-posterior-v1",
+            "run_id": str(gate_report.get("run_id", "run-dry-run")),
+            "candidate_id": "cand-dry-run",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "samples_total": int(hmm_posterior_payload.get("samples_total") or 10),
+            "authoritative_samples": int(
+                hmm_posterior_payload.get("authoritative_samples") or 6
+            ),
+            "authoritative_sample_ratio": str(
+                hmm_posterior_payload.get("authoritative_sample_ratio") or "0.6"
+            ),
+            "transition_shock_samples": 0,
+            "stale_or_defensive_samples": 0,
+            "regime_counts": {"r2": 10},
+            "entropy_band_counts": {"medium": 10},
+            "guardrail_reason_counts": {"none": 10},
+            "posterior_mass_by_regime": {"r2": "6.0", "r1": "4.0"},
+            "top_regime_by_posterior_mass": "r2",
+            "source_lineage": {
+                "walkforward_results_artifact_ref": "backtest/evaluation-report.json",
+                "gate_policy_artifact_ref": "gates/gate-evaluation.json",
+                "decision_source": "walkforward_results",
+            },
+        }
+        hmm_artifact["artifact_hash"] = _stable_hash(
+            {key: value for key, value in hmm_artifact.items() if key != "artifact_hash"}
+        )
+        (root / "gates" / "hmm-state-posterior-v1.json").write_text(
+            json.dumps(hmm_artifact, indent=2), encoding="utf-8"
+        )
 
         if args.simulate_missing_artifact:
             (root / "paper-candidate" / "strategy-configmap-patch.yaml").unlink()

--- a/services/torghut/tests/test_autonomous_lane.py
+++ b/services/torghut/tests/test_autonomous_lane.py
@@ -245,6 +245,10 @@ class TestAutonomousLane(TestCase):
                 evidence["contamination_registry"]["artifact_ref"],
                 str(output_dir / "gates" / "contamination-leakage-report-v1.json"),
             )
+            self.assertEqual(
+                evidence["hmm_state_posterior"]["artifact_ref"],
+                str(output_dir / "gates" / "hmm-state-posterior-v1.json"),
+            )
             self.assertTrue(
                 (output_dir / "gates" / "stress-metrics-v1.json").exists()
             )
@@ -256,6 +260,19 @@ class TestAutonomousLane(TestCase):
                     output_dir / "gates" / "contamination-leakage-report-v1.json"
                 ).exists()
             )
+            self.assertTrue(
+                (output_dir / "gates" / "hmm-state-posterior-v1.json").exists()
+            )
+            hmm_state_posterior_payload = json.loads(
+                (output_dir / "gates" / "hmm-state-posterior-v1.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(
+                hmm_state_posterior_payload["schema_version"],
+                "hmm-state-posterior-v1",
+            )
+            self.assertIn("source_lineage", hmm_state_posterior_payload)
             self.assertEqual(
                 result.benchmark_parity_path,
                 output_dir / "benchmarks" / "benchmark-parity-report-v1.json",
@@ -395,6 +412,10 @@ class TestAutonomousLane(TestCase):
                     evidence["contamination_registry"]["artifact_ref"],
                     str(Path("gates") / "contamination-leakage-report-v1.json"),
                 )
+                self.assertEqual(
+                    evidence["hmm_state_posterior"]["artifact_ref"],
+                    str(Path("gates") / "hmm-state-posterior-v1.json"),
+                )
                 self.assertTrue(
                     (output_dir / "gates" / "stress-metrics-v1.json").exists()
                 )
@@ -405,6 +426,9 @@ class TestAutonomousLane(TestCase):
                     (
                         output_dir / "gates" / "contamination-leakage-report-v1.json"
                     ).exists()
+                )
+                self.assertTrue(
+                    (output_dir / "gates" / "hmm-state-posterior-v1.json").exists()
                 )
             finally:
                 os.chdir(original_cwd)

--- a/services/torghut/tests/test_governance_policy_dry_run.py
+++ b/services/torghut/tests/test_governance_policy_dry_run.py
@@ -61,6 +61,13 @@ def _default_gate_report(now: datetime) -> dict[str, object]:
                 "leakage_detected": False,
                 "leakage_rate": 0.0,
             },
+            "hmm_state_posterior": {
+                "artifact_ref": "gates/hmm-state-posterior-v1.json",
+                "schema_version": "hmm-state-posterior-v1",
+                "samples_total": 10,
+                "authoritative_samples": 6,
+                "authoritative_sample_ratio": "0.6",
+            },
             "promotion_rationale": {
                 "requested_target": "paper",
                 "gate_recommended_mode": "paper",

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -131,6 +131,143 @@ class TestPolicyChecks(TestCase):
             promotion.reasons,
         )
 
+    def test_promotion_prerequisites_fail_when_hmm_state_posterior_required_and_missing(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            gate_report = _gate_report()
+            promotion_evidence = gate_report.get("promotion_evidence", {})
+            assert isinstance(promotion_evidence, dict)
+            promotion_evidence.pop("hmm_state_posterior", None)
+            (root / "gates" / "gate-evaluation.json").write_text(
+                json.dumps(gate_report),
+                encoding="utf-8",
+            )
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_hmm_state_posterior": True,
+                    "promotion_hmm_required_targets": ["paper", "live"],
+                    "promotion_hmm_required_artifacts": [
+                        "gates/hmm-state-posterior-v1.json"
+                    ],
+                    "promotion_require_patch_targets": [],
+                    "promotion_require_profitability_stage_manifest": False,
+                    "promotion_require_benchmark_parity": False,
+                    "promotion_require_contamination_registry": False,
+                    "promotion_require_stress_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "gate6_require_profitability_evidence": False,
+                },
+                gate_report_payload=gate_report,
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn("required_artifacts_missing", promotion.reasons)
+        self.assertIn(
+            "gates/hmm-state-posterior-v1.json",
+            promotion.missing_artifacts,
+        )
+        self.assertIn("hmm_state_posterior_artifact_ref_missing", promotion.reasons)
+
+    def test_promotion_prerequisites_accept_valid_hmm_state_posterior_evidence(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            (root / "gates" / "gate-evaluation.json").write_text(
+                json.dumps(_gate_report()),
+                encoding="utf-8",
+            )
+
+            hmm_artifact = root / "gates" / "hmm-state-posterior-v1.json"
+            hmm_payload = {
+                "schema_version": "hmm-state-posterior-v1",
+                "run_id": "run-test",
+                "candidate_id": "cand-test",
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "samples_total": 5,
+                "authoritative_samples": 3,
+                "authoritative_sample_ratio": "0.6",
+                "transition_shock_samples": 0,
+                "stale_or_defensive_samples": 0,
+                "regime_counts": {"r2": 5},
+                "entropy_band_counts": {"medium": 5},
+                "guardrail_reason_counts": {"none": 5},
+                "posterior_mass_by_regime": {"r2": "4.2"},
+                "top_regime_by_posterior_mass": "r2",
+                "source_lineage": {
+                    "walkforward_results_artifact_ref": "backtest/walkforward-results.json",
+                    "gate_policy_artifact_ref": "gates/gate-evaluation.json",
+                    "decision_source": "walkforward_results",
+                },
+            }
+            hmm_payload["artifact_hash"] = _sha256_json(
+                {key: value for key, value in hmm_payload.items() if key != "artifact_hash"}
+            )
+            hmm_artifact.write_text(json.dumps(hmm_payload), encoding="utf-8")
+
+            gate_report = _gate_report()
+            promotion_evidence = gate_report.get("promotion_evidence", {})
+            assert isinstance(promotion_evidence, dict)
+            promotion_evidence["hmm_state_posterior"] = {
+                "artifact_ref": "gates/hmm-state-posterior-v1.json",
+                "schema_version": "hmm-state-posterior-v1",
+                "samples_total": 5,
+                "authoritative_samples": 3,
+                "authoritative_sample_ratio": "0.6",
+            }
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_hmm_state_posterior": True,
+                    "promotion_hmm_required_targets": ["paper", "live"],
+                    "promotion_hmm_required_artifacts": [
+                        "gates/hmm-state-posterior-v1.json"
+                    ],
+                    "promotion_hmm_min_authoritative_sample_ratio": "0.5",
+                    "promotion_require_patch_targets": [],
+                    "promotion_require_profitability_stage_manifest": False,
+                    "promotion_require_benchmark_parity": False,
+                    "promotion_require_contamination_registry": False,
+                    "promotion_require_stress_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "gate6_require_profitability_evidence": False,
+                },
+                gate_report_payload=gate_report,
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertTrue(promotion.allowed)
+        self.assertNotIn("hmm_state_posterior_artifact_ref_missing", promotion.reasons)
+        self.assertIn(str(root / "gates" / "hmm-state-posterior-v1.json"), promotion.artifact_refs)
+
     def test_promotion_prerequisites_fail_when_profitability_stage_manifest_replay_contract_missing(
         self,
     ) -> None:
@@ -3687,6 +3824,7 @@ def _build_profitability_stage_manifest_payload(
     janus_event_car_path: Path,
     janus_hgrm_reward_path: Path,
     recalibration_report_path: Path,
+    hmm_state_posterior_path: Path | None = None,
     rollback_readiness_path: Path | None = None,
     stage_statuses: dict[str, str] | None = None,
     check_status_overrides: dict[tuple[str, str], str] | None = None,
@@ -3708,6 +3846,38 @@ def _build_profitability_stage_manifest_payload(
     rollback_readiness_path = (
         rollback_readiness_path or (root / "gates" / "rollback-readiness.json")
     )
+    if hmm_state_posterior_path is None:
+        hmm_state_posterior_path = root / "gates" / "hmm-state-posterior-v1.json"
+    if not hmm_state_posterior_path.exists():
+        hmm_state_posterior_path.parent.mkdir(parents=True, exist_ok=True)
+        hmm_payload: dict[str, object] = {
+            "schema_version": "hmm-state-posterior-v1",
+            "run_id": "run-test",
+            "candidate_id": "cand-test",
+            "generated_at": "2026-03-01T00:00:00+00:00",
+            "samples_total": 1,
+            "authoritative_samples": 0,
+            "authoritative_sample_ratio": "0",
+            "transition_shock_samples": 0,
+            "stale_or_defensive_samples": 0,
+            "regime_counts": {"unknown": 1},
+            "entropy_band_counts": {"low": 1},
+            "guardrail_reason_counts": {"none": 1},
+            "posterior_mass_by_regime": {"unknown": "1"},
+            "top_regime_by_posterior_mass": "unknown",
+            "source_lineage": {
+                "walkforward_results_artifact_ref": "backtest/walkforward-results.json",
+                "gate_policy_artifact_ref": "gates/gate-evaluation.json",
+                "decision_source": "walkforward_results",
+            },
+        }
+        hmm_payload["artifact_hash"] = _sha256_json(
+            {k: v for k, v in hmm_payload.items() if k != "artifact_hash"}
+        )
+        hmm_state_posterior_path.write_text(
+            json.dumps(hmm_payload),
+            encoding="utf-8",
+        )
 
     stage_owner = {
         "research": "research-orchestrator",
@@ -3732,6 +3902,7 @@ def _build_profitability_stage_manifest_payload(
             ("walkforward_results_present", "walkforward_results", walkforward_results_path),
             ("evaluation_report_present", "evaluation_report", evaluation_report_path),
             ("gate_evaluation_present", "gate_evaluation", gate_report_path),
+            ("hmm_state_posterior_present", "hmm_state_posterior", hmm_state_posterior_path),
             ("janus_event_car_present", "janus_event_car", janus_event_car_path),
             ("janus_hgrm_reward_present", "janus_hgrm_reward", janus_hgrm_reward_path),
             ("recalibration_report_present", "recalibration_report", recalibration_report_path),
@@ -3987,6 +4158,13 @@ def _gate_report() -> dict[str, object]:
                 "status": "pass",
                 "leakage_detected": False,
                 "leakage_rate": 0.0,
+            },
+            "hmm_state_posterior": {
+                "artifact_ref": "gates/hmm-state-posterior-v1.json",
+                "schema_version": "hmm-state-posterior-v1",
+                "samples_total": 12,
+                "authoritative_samples": 8,
+                "authoritative_sample_ratio": "0.6667",
             },
             "promotion_rationale": {
                 "requested_target": "paper",


### PR DESCRIPTION
## Summary

- Add deterministic `hmm-state-posterior-v1` artifact generation in autonomous lane outputs, including lineage metadata and artifact hash.
- Wire HMM posterior artifact references into gate evidence, profitability stage manifests, stage lineage manifests, and promotion recommendation artifacts.
- Enforce HMM posterior evidence as a fail-closed promotion prerequisite via policy checks and strict runtime policy/config parity (`service config` + `GitOps ConfigMap`).
- Extend dry-run harness and regression tests to cover HMM posterior evidence presence/validation and keep governance checks green.
- Update v6 Wave 3 tracking docs to mark the HMM posterior persistence deliverable complete.

## Related Issues

None (execution run: `torghut-v6-gap-closure-loop10`).

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev --python 3.12`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --with pytest pytest`
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
