### PR TITLE
chore(torghut): promote image ad8b31d1

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:97cb87ca73eebabfc72ce3170518d38a7e241cccb2e7351ebd901646541a2e92
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e4425b730c41ffef5936cdc9d44fd0c8968d5c04a27cf5b57d80b02329f19b91
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T14:02:52Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T14:44:43Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:97cb87ca73eebabfc72ce3170518d38a7e241cccb2e7351ebd901646541a2e92
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e4425b730c41ffef5936cdc9d44fd0c8968d5c04a27cf5b57d80b02329f19b91
           ports:
             - name: http1
               containerPort: 8181
@@ -386,9 +386,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-178-gbddaefd3
+              value: v0.562.0-180-gad8b31d1
             - name: TORGHUT_COMMIT
-              value: bddaefd3e2ba25f6de96462a2355e3635c757c71
+              value: ad8b31d1633c36b40a76b96ef7a7204c99a33ded
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `ad8b31d1633c36b40a76b96ef7a7204c99a33ded`
- Image tag: `ad8b31d1`
- Image digest: `sha256:e4425b730c41ffef5936cdc9d44fd0c8968d5c04a27cf5b57d80b02329f19b91`