### PR TITLE
fix(torghut): correct dspy gpt-5 temperature handling

### DIFF
--- a/services/torghut/app/trading/llm/dspy_programs/modules.py
+++ b/services/torghut/app/trading/llm/dspy_programs/modules.py
@@ -25,6 +25,7 @@ dspy: Any = _dspy
 _SAFE_DEFAULT_CHECKS = ["risk_engine", "order_firewall", "execution_policy"]
 _DSPY_OPENAI_BASE_PATH = "/openai/v1"
 _DSPY_OPENAI_CHAT_COMPLETION_SUFFIX = "/chat/completions"
+_DSPY_TEMPERATURE_ONE_MODEL_PREFIXES = ("gpt-5",)
 
 
 class DSPyCommitteeProgram(Protocol):
@@ -155,7 +156,7 @@ class LiveDSPyCommitteeProgram:
 
         lm_kwargs: dict[str, Any] = {
             "model": normalized_model,
-            "temperature": 0.0,
+            "temperature": _resolve_dspy_temperature(normalized_model),
             "max_tokens": 900,
         }
         api_base = _coerce_dspy_api_base(
@@ -281,6 +282,15 @@ def _coerce_dspy_api_base(
     return (
         f"{parsed.scheme}://{parsed.netloc}{base_path}"
     )
+
+
+def _resolve_dspy_temperature(model_name: str) -> float:
+    normalized = model_name.strip().lower()
+    _, _, model_id = normalized.partition("/")
+    candidate = model_id if model_id else normalized
+    if candidate.startswith(_DSPY_TEMPERATURE_ONE_MODEL_PREFIXES):
+        return 1.0
+    return 0.0
 
 
 __all__ = [

--- a/services/torghut/tests/test_llm_dspy_modules.py
+++ b/services/torghut/tests/test_llm_dspy_modules.py
@@ -82,6 +82,7 @@ class TestDSPyTransportHardening(TestCase):
             captured["lm_kwargs"]["api_base"],
             "http://jangar.openai.local/openai/v1",
         )
+        self.assertEqual(captured["lm_kwargs"]["temperature"], 0.0)
 
     def test_live_program_prefers_api_completion_url(self) -> None:
         captured: dict[str, dict[str, object]] = {}
@@ -113,6 +114,33 @@ class TestDSPyTransportHardening(TestCase):
             captured["lm_kwargs"]["api_base"],
             "https://jangar.openai.local/openai/v1",
         )
+
+    def test_live_program_sets_supported_temperature_for_gpt5_models(self) -> None:
+        captured: dict[str, dict[str, object]] = {}
+
+        class _TrackingLM(_FakeLM):
+            def __init__(self, **kwargs) -> None:
+                super().__init__(**kwargs)
+                captured["lm_kwargs"] = kwargs
+
+        fake_dspy = SimpleNamespace(
+            Signature=type("Signature", (), {}),
+            LM=_TrackingLM,
+            InputField=lambda *_args, **_kwargs: None,
+            OutputField=lambda *_args, **_kwargs: None,
+            Predict=lambda *_args, **_kwargs: _FakePredictor(),
+            context=None,
+            configure=lambda **_kwargs: None,
+        )
+
+        with patch("app.trading.llm.dspy_programs.modules.dspy", fake_dspy):
+            program = LiveDSPyCommitteeProgram(
+                model_name="openai/gpt-5.3-codex-spark",
+                api_base="https://jangar.openai.local/openai/v1",
+            )
+            program._ensure_predictor()
+
+        self.assertEqual(captured["lm_kwargs"]["temperature"], 1.0)
 
     def test_live_program_rejects_non_dict_response_json(self) -> None:
         request_payload = SimpleNamespace(request_json='{"foo":"bar"}')


### PR DESCRIPTION
## Summary

- Fixes the DSPy live runtime root cause where `LiveDSPyCommitteeProgram` always set `temperature=0.0`, which is invalid for GPT-5 model family and caused `UnsupportedParamsError` at execution time.
- Adds model-aware DSPy LM temperature resolution so GPT-5 (`gpt-5*`) uses `temperature=1.0` while non-GPT-5 models keep deterministic `temperature=0.0`.
- Expands DSPy module regression coverage to assert both non-GPT-5 and GPT-5 temperature behavior and prevent recurrence.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev` (in `services/torghut`)
- `uv run --frozen python -m unittest tests.test_llm_dspy_modules tests.test_llm_dspy_runtime` (in `services/torghut`)
- `uv run --frozen pyright --project pyrightconfig.json` (in `services/torghut`)
- `uv run --frozen pyright --project pyrightconfig.alpha.json` (in `services/torghut`)
- `uv run --frozen pyright --project pyrightconfig.scripts.json` (in `services/torghut`)
- `uv run --frozen ruff check app/trading/llm/dspy_programs/modules.py tests/test_llm_dspy_modules.py` (in `services/torghut`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
