### PR TITLE
feat(agents): ship namespace logs to loki via alloy

### DIFF
--- a/argocd/applications/agents/alloy-configmap.yaml
+++ b/argocd/applications/agents/alloy-configmap.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agents-alloy
+  namespace: agents
+data:
+  config.river: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+
+    discovery.kubernetes "agents_pods" {
+      role = "pod"
+
+      namespaces {
+        names = ["agents"]
+      }
+
+      selectors {
+        role  = "pod"
+        field = "metadata.namespace=agents"
+      }
+    }
+
+    discovery.relabel "agents_pod_logs" {
+      targets = discovery.kubernetes.agents_pods.targets
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex         = "agents-alloy-.*"
+        action        = "drop"
+      }
+    }
+
+    loki.source.kubernetes "agents_pod_logs" {
+      targets    = discovery.relabel.agents_pod_logs.output
+      forward_to = [loki.process.agents_pod_logs.receiver]
+    }
+
+    loki.process "agents_pod_logs" {
+      stage.labels {
+        values = {
+          namespace = "{{ .Labels.namespace }}",
+          pod       = "{{ .Labels.pod }}",
+          container = "{{ .Labels.container }}",
+        }
+      }
+
+      stage.static_labels {
+        values = {
+          job       = "agents",
+          namespace = "agents",
+        }
+      }
+
+      forward_to = [loki.write.default.receiver]
+    }
+
+    loki.write "default" {
+      endpoint {
+        url = "http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push"
+      }
+    }

--- a/argocd/applications/agents/alloy-deployment.yaml
+++ b/argocd/applications/agents/alloy-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agents-alloy
+  namespace: agents
+  labels:
+    app.kubernetes.io/name: agents-alloy
+    app.kubernetes.io/component: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agents-alloy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agents-alloy
+        app.kubernetes.io/component: observability
+    spec:
+      serviceAccountName: agents-alloy
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.11.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/alloy/config.river
+          ports:
+            - name: http-metrics
+              containerPort: 12345
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            # alloy image runs as UID 0; Kubernetes rejects runAsNonRoot=true.
+            runAsNonRoot: false
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: agents-alloy
+            items:
+              - key: config.river
+                path: config.river

--- a/argocd/applications/agents/alloy-rbac.yaml
+++ b/argocd/applications/agents/alloy-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agents-alloy
+  namespace: agents
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agents-alloy
+  namespace: agents
+rules:
+  - apiGroups: ['']
+    resources: ['pods', 'pods/log']
+    verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agents-alloy
+  namespace: agents
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agents-alloy
+subjects:
+  - kind: ServiceAccount
+    name: agents-alloy
+    namespace: agents

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -32,6 +32,9 @@ resources:
   - nats-service.yaml
   - tailscale-service.yaml
   - tailscale-networkpolicy.yaml
+  - alloy-rbac.yaml
+  - alloy-configmap.yaml
+  - alloy-deployment.yaml
 helmGlobals:
   chartHome: ../../../charts
 helmCharts:

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -95,6 +95,70 @@ data:
             annotations:
               summary: Jangar SSE error rate elevated
               description: SSE error responses exceed 0.05/sec for 10 minutes across Jangar streams.
+      - name: agents-log-collection.rules
+        rules:
+          - alert: AgentsAlloyDeploymentUnavailable
+            expr: |
+              sum(
+                kube_deployment_status_replicas_available{
+                  namespace="agents",
+                  deployment="agents-alloy"
+                }
+              ) < 1
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Agents Alloy log collector is unavailable
+              description: |
+                The agents-alloy deployment has no available replicas for 5 minutes.
+                AgentRun Job logs in the agents namespace are at risk of being missed.
+              runbook_url: docs/runbooks/agents-log-observability.md
+          - alert: AgentsAlloyContainerRestarts
+            expr: |
+              sum(
+                increase(
+                  kube_pod_container_status_restarts_total{
+                    namespace="agents",
+                    pod=~"agents-alloy-.*",
+                    container="alloy"
+                  }[15m]
+                )
+              ) > 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: Agents Alloy collector is restarting
+              description: |
+                The agents-alloy container restarted in the last 15 minutes.
+                Verify collector health and Loki push connectivity.
+              runbook_url: docs/runbooks/agents-log-observability.md
+          - alert: AgentsJobsRunningWithoutLogCollector
+            expr: |
+              sum(
+                kube_pod_status_phase{
+                  namespace="agents",
+                  phase="Running",
+                  pod=~".*-step-.*"
+                }
+              ) > 0
+              and
+              sum(
+                kube_deployment_status_replicas_available{
+                  namespace="agents",
+                  deployment="agents-alloy"
+                }
+              ) < 1
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: AgentRun jobs are running without a log collector
+              description: |
+                AgentRun step pods are active while agents-alloy has no available replicas.
+                Logs can be lost once Job pods terminate.
+              runbook_url: docs/runbooks/agents-log-observability.md
       - name: torghut-clickhouse.guardrails.rules
         rules:
           - alert: TorghutClickHouseDiskFreeLowWarning

