### PR TITLE
docs(torghut): add risk control matrix to v6 master plan

### DIFF
--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -323,6 +323,18 @@ Each risk must have:
 3. rollback trigger,
 4. postmortem template link.
 
+### Program Risk Control Matrix (Closure Contract)
+
+| Risk                                                                | Detection signal (metric/SLO)                                                                                   | Owner                                                                                     | Rollback trigger                                                                         | Postmortem template link                                                              |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Policy/profile divergence between runtime and repository contracts. | `torghut_policy_parity_mismatch_total > 0` or readiness check fails `--control-plane-contract`.                 | Torghut platform oncall (`argocd/applications/torghut/**`, runtime config).               | Any non-zero parity mismatch in `main` or runtime check failure in rollout verification. | `docs/torghut/design-system/v3/full-loop/09-incident-kill-switch-recovery-runbook.md` |
+| Legacy path regression during DSPy cutover.                         | `torghut_legacy_llm_path_hits_total > 0` in paper/live windows, or DSPy artifact lock validation failures.      | Quant runtime owners (`services/torghut/app/trading/llm/**`).                             | Any observed legacy-path invocation outside approved test fixtures.                      | `docs/torghut/design-system/v3/full-loop/09-incident-kill-switch-recovery-runbook.md` |
+| Hidden contamination/leakage in dataset and benchmark harness.      | `torghut_contamination_guard_failures_total > 0` or parity/coverage gate fails in promotion checks.             | Research + evaluation owners (`services/torghut/app/trading/evaluation.py`, `parity.py`). | Contamination registry failure or missing benchmark parity package for promotion target. | `docs/torghut/design-system/v3/full-loop/09-incident-kill-switch-recovery-runbook.md` |
+| Drift false positives causing promotion starvation.                 | Drift false-positive rate exceeds SLO in `autonomy_drift` evidence package for two consecutive windows.         | Autonomy governance owners (`services/torghut/app/trading/autonomy/drift.py`).            | Drift false-positive rate breach with blocked promotion queue beyond SLO window.         | `docs/torghut/design-system/v3/full-loop/09-incident-kill-switch-recovery-runbook.md` |
+| Over-broad model-family rollout without canary containment.         | Canary breach signals (`advisor_timeout`, `advisor_staleness`, or model-family error budget) exceed thresholds. | Model rollout owners (`forecasting.py`, `microstructure.py`, `execution_policy.py`).      | Any canary SLO breach during paper/live promotion window.                                | `docs/torghut/design-system/v3/full-loop/09-incident-kill-switch-recovery-runbook.md` |
+
+Incident records implementing this template are tracked under `docs/incidents/` and must reference the triggered risk row above.
+
 ## Definition of Done (Program Complete)
 
 Program is complete only when all are true:


### PR DESCRIPTION
## Summary

- Added a program-level risk control matrix to the authoritative Torghut v6 production gap-closure master plan.
- Mapped each documented program risk to required governance fields: metric-based detection signal, owner, rollback trigger, and postmortem template link.
- Documented the incident-recording requirement that ties `docs/incidents/` entries back to a specific risk row for auditability.

## Related Issues

None (AgentRun tracking key: `torghut-v6-gap-closure-loop10`).

## Testing

- `bunx oxfmt docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md`
- `bunx oxfmt --check docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md`
- `kubectl config use-context in-cluster && kubectl auth whoami`
- `kubectl get pod -n torghut torghut-00033-deployment-5dfc59d794-qf96l -o jsonpath='{.status.containerStatuses[?(@.name=="user-container")].imageID}{"\n"}'`
- `kubectl logs -n torghut torghut-00033-deployment-5dfc59d794-qf96l -c user-container --tail=400 | rg 'GET /healthz|GET /trading/status|GET /trading/metrics' | tail -n 10`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
