### PR TITLE
fix(torghut,jangar): harden dspy live workflow contract and prompt rendering

### DIFF
--- a/docs/torghut/design-system/v6/16-dspy-llm-live-gate-root-cause-and-rollout-2026-03-04.md
+++ b/docs/torghut/design-system/v6/16-dspy-llm-live-gate-root-cause-and-rollout-2026-03-04.md
@@ -1,0 +1,85 @@
+# 16. DSPy LLM Live-Gate Root Cause and Rollout Plan (2026-03-04)
+
+## Incident Summary
+
+Date observed: 2026-03-03 (UTC)
+
+Live Torghut decision rejects were dominated by `llm_error`, with `llm_decision_reviews` showing:
+
+- `rationale=llm_dspy_live_runtime_gate_blocked`
+- guardrail reason `dspy_bootstrap_artifact_forbidden`
+
+## Verified Root Cause Chain
+
+1. Live runtime was configured as:
+   - `LLM_DSPY_RUNTIME_MODE=active`
+   - `LLM_DSPY_ARTIFACT_HASH=df087a5e...` (the bootstrap artifact hash)
+2. Active mode forbids bootstrap hash by design, so every DSPy review was gate-blocked before LLM execution.
+3. `llm_dspy_workflow_artifacts` had zero rows in production, so no promotable `dspy_live` artifact existed.
+4. DSPy AgentRun lane prompts were not parameter-rendered:
+   - ImplementationSpec text used `${...}` placeholders
+   - prompt payload in `run.json` shipped placeholders literally
+5. Torghut workflow contract had a promotion gap:
+   - promote lane requires `artifactHash`
+   - default script/orchestration path did not guarantee that value
+
+## Design Goals
+
+- Eliminate placeholder-driven non-deterministic lane execution.
+- Enforce complete promote contract (`artifactHash`) in workflow orchestration.
+- Persist runtime lineage metadata required by DSPy manifest loading.
+- Preserve fail-closed safety in active live mode.
+
+## Implemented Changes
+
+### A. Jangar: render parameterized ImplementationSpec text
+
+Files:
+
+- `services/jangar/src/server/agents-controller/implementation-contract.ts`
+- `services/jangar/src/server/__tests__/agents-controller-implementation-contract.test.ts`
+
+Changes:
+
+- Added prompt/body/title rendering for both template styles:
+  - `{{parameters.foo}}`
+  - `${foo}`
+- Rendered values are now reflected in event payload prompt fields.
+
+### B. Torghut: enforce promote artifact hash + persist executor lineage
+
+Files:
+
+- `services/torghut/app/trading/llm/dspy_compile/workflow.py`
+- `services/torghut/scripts/run_dspy_workflow.py`
+- `services/torghut/tests/test_llm_dspy_workflow.py`
+- `services/torghut/tests/test_run_dspy_workflow.py`
+
+Changes:
+
+- Promote lane now blocks early with explicit error if `artifactHash` is missing and cannot be derived from compile artifact evidence (`dspy_promote_artifact_hash_missing`).
+- Workflow upsert now stamps `metadata_json.executor=dspy_live` when compile lineage is present.
+- Orchestration attempts to load compile/eval/promotion artifact payloads from local artifact refs and persists available lineage fields on terminal updates.
+- `run_dspy_workflow.py` now accepts `--artifact-hash` for promote lane contract completeness.
+
+## Tomorrow Rollout Checklist
+
+1. Merge this change set and deploy Torghut + Jangar.
+2. Run DSPy workflow with real artifact refs and explicit promote hash.
+3. Confirm `llm_dspy_workflow_artifacts` has at least one row with:
+   - non-bootstrap `artifact_hash`
+   - `metadata_json.executor=dspy_live`
+   - `gate_compatibility=pass`
+4. Update Torghut runtime `LLM_DSPY_ARTIFACT_HASH` to the promoted hash.
+5. Verify live readiness:
+   - no `dspy_bootstrap_artifact_forbidden`
+   - `llm_error` no longer dominant rejection reason
+   - successful `llm_decision_reviews` with DSPy runtime lineage.
+
+## Rollback
+
+If readiness checks fail:
+
+1. Revert to last known stable revision.
+2. Keep LLM fail mode strict-veto in active live rollout stages.
+3. Re-run workflow with corrected artifact lineage evidence before re-promoting.

