### PR TITLE
chore(jangar): promote image 16cca3db

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: b3340912
-  digest: sha256:d2b3ffdf4c0c0cb6548056e56c97d4a27ff670cd5b9a1a2e160f7dd4277dc72f
+  tag: 16cca3db
+  digest: sha256:cfd2b827d75cc0e914d076b9379fe013819dbd61ac619a117acadf4dbf3d8c90
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: b3340912
-    digest: sha256:0cbdd076ac56ad13ec728bff4c591641f88840ed57d50a3ad7f79e890f616c9c
+    tag: 16cca3db
+    digest: sha256:7d1899ec6f0cd464f64e233fcbb812fec0c011a81712b4fec1baafc17ec1a600
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: b3340912
-    digest: sha256:d2b3ffdf4c0c0cb6548056e56c97d4a27ff670cd5b9a1a2e160f7dd4277dc72f
+    tag: 16cca3db
+    digest: sha256:cfd2b827d75cc0e914d076b9379fe013819dbd61ac619a117acadf4dbf3d8c90
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-04T07:00:25Z"
+    deploy.knative.dev/rollout: "2026-03-04T07:19:59Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-04T07:00:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-04T07:19:59Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "b3340912"
-    digest: sha256:d2b3ffdf4c0c0cb6548056e56c97d4a27ff670cd5b9a1a2e160f7dd4277dc72f
+    newTag: "16cca3db"
+    digest: sha256:cfd2b827d75cc0e914d076b9379fe013819dbd61ac619a117acadf4dbf3d8c90


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `16cca3dbe8fc7112f1fc6619b1da314fea94491c`
- Image tag: `16cca3db`
- Image digest: `sha256:cfd2b827d75cc0e914d076b9379fe013819dbd61ac619a117acadf4dbf3d8c90`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`