### PR TITLE
chore(jangar): promote image b3340912

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 295dae23
-  digest: sha256:30071ebb00355c4c352a89a6d0b51e981876af3a587fb77e1acb50ee746250eb
+  tag: b3340912
+  digest: sha256:d2b3ffdf4c0c0cb6548056e56c97d4a27ff670cd5b9a1a2e160f7dd4277dc72f
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 295dae23
-    digest: sha256:59e7d3d0da488433fdbc635b6f162808533c27fcec3e23c6582cd78768a332a6
+    tag: b3340912
+    digest: sha256:0cbdd076ac56ad13ec728bff4c591641f88840ed57d50a3ad7f79e890f616c9c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 295dae23
-    digest: sha256:30071ebb00355c4c352a89a6d0b51e981876af3a587fb77e1acb50ee746250eb
+    tag: b3340912
+    digest: sha256:d2b3ffdf4c0c0cb6548056e56c97d4a27ff670cd5b9a1a2e160f7dd4277dc72f
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-04T06:45:31Z"
+    deploy.knative.dev/rollout: "2026-03-04T07:00:25Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-04T06:45:31Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-04T07:00:25Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "295dae23"
-    digest: sha256:30071ebb00355c4c352a89a6d0b51e981876af3a587fb77e1acb50ee746250eb
+    newTag: "b3340912"
+    digest: sha256:d2b3ffdf4c0c0cb6548056e56c97d4a27ff670cd5b9a1a2e160f7dd4277dc72f


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b3340912f1fc7237060a17b91f90fd7c844098b8`
- Image tag: `b3340912`
- Image digest: `sha256:d2b3ffdf4c0c0cb6548056e56c97d4a27ff670cd5b9a1a2e160f7dd4277dc72f`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`