### PR TITLE
fix(jangar): add swarmRequirementObjective fallback for cross-swarm requirements

### DIFF
--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -389,6 +389,37 @@ describe('runCodexImplementation', () => {
     expect(invocation?.prompt).toContain('Original request context:')
   }, 40_000)
 
+  it('uses swarmRequirementObjective fallback when objective is omitted', async () => {
+    const payload = {
+      prompt: 'Implementation prompt',
+      repository: 'owner/repo',
+      issueNumber: 42,
+      base: 'main',
+      head: 'codex/issue-42',
+      issueTitle: 'Title',
+      swarmRequirementChannel: 'huly://swarm-bridge/issues/TORGHUT-1772430502',
+      swarmRequirementId: '00gcj8mx',
+      swarmRequirementSignal: 'torghut-to-jangar-e2e-1772430502',
+      swarmRequirementSource: 'torghut-quant',
+      swarmRequirementTarget: 'jangar-control-plane',
+      swarmRequirementDescription: 'Acceptance-only scope for swarm requirement alias fallback.',
+      swarmRequirementObjective: 'Objective from swarmRequirementObjective alias',
+    }
+    await writeFile(eventPath, JSON.stringify(payload), 'utf8')
+
+    await runCodexImplementation(eventPath)
+
+    const invocation = runCodexSessionMock.mock.calls.at(-1)?.[0]
+    expect(invocation?.prompt).toContain('Cross-swarm implementation requirement (primary scope):')
+    expect(invocation?.prompt).toContain('Objective: Objective from swarmRequirementObjective alias')
+    expect(invocation?.prompt).toContain('Description:\nAcceptance-only scope for swarm requirement alias fallback.')
+
+    const notifyRaw = await readFile(join(workdir, '.codex-implementation-notify.json'), 'utf8')
+    const notify = JSON.parse(notifyRaw) as {
+      swarmRequirementObjective?: string | null
+    }
+    expect(notify.swarmRequirementObjective).toBe('Objective from swarmRequirementObjective alias')
+  }, 40_000)
   it('uses payload objective as cross-swarm primary objective', async () => {
     const payload = {
       prompt: 'Implementation prompt',

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -38,6 +38,7 @@ interface ImplementationEventPayload {
   repository?: string
   issueNumber?: number | string
   objective?: string
+  swarmRequirementObjective?: string
   issueTitle?: string | null
   issueBody?: string | null
   issueUrl?: string | null
@@ -85,6 +86,7 @@ type RequirementMetadata = {
   channel?: string
   description?: string
   objective?: string
+  swarmRequirementObjective?: string
   payload?: string
   payloadBytes?: string
   payloadTruncated?: boolean
@@ -194,7 +196,7 @@ const extractSwarmRequirementMetadata = (event: ImplementationEventPayload): Req
     workerId: resolve('swarmAgentWorkerId', 'swarmAgentWorkerId'),
     workerIdentity: resolve('swarmAgentIdentity', 'swarmAgentIdentity'),
     workerRole: resolve('swarmAgentRole', 'swarmAgentRole'),
-    objective: payloadObjective ?? resolve('objective', 'swarmRequirementObjective'),
+    objective: payloadObjective ?? resolve('objective') ?? resolve('swarmRequirementObjective'),
     payload,
     payloadBytes: resolve('swarmRequirementPayloadBytes', 'swarmRequirementPayloadBytes'),
     payloadTruncated: parseBool(parameters.swarmRequirementPayloadTruncated),
@@ -543,6 +545,7 @@ type CodexNotifyPayload = {
     channel?: string
     description?: string
     objective?: string
+    swarmRequirementObjective?: string
     payload?: string
     payloadBytes?: string
     payloadTruncated?: boolean


### PR DESCRIPTION
## Summary

- Add `swarmRequirementObjective` passthrough support to the cross-swarm scope metadata parser in `services/jangar/scripts/codex/codex-implement.ts`.
- Ensure objective resolution prefers payload objective, then `objective`, then `swarmRequirementObjective` when handling Huly cross-swarm requirements.
- Add a regression test covering the `swarmRequirementObjective` fallback path when `objective` is omitted (`services/jangar/scripts/codex/__tests__/codex-implement.test.ts`).
- Preserve requirement provenance in Codex notify payload for the new alias (`swarmRequirementObjective`).

## Related Issues

- Cross-swarm requirement: `00gc3cxb`
- Signal: `torghut-to-jangar-e2e-1772430506`
- Source/Target: `torghut-quant -> jangar-control-plane`

## Testing

- `bunx oxfmt --check services/jangar/scripts/codex/codex-implement.ts services/jangar/scripts/codex/__tests__/codex-implement.test.ts` ✅
- `bun run --filter @proompteng/jangar lint` ✅
- `bun run --filter @proompteng/jangar tsc` ⚠️ failed in this environment: missing `bun-types` type library when resolving dependencies.
- `bun run --filter @proompteng/jangar test -- services/jangar/scripts/codex/__tests__/codex-implement.test.ts` ⚠️ failed in this environment due missing workspace module resolution (`@proompteng/codex`) and missing dev dependencies.
- `bunx vitest run services/jangar/scripts/codex/__tests__/codex-implement.test.ts` ⚠️ fails in this environment because workspace packages were not fully installable (`@proompteng/codex` package resolution error).

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
