### PR TITLE
chore(torghut): promote image 4f7440bf

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e86761867a4d20e34205124737bab4c8a439ca675d20a26c2f1797f74b8a614e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b94636ff587a44b1521ff2718b312d816312635a5bd01d786951cad474db922d
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T11:58:40Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T12:36:04Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e86761867a4d20e34205124737bab4c8a439ca675d20a26c2f1797f74b8a614e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b94636ff587a44b1521ff2718b312d816312635a5bd01d786951cad474db922d
           ports:
             - name: http1
               containerPort: 8181
@@ -386,9 +386,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-168-g177f1652
+              value: v0.562.0-170-g4f7440bf
             - name: TORGHUT_COMMIT
-              value: 177f16528f37244153a836ddb942c3cc576dbd1a
+              value: 4f7440bf4b5bf36cd516810db573728b6886530f
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `4f7440bf4b5bf36cd516810db573728b6886530f`
- Image tag: `4f7440bf`
- Image digest: `sha256:b94636ff587a44b1521ff2718b312d816312635a5bd01d786951cad474db922d`