### PR TITLE
chore(torghut): promote image 370acb2a

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e3871dc9f41f5338790b9f5f2a549ce01cef0efa2c0eb70b307343a5da8ef54
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7aa73596e7d8062317d238b9ccb529a5dddc26571c215dda2aeb4bca4f96c795
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-04T02:51:52Z"
+        client.knative.dev/updateTimestamp: "2026-03-04T05:09:54Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e3871dc9f41f5338790b9f5f2a549ce01cef0efa2c0eb70b307343a5da8ef54
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7aa73596e7d8062317d238b9ccb529a5dddc26571c215dda2aeb4bca4f96c795
           ports:
             - name: http1
               containerPort: 8181
@@ -412,9 +412,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-196-gf8ca537d
+              value: v0.562.0-198-g370acb2a
             - name: TORGHUT_COMMIT
-              value: f8ca537d81c0e6cf84e7e9d2d55e9f33d49b38d1
+              value: 370acb2a11f0c13f11542e4546b9938826754364
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `370acb2a11f0c13f11542e4546b9938826754364`
- Image tag: `370acb2a`
- Image digest: `sha256:7aa73596e7d8062317d238b9ccb529a5dddc26571c215dda2aeb4bca4f96c795`