### PR TITLE
fix(jangar): include cx-tools in pruned docker context

### DIFF
--- a/packages/scripts/src/jangar/build-image.ts
+++ b/packages/scripts/src/jangar/build-image.ts
@@ -63,6 +63,11 @@ const createPrunedContext = async (): Promise<{ dir: string; cleanup: () => void
       cpSync(agentctlSource, resolve(dir, 'full/services/jangar/agentctl'), { recursive: true })
       cpSync(agentctlSource, resolve(dir, 'json/services/jangar/agentctl'), { recursive: true })
     }
+    const cxToolsSource = resolve(repoRoot, 'packages/cx-tools')
+    if (existsSync(cxToolsSource)) {
+      cpSync(cxToolsSource, resolve(dir, 'full/packages/cx-tools'), { recursive: true })
+      cpSync(cxToolsSource, resolve(dir, 'json/packages/cx-tools'), { recursive: true })
+    }
     // By default we do NOT copy a locally-built `.output` into the Docker build context.
     // Copying `.output` can silently ship stale server bundles if the local build was done on a different commit.
     // If you really need the faster path, opt in explicitly.


### PR DESCRIPTION
## Summary

- Fixes Jangar image builds after PR #3928 by copying `packages/cx-tools` into the pruned Docker build context.
- Adds `packages/cx-tools` to both `full/` and `json/` trees generated by `turbo prune --docker` in `packages/scripts/src/jangar/build-image.ts`.
- Restores compatibility between the Jangar Dockerfile `cx-tools-build` stage and the generated build context used in CI.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/jangar/build-image.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
