### PR TITLE
feat(torghut): enforce expert-router registry promotion evidence

### DIFF
--- a/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
+++ b/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
@@ -99,6 +99,14 @@ data:
         "gates/hmm-state-posterior-v1.json"
       ],
       "promotion_hmm_min_authoritative_sample_ratio": "0.0",
+      "promotion_require_expert_router_registry": true,
+      "promotion_expert_router_required_targets": ["paper", "live"],
+      "promotion_expert_router_required_artifacts": [
+        "gates/expert-router-registry-v1.json"
+      ],
+      "promotion_expert_router_min_route_count": 1,
+      "promotion_expert_router_max_fallback_rate": "0.05",
+      "promotion_expert_router_max_expert_concentration": "0.85",
       "promotion_require_janus_evidence": true,
       "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
       "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",

--- a/docs/torghut/design-system/v6/02-regime-adaptive-expert-router-design.md
+++ b/docs/torghut/design-system/v6/02-regime-adaptive-expert-router-design.md
@@ -12,7 +12,7 @@
   - `services/torghut/app/trading/forecasting.py`
   - `services/torghut/app/trading/scheduler.py`
   - `services/torghut/app/trading/portfolio.py`
-- Rollout gap: no production expert-router artifact registry or concentration/fallback tuning SLO loop exists yet.
+- Rollout gap: expert-router artifact registry and concentration/fallback SLO loop artifacts are implemented in the autonomous lane (`2026-03-03`); remaining closure is wiring regime-quality outputs into promotion + drift governance decisions.
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -149,7 +149,7 @@ Close architecture gaps for regime-adaptive routing with persisted HMM state lin
 ### Deliverables
 
 1. Implement HMM posterior state artifact (`hmm_state_posterior`) persistence and lineage references. (Completed `2026-03-03`)
-2. Add expert-router artifact registry with concentration/fallback SLO feedback loop.
+2. Add expert-router artifact registry with concentration/fallback SLO feedback loop. (Completed `2026-03-03`)
 3. Wire regime-state quality into promotion and drift governance decisions.
 
 ### Primary files

--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -102,6 +102,7 @@ _STAGE_RECOMMENDATION = "promotion-recommendation"
 _STRESS_METRICS_ARTIFACT_PATH = "stress-metrics-v1.json"
 _CONTAMINATION_REGISTRY_ARTIFACT_PATH = "contamination-leakage-report-v1.json"
 _HMM_STATE_POSTERIOR_ARTIFACT_PATH = "gates/hmm-state-posterior-v1.json"
+_EXPERT_ROUTER_REGISTRY_ARTIFACT_PATH = "gates/expert-router-registry-v1.json"
 _STRESS_METRICS_CASES = ("spread", "volatility", "liquidity", "halt")
 _BENCHMARK_PARITY_REPORT_PATH = "benchmarks/benchmark-parity-report-v1.json"
 _STAGE_PROFITABILITY = "profitability_stage_manifest"
