### PR TITLE
fix(jangar): align cx-tools cli paths with dist outputs

### DIFF
--- a/packages/cx-tools/package.json
+++ b/packages/cx-tools/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "bin": {
-    "cx-codex-run": "./dist/cli/cx-codex-run.js",
-    "cx-workflow-cancel": "./dist/cli/cx-workflow-cancel.js",
-    "cx-workflow-query": "./dist/cli/cx-workflow-query.js",
-    "cx-workflow-signal": "./dist/cli/cx-workflow-signal.js",
-    "cx-workflow-start": "./dist/cli/cx-workflow-start.js"
+    "cx-codex-run": "./dist/cx-codex-run.js",
+    "cx-workflow-cancel": "./dist/cx-workflow-cancel.js",
+    "cx-workflow-query": "./dist/cx-workflow-query.js",
+    "cx-workflow-signal": "./dist/cx-workflow-signal.js",
+    "cx-workflow-start": "./dist/cx-workflow-start.js"
   },
   "type": "module",
   "scripts": {

--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -558,11 +558,11 @@ COPY --from=jangar-pty /tmp/node-pty/prebuilds /app/services/jangar/.output/serv
 WORKDIR /app
 COPY --from=jangar-build /app/services/bumba ./services/bumba
 WORKDIR /app/services/jangar
-RUN ln -sf /app/packages/cx-tools/dist/cli/cx-codex-run.js /usr/local/bin/cx-codex-run \
-  && ln -sf /app/packages/cx-tools/dist/cli/cx-workflow-start.js /usr/local/bin/cx-workflow-start \
-  && ln -sf /app/packages/cx-tools/dist/cli/cx-workflow-query.js /usr/local/bin/cx-workflow-query \
-  && ln -sf /app/packages/cx-tools/dist/cli/cx-workflow-signal.js /usr/local/bin/cx-workflow-signal \
-  && ln -sf /app/packages/cx-tools/dist/cli/cx-workflow-cancel.js /usr/local/bin/cx-workflow-cancel \
+RUN ln -sf /app/packages/cx-tools/dist/cx-codex-run.js /usr/local/bin/cx-codex-run \
+  && ln -sf /app/packages/cx-tools/dist/cx-workflow-start.js /usr/local/bin/cx-workflow-start \
+  && ln -sf /app/packages/cx-tools/dist/cx-workflow-query.js /usr/local/bin/cx-workflow-query \
+  && ln -sf /app/packages/cx-tools/dist/cx-workflow-signal.js /usr/local/bin/cx-workflow-signal \
+  && ln -sf /app/packages/cx-tools/dist/cx-workflow-cancel.js /usr/local/bin/cx-workflow-cancel \
   && chmod +x /usr/local/bin/cx-codex-run /usr/local/bin/cx-workflow-start /usr/local/bin/cx-workflow-query /usr/local/bin/cx-workflow-signal /usr/local/bin/cx-workflow-cancel
 
 ENV JANGAR_AGENTS_CONTROLLER_ENABLED=0 \
@@ -605,11 +605,11 @@ COPY --from=jangar-pty /tmp/node-pty/prebuilds /app/services/jangar/.output/serv
 WORKDIR /app
 COPY --from=jangar-build /app/services/bumba ./services/bumba
 WORKDIR /app/services/jangar
-RUN ln -sf /app/packages/cx-tools/dist/cli/cx-codex-run.js /usr/local/bin/cx-codex-run \
-  && ln -sf /app/packages/cx-tools/dist/cli/cx-workflow-start.js /usr/local/bin/cx-workflow-start \
-  && ln -sf /app/packages/cx-tools/dist/cli/cx-workflow-query.js /usr/local/bin/cx-workflow-query \
-  && ln -sf /app/packages/cx-tools/dist/cli/cx-workflow-signal.js /usr/local/bin/cx-workflow-signal \
-  && ln -sf /app/packages/cx-tools/dist/cli/cx-workflow-cancel.js /usr/local/bin/cx-workflow-cancel \
+RUN ln -sf /app/packages/cx-tools/dist/cx-codex-run.js /usr/local/bin/cx-codex-run \
+  && ln -sf /app/packages/cx-tools/dist/cx-workflow-start.js /usr/local/bin/cx-workflow-start \
+  && ln -sf /app/packages/cx-tools/dist/cx-workflow-query.js /usr/local/bin/cx-workflow-query \
+  && ln -sf /app/packages/cx-tools/dist/cx-workflow-signal.js /usr/local/bin/cx-workflow-signal \
+  && ln -sf /app/packages/cx-tools/dist/cx-workflow-cancel.js /usr/local/bin/cx-workflow-cancel \
   && chmod +x /usr/local/bin/cx-codex-run /usr/local/bin/cx-workflow-start /usr/local/bin/cx-workflow-query /usr/local/bin/cx-workflow-signal /usr/local/bin/cx-workflow-cancel
 
 RUN mkdir -p /root/.codex

--- a/services/jangar/Dockerfile.codex
+++ b/services/jangar/Dockerfile.codex
@@ -140,12 +140,12 @@ RUN mkdir -p /usr/local/node_modules/@proompteng \
     && cp -R /opt/proompteng/packages/codex /usr/local/node_modules/@proompteng/codex \
     && cp -R /opt/proompteng/packages/discord /usr/local/node_modules/@proompteng/discord \
     && cp -R /opt/proompteng/packages/cx-tools /usr/local/node_modules/@proompteng/cx-tools \
-    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-codex-run.js /usr/local/bin/cx-codex-run \
-    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-workflow-start.js /usr/local/bin/cx-workflow-start \
-    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-workflow-query.js /usr/local/bin/cx-workflow-query \
-    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-workflow-signal.js /usr/local/bin/cx-workflow-signal \
-    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-workflow-cancel.js /usr/local/bin/cx-workflow-cancel \
-    && chmod +x /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-codex-run.js /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-workflow-start.js /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-workflow-query.js /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-workflow-signal.js /usr/local/node_modules/@proompteng/cx-tools/dist/cli/cx-workflow-cancel.js \
+    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cx-codex-run.js /usr/local/bin/cx-codex-run \
+    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cx-workflow-start.js /usr/local/bin/cx-workflow-start \
+    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cx-workflow-query.js /usr/local/bin/cx-workflow-query \
+    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cx-workflow-signal.js /usr/local/bin/cx-workflow-signal \
+    && ln -sf /usr/local/node_modules/@proompteng/cx-tools/dist/cx-workflow-cancel.js /usr/local/bin/cx-workflow-cancel \
+    && chmod +x /usr/local/node_modules/@proompteng/cx-tools/dist/cx-codex-run.js /usr/local/node_modules/@proompteng/cx-tools/dist/cx-workflow-start.js /usr/local/node_modules/@proompteng/cx-tools/dist/cx-workflow-query.js /usr/local/node_modules/@proompteng/cx-tools/dist/cx-workflow-signal.js /usr/local/node_modules/@proompteng/cx-tools/dist/cx-workflow-cancel.js \
     && chmod +x /usr/local/bin/codex-bootstrap /usr/local/bin/agent-runner /usr/local/bin/codex-implement /usr/local/bin/codex-research /usr/local/bin/codex-graf /usr/local/bin/codex-nats-publish /usr/local/bin/codex-nats-soak /usr/local/bin/discord-channel.ts
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- Fix Jangar Docker runtime symlink targets from `dist/cli/*` to `dist/*` for `cx-tools` binaries in both `services/jangar/Dockerfile` runtime stages.
- Apply the same path correction in `services/jangar/Dockerfile.codex` to keep Codex runtime image wiring consistent.
- Align `@proompteng/cx-tools` `package.json` `bin` entries with actual `bun build --outdir dist` outputs.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/cx-tools build`
- `rg -n "dist/cli/cx-(codex-run|workflow-start|workflow-cancel|workflow-query|workflow-signal)" services/jangar packages/cx-tools -S`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
