### PR TITLE
fix(torghut,jangar): resolve dspy live execution blockers

### DIFF
--- a/services/jangar/src/server/__tests__/chat-completions.test.ts
+++ b/services/jangar/src/server/__tests__/chat-completions.test.ts
@@ -101,6 +101,49 @@ describe('chat completions handler', () => {
     expect(response.headers.get('content-type')).toContain('text/event-stream')
   })
 
+  it('returns a non-stream completion payload when stream is false', async () => {
+    const request = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      }),
+    })
+
+    const response = await chatCompletionsHandler(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    const payload = (await response.json()) as {
+      object?: string
+      choices?: Array<{ message?: { content?: string } }>
+    }
+    expect(payload.object).toBe('chat.completion')
+    expect(payload.choices?.[0]?.message?.content).toContain('hi there')
+  })
+
+  it('returns a non-stream completion payload when stream is omitted', async () => {
+    const request = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    })
+
+    const response = await chatCompletionsHandler(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    const payload = (await response.json()) as {
+      object?: string
+      choices?: Array<{ message?: { content?: string } }>
+    }
+    expect(payload.object).toBe('chat.completion')
+    expect(payload.choices?.[0]?.message?.content).toContain('hi there')
+  })
+
   it('renders plan deltas as markdown todos by default', async () => {
     const mockClient = {
       runTurnStream: vi.fn(async () => ({

--- a/services/jangar/src/server/chat.ts
+++ b/services/jangar/src/server/chat.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { mkdir, readdir, stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
@@ -993,7 +994,141 @@ const handlerRuntime = ManagedRuntime.make(
   ),
 )
 
-export const handleChatCompletion = (request: Request): Promise<Response> =>
-  handlerRuntime.runPromise(handleChatCompletionEffect(request))
+export const handleChatCompletion = (request: Request): Promise<Response> => runChatCompletionWithModeSupport(request)
 
 export { setCodexClientFactory, resetCodexClient }
+
+const runChatCompletionWithModeSupport = async (request: Request): Promise<Response> => {
+  const streamingProxyRequest = await buildStreamingProxyRequest(request)
+  if (!streamingProxyRequest) {
+    return handlerRuntime.runPromise(handleChatCompletionEffect(request))
+  }
+
+  const streamResponse = await handlerRuntime.runPromise(handleChatCompletionEffect(streamingProxyRequest))
+  return convertSseToChatCompletionResponse(streamResponse)
+}
+
+const buildStreamingProxyRequest = async (request: Request): Promise<Request | null> => {
+  if (request.method.toUpperCase() !== 'POST') return null
+
+  let body: unknown
+  try {
+    body = await request.clone().json()
+  } catch {
+    return null
+  }
+  if (!isRecord(body)) return null
+  if (body.stream === true) return null
+
+  const streamOptions = isRecord(body.stream_options) ? body.stream_options : {}
+  const proxiedBody: Record<string, unknown> = {
+    ...body,
+    stream: true,
+    stream_options: {
+      ...streamOptions,
+      include_usage: true,
+    },
+  }
+
+  const headers = new Headers(request.headers)
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'application/json')
+  }
+
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: safeJsonStringify(proxiedBody),
+    signal: request.signal,
+  })
+}
+
+const convertSseToChatCompletionResponse = async (response: Response): Promise<Response> => {
+  const body = await response.text()
+  const frames = parseSseFrames(body)
+
+  const errorFrame = frames.find((frame) => isRecord(frame) && isRecord(frame.error))
+  if (isRecord(errorFrame) && isRecord(errorFrame.error)) {
+    return new Response(safeJsonStringify({ error: errorFrame.error }), {
+      status: response.status,
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+  }
+
+  let model = 'unknown'
+  let content = ''
+  let usage: Record<string, unknown> | null = null
+
+  for (const frame of frames) {
+    if (!isRecord(frame)) continue
+    const frameModel = frame.model
+    if (typeof frameModel === 'string' && frameModel.length > 0) {
+      model = frameModel
+    }
+    if (isRecord(frame.usage)) {
+      usage = frame.usage
+    }
+    const choices = frame.choices
+    if (!Array.isArray(choices)) continue
+    for (const choice of choices) {
+      if (!isRecord(choice)) continue
+      if (isRecord(choice.usage)) {
+        usage = choice.usage
+      }
+      const delta = isRecord(choice.delta) ? choice.delta : null
+      const message = isRecord(choice.message) ? choice.message : null
+      const deltaContent = typeof delta?.content === 'string' ? delta.content : ''
+      const messageContent = typeof message?.content === 'string' ? message.content : ''
+      if (deltaContent.length > 0) {
+        content += deltaContent
+      } else if (messageContent.length > 0) {
+        content += messageContent
+      }
+    }
+  }
+
+  const payload: Record<string, unknown> = {
+    id: `chatcmpl-${randomUUID()}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content,
+        },
+        finish_reason: 'stop',
+      },
+    ],
+  }
+  if (usage) {
+    payload.usage = usage
+  }
+
+  return new Response(safeJsonStringify(payload), {
+    status: response.status,
+    headers: {
+      'content-type': 'application/json',
+    },
+  })
+}
+
+const parseSseFrames = (body: string): unknown[] => {
+  const frames: unknown[] = []
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('data:')) continue
+    const value = trimmed.slice(5).trim()
+    if (!value || value === '[DONE]') continue
+    try {
+      frames.push(JSON.parse(value))
+    } catch {
+      continue
+    }
+  }
+  return frames
+}

--- a/services/torghut/app/trading/llm/dspy_programs/runtime.py
+++ b/services/torghut/app/trading/llm/dspy_programs/runtime.py
@@ -23,6 +23,7 @@ _BOOTSTRAP_PROGRAM_NAME = "trade-review-committee-v1"
 _BOOTSTRAP_SIGNATURE_VERSION = "v1"
 _DSPY_OPENAI_BASE_PATH = "/openai/v1"
 _DSPY_OPENAI_CHAT_COMPLETIONS_PATH = "/chat/completions"
+_DSPY_INTERNAL_API_KEY_PLACEHOLDER = "jangar-internal"
 
 _BOOTSTRAP_ARTIFACT_BODY = {
     "schema_version": "torghut.dspy.runtime-artifact.v1",
@@ -385,12 +386,11 @@ class DSPyReviewRuntime:
             return self._program_cache
 
         if manifest.executor == "dspy_live":
+            api_base = _resolve_dspy_api_base()
             program = LiveDSPyCommitteeProgram(
                 model_name=_resolve_dspy_model_name(),
-                api_completion_url=_resolve_dspy_api_base(),
-                api_key=settings.jangar_api_key.strip()
-                if settings.jangar_api_key
-                else None,
+                api_completion_url=api_base,
+                api_key=_resolve_dspy_api_key(api_base),
             )
         else:
             program = HeuristicCommitteeProgram()
@@ -495,6 +495,18 @@ def _resolve_dspy_api_base() -> str:
 
 def _resolve_dspy_completion_url() -> str:
     return f"{_resolve_dspy_api_base()}{_DSPY_OPENAI_CHAT_COMPLETIONS_PATH}"
+
+
+def _resolve_dspy_api_key(api_base: str) -> str | None:
+    configured = (settings.jangar_api_key or "").strip()
+    if configured:
+        return configured
+
+    parsed = urlsplit(api_base)
+    host = (parsed.hostname or "").strip().lower()
+    if host in {"localhost", "127.0.0.1"} or host.endswith(".svc.cluster.local"):
+        return _DSPY_INTERNAL_API_KEY_PLACEHOLDER
+    return None
 
 
 __all__ = [

--- a/services/torghut/tests/test_llm_dspy_runtime.py
+++ b/services/torghut/tests/test_llm_dspy_runtime.py
@@ -253,6 +253,64 @@ class TestLLMDSPyRuntime(TestCase):
             settings.jangar_base_url = original_base
             settings.jangar_api_key = original_api_key
 
+    def test_live_artifact_uses_internal_api_key_placeholder_when_missing(self) -> None:
+        original_base = settings.jangar_base_url
+        original_api_key = settings.jangar_api_key
+        try:
+            settings.jangar_base_url = "http://jangar.jangar.svc.cluster.local"
+            settings.jangar_api_key = None
+            runtime = DSPyReviewRuntime(
+                mode="active",
+                artifact_hash="a" * 64,
+                program_name="trade-review-committee-v1",
+                signature_version="v1",
+                timeout_seconds=8,
+            )
+            manifest = DSPyArtifactManifest(
+                artifact_hash="a" * 64,
+                program_name="trade-review-committee-v1",
+                signature_version="v1",
+                executor="dspy_live",
+                compiled_prompt={},
+                source="database",
+            )
+
+            program = runtime._resolve_program(manifest)
+            self.assertIsInstance(program, LiveDSPyCommitteeProgram)
+            self.assertEqual(program.api_key, "jangar-internal")
+        finally:
+            settings.jangar_base_url = original_base
+            settings.jangar_api_key = original_api_key
+
+    def test_live_artifact_omits_placeholder_for_non_internal_hosts(self) -> None:
+        original_base = settings.jangar_base_url
+        original_api_key = settings.jangar_api_key
+        try:
+            settings.jangar_base_url = "https://gateway.example"
+            settings.jangar_api_key = None
+            runtime = DSPyReviewRuntime(
+                mode="active",
+                artifact_hash="a" * 64,
+                program_name="trade-review-committee-v1",
+                signature_version="v1",
+                timeout_seconds=8,
+            )
+            manifest = DSPyArtifactManifest(
+                artifact_hash="a" * 64,
+                program_name="trade-review-committee-v1",
+                signature_version="v1",
+                executor="dspy_live",
+                compiled_prompt={},
+                source="database",
+            )
+
+            program = runtime._resolve_program(manifest)
+            self.assertIsInstance(program, LiveDSPyCommitteeProgram)
+            self.assertIsNone(program.api_key)
+        finally:
+            settings.jangar_base_url = original_base
+            settings.jangar_api_key = original_api_key
+
     def test_active_runtime_review_uses_dspy_live_program(self) -> None:
         original_gate = self._enable_live_runtime_gate(
             jangar_base_url="https://jangar.openai.local/openai/v1"


### PR DESCRIPTION
## Summary

- Fixes Jangar OpenAI compatibility for DSPy/LiteLLM non-stream callers by auto-proxying non-stream requests through the existing streaming path and returning standard non-stream `chat.completion` JSON responses.
- Adds Jangar regression tests proving `/openai/v1/chat/completions` now works when `stream=false` and when `stream` is omitted.
- Fixes Torghut DSPy live runtime auth handling for in-cluster Jangar endpoints by supplying a deterministic internal placeholder API key when `JANGAR_API_KEY` is unset (while preserving explicit key usage and external-host behavior).
- Adds Torghut runtime regression tests to prevent missing-key live-runtime failures from reappearing.

## Related Issues

None

## Testing

- `uv run --frozen python -m unittest tests.test_llm_dspy_modules tests.test_llm_dspy_runtime` (in `services/torghut`)
- `uv run --frozen pyright --project pyrightconfig.json` (in `services/torghut`)
- `uv run --frozen pyright --project pyrightconfig.alpha.json` (in `services/torghut`)
- `uv run --frozen pyright --project pyrightconfig.scripts.json` (in `services/torghut`)
- `uv run --frozen ruff check app/trading/llm/dspy_programs/modules.py app/trading/llm/dspy_programs/runtime.py tests/test_llm_dspy_modules.py tests/test_llm_dspy_runtime.py` (in `services/torghut`)
- `bunx oxfmt --check services/jangar/src/server/chat.ts services/jangar/src/server/__tests__/chat-completions.test.ts`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/chat-completions.test.ts` (in `services/jangar`)
- `bunx tsc --noEmit -p tsconfig.app.json` (in `services/jangar`) currently fails due pre-existing unrelated baseline errors in `src/server/agents-controller/workflow-reconciler.ts` and `src/server/bumba.ts`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