--- a/services/jangar/src/server/__tests__/agents-controller-implementation-contract.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller-implementation-contract.test.ts
@@ -57,6 +57,36 @@ describe('agents controller implementation-contract module', () => {
     })
   })
 
+  it('renders parameterized implementation text for prompt and issue body', () => {
+    const implementation = {
+      source: {
+        provider: 'github',
+      },
+      summary: 'Compile ${repository}',
+      text: 'Run compile for ${datasetRef} with {{parameters.optimizer}} -> ${artifactPath}',
+      contract: {
+        requiredKeys: ['repository', 'datasetRef', 'optimizer', 'artifactPath'],
+      },
+    }
+
+    const parameters = {
+      repository: 'proompteng/lab',
+      datasetRef: 'artifacts/dspy/run-1/dataset-build/dspy-dataset.json',
+      optimizer: 'miprov2',
+      artifactPath: 'artifacts/dspy/run-1/compile',
+    }
+
+    const context = buildEventContext(implementation, parameters)
+    expect(context.missingRequiredKeys).toEqual([])
+    expect(context.payload.prompt).toBe(
+      'Run compile for artifacts/dspy/run-1/dataset-build/dspy-dataset.json with miprov2 -> artifacts/dspy/run-1/compile',
+    )
+    expect(context.payload.issueBody).toBe(
+      'Run compile for artifacts/dspy/run-1/dataset-build/dspy-dataset.json with miprov2 -> artifacts/dspy/run-1/compile',
+    )
+    expect(context.payload.issueTitle).toBe('Compile proompteng/lab')
+  })
+
   it('falls back to github external id when repository metadata is missing', () => {
     const implementation = {
       source: {

--- a/services/jangar/src/server/agents-controller/implementation-contract.ts
+++ b/services/jangar/src/server/agents-controller/implementation-contract.ts
@@ -1,4 +1,5 @@
 import { asRecord, asString } from '~/server/primitives-http'
+import { renderTemplate, resolvePath } from './template-hash'
 
 export type ImplementationContractMapping = { from: string; to: string }
 
@@ -78,6 +79,31 @@ const setMetadataIfMissing = (metadata: Record<string, string>, key: string, val
   metadata[key] = value
 }
 
+const stringifyTemplateValue = (value: unknown) => {
+  if (value == null) return ''
+  return typeof value === 'string' ? value : JSON.stringify(value)
+}
+
+const renderParameterTemplate = (template: string, context: Record<string, unknown>) => {
+  const rendered = renderTemplate(template, context)
+  return rendered.replace(/\$\{\s*([^}]+)\s*\}/g, (_match, rawPath) => {
+    const path = String(rawPath).trim()
+    if (!path) return ''
+    const value = resolvePath(context, path) ?? context[path]
+    return stringifyTemplateValue(value)
+  })
+}
+
+const buildTemplateContext = (metadata: Record<string, string>, parameters: Record<string, string>) => {
+  const flat = { ...metadata, ...parameters }
+  return {
+    ...flat,
+    metadata,
+    parameters,
+    inputs: parameters,
+  }
+}
+
 type ResolveParam = (params: Record<string, string>, keys: string[]) => string
 
 export const createImplementationContractTools = (resolveParam: ResolveParam) => {
@@ -113,16 +139,13 @@ export const createImplementationContractTools = (resolveParam: ResolveParam) =>
     let issueNumber = metadata.issueNumber ?? resolveParam(parameters, ['issueNumber'])
 
     const resolvedIssueTitle = metadata.issueTitle ?? resolveParam(parameters, ['issueTitle'])
-    const issueTitle = resolvedIssueTitle || summary
     const resolvedIssueBody = metadata.issueBody ?? resolveParam(parameters, ['issueBody'])
-    const issueBody = resolvedIssueBody || text
     const resolvedIssueUrl = metadata.issueUrl ?? resolveParam(parameters, ['issueUrl'])
-    const issueUrl = resolvedIssueUrl || sourceUrl
     const resolvedPrompt = metadata.prompt ?? resolveParam(parameters, ['prompt'])
-    const prompt = resolvedPrompt || text || summary
     const base = metadata.base ?? resolveParam(parameters, ['base'])
     const head = metadata.head ?? resolveParam(parameters, ['head'])
     const stage = metadata.stage ?? resolveParam(parameters, ['stage'])
+    const issueUrl = resolvedIssueUrl || sourceUrl
 
     if ((!repository || !issueNumber) && provider === 'github' && externalId) {
       const parsed = parseGithubExternalId(externalId)
@@ -134,13 +157,21 @@ export const createImplementationContractTools = (resolveParam: ResolveParam) =>
 
     setMetadataIfMissing(metadata, 'repository', repository)
     setMetadataIfMissing(metadata, 'issueNumber', issueNumber)
-    setMetadataIfMissing(metadata, 'issueTitle', issueTitle)
-    setMetadataIfMissing(metadata, 'issueBody', issueBody)
     setMetadataIfMissing(metadata, 'issueUrl', issueUrl)
     setMetadataIfMissing(metadata, 'url', issueUrl)
     setMetadataIfMissing(metadata, 'base', base)
     setMetadataIfMissing(metadata, 'head', head)
     setMetadataIfMissing(metadata, 'stage', stage)
+
+    const templateContext = buildTemplateContext(metadata, parameters)
+    const renderedSummary = renderParameterTemplate(summary, templateContext)
+    const renderedText = renderParameterTemplate(text, templateContext)
+    const issueTitle = renderParameterTemplate(resolvedIssueTitle || renderedSummary, templateContext)
+    const issueBody = renderParameterTemplate(resolvedIssueBody || renderedText, templateContext)
+    const prompt = renderParameterTemplate(resolvedPrompt || renderedText || renderedSummary, templateContext)
+
+    setMetadataIfMissing(metadata, 'issueTitle', issueTitle)
+    setMetadataIfMissing(metadata, 'issueBody', issueBody)
     setMetadataIfMissing(metadata, 'prompt', prompt)
 
     const payload: Record<string, unknown> = {}

--- a/services/torghut/app/trading/llm/dspy_compile/workflow.py
+++ b/services/torghut/app/trading/llm/dspy_compile/workflow.py
@@ -64,6 +64,21 @@ def _normalize_local_path(candidate_ref: str) -> Path | None:
     return candidate.resolve()
 
 
+def _load_local_artifact_payload(path_ref: str) -> dict[str, Any] | None:
+    candidate = _normalize_local_path(path_ref)
+    if candidate is None:
+        return None
+    if not candidate.exists() or not candidate.is_file():
+        return None
+    try:
+        payload = json.loads(candidate.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return cast(dict[str, Any], payload)
+
+
 def _parse_iso_datetime(value: object) -> datetime | None:
     if not isinstance(value, str):
         return None
@@ -314,8 +329,11 @@ def upsert_workflow_artifact_record(
         if response_payload is not None
         else None
     )
+    metadata_payload = dict(metadata) if metadata is not None else {}
+    if compile_result is not None and "executor" not in metadata_payload:
+        metadata_payload["executor"] = "dspy_live"
     row.metadata_json = (
-        coerce_json_payload(dict(metadata)) if metadata is not None else None
+        coerce_json_payload(metadata_payload) if metadata_payload else None
     )
 
     if compile_result is not None:
@@ -825,6 +843,42 @@ def orchestrate_dspy_agentrun_workflow(
     overrides_by_lane = lane_parameter_overrides or {}
     responses: dict[DSPyWorkflowLane, dict[str, Any]] = {}
     lineage_by_lane: dict[str, dict[str, Any]] = {}
+    compile_result_snapshot: DSPyCompileResult | None = None
+    eval_report_snapshot: DSPyEvalReport | None = None
+    promotion_record_snapshot: DSPyPromotionRecord | None = None
+
+    def _load_compile_result_snapshot() -> DSPyCompileResult | None:
+        payload = _load_local_artifact_payload(
+            f"{artifact_root_normalized}/compile/dspy-compile-result.json"
+        )
+        if payload is None:
+            return None
+        try:
+            return DSPyCompileResult.model_validate(payload)
+        except Exception:
+            return None
+
+    def _load_eval_report_snapshot() -> DSPyEvalReport | None:
+        payload = _load_local_artifact_payload(
+            f"{artifact_root_normalized}/eval/dspy-eval-report.json"
+        )
+        if payload is None:
+            return None
+        try:
+            return DSPyEvalReport.model_validate(payload)
+        except Exception:
+            return None
+
+    def _load_promotion_record_snapshot() -> DSPyPromotionRecord | None:
+        payload = _load_local_artifact_payload(
+            f"{artifact_root_normalized}/promote/dspy-promotion-record.json"
+        )
+        if payload is None:
+            return None
+        try:
+            return DSPyPromotionRecord.model_validate(payload)
+        except Exception:
+            return None
 
     for lane_index, lane in enumerate(lanes):
         raw_lane_overrides = overrides_by_lane.get(lane, {})
@@ -836,6 +890,42 @@ def orchestrate_dspy_agentrun_workflow(
         gate_snapshot: dict[str, Any] | None = None
 
         if lane == "promote":
+            artifact_hash_override = str(lane_overrides.get("artifactHash") or "").strip()
+            if not artifact_hash_override:
+                compile_result_snapshot = compile_result_snapshot or _load_compile_result_snapshot()
+                if compile_result_snapshot is not None:
+                    lane_overrides["artifactHash"] = compile_result_snapshot.artifact_hash
+                else:
+                    run_key = f"{normalized_run_prefix}:{lane}"
+                    idempotency_key = _sanitize_idempotency_key(
+                        f"{normalized_run_prefix}-{lane}"
+                    )
+                    upsert_workflow_artifact_record(
+                        session,
+                        run_key=run_key,
+                        lane=lane,
+                        status="blocked",
+                        implementation_spec_ref=_IMPLEMENTATION_SPEC_BY_LANE[lane],
+                        idempotency_key=idempotency_key,
+                        request_payload=None,
+                        response_payload=None,
+                        compile_result=None,
+                        eval_report=None,
+                        promotion_record=None,
+                        metadata={
+                            "orchestration": {
+                                "runPrefix": normalized_run_prefix,
+                                "laneOrder": lane_index,
+                                "blockedAt": datetime.now(timezone.utc).isoformat(),
+                                "priorityId": priority_id,
+                                "lineageByLane": _json_copy(lineage_by_lane),
+                                "gateFailures": ["artifact_hash_missing"],
+                            }
+                        },
+                    )
+                    session.commit()
+                    raise RuntimeError("dspy_promote_artifact_hash_missing")
+
             gate_snapshot = _resolve_promotion_gate_snapshot(
                 lane_overrides,
                 requested_eval_report_ref=requested_eval_report_ref,
@@ -950,6 +1040,18 @@ def orchestrate_dspy_agentrun_workflow(
                 poll_interval_seconds=poll_interval_seconds,
                 max_wait_seconds=max_wait_seconds,
             )
+
+            if lane in {"compile", "eval", "promote"}:
+                compile_result_snapshot = (
+                    compile_result_snapshot or _load_compile_result_snapshot()
+                )
+            if lane in {"eval", "promote"}:
+                eval_report_snapshot = eval_report_snapshot or _load_eval_report_snapshot()
+            if lane == "promote":
+                promotion_record_snapshot = (
+                    promotion_record_snapshot or _load_promotion_record_snapshot()
+                )
+
             upsert_workflow_artifact_record(
                 session,
                 run_key=run_key,
@@ -959,10 +1061,17 @@ def orchestrate_dspy_agentrun_workflow(
                 idempotency_key=idempotency_key,
                 request_payload=payload,
                 response_payload=response_payload,
-                compile_result=None,
-                eval_report=None,
-                promotion_record=None,
+                compile_result=compile_result_snapshot
+                if lane in {"compile", "eval", "promote"}
+                else None,
+                eval_report=eval_report_snapshot if lane in {"eval", "promote"} else None,
+                promotion_record=promotion_record_snapshot if lane == "promote" else None,
                 metadata={
+                    **(
+                        {"executor": "dspy_live"}
+                        if compile_result_snapshot is not None
+                        else {}
+                    ),
                     "orchestration": {
                         "runPrefix": normalized_run_prefix,
                         "laneOrder": lane_index,

--- a/services/torghut/scripts/run_dspy_workflow.py
+++ b/services/torghut/scripts/run_dspy_workflow.py
@@ -20,7 +20,7 @@ def _default_base_url() -> str:
 
 
 def _build_lane_overrides(args: argparse.Namespace) -> dict[str, dict[str, str]]:
-    artifact_root = args.artifact_root.rstrip("/")
+    artifact_root = args.artifact_root.strip().rstrip("/")
     dataset_ref = args.dataset_ref or f"{artifact_root}/dataset-build/dspy-dataset.json"
     compile_result_ref = (
         args.compile_result_ref or f"{artifact_root}/compile/dspy-compile-result.json"
@@ -28,6 +28,15 @@ def _build_lane_overrides(args: argparse.Namespace) -> dict[str, dict[str, str]]
     eval_report_ref = (
         args.eval_report_ref or f"{artifact_root}/eval/dspy-eval-report.json"
     )
+
+    promote_overrides: dict[str, str] = {
+        "evalReportRef": eval_report_ref,
+        "promotionTarget": args.promotion_target,
+        "approvalRef": args.approval_ref,
+    }
+    artifact_hash = str(args.artifact_hash or "").strip()
+    if artifact_hash:
+        promote_overrides["artifactHash"] = artifact_hash
 
     overrides: dict[str, dict[str, str]] = {
         "dataset-build": {
@@ -43,11 +52,7 @@ def _build_lane_overrides(args: argparse.Namespace) -> dict[str, dict[str, str]]
             "compileResultRef": compile_result_ref,
             "gatePolicyRef": args.gate_policy_ref,
         },
-        "promote": {
-            "evalReportRef": eval_report_ref,
-            "promotionTarget": args.promotion_target,
-            "approvalRef": args.approval_ref,
-        },
+        "promote": promote_overrides,
     }
 
     if args.include_gepa_experiment:
@@ -183,6 +188,11 @@ def parse_args() -> argparse.Namespace:
         choices=["paper", "shadow", "constrained_live", "scaled_live"],
     )
     parser.add_argument("--approval-ref", default="risk-committee")
+    parser.add_argument(
+        "--artifact-hash",
+        default="",
+        help="Optional compile artifact hash for promote lane contract.",
+    )
 
     parser.add_argument("--include-gepa-experiment", action="store_true")
     parser.add_argument("--gepa-baseline-ref", default="")
@@ -204,10 +214,11 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    artifact_root_text = args.artifact_root.strip()
-    if not artifact_root_text:
+    artifact_root_ref = args.artifact_root.strip()
+    if not artifact_root_ref:
         raise ValueError("artifact_root_required")
-    artifact_root = Path(artifact_root_text).resolve()
+    artifact_root = Path(artifact_root_ref).resolve()
+    args.artifact_root = artifact_root_ref
     lane_overrides = _build_lane_overrides(args)
 
     try:
@@ -218,7 +229,7 @@ def main() -> int:
                 repository=args.repository,
                 base=args.base,
                 head=args.head,
-                artifact_root=str(artifact_root),
+                artifact_root=artifact_root_ref,
                 run_prefix=args.run_prefix,
                 auth_token=(args.auth_token.strip() or None),
                 issue_number=args.issue_number,

--- a/services/torghut/tests/test_llm_dspy_workflow.py
+++ b/services/torghut/tests/test_llm_dspy_workflow.py
@@ -222,6 +222,9 @@ class TestLLMDSPyWorkflow(TestCase):
             self.assertEqual(loaded.artifact_hash, compile_result.artifact_hash)
             self.assertEqual(loaded.gate_compatibility, "pass")
             self.assertEqual(loaded.promotion_target, "paper")
+            self.assertIsInstance(loaded.metadata_json, dict)
+            assert isinstance(loaded.metadata_json, dict)
+            self.assertEqual(loaded.metadata_json.get("executor"), "dspy_live")
 
     def test_orchestrate_dspy_agentrun_workflow_submits_lanes_and_persists_rows(
         self,
@@ -345,6 +348,76 @@ class TestLLMDSPyWorkflow(TestCase):
                 self.assertIsInstance(lineage, dict)
                 assert isinstance(lineage, dict)
                 self.assertIn("dataset-build", lineage)
+
+    def test_orchestrate_dspy_agentrun_workflow_blocks_promote_without_artifact_hash(
+        self,
+    ) -> None:
+        responses = [
+            {
+                "agentRun": {"id": "record-dataset"},
+                "resource": {
+                    "metadata": {"name": "run-dataset", "namespace": "agents"}
+                },
+            },
+            {
+                "agentRun": {"id": "record-compile"},
+                "resource": {
+                    "metadata": {"name": "run-compile", "namespace": "agents"}
+                },
+            },
+            {
+                "agentRun": {"id": "record-eval"},
+                "resource": {"metadata": {"name": "run-eval", "namespace": "agents"}},
+            },
+        ]
+
+        with TemporaryDirectory() as tmpdir:
+            artifact_root = Path(tmpdir) / "artifacts" / "dspy" / "run-no-hash"
+            lane_overrides = _build_dspy_lane_overrides(artifact_root=artifact_root)
+            lane_overrides["promote"].pop("artifactHash", None)
+
+            with patch(
+                "app.trading.llm.dspy_compile.workflow.submit_jangar_agentrun",
+                side_effect=responses,
+            ) as submit_mock:
+                with patch(
+                    "app.trading.llm.dspy_compile.workflow.wait_for_jangar_agentrun_terminal_status",
+                    side_effect=["succeeded", "succeeded", "succeeded"],
+                ):
+                    with Session(self.engine) as session:
+                        with self.assertRaisesRegex(
+                            RuntimeError, "dspy_promote_artifact_hash_missing"
+                        ):
+                            orchestrate_dspy_agentrun_workflow(
+                                session,
+                                base_url="http://jangar.test",
+                                repository="proompteng/lab",
+                                base="main",
+                                head="codex/dspy-no-hash",
+                                artifact_root=str(artifact_root),
+                                run_prefix="torghut-dspy-run-no-hash",
+                                auth_token="token-123",
+                                lane_parameter_overrides=lane_overrides,
+                                include_gepa_experiment=False,
+                            )
+
+            self.assertEqual(submit_mock.call_count, 3)
+
+        with Session(self.engine) as session:
+            promote_row = session.execute(
+                select(LLMDSPyWorkflowArtifact).where(
+                    LLMDSPyWorkflowArtifact.run_key
+                    == "torghut-dspy-run-no-hash:promote"
+                )
+            ).scalar_one()
+            self.assertEqual(promote_row.status, "blocked")
+            metadata = promote_row.metadata_json or {}
+            self.assertIsInstance(metadata, dict)
+            assert isinstance(metadata, dict)
+            orchestration = metadata.get("orchestration") or {}
+            self.assertIsInstance(orchestration, dict)
+            assert isinstance(orchestration, dict)
+            self.assertIn("artifact_hash_missing", orchestration.get("gateFailures") or [])
 
     def test_orchestrate_dspy_agentrun_workflow_promotes_with_falsey_eval_report_override(
         self,

--- a/services/torghut/tests/test_run_dspy_workflow.py
+++ b/services/torghut/tests/test_run_dspy_workflow.py
@@ -81,6 +81,30 @@ class TestRunDSPyWorkflowScript(TestCase):
             self.assertIn("- priority_id: P-1", iteration_report)
             self.assertIn("- responses: compile, dataset-build, eval, promote", iteration_report)
 
+    def test_build_lane_overrides_includes_promote_artifact_hash_when_provided(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            artifact_root = Path(tmpdir) / "artifacts" / "dspy" / "run-hash"
+            argv = [
+                "run_dspy_workflow.py",
+                "--repository",
+                "proompteng/lab",
+                "--base",
+                "main",
+                "--head",
+                "codex/dspy-live-hash",
+                "--run-prefix",
+                "torghut-dspy-run-hash",
+                "--artifact-root",
+                str(artifact_root),
+                "--artifact-hash",
+                "b" * 64,
+            ]
+            with patch.object(sys, "argv", argv):
+                args = run_dspy_workflow.parse_args()
+
+        overrides = run_dspy_workflow._build_lane_overrides(args)
+        self.assertEqual(overrides["promote"]["artifactHash"], "b" * 64)
+
     def test_main_records_failure_iteration_report_when_orchestration_fails(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Render AgentRun `ImplementationSpec.spec.text` with runtime parameters (supports both `${param}` and `{{parameters.param}}`) so DSPy lane prompts are executable instead of shipping unresolved placeholders.
- Harden Torghut DSPy orchestration promote contract: block with explicit `dspy_promote_artifact_hash_missing` when promote `artifactHash` is absent and cannot be derived from compile artifacts.
- Persist DSPy lineage executor metadata (`executor=dspy_live`) and best-effort compile/eval/promotion artifact snapshots into workflow rows when local artifacts are available.
- Extend `run_dspy_workflow.py` with optional `--artifact-hash` and pass artifact-root reference semantics through orchestration.
- Add root-cause + rollout design document for this incident under `docs/torghut/design-system/v6/16-dspy-llm-live-gate-root-cause-and-rollout-2026-03-04.md`.

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/agents-controller-implementation-contract.test.ts`
- `cd services/torghut && uv run --frozen python -m unittest tests.test_llm_dspy_workflow tests.test_run_dspy_workflow`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/trading/llm/dspy_compile/workflow.py scripts/run_dspy_workflow.py tests/test_llm_dspy_workflow.py tests/test_run_dspy_workflow.py`
- `bunx oxfmt --check services/jangar/src/server/agents-controller/implementation-contract.ts services/jangar/src/server/__tests__/agents-controller-implementation-contract.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
