### PR TITLE
fix(jangar): include cx-tools in pruned build context

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -12,6 +12,7 @@ on:
       - 'packages/scripts/src/jangar/**'
       - 'packages/scripts/src/shared/**'
       - 'packages/codex/**'
+      - 'packages/cx-tools/**'
       - 'packages/otel/**'
       - 'packages/temporal-bun-sdk/**'
       - 'skills/**'
@@ -64,6 +65,11 @@ jobs:
             mkdir -p "$PRUNE_DIR/full/services/jangar" "$PRUNE_DIR/json/services/jangar"
             cp -R services/jangar/agentctl "$PRUNE_DIR/full/services/jangar/agentctl"
             cp -R services/jangar/agentctl "$PRUNE_DIR/json/services/jangar/agentctl"
+          fi
+          if [ -d packages/cx-tools ]; then
+            mkdir -p "$PRUNE_DIR/full/packages" "$PRUNE_DIR/json/packages"
+            cp -R packages/cx-tools "$PRUNE_DIR/full/packages/cx-tools"
+            cp -R packages/cx-tools "$PRUNE_DIR/json/packages/cx-tools"
           fi
           echo "context=$PRUNE_DIR" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- Add `packages/cx-tools/**` to `jangar-build-push` workflow path filters so cx-tools changes trigger image rebuilds.
- Include `packages/cx-tools` in the workflow's pruned Docker context (`full/` + `json/`) to satisfy `services/jangar/Dockerfile` copy steps.
- Unblock `jangar-build-push` failures where Docker build reported `"/full/packages/cx-tools": not found`.

## Related Issues

None

## Testing

- `bunx js-yaml .github/workflows/jangar-build-push.yaml >/dev/null && echo ok`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
