### PR TITLE
feat(torghut): gate promotion and drift on regime-state quality

### DIFF
--- a/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
+++ b/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
@@ -99,6 +99,8 @@ data:
         "gates/hmm-state-posterior-v1.json"
       ],
       "promotion_hmm_min_authoritative_sample_ratio": "0.0",
+      "promotion_hmm_max_transition_shock_ratio": "0.20",
+      "promotion_hmm_max_stale_or_defensive_ratio": "0.20",
       "promotion_require_expert_router_registry": true,
       "promotion_expert_router_required_targets": ["paper", "live"],
       "promotion_expert_router_required_artifacts": [

--- a/docs/torghut/design-system/v6/02-regime-adaptive-expert-router-design.md
+++ b/docs/torghut/design-system/v6/02-regime-adaptive-expert-router-design.md
@@ -12,7 +12,7 @@
   - `services/torghut/app/trading/forecasting.py`
   - `services/torghut/app/trading/scheduler.py`
   - `services/torghut/app/trading/portfolio.py`
-- Rollout gap: expert-router artifact registry and concentration/fallback SLO loop artifacts are implemented in the autonomous lane (`2026-03-03`); remaining closure is wiring regime-quality outputs into promotion + drift governance decisions.
+- Rollout gap: closed for Wave 3 scope; expert-router registry + concentration/fallback SLO artifacts and regime-quality promotion/drift governance wiring are implemented (`2026-03-03`).
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -150,7 +150,7 @@ Close architecture gaps for regime-adaptive routing with persisted HMM state lin
 
 1. Implement HMM posterior state artifact (`hmm_state_posterior`) persistence and lineage references. (Completed `2026-03-03`)
 2. Add expert-router artifact registry with concentration/fallback SLO feedback loop. (Completed `2026-03-03`)
-3. Wire regime-state quality into promotion and drift governance decisions.
+3. Wire regime-state quality into promotion and drift governance decisions. (Completed `2026-03-03`)
 
 ### Primary files
 

--- a/services/torghut/app/trading/autonomy/drift.py
+++ b/services/torghut/app/trading/autonomy/drift.py
@@ -20,6 +20,8 @@ REASON_DATA_DUPLICATE_RATIO = "data_duplicate_ratio_exceeded"
 REASON_DATA_SCHEMA_MISMATCH = "data_schema_mismatch_detected"
 REASON_MODEL_CALIBRATION_ERROR = "model_calibration_error_exceeded"
 REASON_MODEL_LLM_ERROR_RATIO = "model_llm_error_ratio_exceeded"
+REASON_REGIME_TRANSITION_SHOCK_RATIO = "regime_transition_shock_ratio_exceeded"
+REASON_REGIME_STALE_OR_DEFENSIVE_RATIO = "regime_stale_or_defensive_ratio_exceeded"
 REASON_PERF_NET_PNL = "performance_net_pnl_below_floor"
 REASON_PERF_DRAWDOWN = "performance_drawdown_exceeded"
 REASON_PERF_COST_BPS = "performance_cost_bps_exceeded"
@@ -35,6 +37,8 @@ class DriftThresholds:
     max_schema_mismatch_total: int = 0
     max_model_calibration_error: Decimal = Decimal("0.45")
     max_model_llm_error_ratio: Decimal = Decimal("0.10")
+    max_regime_transition_shock_ratio: Decimal = Decimal("0.20")
+    max_regime_stale_or_defensive_ratio: Decimal = Decimal("0.20")
     min_performance_net_pnl: Decimal = Decimal("0")
     max_performance_drawdown: Decimal = Decimal("0.08")
     max_performance_cost_bps: Decimal = Decimal("35")
@@ -48,6 +52,12 @@ class DriftThresholds:
             "max_schema_mismatch_total": self.max_schema_mismatch_total,
             "max_model_calibration_error": str(self.max_model_calibration_error),
             "max_model_llm_error_ratio": str(self.max_model_llm_error_ratio),
+            "max_regime_transition_shock_ratio": str(
+                self.max_regime_transition_shock_ratio
+            ),
+            "max_regime_stale_or_defensive_ratio": str(
+                self.max_regime_stale_or_defensive_ratio
+            ),
             "min_performance_net_pnl": str(self.min_performance_net_pnl),
             "max_performance_drawdown": str(self.max_performance_drawdown),
             "max_performance_cost_bps": str(self.max_performance_cost_bps),
@@ -180,6 +190,7 @@ def detect_drift(
     signals: list[DriftSignal] = []
     signals.extend(_data_drift_signals(feature_quality_report, thresholds))
     signals.extend(_model_drift_signals(gate_report_payload, thresholds))
+    signals.extend(_regime_drift_signals(gate_report_payload, thresholds))
     signals.extend(
         _performance_drift_signals(
             gate_report_payload=gate_report_payload,
@@ -370,6 +381,50 @@ def _performance_drift_signals(
     return signals
 
 
+def _regime_drift_signals(
+    gate_report_payload: Mapping[str, Any],
+    thresholds: DriftThresholds,
+) -> list[DriftSignal]:
+    evidence_payload = _as_mapping(gate_report_payload.get("promotion_evidence"))
+    hmm_payload = _as_mapping(evidence_payload.get("hmm_state_posterior"))
+    samples_total = _to_int(hmm_payload.get("samples_total"))
+    if samples_total is None or samples_total <= 0:
+        return []
+
+    signals: list[DriftSignal] = []
+
+    transition_shock_samples = _to_int(hmm_payload.get("transition_shock_samples"))
+    if transition_shock_samples is not None and transition_shock_samples >= 0:
+        transition_shock_ratio = Decimal(transition_shock_samples) / Decimal(samples_total)
+        if transition_shock_ratio > thresholds.max_regime_transition_shock_ratio:
+            signals.append(
+                _drift_signal(
+                    category="regime",
+                    reason_code=REASON_REGIME_TRANSITION_SHOCK_RATIO,
+                    observed=transition_shock_ratio,
+                    threshold=thresholds.max_regime_transition_shock_ratio,
+                    comparator=">",
+                )
+            )
+
+    stale_or_defensive_samples = _to_int(hmm_payload.get("stale_or_defensive_samples"))
+    if stale_or_defensive_samples is not None and stale_or_defensive_samples >= 0:
+        stale_or_defensive_ratio = Decimal(stale_or_defensive_samples) / Decimal(
+            samples_total
+        )
+        if stale_or_defensive_ratio > thresholds.max_regime_stale_or_defensive_ratio:
+            signals.append(
+                _drift_signal(
+                    category="regime",
+                    reason_code=REASON_REGIME_STALE_OR_DEFENSIVE_RATIO,
+                    observed=stale_or_defensive_ratio,
+                    threshold=thresholds.max_regime_stale_or_defensive_ratio,
+                    comparator=">",
+                )
+            )
+    return signals
+
+
 def _drift_signal(
     *,
     category: DriftCategory,
@@ -485,6 +540,15 @@ def _to_decimal(raw: Any) -> Decimal | None:
         return None
 
 
+def _to_int(raw: Any) -> int | None:
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except Exception:
+        return None
+
+
 def _extract_profitability_decimal(
     payload: Mapping[str, Any], path: list[str]
 ) -> Decimal | None:
@@ -515,6 +579,8 @@ __all__ = [
     "REASON_DATA_SCHEMA_MISMATCH",
     "REASON_MODEL_CALIBRATION_ERROR",
     "REASON_MODEL_LLM_ERROR_RATIO",
+    "REASON_REGIME_TRANSITION_SHOCK_RATIO",
+    "REASON_REGIME_STALE_OR_DEFENSIVE_RATIO",
     "REASON_PERF_NET_PNL",
     "REASON_PERF_DRAWDOWN",
     "REASON_PERF_COST_BPS",

--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -1970,6 +1970,12 @@ def run_autonomous_lane(
                 "authoritative_sample_ratio": hmm_state_posterior_payload.get(
                     "authoritative_sample_ratio"
                 ),
+                "transition_shock_samples": hmm_state_posterior_payload.get(
+                    "transition_shock_samples"
+                ),
+                "stale_or_defensive_samples": hmm_state_posterior_payload.get(
+                    "stale_or_defensive_samples"
+                ),
                 "top_regime_by_posterior_mass": hmm_state_posterior_payload.get(
                     "top_regime_by_posterior_mass"
                 ),
@@ -2300,6 +2306,12 @@ def run_autonomous_lane(
                 ),
                 "authoritative_sample_ratio": hmm_state_posterior_payload.get(
                     "authoritative_sample_ratio"
+                ),
+                "transition_shock_samples": hmm_state_posterior_payload.get(
+                    "transition_shock_samples"
+                ),
+                "stale_or_defensive_samples": hmm_state_posterior_payload.get(
+                    "stale_or_defensive_samples"
                 ),
                 "top_regime_by_posterior_mass": hmm_state_posterior_payload.get(
                     "top_regime_by_posterior_mass"

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -2744,6 +2744,93 @@ def _evaluate_hmm_state_posterior_evidence(
                 }
             )
 
+    transition_shock_samples = _int_or_default(payload.get("transition_shock_samples"), -1)
+    if transition_shock_samples < 0:
+        reasons.append("hmm_state_posterior_transition_shock_samples_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_transition_shock_samples_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    elif samples_total >= 0 and transition_shock_samples > samples_total:
+        reasons.append("hmm_state_posterior_transition_shock_samples_invalid")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_transition_shock_samples_invalid",
+                "artifact_ref": str(artifact_path),
+                "samples_total": samples_total,
+                "transition_shock_samples": transition_shock_samples,
+            }
+        )
+
+    stale_or_defensive_samples = _int_or_default(
+        payload.get("stale_or_defensive_samples"),
+        -1,
+    )
+    if stale_or_defensive_samples < 0:
+        reasons.append("hmm_state_posterior_stale_or_defensive_samples_missing")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_stale_or_defensive_samples_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    elif samples_total >= 0 and stale_or_defensive_samples > samples_total:
+        reasons.append("hmm_state_posterior_stale_or_defensive_samples_invalid")
+        details.append(
+            {
+                "reason": "hmm_state_posterior_stale_or_defensive_samples_invalid",
+                "artifact_ref": str(artifact_path),
+                "samples_total": samples_total,
+                "stale_or_defensive_samples": stale_or_defensive_samples,
+            }
+        )
+
+    if samples_total > 0:
+        max_transition_shock_ratio = _float_or_none(
+            policy_payload.get("promotion_hmm_max_transition_shock_ratio")
+        )
+        if (
+            max_transition_shock_ratio is not None
+            and transition_shock_samples >= 0
+            and (transition_shock_samples / samples_total) > max_transition_shock_ratio
+        ):
+            reasons.append("hmm_state_posterior_transition_shock_ratio_exceeds_threshold")
+            details.append(
+                {
+                    "reason": "hmm_state_posterior_transition_shock_ratio_exceeds_threshold",
+                    "artifact_ref": str(artifact_path),
+                    "samples_total": samples_total,
+                    "transition_shock_samples": transition_shock_samples,
+                    "actual_ratio": transition_shock_samples / samples_total,
+                    "maximum_ratio": max_transition_shock_ratio,
+                }
+            )
+
+        max_stale_or_defensive_ratio = _float_or_none(
+            policy_payload.get("promotion_hmm_max_stale_or_defensive_ratio")
+        )
+        if (
+            max_stale_or_defensive_ratio is not None
+            and stale_or_defensive_samples >= 0
+            and (stale_or_defensive_samples / samples_total)
+            > max_stale_or_defensive_ratio
+        ):
+            reasons.append(
+                "hmm_state_posterior_stale_or_defensive_ratio_exceeds_threshold"
+            )
+            details.append(
+                {
+                    "reason": "hmm_state_posterior_stale_or_defensive_ratio_exceeds_threshold",
+                    "artifact_ref": str(artifact_path),
+                    "samples_total": samples_total,
+                    "stale_or_defensive_samples": stale_or_defensive_samples,
+                    "actual_ratio": stale_or_defensive_samples / samples_total,
+                    "maximum_ratio": max_stale_or_defensive_ratio,
+                }
+            )
+
     source_lineage = _as_dict(payload.get("source_lineage"))
     walkforward_ref = str(
         source_lineage.get("walkforward_results_artifact_ref") or ""

--- a/services/torghut/config/autonomous-gate-policy.json
+++ b/services/torghut/config/autonomous-gate-policy.json
@@ -88,6 +88,8 @@
     "gates/hmm-state-posterior-v1.json"
   ],
   "promotion_hmm_min_authoritative_sample_ratio": "0.0",
+  "promotion_hmm_max_transition_shock_ratio": "0.20",
+  "promotion_hmm_max_stale_or_defensive_ratio": "0.20",
   "promotion_require_expert_router_registry": true,
   "promotion_expert_router_required_targets": ["paper", "live"],
   "promotion_expert_router_required_artifacts": [

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -88,6 +88,8 @@
     "gates/hmm-state-posterior-v1.json"
   ],
   "promotion_hmm_min_authoritative_sample_ratio": "0.0",
+  "promotion_hmm_max_transition_shock_ratio": "0.20",
+  "promotion_hmm_max_stale_or_defensive_ratio": "0.20",
   "promotion_require_expert_router_registry": true,
   "promotion_expert_router_required_targets": ["paper", "live"],
   "promotion_expert_router_required_artifacts": [

--- a/services/torghut/scripts/run_governance_policy_dry_run.py
+++ b/services/torghut/scripts/run_governance_policy_dry_run.py
@@ -287,8 +287,12 @@ def main() -> int:
             "authoritative_sample_ratio": str(
                 hmm_posterior_payload.get("authoritative_sample_ratio") or "0.6"
             ),
-            "transition_shock_samples": 0,
-            "stale_or_defensive_samples": 0,
+            "transition_shock_samples": int(
+                hmm_posterior_payload.get("transition_shock_samples") or 0
+            ),
+            "stale_or_defensive_samples": int(
+                hmm_posterior_payload.get("stale_or_defensive_samples") or 0
+            ),
             "regime_counts": {"r2": 10},
             "entropy_band_counts": {"medium": 10},
             "guardrail_reason_counts": {"none": 10},

--- a/services/torghut/tests/test_autonomy_drift.py
+++ b/services/torghut/tests/test_autonomy_drift.py
@@ -17,6 +17,8 @@ from app.trading.autonomy.drift import (
     REASON_PERF_DRAWDOWN,
     REASON_PERF_FALLBACK_RATIO,
     REASON_PERF_NET_PNL,
+    REASON_REGIME_STALE_OR_DEFENSIVE_RATIO,
+    REASON_REGIME_TRANSITION_SHOCK_RATIO,
     decide_drift_action,
     detect_drift,
     evaluate_live_promotion_evidence,
@@ -141,3 +143,42 @@ class TestAutonomyDrift(TestCase):
         self.assertFalse(evidence.eligible_for_live_promotion)
         self.assertIn("drift_detected", evidence.reasons)
         self.assertGreaterEqual(len(evidence.evidence_artifact_refs), 2)
+
+    def test_detect_drift_emits_regime_quality_reason_codes(self) -> None:
+        report = FeatureQualityReport(
+            accepted=True,
+            rows_total=10,
+            null_rate_by_field={"macd": 0.0},
+            staleness_ms_p95=100,
+            duplicate_ratio=0.0,
+            schema_mismatch_total=0,
+            reasons=[],
+        )
+        detection = detect_drift(
+            run_id="run-4",
+            feature_quality_report=report,
+            gate_report_payload={
+                "promotion_evidence": {
+                    "hmm_state_posterior": {
+                        "samples_total": 10,
+                        "transition_shock_samples": 4,
+                        "stale_or_defensive_samples": 3,
+                    }
+                }
+            },
+            fallback_ratio=Decimal("0"),
+            thresholds=DriftThresholds(
+                max_regime_transition_shock_ratio=Decimal("0.2"),
+                max_regime_stale_or_defensive_ratio=Decimal("0.2"),
+            ),
+        )
+
+        self.assertTrue(detection.drift_detected)
+        self.assertIn(
+            REASON_REGIME_TRANSITION_SHOCK_RATIO,
+            detection.reason_codes,
+        )
+        self.assertIn(
+            REASON_REGIME_STALE_OR_DEFENSIVE_RATIO,
+            detection.reason_codes,
+        )

--- a/services/torghut/tests/test_governance_policy_dry_run.py
+++ b/services/torghut/tests/test_governance_policy_dry_run.py
@@ -67,6 +67,8 @@ def _default_gate_report(now: datetime) -> dict[str, object]:
                 "samples_total": 10,
                 "authoritative_samples": 6,
                 "authoritative_sample_ratio": "0.6",
+                "transition_shock_samples": 0,
+                "stale_or_defensive_samples": 0,
             },
             "expert_router_registry": {
                 "artifact_ref": "gates/expert-router-registry-v1.json",

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -268,6 +268,89 @@ class TestPolicyChecks(TestCase):
         self.assertNotIn("hmm_state_posterior_artifact_ref_missing", promotion.reasons)
         self.assertIn(str(root / "gates" / "hmm-state-posterior-v1.json"), promotion.artifact_refs)
 
+    def test_promotion_prerequisites_fail_when_hmm_regime_quality_ratio_exceeds_threshold(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            gate_report = _gate_report()
+            (root / "gates" / "gate-evaluation.json").write_text(
+                json.dumps(gate_report),
+                encoding="utf-8",
+            )
+
+            hmm_artifact = root / "gates" / "hmm-state-posterior-v1.json"
+            hmm_payload = {
+                "schema_version": "hmm-state-posterior-v1",
+                "run_id": "run-test",
+                "candidate_id": "cand-test",
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "samples_total": 10,
+                "authoritative_samples": 6,
+                "authoritative_sample_ratio": "0.6",
+                "transition_shock_samples": 4,
+                "stale_or_defensive_samples": 3,
+                "regime_counts": {"r2": 10},
+                "entropy_band_counts": {"medium": 10},
+                "guardrail_reason_counts": {"none": 7, "transition_shock": 3},
+                "posterior_mass_by_regime": {"r2": "6.0", "r1": "4.0"},
+                "top_regime_by_posterior_mass": "r2",
+                "source_lineage": {
+                    "walkforward_results_artifact_ref": "backtest/walkforward-results.json",
+                    "gate_policy_artifact_ref": "gates/gate-evaluation.json",
+                    "decision_source": "walkforward_results",
+                },
+            }
+            hmm_payload["artifact_hash"] = _sha256_json(
+                {key: value for key, value in hmm_payload.items() if key != "artifact_hash"}
+            )
+            hmm_artifact.write_text(json.dumps(hmm_payload), encoding="utf-8")
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_hmm_state_posterior": True,
+                    "promotion_hmm_required_targets": ["paper", "live"],
+                    "promotion_hmm_required_artifacts": [
+                        "gates/hmm-state-posterior-v1.json"
+                    ],
+                    "promotion_hmm_max_transition_shock_ratio": "0.2",
+                    "promotion_hmm_max_stale_or_defensive_ratio": "0.2",
+                    "promotion_require_patch_targets": [],
+                    "promotion_require_profitability_stage_manifest": False,
+                    "promotion_require_benchmark_parity": False,
+                    "promotion_require_contamination_registry": False,
+                    "promotion_require_stress_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "gate6_require_profitability_evidence": False,
+                },
+                gate_report_payload=gate_report,
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn(
+            "hmm_state_posterior_transition_shock_ratio_exceeds_threshold",
+            promotion.reasons,
+        )
+        self.assertIn(
+            "hmm_state_posterior_stale_or_defensive_ratio_exceeds_threshold",
+            promotion.reasons,
+        )
+
     def test_promotion_prerequisites_fail_when_expert_router_registry_required_and_missing(
         self,
     ) -> None:
@@ -4413,6 +4496,8 @@ def _gate_report() -> dict[str, object]:
                 "samples_total": 12,
                 "authoritative_samples": 8,
                 "authoritative_sample_ratio": "0.6667",
+                "transition_shock_samples": 0,
+                "stale_or_defensive_samples": 0,
             },
             "expert_router_registry": {
                 "artifact_ref": "gates/expert-router-registry-v1.json",


### PR DESCRIPTION
## Summary

- Wire regime-state quality signals into drift governance by adding transition-shock and stale/defensive ratio drift checks.
- Extend autonomous lane promotion evidence to include `transition_shock_samples` and `stale_or_defensive_samples` from `hmm-state-posterior-v1`.
- Enforce new fail-closed HMM regime-quality thresholds in promotion prerequisites with policy/config parity in service and GitOps payloads.
- Add regression coverage across drift detection, promotion policy checks, and governance dry-run fixtures; update v6 Wave 3 docs to mark deliverable 3 complete.

## Related Issues

None

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev --python 3.12`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --with pytest pytest`
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
