### PR TITLE
chore(jangar): promote image 61a61384

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f652ff3a
-  digest: sha256:906f0479b27318ff3cd915b2ca2fae4d2ea5395efd729d59c9d0f40d5ecdf310
+  tag: 61a61384
+  digest: sha256:5cfdd81406949b831c4e89420e0bab35e889aa9847e4fcec0050bdf6ad7eedc0
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f652ff3a
-    digest: sha256:f4e26b596f8bf7aa184c761a9e34989aa6ea8720c250789346e16d30f7f6eedd
+    tag: 61a61384
+    digest: sha256:ba041480cc470596cd3115979e56ec9f4bb0ef0a6aee0c7c0e822350376a6cf1
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f652ff3a
-    digest: sha256:906f0479b27318ff3cd915b2ca2fae4d2ea5395efd729d59c9d0f40d5ecdf310
+    tag: 61a61384
+    digest: sha256:5cfdd81406949b831c4e89420e0bab35e889aa9847e4fcec0050bdf6ad7eedc0
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-03T08:32:19Z"
+    deploy.knative.dev/rollout: "2026-03-04T05:59:52Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-03T08:32:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-04T05:59:52Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f652ff3a"
-    digest: sha256:906f0479b27318ff3cd915b2ca2fae4d2ea5395efd729d59c9d0f40d5ecdf310
+    newTag: "61a61384"
+    digest: sha256:5cfdd81406949b831c4e89420e0bab35e889aa9847e4fcec0050bdf6ad7eedc0


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `61a61384bf4dd463dc88045e11eece942ded042e`
- Image tag: `61a61384`
- Image digest: `sha256:5cfdd81406949b831c4e89420e0bab35e889aa9847e4fcec0050bdf6ad7eedc0`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`