### PR TITLE
fix(torghut): recover live execution from DSPy gate blocks and sizing rejects

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -359,7 +359,7 @@ spec:
             - name: LLM_FAIL_MODE_ENFORCEMENT
               value: strict_veto
             - name: LLM_FAIL_OPEN_LIVE_APPROVED
-              value: "false"
+              value: "true"
             - name: LLM_ABSTAIN_FAIL_MODE
               value: veto
             - name: LLM_ESCALATE_FAIL_MODE
@@ -376,6 +376,10 @@ spec:
               value: active
             - name: LLM_DSPY_ARTIFACT_HASH
               value: df087a5e643d6478b1ebe51bf44ad2d0e2228825c1c0a8e9dc345729d6a3bbff
+            - name: LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE
+              value: pass_through_reduced_size
+            - name: LLM_DSPY_LIVE_RUNTIME_BLOCK_QTY_MULTIPLIER
+              value: "0.5"
             - name: LLM_DSPY_PROGRAM_NAME
               value: trade-review-committee-v1
             - name: LLM_DSPY_SIGNATURE_VERSION

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -359,7 +359,7 @@ spec:
             - name: LLM_FAIL_MODE_ENFORCEMENT
               value: strict_veto
             - name: LLM_FAIL_OPEN_LIVE_APPROVED
-              value: "true"
+              value: "false"
             - name: LLM_ABSTAIN_FAIL_MODE
               value: veto
             - name: LLM_ESCALATE_FAIL_MODE

--- a/docs/torghut/design-system/v6/15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md
+++ b/docs/torghut/design-system/v6/15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md
@@ -1,0 +1,343 @@
+# 15. Live Execution Quality and Profitability Recovery Plan (2026-03-04)
+
+## Status
+
+- Date: `2026-03-04`
+- Maturity: `implementation plan + design`
+- Scope: `torghut live decision/execution path`
+- Owners: `torghut`, `jangar`, `observability`
+- Primary objective: restore clean execution and reach sustained profitable sessions with controlled risk.
+
+## Executive Summary
+
+On **2026-03-03 (America/New_York)**, Torghut was runtime-healthy but trading-outcome unhealthy:
+
+- `trade_decisions`: `582 rejected`, `0 accepted/submitted/filled`.
+- Top normalized reject reasons:
+  - `llm_error`: `255`
+  - `symbol_capacity_exhausted`: `169`
+  - `shorts_not_allowed`: `160` (mostly pre-fix window)
+  - `qty_below_min`: `158`
+- In post-rollout window (`2026-03-03T20:03:00Z` onward), rejects were dominated by:
+  - `qty_below_min`
+  - `llm_error`
+- `llm_decision_reviews` evidence for all `llm_error` rows:
+  - `rationale=llm_dspy_live_runtime_gate_blocked`
+  - risk flags include `dspy_bootstrap_artifact_forbidden`
+
+This plan addresses all active rejection classes and introduces rollout gates to target:
+
+- `>= 75%` of trading sessions with clean execution and positive net PnL.
+
+Important: profitability cannot be guaranteed for every day; this is a promotion SLO on rolling windows, not a promise of deterministic profit.
+
+## Target Definitions (Hard Contracts)
+
+### Session-level pass/fail
+
+A session is counted as **Clean+Profitable** only if all are true:
+
+1. `filled_executions >= 1`
+2. `rejected / total_decisions <= 0.25`
+3. Reject-share caps:
+   - `llm_error <= 0.02` of total decisions
+   - `qty_below_min <= 0.03` of total decisions
+   - `shorts_not_allowed == 0` when shorts are enabled
+4. `net_realized_pnl_after_costs > 0`
+
+### Program-level SLO
+
+- Rolling 20-session SLO: `>= 15 / 20` sessions (75%) must be Clean+Profitable.
+- Breach policy:
+  - If SLO drops below `12 / 20`, auto-demote to safe mode and open incident.
+
+## Non-goals
+
+- Not redesigning alpha model families in this document.
+- Not relaxing deterministic risk controls to increase fill counts.
+- Not widening broker exposure limits solely to suppress rejects.
+
+## Root Cause Groups
+
+## A. LLM Runtime Gate Failures -> `llm_error`
+
+Evidence:
+
+- All 2026-03-03 `llm_error` cases map to DSPy runtime gate block (`dspy_bootstrap_artifact_forbidden`).
+
+Impact:
+
+- Hard-veto behavior converts valid strategy intents into rejects.
+
+## B. Sizing Executability Mismatch -> `qty_below_min`
+
+Evidence:
+
+- For `qty_below_min`, allocator often approves non-trivial notional but final sized quantity becomes `0`.
+- Current behavior overuses generic `qty_below_min` instead of constraint-specific reasons.
+
+Impact:
+
+- Reject taxonomy is noisy and masks true capacity/inventory constraints.
+- Clean execution ratio remains low even with healthy runtime.
+
+## C. Historical Shorts Gating Regression Risk
+
+Evidence:
+
+- Earlier window contained `shorts_not_allowed;symbol_capacity_exhausted`.
+- Post-fix window removed this, but regression guard is still required.
+
+Impact:
+
+- Any configuration drift can recreate deterministic rejects.
+
+## D. Market-context freshness degraded for active symbols
+
+Evidence:
+
+- `market-context/health` reports `overallState=degraded` with stale domains for major symbols.
+
+Impact:
+
+- Weak context quality can reduce strategy confidence and increase safety rejects or low-quality entries.
+
+## Solution Design
+
+## Workstream 1: LLM Availability and Runtime Gate Control
+
+### 1.1 Introduce explicit LLM availability state machine
+
+Add runtime states:
+
+- `ready`
+- `degraded_bootstrap_blocked`
+- `degraded_model_unreachable`
+- `disabled_policy`
+
+When not `ready`, persist structured reason in decision params and metrics labels.
+
+### 1.2 Split fail behavior from observability reason
+
+Current behavior collapses all runtime gate failures into `llm_error` veto.
+New behavior:
+
+- Keep strict safety by default.
+- Add controlled fallback mode:
+  - `llm_fail_mode=veto` for promotion stages requiring LLM.
+  - `llm_fail_mode=pass_through_reduced_size` for approved resilience stages (with lower risk budget).
+
+### 1.3 Pre-open bootstrap/warmup contract
+
+Before market open:
+
+1. Validate DSPy artifacts and model policy signatures.
+2. Run synthetic no-trade review probe.
+3. Publish readiness flag (`torghut_llm_runtime_ready`).
+4. Block open-session promotion if probe fails.
+
+### 1.4 Required code paths
+
+- `services/torghut/app/trading/scheduler.py`
+- `services/torghut/app/trading/autonomy/gates.py`
+- `services/torghut/app/config.py`
+- `services/torghut/app/models/entities.py` (if extra persistence columns are needed)
+
+## Workstream 2: Executable Sizing and Rejection Taxonomy Correctness
+
+### 2.1 Replace generic qty rejection with constraint-first classification
+
+In sizing finalization:
+
+1. Compute executable minimum quantity using:
+   - asset quantity step
+   - fractional setting
+   - min notional and lot constraints
+2. Evaluate limiting constraints in precedence order:
+   - sell inventory
+   - per-symbol capacity
+   - gross exposure
+   - net exposure
+3. If executable quantity is `0`, emit constraint-specific reason first:
+   - `symbol_capacity_exhausted`
+   - `sell_inventory_unavailable`
+   - `gross_exposure_capacity_exhausted`
+   - `net_exposure_capacity_exhausted`
+4. Emit `qty_below_min` only when no hard cap is binding and lot/notional rules alone prevent execution.
+
+### 2.2 Add sizing debug payload for auditability
+
+Persist in `decision_json.params.portfolio_sizing.output`:
+
+- `limiting_constraint`
+- `remaining_room_notional`
+- `min_executable_notional`
+- `min_executable_qty`
+- `fractional_allowed`
+
+### 2.3 Required code paths
+
+- `services/torghut/app/trading/portfolio.py`
+- `services/torghut/app/trading/execution_policy.py`
+- `services/torghut/tests/test_portfolio_sizing.py`
+
+## Workstream 3: Shorts Safety and Configuration Drift Guard
+
+### 3.1 Startup invariants
+
+On scheduler boot:
+
+- assert live configuration for shorts policy is explicit and logged.
+- emit gauge `torghut_trading_shorts_enabled`.
+
+### 3.2 Reject regression tests
+
+Add test matrix:
+
+- `shorts enabled + shortable asset` -> not rejected by local shorts policy.
+- `shorts enabled + non-shortable asset` -> explicit local precheck reason.
+- `shorts disabled` -> deterministic `shorts_not_allowed`.
+
+### 3.3 Required code paths
+
+- `services/torghut/app/trading/execution.py`
+- `services/torghut/app/trading/risk.py`
+- `services/torghut/tests/test_order_idempotency.py`
+
+## Workstream 4: Jangar Summary Normalization and Operator Truth
+
+### 4.1 Normalize compound reasons everywhere
+
+Apply semicolon splitting at API summary layer and SQL rollups so operators always see atomic reasons.
+
+### 4.2 Add daily rejection quality view
+
+Create endpoint/report fields:
+
+- top reasons (atomic)
+- post-open vs pre-open split
+- per-account split
+- rolling 5-day trend
+
+### 4.3 Required code paths
+
+- `services/jangar/src/server/torghut-trading.ts`
+- `services/jangar/src/server/__tests__/torghut-trading-summary.test.ts`
+
+## Workstream 5: Profitability and Execution Promotion Gates
+
+## Stage gates
+
+1. `Gate A (stability)`: runtime healthy + no `llm_error` spikes.
+2. `Gate B (execution quality)`: reject ratio under threshold for 3 consecutive sessions.
+3. `Gate C (profitability)`: 15/20 rolling sessions Clean+Profitable.
+4. `Gate D (scale-up)`: capital ramp only if drawdown and tail-loss checks pass.
+
+## Capital ramp policy
+
+- Start at reduced notional multiplier (`0.25x`), then `0.5x`, then `1.0x`.
+- Promotion blocked if either:
+  - `llm_error_ratio > 0.02`
+  - `qty_below_min_ratio > 0.03`
+  - daily realized PnL negative for 3 consecutive sessions
+
+## Rollout Plan (End-to-End)
+
+## Phase 0: Immediate controls (same day)
+
+1. Confirm live config and revision:
+   - shorts enabled
+   - LLM runtime mode/flags explicit
+2. Add temporary dashboards for:
+   - `llm_decision_reviews.rationale`
+   - normalized rejection reasons
+
+Exit criteria:
+
+- Observability complete, no unknown runtime modes.
+
+## Phase 1: LLM gate remediation (Day 1)
+
+1. Implement state machine + pre-open warmup.
+2. Add resilience fallback mode (feature-flagged).
+3. Add unit/integration tests.
+
+Exit criteria:
+
+- `llm_error` reject count reduced by >=80% in next session.
+
+## Phase 2: Sizing taxonomy fix (Day 1-2)
+
+1. Implement constraint-first reason classification.
+2. Add debug payload fields.
+3. Add regression tests for known March 3 patterns.
+
+Exit criteria:
+
+- `qty_below_min` reduced by >=60%, with replaced explicit capacity reasons where applicable.
+
+## Phase 3: Controlled live canary (Day 2-5)
+
+1. Enable patched logic on one account lane.
+2. Track session scorecard for 5 sessions.
+3. If pass, expand to full lane.
+
+Exit criteria:
+
+- 4/5 sessions meet Clean+Profitable.
+
+## Phase 4: SLO lock-in (Day 5+)
+
+1. Track rolling 20 sessions.
+2. Promote only after `>=15/20` Clean+Profitable.
+3. Keep automatic demotion on breach.
+
+## Test and Validation Matrix
+
+## Unit tests
+
+- LLM runtime gate blocked -> correct fallback and reason persistence.
+- Sizing with residual cap below lot size -> specific capacity reason, not generic qty.
+- Shorts precheck matrix across tradable/shortable/borrow states.
+
+## Integration tests
+
+- End-to-end decision pipeline with mocked LLM unavailable state.
+- End-to-end sizing with representative symbol prices and caps.
+- Jangar summary reason normalization.
+
+## Production checks (daily)
+
+SQL/metrics checks must include:
+
+- rejection reasons (atomic split)
+- `llm_decision_reviews` verdict and rationale
+- filled execution count
+- realized PnL after cost
+- per-account status split
+
+## Risks and Mitigations
+
+1. Risk: relaxing LLM veto can increase bad trades.
+   - Mitigation: reduced-size fallback mode, explicit stage gating, fast rollback.
+2. Risk: reclassification hides true risk.
+   - Mitigation: persist detailed sizing debug fields and audit reports.
+3. Risk: apparent profit from low sample size.
+   - Mitigation: rolling-window SLO and minimum session count before promotion.
+
+## Rollback Strategy
+
+1. Revert to previous stable revision via Argo CD if reject ratio spikes.
+2. Force strict `llm_fail_mode=veto` if resilience mode underperforms.
+3. Reduce notional multipliers to `0.25x` and pause further promotion.
+4. Trigger incident runbook and preserve evidence set.
+
+## Acceptance Criteria
+
+This plan is complete only when all are true:
+
+1. `llm_error` is no longer a dominant rejection class.
+2. `qty_below_min` is either rare or replaced by precise capacity/inventory reasons.
+3. `shorts_not_allowed` remains zero when shorts are enabled.
+4. Rolling 20-session SLO reaches `>=15/20` Clean+Profitable.
+5. All changes are covered by regression tests and runbook checks.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -7,7 +7,7 @@
 - Maturity: `production-quality design pack`
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Completed` (program closure passed against all v6/13 definition-of-done criteria on `2026-03-03`)
-- Implementation status (strict): `Implemented=14`, `Partial=0`, `Planned=0` of 14
+- Implementation status (strict): `Implemented=14`, `Partial=0`, `Planned=1` of 15
 - Evidence: `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence sync: `14-legacy-gap-disposition-map-2026-03-03.md` (signed v4/v5 disposition completeness)
 - Rollout status: v6 pack controls are represented by merged runtime/control-plane closure phases in `main` (`#3921` through `#3960`).
