### PR TITLE
fix(huly-api): clamp mission body size for storage compatibility

### DIFF
--- a/skills/huly-api/scripts/huly-api.py
+++ b/skills/huly-api/scripts/huly-api.py
@@ -38,6 +38,8 @@ DEFAULT_DOCUMENT_PARENT = 'document:ids:NoParent'
 DEFAULT_RANK = '0|zzzzzz:'
 DEFAULT_TEAMSPACE = 'PROOMPTENG'
 DEFAULT_TRACKER_URL = 'https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues'
+MAX_INLINE_MISSION_BODY_CHARS = 900
+TRUNCATION_NOTICE = '\n\n[Truncated for Huly storage compatibility. Full details are in the channel update.]'
 
 
 @dataclass
@@ -195,6 +197,18 @@ def build_upsert_mission_context_message(*, metadata: dict[str, str]) -> str:
     if not segments:
         return ''
     return ' | '.join(segments)
+
+
+def ensure_inline_body_limit(body: str) -> str:
+    text = body.strip()
+    if len(text) <= MAX_INLINE_MISSION_BODY_CHARS:
+        return text
+
+    reserved = len(TRUNCATION_NOTICE)
+    cutoff = MAX_INLINE_MISSION_BODY_CHARS - reserved
+    if cutoff < 1:
+        return text[:MAX_INLINE_MISSION_BODY_CHARS]
+    return f'{text[:cutoff].rstrip()}{TRUNCATION_NOTICE}'
 
 
 def is_worker_scoped_token_source(source: str) -> bool:
@@ -627,6 +641,7 @@ def create_or_update_issue(
     status: str,
     priority: int,
 ) -> dict[str, Any]:
+    body = ensure_inline_body_limit(body)
     project = resolve_project(context, project_ref)
     project_id = str(project.get('_id') or '')
     project_identifier = str(project.get('identifier') or '').strip()
@@ -724,6 +739,7 @@ def create_or_update_document(
     body: str,
     mission_id: str,
 ) -> dict[str, Any]:
+    body = ensure_inline_body_limit(body)
     teamspace = resolve_teamspace(context, teamspace_ref)
     teamspace_id = str(teamspace.get('_id') or '')
     if not teamspace_id:

--- a/skills/huly-api/scripts/test_huly_api.py
+++ b/skills/huly-api/scripts/test_huly_api.py
@@ -231,6 +231,97 @@ class HulyApiFormattingTests(unittest.TestCase):
         result = self.module.run_upsert_mission(args)
         self.assertEqual(result, 2)
 
+    def test_ensure_inline_body_limit_truncates_long_text(self):
+        module = self.module
+        text = 'a' * (module.MAX_INLINE_MISSION_BODY_CHARS + 200)
+        trimmed = module.ensure_inline_body_limit(text)
+        self.assertLessEqual(len(trimmed), module.MAX_INLINE_MISSION_BODY_CHARS)
+        self.assertTrue(trimmed.endswith(module.TRUNCATION_NOTICE))
+
+    def test_create_or_update_issue_clamps_body_before_tx(self):
+        module = self.module
+        context = module.HulyContext(
+            base_url='https://example.com',
+            token='token',
+            token_source='test',
+            workspace_id='workspace-1',
+            actor_id='actor-1',
+            timeout_seconds=30,
+        )
+        called = {}
+
+        original_resolve_project = module.resolve_project
+        original_find_issue_by_title = module.find_issue_by_title
+        original_create_tx_update_doc = module.create_tx_update_doc
+        original_submit_tx = module.submit_tx
+
+        module.resolve_project = lambda ctx, ref: {'_id': 'project-1', 'identifier': 'TSK'}
+        module.find_issue_by_title = lambda ctx, project_id, title: {'_id': 'issue-1'}
+        module.create_tx_update_doc = lambda **kwargs: called.setdefault('tx', kwargs) or {'_id': 'tx-1'}
+        module.submit_tx = lambda **kwargs: {}
+
+        try:
+            result = module.create_or_update_issue(
+                context=context,
+                project_ref='DefaultProject',
+                title='Issue title',
+                body='X' * 3000,
+                mission_id='swarm-test',
+                status='tracker:status:Backlog',
+                priority=2,
+            )
+            self.assertEqual(result['action'], 'updated')
+        finally:
+            module.resolve_project = original_resolve_project
+            module.find_issue_by_title = original_find_issue_by_title
+            module.create_tx_update_doc = original_create_tx_update_doc
+            module.submit_tx = original_submit_tx
+
+        description = called['tx']['operations']['description']
+        self.assertLessEqual(len(description), module.MAX_INLINE_MISSION_BODY_CHARS)
+        self.assertTrue(description.endswith(module.TRUNCATION_NOTICE))
+
+    def test_create_or_update_document_clamps_body_before_tx(self):
+        module = self.module
+        context = module.HulyContext(
+            base_url='https://example.com',
+            token='token',
+            token_source='test',
+            workspace_id='workspace-1',
+            actor_id='actor-1',
+            timeout_seconds=30,
+        )
+        called = {}
+
+        original_resolve_teamspace = module.resolve_teamspace
+        original_find_document_by_title = module.find_document_by_title
+        original_create_tx_update_doc = module.create_tx_update_doc
+        original_submit_tx = module.submit_tx
+
+        module.resolve_teamspace = lambda ctx, ref: {'_id': 'teamspace-1'}
+        module.find_document_by_title = lambda ctx, teamspace_id, title: {'_id': 'doc-1'}
+        module.create_tx_update_doc = lambda **kwargs: called.setdefault('tx', kwargs) or {'_id': 'tx-1'}
+        module.submit_tx = lambda **kwargs: {}
+
+        try:
+            result = module.create_or_update_document(
+                context=context,
+                teamspace_ref='PROOMPTENG',
+                title='Doc title',
+                body='Y' * 3000,
+                mission_id='swarm-test',
+            )
+            self.assertEqual(result['action'], 'updated')
+        finally:
+            module.resolve_teamspace = original_resolve_teamspace
+            module.find_document_by_title = original_find_document_by_title
+            module.create_tx_update_doc = original_create_tx_update_doc
+            module.submit_tx = original_submit_tx
+
+        content = called['tx']['operations']['content']
+        self.assertLessEqual(len(content), module.MAX_INLINE_MISSION_BODY_CHARS)
+        self.assertTrue(content.endswith(module.TRUNCATION_NOTICE))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Clamp Huly mission issue/document inline body payloads to a safe maximum before submitting tx updates.
- Add an explicit truncation notice so long mission details remain understandable while avoiding invalid storage object-name paths.
- Add regression tests that verify truncation behavior and confirm `create_or_update_issue` / `create_or_update_document` clamp bodies before tx write.

## Related Issues

None

## Testing

- `python3 skills/huly-api/scripts/test_huly_api.py`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
