### PR TITLE
chore(jangar): promote image 295dae23

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 61a61384
-  digest: sha256:5cfdd81406949b831c4e89420e0bab35e889aa9847e4fcec0050bdf6ad7eedc0
+  tag: 295dae23
+  digest: sha256:30071ebb00355c4c352a89a6d0b51e981876af3a587fb77e1acb50ee746250eb
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 61a61384
-    digest: sha256:ba041480cc470596cd3115979e56ec9f4bb0ef0a6aee0c7c0e822350376a6cf1
+    tag: 295dae23
+    digest: sha256:59e7d3d0da488433fdbc635b6f162808533c27fcec3e23c6582cd78768a332a6
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 61a61384
-    digest: sha256:5cfdd81406949b831c4e89420e0bab35e889aa9847e4fcec0050bdf6ad7eedc0
+    tag: 295dae23
+    digest: sha256:30071ebb00355c4c352a89a6d0b51e981876af3a587fb77e1acb50ee746250eb
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-04T05:59:52Z"
+    deploy.knative.dev/rollout: "2026-03-04T06:45:31Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-04T05:59:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-04T06:45:31Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "61a61384"
-    digest: sha256:5cfdd81406949b831c4e89420e0bab35e889aa9847e4fcec0050bdf6ad7eedc0
+    newTag: "295dae23"
+    digest: sha256:30071ebb00355c4c352a89a6d0b51e981876af3a587fb77e1acb50ee746250eb


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `295dae23b373320908e733dcf5a3826c4aaa5ce1`
- Image tag: `295dae23`
- Image digest: `sha256:30071ebb00355c4c352a89a6d0b51e981876af3a587fb77e1acb50ee746250eb`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`