### PR TITLE
chore(torghut): promote image d3c89aca

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a201d696ac99865fbd2900feb16b8b7464992a359eba50508ea45f0bd198b781
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:614c4bbbd2ea1d0dab832616cae11af7f9ddbd778a517e81d4c0611a2635ece2
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T17:24:49Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T17:35:55Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a201d696ac99865fbd2900feb16b8b7464992a359eba50508ea45f0bd198b781
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:614c4bbbd2ea1d0dab832616cae11af7f9ddbd778a517e81d4c0611a2635ece2
           ports:
             - name: http1
               containerPort: 8181
@@ -388,9 +388,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-184-g3eac27ef
+              value: v0.562.0-186-gd3c89aca
             - name: TORGHUT_COMMIT
-              value: 3eac27efbb97632263fc4de9720beb38e9ba5140
+              value: d3c89aca9cc17b271e70e7b54977274bfe84d07e
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `d3c89aca9cc17b271e70e7b54977274bfe84d07e`
- Image tag: `d3c89aca`
- Image digest: `sha256:614c4bbbd2ea1d0dab832616cae11af7f9ddbd778a517e81d4c0611a2635ece2`