### PR TITLE
feat(torghut): standardize benchmark parity artifact contracts

### DIFF
--- a/docs/torghut/design-system/v6/09-external-benchmark-parity-suite-ai-trader-fev-gift.md
+++ b/docs/torghut/design-system/v6/09-external-benchmark-parity-suite-ai-trader-fev-gift.md
@@ -6,10 +6,13 @@
 - Date: `2026-03-01`
 - Maturity: `production design`
 - Scope: external benchmark parity contract for Torghut validation and promotion gates
-- Implementation status: `Planned`
+- Implementation status: `Partial`
 - Evidence:
-  - `docs/torghut/design-system/v6/09-external-benchmark-parity-suite-ai-trader-fev-gift.md` (design-level contract)
-- Rollout gap: current evaluation artifacts do not yet include explicit parity reports against modern public financial-agent benchmark families.
+  - `services/torghut/app/trading/parity.py`
+  - `services/torghut/app/trading/autonomy/policy_checks.py`
+  - `services/torghut/tests/test_feature_parity.py`
+  - `services/torghut/tests/test_policy_checks.py`
+- Rollout gap: benchmark parity artifact contract standardization is implemented (`2026-03-03`); remaining closure is Wave 4 deliverables 2-3 (coverage/calibration drift bounds hardening and promotion block completeness).
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -174,7 +174,7 @@ Require explicit parity reports against external benchmark families before promo
 
 ### Deliverables
 
-1. Standardize benchmark-parity artifact generation contracts.
+1. Standardize benchmark-parity artifact generation contracts. (Completed `2026-03-03`)
 2. Add benchmark family coverage checks and confidence calibration drift bounds.
 3. Block promotion on missing/incomplete parity scorecards.
 

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -12,10 +12,12 @@ from pathlib import Path
 from typing import Any, cast
 
 from ..parity import (
+    BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
     BENCHMARK_PARITY_REQUIRED_FAMILIES,
-    BENCHMARK_PARITY_REQUIRED_SCORECARDS,
-    BENCHMARK_PARITY_SCHEMA_VERSION,
     BENCHMARK_PARITY_REQUIRED_RUN_FIELDS,
+    BENCHMARK_PARITY_REQUIRED_SCORECARDS,
+    BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
+    BENCHMARK_PARITY_SCHEMA_VERSION,
 )
 
 
@@ -1847,6 +1849,94 @@ def _evaluate_benchmark_parity_evidence(
             }
         )
 
