### PR TITLE
feat(torghut): externalize regime-confidence thresholds

### DIFF
--- a/argocd/applications/torghut/autonomy-configmap.yaml
+++ b/argocd/applications/torghut/autonomy-configmap.yaml
@@ -38,6 +38,8 @@ data:
     {"trend": 1.0, "mean_revert": 0.82, "range": 0.58, "unknown": 0.5, "default": 0.7}
   TRADING_ALLOCATOR_REGIME_CAPACITY_MULTIPLIERS: |
     {"trend": 1.0, "mean_revert": 0.8, "range": 0.52, "unknown": 0.45, "default": 0.65}
+  TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND: |
+    {"low":[0.65,0.45],"medium":[0.75,0.55],"high":[0.85,0.70]}
   TRADING_FRAGILITY_MODE: "enforce"
   TRADING_FRAGILITY_UNKNOWN_STATE: "elevated"
   TRADING_FRAGILITY_ELEVATED_THRESHOLD: "0.42"

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1021,6 +1021,20 @@ class Settings(BaseSettings):
             "gate selects degrade."
         ),
     )
+    trading_runtime_regime_confidence_thresholds_by_entropy_band: dict[
+        str, tuple[float, float]
+    ] = Field(
+        default_factory=lambda: {
+            "low": (0.65, 0.45),
+            "medium": (0.75, 0.55),
+            "high": (0.85, 0.70),
+        },
+        alias="TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND",
+        description=(
+            "Entropy-band->(degrade_threshold, abstain_threshold) pairs used by "
+            "runtime regime-confidence gating."
+        ),
+    )
     trading_allocator_strategy_notional_caps: dict[str, float] = Field(
         default_factory=dict,
         alias="TRADING_ALLOCATOR_STRATEGY_NOTIONAL_CAPS",
@@ -1653,6 +1667,17 @@ class Settings(BaseSettings):
             normalized_correlation_caps
         )
 
+    def _normalize_runtime_regime_confidence_thresholds_by_entropy_band(self) -> None:
+        normalized: dict[str, tuple[float, float]] = {}
+        for key, thresholds in (
+            self.trading_runtime_regime_confidence_thresholds_by_entropy_band.items()
+        ):
+            normalized_key = str(key).strip().lower()
+            if not normalized_key:
+                continue
+            normalized[normalized_key] = (float(thresholds[0]), float(thresholds[1]))
+        self.trading_runtime_regime_confidence_thresholds_by_entropy_band = normalized
+
     @staticmethod
     def _normalize_regime_keyed_float_map(values: dict[str, float]) -> dict[str, float]:
         normalized: dict[str, float] = {}
@@ -1839,6 +1864,32 @@ class Settings(BaseSettings):
                     f"[{key}] must be >= 0"
                 )
 
+    def _validate_runtime_regime_confidence_thresholds_by_entropy_band(self) -> None:
+        for entropy_band, thresholds in (
+            self.trading_runtime_regime_confidence_thresholds_by_entropy_band.items()
+        ):
+            if len(thresholds) != 2:
+                raise ValueError(
+                    "TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND"
+                    f"[{entropy_band}] must contain exactly two values"
+                )
+            degrade_threshold, abstain_threshold = thresholds
+            if not (0 <= degrade_threshold <= 1):
+                raise ValueError(
+                    "TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND"
+                    f"[{entropy_band}] degrade_threshold must be within [0, 1]"
+                )
+            if not (0 <= abstain_threshold <= 1):
+                raise ValueError(
+                    "TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND"
+                    f"[{entropy_band}] abstain_threshold must be within [0, 1]"
+                )
+            if degrade_threshold < abstain_threshold:
+                raise ValueError(
+                    "TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND"
+                    f"[{entropy_band}] requires degrade_threshold >= abstain_threshold"
+                )
+
     def _validate_fragility_settings(self) -> None:
         if not (
             0 <= self.trading_fragility_elevated_threshold <= 1
@@ -1960,9 +2011,11 @@ class Settings(BaseSettings):
             self.trading_allocator_regime_budget_multipliers,
         )
         self._normalize_allocator_settings()
+        self._normalize_runtime_regime_confidence_thresholds_by_entropy_band()
         self._normalize_runtime_uncertainty_degrade_maps()
         self._validate_allocator_map_settings()
         self._validate_runtime_uncertainty_degrade_map_settings()
+        self._validate_runtime_regime_confidence_thresholds_by_entropy_band()
         self._validate_fragility_settings()
         self._validate_llm_settings()
         self._validate_posthog_settings()

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -106,13 +106,6 @@ _RUNTIME_UNCERTAINTY_DEGRADE_QTY_MULTIPLIER = Decimal("0.50")
 _RUNTIME_UNCERTAINTY_DEGRADE_MAX_PARTICIPATION_RATE = Decimal("0.05")
 _RUNTIME_UNCERTAINTY_DEGRADE_MIN_EXECUTION_SECONDS = 120
 _RUNTIME_UNCERTAINTY_GATE_MAX_STALENESS_SECONDS = 15 * 60
-_RUNTIME_REGIME_CONFIDENCE_DEGRADE_BY_ENTROPY_BAND: dict[
-    str, tuple[Decimal, Decimal]
-] = {
-    "low": (Decimal("0.65"), Decimal("0.45")),
-    "medium": (Decimal("0.75"), Decimal("0.55")),
-    "high": (Decimal("0.85"), Decimal("0.70")),
-}
 _RUNTIME_REGIME_CONFIDENCE_DEFAULT_THRESHOLDS = (Decimal("0.75"), Decimal("0.55"))
 RuntimeUncertaintyGateAction = Literal["pass", "degrade", "abstain", "fail"]
 