--- a/docs/runbooks/agents-log-observability.md
+++ b/docs/runbooks/agents-log-observability.md
@@ -1,0 +1,79 @@
+# Agents Log Observability Runbook
+
+## Overview
+
+This runbook covers collection and verification of logs for ephemeral AgentRun Job pods in namespace `agents`.
+
+The log shipping path is:
+
+1. pod logs in `agents` namespace,
+2. `agents-alloy` (Grafana Alloy) Kubernetes log source,
+3. Loki gateway in namespace `observability`.
+
+## GitOps Source of Truth
+
+- `argocd/applications/agents/alloy-rbac.yaml`
+- `argocd/applications/agents/alloy-configmap.yaml`
+- `argocd/applications/agents/alloy-deployment.yaml`
+- `argocd/applications/agents/kustomization.yaml`
+- `argocd/applications/observability/graf-mimir-rules.yaml`
+
+## Operational SLO
+
+1. `agents-alloy` availability: at least one ready replica at all times.
+2. Job log ingestion latency: logs visible in Loki within 30 seconds (p95) for active AgentRun jobs.
+3. Data loss budget: no sustained periods where AgentRun step pods are running while `agents-alloy` is unavailable.
+
+## Rollout Steps
+
+1. Merge GitOps changes to `main`.
+2. Sync Argo CD applications:
+   - `argocd app sync agents`
+   - `argocd app sync observability`
+3. Confirm deployment readiness:
+   - `kubectl -n agents rollout status deploy/agents-alloy`
+4. Confirm config and RBAC objects exist:
+   - `kubectl -n agents get sa,role,rolebinding,configmap,deploy | rg agents-alloy`
+
+## Validation
+
+1. Ensure collector pod is running:
+   - `kubectl -n agents get pods -l app.kubernetes.io/name=agents-alloy`
+2. Inspect collector logs for discovery/push errors:
+   - `kubectl -n agents logs deploy/agents-alloy --tail=200`
+3. Run a short-lived test job in `agents` and emit log lines:
+   - `kubectl -n agents create job agents-log-smoke --image=busybox:1.36 -- sh -lc 'echo agents-smoke-start; sleep 5; echo agents-smoke-end'`
+4. Query Loki:
+   - `{job="agents",namespace="agents"} |= "agents-smoke"`
+5. Clean up smoke job:
+   - `kubectl -n agents delete job agents-log-smoke`
+
+## Alert Reference
+
+Alert definitions are in `argocd/applications/observability/graf-mimir-rules.yaml` under `agents-log-collection.rules`:
+
+1. `AgentsAlloyDeploymentUnavailable`
+2. `AgentsAlloyContainerRestarts`
+3. `AgentsJobsRunningWithoutLogCollector`
+
+## Troubleshooting
+
+1. `AgentsAlloyDeploymentUnavailable`:
+   - `kubectl -n agents describe deploy agents-alloy`
+   - `kubectl -n agents get pods -l app.kubernetes.io/name=agents-alloy -o wide`
+2. RBAC errors in Alloy logs:
+   - verify `agents-alloy` Role includes `pods` and `pods/log` with `get,list,watch`.
+3. Loki push/connectivity errors:
+   - confirm endpoint in ConfigMap:
+     - `kubectl -n agents get cm agents-alloy -o yaml | rg loki/api/v1/push`
+   - verify gateway service exists:
+     - `kubectl -n observability get svc observability-loki-loki-distributed-gateway`
+
+## Rollback
+
+1. Revert these resources from `argocd/applications/agents/kustomization.yaml`:
+   - `alloy-rbac.yaml`
+   - `alloy-configmap.yaml`
+   - `alloy-deployment.yaml`
+2. Sync `agents` app.
+3. Leave alerts muted until collector is intentionally re-enabled.


### PR DESCRIPTION
## Summary

- Added a namespace-local Alloy collector in `agents` to ship pod logs (including ephemeral AgentRun Job pods) to Loki.
- Wired the collector manifests into `argocd/applications/agents/kustomization.yaml` and added a dedicated operators runbook.
- Added observability alert rules for collector availability/restarts and for active AgentRun jobs running without a collector.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/observability > /tmp/observability-rendered-final.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/agents/alloy-rbac.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/agents/alloy-configmap.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/agents/alloy-deployment.yaml`
- `kubectl -n agents rollout status deploy/agents-alloy --timeout=180s`
- `kubectl -n agents logs deploy/agents-alloy --tail=120` (verified tailers start for AgentRun job pods)
- Live E2E smoke validation: created jobs that emitted unique markers and confirmed Loki query hits with `{job="agents",namespace="agents"} |= "<marker>"` for:
  - `agents-smoke-ns-1772601294-a/b/c`
  - `agents-e2e-1772601523-1/2/3`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
