### PR TITLE
fix(codex): stop sending null reasoning summary

### DIFF
--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -73,9 +73,14 @@ const respondToThreadStart = async (child: FakeChildProcess, threadId: string) =
   })
 }
 
-const respondToTurnStart = async (child: FakeChildProcess, turnId: string) => {
+const respondToTurnStart = async (
+  child: FakeChildProcess,
+  turnId: string,
+  inspect?: (request: JsonRpcRequest) => void,
+) => {
   const request = await nextRequest(child)
   expect(request.method).toBe('turn/start')
+  inspect?.(request)
   writeLine(child, {
     id: request.id,
     result: { turn: { id: turnId, status: 'inProgress', items: [], error: null } },
@@ -136,6 +141,26 @@ describe('CodexAppServerClient v2 notifications', () => {
 
     const delta = await stream.next()
     expect(delta.value).toEqual({ type: 'usage', usage: tokenUsage })
+
+    writeLine(child, {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: { id: 'turn-1', status: 'completed', items: [], error: null } },
+    })
+    await drainStream(stream as unknown as AsyncGenerator<unknown, unknown, void>)
+  })
+
+  it('omits summary override from turn/start payload by default', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStart(child, 'turn-1', (request) => {
+      const params = request.params as Record<string, unknown>
+      expect(params).not.toHaveProperty('summary')
+    })
+    const { stream } = await runPromise
 
     writeLine(child, {
       method: 'turn/completed',

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -437,7 +437,6 @@ export class CodexAppServerClient {
       sandboxPolicy: toSandboxPolicy(this.sandbox),
       model: turnOptions.model ?? this.defaultModel,
       effort: turnOptions.effort ?? this.defaultEffort,
-      summary: null,
       personality: null,
       outputSchema: null,
       collaborationMode: null,


### PR DESCRIPTION
## Summary

- Remove `summary: null` from Codex `turn/start` payload construction so unsupported `reasoning.summary` is not sent by default.
- Add a regression test that inspects the `turn/start` request and asserts `summary` is absent unless explicitly set.
- Preserve existing turn-start behavior otherwise (model, effort, sandbox/approval options unchanged).

## Related Issues

None

## Testing

- `bun run --filter @proompteng/codex test -- app-server-client.events.test.ts`
- `bun run --filter @proompteng/codex test`
- `bun run --filter @proompteng/codex build`
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/chat-completions.test.ts -t "returns a non-stream completion payload when stream is false"` (test passed; package `pretest` currently reports an unrelated `@proompteng/temporal-bun-sdk build` TypeScript target error in this workspace)

## Screenshots (if applicable)

N/A (backend change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
