### PR TITLE
feat(torghut): harden dspy compile artifact guardrails

### DIFF
--- a/services/torghut/app/trading/llm/dspy_compile/compiler.py
+++ b/services/torghut/app/trading/llm/dspy_compile/compiler.py
@@ -23,6 +23,12 @@ DEFAULT_SIGNATURE_VERSION = "v1"
 DEFAULT_COMPILED_ARTIFACT_NAME = "dspy-compiled-program.json"
 DEFAULT_COMPILE_RESULT_NAME = "dspy-compile-result.json"
 DEFAULT_COMPILE_METRICS_NAME = "dspy-compile-metrics.json"
+_MIPRO_OPTIMIZERS = {
+    "mipro",
+    "mipro-v2",
+    "mipro_v2",
+    "miprov2",
+}
 
 
 @dataclass(frozen=True)
@@ -64,7 +70,7 @@ def compile_dspy_program_artifacts(
     normalized_repository = _require_value(repository, "repository")
     normalized_base = _require_value(base, "base")
     normalized_head = _require_value(head, "head")
-    normalized_optimizer = _require_value(optimizer, "optimizer").lower()
+    normalized_optimizer = _normalize_optimizer(optimizer)
     normalized_program_name = _require_value(program_name, "program_name")
     normalized_signature_version = _require_value(
         signature_version, "signature_version"
@@ -73,13 +79,13 @@ def compile_dspy_program_artifacts(
     normalized_artifact_ref = _require_value(str(artifact_path), "artifact_path")
     normalized_dataset_ref = _require_value(dataset_ref, "dataset_ref")
     normalized_metric_policy_ref = _require_value(metric_policy_ref, "metric_policy_ref")
-    normalized_compiled_artifact_name = _require_value(
+    normalized_compiled_artifact_name = _normalize_artifact_file_name(
         compiled_artifact_name, "compiled_artifact_name"
     )
-    normalized_compile_result_name = _require_value(
+    normalized_compile_result_name = _normalize_artifact_file_name(
         compile_result_name, "compile_result_name"
     )
-    normalized_compile_metrics_name = _require_value(
+    normalized_compile_metrics_name = _normalize_artifact_file_name(
         compile_metrics_name, "compile_metrics_name"
     )
 
@@ -175,6 +181,9 @@ def compile_dspy_program_artifacts(
             "schemaVersion": COMPILE_METRICS_SCHEMA_VERSION,
             "programName": normalized_program_name,
             "optimizer": normalized_optimizer,
+            "compiledArtifactUri": compiled_artifact_uri,
+            "artifactHash": compile_result.artifact_hash,
+            "reproducibilityHash": compile_result.reproducibility_hash,
             "metricBundleHash": metric_bundle_hash,
             "metricBundle": metric_bundle,
         },
@@ -194,6 +203,24 @@ def _require_value(value: str, field_name: str) -> str:
     normalized = value.strip()
     if not normalized:
         raise ValueError(f"{field_name}_required")
+    return normalized
+
+
+def _normalize_optimizer(optimizer: str) -> str:
+    normalized = _require_value(optimizer, "optimizer").lower()
+    if normalized not in _MIPRO_OPTIMIZERS:
+        raise ValueError("optimizer_must_be_mipro")
+    if normalized in {"mipro-v2", "mipro_v2"}:
+        return "miprov2"
+    return normalized
+
+
+def _normalize_artifact_file_name(file_name: str, field_name: str) -> str:
+    normalized = _require_value(file_name, field_name)
+    if "/" in normalized or "\\" in normalized:
+        raise ValueError(f"{field_name}_must_be_file_name")
+    if normalized in {".", ".."}:
+        raise ValueError(f"{field_name}_must_be_file_name")
     return normalized
 
 

--- a/services/torghut/scripts/compile_dspy_program.py
+++ b/services/torghut/scripts/compile_dspy_program.py
@@ -110,7 +110,7 @@ def main() -> int:
         "artifactPath": str(args.artifact_path),
         "datasetRef": args.dataset_ref,
         "metricPolicyRef": args.metric_policy_ref,
-        "optimizer": args.optimizer,
+        "optimizer": result.compile_result.optimizer,
         "compileResultRef": str(result.compile_result_path),
         "compiledArtifactUri": result.compiled_artifact_uri,
         "compiledArtifactPath": str(result.compiled_artifact_path),

--- a/services/torghut/tests/test_llm_dspy_compiler.py
+++ b/services/torghut/tests/test_llm_dspy_compiler.py
@@ -228,3 +228,116 @@ class TestLLMDSPyCompiler(TestCase):
                     optimizer="miprov2",
                     schema_valid_rate=0.998,
                 )
+
+    def test_compile_metrics_persist_hashes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset_path = root / "dspy-dataset.json"
+            metric_policy_path = root / "dspy-metrics.yaml"
+            dataset_path.write_text(
+                canonical_json(
+                    {
+                        "schemaVersion": "torghut.dspy.dataset.v1",
+                        "rows": [{"rowId": "row-1", "split": "train"}],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            metric_policy_path.write_text(
+                "schemaVersion: torghut.dspy.metrics.v1\npolicy: {}\n",
+                encoding="utf-8",
+            )
+
+            result = compile_dspy_program_artifacts(
+                repository="proompteng/lab",
+                base="main",
+                head="codex/dspy-compile-test",
+                artifact_path=root / "compile",
+                dataset_ref=str(dataset_path),
+                metric_policy_ref=str(metric_policy_path),
+                optimizer="mipro-v2",
+            )
+
+            compile_metrics_payload = json.loads(
+                result.compile_metrics_path.read_text(encoding="utf-8")
+            )
+            self.assertEqual(compile_metrics_payload["optimizer"], "miprov2")
+            self.assertEqual(
+                compile_metrics_payload["compiledArtifactUri"],
+                result.compile_result.compiled_artifact_uri,
+            )
+            self.assertEqual(
+                compile_metrics_payload["artifactHash"],
+                result.compile_result.artifact_hash,
+            )
+            self.assertEqual(
+                compile_metrics_payload["reproducibilityHash"],
+                result.compile_result.reproducibility_hash,
+            )
+            self.assertEqual(len(compile_metrics_payload["metricBundleHash"]), 64)
+
+    def test_compile_rejects_non_mipro_optimizer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset_path = root / "dspy-dataset.json"
+            metric_policy_path = root / "dspy-metrics.yaml"
+            dataset_path.write_text(
+                canonical_json(
+                    {
+                        "schemaVersion": "torghut.dspy.dataset.v1",
+                        "rows": [{"rowId": "row-1", "split": "train"}],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            metric_policy_path.write_text(
+                "schemaVersion: torghut.dspy.metrics.v1\npolicy: {}\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "optimizer_must_be_mipro"):
+                compile_dspy_program_artifacts(
+                    repository="proompteng/lab",
+                    base="main",
+                    head="codex/dspy-compile-test",
+                    artifact_path=root / "compile",
+                    dataset_ref=str(dataset_path),
+                    metric_policy_ref=str(metric_policy_path),
+                    optimizer="gepa",
+                )
+
+    def test_compile_rejects_artifact_name_outside_artifact_path(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset_path = root / "dspy-dataset.json"
+            metric_policy_path = root / "dspy-metrics.yaml"
+            dataset_path.write_text(
+                canonical_json(
+                    {
+                        "schemaVersion": "torghut.dspy.dataset.v1",
+                        "rows": [{"rowId": "row-1", "split": "train"}],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            metric_policy_path.write_text(
+                "schemaVersion: torghut.dspy.metrics.v1\npolicy: {}\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                ValueError, "compiled_artifact_name_must_be_file_name"
+            ):
+                compile_dspy_program_artifacts(
+                    repository="proompteng/lab",
+                    base="main",
+                    head="codex/dspy-compile-test",
+                    artifact_path=root / "compile",
+                    dataset_ref=str(dataset_path),
+                    metric_policy_ref=str(metric_policy_path),
+                    optimizer="miprov2",
+                    compiled_artifact_name="../escape.json",
+                )


### PR DESCRIPTION
## Summary

- Enforced MIPRO-only optimizer validation in Torghut DSPy compile artifact generation, with alias normalization (for example `MIPROv2` -> `miprov2`).
- Added artifact filename guardrails so compile outputs cannot escape `artifactPath` via path traversal in artifact file-name parameters.
- Extended persisted compile metrics artifact to include `compiledArtifactUri`, `artifactHash`, and `reproducibilityHash` for deterministic auditability.
- Updated compile CLI output to report the normalized optimizer actually used by the compiler.
- Added regression tests covering optimizer guardrails, artifact-path enforcement, and compile-metrics hash persistence.

## Related Issues

None

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev`
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff check app/trading/llm/dspy_compile/compiler.py scripts/compile_dspy_program.py tests/test_llm_dspy_compiler.py`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /root/.local/bin/uv run --frozen python -m unittest tests.test_llm_dspy_compiler`
- `cd services/torghut && /root/.local/bin/uv run --frozen python scripts/compile_dspy_program.py --repository proompteng/lab --base main --head codex/test-compile --artifact-path <tmp>/compile --dataset-ref <tmp>/dspy-dataset.json --metric-policy-ref <tmp>/dspy-metrics.yaml --optimizer MIPROv2`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
