### PR TITLE
chore(torghut): promote image 3eac27ef

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:34504681e05c73021d57047a8cd3cd4b7e236a70e2639e32e9b11d37634bbee0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a201d696ac99865fbd2900feb16b8b7464992a359eba50508ea45f0bd198b781
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T15:24:35Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T17:24:49Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:34504681e05c73021d57047a8cd3cd4b7e236a70e2639e32e9b11d37634bbee0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a201d696ac99865fbd2900feb16b8b7464992a359eba50508ea45f0bd198b781
           ports:
             - name: http1
               containerPort: 8181
@@ -386,9 +386,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-182-gf57d0ef0
+              value: v0.562.0-184-g3eac27ef
             - name: TORGHUT_COMMIT
-              value: f57d0ef01db5ab0bb526bf65d15c4beaf7206517
+              value: 3eac27efbb97632263fc4de9720beb38e9ba5140
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `3eac27efbb97632263fc4de9720beb38e9ba5140`
- Image tag: `3eac27ef`
- Image digest: `sha256:a201d696ac99865fbd2900feb16b8b7464992a359eba50508ea45f0bd198b781`