### PR TITLE
chore(torghut): promote image 9c0c4e61

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc5033be0fbb0e697fa4a09601a57e076354d8aa0dc3841866c6004ba1d1743b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:574761aa6d2967369c5101000e142b21aeb2811ccba326b9bd12d1f73b96e05e
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-03T19:58:30Z"
+        client.knative.dev/updateTimestamp: "2026-03-03T23:21:49Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc5033be0fbb0e697fa4a09601a57e076354d8aa0dc3841866c6004ba1d1743b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:574761aa6d2967369c5101000e142b21aeb2811ccba326b9bd12d1f73b96e05e
           ports:
             - name: http1
               containerPort: 8181
@@ -408,9 +408,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-188-g5fcd9e62
+              value: v0.562.0-190-g9c0c4e61
             - name: TORGHUT_COMMIT
-              value: 5fcd9e62d49bf2afca43c6310f36e326db99d83e
+              value: 9c0c4e6108768bd503c38dd169b0683f737cfff3
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `9c0c4e6108768bd503c38dd169b0683f737cfff3`
- Image tag: `9c0c4e61`
- Image digest: `sha256:574761aa6d2967369c5101000e142b21aeb2811ccba326b9bd12d1f73b96e05e`