### PR TITLE
feat(torghut): close wave4 benchmark parity gating gaps

### DIFF
--- a/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
+++ b/argocd/applications/torghut/autonomy-gate-policy-configmap.yaml
@@ -72,9 +72,11 @@ data:
       "promotion_benchmark_parity_max_policy_violation_rate_degradation": "0.05",
       "promotion_benchmark_parity_max_fallback_rate": "0.01",
       "promotion_benchmark_parity_max_timeout_rate": "0.005",
+      "promotion_benchmark_parity_min_family_coverage_ratio": "1.0",
       "promotion_benchmark_parity_max_adverse_regime_decision_quality_degradation": "0.01",
       "promotion_benchmark_parity_max_risk_veto_alignment_degradation": "0.01",
       "promotion_benchmark_parity_max_confidence_calibration_error_degradation": "0.01",
+      "promotion_benchmark_parity_max_scorecard_confidence_calibration_error_drift": "0.01",
       "promotion_require_contamination_registry": true,
       "promotion_contamination_required_targets": ["paper", "live"],
       "promotion_contamination_required_artifacts": [

--- a/docs/torghut/design-system/v6/09-external-benchmark-parity-suite-ai-trader-fev-gift.md
+++ b/docs/torghut/design-system/v6/09-external-benchmark-parity-suite-ai-trader-fev-gift.md
@@ -12,7 +12,7 @@
   - `services/torghut/app/trading/autonomy/policy_checks.py`
   - `services/torghut/tests/test_feature_parity.py`
   - `services/torghut/tests/test_policy_checks.py`
-- Rollout gap: benchmark parity artifact contract standardization is implemented (`2026-03-03`); remaining closure is Wave 4 deliverables 2-3 (coverage/calibration drift bounds hardening and promotion block completeness).
+- Rollout gap: Wave 4 benchmark parity closure is implemented (`2026-03-03`) across contract standardization, family coverage/calibration drift bounds, and fail-closed scorecard completeness checks; remaining program closure is Wave 5-6.
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -41,7 +41,7 @@ No promotion path may bypass these controls.
 3. `v6/03` DSPy production cutover is implemented with live fail-closed runtime posture. (Completed `2026-03-03`)
 4. `v6/02` expert-router artifact registry and tuning SLO loop are partial.
 5. `v6/07` HMM posterior state service + lineage are partial.
-6. `v6/09` external benchmark parity suite is planned.
+6. `v6/09` external benchmark parity suite is implemented with fail-closed contract + coverage/calibration gating. (Completed `2026-03-03`)
 7. `v6/10` TimesFM parity contract is planned.
 8. `v6/11` DeepLOB/BDLOB production contract is planned.
 9. `v6/12` PostHog domain telemetry pipeline is planned.
@@ -175,8 +175,8 @@ Require explicit parity reports against external benchmark families before promo
 ### Deliverables
 
 1. Standardize benchmark-parity artifact generation contracts. (Completed `2026-03-03`)
-2. Add benchmark family coverage checks and confidence calibration drift bounds.
-3. Block promotion on missing/incomplete parity scorecards.
+2. Add benchmark family coverage checks and confidence calibration drift bounds. (Completed `2026-03-03`)
+3. Block promotion on missing/incomplete parity scorecards. (Completed `2026-03-03`)
 
 ### Primary files
 

--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -15,6 +15,7 @@ from ..parity import (
     BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
     BENCHMARK_PARITY_REQUIRED_FAMILIES,
     BENCHMARK_PARITY_REQUIRED_RUN_FIELDS,
+    BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS,
     BENCHMARK_PARITY_REQUIRED_SCORECARDS,
     BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
     BENCHMARK_PARITY_SCHEMA_VERSION,
@@ -1907,6 +1908,34 @@ def _evaluate_benchmark_parity_evidence(
                 }
             )
 
+        required_scorecard_fields_contract = {
+            str(scorecard_name).strip(): tuple(
+                str(field).strip()
+                for field in _list_from_any(required_fields)
+                if str(field).strip()
+            )
+            for scorecard_name, required_fields in _as_dict(
+                contract.get("required_scorecard_fields")
+            ).items()
+            if str(scorecard_name).strip()
+        }
+        if required_scorecard_fields_contract != BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS:
+            reasons.append("benchmark_parity_contract_required_scorecard_fields_invalid")
+            details.append(
+                {
+                    "reason": "benchmark_parity_contract_required_scorecard_fields_invalid",
+                    "artifact_ref": str(artifact_path),
+                    "required_scorecard_fields": {
+                        name: list(fields)
+                        for name, fields in required_scorecard_fields_contract.items()
+                    },
+                    "expected_required_scorecard_fields": {
+                        name: list(fields)
+                        for name, fields in BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS.items()
+                    },
+                }
+            )
+
         required_run_fields_contract = {
             str(item).strip()
             for item in _list_from_any(contract.get("required_run_fields"))
@@ -1974,6 +2003,23 @@ def _evaluate_benchmark_parity_evidence(
                     "status": card_status,
                 }
             )
+        missing_required_scorecard_fields = [
+            field
+            for field in BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS.get(
+                scorecard_name, ()
+            )
+            if field not in scorecard_payload
+        ]
+        if missing_required_scorecard_fields:
+            reasons.append("benchmark_parity_scorecard_missing_required_fields")
+            details.append(
+                {
+                    "reason": "benchmark_parity_scorecard_missing_required_fields",
+                    "artifact_ref": str(artifact_path),
+                    "scorecard": scorecard_name,
+                    "missing_fields": missing_required_scorecard_fields,
+                }
+            )
 
     benchmark_runs = _list_from_any(payload.get("benchmark_runs"))
     if not benchmark_runs:
@@ -2029,6 +2075,52 @@ def _evaluate_benchmark_parity_evidence(
     )
     if max_confidence_degradation is None:
         max_confidence_degradation = 0.01
+    max_scorecard_confidence_drift = _float_or_none(
+        policy_payload.get(
+            "promotion_benchmark_parity_max_scorecard_confidence_calibration_error_drift"
+        )
+    )
+    if max_scorecard_confidence_drift is None:
+        max_scorecard_confidence_drift = max_confidence_degradation
+    min_family_coverage_ratio = _float_or_none(
+        policy_payload.get("promotion_benchmark_parity_min_family_coverage_ratio")
+    )
+    if min_family_coverage_ratio is None:
+        min_family_coverage_ratio = 1.0
+
+    forecast_scorecard = _as_dict(scorecards.get("forecast_quality"))
+    forecast_confidence_error = _float_or_none(
+        forecast_scorecard.get("confidence_calibration_error")
+    )
+    forecast_confidence_error_baseline = _float_or_none(
+        forecast_scorecard.get("confidence_calibration_error_baseline")
+    )
+    if forecast_confidence_error is None or forecast_confidence_error_baseline is None:
+        reasons.append(
+            "benchmark_parity_scorecard_confidence_calibration_error_fields_missing"
+        )
+        details.append(
+            {
+                "reason": "benchmark_parity_scorecard_confidence_calibration_error_fields_missing",
+                "artifact_ref": str(artifact_path),
+            }
+        )
+    elif (
+        forecast_confidence_error - forecast_confidence_error_baseline
+        > max_scorecard_confidence_drift
+    ):
+        reasons.append(
+            "benchmark_parity_scorecard_confidence_calibration_error_drift_exceeds_threshold"
+        )
+        details.append(
+            {
+                "reason": "benchmark_parity_scorecard_confidence_calibration_error_drift_exceeds_threshold",
+                "artifact_ref": str(artifact_path),
+                "actual_confidence_calibration_error": forecast_confidence_error,
+                "baseline_confidence_calibration_error": forecast_confidence_error_baseline,
+                "maximum_drift": max_scorecard_confidence_drift,
+            }
+        )
 
     families_seen = set[str]()
     required_families = set(BENCHMARK_PARITY_REQUIRED_FAMILIES)
@@ -2187,6 +2279,31 @@ def _evaluate_benchmark_parity_evidence(
                 "reason": "benchmark_parity_family_results_missing",
                 "artifact_ref": str(artifact_path),
                 "missing_families": missing_families,
+            }
+        )
+    unexpected_families = sorted(families_seen - required_families)
+    if unexpected_families:
+        reasons.append("benchmark_parity_family_results_unexpected")
+        details.append(
+            {
+                "reason": "benchmark_parity_family_results_unexpected",
+                "artifact_ref": str(artifact_path),
+                "unexpected_families": unexpected_families,
+            }
+        )
+    family_coverage_ratio = (
+        (len(families_seen & required_families) / len(required_families))
+        if required_families
+        else 1.0
+    )
+    if family_coverage_ratio < min_family_coverage_ratio:
+        reasons.append("benchmark_parity_family_coverage_ratio_below_minimum")
+        details.append(
+            {
+                "reason": "benchmark_parity_family_coverage_ratio_below_minimum",
+                "artifact_ref": str(artifact_path),
+                "coverage_ratio": family_coverage_ratio,
+                "minimum_coverage_ratio": min_family_coverage_ratio,
             }
         )
 

