### PR TITLE
chore(torghut): promote image 2795c236

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:921582bb8ebd5f225559f8a7367af858e04557bd946730dff7879fa48434262c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5d144d3d644bc81417e59e0074a0161df80f6403410c4cebf0688ca0e76ee05
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T12:52:51Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T13:15:09Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:921582bb8ebd5f225559f8a7367af858e04557bd946730dff7879fa48434262c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f5d144d3d644bc81417e59e0074a0161df80f6403410c4cebf0688ca0e76ee05
           ports:
             - name: http1
               containerPort: 8181
@@ -386,9 +386,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-172-g4de46b9d
+              value: v0.562.0-174-g2795c236
             - name: TORGHUT_COMMIT
-              value: 4de46b9df87b83f40a613b73f8003d89dbb90445
+              value: 2795c2365418a02d3b5129c304ced1ab3e5d7095
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2795c2365418a02d3b5129c304ced1ab3e5d7095`
- Image tag: `2795c236`
- Image digest: `sha256:f5d144d3d644bc81417e59e0074a0161df80f6403410c4cebf0688ca0e76ee05`