### PR TITLE
chore(torghut): promote image 5fcd9e62

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:614c4bbbd2ea1d0dab832616cae11af7f9ddbd778a517e81d4c0611a2635ece2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc5033be0fbb0e697fa4a09601a57e076354d8aa0dc3841866c6004ba1d1743b
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T17:35:55Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T19:58:30Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:614c4bbbd2ea1d0dab832616cae11af7f9ddbd778a517e81d4c0611a2635ece2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc5033be0fbb0e697fa4a09601a57e076354d8aa0dc3841866c6004ba1d1743b
           ports:
             - name: http1
               containerPort: 8181
@@ -388,9 +388,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-186-gd3c89aca
+              value: v0.562.0-188-g5fcd9e62
             - name: TORGHUT_COMMIT
-              value: d3c89aca9cc17b271e70e7b54977274bfe84d07e
+              value: 5fcd9e62d49bf2afca43c6310f36e326db99d83e
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `5fcd9e62d49bf2afca43c6310f36e326db99d83e`
- Image tag: `5fcd9e62`
- Image digest: `sha256:bc5033be0fbb0e697fa4a09601a57e076354d8aa0dc3841866c6004ba1d1743b`