--- a/services/torghut/app/trading/autonomy/policy_contract.py
+++ b/services/torghut/app/trading/autonomy/policy_contract.py
@@ -18,6 +18,8 @@ _REQUIRED_BOOL_KEYS: tuple[str, ...] = (
 
 _REQUIRED_STRING_KEYS: tuple[str, ...] = (
     "promotion_profitability_stage_manifest_artifact",
+    "promotion_benchmark_parity_min_family_coverage_ratio",
+    "promotion_benchmark_parity_max_scorecard_confidence_calibration_error_drift",
 )
 
 _REQUIRED_LIST_KEYS: tuple[str, ...] = (

--- a/services/torghut/app/trading/parity.py
+++ b/services/torghut/app/trading/parity.py
@@ -22,6 +22,34 @@ BENCHMARK_PARITY_REQUIRED_SCORECARDS: tuple[str, ...] = (
     "reasoning_quality",
     "forecast_quality",
 )
+BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS: dict[str, tuple[str, ...]] = {
+    "decision_quality": (
+        "advisory_output_rate",
+        "advisory_output_rate_baseline",
+        "policy_violation_rate",
+        "policy_violation_rate_baseline",
+        "deterministic_gate_compatible",
+        "decision_count",
+    ),
+    "reasoning_quality": (
+        "policy_violation_rate",
+        "policy_violation_rate_baseline",
+        "advisory_output_rate",
+        "advisory_output_rate_baseline",
+        "deterministic_gate_compatible",
+    ),
+    "forecast_quality": (
+        "confidence_calibration_error",
+        "confidence_calibration_error_baseline",
+        "risk_veto_alignment",
+        "risk_veto_alignment_baseline",
+        "policy_violation_rate",
+        "policy_violation_rate_baseline",
+        "advisory_output_rate",
+        "advisory_output_rate_baseline",
+        "deterministic_gate_compatible",
+    ),
+}
 BENCHMARK_PARITY_REQUIRED_FAMILIES: tuple[str, ...] = (
     "ai-trader",
     "fev-bench",
@@ -236,6 +264,10 @@ def build_benchmark_parity_report(
             "schema_version": BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
             "required_families": list(BENCHMARK_PARITY_REQUIRED_FAMILIES),
             "required_scorecards": list(BENCHMARK_PARITY_REQUIRED_SCORECARDS),
+            "required_scorecard_fields": {
+                name: list(fields)
+                for name, fields in BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS.items()
+            },
             "required_run_fields": list(BENCHMARK_PARITY_REQUIRED_RUN_FIELDS),
             "hash_algorithm": "sha256",
             "generation_mode": "deterministic_benchmark_parity_v1",
@@ -418,6 +450,7 @@ __all__ = [
     'BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION',
     'BENCHMARK_PARITY_RUN_SCHEMA_VERSION',
     'BENCHMARK_PARITY_REQUIRED_SCORECARDS',
+    'BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS',
     'BENCHMARK_PARITY_REQUIRED_FAMILIES',
     'BENCHMARK_PARITY_REQUIRED_RUN_FIELDS',
     'build_benchmark_parity_report',

--- a/services/torghut/config/autonomous-gate-policy.json
+++ b/services/torghut/config/autonomous-gate-policy.json
@@ -61,9 +61,11 @@
   "promotion_benchmark_parity_max_policy_violation_rate_degradation": "0.05",
   "promotion_benchmark_parity_max_fallback_rate": "0.01",
   "promotion_benchmark_parity_max_timeout_rate": "0.005",
+  "promotion_benchmark_parity_min_family_coverage_ratio": "1.0",
   "promotion_benchmark_parity_max_adverse_regime_decision_quality_degradation": "0.01",
   "promotion_benchmark_parity_max_risk_veto_alignment_degradation": "0.01",
   "promotion_benchmark_parity_max_confidence_calibration_error_degradation": "0.01",
+  "promotion_benchmark_parity_max_scorecard_confidence_calibration_error_drift": "0.01",
   "promotion_require_contamination_registry": true,
   "promotion_contamination_required_targets": ["paper", "live"],
   "promotion_contamination_required_artifacts": [

--- a/services/torghut/config/autonomy-gates-v3.json
+++ b/services/torghut/config/autonomy-gates-v3.json
@@ -61,9 +61,11 @@
   "promotion_benchmark_parity_max_policy_violation_rate_degradation": "0.05",
   "promotion_benchmark_parity_max_fallback_rate": "0.01",
   "promotion_benchmark_parity_max_timeout_rate": "0.005",
+  "promotion_benchmark_parity_min_family_coverage_ratio": "1.0",
   "promotion_benchmark_parity_max_adverse_regime_decision_quality_degradation": "0.01",
   "promotion_benchmark_parity_max_risk_veto_alignment_degradation": "0.01",
   "promotion_benchmark_parity_max_confidence_calibration_error_degradation": "0.01",
+  "promotion_benchmark_parity_max_scorecard_confidence_calibration_error_drift": "0.01",
   "promotion_require_contamination_registry": true,
   "promotion_contamination_required_targets": ["paper", "live"],
   "promotion_contamination_required_artifacts": [

--- a/services/torghut/tests/test_feature_parity.py
+++ b/services/torghut/tests/test_feature_parity.py
@@ -11,6 +11,7 @@ from app.trading.parity import (
     BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
     BENCHMARK_PARITY_REQUIRED_FAMILIES,
     BENCHMARK_PARITY_REQUIRED_RUN_FIELDS,
+    BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS,
     BENCHMARK_PARITY_REQUIRED_SCORECARDS,
     BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
     _benchmark_report_hash,
@@ -77,6 +78,13 @@ class TestFeatureParity(TestCase):
         self.assertEqual(
             contract.get('required_scorecards'),
             list(BENCHMARK_PARITY_REQUIRED_SCORECARDS),
+        )
+        self.assertEqual(
+            contract.get('required_scorecard_fields'),
+            {
+                name: list(fields)
+                for name, fields in BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS.items()
+            },
         )
         self.assertEqual(
             contract.get('required_run_fields'),

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -14,6 +14,7 @@ from app.trading.parity import (
     BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
     BENCHMARK_PARITY_REQUIRED_FAMILIES,
     BENCHMARK_PARITY_REQUIRED_RUN_FIELDS,
+    BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS,
     BENCHMARK_PARITY_REQUIRED_SCORECARDS,
     BENCHMARK_PARITY_RUN_SCHEMA_VERSION,
     BENCHMARK_PARITY_SCHEMA_VERSION,
@@ -3637,6 +3638,45 @@ class TestPolicyChecks(TestCase):
         self.assertFalse(promotion.allowed)
         self.assertIn("benchmark_parity_contract_missing", promotion.reasons)
 
+    def test_promotion_prerequisites_fail_when_benchmark_parity_contract_scorecard_fields_are_invalid(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "benchmarks").mkdir(parents=True, exist_ok=True)
+            payload = _build_benchmark_parity_payload()
+            contract = payload.get("contract")
+            if isinstance(contract, dict):
+                contract["required_scorecard_fields"] = {
+                    "forecast_quality": ["status"]
+                }
+            _recompute_benchmark_artifact_hash(payload)
+            _write_benchmark_parity_payload_payload(root, payload=payload)
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_benchmark_parity": True,
+                    "promotion_benchmark_parity_required_targets": ["paper"],
+                    "gate6_require_profitability_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "promotion_require_profitability_stage_manifest": False,
+                },
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn(
+            "benchmark_parity_contract_required_scorecard_fields_invalid",
+            promotion.reasons,
+        )
+
     def test_promotion_prerequisites_fail_when_benchmark_parity_run_schema_is_invalid(
         self,
     ) -> None:
@@ -4000,6 +4040,82 @@ class TestPolicyChecks(TestCase):
             )
         )
 
+    def test_promotion_prerequisites_fail_when_benchmark_parity_scorecard_is_incomplete(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "benchmarks").mkdir(parents=True, exist_ok=True)
+            payload = _build_benchmark_parity_payload()
+            scorecards = payload.get("scorecards")
+            if isinstance(scorecards, dict):
+                forecast = scorecards.get("forecast_quality")
+                if isinstance(forecast, dict):
+                    forecast.pop("confidence_calibration_error_baseline", None)
+            _recompute_benchmark_artifact_hash(payload)
+            _write_benchmark_parity_payload_payload(root, payload=payload)
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_benchmark_parity": True,
+                    "promotion_benchmark_parity_required_targets": ["paper"],
+                    "gate6_require_profitability_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "promotion_require_profitability_stage_manifest": False,
+                },
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn(
+            "benchmark_parity_scorecard_missing_required_fields",
+            promotion.reasons,
+        )
+
+    def test_promotion_prerequisites_fail_when_benchmark_parity_scorecard_confidence_drift_is_exceeded(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "benchmarks").mkdir(parents=True, exist_ok=True)
+            _write_benchmark_parity_payload(
+                root,
+                forecast_confidence_calibration_error=0.03,
+                forecast_confidence_calibration_error_baseline=0.01,
+            )
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_benchmark_parity": True,
+                    "promotion_benchmark_parity_required_targets": ["paper"],
+                    "promotion_benchmark_parity_max_scorecard_confidence_calibration_error_drift": 0.01,
+                    "gate6_require_profitability_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "promotion_require_profitability_stage_manifest": False,
+                },
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertFalse(promotion.allowed)
+        self.assertIn(
+            "benchmark_parity_scorecard_confidence_calibration_error_drift_exceeds_threshold",
+            promotion.reasons,
+        )
+
 
 def _candidate_state() -> dict[str, object]:
     return {
@@ -4026,6 +4142,8 @@ def _write_benchmark_parity_payload(
     adverse_regime_degradation: float = 0.0,
     risk_veto_degradation: float = 0.0,
     confidence_calibration_error_degradation: float = 0.0,
+    forecast_confidence_calibration_error: float = 0.015,
+    forecast_confidence_calibration_error_baseline: float = 0.015,
     families: tuple[str, ...] = BENCHMARK_PARITY_REQUIRED_FAMILIES,
     schema_version: str = BENCHMARK_PARITY_SCHEMA_VERSION,
 ) -> Path:
@@ -4034,6 +4152,8 @@ def _write_benchmark_parity_payload(
         adverse_regime_degradation=adverse_regime_degradation,
         risk_veto_degradation=risk_veto_degradation,
         confidence_calibration_error_degradation=confidence_calibration_error_degradation,
+        forecast_confidence_calibration_error=forecast_confidence_calibration_error,
+        forecast_confidence_calibration_error_baseline=forecast_confidence_calibration_error_baseline,
         schema_version=schema_version,
     )
     return _write_benchmark_parity_payload_payload(root, payload=payload)
@@ -4061,6 +4181,8 @@ def _build_benchmark_parity_payload(
     adverse_regime_degradation: float = 0.0,
     risk_veto_degradation: float = 0.0,
     confidence_calibration_error_degradation: float = 0.0,
+    forecast_confidence_calibration_error: float = 0.015,
+    forecast_confidence_calibration_error_baseline: float = 0.015,
     schema_version: str = BENCHMARK_PARITY_SCHEMA_VERSION,
 ) -> dict[str, object]:
     payload = {
@@ -4071,6 +4193,10 @@ def _build_benchmark_parity_payload(
             "schema_version": BENCHMARK_PARITY_CONTRACT_SCHEMA_VERSION,
             "required_families": list(BENCHMARK_PARITY_REQUIRED_FAMILIES),
             "required_scorecards": list(BENCHMARK_PARITY_REQUIRED_SCORECARDS),
+            "required_scorecard_fields": {
+                name: list(fields)
+                for name, fields in BENCHMARK_PARITY_REQUIRED_SCORECARD_FIELDS.items()
+            },
             "required_run_fields": list(BENCHMARK_PARITY_REQUIRED_RUN_FIELDS),
             "hash_algorithm": "sha256",
             "generation_mode": "deterministic_benchmark_parity_v1",
@@ -4080,9 +4206,35 @@ def _build_benchmark_parity_payload(
             for family in families
         ],
         "scorecards": {
-            "decision_quality": {"status": "pass"},
-            "reasoning_quality": {"status": "pass"},
-            "forecast_quality": {"status": "pass"},
+            "decision_quality": {
+                "status": "pass",
+                "advisory_output_rate": 0.998,
+                "advisory_output_rate_baseline": 0.998,
+                "policy_violation_rate": 0.01,
+                "policy_violation_rate_baseline": 0.01,
+                "deterministic_gate_compatible": True,
+                "decision_count": 144,
+            },
+            "reasoning_quality": {
+                "status": "pass",
+                "policy_violation_rate": 0.01,
+                "policy_violation_rate_baseline": 0.01,
+                "advisory_output_rate": 0.997,
+                "advisory_output_rate_baseline": 0.997,
+                "deterministic_gate_compatible": True,
+            },
+            "forecast_quality": {
+                "status": "pass",
+                "confidence_calibration_error": forecast_confidence_calibration_error,
+                "confidence_calibration_error_baseline": forecast_confidence_calibration_error_baseline,
+                "risk_veto_alignment": 0.95,
+                "risk_veto_alignment_baseline": 0.95,
+                "policy_violation_rate": 0.01,
+                "policy_violation_rate_baseline": 0.01,
+                "advisory_output_rate": 0.997,
+                "advisory_output_rate_baseline": 0.997,
+                "deterministic_gate_compatible": True,
+            },
         },
         "overall_parity_status": "pass",
         "degradation_summary": {


### PR DESCRIPTION
## Summary

- Hardened benchmark parity promotion gating to fail closed on incomplete scorecards by enforcing required per-scorecard fields and validating contract-level `required_scorecard_fields`.
- Added deterministic confidence-calibration drift enforcement from forecast scorecards plus explicit family coverage ratio/unexpected family checks in promotion policy checks.
- Extended benchmark parity artifact contract metadata, synchronized new policy thresholds across service and GitOps policy payloads, and updated v6 Wave 4 design/master-plan docs to record deliverables 2-3 closure.
- Added regression coverage in parity/policy tests for scorecard contract/field completeness and scorecard-level confidence drift threshold failures.

## Related Issues

None

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev --python 3.12`
- `cd services/torghut && /root/.local/bin/uv run --frozen --python 3.12 pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen --python 3.12 pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen --python 3.12 pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen --python 3.12 --with pytest pytest`
- `cd services/torghut && /root/.local/bin/uv run --frozen --python 3.12 ruff check app tests scripts migrations`
- `cd /workspace/lab && bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