+    contract = _as_dict(payload.get("contract"))
+    if not contract:
+        reasons.append("benchmark_parity_contract_missing")
+        details.append(
+            {
+                "reason": "benchmark_parity_contract_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    else:
+        contract_schema_version = str(contract.get("schema_version", "")).strip()
+        if contract_schema_version != BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION:
+            reasons.append("benchmark_parity_contract_schema_version_invalid")
+            details.append(
+                {
+                    "reason": "benchmark_parity_contract_schema_version_invalid",
+                    "artifact_ref": str(artifact_path),
+                    "schema_version": contract_schema_version,
+                    "expected_schema_version": BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
+                }
+            )
+
+        required_families_contract = {
+            str(item).strip().lower()
+            for item in _list_from_any(contract.get("required_families"))
+            if str(item).strip()
+        }
+        if required_families_contract != set(BENCHMARK_PARITY_REQUIRED_FAMILIES):
+            reasons.append("benchmark_parity_contract_required_families_invalid")
+            details.append(
+                {
+                    "reason": "benchmark_parity_contract_required_families_invalid",
+                    "artifact_ref": str(artifact_path),
+                    "required_families": sorted(required_families_contract),
+                    "expected_required_families": sorted(
+                        BENCHMARK_PARITY_REQUIRED_FAMILIES
+                    ),
+                }
+            )
+
+        required_scorecards_contract = {
+            str(item).strip().lower()
+            for item in _list_from_any(contract.get("required_scorecards"))
+            if str(item).strip()
+        }
+        if required_scorecards_contract != set(BENCHMARK_PARITY_REQUIRED_SCORECARDS):
+            reasons.append("benchmark_parity_contract_required_scorecards_invalid")
+            details.append(
+                {
+                    "reason": "benchmark_parity_contract_required_scorecards_invalid",
+                    "artifact_ref": str(artifact_path),
+                    "required_scorecards": sorted(required_scorecards_contract),
+                    "expected_required_scorecards": sorted(
+                        BENCHMARK_PARITY_REQUIRED_SCORECARDS
+                    ),
+                }
+            )
+
+        required_run_fields_contract = {
+            str(item).strip()
+            for item in _list_from_any(contract.get("required_run_fields"))
+            if str(item).strip()
+        }
+        if required_run_fields_contract != set(BENCHMARK_PARITY_REQUIRED_RUN_FIELDS):
+            reasons.append("benchmark_parity_contract_required_run_fields_invalid")
+            details.append(
+                {
+                    "reason": "benchmark_parity_contract_required_run_fields_invalid",
+                    "artifact_ref": str(artifact_path),
+                    "required_run_fields": sorted(required_run_fields_contract),
+                    "expected_required_run_fields": sorted(
+                        BENCHMARK_PARITY_REQUIRED_RUN_FIELDS
+                    ),
+                }
+            )
+
+        hash_algorithm = str(contract.get("hash_algorithm", "")).strip().lower()
+        if hash_algorithm != "sha256":
+            reasons.append("benchmark_parity_contract_hash_algorithm_invalid")
+            details.append(
+                {
+                    "reason": "benchmark_parity_contract_hash_algorithm_invalid",
+                    "artifact_ref": str(artifact_path),
+                    "hash_algorithm": hash_algorithm,
+                    "expected_hash_algorithm": "sha256",
+                }
+            )
+
     if str(payload.get("overall_parity_status", "")).strip() != "pass":
         reasons.append("benchmark_parity_status_not_pass")
         details.append(
@@ -1946,6 +2036,19 @@ def _evaluate_benchmark_parity_evidence(
         family = str(run.get("family", "")).strip().lower()
         if family:
             families_seen.add(family)
+
+        run_schema_version = str(run.get("schema_version", "")).strip()
+        if run_schema_version != BENCHMARK_PARITY_RUN_SCHEMA_VERSION:
+            reasons.append("benchmark_parity_run_schema_version_invalid")
+            details.append(
+                {
+                    "reason": "benchmark_parity_run_schema_version_invalid",
+                    "artifact_ref": str(artifact_path),
+                    "family": family,
+                    "schema_version": run_schema_version,
+                    "expected_schema_version": BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
+                }
+            )
 
         missing_required_run_fields: list[str] = []
         for field in BENCHMARK_PARITY_REQUIRED_RUN_FIELDS:

--- a/services/torghut/app/trading/parity.py
+++ b/services/torghut/app/trading/parity.py
@@ -15,6 +15,8 @@ from .models import SignalEnvelope
 
 
 BENCHMARK_PARITY_SCHEMA_VERSION = "benchmark-parity-report-v1"
+BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION = "benchmark-parity-contract-v1"
+BENCHMARK_PARITY_RUN_SCHEMA_VERSION = "benchmark-parity-run-v1"
 BENCHMARK_PARITY_REQUIRED_SCORECARDS: tuple[str, ...] = (
     "decision_quality",
     "reasoning_quality",
@@ -55,6 +57,7 @@ def _build_benchmark_run(
     run_hash_seed = f"{family_seed}:run-hash"
     run_hash = hashlib.sha256(run_hash_seed.encode("utf-8")).hexdigest()
     return {
+        "schema_version": BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
         "dataset_ref": "benchmarks/external-labeled-stream-v1",
         "window_ref": now.strftime("%Y%m%dT%H%M%SZ"),
         "family": family,
@@ -229,6 +232,14 @@ def build_benchmark_parity_report(
         "schema_version": BENCHMARK_PARITY_SCHEMA_VERSION,
         "candidate_id": candidate_id,
         "baseline_candidate_id": baseline_candidate_id,
+        "contract": {
+            "schema_version": BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
+            "required_families": list(BENCHMARK_PARITY_REQUIRED_FAMILIES),
+            "required_scorecards": list(BENCHMARK_PARITY_REQUIRED_SCORECARDS),
+            "required_run_fields": list(BENCHMARK_PARITY_REQUIRED_RUN_FIELDS),
+            "hash_algorithm": "sha256",
+            "generation_mode": "deterministic_benchmark_parity_v1",
+        },
         "benchmark_runs": benchmark_runs,
         "scorecards": scorecards,
         "overall_parity_status": "pass" if scorecards_pass and runs_det else "degrade",
@@ -404,6 +415,8 @@ __all__ = [
     'run_feature_parity',
     'write_feature_parity_report',
     'BENCHMARK_PARITY_SCHEMA_VERSION',
+    'BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION',
+    'BENCHMARK_PARITY_RUN_SCHEMA_VERSION',
     'BENCHMARK_PARITY_REQUIRED_SCORECARDS',
     'BENCHMARK_PARITY_REQUIRED_FAMILIES',
     'BENCHMARK_PARITY_REQUIRED_RUN_FIELDS',

--- a/services/torghut/tests/test_feature_parity.py
+++ b/services/torghut/tests/test_feature_parity.py
@@ -7,7 +7,17 @@ from pathlib import Path
 from unittest import TestCase
 
 from app.trading.models import SignalEnvelope
-from app.trading.parity import run_feature_parity, write_feature_parity_report
+from app.trading.parity import (
+    BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
+    BENCHMARK_PARITY_REQUIRED_FAMILIES,
+    BENCHMARK_PARITY_REQUIRED_RUN_FIELDS,
+    BENCHMARK_PARITY_REQUIRED_SCORECARDS,
+    BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
+    _benchmark_report_hash,
+    build_benchmark_parity_report,
+    run_feature_parity,
+    write_feature_parity_report,
+)
 
 
 class TestFeatureParity(TestCase):
@@ -44,3 +54,46 @@ class TestFeatureParity(TestCase):
             self.assertEqual(payload['accepted'], report.accepted)
             self.assertEqual(payload['checked_rows'], 1)
             self.assertEqual(payload['top_drift_fields'][0]['field'], 'price')
+
+    def test_benchmark_parity_report_includes_standardized_contract(self) -> None:
+        now = datetime(2026, 3, 3, tzinfo=timezone.utc)
+        report = build_benchmark_parity_report(
+            candidate_id='cand-test',
+            baseline_candidate_id='base-test',
+            now=now,
+        )
+
+        contract = report.get('contract')
+        self.assertIsInstance(contract, dict)
+        assert isinstance(contract, dict)
+        self.assertEqual(
+            contract.get('schema_version'),
+            BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            contract.get('required_families'),
+            list(BENCHMARK_PARITY_REQUIRED_FAMILIES),
+        )
+        self.assertEqual(
+            contract.get('required_scorecards'),
+            list(BENCHMARK_PARITY_REQUIRED_SCORECARDS),
+        )
+        self.assertEqual(
+            contract.get('required_run_fields'),
+            list(BENCHMARK_PARITY_REQUIRED_RUN_FIELDS),
+        )
+        self.assertEqual(contract.get('hash_algorithm'), 'sha256')
+
+        benchmark_runs = report.get('benchmark_runs')
+        self.assertIsInstance(benchmark_runs, list)
+        assert isinstance(benchmark_runs, list)
+        self.assertGreater(len(benchmark_runs), 0)
+        for run in benchmark_runs:
+            self.assertIsInstance(run, dict)
+            assert isinstance(run, dict)
+            self.assertEqual(
+                run.get('schema_version'),
+                BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
+            )
+
+        self.assertEqual(report.get('artifact_hash'), _benchmark_report_hash(report))

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -11,7 +11,11 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from app.trading.parity import (
+    BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
     BENCHMARK_PARITY_REQUIRED_FAMILIES,
+    BENCHMARK_PARITY_REQUIRED_RUN_FIELDS,
+    BENCHMARK_PARITY_REQUIRED_SCORECARDS,
+    BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
     BENCHMARK_PARITY_SCHEMA_VERSION,
 )
 from app.trading.autonomy.policy_checks import (
@@ -3602,6 +3606,75 @@ class TestPolicyChecks(TestCase):
         self.assertFalse(promotion.allowed)
         self.assertIn("benchmark_parity_schema_version_invalid", promotion.reasons)
 
+    def test_promotion_prerequisites_fail_when_benchmark_parity_contract_is_missing(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "benchmarks").mkdir(parents=True, exist_ok=True)
+            payload = _build_benchmark_parity_payload()
+            payload.pop("contract", None)
+            _write_benchmark_parity_payload_payload(root, payload=payload)
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_benchmark_parity": True,
+                    "promotion_benchmark_parity_required_targets": ["paper"],
+                    "gate6_require_profitability_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "promotion_require_profitability_stage_manifest": False,
+                },
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn("benchmark_parity_contract_missing", promotion.reasons)
+
+    def test_promotion_prerequisites_fail_when_benchmark_parity_run_schema_is_invalid(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "benchmarks").mkdir(parents=True, exist_ok=True)
+            payload = _build_benchmark_parity_payload()
+            benchmark_runs = payload.get("benchmark_runs")
+            if isinstance(benchmark_runs, list) and benchmark_runs:
+                if isinstance(benchmark_runs[0], dict):
+                    benchmark_runs[0]["schema_version"] = "benchmark-run-v0"
+            _recompute_benchmark_artifact_hash(payload)
+            _write_benchmark_parity_payload_payload(root, payload=payload)
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_benchmark_parity": True,
+                    "promotion_benchmark_parity_required_targets": ["paper"],
+                    "gate6_require_profitability_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "promotion_require_profitability_stage_manifest": False,
+                },
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn(
+            "benchmark_parity_run_schema_version_invalid",
+            promotion.reasons,
+        )
+
     def test_promotion_prerequisites_fail_when_benchmark_parity_artifact_hash_is_missing(
         self,
     ) -> None:
@@ -3994,6 +4067,14 @@ def _build_benchmark_parity_payload(
         "schema_version": schema_version,
         "candidate_id": "cand-test",
         "baseline_candidate_id": "base-test",
+        "contract": {
+            "schema_version": BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
+            "required_families": list(BENCHMARK_PARITY_REQUIRED_FAMILIES),
+            "required_scorecards": list(BENCHMARK_PARITY_REQUIRED_SCORECARDS),
+            "required_run_fields": list(BENCHMARK_PARITY_REQUIRED_RUN_FIELDS),
+            "hash_algorithm": "sha256",
+            "generation_mode": "deterministic_benchmark_parity_v1",
+        },
         "benchmark_runs": [
             _build_test_benchmark_parity_run(family)
             for family in families
@@ -4027,6 +4108,7 @@ def _build_test_benchmark_parity_run(
     run_hash: str = "test-run-hash",
 ) -> dict[str, object]:
     return {
+        "schema_version": BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
         "family": family,
         "dataset_ref": "benchmarks/external-labeled-stream-v1",
         "window_ref": "20260201T000000Z",


### PR DESCRIPTION
## Summary

- Standardize `benchmark-parity-report-v1` generation with explicit artifact contract metadata (`contract.schema_version`, required families/scorecards/run fields, hash algorithm) and per-run schema versioning.
- Enforce fail-closed benchmark-parity contract validation in promotion policy checks (contract presence/schema/content/hash algorithm and run schema checks).
- Add regression coverage for benchmark parity contract/run-schema enforcement and parity artifact generation contract fields.
- Update v6 Wave 4 planning/docs to mark deliverable 1 complete and reflect current rollout status.

## Related Issues

None

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev --python 3.12`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --with pytest pytest`
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
