### PR TITLE
fix(codex): omit null reasoning summary on turn start

### DIFF
--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -437,7 +437,6 @@ export class CodexAppServerClient {
       sandboxPolicy: toSandboxPolicy(this.sandbox),
       model: turnOptions.model ?? this.defaultModel,
       effort: turnOptions.effort ?? this.defaultEffort,
-      summary: null,
       personality: null,
       outputSchema: null,
       collaborationMode: null,


### PR DESCRIPTION
## Summary

- Fixes Codex app-server turn-start payload generation to omit `summary` instead of forcing `summary: null`.
- Prevents unsupported `reasoning.summary` upstream parameter propagation for `gpt-5.3-codex-spark` model paths used by Jangar/Torghut DSPy live execution.
- Keeps existing turn-start behavior intact while removing the incompatible null field.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/codex test -- app-server-client.events.test.ts`
- `bun run --filter @proompteng/codex build`
- `bunx oxfmt --check packages/codex/src/app-server-client.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