@@ -2848,13 +2841,17 @@ class TradingPipeline:
         self,
         entropy_band: str,
     ) -> tuple[Decimal, Decimal]:
-        degrade_threshold, abstain_threshold = (
-            _RUNTIME_REGIME_CONFIDENCE_DEGRADE_BY_ENTROPY_BAND.get(
-                entropy_band,
-                _RUNTIME_REGIME_CONFIDENCE_DEFAULT_THRESHOLDS,
-            )
+        normalized_entropy_band = (entropy_band or "").strip().lower()
+        (
+            degrade_threshold,
+            abstain_threshold,
+        ) = settings.trading_runtime_regime_confidence_thresholds_by_entropy_band.get(
+            normalized_entropy_band,
+            _RUNTIME_REGIME_CONFIDENCE_DEFAULT_THRESHOLDS,
         )
-        return max(degrade_threshold, abstain_threshold), abstain_threshold
+        decimal_degrade_threshold = Decimal(str(degrade_threshold))
+        decimal_abstain_threshold = Decimal(str(abstain_threshold))
+        return max(decimal_degrade_threshold, decimal_abstain_threshold), decimal_abstain_threshold
 
     def _apply_runtime_uncertainty_gate(
         self,

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -514,6 +514,43 @@ class TestConfig(TestCase):
                 DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
             )
 
+    def test_runtime_regime_confidence_thresholds_by_entropy_band_are_normalized(self) -> None:
+        settings = Settings(
+            TRADING_UNIVERSE_SOURCE="static",
+            TRADING_ENABLED=False,
+            TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND={
+                " High ": [0.80, 0.60],
+                " low ": [0.66, 0.46],
+            },
+            DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+        )
+        self.assertEqual(
+            settings.trading_runtime_regime_confidence_thresholds_by_entropy_band,
+            {"high": (0.80, 0.60), "low": (0.66, 0.46)},
+        )
+
+    def test_runtime_regime_confidence_thresholds_by_entropy_band_reject_invalid_values(
+        self,
+    ) -> None:
+        with self.assertRaises(ValidationError):
+            Settings(
+                TRADING_UNIVERSE_SOURCE="static",
+                TRADING_ENABLED=False,
+                TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND={
+                    "low": [1.05, 0.45],
+                },
+                DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+            )
+        with self.assertRaises(ValidationError):
+            Settings(
+                TRADING_UNIVERSE_SOURCE="static",
+                TRADING_ENABLED=False,
+                TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND={
+                    "low": [0.55, 0.65],
+                },
+                DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
+            )
+
     def test_allocator_rejects_negative_strategy_budget_cap(self) -> None:
         with self.assertRaises(ValidationError):
             Settings(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -1231,6 +1231,62 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(gate.source, "regime_hmm_confidence")
         self.assertEqual(gate.reason, "regime_hmm_confidence_too_low")
 
+    def test_pipeline_runtime_regime_gate_respects_configured_entropy_band_thresholds(
+        self,
+    ) -> None:
+        from app import config
+
+        original_thresholds = dict(
+            config.settings.trading_runtime_regime_confidence_thresholds_by_entropy_band
+        )
+        config.settings.trading_runtime_regime_confidence_thresholds_by_entropy_band = {
+            **original_thresholds,
+            "high": (0.55, 0.45),
+        }
+        try:
+            pipeline = TradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            decision = StrategyDecision(
+                strategy_id="strategy",
+                symbol="AAPL",
+                event_ts=datetime.now(timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("10"),
+                params={
+                    "regime_hmm": {
+                        "schema_version": "hmm_regime_context_v1",
+                        "regime_id": "R2",
+                        "posterior": {"R2": "0.60", "R3": "0.40"},
+                        "entropy": "2.2",
+                        "entropy_band": "high",
+                        "predicted_next": "R3",
+                        "artifact": {"model_id": "hmm-regime-v1.2.0"},
+                        "guardrail": {"reason": "stable"},
+                    },
+                },
+            )
+
+            gate = pipeline._resolve_runtime_regime_gate(decision)
+            self.assertEqual(gate.action, "pass")
+            self.assertEqual(gate.source, "regime_hmm")
+        finally:
+            config.settings.trading_runtime_regime_confidence_thresholds_by_entropy_band = (
+                original_thresholds
+            )
+
     def test_pipeline_runtime_regime_gate_invalid_regime_gate_action_fails_closed(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Added a new runtime regime-confidence threshold setting for `TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND` in `services/torghut/app/config.py` with normalization + strict validation, preserving safe defaults.
- Updated scheduler resolution in `services/torghut/app/trading/scheduler.py` to consume the configured entropy-band thresholds with graceful fallback to built-in defaults.
- Added regression coverage for config map parsing/validation and runtime gate behavior in `services/torghut/tests/test_config.py` and `services/torghut/tests/test_trading_pipeline.py`.
- Updated GitOps deployment defaults in `argocd/applications/torghut/autonomy-configmap.yaml` to expose configurable thresholds for entropy bands.
- Requirement provenance: this run was not triggered from a cross-swarm signal; it used direct implementation objective from stage request. Active channel: `general`. PR: https://github.com/proompteng/lab/pull/3976.

## Related Issues

None.

## Testing

- `python3 -m compileall services/torghut/app/config.py services/torghut/app/trading/scheduler.py services/torghut/tests/test_config.py services/torghut/tests/test_trading_pipeline.py` (pass)
- `python3 -m pytest services/torghut/tests/test_config.py services/torghut/tests/test_trading_pipeline.py -q` (blocked in this runtime: `No module named pytest`)
- GitHub CI checks for PR #3976: check_changed_files, lint, validate, Pyright, Bytecode + unit tests all successful; deploy/auxiliary checks remained skipped by workflow matrix.

## Screenshots

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
