### PR TITLE
fix(torghut): switch live dspy artifact hash to promoted manifest

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -375,7 +375,7 @@ spec:
             - name: LLM_DSPY_RUNTIME_MODE
               value: active
             - name: LLM_DSPY_ARTIFACT_HASH
-              value: df087a5e643d6478b1ebe51bf44ad2d0e2228825c1c0a8e9dc345729d6a3bbff
+              value: 373bb47d4588d86a6fcf682e8b127420305a27860ba91c3508448f037e4adca8
             - name: LLM_DSPY_LIVE_RUNTIME_BLOCK_FAIL_MODE
               value: pass_through_reduced_size
             - name: LLM_DSPY_LIVE_RUNTIME_BLOCK_QTY_MULTIPLIER


### PR DESCRIPTION
## Summary

- Replace Torghut live `LLM_DSPY_ARTIFACT_HASH` in GitOps manifest with promoted non-bootstrap hash `373bb47d4588d86a6fcf682e8b127420305a27860ba91c3508448f037e4adca8`.
- Remove bootstrap-hash live gate block path that produced `dspy_bootstrap_artifact_forbidden` in active mode.
- Keep all existing strict-veto DSPy live guardrails unchanged; only artifact lineage pointer changes.

## Related Issues

None

## Testing

- `kubectl exec -i -n torghut torghut-00037-deployment-74d95d54f5-gzkxg -c user-container -- python - <<'PY' ... upsert_workflow_artifact_record(... metadata.executor='dspy_live' ...) ... PY`
- `kubectl exec -i -n torghut torghut-00037-deployment-74d95d54f5-gzkxg -c user-container -- python - <<'PY' from app.config import settings; from app.trading.llm.dspy_programs.runtime import DSPyReviewRuntime; settings.llm_dspy_artifact_hash='373bb47d4588d86a6fcf682e8b127420305a27860ba91c3508448f037e4adca8'; rt=DSPyReviewRuntime(mode='active',artifact_hash=settings.llm_dspy_artifact_hash,program_name=settings.llm_dspy_program_name,signature_version=settings.llm_dspy_signature_version,timeout_seconds=settings.llm_dspy_timeout_seconds); print(rt.evaluate_live_readiness()); PY`
- `git diff -- argocd/applications/torghut/knative-service.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