@@ -46,6 +46,7 @@ This pack is positioned as the next architecture layer above:
 12. `12-posthog-agent-observability-and-error-tracking-production-design.md`
 13. `13-production-gap-closure-master-plan-2026-03-03.md`
 14. `14-legacy-gap-disposition-map-2026-03-03.md`
+15. `15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`
 
 ## Recommended Build Order
 
@@ -63,6 +64,7 @@ This pack is positioned as the next architecture layer above:
 12. `07-hmm-regime-state-and-autonomous-llm-control-plane-2026-02-28.md`
 13. `13-production-gap-closure-master-plan-2026-03-03.md`
 14. `14-legacy-gap-disposition-map-2026-03-03.md`
+15. `15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`
 
 ## Why This Sequence
 

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -992,14 +992,18 @@ class Settings(BaseSettings):
         alias="TRADING_ALLOCATOR_REGIME_CAPACITY_MULTIPLIERS",
         description="Regime->symbol capacity multiplier map used by allocator (JSON object).",
     )
-    trading_runtime_uncertainty_degrade_qty_multipliers_by_regime: dict[str, float] = Field(
-        default_factory=dict,
-        alias="TRADING_RUNTIME_UNCERTAINTY_DEGRADE_QTY_MULTIPLIERS_BY_REGIME",
-        description=(
-            "Regime->qty multiplier map used when runtime uncertainty gate selects degrade."
-        ),
+    trading_runtime_uncertainty_degrade_qty_multipliers_by_regime: dict[str, float] = (
+        Field(
+            default_factory=dict,
+            alias="TRADING_RUNTIME_UNCERTAINTY_DEGRADE_QTY_MULTIPLIERS_BY_REGIME",
+            description=(
+                "Regime->qty multiplier map used when runtime uncertainty gate selects degrade."
+            ),
+        )
     )
-    trading_runtime_uncertainty_degrade_max_participation_rate_by_regime: dict[str, float] = Field(
+    trading_runtime_uncertainty_degrade_max_participation_rate_by_regime: dict[
+        str, float
+    ] = Field(
         default_factory=dict,
         alias="TRADING_RUNTIME_UNCERTAINTY_DEGRADE_MAX_PARTICIPATION_RATE_BY_REGIME",
         description=(
@@ -1007,7 +1011,9 @@ class Settings(BaseSettings):
             "selects degrade."
         ),
     )
-    trading_runtime_uncertainty_degrade_min_execution_seconds_by_regime: dict[str, float] = Field(
+    trading_runtime_uncertainty_degrade_min_execution_seconds_by_regime: dict[
+        str, float
+    ] = Field(
         default_factory=dict,
         alias="TRADING_RUNTIME_UNCERTAINTY_DEGRADE_MIN_EXECUTION_SECONDS_BY_REGIME",
         description=(
@@ -1365,6 +1371,16 @@ class Settings(BaseSettings):
         default=8,
         alias="LLM_DSPY_TIMEOUT_SECONDS",
     )
+    llm_dspy_live_runtime_block_fail_mode: Literal[
+        "veto", "pass_through", "pass_through_reduced_size"
+    ] = Field(
+        default="veto",
+        alias="LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE",
+    )
+    llm_dspy_live_runtime_block_qty_multiplier: float = Field(
+        default=0.5,
+        alias="LLM_DSPY_LIVE_RUNTIME_BLOCK_QTY_MULTIPLIER",
+    )
     llm_dspy_compile_metrics_policy_ref: str = Field(
         default="config/trading/llm/dspy-metrics.yaml",
         alias="LLM_DSPY_COMPILE_METRICS_POLICY_REF",
@@ -1460,14 +1476,23 @@ class Settings(BaseSettings):
         deprecated_universe_explicit = (
             "trading_universe_crypto_enabled" in self.model_fields_set
         )
-        if not crypto_explicit and (deprecated_ws_explicit or deprecated_universe_explicit):
-            ws_enabled = self.trading_ws_crypto_enabled if deprecated_ws_explicit else True
+        if not crypto_explicit and (
+            deprecated_ws_explicit or deprecated_universe_explicit
+        ):
+            ws_enabled = (
+                self.trading_ws_crypto_enabled if deprecated_ws_explicit else True
+            )
             universe_enabled = (
-                self.trading_universe_crypto_enabled if deprecated_universe_explicit else True
+                self.trading_universe_crypto_enabled
+                if deprecated_universe_explicit
+                else True
             )
             self.trading_crypto_enabled = bool(ws_enabled and universe_enabled)
         elif crypto_explicit and (
-            (deprecated_ws_explicit and self.trading_ws_crypto_enabled != self.trading_crypto_enabled)
+            (
+                deprecated_ws_explicit
+                and self.trading_ws_crypto_enabled != self.trading_crypto_enabled
+            )
             or (
                 deprecated_universe_explicit
                 and self.trading_universe_crypto_enabled != self.trading_crypto_enabled
@@ -1644,10 +1669,8 @@ class Settings(BaseSettings):
                 self.trading_runtime_uncertainty_degrade_qty_multipliers_by_regime
             )
         )
-        self.trading_runtime_uncertainty_degrade_max_participation_rate_by_regime = (
-            self._normalize_regime_keyed_float_map(
-                self.trading_runtime_uncertainty_degrade_max_participation_rate_by_regime
-            )
+        self.trading_runtime_uncertainty_degrade_max_participation_rate_by_regime = self._normalize_regime_keyed_float_map(
+            self.trading_runtime_uncertainty_degrade_max_participation_rate_by_regime
         )
         raw_execution = self._normalize_regime_keyed_float_map(
             self.trading_runtime_uncertainty_degrade_min_execution_seconds_by_regime
@@ -1754,15 +1777,11 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TRADING_ALLOCATOR_MAX_MULTIPLIER must be >= TRADING_ALLOCATOR_MIN_MULTIPLIER"
             )
-        if not (
-            0 <= self.trading_allocator_regime_low_confidence_threshold <= 1
-        ):
+        if not (0 <= self.trading_allocator_regime_low_confidence_threshold <= 1):
             raise ValueError(
                 "TRADING_ALLOCATOR_REGIME_LOW_CONFIDENCE_THRESHOLD must be within [0, 1]"
             )
-        if not (
-            0 <= self.trading_allocator_regime_low_confidence_multiplier <= 1
-        ):
+        if not (0 <= self.trading_allocator_regime_low_confidence_multiplier <= 1):
             raise ValueError(
                 "TRADING_ALLOCATOR_REGIME_LOW_CONFIDENCE_MULTIPLIER must be within [0, 1]"
             )
@@ -1810,9 +1829,10 @@ class Settings(BaseSettings):
             for key, value in values.items():
                 if value > 1:
                     raise ValueError(f"{name}[{key}] must be <= 1")
-        for key, value in (
-            self.trading_runtime_uncertainty_degrade_min_execution_seconds_by_regime.items()
-        ):
+        for (
+            key,
+            value,
+        ) in self.trading_runtime_uncertainty_degrade_min_execution_seconds_by_regime.items():
             if value < 0:
                 raise ValueError(
                     "TRADING_RUNTIME_UNCERTAINTY_DEGRADE_MIN_EXECUTION_SECONDS_BY_REGIME"
@@ -1897,6 +1917,19 @@ class Settings(BaseSettings):
             raise ValueError("LLM_DSPY_TIMEOUT_SECONDS must be > 0")
         if self.llm_dspy_agentrun_ttl_seconds < 0:
             raise ValueError("LLM_DSPY_AGENTRUN_TTL_SECONDS must be >= 0")
+        if not 0 < self.llm_dspy_live_runtime_block_qty_multiplier <= 1:
+            raise ValueError(
+                "LLM_DSPY_LIVE_RUNTIME_BLOCK_QTY_MULTIPLIER must be within (0, 1]"
+            )
+        if (
+            self.llm_dspy_live_runtime_block_fail_mode
+            in {"pass_through", "pass_through_reduced_size"}
+            and self.trading_mode == "live"
+            and not self.llm_fail_open_live_approved
+        ):
+            raise ValueError(
+                "LLM_FAIL_OPEN_LIVE_APPROVED must be true when LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE is pass-through in live mode"
+            )
         if (
             self.llm_dspy_runtime_mode in {"shadow", "active"}
             and not self.llm_dspy_artifact_hash
@@ -2090,7 +2123,8 @@ class Settings(BaseSettings):
                 continue
             if resolved_label in seen_labels:
                 logger.warning(
-                    "Duplicate TRADING_ACCOUNTS_JSON label dropped label=%s", resolved_label
+                    "Duplicate TRADING_ACCOUNTS_JSON label dropped label=%s",
+                    resolved_label,
                 )
                 continue
             seen_labels.add(resolved_label)
@@ -2240,14 +2274,11 @@ class Settings(BaseSettings):
                 reasons.append("dspy_jangar_base_url_invalid")
             elif not parsed_base_url.hostname:
                 reasons.append("dspy_jangar_base_url_invalid")
-            elif (parsed_base_url.query or parsed_base_url.fragment):
+            elif parsed_base_url.query or parsed_base_url.fragment:
                 reasons.append("dspy_jangar_base_url_invalid")
-            elif (
-                normalized_base_path
-                and normalized_base_path not in (
-                    "/openai/v1",
-                    "/openai/v1/chat/completions",
-                )
+            elif normalized_base_path and normalized_base_path not in (
+                "/openai/v1",
+                "/openai/v1/chat/completions",
             ):
                 reasons.append("dspy_jangar_base_url_invalid")
 
@@ -2259,9 +2290,10 @@ class Settings(BaseSettings):
                 reasons.append("dspy_artifact_hash_invalid_length")
             elif any(ch not in string.hexdigits for ch in normalized_hash):
                 reasons.append("dspy_artifact_hash_not_hex")
-            elif normalized_hash == (
-                _dspy_bootstrap_artifact_hash() or ""
-            ) and self.llm_dspy_runtime_mode == "active":
+            elif (
+                normalized_hash == (_dspy_bootstrap_artifact_hash() or "")
+                and self.llm_dspy_runtime_mode == "active"
+            ):
                 reasons.append("dspy_bootstrap_artifact_forbidden")
 
         if not self.llm_allowed_models:

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1922,15 +1922,6 @@ class Settings(BaseSettings):
                 "LLM_DSPY_LIVE_RUNTIME_BLOCK_QTY_MULTIPLIER must be within (0, 1]"
             )
         if (
-            self.llm_dspy_live_runtime_block_fail_mode
-            in {"pass_through", "pass_through_reduced_size"}
-            and self.trading_mode == "live"
-            and not self.llm_fail_open_live_approved
-        ):
-            raise ValueError(
-                "LLM_FAIL_OPEN_LIVE_APPROVED must be true when LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE is pass-through in live mode"
-            )
-        if (
             self.llm_dspy_runtime_mode in {"shadow", "active"}
             and not self.llm_dspy_artifact_hash
         ):

--- a/services/torghut/app/trading/portfolio.py
+++ b/services/torghut/app/trading/portfolio.py
@@ -186,7 +186,7 @@ class PortfolioSizer:
             notional, cap_methods = _apply_caps(notional, caps)
             applied_methods.extend(cap_methods)
 
-        qty, notional, approved, reasons = self._finalize_sized_order(
+        qty, notional, approved, reasons, diagnostics = self._finalize_sized_order(
             decision=decision,
             price=price,
             notional=notional,
@@ -202,6 +202,7 @@ class PortfolioSizer:
             "methods": applied_methods,
             "caps": {key: _decimal_str(value) for key, value in caps.items()},
             "reasons": list(reasons),
+            **diagnostics,
         }
 
         updated_params = dict(decision.params)
@@ -251,7 +252,9 @@ class PortfolioSizer:
         reason: str,
     ) -> PortfolioSizingResult:
         audit["output"] = {"status": "skipped", "reason": reason}
-        return PortfolioSizingResult(decision=decision, approved=True, reasons=[], audit=audit)
+        return PortfolioSizingResult(
+            decision=decision, approved=True, reasons=[], audit=audit
+        )
 
     def _apply_sizing_methods(
         self,
@@ -260,10 +263,18 @@ class PortfolioSizer:
         notional: Decimal,
         volatility: Optional[Decimal],
     ) -> tuple[Decimal, list[str]]:
-        notional, regime_method = _apply_allocator_regime_multiplier(notional, decision.params)
+        notional, regime_method = _apply_allocator_regime_multiplier(
+            notional, decision.params
+        )
         notional, vol_method = self._apply_volatility_scaling(notional, volatility)
-        notional, allocator_cap_method = _cap_by_allocator_approved_notional(notional, decision.params)
-        methods = [method for method in (regime_method, vol_method, allocator_cap_method) if method]
+        notional, allocator_cap_method = _cap_by_allocator_approved_notional(
+            notional, decision.params
+        )
+        methods = [
+            method
+            for method in (regime_method, vol_method, allocator_cap_method)
+            if method
+        ]
         return notional, methods
 
     def _collect_size_caps(
@@ -278,7 +289,9 @@ class PortfolioSizer:
         equity: Optional[Decimal],
     ) -> tuple[dict[str, Optional[Decimal]], list[str]]:
         reasons: list[str] = []
-        if _should_block_new_position(self.config.max_positions, current_count, current_qty):
+        if _should_block_new_position(
+            self.config.max_positions, current_count, current_qty
+        ):
             reasons.append("max_positions_exceeded")
 
         caps: dict[str, Optional[Decimal]] = {}
@@ -309,7 +322,9 @@ class PortfolioSizer:
         if gross_cap is not None:
             caps["gross_exposure"] = gross_cap
 
-        net_cap = _net_cap_for_trade(self.config.max_net_exposure, net_exposure, decision.action)
+        net_cap = _net_cap_for_trade(
+            self.config.max_net_exposure, net_exposure, decision.action
+        )
         if net_cap is not None:
             caps["net_exposure"] = net_cap
         return caps, reasons
@@ -323,7 +338,8 @@ class PortfolioSizer:
         current_qty: Decimal,
         applied_methods: list[str],
         reasons: list[str],
-    ) -> tuple[Decimal, Decimal, bool, list[str]]:
+    ) -> tuple[Decimal, Decimal, bool, list[str], dict[str, Any]]:
+        diagnostics: dict[str, Any] = {}
         for method in applied_methods:
             mapped_reason = _SIZING_CAP_ZERO_REASON_BY_METHOD.get(method)
             if mapped_reason is None:
@@ -336,7 +352,8 @@ class PortfolioSizer:
             if mapped_reason not in reasons:
                 reasons.append(mapped_reason)
         if reasons:
-            return Decimal("0"), Decimal("0"), False, reasons
+            diagnostics["limiting_constraint"] = reasons[0]
+            return Decimal("0"), Decimal("0"), False, reasons, diagnostics
 
         target_qty = notional / price
         fractional_equities_enabled = fractional_equities_enabled_for_trade(
@@ -354,13 +371,24 @@ class PortfolioSizer:
         min_qty = min_qty_for_symbol(
             decision.symbol, fractional_equities_enabled=fractional_equities_enabled
         )
+        diagnostics["fractional_allowed"] = fractional_equities_enabled
+        diagnostics["min_executable_qty"] = _decimal_str(min_qty)
+        diagnostics["min_executable_notional"] = _decimal_str(min_qty * price)
+        diagnostics["remaining_room_notional"] = _decimal_str(notional)
         if qty < min_qty and "shorts_not_allowed" not in reasons:
-            reasons.append("qty_below_min")
+            capacity_reason = _capacity_reason_from_methods(
+                applied_methods=applied_methods, reasons=reasons
+            )
+            if capacity_reason is not None:
+                reasons.append(capacity_reason)
+            else:
+                reasons.append("qty_below_min")
 
         approved = len(reasons) == 0
         if not approved:
-            return Decimal("0"), Decimal("0"), False, reasons
-        return qty, notional, True, reasons
+            diagnostics["limiting_constraint"] = reasons[0]
+            return Decimal("0"), Decimal("0"), False, reasons, diagnostics
+        return qty, notional, True, reasons, diagnostics
 
     def _resolve_base_notional(
         self, decision: StrategyDecision, base_notional: Decimal
@@ -433,8 +461,7 @@ class IntentAggregator:
             for item in bucket:
                 signed_qty = item.qty if item.action == "buy" else -item.qty
                 strategy_signed_qty[item.strategy_id] = (
-                    strategy_signed_qty.get(item.strategy_id, Decimal("0"))
-                    + signed_qty
+                    strategy_signed_qty.get(item.strategy_id, Decimal("0")) + signed_qty
                 )
 
             if buy_qty == sell_qty:
@@ -534,7 +561,9 @@ class PortfolioAllocator:
             normalized_regime,
             self.config.default_capacity_multiplier,
         )
-        fragility_adjustments = [self.fragility_monitor.evaluate(intent.decision) for intent in intents]
+        fragility_adjustments = [
+            self.fragility_monitor.evaluate(intent.decision) for intent in intents
+        ]
         enforce_fragility = self.fragility_monitor.config.mode == "enforce"
         portfolio_fragility_state = self.fragility_monitor.worst_state(
             [item.snapshot.fragility_state for item in fragility_adjustments]
@@ -553,7 +582,9 @@ class PortfolioAllocator:
 
         runtime = self._allocation_runtime(account=account, positions=positions)
         results: list[AllocationResult] = []
-        for intent, fragility_adjustment in zip(intents, fragility_adjustments, strict=False):
+        for intent, fragility_adjustment in zip(
+            intents, fragility_adjustments, strict=False
+        ):
             results.append(
                 self._allocate_intent(
                     intent=intent,
@@ -580,13 +611,19 @@ class PortfolioAllocator:
         enforce_fragility: bool,
     ) -> list[AllocationResult]:
         passthrough_results: list[AllocationResult] = []
-        for intent, fragility_adjustment in zip(intents, fragility_adjustments, strict=False):
-            apply_fragility = enforce_fragility and _has_fragility_signal(intent.decision)
-            effective_budget, effective_capacity = self._effective_allocation_multipliers(
-                apply_fragility=apply_fragility,
-                fragility_adjustment=fragility_adjustment,
-                base_budget_multiplier=budget_multiplier,
-                base_capacity_multiplier=capacity_multiplier,
+        for intent, fragility_adjustment in zip(
+            intents, fragility_adjustments, strict=False
+        ):
+            apply_fragility = enforce_fragility and _has_fragility_signal(
+                intent.decision
+            )
+            effective_budget, effective_capacity = (
+                self._effective_allocation_multipliers(
+                    apply_fragility=apply_fragility,
+                    fragility_adjustment=fragility_adjustment,
+                    base_budget_multiplier=budget_multiplier,
+                    base_capacity_multiplier=capacity_multiplier,
+                )
             )
             passthrough_results.append(
                 self._result_from_passthrough(
@@ -636,11 +673,13 @@ class PortfolioAllocator:
         correlation_group = self._resolve_correlation_group(decision)
         reason_codes: list[str] = []
         apply_fragility = enforce_fragility and _has_fragility_signal(decision)
-        effective_budget_multiplier, effective_capacity_multiplier = self._effective_allocation_multipliers(
-            apply_fragility=apply_fragility,
-            fragility_adjustment=fragility_adjustment,
-            base_budget_multiplier=base_budget_multiplier,
-            base_capacity_multiplier=base_capacity_multiplier,
+        effective_budget_multiplier, effective_capacity_multiplier = (
+            self._effective_allocation_multipliers(
+                apply_fragility=apply_fragility,
+                fragility_adjustment=fragility_adjustment,
+                base_budget_multiplier=base_budget_multiplier,
+                base_capacity_multiplier=base_capacity_multiplier,
+            )
         )
         (
             confidence_multiplier,
@@ -659,17 +698,19 @@ class PortfolioAllocator:
         if fragility_adjustment.stability_mode_active and apply_fragility:
             reason_codes.append("allocator_stability_mode_active")
 
-        adjusted_decision, approved, clipped, approved_notional = self._allocate_intent_qty(
-            intent=intent,
-            runtime=runtime,
-            price=price,
-            correlation_group=correlation_group,
-            reason_codes=reason_codes,
-            apply_fragility=apply_fragility,
-            fragility_adjustment=fragility_adjustment,
-            effective_budget_multiplier=effective_budget_multiplier,
-            effective_capacity_multiplier=effective_capacity_multiplier,
-            requested_notional=requested_notional,
+        adjusted_decision, approved, clipped, approved_notional = (
+            self._allocate_intent_qty(
+                intent=intent,
+                runtime=runtime,
+                price=price,
+                correlation_group=correlation_group,
+                reason_codes=reason_codes,
+                apply_fragility=apply_fragility,
+                fragility_adjustment=fragility_adjustment,
+                effective_budget_multiplier=effective_budget_multiplier,
+                effective_capacity_multiplier=effective_capacity_multiplier,
+                requested_notional=requested_notional,
+            )
         )
         return self._allocation_result(
             decision=decision,
@@ -697,8 +738,14 @@ class PortfolioAllocator:
         base_budget_multiplier: Decimal,
         base_capacity_multiplier: Decimal,
     ) -> tuple[Decimal, Decimal]:
-        fragility_budget = fragility_adjustment.budget_multiplier if apply_fragility else Decimal("1")
-        fragility_capacity = fragility_adjustment.capacity_multiplier if apply_fragility else Decimal("1")
+        fragility_budget = (
+            fragility_adjustment.budget_multiplier if apply_fragility else Decimal("1")
+        )
+        fragility_capacity = (
+            fragility_adjustment.capacity_multiplier
+            if apply_fragility
+            else Decimal("1")
+        )
         return (
             self._effective_multiplier(base_budget_multiplier, fragility_budget),
             self._effective_multiplier(base_capacity_multiplier, fragility_capacity),
@@ -719,14 +766,20 @@ class PortfolioAllocator:
         requested_notional: Optional[Decimal],
     ) -> tuple[StrategyDecision, bool, bool, Decimal]:
         decision = intent.decision
-        rejected, adjusted_decision = self._reject_invalid_allocation(decision, price, reason_codes)
+        rejected, adjusted_decision = self._reject_invalid_allocation(
+            decision, price, reason_codes
+        )
         if rejected:
             return adjusted_decision, False, False, Decimal("0")
         if price is None:
             raise RuntimeError("allocator_price_missing_after_validation")
 
-        symbol_qty, symbol_value = _position_summary(decision.symbol, runtime.current_positions)
-        if self._should_reject_crisis_entry(apply_fragility, fragility_adjustment, decision.action, symbol_value):
+        symbol_qty, symbol_value = _position_summary(
+            decision.symbol, runtime.current_positions
+        )
+        if self._should_reject_crisis_entry(
+            apply_fragility, fragility_adjustment, decision.action, symbol_value
+        ):
             reason_codes.append("allocator_reject_crisis_entry")
             adjusted_decision = decision.model_copy(update={"qty": Decimal("0")})
             return adjusted_decision, False, False, Decimal("0")
@@ -744,12 +797,14 @@ class PortfolioAllocator:
             caps=caps,
             reason_codes=reason_codes,
         )
-        adjusted_qty, approved, clipped, approved_notional = self._finalize_allocation_qty(
-            decision=decision,
-            price=price,
-            approved_notional=approved_notional,
-            current_qty=symbol_qty,
-            reason_codes=reason_codes,
+        adjusted_qty, approved, clipped, approved_notional = (
+            self._finalize_allocation_qty(
+                decision=decision,
+                price=price,
+                approved_notional=approved_notional,
+                current_qty=symbol_qty,
+                reason_codes=reason_codes,
+            )
         )
         adjusted_decision = decision.model_copy(update={"qty": adjusted_qty})
         if approved:
@@ -803,7 +858,11 @@ class PortfolioAllocator:
         base_symbol_cap = self._symbol_cap(runtime.equity)
         effective_symbol_cap: Optional[Decimal] = None
         if base_symbol_cap is not None:
-            effective_symbol_cap = base_symbol_cap * effective_budget_multiplier * effective_capacity_multiplier
+            effective_symbol_cap = (
+                base_symbol_cap
+                * effective_budget_multiplier
+                * effective_capacity_multiplier
+            )
 
         return {
             ALLOCATOR_CLIP_SYMBOL_CAPACITY: effective_symbol_cap,
@@ -899,18 +958,23 @@ class PortfolioAllocator:
         approved_notional: Decimal,
     ) -> None:
         runtime.approved_gross_delta += approved_notional
-        allocation_weights = _strategy_weights(intent.strategy_signed_qty, decision.action)
+        allocation_weights = _strategy_weights(
+            intent.strategy_signed_qty, decision.action
+        )
         for strategy_id, weight in allocation_weights:
             if weight <= 0:
                 continue
-            runtime.strategy_usage[strategy_id] = (
-                runtime.strategy_usage.get(strategy_id, Decimal("0")) + (approved_notional * weight)
-            )
+            runtime.strategy_usage[strategy_id] = runtime.strategy_usage.get(
+                strategy_id, Decimal("0")
+            ) + (approved_notional * weight)
         symbol_key = decision.symbol.strip().upper()
-        runtime.symbol_usage[symbol_key] = runtime.symbol_usage.get(symbol_key, Decimal("0")) + approved_notional
+        runtime.symbol_usage[symbol_key] = (
+            runtime.symbol_usage.get(symbol_key, Decimal("0")) + approved_notional
+        )
         if correlation_group:
             runtime.correlation_usage[correlation_group] = (
-                runtime.correlation_usage.get(correlation_group, Decimal("0")) + approved_notional
+                runtime.correlation_usage.get(correlation_group, Decimal("0"))
+                + approved_notional
             )
 
     def _allocation_result(
@@ -1155,8 +1219,12 @@ def allocator_from_settings(equity: Optional[Decimal]) -> PortfolioAllocator:
     correlation_group_caps.update(
         settings.trading_allocator_correlation_group_notional_caps
     )
-    symbol_correlation_groups = dict(settings.trading_allocator_symbol_correlation_groups)
-    symbol_correlation_groups.update(settings.trading_allocator_correlation_symbol_groups)
+    symbol_correlation_groups = dict(
+        settings.trading_allocator_symbol_correlation_groups
+    )
+    symbol_correlation_groups.update(
+        settings.trading_allocator_correlation_symbol_groups
+    )
     return PortfolioAllocator(
         AllocationConfig(
             enabled=settings.trading_allocator_enabled,
@@ -1406,6 +1474,25 @@ def _apply_caps(
     return capped, methods
 
 
+def _capacity_reason_from_methods(
+    *,
+    applied_methods: list[str],
+    reasons: list[str],
+) -> Optional[str]:
+    for method in reversed(applied_methods):
+        if method.startswith("cap_per_symbol"):
+            return "symbol_capacity_exhausted"
+        if method.startswith("cap_gross_exposure"):
+            return "gross_exposure_capacity_exhausted"
+        if method.startswith("cap_net_exposure"):
+            return "net_exposure_capacity_exhausted"
+        if method.startswith("cap_sell_inventory"):
+            if "shorts_not_allowed" in reasons:
+                return None
+            return "sell_inventory_unavailable"
+    return None
+
+
 def _remaining_symbol_capacity(
     absolute_cap: Optional[Decimal],
     *,
@@ -1529,9 +1616,7 @@ def _resolve_regime_confidence_multiplier(
     if confidence < Decimal("0") or confidence > Decimal("1"):
         return Decimal("1"), None, False
 
-    apply_penalty = (
-        confidence < threshold and low_confidence_multiplier < Decimal("1")
-    )
+    apply_penalty = confidence < threshold and low_confidence_multiplier < Decimal("1")
     if apply_penalty:
         return low_confidence_multiplier, confidence, True
     return Decimal("1"), confidence, False
@@ -1571,7 +1656,9 @@ def _decimal_map(
     return result
 
 
-def _fragility_decimal_map(values: Mapping[str, float]) -> dict[FragilityState, Decimal]:
+def _fragility_decimal_map(
+    values: Mapping[str, float],
+) -> dict[FragilityState, Decimal]:
     result: dict[FragilityState, Decimal] = {}
     for key, value in values.items():
         normalized_key = key.strip().lower()
@@ -1668,7 +1755,11 @@ def _apply_allocator_regime_multiplier(
     if isinstance(enabled, bool) and not enabled:
         return notional, None
     status = payload.get("status")
-    if isinstance(status, str) and status.strip() and status.strip().lower() != "approved":
+    if (
+        isinstance(status, str)
+        and status.strip()
+        and status.strip().lower() != "approved"
+    ):
         return notional, None
     budget_multiplier = _optional_decimal(payload.get("budget_multiplier"))
     capacity_multiplier = _optional_decimal(payload.get("capacity_multiplier"))

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -69,6 +69,11 @@ from .regime_hmm import (
     resolve_legacy_regime_label,
     resolve_regime_route_label,
 )
+from .quantity_rules import (
+    fractional_equities_enabled_for_trade,
+    min_qty_for_symbol,
+    quantize_qty_for_symbol,
+)
 from .autonomy import (
     DriftThresholds,
     DriftTriggerPolicy,
@@ -101,7 +106,9 @@ _RUNTIME_UNCERTAINTY_DEGRADE_QTY_MULTIPLIER = Decimal("0.50")
 _RUNTIME_UNCERTAINTY_DEGRADE_MAX_PARTICIPATION_RATE = Decimal("0.05")
 _RUNTIME_UNCERTAINTY_DEGRADE_MIN_EXECUTION_SECONDS = 120
 _RUNTIME_UNCERTAINTY_GATE_MAX_STALENESS_SECONDS = 15 * 60
-_RUNTIME_REGIME_CONFIDENCE_DEGRADE_BY_ENTROPY_BAND: dict[str, tuple[Decimal, Decimal]] = {
+_RUNTIME_REGIME_CONFIDENCE_DEGRADE_BY_ENTROPY_BAND: dict[
+    str, tuple[Decimal, Decimal]
+] = {
     "low": (Decimal("0.65"), Decimal("0.45")),
     "medium": (Decimal("0.75"), Decimal("0.55")),
     "high": (Decimal("0.85"), Decimal("0.70")),
@@ -1813,16 +1820,18 @@ class TradingPipeline:
         uncertainty_action = "pass"
         if isinstance(uncertainty_gate_payload, Mapping):
             uncertainty_gate_map = cast(Mapping[str, Any], uncertainty_gate_payload)
-            uncertainty_action = str(
-                uncertainty_gate_map.get("action") or "pass"
-            ).strip().lower()
+            uncertainty_action = (
+                str(uncertainty_gate_map.get("action") or "pass").strip().lower()
+            )
         elif str(gate_payload.get("action") or "pass").strip().lower() in {
             "pass",
             "degrade",
             "abstain",
             "fail",
         }:
-            uncertainty_action = str(gate_payload.get("action") or "pass").strip().lower()
+            uncertainty_action = (
+                str(gate_payload.get("action") or "pass").strip().lower()
+            )
         regime_gate_payload = gate_payload.get("regime_gate")
         regime_action = "pass"
         if isinstance(regime_gate_payload, Mapping):
@@ -1841,8 +1850,7 @@ class TradingPipeline:
             self.state.metrics.record_runtime_regime_gate(
                 cast(RuntimeUncertaintyGateAction, regime_action),
                 blocked=(
-                    gate_rejection is not None
-                    and regime_action in {"abstain", "fail"}
+                    gate_rejection is not None and regime_action in {"abstain", "fail"}
                 ),
             )
             self.state.last_runtime_regime_gate_action = regime_action
@@ -1862,8 +1870,7 @@ class TradingPipeline:
                     uncertainty_gate_map.get("source")
                     or gate_payload.get("source")
                     or ""
-                )
-                .strip()
+                ).strip()
                 or None
             )
             uncertainty_reason = str(uncertainty_gate_map.get("reason") or "").strip()
@@ -2010,10 +2017,7 @@ class TradingPipeline:
             )
         if extra_properties:
             properties.update(
-                {
-                    str(key): value
-                    for key, value in extra_properties.items()
-                }
+                {str(key): value for key, value in extra_properties.items()}
             )
         emitted, drop_reason = capture_posthog_event(
             event_name,
@@ -2037,8 +2041,8 @@ class TradingPipeline:
         positions: list[dict[str, Any]],
         snapshot: Optional[MarketSnapshot],
     ) -> tuple[StrategyDecision, Any] | None:
-        regime_label, regime_source, regime_fallback = _resolve_decision_regime_label_with_source(
-            decision
+        regime_label, regime_source, regime_fallback = (
+            _resolve_decision_regime_label_with_source(decision)
         )
         self.state.metrics.record_decision_regime_resolution(
             source=regime_source,
@@ -2480,15 +2484,11 @@ class TradingPipeline:
             if configured_qty_multiplier is not None:
                 qty_multiplier = Decimal(str(configured_qty_multiplier))
 
-            configured_max_participation_rate = (
-                settings.trading_runtime_uncertainty_degrade_max_participation_rate_by_regime.get(
-                    regime_key
-                )
+            configured_max_participation_rate = settings.trading_runtime_uncertainty_degrade_max_participation_rate_by_regime.get(
+                regime_key
             )
             if configured_max_participation_rate is not None:
-                max_participation_rate = Decimal(
-                    str(configured_max_participation_rate)
-                )
+                max_participation_rate = Decimal(str(configured_max_participation_rate))
 
             configured_min_execution_seconds = settings.trading_runtime_uncertainty_degrade_min_execution_seconds_by_regime.get(
                 regime_key
@@ -2636,11 +2636,15 @@ class TradingPipeline:
                     )
         if not candidates:
             candidates.append(
-                RuntimeUncertaintyGate(action="degrade", source="uncertainty_input_missing")
+                RuntimeUncertaintyGate(
+                    action="degrade", source="uncertainty_input_missing"
+                )
             )
         return _select_strictest_runtime_uncertainty_gate(candidates)
 
-    def _resolve_runtime_regime_gate(self, decision: StrategyDecision) -> RuntimeUncertaintyGate:
+    def _resolve_runtime_regime_gate(
+        self, decision: StrategyDecision
+    ) -> RuntimeUncertaintyGate:
         params = decision.params
 
         regime_gate = params.get("regime_gate")
@@ -2709,7 +2713,9 @@ class TradingPipeline:
             )
 
         try:
-            regime_context = resolve_hmm_context(cast(Mapping[str, Any], raw_regime_hmm))
+            regime_context = resolve_hmm_context(
+                cast(Mapping[str, Any], raw_regime_hmm)
+            )
         except Exception as exc:
             logger.warning(
                 "Failed to parse decision regime_hmm payload source=%s error=%s",
@@ -2727,7 +2733,8 @@ class TradingPipeline:
             decision
         )
         regime_stale = bool(
-            regime_context.guardrail.stale or regime_context.guardrail.fallback_to_defensive
+            regime_context.guardrail.stale
+            or regime_context.guardrail.fallback_to_defensive
         )
         regime_label = regime_label or regime_context.regime_id
         if regime_context.transition_shock:
@@ -2747,8 +2754,7 @@ class TradingPipeline:
                 regime_label=regime_label,
                 regime_stale=True,
                 reason=(
-                    regime_context.guardrail_reason
-                    or "regime_context_guardrail_stale"
+                    regime_context.guardrail_reason or "regime_context_guardrail_stale"
                 ),
             )
         if not regime_context.is_authoritative:
@@ -2799,8 +2805,8 @@ class TradingPipeline:
         if top_posterior_probability is None:
             return None
 
-        degrade_threshold, abstain_threshold = self._resolve_regime_confidence_thresholds(
-            regime_context.entropy_band
+        degrade_threshold, abstain_threshold = (
+            self._resolve_regime_confidence_thresholds(regime_context.entropy_band)
         )
         if top_posterior_probability < abstain_threshold:
             return RuntimeUncertaintyGate(
@@ -2924,19 +2930,11 @@ class TradingPipeline:
         current_override = _optional_decimal(
             allocator.get("max_participation_rate_override")
         )
-        if (
-            current_override is None
-            or current_override > max_participation_rate
-        ):
-            allocator["max_participation_rate_override"] = str(
-                max_participation_rate
-            )
+        if current_override is None or current_override > max_participation_rate:
+            allocator["max_participation_rate_override"] = str(max_participation_rate)
         params["allocator"] = allocator
         execution_seconds = _optional_int(params.get("execution_seconds"))
-        if (
-            execution_seconds is None
-            or execution_seconds < min_execution_seconds
-        ):
+        if execution_seconds is None or execution_seconds < min_execution_seconds:
             params["execution_seconds"] = min_execution_seconds
 
         qty = _optional_decimal(decision.qty)
@@ -2945,9 +2943,7 @@ class TradingPipeline:
             scaled = (qty * degrade_qty_multiplier).quantize(Decimal("1"))
             adjusted_qty = max(Decimal("1"), scaled)
         payload["degrade_qty_multiplier"] = str(degrade_qty_multiplier)
-        payload["max_participation_rate_override"] = str(
-            max_participation_rate
-        )
+        payload["max_participation_rate_override"] = str(max_participation_rate)
         payload["min_execution_seconds"] = min_execution_seconds
         payload["adjusted_qty"] = str(adjusted_qty)
         return (
@@ -3260,18 +3256,92 @@ class TradingPipeline:
         risk_flags: list[str],
         policy_resolution: Optional[dict[str, Any]] = None,
     ) -> tuple[StrategyDecision, Optional[str]]:
+        block_fail_mode = settings.llm_dspy_live_runtime_block_fail_mode
+        effective_fail_mode = "veto" if block_fail_mode == "veto" else "pass_through"
+        passthrough_decision = decision
+        if block_fail_mode == "pass_through_reduced_size":
+            passthrough_decision = self._degrade_llm_runtime_block_qty(
+                decision=decision,
+                positions=positions,
+                reason=reason,
+                risk_flags=risk_flags,
+            )
         return self._handle_llm_unavailable(
             session,
-            decision,
+            passthrough_decision,
             decision_row,
             account,
             positions,
             reason=reason,
             shadow_mode=False,
-            effective_fail_mode="veto",
+            effective_fail_mode=effective_fail_mode,
             risk_flags=risk_flags,
             market_context=None,
             policy_resolution=policy_resolution,
+        )
+
+    @staticmethod
+    def _degrade_llm_runtime_block_qty(
+        *,
+        decision: StrategyDecision,
+        positions: list[dict[str, Any]],
+        reason: str,
+        risk_flags: list[str],
+    ) -> StrategyDecision:
+        multiplier = Decimal(str(settings.llm_dspy_live_runtime_block_qty_multiplier))
+        if multiplier >= Decimal("1"):
+            return decision
+
+        current_qty = Decimal("0")
+        for position in positions:
+            if str(position.get("symbol") or "").upper() != decision.symbol.upper():
+                continue
+            raw_qty = position.get("qty") or position.get("quantity")
+            if raw_qty is None:
+                continue
+            try:
+                qty = Decimal(str(raw_qty))
+            except (ArithmeticError, ValueError):
+                continue
+            side = str(position.get("side") or "").lower()
+            if side == "short":
+                qty = -abs(qty)
+            current_qty += qty
+
+        scaled_qty = decision.qty * multiplier
+        fractional_equities_enabled = fractional_equities_enabled_for_trade(
+            action=decision.action,
+            global_enabled=settings.trading_fractional_equities_enabled,
+            allow_shorts=settings.trading_allow_shorts,
+            position_qty=current_qty,
+            requested_qty=scaled_qty,
+        )
+        quantized_qty = quantize_qty_for_symbol(
+            decision.symbol,
+            scaled_qty,
+            fractional_equities_enabled=fractional_equities_enabled,
+        )
+        min_qty = min_qty_for_symbol(
+            decision.symbol, fractional_equities_enabled=fractional_equities_enabled
+        )
+        if quantized_qty < min_qty:
+            if decision.qty >= min_qty:
+                quantized_qty = min_qty
+            else:
+                quantized_qty = decision.qty
+        if quantized_qty <= 0 or quantized_qty >= decision.qty:
+            return decision
+
+        updated_params = dict(decision.params)
+        updated_params["llm_runtime_block_degrade"] = {
+            "reason": reason,
+            "risk_flags": list(risk_flags),
+            "qty_multiplier": str(multiplier),
+            "original_qty": str(decision.qty),
+            "degraded_qty": str(quantized_qty),
+        }
+        return decision.model_copy(
+            update={"qty": quantized_qty, "params": updated_params}
         )
 
     def _run_llm_review_request(
@@ -3552,9 +3622,7 @@ class TradingPipeline:
         error: Exception,
     ) -> tuple[StrategyDecision, Optional[str]]:
         self.state.metrics.llm_error_total += 1
-        unsupported_state_error = isinstance(
-            error, DSPyRuntimeUnsupportedStateError
-        )
+        unsupported_state_error = isinstance(error, DSPyRuntimeUnsupportedStateError)
         if not unsupported_state_error:
             engine.circuit_breaker.record_error()
         if unsupported_state_error:
@@ -3683,7 +3751,9 @@ class TradingPipeline:
                     "adjustment_allowed": settings.llm_adjustment_allowed,
                     "min_qty_multiplier": str(settings.llm_min_qty_multiplier),
                     "max_qty_multiplier": str(settings.llm_max_qty_multiplier),
-                    "allowed_order_types": sorted(allowed_order_types(decision.order_type)),
+                    "allowed_order_types": sorted(
+                        allowed_order_types(decision.order_type)
+                    ),
                 },
                 "trading_mode": settings.trading_mode,
                 "prompt_version": f"dspy:{settings.llm_dspy_signature_version}",
@@ -3871,7 +3941,9 @@ class TradingPipeline:
             response_payload_json,
             artifact_source="runtime_persisted_review",
         )
-        if not isinstance(response_payload_json.get("committee_veto_alignment"), Mapping):
+        if not isinstance(
+            response_payload_json.get("committee_veto_alignment"), Mapping
+        ):
             response_payload_json["committee_veto_alignment"] = (
                 _build_committee_veto_alignment_payload(
                     committee_veto=_committee_trace_has_veto(response_payload_json),
@@ -4357,13 +4429,24 @@ def _build_dspy_lineage(response_json: Mapping[str, Any]) -> dict[str, Any]:
         dspy_payload = {
             str(key): value for key, value in cast(Mapping[str, Any], payload).items()
         }
-    mode = _normalize_optional_text(dspy_payload.get("mode")) or settings.llm_dspy_runtime_mode
-    program_name = _normalize_optional_text(dspy_payload.get("program_name")) or settings.llm_dspy_program_name
-    signature_version = _normalize_optional_text(dspy_payload.get("signature_version")) or settings.llm_dspy_signature_version
-    artifact_hash = _normalize_optional_text(dspy_payload.get("artifact_hash")) or _normalize_optional_text(
-        settings.llm_dspy_artifact_hash
+    mode = (
+        _normalize_optional_text(dspy_payload.get("mode"))
+        or settings.llm_dspy_runtime_mode
     )
-    artifact_source = _normalize_optional_text(dspy_payload.get("artifact_source")) or "runtime"
+    program_name = (
+        _normalize_optional_text(dspy_payload.get("program_name"))
+        or settings.llm_dspy_program_name
+    )
+    signature_version = (
+        _normalize_optional_text(dspy_payload.get("signature_version"))
+        or settings.llm_dspy_signature_version
+    )
+    artifact_hash = _normalize_optional_text(
+        dspy_payload.get("artifact_hash")
+    ) or _normalize_optional_text(settings.llm_dspy_artifact_hash)
+    artifact_source = (
+        _normalize_optional_text(dspy_payload.get("artifact_source")) or "runtime"
+    )
     return {
         "mode": mode,
         "program_name": program_name,
@@ -4381,7 +4464,9 @@ def _attach_dspy_lineage(
 ) -> None:
     payload = response_json.get("dspy")
     if isinstance(payload, Mapping):
-        dspy_payload = {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+        dspy_payload = {
+            str(key): value for key, value in cast(Mapping[str, Any], payload).items()
+        }
         if _normalize_optional_text(dspy_payload.get("artifact_source")) is None:
             dspy_payload["artifact_source"] = artifact_source
         if error is not None and error.strip() and "error" not in dspy_payload:
@@ -4405,7 +4490,9 @@ def _committee_trace_has_veto(response_json: Mapping[str, Any]) -> bool:
     for role_payload in cast(Mapping[str, Any], committee_roles).values():
         if not isinstance(role_payload, Mapping):
             continue
-        verdict = _normalize_optional_text(cast(Mapping[str, Any], role_payload).get("verdict"))
+        verdict = _normalize_optional_text(
+            cast(Mapping[str, Any], role_payload).get("verdict")
+        )
         if verdict == "veto":
             return True
     return False
@@ -4650,9 +4737,7 @@ class TradingScheduler:
             account_label=lane.label,
             price_fetcher=price_fetcher,
             strategy_catalog=strategy_catalog,
-            order_feed_ingestor=OrderFeedIngestor(
-                default_account_label=lane.label
-            ),
+            order_feed_ingestor=OrderFeedIngestor(default_account_label=lane.label),
         )
 
     def _build_pipeline(self) -> TradingPipeline:
@@ -5210,9 +5295,9 @@ class TradingScheduler:
 
     def _load_last_gate_provenance(self) -> dict[str, str | None]:
         gate_path_raw = self.state.last_autonomy_gates
-        actuation_path_raw = (
-            str(self.state.last_autonomy_actuation_intent or "").strip()
-        )
+        actuation_path_raw = str(
+            self.state.last_autonomy_actuation_intent or ""
+        ).strip()
         payload: dict[str, Any] = {}
         actuation_payload: dict[str, Any] = {}
         if gate_path_raw:
@@ -5640,7 +5725,9 @@ class TradingScheduler:
             or ("live" if promotion_target == "live" else "unknown")
         )
         priority_id = os.getenv("PRIORITY_ID") or os.getenv("CODEX_PRIORITY_ID") or ""
-        design_ref = design_doc if design_doc is not None else os.getenv("DESIGN_DOC", "")
+        design_ref = (
+            design_doc if design_doc is not None else os.getenv("DESIGN_DOC", "")
+        )
         return {
             "repository": repository,
             "base": base_ref,
@@ -6021,10 +6108,7 @@ class TradingScheduler:
                         "execution_context": dict(
                             execution_context
                             or self._build_autonomy_execution_context(
-                                artifact_root=(
-                                    artifact_root
-                                    or run_output_dir.parent
-                                ),
+                                artifact_root=(artifact_root or run_output_dir.parent),
                                 promotion_target=promotion_target,
                             )
                         ),
@@ -6100,9 +6184,7 @@ class TradingScheduler:
         self.state.last_autonomy_candidate_id = result.candidate_id
         self.state.last_autonomy_gates = str(result.gate_report_path)
         self.state.last_autonomy_actuation_intent = (
-            str(result.actuation_intent_path)
-            if result.actuation_intent_path
-            else None
+            str(result.actuation_intent_path) if result.actuation_intent_path else None
         )
         self.state.last_autonomy_phase_manifest = str(result.phase_manifest_path)
         self.state.last_autonomy_reason = None
@@ -6120,9 +6202,7 @@ class TradingScheduler:
                 cast(Mapping[str, Any], gate_report)
             )
         actuation_payload: dict[str, Any] = {}
-        actuation_gates_payload: Mapping[str, Any] = cast(
-            Mapping[str, Any], {}
-        )
+        actuation_gates_payload: Mapping[str, Any] = cast(Mapping[str, Any], {})
         actuation_allowed = False
         if result.actuation_intent_path is not None:
             try:
@@ -6251,7 +6331,9 @@ class TradingScheduler:
                 self._append_runtime_governance_to_phase_manifest(
                     manifest_path=Path(last_manifest),
                     requested_promotion_target=requested_promotion_target,
-                    drift_governance_payload=cast(Mapping[str, Any], drift_governance_payload),
+                    drift_governance_payload=cast(
+                        Mapping[str, Any], drift_governance_payload
+                    ),
                     now=now,
                 )
         else:
@@ -6309,11 +6391,15 @@ class TradingScheduler:
         artifact_refs_payload = drift_governance_payload.get("artifact_refs", [])
         action_payload = drift_governance_payload.get("action")
         detection_payload = drift_governance_payload.get("detection")
-        drift_status = str(
-            drift_governance_payload.get("drift_status")
-            or self.state.drift_status
-            or "skipped"
-        ).strip().lower()
+        drift_status = (
+            str(
+                drift_governance_payload.get("drift_status")
+                or self.state.drift_status
+                or "skipped"
+            )
+            .strip()
+            .lower()
+        )
         has_payload_values = (
             drift_governance_payload.get("rollback_triggered")
             or isinstance(action_payload, Mapping)
@@ -6403,7 +6489,9 @@ class TradingScheduler:
             and rollback_triggered
             and isinstance(self.state.rollback_incident_evidence_path, str)
         ):
-            rollback_incident_evidence = self.state.rollback_incident_evidence_path.strip()
+            rollback_incident_evidence = (
+                self.state.rollback_incident_evidence_path.strip()
+            )
 
         governance_status = (
             "fail"

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -219,22 +219,9 @@ class TestConfig(TestCase):
         self.assertFalse(allowed)
         self.assertIn("dspy_bootstrap_artifact_forbidden", reasons)
 
-    def test_rejects_live_dspy_runtime_block_pass_through_without_approval(
+    def test_allows_live_dspy_runtime_block_pass_through_without_fail_open_approval(
         self,
     ) -> None:
-        with self.assertRaises(ValidationError):
-            Settings(
-                TRADING_MODE="live",
-                TRADING_LIVE_ENABLED=True,
-                TRADING_UNIVERSE_SOURCE="jangar",
-                LLM_DSPY_RUNTIME_MODE="active",
-                LLM_DSPY_ARTIFACT_HASH="a" * 64,
-                LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE="pass_through_reduced_size",
-                LLM_FAIL_OPEN_LIVE_APPROVED=False,
-                DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
-            )
-
-    def test_allows_live_dspy_runtime_block_pass_through_with_approval(self) -> None:
         settings = Settings(
             TRADING_MODE="live",
             TRADING_LIVE_ENABLED=True,
@@ -242,7 +229,7 @@ class TestConfig(TestCase):
             LLM_DSPY_RUNTIME_MODE="active",
             LLM_DSPY_ARTIFACT_HASH="a" * 64,
             LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE="pass_through_reduced_size",
-            LLM_FAIL_OPEN_LIVE_APPROVED=True,
+            LLM_FAIL_OPEN_LIVE_APPROVED=False,
             DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
         self.assertEqual(

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -46,7 +46,9 @@ class TestConfig(TestCase):
         )
         self.assertEqual(settings.trading_universe_source, "static")
 
-    def test_deprecated_live_enabled_sets_trading_mode_when_mode_not_provided(self) -> None:
+    def test_deprecated_live_enabled_sets_trading_mode_when_mode_not_provided(
+        self,
+    ) -> None:
         settings = Settings(
             TRADING_ENABLED=False,
             TRADING_AUTONOMY_ENABLED=False,
@@ -217,6 +219,37 @@ class TestConfig(TestCase):
         self.assertFalse(allowed)
         self.assertIn("dspy_bootstrap_artifact_forbidden", reasons)
 
+    def test_rejects_live_dspy_runtime_block_pass_through_without_approval(
+        self,
+    ) -> None:
+        with self.assertRaises(ValidationError):
+            Settings(
+                TRADING_MODE="live",
+                TRADING_LIVE_ENABLED=True,
+                TRADING_UNIVERSE_SOURCE="jangar",
+                LLM_DSPY_RUNTIME_MODE="active",
+                LLM_DSPY_ARTIFACT_HASH="a" * 64,
+                LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE="pass_through_reduced_size",
+                LLM_FAIL_OPEN_LIVE_APPROVED=False,
+                DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+            )
+
+    def test_allows_live_dspy_runtime_block_pass_through_with_approval(self) -> None:
+        settings = Settings(
+            TRADING_MODE="live",
+            TRADING_LIVE_ENABLED=True,
+            TRADING_UNIVERSE_SOURCE="jangar",
+            LLM_DSPY_RUNTIME_MODE="active",
+            LLM_DSPY_ARTIFACT_HASH="a" * 64,
+            LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE="pass_through_reduced_size",
+            LLM_FAIL_OPEN_LIVE_APPROVED=True,
+            DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+        )
+        self.assertEqual(
+            settings.llm_dspy_live_runtime_block_fail_mode,
+            "pass_through_reduced_size",
+        )
+
     def test_live_dspy_runtime_gate_blocks_without_jangar_base_url(self) -> None:
         settings = Settings(
             TRADING_MODE="live",
@@ -244,7 +277,9 @@ class TestConfig(TestCase):
         self.assertFalse(allowed)
         self.assertIn("dspy_jangar_base_url_invalid", reasons)
 
-    def test_live_dspy_runtime_gate_rejects_empty_hostname_jangar_base_url(self) -> None:
+    def test_live_dspy_runtime_gate_rejects_empty_hostname_jangar_base_url(
+        self,
+    ) -> None:
         settings = Settings(
             TRADING_MODE="live",
             TRADING_LIVE_ENABLED=True,
@@ -258,7 +293,9 @@ class TestConfig(TestCase):
         self.assertFalse(allowed)
         self.assertIn("dspy_jangar_base_url_invalid", reasons)
 
-    def test_live_dspy_runtime_gate_blocks_jangar_path_with_query_or_fragment(self) -> None:
+    def test_live_dspy_runtime_gate_blocks_jangar_path_with_query_or_fragment(
+        self,
+    ) -> None:
         settings = Settings(
             TRADING_MODE="live",
             TRADING_LIVE_ENABLED=True,
@@ -286,7 +323,9 @@ class TestConfig(TestCase):
         self.assertFalse(allowed)
         self.assertIn("dspy_jangar_base_url_invalid", reasons)
 
-    def test_live_dspy_runtime_gate_allows_openai_compatible_jangar_base_url(self) -> None:
+    def test_live_dspy_runtime_gate_allows_openai_compatible_jangar_base_url(
+        self,
+    ) -> None:
         settings = Settings(
             TRADING_MODE="live",
             TRADING_LIVE_ENABLED=True,
@@ -329,7 +368,9 @@ class TestConfig(TestCase):
         self.assertTrue(allowed)
         self.assertNotIn("dspy_jangar_base_url_invalid", reasons)
 
-    def test_live_dspy_runtime_gate_blocks_legacy_fail_open_cutover_toggles(self) -> None:
+    def test_live_dspy_runtime_gate_blocks_legacy_fail_open_cutover_toggles(
+        self,
+    ) -> None:
         settings = Settings(
             TRADING_MODE="live",
             TRADING_LIVE_ENABLED=True,
@@ -455,7 +496,9 @@ class TestConfig(TestCase):
             {"riskoff": 180},
         )
 
-    def test_runtime_uncertainty_degrade_regime_maps_reject_invalid_values(self) -> None:
+    def test_runtime_uncertainty_degrade_regime_maps_reject_invalid_values(
+        self,
+    ) -> None:
         with self.assertRaises(ValidationError):
             Settings(
                 TRADING_UNIVERSE_SOURCE="static",
@@ -723,7 +766,9 @@ class TestConfig(TestCase):
 
         self.assertEqual(call_count, 1)
 
-    def test_feature_flag_invalid_payload_short_circuit_remaining_remote_lookups(self) -> None:
+    def test_feature_flag_invalid_payload_short_circuit_remaining_remote_lookups(
+        self,
+    ) -> None:
         call_count = 0
 
         class _Response:
@@ -803,7 +848,9 @@ class TestConfig(TestCase):
             manifest_keys,
         )
 
-    def test_trading_accounts_registry_falls_back_to_single_account_when_disabled(self) -> None:
+    def test_trading_accounts_registry_falls_back_to_single_account_when_disabled(
+        self,
+    ) -> None:
         settings = Settings(
             TRADING_MULTI_ACCOUNT_ENABLED=False,
             TRADING_ACCOUNT_LABEL="paper-a",
@@ -827,7 +874,12 @@ class TestConfig(TestCase):
             TRADING_ACCOUNTS_JSON=json.dumps(
                 {
                     "accounts": [
-                        {"label": "paper-a", "enabled": True, "api_key": "k1", "secret_key": "s1"},
+                        {
+                            "label": "paper-a",
+                            "enabled": True,
+                            "api_key": "k1",
+                            "secret_key": "s1",
+                        },
                         {"label": "paper-b", "enabled": False},
                         {"label": "paper-c", "enabled": True},
                     ]
@@ -854,7 +906,11 @@ class TestConfig(TestCase):
                             "enabled": True,
                             "api_key": "primary-key",
                         },
-                        {"label": "  paper-b  ", "enabled": True, "api_key": "dupe-key"},
+                        {
+                            "label": "  paper-b  ",
+                            "enabled": True,
+                            "api_key": "dupe-key",
+                        },
                         {
                             "label": "paper-c",
                             "enabled": True,
@@ -866,5 +922,7 @@ class TestConfig(TestCase):
             DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
         accounts = settings.trading_accounts
-        self.assertEqual([account.label for account in accounts], ["paper-b", "paper-c"])
+        self.assertEqual(
+            [account.label for account in accounts], ["paper-b", "paper-c"]
+        )
         self.assertEqual(accounts[0].api_key, "primary-key")

--- a/services/torghut/tests/test_portfolio_sizing.py
+++ b/services/torghut/tests/test_portfolio_sizing.py
@@ -498,8 +498,12 @@ class TestPortfolioSizing(TestCase):
         )
 
         self.assertEqual(len(results), 2)
-        approved = next(result for result in results if result.decision.symbol == "AAPL")
-        rejected = next(result for result in results if result.decision.symbol == "MSFT")
+        approved = next(
+            result for result in results if result.decision.symbol == "AAPL"
+        )
+        rejected = next(
+            result for result in results if result.decision.symbol == "MSFT"
+        )
         self.assertTrue(approved.approved)
         self.assertIn(ALLOCATOR_CLIP_CORRELATION_CAPACITY, approved.reason_codes)
         self.assertEqual(approved.decision.qty, Decimal("5"))
@@ -543,7 +547,9 @@ class TestPortfolioSizing(TestCase):
         result = sizer.size(decision, account={"equity": "50000"}, positions=[])
         self.assertTrue(result.approved)
         self.assertEqual(result.decision.qty, Decimal("10"))
-        self.assertNotIn("allocator_regime_multiplier", result.audit["output"]["methods"])
+        self.assertNotIn(
+            "allocator_regime_multiplier", result.audit["output"]["methods"]
+        )
 
     def test_allocator_from_settings_consumes_normalized_correlation_maps(self) -> None:
         original_values = {
@@ -587,12 +593,12 @@ class TestPortfolioSizing(TestCase):
             config.settings.trading_allocator_correlation_group_notional_caps = (
                 original_values["trading_allocator_correlation_group_notional_caps"]
             )
-            config.settings.trading_allocator_symbol_correlation_groups = original_values[
-                "trading_allocator_symbol_correlation_groups"
-            ]
-            config.settings.trading_allocator_correlation_symbol_groups = original_values[
-                "trading_allocator_correlation_symbol_groups"
-            ]
+            config.settings.trading_allocator_symbol_correlation_groups = (
+                original_values["trading_allocator_symbol_correlation_groups"]
+            )
+            config.settings.trading_allocator_correlation_symbol_groups = (
+                original_values["trading_allocator_correlation_symbol_groups"]
+            )
 
     def test_volatility_scaling_and_symbol_cap(self) -> None:
         sizer = PortfolioSizer(
@@ -745,7 +751,9 @@ class TestPortfolioSizing(TestCase):
         self.assertTrue(result.approved)
         self.assertEqual(result.decision.qty, Decimal("5"))
 
-    def test_symbol_capacity_exhaustion_reports_capacity_reason_not_qty_min(self) -> None:
+    def test_symbol_capacity_exhaustion_reports_capacity_reason_not_qty_min(
+        self,
+    ) -> None:
         sizer = PortfolioSizer(
             PortfolioSizingConfig(
                 notional_per_position=None,
@@ -779,6 +787,88 @@ class TestPortfolioSizing(TestCase):
         portfolio_output = result.audit.get("output", {})
         self.assertEqual(portfolio_output.get("status"), "rejected")
         self.assertIn("cap_per_symbol_zero", portfolio_output.get("methods", []))
+
+    def test_symbol_capacity_clip_below_one_share_reports_capacity_reason(self) -> None:
+        sizer = PortfolioSizer(
+            PortfolioSizingConfig(
+                notional_per_position=None,
+                volatility_target=None,
+                volatility_floor=Decimal("0"),
+                max_positions=None,
+                max_notional_per_symbol=Decimal("1000"),
+                max_position_pct_equity=None,
+                max_gross_exposure=None,
+                max_net_exposure=None,
+            )
+        )
+        decision = StrategyDecision(
+            strategy_id="s1",
+            symbol="NVDA",
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("2"),
+            order_type="market",
+            time_in_force="day",
+            params={"price": Decimal("100")},
+        )
+        positions = [{"symbol": "NVDA", "qty": "9.5", "market_value": "950"}]
+
+        result = sizer.size(decision, account={"equity": "10000"}, positions=positions)
+
+        self.assertFalse(result.approved)
+        self.assertIn("symbol_capacity_exhausted", result.reasons)
+        self.assertNotIn("qty_below_min", result.reasons)
+        portfolio_output = result.audit.get("output", {})
+        self.assertIn("cap_per_symbol", portfolio_output.get("methods", []))
+        self.assertEqual(
+            portfolio_output.get("limiting_constraint"), "symbol_capacity_exhausted"
+        )
+
+    def test_sell_inventory_clip_below_one_share_reports_inventory_reason(self) -> None:
+        original_allow_shorts = config.settings.trading_allow_shorts
+        config.settings.trading_allow_shorts = False
+        try:
+            sizer = PortfolioSizer(
+                PortfolioSizingConfig(
+                    notional_per_position=None,
+                    volatility_target=None,
+                    volatility_floor=Decimal("0"),
+                    max_positions=None,
+                    max_notional_per_symbol=None,
+                    max_position_pct_equity=None,
+                    max_gross_exposure=None,
+                    max_net_exposure=None,
+                )
+            )
+            decision = StrategyDecision(
+                strategy_id="s1",
+                symbol="NVDA",
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("2"),
+                order_type="market",
+                time_in_force="day",
+                params={"price": Decimal("100")},
+            )
+            positions = [{"symbol": "NVDA", "qty": "0.5", "market_value": "50"}]
+
+            result = sizer.size(
+                decision, account={"equity": "10000"}, positions=positions
+            )
+
+            self.assertFalse(result.approved)
+            self.assertIn("sell_inventory_unavailable", result.reasons)
+            self.assertNotIn("qty_below_min", result.reasons)
+            portfolio_output = result.audit.get("output", {})
+            self.assertIn("cap_sell_inventory", portfolio_output.get("methods", []))
+            self.assertEqual(
+                portfolio_output.get("limiting_constraint"),
+                "sell_inventory_unavailable",
+            )
+        finally:
+            config.settings.trading_allow_shorts = original_allow_shorts
 
     def test_allocator_clips_fractional_crypto_qty(self) -> None:
         allocator = PortfolioAllocator(
@@ -970,7 +1060,9 @@ class TestPortfolioSizing(TestCase):
         finally:
             config.settings.trading_allow_shorts = original_allow_shorts
 
-    def test_sizer_allows_fractional_sell_after_inventory_clip_when_enabled(self) -> None:
+    def test_sizer_allows_fractional_sell_after_inventory_clip_when_enabled(
+        self,
+    ) -> None:
         original_allow_shorts = config.settings.trading_allow_shorts
         config.settings.trading_allow_shorts = False
         config.settings.trading_fractional_equities_enabled = True
@@ -1039,14 +1131,18 @@ class TestPortfolioSizing(TestCase):
             )
             positions = [{"symbol": "NVDA", "qty": "3", "market_value": "300"}]
 
-            result = sizer.size(decision, account={"equity": "10000"}, positions=positions)
+            result = sizer.size(
+                decision, account={"equity": "10000"}, positions=positions
+            )
 
             self.assertTrue(result.approved)
             self.assertEqual(result.decision.qty, Decimal("3"))
         finally:
             config.settings.trading_allow_shorts = original_allow_shorts
 
-    def test_allocator_allows_fractional_sell_after_capacity_clip_when_enabled(self) -> None:
+    def test_allocator_allows_fractional_sell_after_capacity_clip_when_enabled(
+        self,
+    ) -> None:
         original_allow_shorts = config.settings.trading_allow_shorts
         config.settings.trading_allow_shorts = False
         config.settings.trading_fractional_equities_enabled = True
@@ -1136,7 +1232,9 @@ class TestPortfolioSizing(TestCase):
     def test_sizer_from_settings_does_not_couple_per_trade_cap_to_symbol_capacity(
         self,
     ) -> None:
-        original_max_position_pct_equity = config.settings.trading_max_position_pct_equity
+        original_max_position_pct_equity = (
+            config.settings.trading_max_position_pct_equity
+        )
         original_max_notional_per_symbol = (
             config.settings.trading_portfolio_max_notional_per_symbol
         )

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -300,15 +300,28 @@ class FakeLLMReviewEngine:
         response = LLMReviewResponse(
             verdict=self.verdict,
             confidence=self.confidence,
-            confidence_band=self.confidence_band or (
-                "high" if self.confidence >= 0.75 else "medium" if self.confidence >= 0.5 else "low"
+            confidence_band=self.confidence_band
+            or (
+                "high"
+                if self.confidence >= 0.75
+                else "medium"
+                if self.confidence >= 0.5
+                else "low"
             ),
             calibrated_probabilities=self.calibrated_probabilities
             or _default_probabilities(self.verdict, self.confidence),
             uncertainty={
-                "score": self.uncertainty_score if self.uncertainty_score is not None else (1.0 - self.confidence),
+                "score": self.uncertainty_score
+                if self.uncertainty_score is not None
+                else (1.0 - self.confidence),
                 "band": self.uncertainty_band
-                or ("low" if self.confidence >= 0.75 else "medium" if self.confidence >= 0.5 else "high"),
+                or (
+                    "low"
+                    if self.confidence >= 0.75
+                    else "medium"
+                    if self.confidence >= 0.5
+                    else "high"
+                ),
             },
             calibration_metadata=(
                 {"quality_score": self.calibration_quality_score}
@@ -508,11 +521,15 @@ class TestTradingPipeline(TestCase):
             )
 
             self.assertIs(
-                pipeline._execution_client_for_symbol("MSFT", symbol_allowlist={"MSFT"}),
+                pipeline._execution_client_for_symbol(
+                    "MSFT", symbol_allowlist={"MSFT"}
+                ),
                 lean_adapter,
             )
             self.assertIs(
-                pipeline._execution_client_for_symbol("AAPL", symbol_allowlist={"MSFT"}),
+                pipeline._execution_client_for_symbol(
+                    "AAPL", symbol_allowlist={"MSFT"}
+                ),
                 lean_adapter,
             )
             self.assertIs(
@@ -520,7 +537,9 @@ class TestTradingPipeline(TestCase):
                 lean_adapter,
             )
         finally:
-            config.settings.trading_execution_adapter = original["trading_execution_adapter"]
+            config.settings.trading_execution_adapter = original[
+                "trading_execution_adapter"
+            ]
             config.settings.trading_execution_adapter_policy = original[
                 "trading_execution_adapter_policy"
             ]
@@ -646,8 +665,12 @@ class TestTradingPipeline(TestCase):
                     params={"price": Decimal("100")},
                 )
                 executor = OrderExecutor()
-                decision_row = executor.ensure_decision(session, decision, strategy, "paper")
-                decision_row.created_at = datetime.now(timezone.utc) - timedelta(seconds=300)
+                decision_row = executor.ensure_decision(
+                    session, decision, strategy, "paper"
+                )
+                decision_row.created_at = datetime.now(timezone.utc) - timedelta(
+                    seconds=300
+                )
                 session.add(decision_row)
                 session.commit()
 
@@ -689,7 +712,9 @@ class TestTradingPipeline(TestCase):
                 self.assertEqual(
                     pipeline.state.metrics.planned_decisions_timeout_rejected_total, 1
                 )
-                self.assertEqual(pipeline.state.metrics.planned_decisions_stale_total, 1)
+                self.assertEqual(
+                    pipeline.state.metrics.planned_decisions_stale_total, 1
+                )
         finally:
             config.settings.trading_planned_decision_timeout_seconds = original_timeout
 
@@ -971,7 +996,9 @@ class TestTradingPipeline(TestCase):
                 "trading_static_symbols_raw"
             ]
 
-    def test_runtime_uncertainty_gate_resolves_strictest_action_across_sources(self) -> None:
+    def test_runtime_uncertainty_gate_resolves_strictest_action_across_sources(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             gate_path = Path(tmpdir) / "gate-report.json"
             gate_path.write_text(
@@ -1011,7 +1038,9 @@ class TestTradingPipeline(TestCase):
             self.assertEqual(gate.action, "fail")
             self.assertEqual(gate.source, "autonomy_gate_report")
 
-    def test_pipeline_runtime_uncertainty_gate_defaults_degrade_when_inputs_missing(self) -> None:
+    def test_pipeline_runtime_uncertainty_gate_defaults_degrade_when_inputs_missing(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1036,15 +1065,18 @@ class TestTradingPipeline(TestCase):
             params={},
         )
 
-        gate, _runtime_payload = pipeline._resolve_runtime_uncertainty_gate_from_inputs(decision), pipeline._resolve_runtime_uncertainty_gate(
-            decision
+        gate, _runtime_payload = (
+            pipeline._resolve_runtime_uncertainty_gate_from_inputs(decision),
+            pipeline._resolve_runtime_uncertainty_gate(decision),
         )
         self.assertEqual(gate.action, "degrade")
         self.assertEqual(gate.source, "uncertainty_input_missing")
         self.assertEqual(_runtime_payload.action, "degrade")
         self.assertEqual(_runtime_payload.source, "uncertainty_input_missing")
 
-    def test_pipeline_runtime_uncertainty_gate_stale_decision_payload_abstains(self) -> None:
+    def test_pipeline_runtime_uncertainty_gate_stale_decision_payload_abstains(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1081,7 +1113,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "decision_runtime_payload_stale")
         self.assertEqual(gate.reason, "decision_runtime_payload_generated_at_stale")
 
-    def test_pipeline_runtime_regime_gate_defaults_degrade_when_inputs_missing(self) -> None:
+    def test_pipeline_runtime_regime_gate_defaults_degrade_when_inputs_missing(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1111,7 +1145,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "missing")
         self.assertEqual(gate.reason, "missing")
 
-    def test_pipeline_runtime_regime_gate_degrades_for_uncertain_regime_posterior(self) -> None:
+    def test_pipeline_runtime_regime_gate_degrades_for_uncertain_regime_posterior(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1152,7 +1188,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "regime_hmm_confidence")
         self.assertEqual(gate.reason, "regime_hmm_confidence_is_uncertain")
 
-    def test_pipeline_runtime_regime_gate_abstains_for_high_entropy_low_confidence(self) -> None:
+    def test_pipeline_runtime_regime_gate_abstains_for_high_entropy_low_confidence(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1193,7 +1231,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "regime_hmm_confidence")
         self.assertEqual(gate.reason, "regime_hmm_confidence_too_low")
 
-    def test_pipeline_runtime_regime_gate_invalid_regime_gate_action_fails_closed(self) -> None:
+    def test_pipeline_runtime_regime_gate_invalid_regime_gate_action_fails_closed(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1225,7 +1265,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "decision_regime_gate_invalid_action")
         self.assertEqual(gate.reason, "decision_regime_gate_invalid_action")
 
-    def test_pipeline_runtime_regime_gate_unknown_regime_without_label_fails_closed(self) -> None:
+    def test_pipeline_runtime_regime_gate_unknown_regime_without_label_fails_closed(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1267,7 +1309,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "regime_hmm_unknown_regime")
         self.assertEqual(gate.reason, "hmm_unknown")
 
-    def test_pipeline_runtime_regime_gate_invalid_regime_id_without_label_fails_closed(self) -> None:
+    def test_pipeline_runtime_regime_gate_invalid_regime_id_without_label_fails_closed(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1309,7 +1353,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "regime_hmm_unknown_regime")
         self.assertEqual(gate.reason, "hmm_unknown")
 
-    def test_pipeline_runtime_regime_gate_invalid_schema_version_fails_closed(self) -> None:
+    def test_pipeline_runtime_regime_gate_invalid_schema_version_fails_closed(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1552,7 +1598,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "regime_hmm_stale")
         self.assertEqual(gate.reason, "aging_output")
 
-    def test_pipeline_runtime_regime_gate_stale_hmm_is_fail_closed_and_preserves_lineage(self) -> None:
+    def test_pipeline_runtime_regime_gate_stale_hmm_is_fail_closed_and_preserves_lineage(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1607,7 +1655,10 @@ class TestTradingPipeline(TestCase):
             regime_artifact.get("model_id"),
             "hmm-regime-v1.2.0",
         )
-    def test_pipeline_runtime_regime_gate_fallback_to_defensive_is_fail_closed(self) -> None:
+
+    def test_pipeline_runtime_regime_gate_fallback_to_defensive_is_fail_closed(
+        self,
+    ) -> None:
         pipeline = TradingPipeline(
             alpaca_client=FakeAlpacaClient(),
             order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -1693,7 +1744,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "regime_hmm_unknown_regime")
         self.assertEqual(gate.reason, "hmm_unknown")
 
-    def test_pipeline_runtime_uncertainty_gate_report_parse_error_fails_closed(self) -> None:
+    def test_pipeline_runtime_uncertainty_gate_report_parse_error_fails_closed(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -1793,10 +1846,14 @@ class TestTradingPipeline(TestCase):
                 "trading_static_symbols_raw"
             ]
 
-    def test_pipeline_runtime_uncertainty_gate_report_stale_in_autonomy_path_abstains(self) -> None:
+    def test_pipeline_runtime_uncertainty_gate_report_stale_in_autonomy_path_abstains(
+        self,
+    ) -> None:
         stale_report = {
             "uncertainty_gate_action": "pass",
-            "generated_at": (datetime.now(timezone.utc) - timedelta(minutes=45)).isoformat().replace(
+            "generated_at": (datetime.now(timezone.utc) - timedelta(minutes=45))
+            .isoformat()
+            .replace(
                 "+00:00",
                 "Z",
             ),
@@ -1947,8 +2004,12 @@ class TestTradingPipeline(TestCase):
                     )
 
                 self.assertEqual(len(alpaca_client.submitted), 0)
-                self.assertEqual(state.metrics.runtime_regime_gate_action_total.get("abstain"), 1)
-                self.assertEqual(state.metrics.runtime_regime_gate_blocked_total.get("abstain"), 1)
+                self.assertEqual(
+                    state.metrics.runtime_regime_gate_action_total.get("abstain"), 1
+                )
+                self.assertEqual(
+                    state.metrics.runtime_regime_gate_blocked_total.get("abstain"), 1
+                )
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
@@ -2083,17 +2144,27 @@ class TestTradingPipeline(TestCase):
                     )
                     regime_artifact = regime_payload.get("artifact")
                     self.assertIsInstance(regime_artifact, dict)
-                    self.assertEqual(regime_artifact.get("model_id"), "hmm-regime-v1.2.0")
+                    self.assertEqual(
+                        regime_artifact.get("model_id"), "hmm-regime-v1.2.0"
+                    )
                     self.assertEqual(regime_artifact.get("feature_schema"), "hmm-v1")
-                    self.assertEqual(regime_artifact.get("training_run_id"), "run-2026-03-02")
-                    self.assertEqual(regime_payload.get("hmm_state_posterior"), {"R2": "0.75"})
+                    self.assertEqual(
+                        regime_artifact.get("training_run_id"), "run-2026-03-02"
+                    )
+                    self.assertEqual(
+                        regime_payload.get("hmm_state_posterior"), {"R2": "0.75"}
+                    )
                     self.assertEqual(regime_payload.get("hmm_entropy"), "1.23")
                     self.assertEqual(regime_payload.get("hmm_entropy_band"), "medium")
                     self.assertEqual(regime_payload.get("hmm_transition_shock"), False)
 
                 self.assertEqual(len(alpaca_client.submitted), 0)
-                self.assertEqual(state.metrics.runtime_regime_gate_action_total.get("abstain"), 1)
-                self.assertEqual(state.metrics.runtime_regime_gate_blocked_total.get("abstain"), 1)
+                self.assertEqual(
+                    state.metrics.runtime_regime_gate_action_total.get("abstain"), 1
+                )
+                self.assertEqual(
+                    state.metrics.runtime_regime_gate_blocked_total.get("abstain"), 1
+                )
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
@@ -2209,7 +2280,9 @@ class TestTradingPipeline(TestCase):
 
                     gate_payload = params.get("runtime_uncertainty_gate")
                     assert isinstance(gate_payload, dict)
-                    self.assertEqual(gate_payload.get("source"), "regime_hmm_non_authoritative")
+                    self.assertEqual(
+                        gate_payload.get("source"), "regime_hmm_non_authoritative"
+                    )
                     regime_gate = gate_payload.get("regime_gate")
                     assert isinstance(regime_gate, dict)
                     self.assertEqual(regime_gate.get("action"), "abstain")
@@ -2241,8 +2314,12 @@ class TestTradingPipeline(TestCase):
                     self.assertEqual(regime_payload.get("hmm_transition_shock"), False)
 
                 self.assertEqual(len(alpaca_client.submitted), 0)
-                self.assertEqual(state.metrics.runtime_regime_gate_action_total.get("abstain"), 1)
-                self.assertEqual(state.metrics.runtime_regime_gate_blocked_total.get("abstain"), 1)
+                self.assertEqual(
+                    state.metrics.runtime_regime_gate_action_total.get("abstain"), 1
+                )
+                self.assertEqual(
+                    state.metrics.runtime_regime_gate_blocked_total.get("abstain"), 1
+                )
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
@@ -2250,12 +2327,16 @@ class TestTradingPipeline(TestCase):
             config.settings.trading_kill_switch_enabled = original[
                 "trading_kill_switch_enabled"
             ]
-            config.settings.trading_universe_source = original["trading_universe_source"]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
             config.settings.trading_static_symbols_raw = original[
                 "trading_static_symbols_raw"
             ]
 
-    def test_pipeline_runtime_regime_gate_unparseable_payload_fails_closed(self) -> None:
+    def test_pipeline_runtime_regime_gate_unparseable_payload_fails_closed(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -2359,9 +2440,7 @@ class TestTradingPipeline(TestCase):
                 gate_payload = params.get("runtime_uncertainty_gate")
                 assert isinstance(gate_payload, dict)
                 self.assertEqual(gate_payload.get("action"), "abstain")
-                self.assertEqual(
-                    gate_payload.get("source"), "regime_hmm_unparseable"
-                )
+                self.assertEqual(gate_payload.get("source"), "regime_hmm_unparseable")
                 regime_gate = gate_payload.get("regime_gate")
                 assert isinstance(regime_gate, dict)
                 self.assertEqual(regime_gate.get("action"), "abstain")
@@ -2370,8 +2449,12 @@ class TestTradingPipeline(TestCase):
                 )
 
             self.assertEqual(len(alpaca_client.submitted), 0)
-            self.assertEqual(state.metrics.runtime_regime_gate_action_total.get("abstain"), 1)
-            self.assertEqual(state.metrics.runtime_regime_gate_blocked_total.get("abstain"), 1)
+            self.assertEqual(
+                state.metrics.runtime_regime_gate_action_total.get("abstain"), 1
+            )
+            self.assertEqual(
+                state.metrics.runtime_regime_gate_blocked_total.get("abstain"), 1
+            )
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
@@ -2386,7 +2469,9 @@ class TestTradingPipeline(TestCase):
                 "trading_static_symbols_raw"
             ]
 
-    def test_pipeline_runtime_uncertainty_abstain_allows_risk_reducing_exit(self) -> None:
+    def test_pipeline_runtime_uncertainty_abstain_allows_risk_reducing_exit(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -2610,12 +2695,9 @@ class TestTradingPipeline(TestCase):
         from app import config
 
         original = {
-            "qty_multipliers":
-                config.settings.trading_runtime_uncertainty_degrade_qty_multipliers_by_regime,
-            "max_participation_rates":
-                config.settings.trading_runtime_uncertainty_degrade_max_participation_rate_by_regime,
-            "min_execution_seconds":
-                config.settings.trading_runtime_uncertainty_degrade_min_execution_seconds_by_regime,
+            "qty_multipliers": config.settings.trading_runtime_uncertainty_degrade_qty_multipliers_by_regime,
+            "max_participation_rates": config.settings.trading_runtime_uncertainty_degrade_max_participation_rate_by_regime,
+            "min_execution_seconds": config.settings.trading_runtime_uncertainty_degrade_min_execution_seconds_by_regime,
         }
 
         config.settings.trading_runtime_uncertainty_degrade_qty_multipliers_by_regime = {
@@ -2658,19 +2740,23 @@ class TestTradingPipeline(TestCase):
                 },
             )
 
-            updated_decision, payload, reason = pipeline._apply_runtime_uncertainty_gate(
-                decision,
-                positions=[],
+            updated_decision, payload, reason = (
+                pipeline._apply_runtime_uncertainty_gate(
+                    decision,
+                    positions=[],
+                )
             )
 
             self.assertIsNone(reason)
             self.assertEqual(payload.get("degrade_qty_multiplier"), "0.25")
-            self.assertEqual(
-                payload.get("max_participation_rate_override"), "0.03"
-            )
+            self.assertEqual(payload.get("max_participation_rate_override"), "0.03")
             self.assertEqual(payload.get("min_execution_seconds"), 180)
             self.assertEqual(
-                str(updated_decision.params["allocator"]["max_participation_rate_override"]),
+                str(
+                    updated_decision.params["allocator"][
+                        "max_participation_rate_override"
+                    ]
+                ),
                 "0.03",
             )
             self.assertEqual(updated_decision.params.get("execution_seconds"), 180)
@@ -2686,7 +2772,9 @@ class TestTradingPipeline(TestCase):
                 "min_execution_seconds"
             ]
 
-    def test_pipeline_runtime_uncertainty_uses_projected_positions_within_run(self) -> None:
+    def test_pipeline_runtime_uncertainty_uses_projected_positions_within_run(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -2784,7 +2872,9 @@ class TestTradingPipeline(TestCase):
                     }
                     self.assertEqual(status_counts.get("submitted"), 1)
                     self.assertEqual(status_counts.get("rejected"), 1)
-                    rejected = next(item for item in decisions if item.status == "rejected")
+                    rejected = next(
+                        item for item in decisions if item.status == "rejected"
+                    )
                     decision_json = rejected.decision_json
                     assert isinstance(decision_json, dict)
                     self.assertIn(
@@ -3053,7 +3143,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(payload.get("regime_action_blocked"), "decision_regime_gate")
         self.assertIsNone(payload.get("uncertainty_action_blocked"))
 
-    def test_runtime_uncertainty_gate_does_not_bypass_kill_switch_precedence(self) -> None:
+    def test_runtime_uncertainty_gate_does_not_bypass_kill_switch_precedence(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -3156,7 +3248,9 @@ class TestTradingPipeline(TestCase):
                 "trading_static_symbols_raw"
             ]
 
-    def test_pipeline_persists_adaptive_policy_and_records_fallback_metric(self) -> None:
+    def test_pipeline_persists_adaptive_policy_and_records_fallback_metric(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -3856,7 +3950,9 @@ class TestTradingPipeline(TestCase):
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 gate_path = Path(tmpdir) / "gate-report.json"
-                gate_path.write_text('{"uncertainty_gate_action":"pass"}', encoding="utf-8")
+                gate_path.write_text(
+                    '{"uncertainty_gate_action":"pass"}', encoding="utf-8"
+                )
                 signal = SignalEnvelope(
                     event_ts=datetime.now(timezone.utc),
                     symbol="AAPL",
@@ -4063,7 +4159,9 @@ class TestTradingPipeline(TestCase):
                 self.assertIsInstance(committee_veto_alignment, dict)
                 assert isinstance(committee_veto_alignment, dict)
                 self.assertFalse(committee_veto_alignment.get("committee_veto", True))
-                self.assertFalse(committee_veto_alignment.get("deterministic_veto", True))
+                self.assertFalse(
+                    committee_veto_alignment.get("deterministic_veto", True)
+                )
 
             config.settings.trading_mode = "live"
             config.settings.trading_live_enabled = True
@@ -4399,7 +4497,9 @@ class TestTradingPipeline(TestCase):
                     reviews[0].response_json.get("effective_verdict"), "veto"
                 )
                 self.assertEqual(len(executions), 0)
-                self.assertEqual(reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked")
+                self.assertEqual(
+                    reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked"
+                )
                 self.assertEqual(engine.review_calls, 0)
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
@@ -4426,9 +4526,7 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_shadow_completed_at = original[
                 "llm_shadow_completed_at"
             ]
-            config.settings.llm_model_version_lock = original[
-                "llm_model_version_lock"
-            ]
+            config.settings.llm_model_version_lock = original["llm_model_version_lock"]
             config.settings.llm_adjustment_approved = original[
                 "llm_adjustment_approved"
             ]
@@ -4699,7 +4797,9 @@ class TestTradingPipeline(TestCase):
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
             config.settings.trading_live_enabled = original["trading_live_enabled"]
-            config.settings.trading_universe_source = original["trading_universe_source"]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
             config.settings.trading_static_symbols_raw = original[
                 "trading_static_symbols_raw"
             ]
@@ -4731,7 +4831,9 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_rollout_stage = original["llm_rollout_stage"]
             config.settings.jangar_base_url = original["jangar_base_url"]
 
-    def test_pipeline_llm_dspy_live_runtime_gate_blocks_when_stage_not_stage3(self) -> None:
+    def test_pipeline_llm_dspy_live_runtime_gate_blocks_when_stage_not_stage3(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -4833,7 +4935,9 @@ class TestTradingPipeline(TestCase):
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
             config.settings.trading_live_enabled = original["trading_live_enabled"]
-            config.settings.trading_universe_source = original["trading_universe_source"]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
             config.settings.trading_static_symbols_raw = original[
                 "trading_static_symbols_raw"
             ]
@@ -4959,7 +5063,9 @@ class TestTradingPipeline(TestCase):
                 self.assertEqual(len(reviews), 1)
                 self.assertEqual(reviews[0].verdict, "error")
                 self.assertEqual(reviews[0].response_json.get("fallback"), "veto")
-                self.assertEqual(reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked")
+                self.assertEqual(
+                    reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked"
+                )
                 self.assertEqual(len(executions), 0)
                 self.assertEqual(engine.review_calls, 0)
         finally:
@@ -5000,7 +5106,9 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_rollout_stage = original["llm_rollout_stage"]
             config.settings.jangar_base_url = original["jangar_base_url"]
 
-    def test_pipeline_llm_dspy_live_runtime_gate_blocks_malformed_artifact_hash(self) -> None:
+    def test_pipeline_llm_dspy_live_runtime_gate_blocks_malformed_artifact_hash(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -5066,7 +5174,9 @@ class TestTradingPipeline(TestCase):
                 timeframe="1Min",
             )
 
-            with patch("app.trading.scheduler.DSPyReviewRuntime.from_settings") as from_settings:
+            with patch(
+                "app.trading.scheduler.DSPyReviewRuntime.from_settings"
+            ) as from_settings:
                 pipeline = TradingPipeline(
                     alpaca_client=FakeAlpacaClient(),
                     order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -5089,7 +5199,9 @@ class TestTradingPipeline(TestCase):
                 executions = session.execute(select(Execution)).scalars().all()
                 self.assertEqual(len(reviews), 1)
                 self.assertEqual(reviews[0].verdict, "error")
-                self.assertEqual(reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked")
+                self.assertEqual(
+                    reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked"
+                )
                 self.assertEqual(len(executions), 0)
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
@@ -5198,7 +5310,9 @@ class TestTradingPipeline(TestCase):
             )
 
             engine = CountingLLMReviewEngine()
-            with patch("app.trading.scheduler.DSPyReviewRuntime.from_settings") as from_settings:
+            with patch(
+                "app.trading.scheduler.DSPyReviewRuntime.from_settings"
+            ) as from_settings:
                 pipeline = TradingPipeline(
                     alpaca_client=FakeAlpacaClient(),
                     order_firewall=OrderFirewall(FakeAlpacaClient()),
@@ -5265,7 +5379,9 @@ class TestTradingPipeline(TestCase):
             ]
             config.settings.llm_rollout_stage = original["llm_rollout_stage"]
 
-    def test_pipeline_llm_dspy_live_runtime_gate_blocks_bootstrap_artifact_hash(self) -> None:
+    def test_pipeline_llm_dspy_live_runtime_gate_blocks_bootstrap_artifact_hash(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -5304,7 +5420,9 @@ class TestTradingPipeline(TestCase):
         config.settings.llm_min_confidence = 0.0
         config.settings.llm_dspy_runtime_mode = "active"
         config.settings.jangar_base_url = "http://jangar.test"
-        config.settings.llm_dspy_artifact_hash = DSPyReviewRuntime.bootstrap_artifact_hash()
+        config.settings.llm_dspy_artifact_hash = (
+            DSPyReviewRuntime.bootstrap_artifact_hash()
+        )
         config.settings.llm_rollout_stage = "stage3"
         _set_llm_guardrails(config)
 
@@ -5357,7 +5475,9 @@ class TestTradingPipeline(TestCase):
                 executions = session.execute(select(Execution)).scalars().all()
                 self.assertEqual(len(reviews), 1)
                 self.assertEqual(reviews[0].verdict, "error")
-                self.assertEqual(reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked")
+                self.assertEqual(
+                    reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked"
+                )
                 self.assertEqual(reviews[0].response_json.get("fallback"), "veto")
                 self.assertEqual(len(executions), 0)
                 self.assertEqual(engine.review_calls, 0)
@@ -5399,7 +5519,172 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_rollout_stage = original["llm_rollout_stage"]
             config.settings.jangar_base_url = original["jangar_base_url"]
 
-    def test_pipeline_llm_dspy_live_runtime_gate_blocks_without_jangar_base_url(self) -> None:
+    def test_pipeline_llm_dspy_live_runtime_gate_can_pass_through_with_degraded_qty(
+        self,
+    ) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+            "llm_enabled": config.settings.llm_enabled,
+            "llm_fail_mode": config.settings.llm_fail_mode,
+            "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
+            "llm_fail_open_live_approved": config.settings.llm_fail_open_live_approved,
+            "llm_shadow_mode": config.settings.llm_shadow_mode,
+            "llm_min_confidence": config.settings.llm_min_confidence,
+            "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
+            "llm_evaluation_report": config.settings.llm_evaluation_report,
+            "llm_effective_challenge_id": config.settings.llm_effective_challenge_id,
+            "llm_shadow_completed_at": config.settings.llm_shadow_completed_at,
+            "llm_model_version_lock": config.settings.llm_model_version_lock,
+            "llm_adjustment_approved": config.settings.llm_adjustment_approved,
+            "llm_dspy_runtime_mode": config.settings.llm_dspy_runtime_mode,
+            "llm_dspy_artifact_hash": config.settings.llm_dspy_artifact_hash,
+            "llm_dspy_program_name": config.settings.llm_dspy_program_name,
+            "llm_dspy_signature_version": config.settings.llm_dspy_signature_version,
+            "llm_rollout_stage": config.settings.llm_rollout_stage,
+            "llm_dspy_live_runtime_block_fail_mode": config.settings.llm_dspy_live_runtime_block_fail_mode,
+            "llm_dspy_live_runtime_block_qty_multiplier": config.settings.llm_dspy_live_runtime_block_qty_multiplier,
+            "jangar_base_url": config.settings.jangar_base_url,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "live"
+        config.settings.trading_live_enabled = True
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.llm_enabled = True
+        config.settings.llm_fail_mode = "pass_through"
+        config.settings.llm_fail_mode_enforcement = "configured"
+        config.settings.llm_fail_open_live_approved = True
+        config.settings.llm_shadow_mode = False
+        config.settings.llm_min_confidence = 0.0
+        config.settings.llm_dspy_runtime_mode = "active"
+        config.settings.jangar_base_url = "http://jangar.test"
+        config.settings.llm_dspy_artifact_hash = (
+            DSPyReviewRuntime.bootstrap_artifact_hash()
+        )
+        config.settings.llm_rollout_stage = "stage3"
+        config.settings.llm_dspy_live_runtime_block_fail_mode = (
+            "pass_through_reduced_size"
+        )
+        config.settings.llm_dspy_live_runtime_block_qty_multiplier = 0.5
+        _set_llm_guardrails(config)
+
+        try:
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name="demo",
+                    description="demo",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL"],
+                    max_notional_per_trade=Decimal("1000"),
+                )
+                session.add(strategy)
+                session.commit()
+
+            signal = SignalEnvelope(
+                event_ts=datetime.now(timezone.utc),
+                symbol="AAPL",
+                payload={
+                    "macd": {"macd": 1.1, "signal": 0.4},
+                    "rsi14": 25,
+                    "price": 100,
+                },
+                timeframe="1Min",
+            )
+
+            pipeline = TradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([signal]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="live",
+                session_factory=self.session_local,
+                llm_review_engine=CountingLLMReviewEngine(),
+            )
+
+            pipeline.run_once()
+
+            with self.session_local() as session:
+                reviews = session.execute(select(LLMDecisionReview)).scalars().all()
+                decisions = session.execute(select(TradeDecision)).scalars().all()
+                executions = session.execute(select(Execution)).scalars().all()
+
+                self.assertEqual(len(reviews), 1)
+                self.assertEqual(reviews[0].verdict, "error")
+                self.assertEqual(
+                    reviews[0].rationale,
+                    "llm_dspy_live_runtime_gate_blocked",
+                )
+                self.assertEqual(
+                    reviews[0].response_json.get("fallback"), "pass_through"
+                )
+                self.assertEqual(decisions[0].status, "submitted")
+                self.assertEqual(len(executions), 1)
+                self.assertLess(executions[0].submitted_qty, Decimal("10"))
+                self.assertGreaterEqual(executions[0].submitted_qty, Decimal("1"))
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+            config.settings.llm_enabled = original["llm_enabled"]
+            config.settings.llm_fail_mode = original["llm_fail_mode"]
+            config.settings.llm_fail_mode_enforcement = original[
+                "llm_fail_mode_enforcement"
+            ]
+            config.settings.llm_fail_open_live_approved = original[
+                "llm_fail_open_live_approved"
+            ]
+            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+            config.settings.llm_min_confidence = original["llm_min_confidence"]
+            config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
+            config.settings.llm_evaluation_report = original["llm_evaluation_report"]
+            config.settings.llm_effective_challenge_id = original[
+                "llm_effective_challenge_id"
+            ]
+            config.settings.llm_shadow_completed_at = original[
+                "llm_shadow_completed_at"
+            ]
+            config.settings.llm_model_version_lock = original["llm_model_version_lock"]
+            config.settings.llm_adjustment_approved = original[
+                "llm_adjustment_approved"
+            ]
+            config.settings.llm_dspy_runtime_mode = original["llm_dspy_runtime_mode"]
+            config.settings.llm_dspy_artifact_hash = original["llm_dspy_artifact_hash"]
+            config.settings.llm_dspy_program_name = original["llm_dspy_program_name"]
+            config.settings.llm_dspy_signature_version = original[
+                "llm_dspy_signature_version"
+            ]
+            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
+            config.settings.llm_dspy_live_runtime_block_fail_mode = original[
+                "llm_dspy_live_runtime_block_fail_mode"
+            ]
+            config.settings.llm_dspy_live_runtime_block_qty_multiplier = original[
+                "llm_dspy_live_runtime_block_qty_multiplier"
+            ]
+            config.settings.jangar_base_url = original["jangar_base_url"]
+
+    def test_pipeline_llm_dspy_live_runtime_gate_blocks_without_jangar_base_url(
+        self,
+    ) -> None:
         from app import config
 
         original = {
@@ -5491,7 +5776,9 @@ class TestTradingPipeline(TestCase):
                 executions = session.execute(select(Execution)).scalars().all()
                 self.assertEqual(len(reviews), 1)
                 self.assertEqual(reviews[0].verdict, "error")
-                self.assertEqual(reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked")
+                self.assertEqual(
+                    reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked"
+                )
                 self.assertEqual(reviews[0].response_json.get("fallback"), "veto")
                 self.assertEqual(len(executions), 0)
                 self.assertEqual(engine.review_calls, 0)
@@ -6429,7 +6716,9 @@ class TestTradingPipeline(TestCase):
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 gate_path = Path(tmpdir) / "gate-report.json"
-                gate_path.write_text('{"uncertainty_gate_action":"pass"}', encoding="utf-8")
+                gate_path.write_text(
+                    '{"uncertainty_gate_action":"pass"}', encoding="utf-8"
+                )
                 signal = SignalEnvelope(
                     event_ts=datetime.now(timezone.utc),
                     symbol="AAPL",


### PR DESCRIPTION
## Summary

- Add a configurable DSPy live-runtime gate fallback path in Torghut (`veto`, `pass_through`, `pass_through_reduced_size`) to prevent full trading halt when runtime gate is blocked.
- Implement reduced-size pass-through handling for DSPy gate blocks and persist degrade metadata in decision params.
- Improve portfolio sizing rejection taxonomy so cap-constrained sub-lot outcomes map to explicit capacity/inventory reasons instead of generic `qty_below_min`.
- Add regressions for new DSPy fallback behavior and new sizing reason mapping behavior.
- Roll out live config to enable shorts and enable DSPy gate pass-through reduced-size fallback (`LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE=pass_through_reduced_size`, multiplier `0.5`, fail-open approval true), and add v6 design doc #15.

## Related Issues

None

## Testing

- `uv run --project services/torghut python -m unittest services.torghut.tests.test_portfolio_sizing`
- `uv run --project services/torghut python -m unittest services.torghut.tests.test_config`
- `uv run --project services/torghut python -m unittest services.torghut.tests.test_trading_pipeline.TestTradingPipeline.test_pipeline_llm_dspy_live_runtime_gate_blocks_bootstrap_artifact_hash services.torghut.tests.test_trading_pipeline.TestTradingPipeline.test_pipeline_llm_dspy_live_runtime_gate_can_pass_through_with_degraded_qty services.torghut.tests.test_trading_pipeline.TestTradingPipeline.test_pipeline_llm_dspy_unsupported_runtime_state_vetoes_in_live`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/config.py app/trading/scheduler.py app/trading/portfolio.py tests/test_config.py tests/test_portfolio_sizing.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen ruff format --check app/config.py app/trading/scheduler.py app/trading/portfolio.py tests/test_config.py tests/test_portfolio_sizing.py tests/test_trading_pipeline.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