@@ -678,6 +679,276 @@ def _build_hmm_state_posterior_payload(
     return payload
 
 
+def _decimal_or_zero(value: object) -> Decimal:
+    try:
+        decimal_value = Decimal(str(value))
+    except Exception:
+        return Decimal("0")
+    if decimal_value.is_nan() or decimal_value.is_infinite():
+        return Decimal("0")
+    return decimal_value
+
+
+def _normalize_expert_weights(weights: Mapping[str, Decimal]) -> dict[str, Decimal]:
+    total = Decimal("0")
+    for value in weights.values():
+        if value > 0:
+            total += value
+    if total <= 0:
+        return {
+            "trend": Decimal("0.05"),
+            "reversal": Decimal("0.05"),
+            "breakout": Decimal("0.10"),
+            "defensive": Decimal("0.80"),
+        }
+    return {
+        "trend": max(Decimal("0"), weights.get("trend", Decimal("0"))) / total,
+        "reversal": max(Decimal("0"), weights.get("reversal", Decimal("0"))) / total,
+        "breakout": max(Decimal("0"), weights.get("breakout", Decimal("0"))) / total,
+        "defensive": max(Decimal("0"), weights.get("defensive", Decimal("0"))) / total,
+    }
+
+
+def _build_expert_router_weights(
+    *,
+    regime_label: str,
+    context: Any,
+) -> tuple[dict[str, Decimal], bool]:
+    fallback_active = bool(
+        context.guardrail.fallback_to_defensive
+        or context.guardrail.stale
+        or context.transition_shock
+    )
+    if context.entropy_band == "high":
+        fallback_active = True
+    if fallback_active:
+        return (
+            _normalize_expert_weights(
+                {
+                    "trend": Decimal("0.05"),
+                    "reversal": Decimal("0.05"),
+                    "breakout": Decimal("0.10"),
+                    "defensive": Decimal("0.80"),
+                }
+            ),
+            True,
+        )
+
+    normalized_regime_label = regime_label.strip().lower()
+    if normalized_regime_label in {"r2", "trend", "trend_up"}:
+        return (
+            _normalize_expert_weights(
+                {
+                    "trend": Decimal("0.62"),
+                    "reversal": Decimal("0.14"),
+                    "breakout": Decimal("0.20"),
+                    "defensive": Decimal("0.04"),
+                }
+            ),
+            False,
+        )
+    if normalized_regime_label in {"r3", "breakout", "risk_on_breakout"}:
+        return (
+            _normalize_expert_weights(
+                {
+                    "trend": Decimal("0.24"),
+                    "reversal": Decimal("0.11"),
+                    "breakout": Decimal("0.55"),
+                    "defensive": Decimal("0.10"),
+                }
+            ),
+            False,
+        )
+    if normalized_regime_label in {"r1", "range", "mean_revert", "reversal"}:
+        return (
+            _normalize_expert_weights(
+                {
+                    "trend": Decimal("0.18"),
+                    "reversal": Decimal("0.55"),
+                    "breakout": Decimal("0.12"),
+                    "defensive": Decimal("0.15"),
+                }
+            ),
+            False,
+        )
+    if normalized_regime_label in {"r4", "r5", "stressed", "stress"}:
+        return (
+            _normalize_expert_weights(
+                {
+                    "trend": Decimal("0.08"),
+                    "reversal": Decimal("0.12"),
+                    "breakout": Decimal("0.10"),
+                    "defensive": Decimal("0.70"),
+                }
+            ),
+            False,
+        )
+
+    return (
+        _normalize_expert_weights(
+            {
+                "trend": Decimal("0.28"),
+                "reversal": Decimal("0.22"),
+                "breakout": Decimal("0.26"),
+                "defensive": Decimal("0.24"),
+            }
+        ),
+        False,
+    )
+
+
+def _build_expert_router_registry_payload(
+    *,
+    output_dir: Path,
+    run_id: str,
+    candidate_id: str,
+    now: datetime,
+    walk_decisions: Sequence[WalkForwardDecision],
+    walkforward_results_path: Path,
+    gate_policy_path: Path,
+    strategy_config_path: Path,
+    hmm_state_posterior_path: Path,
+    policy_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    expert_sums: dict[str, Decimal] = {
+        "trend": Decimal("0"),
+        "reversal": Decimal("0"),
+        "breakout": Decimal("0"),
+        "defensive": Decimal("0"),
+    }
+    top_expert_counts: dict[str, int] = {
+        "trend": 0,
+        "reversal": 0,
+        "breakout": 0,
+        "defensive": 0,
+    }
+    fallback_count = 0
+    max_expert_weight = Decimal("0")
+
+    for decision in walk_decisions:
+        params = decision.decision.params
+        context = resolve_hmm_context(params)
+        route_regime_label = str(
+            params.get("route_regime_label") or params.get("regime_label") or context.regime_id
+        )
+        weights, fallback_active = _build_expert_router_weights(
+            regime_label=route_regime_label,
+            context=context,
+        )
+        if fallback_active:
+            fallback_count += 1
+
+        top_expert = "defensive"
+        top_weight = Decimal("-1")
+        for expert_name in ("trend", "reversal", "breakout", "defensive"):
+            weight = weights.get(expert_name, Decimal("0"))
+            expert_sums[expert_name] = expert_sums[expert_name] + weight
+            if weight > top_weight:
+                top_weight = weight
+                top_expert = expert_name
+        top_expert_counts[top_expert] = top_expert_counts.get(top_expert, 0) + 1
+        if top_weight > max_expert_weight:
+            max_expert_weight = top_weight
+
+    route_count = len(walk_decisions)
+    if route_count > 0:
+        fallback_rate = Decimal(fallback_count) / Decimal(route_count)
+    else:
+        fallback_rate = Decimal("0")
+    if route_count > 0:
+        avg_expert_weights = {
+            expert: str(expert_sums[expert] / Decimal(route_count))
+            for expert in ("trend", "reversal", "breakout", "defensive")
+        }
+    else:
+        avg_expert_weights = {
+            "trend": "0",
+            "reversal": "0",
+            "breakout": "0",
+            "defensive": "0",
+        }
+
+    max_fallback_rate = _decimal_or_zero(
+        policy_payload.get("promotion_expert_router_max_fallback_rate")
+    )
+    if max_fallback_rate <= 0:
+        max_fallback_rate = Decimal("0.05")
+    max_concentration = _decimal_or_zero(
+        policy_payload.get("promotion_expert_router_max_expert_concentration")
+    )
+    if max_concentration <= 0:
+        max_concentration = Decimal("0.85")
+
+    fallback_slo_pass = fallback_rate <= max_fallback_rate
+    concentration_slo_pass = max_expert_weight <= max_concentration
+    reasons: list[str] = []
+    if not fallback_slo_pass:
+        reasons.append("fallback_rate_exceeds_threshold")
+    if not concentration_slo_pass:
+        reasons.append("expert_concentration_exceeds_threshold")
+    if route_count <= 0:
+        reasons.append("router_decisions_missing")
+
+    dominant_expert = "defensive"
+    dominant_expert_count = -1
+    for expert_name in ("trend", "reversal", "breakout", "defensive"):
+        count = top_expert_counts.get(expert_name, 0)
+        if count > dominant_expert_count:
+            dominant_expert = expert_name
+            dominant_expert_count = count
+
+    payload: dict[str, Any] = {
+        "schema_version": "expert-router-registry-v1",
+        "run_id": run_id,
+        "candidate_id": candidate_id,
+        "generated_at": now.isoformat(),
+        "router_version": "router-v1",
+        "route_count": route_count,
+        "fallback_count": fallback_count,
+        "fallback_rate": str(fallback_rate),
+        "max_expert_weight": str(max_expert_weight),
+        "avg_expert_weights": avg_expert_weights,
+        "top_expert_counts": dict(sorted(top_expert_counts.items())),
+        "concentration": {
+            "dominant_expert": dominant_expert,
+            "dominant_expert_count": dominant_expert_count,
+            "max_expert_weight": str(max_expert_weight),
+        },
+        "slo_feedback": {
+            "max_fallback_rate": str(max_fallback_rate),
+            "max_expert_concentration": str(max_concentration),
+            "fallback_rate": str(fallback_rate),
+            "max_observed_expert_weight": str(max_expert_weight),
+            "fallback_slo_pass": fallback_slo_pass,
+            "concentration_slo_pass": concentration_slo_pass,
+            "overall_status": (
+                "pass"
+                if fallback_slo_pass and concentration_slo_pass and route_count > 0
+                else "fail"
+            ),
+            "reasons": reasons,
+        },
+        "source_lineage": {
+            "walkforward_results_artifact_ref": _manifest_relative_path(
+                output_dir, walkforward_results_path
+            ),
+            "hmm_state_posterior_artifact_ref": _manifest_relative_path(
+                output_dir, hmm_state_posterior_path
+            ),
+            "gate_policy_artifact_ref": _manifest_relative_path(
+                output_dir, gate_policy_path
+            ),
+            "strategy_config_artifact_ref": _manifest_relative_path(
+                output_dir, strategy_config_path
+            ),
+        },
+    }
+    payload["artifact_hash"] = _stable_hash(
+        {key: value for key, value in payload.items() if key != "artifact_hash"}
+    )
+    return payload
+
+
 def _build_profitability_stage_manifest(
     *,
     output_dir: Path,
@@ -700,6 +971,7 @@ def _build_profitability_stage_manifest(
     profitability_evidence_path: Path,
     profitability_validation_path: Path,
     hmm_state_posterior_path: Path,
+    expert_router_registry_path: Path,
     janus_event_car_path: Path,
     janus_hgrm_reward_path: Path,
     recalibration_report_path: Path,
@@ -814,6 +1086,11 @@ def _build_profitability_stage_manifest(
             "hmm_state_posterior_present",
             "hmm_state_posterior",
             hmm_state_posterior_path,
+        ),
+        (
+            "expert_router_registry_present",
+            "expert_router_registry",
+            expert_router_registry_path,
         ),
         ("janus_event_car_present", "janus_event_car", janus_event_car_path),
         ("janus_hgrm_reward_present", "janus_hgrm_reward", janus_hgrm_reward_path),
@@ -990,6 +1267,9 @@ def _build_profitability_stage_manifest(
         "hmm_state_posterior_artifact_ref": _manifest_relative_path(
             output_dir, hmm_state_posterior_path
         ),
+        "expert_router_registry_artifact_ref": _manifest_relative_path(
+            output_dir, expert_router_registry_path
+        ),
         "run_context": {
             "repository": run_context.get("repository", "unknown"),
             "base": run_context.get("base", "main"),
@@ -1150,6 +1430,7 @@ def run_autonomous_lane(
     janus_hgrm_reward_path = gates_dir / "janus-hgrm-reward-v1.json"
     stress_metrics_path = gates_dir / _STRESS_METRICS_ARTIFACT_PATH
     hmm_state_posterior_path = output_dir / _HMM_STATE_POSTERIOR_ARTIFACT_PATH
+    expert_router_registry_path = output_dir / _EXPERT_ROUTER_REGISTRY_ARTIFACT_PATH
     benchmark_parity_path = output_dir / _BENCHMARK_PARITY_REPORT_PATH
     recalibration_report_path = gates_dir / "recalibration-report.json"
     promotion_gate_path = gates_dir / "promotion-evidence-gate.json"
@@ -1190,6 +1471,7 @@ def run_autonomous_lane(
     manifest_paths: dict[str, Path] = {}
     stage_trace_ids: dict[str, str] = {}
     hmm_state_posterior_payload: dict[str, Any] = {}
+    expert_router_registry_payload: dict[str, Any] = {}
 
     factory = session_factory or SessionLocal
     if persist_results:
@@ -1388,6 +1670,24 @@ def run_autonomous_lane(
             now=now,
         )
         write_benchmark_parity_report(benchmark_parity_report, benchmark_parity_path)
+        gate_policy_payload = json.loads(gate_policy_path.read_text(encoding="utf-8"))
+        expert_router_registry_payload = _build_expert_router_registry_payload(
+            output_dir=output_dir,
+            run_id=run_id,
+            candidate_id=candidate_id,
+            now=now,
+            walk_decisions=walk_decisions,
+            walkforward_results_path=walk_results_path,
+            gate_policy_path=gate_policy_path,
+            strategy_config_path=strategy_config_path,
+            hmm_state_posterior_path=hmm_state_posterior_path,
+            policy_payload=gate_policy_payload,
+        )
+        expert_router_registry_path.parent.mkdir(parents=True, exist_ok=True)
+        expert_router_registry_path.write_text(
+            json.dumps(expert_router_registry_payload, indent=2),
+            encoding="utf-8",
+        )
 
         confidence_values = _collect_confidence_values(walk_decisions)
         reproducibility_hashes = {
@@ -1396,6 +1696,7 @@ def run_autonomous_lane(
             "gate_policy": _sha256_path(gate_policy_path),
             "walkforward_results": _sha256_path(walk_results_path),
             "hmm_state_posterior": _sha256_path(hmm_state_posterior_path),
+            "expert_router_registry": _sha256_path(expert_router_registry_path),
             "candidate_report": _sha256_path(evaluation_report_path),
             "baseline_report": _sha256_path(baseline_report_path),
             "janus_event_car": _sha256_path(janus_event_car_path),
@@ -1414,6 +1715,7 @@ def run_autonomous_lane(
                 str(baseline_report_path),
                 str(walk_results_path),
                 str(hmm_state_posterior_path),
+                str(expert_router_registry_path),
                 str(signals_path),
                 str(strategy_config_path),
                 str(gate_policy_path),
@@ -1426,7 +1728,6 @@ def run_autonomous_lane(
             json.dumps(profitability_evidence_payload, indent=2), encoding="utf-8"
         )
 
-        gate_policy_payload = json.loads(gate_policy_path.read_text(encoding="utf-8"))
         profitability_thresholds = ProfitabilityEvidenceThresholdsV4.from_payload(
             _profitability_threshold_payload(gate_policy_payload)
         )
@@ -1456,6 +1757,7 @@ def run_autonomous_lane(
                 profitability_benchmark_path,
                 benchmark_parity_path,
                 hmm_state_posterior_path,
+                expert_router_registry_path,
             ],
         )
         contamination_registry_path.write_text(
@@ -1616,6 +1918,11 @@ def run_autonomous_lane(
             hmm_state_posterior_artifact_ref = str(
                 hmm_state_posterior_path.relative_to(output_dir)
             )
+        expert_router_registry_artifact_ref = str(expert_router_registry_path)
+        if not output_dir.is_absolute():
+            expert_router_registry_artifact_ref = str(
+                expert_router_registry_path.relative_to(output_dir)
+            )
         gate_report_payload = gate_report.to_payload()
         gate_report_payload["run_id"] = run_id
         gate_report_payload["throughput"] = {
@@ -1668,6 +1975,20 @@ def run_autonomous_lane(
                 ),
                 "artifact_hash": hmm_state_posterior_payload.get("artifact_hash"),
             },
+            "expert_router_registry": {
+                "artifact_ref": expert_router_registry_artifact_ref,
+                "schema_version": expert_router_registry_payload.get(
+                    "schema_version"
+                ),
+                "router_version": expert_router_registry_payload.get("router_version"),
+                "route_count": expert_router_registry_payload.get("route_count"),
+                "fallback_count": expert_router_registry_payload.get("fallback_count"),
+                "fallback_rate": expert_router_registry_payload.get("fallback_rate"),
+                "max_expert_weight": expert_router_registry_payload.get(
+                    "max_expert_weight"
+                ),
+                "artifact_hash": expert_router_registry_payload.get("artifact_hash"),
+            },
             "contamination_registry": {
                 "artifact_ref": contamination_registry_artifact_ref,
                 "status": contamination_registry_payload.get("status", "fail"),
@@ -1716,6 +2037,7 @@ def run_autonomous_lane(
                 "profitability_validation": str(profitability_validation_path),
                 "stress_metrics": str(stress_metrics_path),
                 "hmm_state_posterior": str(hmm_state_posterior_path),
+                "expert_router_registry": str(expert_router_registry_path),
                 "janus_event_car": str(janus_event_car_path),
                 "janus_hgrm_reward": str(janus_hgrm_reward_path),
                 "recalibration_report": str(recalibration_report_path),
@@ -1792,6 +2114,7 @@ def run_autonomous_lane(
                 profitability_evidence_path=profitability_evidence_path,
                 profitability_validation_path=profitability_validation_path,
                 hmm_state_posterior_path=hmm_state_posterior_path,
+                expert_router_registry_path=expert_router_registry_path,
                 benchmark_parity_path=benchmark_parity_path,
                 janus_event_car_path=janus_event_car_path,
                 janus_hgrm_reward_path=janus_hgrm_reward_path,
@@ -1896,6 +2219,7 @@ def run_autonomous_lane(
                         str(profitability_validation_path),
                         str(stress_metrics_path),
                         str(hmm_state_posterior_path),
+                        str(expert_router_registry_path),
                         str(janus_event_car_path),
                         str(janus_hgrm_reward_path),
                         str(recalibration_report_path),
@@ -1922,6 +2246,7 @@ def run_autonomous_lane(
                         str(profitability_validation_path),
                         str(stress_metrics_path),
                         str(hmm_state_posterior_path),
+                        str(expert_router_registry_path),
                         str(janus_event_car_path),
                         str(janus_hgrm_reward_path),
                         *[
@@ -1981,6 +2306,20 @@ def run_autonomous_lane(
                 ),
                 "artifact_hash": hmm_state_posterior_payload.get("artifact_hash"),
             },
+            "expert_router_registry": {
+                "artifact_ref": expert_router_registry_artifact_ref,
+                "schema_version": expert_router_registry_payload.get(
+                    "schema_version"
+                ),
+                "router_version": expert_router_registry_payload.get("router_version"),
+                "route_count": expert_router_registry_payload.get("route_count"),
+                "fallback_count": expert_router_registry_payload.get("fallback_count"),
+                "fallback_rate": expert_router_registry_payload.get("fallback_rate"),
+                "max_expert_weight": expert_router_registry_payload.get(
+                    "max_expert_weight"
+                ),
+                "artifact_hash": expert_router_registry_payload.get("artifact_hash"),
+            },
             "contamination_registry": {
                 "artifact_ref": contamination_registry_artifact_ref,
                 "status": contamination_registry_payload.get("status", "fail"),
@@ -2018,6 +2357,7 @@ def run_autonomous_lane(
             "profitability_evidence_artifact": str(profitability_evidence_path),
             "profitability_validation_artifact": str(profitability_validation_path),
             "hmm_state_posterior_artifact": str(hmm_state_posterior_path),
+            "expert_router_registry_artifact": str(expert_router_registry_path),
             "janus_event_car_artifact": str(janus_event_car_path),
             "janus_hgrm_reward_artifact": str(janus_hgrm_reward_path),
             "recalibration_artifact": str(recalibration_report_path),
@@ -2054,6 +2394,7 @@ def run_autonomous_lane(
                 "profitability_evidence": profitability_evidence_path,
                 "profitability_validation": profitability_validation_path,
                 "hmm_state_posterior": hmm_state_posterior_path,
+                "expert_router_registry": expert_router_registry_path,
                 "janus_event_car": janus_event_car_path,
                 "janus_hgrm_reward": janus_hgrm_reward_path,
                 "recalibration_report": recalibration_report_path,
@@ -2093,6 +2434,7 @@ def run_autonomous_lane(
                         str(profitability_evidence_path),
                         str(profitability_validation_path),
                         str(hmm_state_posterior_path),
+                        str(expert_router_registry_path),
                         str(janus_event_car_path),
                         str(janus_hgrm_reward_path),
                         str(recalibration_report_path),
@@ -2154,6 +2496,7 @@ def run_autonomous_lane(
             "profitability_benchmark": profitability_benchmark_path,
             "profitability_evidence": profitability_evidence_path,
             "profitability_validation": profitability_validation_path,
+            "expert_router_registry": expert_router_registry_path,
             "janus_event_car": janus_event_car_path,
             "janus_hgrm_reward": janus_hgrm_reward_path,
             "recalibration_report": recalibration_report_path,

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -44,6 +44,7 @@ _PROFITABILITY_STAGE_REQUIRED_CHECKS: dict[str, tuple[str, ...]] = {
         "evaluation_report_present",
         "gate_evaluation_present",
         "hmm_state_posterior_present",
+        "expert_router_registry_present",
         "janus_event_car_present",
         "janus_hgrm_reward_present",
         "recalibration_report_present",
@@ -140,6 +141,10 @@ def evaluate_promotion_prerequisites(
         policy_payload=policy_payload,
         promotion_target=promotion_target,
     )
+    expert_router_registry_required = _requires_expert_router_registry(
+        policy_payload=policy_payload,
+        promotion_target=promotion_target,
+    )
     required_artifacts = _required_artifacts_for_target(
         policy_payload,
         promotion_target,
@@ -149,6 +154,7 @@ def evaluate_promotion_prerequisites(
         include_contamination_artifacts=contamination_registry_required,
         include_stress_artifacts=stress_required,
         include_hmm_state_posterior_artifacts=hmm_state_posterior_required,
+        include_expert_router_artifacts=expert_router_registry_required,
         require_profitability_manifest=require_profitability_manifest,
     )
     missing_artifacts = [
@@ -643,9 +649,21 @@ def _append_profitability_stage_manifest_reasons(
                     )
                     continue
                 stage_checks[check_name] = check_status
-            for required_check in _PROFITABILITY_STAGE_REQUIRED_CHECKS.get(
-                stage_name, ()
+            required_checks = list(
+                _PROFITABILITY_STAGE_REQUIRED_CHECKS.get(stage_name, ())
+            )
+            if (
+                stage_name == "execution"
+                and not bool(
+                    policy_payload.get("promotion_require_expert_router_registry", False)
+                )
             ):
+                required_checks = [
+                    check
+                    for check in required_checks
+                    if check != "expert_router_registry_present"
+                ]
+            for required_check in required_checks:
                 if required_check not in stage_checks:
                     reasons.append("profitability_stage_manifest_required_check_missing")
                     reason_details.append(
@@ -1214,6 +1232,7 @@ def _required_artifacts_for_target(
     include_contamination_artifacts: bool,
     include_stress_artifacts: bool,
     include_hmm_state_posterior_artifacts: bool,
+    include_expert_router_artifacts: bool,
     require_profitability_manifest: bool,
 ) -> list[str]:
     base_raw = policy_payload.get(
@@ -1289,6 +1308,10 @@ def _required_artifacts_for_target(
     if include_hmm_state_posterior_artifacts:
         hmm_artifacts = _hmm_state_posterior_required_artifact_refs(policy_payload)
         for artifact in hmm_artifacts:
+            required.append(artifact)
+    if include_expert_router_artifacts:
+        expert_router_artifacts = _expert_router_required_artifact_refs(policy_payload)
+        for artifact in expert_router_artifacts:
             required.append(artifact)
     return sorted(set(required))
 
@@ -1371,6 +1394,23 @@ def _hmm_state_posterior_required_artifact_refs(
     return ["gates/hmm-state-posterior-v1.json"]
 
 
+def _expert_router_required_artifact_refs(
+    policy_payload: dict[str, Any],
+) -> list[str]:
+    artifacts_raw = policy_payload.get(
+        "promotion_expert_router_required_artifacts",
+        ["gates/expert-router-registry-v1.json"],
+    )
+    artifacts = [
+        str(artifact).strip()
+        for artifact in _list_from_any(artifacts_raw)
+        if isinstance(artifact, str) and artifact.strip()
+    ]
+    if artifacts:
+        return artifacts
+    return ["gates/expert-router-registry-v1.json"]
+
+
 def _requires_hmm_state_posterior(
     *, policy_payload: dict[str, Any], promotion_target: str
 ) -> bool:
@@ -1380,6 +1420,27 @@ def _requires_hmm_state_posterior(
         return False
     required_targets_raw = policy_payload.get(
         "promotion_hmm_required_targets",
+        ["paper", "live"],
+    )
+    required_targets = [
+        str(target)
+        for target in _list_from_any(required_targets_raw)
+        if isinstance(target, str)
+    ]
+    if not required_targets:
+        return False
+    return promotion_target in required_targets
+
+
+def _requires_expert_router_registry(
+    *, policy_payload: dict[str, Any], promotion_target: str
+) -> bool:
+    if promotion_target == "shadow":
+        return False
+    if not bool(policy_payload.get("promotion_require_expert_router_registry", False)):
+        return False
+    required_targets_raw = policy_payload.get(
+        "promotion_expert_router_required_targets",
         ["paper", "live"],
     )
     required_targets = [
@@ -1602,6 +1663,18 @@ def _evaluate_promotion_evidence(
     reasons.extend(hmm_reasons)
     details.extend(hmm_details)
     refs.extend(hmm_refs)
+
+    expert_router_reasons, expert_router_details, expert_router_refs = (
+        _evaluate_expert_router_registry_evidence(
+            policy_payload=policy_payload,
+            gate_report_payload=gate_report_payload,
+            artifact_root=artifact_root,
+            promotion_target=promotion_target,
+        )
+    )
+    reasons.extend(expert_router_reasons)
+    details.extend(expert_router_details)
+    refs.extend(expert_router_refs)
 
     rationale_reasons, rationale_details = _evaluate_rationale_evidence(
         policy_payload=policy_payload,
@@ -2715,6 +2788,207 @@ def _evaluate_hmm_state_posterior_evidence(
             details.append(
                 {
                     "reason": "hmm_state_posterior_artifact_hash_mismatch",
+                    "artifact_ref": str(artifact_path),
+                    "artifact_hash": artifact_hash,
+                    "expected_artifact_hash": expected_hash,
+                }
+            )
+
+    return reasons, details, refs
+
+
+def _evaluate_expert_router_registry_evidence(
+    *,
+    policy_payload: dict[str, Any],
+    gate_report_payload: dict[str, Any],
+    artifact_root: Path,
+    promotion_target: str,
+) -> tuple[list[str], list[dict[str, object]], list[str]]:
+    if not _requires_expert_router_registry(
+        policy_payload=policy_payload,
+        promotion_target=promotion_target,
+    ):
+        return [], [], []
+
+    reasons: list[str] = []
+    details: list[dict[str, object]] = []
+    refs: list[str] = []
+
+    evidence = _as_dict(gate_report_payload.get("promotion_evidence"))
+    expert_router = _as_dict(evidence.get("expert_router_registry"))
+    evidence_ref = str(expert_router.get("artifact_ref") or "").strip()
+    if not evidence_ref:
+        reasons.append("expert_router_registry_artifact_ref_missing")
+        details.append({"reason": "expert_router_registry_artifact_ref_missing"})
+
+    required_artifacts = _expert_router_required_artifact_refs(policy_payload)
+    artifact_ref = (evidence_ref or required_artifacts[0]).strip()
+    artifact_path = _normalize_artifact_path(artifact_ref, artifact_root=artifact_root)
+    if artifact_path is None:
+        reasons.append("expert_router_registry_artifact_ref_invalid")
+        details.append(
+            {
+                "reason": "expert_router_registry_artifact_ref_invalid",
+                "artifact_ref": artifact_ref,
+            }
+        )
+        return reasons, details, refs
+
+    refs.append(evidence_ref or str(artifact_path))
+    payload = _load_json_if_exists(artifact_path)
+    if payload is None:
+        reasons.append("expert_router_registry_artifact_invalid_json")
+        details.append(
+            {
+                "reason": "expert_router_registry_artifact_invalid_json",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+        return reasons, details, refs
+
+    schema_version = str(payload.get("schema_version", "")).strip()
+    if schema_version != "expert-router-registry-v1":
+        reasons.append("expert_router_registry_schema_version_invalid")
+        details.append(
+            {
+                "reason": "expert_router_registry_schema_version_invalid",
+                "artifact_ref": str(artifact_path),
+                "schema_version": schema_version,
+                "expected_schema_version": "expert-router-registry-v1",
+            }
+        )
+
+    if not str(payload.get("run_id", "")).strip():
+        reasons.append("expert_router_registry_run_id_missing")
+        details.append(
+            {
+                "reason": "expert_router_registry_run_id_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    if not str(payload.get("candidate_id", "")).strip():
+        reasons.append("expert_router_registry_candidate_id_missing")
+        details.append(
+            {
+                "reason": "expert_router_registry_candidate_id_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+
+    route_count = _int_or_default(payload.get("route_count"), -1)
+    min_route_count = max(
+        1, _int_or_default(policy_payload.get("promotion_expert_router_min_route_count"), 1)
+    )
+    if route_count < min_route_count:
+        reasons.append("expert_router_registry_route_count_below_minimum")
+        details.append(
+            {
+                "reason": "expert_router_registry_route_count_below_minimum",
+                "artifact_ref": str(artifact_path),
+                "actual_route_count": route_count,
+                "minimum_route_count": min_route_count,
+            }
+        )
+
+    fallback_rate = _float_or_none(payload.get("fallback_rate"))
+    max_fallback_rate = _float_or_none(
+        policy_payload.get("promotion_expert_router_max_fallback_rate")
+    )
+    if max_fallback_rate is None:
+        max_fallback_rate = 0.05
+    if fallback_rate is None:
+        reasons.append("expert_router_registry_fallback_rate_missing")
+        details.append(
+            {
+                "reason": "expert_router_registry_fallback_rate_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    elif fallback_rate > max_fallback_rate:
+        reasons.append("expert_router_registry_fallback_rate_exceeds_threshold")
+        details.append(
+            {
+                "reason": "expert_router_registry_fallback_rate_exceeds_threshold",
+                "artifact_ref": str(artifact_path),
+                "actual_fallback_rate": fallback_rate,
+                "maximum_fallback_rate": max_fallback_rate,
+            }
+        )
+
+    max_expert_weight = _float_or_none(payload.get("max_expert_weight"))
+    max_concentration = _float_or_none(
+        policy_payload.get("promotion_expert_router_max_expert_concentration")
+    )
+    if max_concentration is None:
+        max_concentration = 0.85
+    if max_expert_weight is None:
+        reasons.append("expert_router_registry_max_expert_weight_missing")
+        details.append(
+            {
+                "reason": "expert_router_registry_max_expert_weight_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    elif max_expert_weight > max_concentration:
+        reasons.append("expert_router_registry_expert_concentration_exceeds_threshold")
+        details.append(
+            {
+                "reason": "expert_router_registry_expert_concentration_exceeds_threshold",
+                "artifact_ref": str(artifact_path),
+                "actual_max_expert_weight": max_expert_weight,
+                "maximum_expert_weight": max_concentration,
+            }
+        )
+
+    slo_feedback = _as_dict(payload.get("slo_feedback"))
+    overall_status = str(slo_feedback.get("overall_status") or "").strip()
+    if overall_status != "pass":
+        reasons.append("expert_router_registry_slo_feedback_not_pass")
+        details.append(
+            {
+                "reason": "expert_router_registry_slo_feedback_not_pass",
+                "artifact_ref": str(artifact_path),
+                "overall_status": overall_status,
+                "slo_reasons": _list_of_strings(slo_feedback.get("reasons")),
+            }
+        )
+
+    source_lineage = _as_dict(payload.get("source_lineage"))
+    walkforward_ref = str(
+        source_lineage.get("walkforward_results_artifact_ref") or ""
+    ).strip()
+    hmm_ref = str(source_lineage.get("hmm_state_posterior_artifact_ref") or "").strip()
+    gate_policy_ref = str(source_lineage.get("gate_policy_artifact_ref") or "").strip()
+    if not walkforward_ref or not hmm_ref or not gate_policy_ref:
+        reasons.append("expert_router_registry_source_lineage_incomplete")
+        details.append(
+            {
+                "reason": "expert_router_registry_source_lineage_incomplete",
+                "artifact_ref": str(artifact_path),
+                "walkforward_results_artifact_ref": walkforward_ref,
+                "hmm_state_posterior_artifact_ref": hmm_ref,
+                "gate_policy_artifact_ref": gate_policy_ref,
+            }
+        )
+
+    artifact_hash = str(payload.get("artifact_hash", "")).strip()
+    if not artifact_hash:
+        reasons.append("expert_router_registry_artifact_hash_missing")
+        details.append(
+            {
+                "reason": "expert_router_registry_artifact_hash_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    else:
+        expected_hash = _sha256_json(
+            {key: value for key, value in payload.items() if key != "artifact_hash"}
+        )
+        if artifact_hash != expected_hash:
+            reasons.append("expert_router_registry_artifact_hash_mismatch")
+            details.append(
+                {
+                    "reason": "expert_router_registry_artifact_hash_mismatch",
                     "artifact_ref": str(artifact_path),
                     "artifact_hash": artifact_hash,
                     "expected_artifact_hash": expected_hash,

--- a/services/torghut/app/trading/autonomy/policy_contract.py
+++ b/services/torghut/app/trading/autonomy/policy_contract.py
@@ -11,6 +11,7 @@ _REQUIRED_BOOL_KEYS: tuple[str, ...] = (
     "promotion_require_profitability_stage_replay_contract",
     "promotion_require_benchmark_parity",
     "promotion_require_hmm_state_posterior",
+    "promotion_require_expert_router_registry",
     "promotion_require_janus_evidence",
     "promotion_require_stress_evidence",
 )
@@ -22,6 +23,7 @@ _REQUIRED_STRING_KEYS: tuple[str, ...] = (
 _REQUIRED_LIST_KEYS: tuple[str, ...] = (
     "promotion_benchmark_required_artifacts",
     "promotion_hmm_required_artifacts",
+    "promotion_expert_router_required_artifacts",
     "promotion_janus_required_artifacts",
     "promotion_stress_required_artifacts",
 )

--- a/services/torghut/config/autonomous-gate-policy.json
+++ b/services/torghut/config/autonomous-gate-policy.json
@@ -88,6 +88,14 @@
     "gates/hmm-state-posterior-v1.json"
   ],
   "promotion_hmm_min_authoritative_sample_ratio": "0.0",
+  "promotion_require_expert_router_registry": true,
+  "promotion_expert_router_required_targets": ["paper", "live"],
+  "promotion_expert_router_required_artifacts": [
+    "gates/expert-router-registry-v1.json"
+  ],
+  "promotion_expert_router_min_route_count": 1,
+  "promotion_expert_router_max_fallback_rate": "0.05",
+  "promotion_expert_router_max_expert_concentration": "0.85",
   "promotion_require_janus_evidence": true,
   "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
   "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -88,6 +88,14 @@
     "gates/hmm-state-posterior-v1.json"
   ],
   "promotion_hmm_min_authoritative_sample_ratio": "0.0",
+  "promotion_require_expert_router_registry": true,
+  "promotion_expert_router_required_targets": ["paper", "live"],
+  "promotion_expert_router_required_artifacts": [
+    "gates/expert-router-registry-v1.json"
+  ],
+  "promotion_expert_router_min_route_count": 1,
+  "promotion_expert_router_max_fallback_rate": "0.05",
+  "promotion_expert_router_max_expert_concentration": "0.85",
   "promotion_require_janus_evidence": true,
   "promotion_janus_event_car_artifact": "gates/janus-event-car-v1.json",
   "promotion_janus_hgrm_reward_artifact": "gates/janus-hgrm-reward-v1.json",

--- a/services/torghut/scripts/run_governance_policy_dry_run.py
+++ b/services/torghut/scripts/run_governance_policy_dry_run.py
@@ -161,6 +161,7 @@ def main() -> int:
         }
         promotion_evidence = gate_report.get("promotion_evidence")
         hmm_posterior_payload: dict[str, Any] = {}
+        expert_router_payload: dict[str, Any] = {}
         if isinstance(promotion_evidence, dict):
             stress_metrics = promotion_evidence.get("stress_metrics")
             if isinstance(stress_metrics, dict):
@@ -193,6 +194,19 @@ def main() -> int:
                 }
             promotion_evidence["hmm_state_posterior"]["artifact_ref"] = (
                 "gates/hmm-state-posterior-v1.json"
+            )
+            expert_router_registry = promotion_evidence.get("expert_router_registry")
+            if isinstance(expert_router_registry, dict):
+                expert_router_payload = {
+                    str(key): value for key, value in expert_router_registry.items()
+                }
+            else:
+                expert_router_payload = {}
+                promotion_evidence["expert_router_registry"] = {
+                    "artifact_ref": "gates/expert-router-registry-v1.json"
+                }
+            promotion_evidence["expert_router_registry"]["artifact_ref"] = (
+                "gates/expert-router-registry-v1.json"
             )
         if "generated_at" not in stress_artifact:
             stress_artifact["generated_at"] = datetime.now(timezone.utc).isoformat()
@@ -291,6 +305,70 @@ def main() -> int:
         )
         (root / "gates" / "hmm-state-posterior-v1.json").write_text(
             json.dumps(hmm_artifact, indent=2), encoding="utf-8"
+        )
+        expert_router_artifact: dict[str, Any] = {
+            "schema_version": "expert-router-registry-v1",
+            "run_id": str(gate_report.get("run_id", "run-dry-run")),
+            "candidate_id": "cand-dry-run",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "router_version": str(expert_router_payload.get("router_version") or "router-v1"),
+            "route_count": int(expert_router_payload.get("route_count") or 10),
+            "fallback_count": int(expert_router_payload.get("fallback_count") or 0),
+            "fallback_rate": str(expert_router_payload.get("fallback_rate") or "0"),
+            "max_expert_weight": str(expert_router_payload.get("max_expert_weight") or "0.62"),
+            "avg_expert_weights": {
+                "trend": "0.62",
+                "reversal": "0.14",
+                "breakout": "0.20",
+                "defensive": "0.04",
+            },
+            "top_expert_counts": {
+                "trend": 10,
+                "reversal": 0,
+                "breakout": 0,
+                "defensive": 0,
+            },
+            "concentration": {
+                "dominant_expert": "trend",
+                "dominant_expert_count": 10,
+                "max_expert_weight": str(
+                    expert_router_payload.get("max_expert_weight") or "0.62"
+                ),
+            },
+            "slo_feedback": {
+                "max_fallback_rate": str(
+                    policy.get("promotion_expert_router_max_fallback_rate", "0.05")
+                ),
+                "max_expert_concentration": str(
+                    policy.get(
+                        "promotion_expert_router_max_expert_concentration", "0.85"
+                    )
+                ),
+                "fallback_rate": str(expert_router_payload.get("fallback_rate") or "0"),
+                "max_observed_expert_weight": str(
+                    expert_router_payload.get("max_expert_weight") or "0.62"
+                ),
+                "fallback_slo_pass": True,
+                "concentration_slo_pass": True,
+                "overall_status": "pass",
+                "reasons": [],
+            },
+            "source_lineage": {
+                "walkforward_results_artifact_ref": "backtest/evaluation-report.json",
+                "hmm_state_posterior_artifact_ref": "gates/hmm-state-posterior-v1.json",
+                "gate_policy_artifact_ref": "gates/gate-evaluation.json",
+                "strategy_config_artifact_ref": "research/candidate-spec.json",
+            },
+        }
+        expert_router_artifact["artifact_hash"] = _stable_hash(
+            {
+                key: value
+                for key, value in expert_router_artifact.items()
+                if key != "artifact_hash"
+            }
+        )
+        (root / "gates" / "expert-router-registry-v1.json").write_text(
+            json.dumps(expert_router_artifact, indent=2), encoding="utf-8"
         )
 
         if args.simulate_missing_artifact:

--- a/services/torghut/tests/test_autonomous_lane.py
+++ b/services/torghut/tests/test_autonomous_lane.py
@@ -249,6 +249,10 @@ class TestAutonomousLane(TestCase):
                 evidence["hmm_state_posterior"]["artifact_ref"],
                 str(output_dir / "gates" / "hmm-state-posterior-v1.json"),
             )
+            self.assertEqual(
+                evidence["expert_router_registry"]["artifact_ref"],
+                str(output_dir / "gates" / "expert-router-registry-v1.json"),
+            )
             self.assertTrue(
                 (output_dir / "gates" / "stress-metrics-v1.json").exists()
             )
@@ -262,6 +266,9 @@ class TestAutonomousLane(TestCase):
             )
             self.assertTrue(
                 (output_dir / "gates" / "hmm-state-posterior-v1.json").exists()
+            )
+            self.assertTrue(
+                (output_dir / "gates" / "expert-router-registry-v1.json").exists()
             )
             hmm_state_posterior_payload = json.loads(
                 (output_dir / "gates" / "hmm-state-posterior-v1.json").read_text(
@@ -416,6 +423,10 @@ class TestAutonomousLane(TestCase):
                     evidence["hmm_state_posterior"]["artifact_ref"],
                     str(Path("gates") / "hmm-state-posterior-v1.json"),
                 )
+                self.assertEqual(
+                    evidence["expert_router_registry"]["artifact_ref"],
+                    str(Path("gates") / "expert-router-registry-v1.json"),
+                )
                 self.assertTrue(
                     (output_dir / "gates" / "stress-metrics-v1.json").exists()
                 )
@@ -429,6 +440,9 @@ class TestAutonomousLane(TestCase):
                 )
                 self.assertTrue(
                     (output_dir / "gates" / "hmm-state-posterior-v1.json").exists()
+                )
+                self.assertTrue(
+                    (output_dir / "gates" / "expert-router-registry-v1.json").exists()
                 )
             finally:
                 os.chdir(original_cwd)

--- a/services/torghut/tests/test_governance_policy_dry_run.py
+++ b/services/torghut/tests/test_governance_policy_dry_run.py
@@ -68,6 +68,15 @@ def _default_gate_report(now: datetime) -> dict[str, object]:
                 "authoritative_samples": 6,
                 "authoritative_sample_ratio": "0.6",
             },
+            "expert_router_registry": {
+                "artifact_ref": "gates/expert-router-registry-v1.json",
+                "schema_version": "expert-router-registry-v1",
+                "router_version": "router-v1",
+                "route_count": 10,
+                "fallback_count": 0,
+                "fallback_rate": "0",
+                "max_expert_weight": "0.62",
+            },
             "promotion_rationale": {
                 "requested_target": "paper",
                 "gate_recommended_mode": "paper",

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -268,6 +268,189 @@ class TestPolicyChecks(TestCase):
         self.assertNotIn("hmm_state_posterior_artifact_ref_missing", promotion.reasons)
         self.assertIn(str(root / "gates" / "hmm-state-posterior-v1.json"), promotion.artifact_refs)
 
+    def test_promotion_prerequisites_fail_when_expert_router_registry_required_and_missing(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            gate_report = _gate_report()
+            promotion_evidence = gate_report.get("promotion_evidence", {})
+            assert isinstance(promotion_evidence, dict)
+            promotion_evidence.pop("expert_router_registry", None)
+            (root / "gates" / "gate-evaluation.json").write_text(
+                json.dumps(gate_report),
+                encoding="utf-8",
+            )
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_expert_router_registry": True,
+                    "promotion_expert_router_required_targets": ["paper", "live"],
+                    "promotion_expert_router_required_artifacts": [
+                        "gates/expert-router-registry-v1.json"
+                    ],
+                    "promotion_require_patch_targets": [],
+                    "promotion_require_profitability_stage_manifest": False,
+                    "promotion_require_benchmark_parity": False,
+                    "promotion_require_contamination_registry": False,
+                    "promotion_require_stress_evidence": False,
+                    "promotion_require_hmm_state_posterior": False,
+                    "promotion_require_janus_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "gate6_require_profitability_evidence": False,
+                },
+                gate_report_payload=gate_report,
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn("required_artifacts_missing", promotion.reasons)
+        self.assertIn(
+            "gates/expert-router-registry-v1.json",
+            promotion.missing_artifacts,
+        )
+        self.assertIn(
+            "expert_router_registry_artifact_ref_missing",
+            promotion.reasons,
+        )
+
+    def test_promotion_prerequisites_accept_valid_expert_router_registry_evidence(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            (root / "gates" / "gate-evaluation.json").write_text(
+                json.dumps(_gate_report()),
+                encoding="utf-8",
+            )
+            expert_router_artifact = root / "gates" / "expert-router-registry-v1.json"
+            expert_router_payload = {
+                "schema_version": "expert-router-registry-v1",
+                "run_id": "run-test",
+                "candidate_id": "cand-test",
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "router_version": "router-v1",
+                "route_count": 5,
+                "fallback_count": 0,
+                "fallback_rate": "0",
+                "max_expert_weight": "0.62",
+                "avg_expert_weights": {
+                    "trend": "0.62",
+                    "reversal": "0.14",
+                    "breakout": "0.20",
+                    "defensive": "0.04",
+                },
+                "top_expert_counts": {
+                    "trend": 5,
+                    "reversal": 0,
+                    "breakout": 0,
+                    "defensive": 0,
+                },
+                "concentration": {
+                    "dominant_expert": "trend",
+                    "dominant_expert_count": 5,
+                    "max_expert_weight": "0.62",
+                },
+                "slo_feedback": {
+                    "max_fallback_rate": "0.05",
+                    "max_expert_concentration": "0.85",
+                    "fallback_rate": "0",
+                    "max_observed_expert_weight": "0.62",
+                    "fallback_slo_pass": True,
+                    "concentration_slo_pass": True,
+                    "overall_status": "pass",
+                    "reasons": [],
+                },
+                "source_lineage": {
+                    "walkforward_results_artifact_ref": "backtest/walkforward-results.json",
+                    "hmm_state_posterior_artifact_ref": "gates/hmm-state-posterior-v1.json",
+                    "gate_policy_artifact_ref": "gates/gate-evaluation.json",
+                    "strategy_config_artifact_ref": "research/candidate-spec.json",
+                },
+            }
+            expert_router_payload["artifact_hash"] = _sha256_json(
+                {
+                    key: value
+                    for key, value in expert_router_payload.items()
+                    if key != "artifact_hash"
+                }
+            )
+            expert_router_artifact.write_text(
+                json.dumps(expert_router_payload),
+                encoding="utf-8",
+            )
+
+            gate_report = _gate_report()
+            promotion_evidence = gate_report.get("promotion_evidence", {})
+            assert isinstance(promotion_evidence, dict)
+            promotion_evidence["expert_router_registry"] = {
+                "artifact_ref": "gates/expert-router-registry-v1.json",
+                "schema_version": "expert-router-registry-v1",
+                "route_count": 5,
+                "fallback_rate": "0",
+                "max_expert_weight": "0.62",
+            }
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_expert_router_registry": True,
+                    "promotion_expert_router_required_targets": ["paper", "live"],
+                    "promotion_expert_router_required_artifacts": [
+                        "gates/expert-router-registry-v1.json"
+                    ],
+                    "promotion_expert_router_min_route_count": 1,
+                    "promotion_expert_router_max_fallback_rate": "0.05",
+                    "promotion_expert_router_max_expert_concentration": "0.85",
+                    "promotion_require_patch_targets": [],
+                    "promotion_require_profitability_stage_manifest": False,
+                    "promotion_require_benchmark_parity": False,
+                    "promotion_require_contamination_registry": False,
+                    "promotion_require_stress_evidence": False,
+                    "promotion_require_hmm_state_posterior": False,
+                    "promotion_require_janus_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "gate6_require_profitability_evidence": False,
+                },
+                gate_report_payload=gate_report,
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertTrue(promotion.allowed)
+        self.assertNotIn(
+            "expert_router_registry_artifact_ref_missing",
+            promotion.reasons,
+        )
+        self.assertIn(
+            str(root / "gates" / "expert-router-registry-v1.json"),
+            promotion.artifact_refs,
+        )
+
     def test_promotion_prerequisites_fail_when_profitability_stage_manifest_replay_contract_missing(
         self,
     ) -> None:
@@ -3825,6 +4008,7 @@ def _build_profitability_stage_manifest_payload(
     janus_hgrm_reward_path: Path,
     recalibration_report_path: Path,
     hmm_state_posterior_path: Path | None = None,
+    expert_router_registry_path: Path | None = None,
     rollback_readiness_path: Path | None = None,
     stage_statuses: dict[str, str] | None = None,
     check_status_overrides: dict[tuple[str, str], str] | None = None,
@@ -3878,6 +4062,65 @@ def _build_profitability_stage_manifest_payload(
             json.dumps(hmm_payload),
             encoding="utf-8",
         )
+    if expert_router_registry_path is None:
+        expert_router_registry_path = root / "gates" / "expert-router-registry-v1.json"
+    if not expert_router_registry_path.exists():
+        expert_router_registry_path.parent.mkdir(parents=True, exist_ok=True)
+        expert_router_payload: dict[str, object] = {
+            "schema_version": "expert-router-registry-v1",
+            "run_id": "run-test",
+            "candidate_id": "cand-test",
+            "generated_at": "2026-03-01T00:00:00+00:00",
+            "router_version": "router-v1",
+            "route_count": 1,
+            "fallback_count": 0,
+            "fallback_rate": "0",
+            "max_expert_weight": "0.62",
+            "avg_expert_weights": {
+                "trend": "0.62",
+                "reversal": "0.14",
+                "breakout": "0.20",
+                "defensive": "0.04",
+            },
+            "top_expert_counts": {
+                "trend": 1,
+                "reversal": 0,
+                "breakout": 0,
+                "defensive": 0,
+            },
+            "concentration": {
+                "dominant_expert": "trend",
+                "dominant_expert_count": 1,
+                "max_expert_weight": "0.62",
+            },
+            "slo_feedback": {
+                "max_fallback_rate": "0.05",
+                "max_expert_concentration": "0.85",
+                "fallback_rate": "0",
+                "max_observed_expert_weight": "0.62",
+                "fallback_slo_pass": True,
+                "concentration_slo_pass": True,
+                "overall_status": "pass",
+                "reasons": [],
+            },
+            "source_lineage": {
+                "walkforward_results_artifact_ref": "backtest/walkforward-results.json",
+                "hmm_state_posterior_artifact_ref": "gates/hmm-state-posterior-v1.json",
+                "gate_policy_artifact_ref": "gates/gate-evaluation.json",
+                "strategy_config_artifact_ref": "research/candidate-spec.json",
+            },
+        }
+        expert_router_payload["artifact_hash"] = _sha256_json(
+            {
+                key: value
+                for key, value in expert_router_payload.items()
+                if key != "artifact_hash"
+            }
+        )
+        expert_router_registry_path.write_text(
+            json.dumps(expert_router_payload),
+            encoding="utf-8",
+        )
 
     stage_owner = {
         "research": "research-orchestrator",
@@ -3903,6 +4146,11 @@ def _build_profitability_stage_manifest_payload(
             ("evaluation_report_present", "evaluation_report", evaluation_report_path),
             ("gate_evaluation_present", "gate_evaluation", gate_report_path),
             ("hmm_state_posterior_present", "hmm_state_posterior", hmm_state_posterior_path),
+            (
+                "expert_router_registry_present",
+                "expert_router_registry",
+                expert_router_registry_path,
+            ),
             ("janus_event_car_present", "janus_event_car", janus_event_car_path),
             ("janus_hgrm_reward_present", "janus_hgrm_reward", janus_hgrm_reward_path),
             ("recalibration_report_present", "recalibration_report", recalibration_report_path),
@@ -4165,6 +4413,15 @@ def _gate_report() -> dict[str, object]:
                 "samples_total": 12,
                 "authoritative_samples": 8,
                 "authoritative_sample_ratio": "0.6667",
+            },
+            "expert_router_registry": {
+                "artifact_ref": "gates/expert-router-registry-v1.json",
+                "schema_version": "expert-router-registry-v1",
+                "router_version": "router-v1",
+                "route_count": 12,
+                "fallback_count": 0,
+                "fallback_rate": "0",
+                "max_expert_weight": "0.62",
             },
             "promotion_rationale": {
                 "requested_target": "paper",


### PR DESCRIPTION
## Summary

- Added deterministic `expert-router-registry-v1` artifact generation in the Torghut autonomous lane, including concentration and fallback-rate SLO feedback fields with lineage and artifact hashing.
- Wired expert-router registry evidence into gate promotion evidence, profitability stage manifests, provenance/recommendation artifacts, and replay artifact references.
- Enforced fail-closed policy checks for expert-router evidence (artifact ref/path trust, schema, route count, fallback/concentration thresholds, lineage completeness, hash integrity).
- Updated runtime/GitOps policy contracts and policy parity payloads to require expert-router registry artifacts for `paper` and `live` targets.
- Extended dry-run harness and regression tests across autonomy lane, policy checks, and governance dry-run fixtures; marked Wave 3 deliverable 2 complete in v6 docs.

## Related Issues

None

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev --python 3.12`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --with pytest pytest`
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
