### PR TITLE
fix(agents): enforce agent-level system prompt policy

### DIFF
--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -485,10 +485,17 @@ controller:
 
 Set defaults for AgentRun and Schedule workload images when the CRD does not specify one:
 
-- `runtime.agentRunnerImage` → `JANGAR_AGENT_RUNNER_IMAGE`
+- `runner.image.repository`/`runner.image.tag`/`runner.image.digest` → `JANGAR_AGENT_RUNNER_IMAGE` (recommended)
+- `runtime.agentRunnerImage` → `JANGAR_AGENT_RUNNER_IMAGE` (legacy compatibility fallback)
 - `runtime.agentImage` → `JANGAR_AGENT_IMAGE`
 - `runtime.scheduleRunnerImage` → `JANGAR_SCHEDULE_RUNNER_IMAGE`
 - `runtime.scheduleServiceAccount` → `JANGAR_SCHEDULE_SERVICE_ACCOUNT`
+
+Effective `JANGAR_AGENT_RUNNER_IMAGE` precedence in rendered Deployments:
+
+1. `env.vars.JANGAR_AGENT_RUNNER_IMAGE` (explicit operator override)
+2. `runner.image.*`
+3. `runtime.agentRunnerImage`
 
 ### Agent comms subjects (optional)
 
@@ -673,7 +680,13 @@ If your agent-runner uses NATS for context streaming, set `NATS_URL` in the Agen
 
 ## Runner image defaults
 
-The chart sets `JANGAR_AGENT_RUNNER_IMAGE` from `runner.image.*` to avoid missing workload image errors.
+The chart emits a single `JANGAR_AGENT_RUNNER_IMAGE` env var per container with this precedence:
+
+1. `env.vars.JANGAR_AGENT_RUNNER_IMAGE`
+2. `runner.image.*`
+3. `runtime.agentRunnerImage`
+
+Use `runner.image.*` as the normal configuration path. `runtime.agentRunnerImage` is kept only for compatibility.
 Override `runner.image.repository`, `runner.image.tag`, or `runner.image.digest` to point at your own build.
 
 ## Job TTL behavior

--- a/charts/agents/crds/agents.proompteng.ai_agentruns.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_agentruns.yaml
@@ -363,6 +363,10 @@ spec:
                             type: string
                           maxProperties: 100
                           type: object
+                          x-kubernetes-validations:
+                          - message: workflow step parameters.prompt is not allowed;
+                              use ImplementationSpec.spec.text
+                            rule: '!has(self.parameters) || !(''prompt'' in self.parameters)'
                         retries:
                           format: int32
                           type: integer
@@ -480,6 +484,11 @@ spec:
             - message: Only one of spec.systemPrompt or spec.systemPromptRef may be
                 set
               rule: '!(has(self.systemPrompt) && has(self.systemPromptRef))'
+            - message: AgentRun-level systemPrompt/systemPromptRef overrides are not
+                allowed; configure Agent.spec.defaults instead
+              rule: '!has(self.systemPrompt) && !has(self.systemPromptRef)'
+            - message: spec.parameters.prompt is not allowed; use ImplementationSpec.spec.text
+              rule: '!has(self.parameters) || !(''prompt'' in self.parameters)'
           status:
             properties:
               artifacts:

--- a/charts/agents/templates/deployment-controllers.yaml
+++ b/charts/agents/templates/deployment-controllers.yaml
@@ -165,7 +165,10 @@ spec:
             - name: JANGAR_SYSTEM_IMPROVEMENT_ORCHESTRATION_NAMESPACE
               value: {{ .Values.workflowRuntime.native.systemImprovementOrchestrationNamespace | quote }}
             {{- end }}
-            {{- if and .Values.runtime.agentRunnerImage (not (hasKey $envVars "JANGAR_AGENT_RUNNER_IMAGE")) }}
+            {{- if and (not (hasKey $envVars "JANGAR_AGENT_RUNNER_IMAGE")) .Values.runner.image.repository }}
+            - name: JANGAR_AGENT_RUNNER_IMAGE
+              value: "{{ .Values.runner.image.repository }}:{{ .Values.runner.image.tag }}{{- if .Values.runner.image.digest }}@{{ .Values.runner.image.digest }}{{ end }}"
+            {{- else if and .Values.runtime.agentRunnerImage (not (hasKey $envVars "JANGAR_AGENT_RUNNER_IMAGE")) }}
             - name: JANGAR_AGENT_RUNNER_IMAGE
               value: {{ .Values.runtime.agentRunnerImage | quote }}
             {{- end }}
@@ -203,10 +206,6 @@ spec:
             {{- end }}
             - name: JANGAR_IMAGE
               value: "{{ $imageRepo }}:{{ $imageTag }}{{- if $imageDigest }}@{{ $imageDigest }}{{ end }}"
-            {{- if .Values.runner.image.repository }}
-            - name: JANGAR_AGENT_RUNNER_IMAGE
-              value: "{{ .Values.runner.image.repository }}:{{ .Values.runner.image.tag }}{{- if .Values.runner.image.digest }}@{{ .Values.runner.image.digest }}{{ end }}"
-            {{- end }}
             {{- if hasKey .Values.controller "jobTtlSecondsAfterFinished" }}
             - name: JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS
               value: {{ .Values.controller.jobTtlSecondsAfterFinished | quote }}

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -142,7 +142,10 @@ spec:
             - name: JANGAR_SYSTEM_IMPROVEMENT_ORCHESTRATION_NAMESPACE
               value: {{ .Values.workflowRuntime.native.systemImprovementOrchestrationNamespace | quote }}
             {{- end }}
-            {{- if and .Values.runtime.agentRunnerImage (not (hasKey $envVars "JANGAR_AGENT_RUNNER_IMAGE")) }}
+            {{- if and (not (hasKey $envVars "JANGAR_AGENT_RUNNER_IMAGE")) .Values.runner.image.repository }}
+            - name: JANGAR_AGENT_RUNNER_IMAGE
+              value: "{{ .Values.runner.image.repository }}:{{ .Values.runner.image.tag }}{{- if .Values.runner.image.digest }}@{{ .Values.runner.image.digest }}{{ end }}"
+            {{- else if and .Values.runtime.agentRunnerImage (not (hasKey $envVars "JANGAR_AGENT_RUNNER_IMAGE")) }}
             - name: JANGAR_AGENT_RUNNER_IMAGE
               value: {{ .Values.runtime.agentRunnerImage | quote }}
             {{- end }}
@@ -180,10 +183,6 @@ spec:
             {{- end }}
             - name: JANGAR_IMAGE
               value: "{{ $imageRepo }}:{{ $imageTag }}{{- if $imageDigest }}@{{ $imageDigest }}{{ end }}"
-            {{- if .Values.runner.image.repository }}
-            - name: JANGAR_AGENT_RUNNER_IMAGE
-              value: "{{ .Values.runner.image.repository }}:{{ .Values.runner.image.tag }}{{- if .Values.runner.image.digest }}@{{ .Values.runner.image.digest }}{{ end }}"
-            {{- end }}
             {{- $jobTtl := .Values.controller.jobTtlSecondsAfterFinished }}
             {{- if hasKey .Values.controller "jobTtlSeconds" }}
             {{- $jobTtl = .Values.controller.jobTtlSeconds }}

--- a/docs/agents/agentrun-creation-guide.md
+++ b/docs/agents/agentrun-creation-guide.md
@@ -1,6 +1,6 @@
-# AgentRun Creation Guide (Prompt Precedence)
+# AgentRun Creation Guide (Prompt Contract)
 
-Status: Current (2026-02-11)
+Status: Current (2026-03-04)
 
 Docs index: [README](README.md)
 
@@ -11,25 +11,22 @@ turning a “ship code + chart” task into a docs-only PR).
 
 This guide focuses on prompt precedence and the minimum fields needed for reliable runs.
 
-## Prompt Precedence (The Common Failure Mode)
+## Prompt Source Rules (No Run-Level Overrides)
 
 The Codex runner ultimately receives a single “user prompt” string in the generated run payload (`run.json.prompt`).
 
-Precedence (highest first):
+Allowed sources (highest first):
 
-1. `AgentRun.spec.parameters.prompt` (if set)
-2. `ImplementationSpec.spec.text` (when `spec.implementationSpecRef` is used)
-3. `AgentRun.spec.implementation.inline.text` (when inline implementations are used)
+1. `ImplementationSpec.spec.text` (when `spec.implementationSpecRef` is used)
+2. `AgentRun.spec.implementation.inline.text` (when inline implementations are used)
 
-Rule:
+Disallowed:
 
-If you are running an ImplementationSpec, do not set `AgentRun.spec.parameters.prompt` unless you intentionally want to
-override the ImplementationSpec text.
+- `AgentRun.spec.parameters.prompt`
+- `AgentRun.spec.workflow.steps[].parameters.prompt`
 
-Why:
-
-`parameters.prompt` is treated as authoritative. If you set it to something like “Implement docs/...”, the runner will
-optimize for that smaller scope even if the referenced ImplementationSpec asks for code, chart, and validation changes.
+`parameters.prompt` is rejected at API/controller validation time and CRD validation. Use
+`ImplementationSpec.spec.text` as the task source of truth.
 
 ## Minimal AgentRun (Reference An ImplementationSpec, No Prompt Override)
 
@@ -95,6 +92,19 @@ Image resolution order (highest first):
 2. `JANGAR_AGENT_RUNNER_IMAGE`
 3. `JANGAR_AGENT_IMAGE`
 
+Runner image entry points by interface:
+
+- HTTP `/v1/agent-runs`: `spec.workload.image` (and workflow step `spec.workflow.steps[].workload.image`)
+- gRPC `SubmitAgentRun`: `workload.image` (mapped into `AgentRun.spec.workload.image`)
+- Native `OrchestrationRun` AgentRun steps: `step.workload.image` (mapped into submitted `AgentRun.spec.workload.image`)
+- Controller fallback defaults: `JANGAR_AGENT_RUNNER_IMAGE`, then `JANGAR_AGENT_IMAGE`
+
+Chart default wiring for `JANGAR_AGENT_RUNNER_IMAGE` (highest first):
+
+1. `env.vars.JANGAR_AGENT_RUNNER_IMAGE`
+2. `runner.image.*`
+3. `runtime.agentRunnerImage` (legacy fallback)
+
 Safe default for normal runs:
 
 - Do not set `spec.workload.image`; let the controller-provided default image drive execution.
@@ -118,12 +128,11 @@ kubectl get cm -n agents <run-spec-configmap> -o yaml | rg -n 'run.json:|\"promp
 
 If `run.json.prompt` contains your ImplementationSpec `text`, you did not override the prompt.
 
-If `run.json.prompt` contains your `parameters.prompt`, you did override it.
+If `run.json.prompt` does not contain the expected ImplementationSpec text, fail the run setup and fix the spec.
 
 ## Verify System Prompt Is Actually Enforced
 
-If the Agent relies on `defaults.systemPromptRef` or run-level `systemPromptRef`, validate the runtime pod before
-trusting results:
+If the Agent relies on `defaults.systemPromptRef`, validate the runtime pod before trusting results:
 
 ```bash
 RUN=leader-election-implementation-20260207-run
@@ -181,36 +190,29 @@ Notes:
 - Ensure loop state volumes are PVC-backed and reused across iterations.
 - Conditional loops use CEL expressions under `workflow.steps[].loop.condition.expression`.
 
-## When To Use `parameters.prompt` (And When Not To)
+## `parameters.prompt` Policy
 
-Use `parameters.prompt` when:
-
-- You are doing an ad-hoc run without an ImplementationSpec, or you are intentionally overriding the spec’s text for a
-  narrow one-off (for example, “summarize logs”).
-
-Avoid `parameters.prompt` when:
-
-- The ImplementationSpec is the source of truth for deliverables (code + chart + validation).
-- You are using a “design doc” ImplementationSpec and want it implemented as written.
+`spec.parameters.prompt` is not supported for AgentRuns. Define the task in `ImplementationSpec.spec.text` (or
+`spec.implementation.inline.text` for inline runs).
 
 ## System Prompt Versus User Prompt
 
 System prompt:
 
 - Configures “how the agent behaves” (process, constraints, formatting, safety).
-- Comes from Agent defaults and optional per-run overrides.
+- Comes from Agent defaults only (`Agent.spec.defaults.systemPrompt` or `Agent.spec.defaults.systemPromptRef`).
 - See `docs/agents/designs/custom-system-prompt-agent-runs.md`.
 
 User prompt:
 
 - Describes “what to do” for this run.
-- Comes from `parameters.prompt` or `ImplementationSpec.spec.text` (depending on what you set).
+- Comes from `ImplementationSpec.spec.text` (or inline implementation text).
 
 Do not use system prompt customization to compensate for an incorrect user prompt.
 
 ## Common Pitfalls Checklist
 
-- You set `spec.parameters.prompt` and unintentionally narrowed the task scope.
+- You tried to use `spec.parameters.prompt` (this is rejected by validation).
 - You used a multi-step workflow (`plan` + `implement`) for a design-doc run that should have been a single `implement` step.
 - You referenced the wrong `ImplementationSpec` (check `spec.implementationSpecRef.name`).
 - You assumed `${parameter}` placeholders were auto-expanded in prompt text without verifying `run.json.prompt`.

--- a/docs/agents/agentrun-workflow-loop-launch-guide.md
+++ b/docs/agents/agentrun-workflow-loop-launch-guide.md
@@ -117,6 +117,7 @@ spec:
 Runner image safety:
 
 - Default: do not set `spec.workload.image` in AgentRun manifests.
+- Workflow steps may also set `spec.workflow.steps[].workload.image`; if omitted, step jobs inherit top-level `spec.workload`.
 - The controller resolves runner image in this order:
   1. `AgentRun.spec.workload.image`
   2. `JANGAR_AGENT_RUNNER_IMAGE`
@@ -161,7 +162,7 @@ Your `ImplementationSpec.spec.text` should explicitly require:
 - write per-iteration notes (for example `${artifactPath}/iteration-<n>.md`),
 - continue from existing branch/worktree, not a fresh unrelated location.
 
-Avoid `spec.parameters.prompt` unless intentionally overriding the ImplementationSpec text.
+Do not set `spec.parameters.prompt`; AgentRuns use `ImplementationSpec.spec.text` (or inline implementation text).
 
 ## Launch Commands
 

--- a/docs/agents/designs/custom-system-prompt-agent-runs.md
+++ b/docs/agents/designs/custom-system-prompt-agent-runs.md
@@ -1,6 +1,6 @@
 # Custom System Prompt for Agent Runs
 
-Status: Implemented (2026-02-07)
+Status: Implemented (2026-03-04 policy update)
 
 Docs index: [README](../README.md)
 
@@ -8,12 +8,13 @@ Note: Clusters will accept/run the new fields once the updated `charts/agents` C
 
 ## Summary
 
-Agent runs now support per-run system prompts with Agent-level defaults. Prompts can be provided inline or by reference (Secret/ConfigMap). Codex runs apply the resolved prompt and record a SHA-256 hash for audit without logging prompt contents.
+Agent runs enforce Agent-level system prompts. Prompts are configured on `Agent.spec.defaults` (inline or Secret/ConfigMap
+ref), applied by all runtimes, and recorded via SHA-256 hash for audit without logging prompt contents.
 
 ## Goals (Shipped)
 
-- Per-run custom system prompt for AgentRun executions, with optional defaults at Agent level.
-- Prompts can be supplied inline or by reference (ConfigMap/Secret).
+- Agent-level system prompt configuration for AgentRun executions.
+- Prompts supplied from Agent defaults inline or by reference (ConfigMap/Secret).
 - Codex job/workflow runs apply the system prompt without breaking existing runs.
 - Auditability via hashes/metadata without leaking prompt contents.
 
@@ -25,8 +26,8 @@ Agent runs now support per-run system prompts with Agent-level defaults. Prompts
 
 ## Current State (Implemented)
 
-- CRDs add `systemPrompt` / `systemPromptRef` on `AgentRun.spec` and `Agent.spec.defaults`, plus `status.systemPromptHash` on `AgentRun`. See `services/jangar/api/agents/v1alpha1/types.go` and `charts/agents/crds/`.
-- Jangar resolves a system prompt using precedence rules, applies security checks, and records a SHA-256 hash in `AgentRun.status`. See `services/jangar/src/server/agents-controller.ts`.
+- CRDs include `systemPrompt` / `systemPromptRef` on `AgentRun.spec` and `Agent.spec.defaults`, plus `status.systemPromptHash` on `AgentRun`. Controller policy rejects run-level overrides on AgentRun and only uses Agent defaults.
+- Jangar resolves a system prompt from Agent defaults, applies security checks, and records a SHA-256 hash in `AgentRun.status`. See `services/jangar/src/server/agents-controller.ts`.
 - `codex-implement` resolves system prompt from `CODEX_SYSTEM_PROMPT_PATH` (preferred) or the event payload, logs only hash/length, and passes it to Codex. See `services/jangar/scripts/codex/codex-implement.ts`.
 - `CodexRunner` forwards the system prompt as `--config developer_instructions=<toml-string>` when non-empty. See `packages/codex/src/runner.ts`.
 - Argo templates accept inline + Secret/ConfigMap system prompt inputs and set `CODEX_SYSTEM_PROMPT_PATH` when a ref is supplied. See `argocd/applications/froussard/*workflow-template*.yaml`.
@@ -65,11 +66,9 @@ Validation:
 
 ## Resolution Order
 
-1. `AgentRun.spec.systemPromptRef`
-2. `AgentRun.spec.systemPrompt`
-3. `Agent.spec.defaults.systemPromptRef`
-4. `Agent.spec.defaults.systemPrompt`
-5. No system prompt override
+1. `Agent.spec.defaults.systemPromptRef`
+2. `Agent.spec.defaults.systemPrompt`
+3. Fail run with `MissingSystemPromptConfiguration`
 
 Notes:
 
@@ -78,7 +77,8 @@ Notes:
 
 ## Controller Behavior (Jangar)
 
-- Resolves system prompt per the precedence above.
+- Rejects `AgentRun.spec.systemPrompt` and `AgentRun.spec.systemPromptRef`.
+- Resolves system prompt from Agent defaults only.
 - Inline prompt: included in the run payload (`systemPrompt` in event JSON).
 - Ref prompt: mounted into the runtime pod as `/workspace/.codex/system-prompt.txt`, and `CODEX_SYSTEM_PROMPT_PATH` is set.
 - Ref prompt: the prompt contents are not injected into the run payload.
@@ -95,7 +95,7 @@ Security constraints:
 
 ## Runtime Behavior (Codex)
 
-- `codex-implement` prefers `CODEX_SYSTEM_PROMPT_PATH` when the file exists and is non-empty; otherwise it falls back to `event.systemPrompt`.
+- `codex-implement` prefers `CODEX_SYSTEM_PROMPT_PATH` when the file exists and is non-empty; otherwise it uses `event.systemPrompt`.
 - The resolved system prompt is passed to `CodexRunner` as `--config developer_instructions=<toml-string>`.
 - Prompt contents are never logged; only hash and length are logged. A `systemPromptHash` attribute is attached to the NATS `run-started` event.
 - `developer_instructions` is encoded as a quoted TOML string literal (do not attempt manual shell-escaping).
@@ -141,7 +141,7 @@ argo submit \
 
 ## Data Flow (Codex, Inline Prompt)
 
-1. AgentRun created with `spec.systemPrompt`.
+1. Agent default is configured with `spec.defaults.systemPrompt`.
 2. Jangar resolves the system prompt and adds it to the event payload.
 3. `agent-runner` writes event JSON to disk.
 4. `codex-implement` reads event JSON and extracts `systemPrompt`.
@@ -149,7 +149,7 @@ argo submit \
 
 ## Data Flow (Codex, Ref Prompt)
 
-1. AgentRun created with `spec.systemPromptRef`.
+1. Agent default is configured with `spec.defaults.systemPromptRef`.
 2. Jangar mounts the Secret/ConfigMap into `/workspace/.codex/system-prompt.txt` and exports `CODEX_SYSTEM_PROMPT_PATH`.
 3. `codex-implement` reads `CODEX_SYSTEM_PROMPT_PATH` (preferred) and resolves the prompt.
 4. `CodexRunner` invokes `codex exec --config developer_instructions="<prompt>"`.
@@ -163,10 +163,8 @@ argo submit \
 
 ## Limitations
 
-- Temporal runtime only receives inline `systemPrompt` in the payload. `systemPromptRef` is not mounted and is ignored for temporal runs.
-- Custom runtime uses `spec.runtime.config.payload` (if set) else `{agentRun, implementation, memory}`. It does not receive the resolved system prompt (after applying Agent defaults or reading refs) unless you include it explicitly.
-- No per-workflow-step system prompt overrides; workflow steps all share the resolved prompt.
-- `systemPrompt` is not injected into any additional contract metadata beyond the event payload and `systemPromptHash` status field.
+- No per-workflow-step system prompt overrides; workflow steps all share the resolved Agent default prompt.
+- `systemPrompt` is not injected into additional contract metadata beyond runtime payloads and `systemPromptHash`.
 
 ## Handoff Appendix (Repo + Chart + Cluster)
 

--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -49,6 +49,8 @@ The Application renders `argocd/applications/agents` (Helm + kustomize) and inst
 into the `agents` namespace using `argocd/applications/agents/values.yaml`.
 Update the values file with your Jangar image tag, database secret, and (optional) runner image via `runner.image.*`.
 The chart defaults `controller.jobTtlSecondsAfterFinished` to a safe value; set it to `0` to disable job cleanup.
+Runner image env precedence is: `env.vars.JANGAR_AGENT_RUNNER_IMAGE` > `runner.image.*` >
+`runtime.agentRunnerImage` (legacy fallback).
 
 If `controller.namespaces` spans multiple namespaces or `"*"`, set `rbac.clusterScoped=true`.
 Guardrail rules that fail install-time validation:

--- a/services/jangar/api/agents/v1alpha1/types.go
+++ b/services/jangar/api/agents/v1alpha1/types.go
@@ -84,6 +84,8 @@ type AgentRun struct {
 
 // +kubebuilder:validation:XValidation:rule="has(self.implementationSpecRef) || has(self.implementation)",message="spec.implementationSpecRef or spec.implementation is required"
 // +kubebuilder:validation:XValidation:rule="!(has(self.systemPrompt) && has(self.systemPromptRef))",message="Only one of spec.systemPrompt or spec.systemPromptRef may be set"
+// +kubebuilder:validation:XValidation:rule="!has(self.systemPrompt) && !has(self.systemPromptRef)",message="AgentRun-level systemPrompt/systemPromptRef overrides are not allowed; configure Agent.spec.defaults instead"
+// +kubebuilder:validation:XValidation:rule="!has(self.parameters) || !('prompt' in self.parameters)",message="spec.parameters.prompt is not allowed; use ImplementationSpec.spec.text"
 type AgentRunSpec struct {
 	AgentRef              LocalRef              `json:"agentRef"`
 	ImplementationSpecRef *LocalRef             `json:"implementationSpecRef,omitempty"`
@@ -125,6 +127,7 @@ type WorkflowStep struct {
 	ImplementationSpecRef *LocalRef             `json:"implementationSpecRef,omitempty"`
 	Implementation        *InlineImplementation `json:"implementation,omitempty"`
 	// +kubebuilder:validation:MaxProperties=100
+	// +kubebuilder:validation:XValidation:rule="!has(self.parameters) || !('prompt' in self.parameters)",message="workflow step parameters.prompt is not allowed; use ImplementationSpec.spec.text"
 	Parameters          map[string]string `json:"parameters,omitempty"`
 	Workload            *WorkloadSpec     `json:"workload,omitempty"`
 	Retries             int32             `json:"retries,omitempty"`

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -928,6 +928,22 @@ describe('runCodexImplementation', () => {
     expect(notify.pr_url).toBe('https://example.test/pull/456')
   }, 40_000)
 
+  it('fails implementation runs when pull requests are required and PR_URL is missing', async () => {
+    process.env.VCS_PULL_REQUESTS_ENABLED = 'true'
+    delete process.env.CODEX_REQUIRE_PULL_REQUEST
+
+    await expect(runCodexImplementation(eventPath)).rejects.toThrow(
+      'Implementation run completed without creating a pull request (missing PR_URL output)',
+    )
+  }, 40_000)
+
+  it('allows implementation runs without PR_URL when CODEX_REQUIRE_PULL_REQUEST is false', async () => {
+    process.env.VCS_PULL_REQUESTS_ENABLED = 'true'
+    process.env.CODEX_REQUIRE_PULL_REQUEST = 'false'
+
+    await expect(runCodexImplementation(eventPath)).resolves.toBeDefined()
+  }, 40_000)
+
   it('throws when the event file is missing', async () => {
     await expect(runCodexImplementation(join(workdir, 'missing.json'))).rejects.toThrow(/Event payload file not found/)
   }, 40_000)

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -17,6 +17,7 @@ import {
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
+import { Effect } from 'effect'
 
 import { runCli } from './lib/cli'
 import { pushCodexEventsToLoki, type RunCodexSessionResult, runCodexSession } from './lib/codex-runner'
@@ -30,6 +31,7 @@ import {
 } from './lib/codex-utils'
 import { ensureFileDirectory } from './lib/fs'
 import { type CodexLogger, consoleLogger, createCodexLogger } from './lib/logger'
+import { evaluatePullRequestPolicy } from './lib/pull-request-policy'
 import { runCodexProgressComment } from './codex-progress-comment'
 
 interface ImplementationEventPayload {
@@ -2291,6 +2293,18 @@ export const runCodexImplementation = async (eventPath: string) => {
     const prUrlRaw = await readOptionalTextFile(prUrlPath, logger)
     const prNumber = prNumberRaw ? parseOptionalPrNumber(prNumberRaw) : null
     prUrl = prUrlRaw ? prUrlRaw : null
+    const pullRequestsEnabled = parseBoolean(process.env.VCS_PULL_REQUESTS_ENABLED, false)
+    const requirePullRequest = parseBoolean(process.env.CODEX_REQUIRE_PULL_REQUEST, pullRequestsEnabled)
+    const pullRequestPolicyDecision = Effect.runSync(
+      evaluatePullRequestPolicy({
+        stage,
+        requirePullRequest,
+        prUrl,
+      }),
+    )
+    if (!pullRequestPolicyDecision.ok) {
+      throw new Error(pullRequestPolicyDecision.message)
+    }
     const headSha = commitSha ?? null
     try {
       await ensureFileDirectory(headShaPath)

--- a/services/jangar/scripts/codex/lib/__tests__/pull-request-policy.test.ts
+++ b/services/jangar/scripts/codex/lib/__tests__/pull-request-policy.test.ts
@@ -1,0 +1,67 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { evaluatePullRequestPolicy } from '../pull-request-policy'
+
+describe('evaluatePullRequestPolicy', () => {
+  it('does not enforce PR creation for non-implementation stages', () => {
+    const decision = Effect.runSync(
+      evaluatePullRequestPolicy({
+        stage: 'plan',
+        requirePullRequest: true,
+        prUrl: null,
+      }),
+    )
+
+    expect(decision).toEqual({
+      ok: true,
+      enforced: false,
+    })
+  })
+
+  it('does not enforce PR creation when requirePullRequest is false', () => {
+    const decision = Effect.runSync(
+      evaluatePullRequestPolicy({
+        stage: 'implementation',
+        requirePullRequest: false,
+        prUrl: null,
+      }),
+    )
+
+    expect(decision).toEqual({
+      ok: true,
+      enforced: false,
+    })
+  })
+
+  it('fails when implementation requires a PR but no URL is present', () => {
+    const decision = Effect.runSync(
+      evaluatePullRequestPolicy({
+        stage: 'implementation',
+        requirePullRequest: true,
+        prUrl: null,
+      }),
+    )
+
+    expect(decision).toEqual({
+      ok: false,
+      reason: 'MissingPullRequest',
+      message: 'Implementation run completed without creating a pull request (missing PR_URL output)',
+    })
+  })
+
+  it('passes when implementation requires a PR and URL is present', () => {
+    const decision = Effect.runSync(
+      evaluatePullRequestPolicy({
+        stage: 'implementation',
+        requirePullRequest: true,
+        prUrl: 'https://github.com/proompteng/lab/pull/123',
+      }),
+    )
+
+    expect(decision).toEqual({
+      ok: true,
+      enforced: true,
+    })
+  })
+})

--- a/services/jangar/scripts/codex/lib/pull-request-policy.ts
+++ b/services/jangar/scripts/codex/lib/pull-request-policy.ts
@@ -1,0 +1,67 @@
+import { Effect } from 'effect'
+import { createActor, createMachine } from 'xstate'
+
+type PullRequestPolicyInput = {
+  stage: string
+  requirePullRequest: boolean
+  prUrl: string | null
+}
+
+type PullRequestPolicySatisfied = {
+  ok: true
+  enforced: boolean
+}
+
+type PullRequestPolicyViolation = {
+  ok: false
+  reason: 'MissingPullRequest'
+  message: string
+}
+
+export type PullRequestPolicyDecision = PullRequestPolicySatisfied | PullRequestPolicyViolation
+
+const createPullRequestPolicyMachine = (input: PullRequestPolicyInput) =>
+  createMachine({
+    id: 'codexImplementationPullRequestPolicy',
+    initial: 'evaluate',
+    states: {
+      evaluate: {
+        always: [
+          { guard: () => input.stage !== 'implementation', target: 'allowedNotEnforced' },
+          { guard: () => !input.requirePullRequest, target: 'allowedNotEnforced' },
+          { guard: () => Boolean(input.prUrl && input.prUrl.trim().length > 0), target: 'allowedEnforced' },
+          { target: 'rejectedMissingPullRequest' },
+        ],
+      },
+      allowedNotEnforced: { type: 'final' },
+      allowedEnforced: { type: 'final' },
+      rejectedMissingPullRequest: { type: 'final' },
+    },
+  })
+
+export const evaluatePullRequestPolicy = (input: PullRequestPolicyInput) =>
+  Effect.sync<PullRequestPolicyDecision>(() => {
+    const actor = createActor(createPullRequestPolicyMachine(input))
+    actor.start()
+    const snapshot = actor.getSnapshot()
+
+    if (snapshot.matches('rejectedMissingPullRequest')) {
+      return {
+        ok: false,
+        reason: 'MissingPullRequest',
+        message: 'Implementation run completed without creating a pull request (missing PR_URL output)',
+      }
+    }
+
+    if (snapshot.matches('allowedEnforced')) {
+      return {
+        ok: true,
+        enforced: true,
+      }
+    }
+
+    return {
+      ok: true,
+      enforced: false,
+    }
+  })

--- a/services/jangar/src/routes/v1/agent-runs.ts
+++ b/services/jangar/src/routes/v1/agent-runs.ts
@@ -51,6 +51,8 @@ type AgentRunPayload = {
   secrets?: string[]
   policy?: Record<string, unknown>
   ttlSecondsAfterFinished?: number
+  systemPrompt?: unknown
+  systemPromptRef?: unknown
 }
 
 type WorkflowStepPayload = {
@@ -288,6 +290,12 @@ const parseWorkflowSteps = (value: Record<string, unknown> | null): WorkflowStep
       const message = error instanceof Error ? error.message : String(error)
       throw new Error(`workflow.steps[${index}] ${message}`)
     }
+    const forbiddenStepPromptKey = Object.keys(parameters ?? {}).find((key) => key.trim().toLowerCase() === 'prompt')
+    if (forbiddenStepPromptKey) {
+      throw new Error(
+        `workflow.steps[${index}].parameters.${forbiddenStepPromptKey} is not allowed; use ImplementationSpec.spec.text`,
+      )
+    }
 
     const implementationSpecRef = asRecord(step.implementationSpecRef)
     const implementationSpecName = asString(implementationSpecRef?.name)
@@ -319,6 +327,11 @@ const parseAgentRunPayload = (payload: Record<string, unknown>): AgentRunPayload
   if (idempotencyKeyRaw != null && !idempotencyKey) {
     throw new Error('idempotencyKey must be a string')
   }
+  if (payload.systemPrompt != null || payload.systemPromptRef != null) {
+    throw new Error(
+      'AgentRun-level systemPrompt/systemPromptRef overrides are not allowed; configure Agent.spec.defaults instead',
+    )
+  }
 
   const implementationSpecRef = asRecord(payload.implementationSpecRef)
   const implementationSpecName = asString(implementationSpecRef?.name)
@@ -330,6 +343,10 @@ const parseAgentRunPayload = (payload: Record<string, unknown>): AgentRunPayload
   if (!runtimeType) throw new Error('runtime.type is required')
 
   const parameters = normalizeParameterMap(asRecord(payload.parameters))
+  const forbiddenPromptKey = Object.keys(parameters ?? {}).find((key) => key.trim().toLowerCase() === 'prompt')
+  if (forbiddenPromptKey) {
+    throw new Error(`parameters.${forbiddenPromptKey} is not allowed; use ImplementationSpec.spec.text`)
+  }
   const policy = asRecord(payload.policy) ?? undefined
   const secrets = Array.isArray(payload.secrets)
     ? payload.secrets.filter((item) => typeof item === 'string')

--- a/services/jangar/src/server/__tests__/agents-controller-implementation-contract.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller-implementation-contract.test.ts
@@ -33,7 +33,7 @@ describe('agents controller implementation-contract module', () => {
       codexStage: 'implementation',
       baseBranch: 'main',
       headBranch: 'codex/123',
-      prompt: '   ',
+      prompt: 'do-not-override',
     }
 
     const context = buildEventContext(implementation, parameters)

--- a/services/jangar/src/server/__tests__/agents-controller-system-prompt-policy.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller-system-prompt-policy.test.ts
@@ -1,0 +1,69 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { evaluateSystemPromptPolicy } from '~/server/agents-controller/system-prompt-policy'
+
+describe('system prompt policy machine', () => {
+  it('rejects AgentRun-level overrides before evaluating defaults', () => {
+    const decision = Effect.runSync(
+      evaluateSystemPromptPolicy({
+        hasRunOverride: true,
+        hasDefaultRef: true,
+        hasDefaultInline: true,
+      }),
+    )
+
+    expect(decision).toEqual({
+      ok: false,
+      reason: 'SystemPromptOverrideNotAllowed',
+      message:
+        'AgentRun-level systemPrompt/systemPromptRef overrides are not allowed; configure Agent.spec.defaults instead',
+    })
+  })
+
+  it('prioritizes default refs and keeps inline fallback when both are set', () => {
+    const decision = Effect.runSync(
+      evaluateSystemPromptPolicy({
+        hasRunOverride: false,
+        hasDefaultRef: true,
+        hasDefaultInline: true,
+      }),
+    )
+
+    expect(decision).toEqual({
+      ok: true,
+      candidateOrder: ['ref', 'inline'],
+    })
+  })
+
+  it('uses inline defaults when refs are absent', () => {
+    const decision = Effect.runSync(
+      evaluateSystemPromptPolicy({
+        hasRunOverride: false,
+        hasDefaultRef: false,
+        hasDefaultInline: true,
+      }),
+    )
+
+    expect(decision).toEqual({
+      ok: true,
+      candidateOrder: ['inline'],
+    })
+  })
+
+  it('fails when neither default source is configured', () => {
+    const decision = Effect.runSync(
+      evaluateSystemPromptPolicy({
+        hasRunOverride: false,
+        hasDefaultRef: false,
+        hasDefaultInline: false,
+      }),
+    )
+
+    expect(decision).toEqual({
+      ok: false,
+      reason: 'MissingSystemPromptConfiguration',
+      message: 'Agent.spec.defaults.systemPrompt or Agent.spec.defaults.systemPromptRef is required',
+    })
+  })
+})

--- a/services/jangar/src/server/__tests__/agents-controller-system-prompt.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller-system-prompt.test.ts
@@ -15,7 +15,7 @@ describe('agents controller system-prompt module', () => {
     })
   })
 
-  it('resolves inline system prompt from AgentRun spec', async () => {
+  it('rejects AgentRun-level inline system prompt overrides', async () => {
     const kube = { get: vi.fn() }
     const result = await resolveSystemPrompt({
       kube,
@@ -27,15 +27,15 @@ describe('agents controller system-prompt module', () => {
     })
 
     expect(result).toEqual({
-      ok: true,
-      systemPrompt: 'be concise',
-      systemPromptRef: null,
-      systemPromptHash: sha256Hex('be concise'),
+      ok: false,
+      reason: 'SystemPromptOverrideNotAllowed',
+      message:
+        'AgentRun-level systemPrompt/systemPromptRef overrides are not allowed; configure Agent.spec.defaults instead',
     })
     expect(kube.get).not.toHaveBeenCalled()
   })
 
-  it('falls back to agent defaults when AgentRun prompt fields are absent', async () => {
+  it('resolves inline system prompt from Agent defaults', async () => {
     const kube = { get: vi.fn() }
     const result = await resolveSystemPrompt({
       kube,
@@ -51,15 +51,16 @@ describe('agents controller system-prompt module', () => {
       systemPrompt: 'from-defaults',
       systemPromptRef: null,
       systemPromptHash: sha256Hex('from-defaults'),
+      resolvedSystemPrompt: 'from-defaults',
     })
   })
 
-  it('rejects inline prompts above maxInlineLength', async () => {
+  it('rejects agent default inline prompts above maxInlineLength', async () => {
     const result = await resolveSystemPrompt({
       kube: { get: vi.fn() },
       namespace: 'agents',
-      agentRun: { spec: { systemPrompt: '12345' } },
-      agent: null,
+      agentRun: { spec: {} },
+      agent: { spec: { defaults: { systemPrompt: '12345' } } },
       runSecrets: [],
       allowedSecrets: [],
       maxInlineLength: 4,
@@ -72,7 +73,7 @@ describe('agents controller system-prompt module', () => {
     })
   })
 
-  it('rejects secret refs that are not in spec.secrets', async () => {
+  it('rejects AgentRun-level secret ref system prompt overrides', async () => {
     const result = await resolveSystemPrompt({
       kube: { get: vi.fn() },
       namespace: 'agents',
@@ -84,12 +85,13 @@ describe('agents controller system-prompt module', () => {
 
     expect(result).toEqual({
       ok: false,
-      reason: 'SecretNotAllowed',
-      message: 'system prompt secret prompt-secret is not included in spec.secrets',
+      reason: 'SystemPromptOverrideNotAllowed',
+      message:
+        'AgentRun-level systemPrompt/systemPromptRef overrides are not allowed; configure Agent.spec.defaults instead',
     })
   })
 
-  it('loads prompt content from referenced secret and returns hash', async () => {
+  it('loads prompt content from agent default secret ref and returns hash', async () => {
     const kube = {
       get: vi.fn().mockResolvedValue({
         data: { 'prompt.txt': Buffer.from('from-secret').toString('base64') },
@@ -98,8 +100,8 @@ describe('agents controller system-prompt module', () => {
     const result = await resolveSystemPrompt({
       kube,
       namespace: 'agents',
-      agentRun: { spec: { systemPromptRef: { kind: 'Secret', name: 'prompt-secret', key: 'prompt.txt' } } },
-      agent: null,
+      agentRun: { spec: {} },
+      agent: { spec: { defaults: { systemPromptRef: { kind: 'Secret', name: 'prompt-secret', key: 'prompt.txt' } } } },
       runSecrets: ['prompt-secret'],
       allowedSecrets: ['prompt-secret'],
     })
@@ -110,6 +112,24 @@ describe('agents controller system-prompt module', () => {
       systemPrompt: null,
       systemPromptRef: { kind: 'Secret', name: 'prompt-secret', key: 'prompt.txt' },
       systemPromptHash: sha256Hex('from-secret'),
+      resolvedSystemPrompt: 'from-secret',
+    })
+  })
+
+  it('fails when Agent defaults have no system prompt configured', async () => {
+    const result = await resolveSystemPrompt({
+      kube: { get: vi.fn() },
+      namespace: 'agents',
+      agentRun: { spec: {} },
+      agent: { spec: {} },
+      runSecrets: [],
+      allowedSecrets: [],
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'MissingSystemPromptConfiguration',
+      message: 'Agent.spec.defaults.systemPrompt or Agent.spec.defaults.systemPromptRef is required',
     })
   })
 })

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -583,7 +583,10 @@ describe('agents controller reconcileAgentRun', () => {
     const kube = buildKube({
       get: vi.fn(async (resource: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
@@ -635,7 +638,10 @@ describe('agents controller reconcileAgentRun', () => {
       const kube = buildKube({
         get: vi.fn(async (resource: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
@@ -745,7 +751,10 @@ describe('agents controller reconcileAgentRun', () => {
       get: vi.fn(async (resource: string, name?: string) => {
         if (resource === RESOURCE_MAP.AgentRun && name === 'stale-run') return null
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
@@ -813,7 +822,11 @@ describe('agents controller reconcileAgentRun', () => {
         if (resource === RESOURCE_MAP.Agent) {
           return {
             metadata: { name: 'agent-1' },
-            spec: { providerRef: { name: 'provider-1' }, memoryRef: { name: 'default-memory' } },
+            spec: {
+              providerRef: { name: 'provider-1' },
+              defaults: { systemPrompt: 'default-agent-prompt' },
+              memoryRef: { name: 'default-memory' },
+            },
           }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
@@ -849,7 +862,7 @@ describe('agents controller reconcileAgentRun', () => {
         if (resource === RESOURCE_MAP.Agent) {
           return {
             metadata: { name: 'agent-1' },
-            spec: { providerRef: { name: 'provider-1' } },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
           }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
@@ -888,7 +901,7 @@ describe('agents controller reconcileAgentRun', () => {
         if (resource === RESOURCE_MAP.Agent) {
           return {
             metadata: { name: 'agent-1' },
-            spec: { providerRef: { name: 'provider-1' } },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
           }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
@@ -919,6 +932,94 @@ describe('agents controller reconcileAgentRun', () => {
     expect(condition?.reason).toBe('InvalidContract')
   })
 
+  it('rejects top-level parameters.prompt even when AgentRun bypasses HTTP API', async () => {
+    const kube = buildKube({
+      get: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        return null
+      }),
+    })
+
+    const agentRun = buildAgentRun({
+      spec: {
+        agentRef: { name: 'agent-1' },
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'job', config: {} },
+        workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
+        parameters: { prompt: 'forbidden override' },
+      },
+    })
+
+    await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
+
+    const status = getLastStatus(kube)
+    expect(status.phase).toBe('Failed')
+    const condition = findCondition(status, 'InvalidSpec')
+    expect(condition?.reason).toBe('ForbiddenParameterKey')
+    expect(condition?.message).toContain('spec.parameters.prompt is not allowed')
+    expect(kube.apply).not.toHaveBeenCalled()
+  })
+
+  it('rejects workflow step parameters.prompt even when AgentRun bypasses HTTP API', async () => {
+    const kube = buildKube({
+      get: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        return null
+      }),
+    })
+
+    const agentRun = buildAgentRun({
+      spec: {
+        agentRef: { name: 'agent-1' },
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'workflow', config: {} },
+        workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
+        workflow: {
+          steps: [
+            {
+              name: 'step-one',
+              parameters: {
+                prompt: 'forbidden override',
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
+
+    const status = getLastStatus(kube)
+    expect(status.phase).toBe('Failed')
+    const condition = findCondition(status, 'InvalidSpec')
+    expect(condition?.reason).toBe('ForbiddenParameterKey')
+    expect(condition?.message).toContain('workflow step step-one')
+    expect(condition?.message).toContain('spec.parameters.prompt is not allowed')
+    expect(kube.apply).not.toHaveBeenCalled()
+  })
+
   it('accepts mapped metadata keys for required contract fields', async () => {
     const apply = vi.fn(async (resource: Record<string, unknown>) => {
       const metadata = (resource.metadata ?? {}) as Record<string, unknown>
@@ -932,7 +1033,7 @@ describe('agents controller reconcileAgentRun', () => {
         if (resource === RESOURCE_MAP.Agent) {
           return {
             metadata: { name: 'agent-1' },
-            spec: { providerRef: { name: 'provider-1' } },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
           }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
@@ -1154,7 +1255,10 @@ describe('agents controller reconcileAgentRun', () => {
       apply,
       get: vi.fn(async (resource: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return {
@@ -1226,6 +1330,7 @@ describe('agents controller reconcileAgentRun', () => {
               metadata: { name: 'agent-1' },
               spec: {
                 providerRef: { name: 'provider-1' },
+                defaults: { systemPrompt: 'default-agent-prompt' },
                 security: { allowedSecrets: ['codex-nats-credentials'] },
               },
             }
@@ -1289,7 +1394,10 @@ describe('agents controller reconcileAgentRun', () => {
       apply,
       get: vi.fn(async (resource: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
@@ -1319,7 +1427,7 @@ describe('agents controller reconcileAgentRun', () => {
     expect(jobSpec.backoffLimit).toBe(2)
   })
 
-  it('includes inline systemPrompt in run payload and stores hash', async () => {
+  it('uses Agent default inline systemPrompt in run payload and stores hash', async () => {
     const apply = vi.fn(async (resource: Record<string, unknown>) => {
       const metadata = (resource.metadata ?? {}) as Record<string, unknown>
       const uid = metadata.uid ?? `uid-${String(resource.kind ?? 'resource').toLowerCase()}`
@@ -1356,7 +1464,6 @@ describe('agents controller reconcileAgentRun', () => {
         implementationSpecRef: { name: 'impl-1' },
         runtime: { type: 'job', config: {} },
         workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
-        systemPrompt: 'from-run',
       },
     })
 
@@ -1373,10 +1480,10 @@ describe('agents controller reconcileAgentRun', () => {
     const runJson = JSON.parse(
       String((specConfigMap?.data as Record<string, unknown>)?.['run.json'] ?? '{}'),
     ) as Record<string, unknown>
-    expect(runJson.systemPrompt).toBe('from-run')
+    expect(runJson.systemPrompt).toBe('from-agent')
 
     const status = getLastStatus(kube)
-    expect(status.systemPromptHash).toBe(createHash('sha256').update('from-run').digest('hex'))
+    expect(status.systemPromptHash).toBe(createHash('sha256').update('from-agent').digest('hex'))
 
     const podSpec = (job?.spec as Record<string, unknown> | undefined)?.template as Record<string, unknown> | undefined
     const podSpecSpec = (podSpec?.spec as Record<string, unknown> | undefined) ?? {}
@@ -1387,14 +1494,59 @@ describe('agents controller reconcileAgentRun', () => {
     const expectedHashVar = env.find((entry) => entry.name === 'CODEX_SYSTEM_PROMPT_EXPECTED_HASH') as
       | Record<string, unknown>
       | undefined
-    expect(expectedHashVar?.value).toBe(createHash('sha256').update('from-run').digest('hex'))
+    expect(expectedHashVar?.value).toBe(createHash('sha256').update('from-agent').digest('hex'))
     const requiredVar = env.find((entry) => entry.name === 'CODEX_SYSTEM_PROMPT_REQUIRED') as
       | Record<string, unknown>
       | undefined
     expect(requiredVar?.value).toBe('true')
   })
 
-  it('mounts ConfigMap systemPromptRef and stores hash without inline prompt leakage', async () => {
+  it('rejects AgentRun-level inline systemPrompt overrides', async () => {
+    const kube = buildKube({
+      get: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: {
+              providerRef: { name: 'provider-1' },
+              defaults: { systemPrompt: 'from-agent' },
+            },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return {
+            metadata: { name: 'provider-1' },
+            spec: { binary: '/usr/local/bin/agent-runner' },
+          }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        return null
+      }),
+    })
+
+    const agentRun = buildAgentRun({
+      spec: {
+        agentRef: { name: 'agent-1' },
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'job', config: {} },
+        workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
+        systemPrompt: 'from-run',
+      },
+    })
+
+    await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
+
+    const status = getLastStatus(kube)
+    expect(status.phase).toBe('Failed')
+    const condition = findCondition(status, 'InvalidSpec')
+    expect(condition?.reason).toBe('SystemPromptOverrideNotAllowed')
+    expect(condition?.message).toContain('AgentRun-level systemPrompt/systemPromptRef overrides are not allowed')
+    expect(kube.apply).not.toHaveBeenCalled()
+  })
+
+  it('mounts Agent default ConfigMap systemPromptRef and stores hash without inline prompt leakage', async () => {
     const apply = vi.fn(async (resource: Record<string, unknown>) => {
       const metadata = (resource.metadata ?? {}) as Record<string, unknown>
       const uid = metadata.uid ?? `uid-${String(resource.kind ?? 'resource').toLowerCase()}`
@@ -1404,7 +1556,19 @@ describe('agents controller reconcileAgentRun', () => {
       apply,
       get: vi.fn(async (resource: string, name: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: {
+              providerRef: { name: 'provider-1' },
+              defaults: {
+                systemPromptRef: {
+                  kind: 'ConfigMap',
+                  name: 'prompt-config',
+                  key: 'prompt',
+                },
+              },
+            },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return {
@@ -1428,12 +1592,6 @@ describe('agents controller reconcileAgentRun', () => {
         implementationSpecRef: { name: 'impl-1' },
         runtime: { type: 'job', config: {} },
         workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
-        systemPrompt: 'inline-ignored',
-        systemPromptRef: {
-          kind: 'ConfigMap',
-          name: 'prompt-config',
-          key: 'prompt',
-        },
       },
     })
 
@@ -1491,7 +1649,7 @@ describe('agents controller reconcileAgentRun', () => {
     expect(requiredVar?.value).toBe('true')
   })
 
-  it('mounts Secret systemPromptRef when allowlisted and included in spec.secrets', async () => {
+  it('mounts Agent default Secret systemPromptRef when allowlisted and included in spec.secrets', async () => {
     const apply = vi.fn(async (resource: Record<string, unknown>) => {
       const metadata = (resource.metadata ?? {}) as Record<string, unknown>
       const uid = metadata.uid ?? `uid-${String(resource.kind ?? 'resource').toLowerCase()}`
@@ -1506,6 +1664,13 @@ describe('agents controller reconcileAgentRun', () => {
             spec: {
               providerRef: { name: 'provider-1' },
               security: { allowedSecrets: ['prompt-secret'] },
+              defaults: {
+                systemPromptRef: {
+                  kind: 'Secret',
+                  name: 'prompt-secret',
+                  key: 'prompt',
+                },
+              },
             },
           }
         }
@@ -1532,11 +1697,6 @@ describe('agents controller reconcileAgentRun', () => {
         runtime: { type: 'job', config: {} },
         workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
         secrets: ['prompt-secret'],
-        systemPromptRef: {
-          kind: 'Secret',
-          name: 'prompt-secret',
-          key: 'prompt',
-        },
       },
     })
 
@@ -1588,7 +1748,7 @@ describe('agents controller reconcileAgentRun', () => {
     expect(requiredVar?.value).toBe('true')
   })
 
-  it('rejects Secret systemPromptRef when not included in spec.secrets', async () => {
+  it('rejects Agent default Secret systemPromptRef when not included in spec.secrets', async () => {
     const kube = buildKube({
       get: vi.fn(async (resource: string) => {
         if (resource === RESOURCE_MAP.Agent) {
@@ -1597,6 +1757,13 @@ describe('agents controller reconcileAgentRun', () => {
             spec: {
               providerRef: { name: 'provider-1' },
               security: { allowedSecrets: ['prompt-secret'] },
+              defaults: {
+                systemPromptRef: {
+                  kind: 'Secret',
+                  name: 'prompt-secret',
+                  key: 'prompt',
+                },
+              },
             },
           }
         }
@@ -1619,11 +1786,6 @@ describe('agents controller reconcileAgentRun', () => {
         implementationSpecRef: { name: 'impl-1' },
         runtime: { type: 'job', config: {} },
         workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
-        systemPromptRef: {
-          kind: 'Secret',
-          name: 'prompt-secret',
-          key: 'prompt',
-        },
       },
     })
 
@@ -1637,7 +1799,7 @@ describe('agents controller reconcileAgentRun', () => {
     expect(kube.apply).not.toHaveBeenCalled()
   })
 
-  it('rejects Secret systemPromptRef when secret is not allowlisted by the Agent', async () => {
+  it('rejects Agent default Secret systemPromptRef when secret is not allowlisted by the Agent', async () => {
     const kube = buildKube({
       get: vi.fn(async (resource: string) => {
         if (resource === RESOURCE_MAP.Agent) {
@@ -1646,6 +1808,13 @@ describe('agents controller reconcileAgentRun', () => {
             spec: {
               providerRef: { name: 'provider-1' },
               security: { allowedSecrets: ['some-other-secret'] },
+              defaults: {
+                systemPromptRef: {
+                  kind: 'Secret',
+                  name: 'prompt-secret',
+                  key: 'prompt',
+                },
+              },
             },
           }
         }
@@ -1669,11 +1838,6 @@ describe('agents controller reconcileAgentRun', () => {
         runtime: { type: 'job', config: {} },
         workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
         secrets: ['prompt-secret'],
-        systemPromptRef: {
-          kind: 'Secret',
-          name: 'prompt-secret',
-          key: 'prompt',
-        },
       },
     })
 
@@ -1705,7 +1869,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return {
@@ -1831,7 +1998,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
@@ -1964,7 +2134,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
@@ -2001,7 +2174,10 @@ describe('agents controller reconcileAgentRun', () => {
       const kube = buildKube({
         get: vi.fn(async (resource: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
@@ -2048,6 +2224,7 @@ describe('agents controller reconcileAgentRun', () => {
               metadata: { name: 'agent-1' },
               spec: {
                 providerRef: { name: 'provider-1' },
+                defaults: { systemPrompt: 'default-agent-prompt' },
                 security: { allowedSecrets: ['some-other-secret'] },
               },
             }
@@ -2078,7 +2255,7 @@ describe('agents controller reconcileAgentRun', () => {
     }
   })
 
-  it('mounts ConfigMap systemPromptRef for workflow step jobs and stores hash', async () => {
+  it('mounts Agent default ConfigMap systemPromptRef for workflow step jobs and stores hash', async () => {
     let lastJob: Record<string, unknown> | null = null
     const apply = vi.fn(async (resource: Record<string, unknown>) => {
       const metadata = (resource.metadata ?? {}) as Record<string, unknown>
@@ -2093,7 +2270,15 @@ describe('agents controller reconcileAgentRun', () => {
       apply,
       get: vi.fn(async (resource: string, name: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: {
+              providerRef: { name: 'provider-1' },
+              defaults: {
+                systemPromptRef: { kind: 'ConfigMap', name: 'prompt-config', key: 'prompt' },
+              },
+            },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
@@ -2115,7 +2300,6 @@ describe('agents controller reconcileAgentRun', () => {
         runtime: { type: 'workflow', config: {} },
         workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
         workflow: { steps: [{ name: 'step-one' }] },
-        systemPromptRef: { kind: 'ConfigMap', name: 'prompt-config', key: 'prompt' },
       },
     })
 
@@ -2178,7 +2362,10 @@ describe('agents controller reconcileAgentRun', () => {
       apply,
       get: vi.fn(async (resource: string, name: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return {
@@ -2291,7 +2478,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string, name: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return {
@@ -2451,7 +2641,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string, name: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return {
@@ -2617,7 +2810,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string, name: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return {
@@ -2724,7 +2920,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string, name: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return {
@@ -2831,7 +3030,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string, name: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return {
@@ -2942,7 +3144,10 @@ describe('agents controller reconcileAgentRun', () => {
         apply,
         get: vi.fn(async (resource: string, name: string) => {
           if (resource === RESOURCE_MAP.Agent) {
-            return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
           }
           if (resource === RESOURCE_MAP.AgentProvider) {
             return {
@@ -3060,7 +3265,10 @@ describe('agents controller reconcileAgentRun', () => {
     const kube = buildKube({
       get: vi.fn(async (resource: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return {
@@ -3118,7 +3326,10 @@ describe('agents controller reconcileAgentRun', () => {
     const kube = buildKube({
       get: vi.fn(async (resource: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return {
@@ -3189,7 +3400,10 @@ describe('agents controller reconcileAgentRun', () => {
       apply,
       get: vi.fn(async (resource: string, name: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return {
@@ -3289,7 +3503,10 @@ describe('agents controller reconcileAgentRun', () => {
       apply,
       get: vi.fn(async (resource: string, name: string) => {
         if (resource === RESOURCE_MAP.Agent) {
-          return { metadata: { name: 'agent-1' }, spec: { providerRef: { name: 'provider-1' } } }
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
         }
         if (resource === RESOURCE_MAP.AgentProvider) {
           return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }

--- a/services/jangar/src/server/__tests__/primitives-endpoints.test.ts
+++ b/services/jangar/src/server/__tests__/primitives-endpoints.test.ts
@@ -257,6 +257,92 @@ describe('primitives endpoints', () => {
     expect(body.details?.existingAgentRunName).toBe('demo-agent-run-1')
   })
 
+  it('rejects AgentRun-level system prompt overrides at API boundary', async () => {
+    const store = createStoreMock()
+    const kube = createKubeMock({
+      'agents.agents.proompteng.ai:jangar:demo-agent': { spec: {} },
+    })
+
+    const request = buildRequest(
+      'http://localhost/v1/agent-runs',
+      {
+        agentRef: { name: 'demo-agent' },
+        namespace: 'jangar',
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'job', config: {} },
+        systemPrompt: 'forbidden',
+      },
+      { 'Idempotency-Key': 'demo-agent-run-system-prompt-override-1' },
+    )
+
+    const response = await postAgentRunsHandler(request, { storeFactory: () => store, kubeClient: kube })
+    expect(response.status).toBe(400)
+    expect(kube.apply).not.toHaveBeenCalled()
+    const body = (await response.json()) as { error?: string }
+    expect(body.error).toContain('systemPrompt/systemPromptRef overrides are not allowed')
+  })
+
+  it('rejects parameters.prompt overrides at API boundary', async () => {
+    const store = createStoreMock()
+    const kube = createKubeMock({
+      'agents.agents.proompteng.ai:jangar:demo-agent': { spec: {} },
+    })
+
+    const request = buildRequest(
+      'http://localhost/v1/agent-runs',
+      {
+        agentRef: { name: 'demo-agent' },
+        namespace: 'jangar',
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'job', config: {} },
+        parameters: {
+          prompt: 'forbidden',
+        },
+      },
+      { 'Idempotency-Key': 'demo-agent-run-prompt-param-override-1' },
+    )
+
+    const response = await postAgentRunsHandler(request, { storeFactory: () => store, kubeClient: kube })
+    expect(response.status).toBe(400)
+    expect(kube.apply).not.toHaveBeenCalled()
+    const body = (await response.json()) as { error?: string }
+    expect(body.error).toContain('parameters.prompt is not allowed')
+  })
+
+  it('rejects workflow step parameters.prompt overrides at API boundary', async () => {
+    const store = createStoreMock()
+    const kube = createKubeMock({
+      'agents.agents.proompteng.ai:jangar:demo-agent': { spec: {} },
+    })
+
+    const request = buildRequest(
+      'http://localhost/v1/agent-runs',
+      {
+        agentRef: { name: 'demo-agent' },
+        namespace: 'jangar',
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'workflow', config: {} },
+        workflow: {
+          steps: [
+            {
+              name: 'step-one',
+              parameters: {
+                prompt: 'forbidden',
+              },
+            },
+          ],
+        },
+      },
+      { 'Idempotency-Key': 'demo-agent-run-workflow-step-prompt-override-1' },
+    )
+
+    const response = await postAgentRunsHandler(request, { storeFactory: () => store, kubeClient: kube })
+    expect(response.status).toBe(400)
+    expect(kube.apply).not.toHaveBeenCalled()
+    const body = (await response.json()) as { error?: string }
+    expect(body.error).toContain('workflow.steps[0].parameters.prompt is not allowed')
+  })
+
   it('reclaims stale AgentRun idempotency reservations', async () => {
     const scope = new Map<string, AgentRunIdempotencyRecord>()
     const kubeResources: Record<string, Record<string, unknown> | null> = {

--- a/services/jangar/src/server/agents-controller/agent-run-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/agent-run-reconciler.ts
@@ -97,6 +97,7 @@ type AgentRunReconcilerDependencies = {
     agentRun: Record<string, unknown>,
     implementation: Record<string, unknown>,
     memory: Record<string, unknown> | null,
+    systemPrompt?: string | null,
   ) => Promise<RuntimeRef>
   submitTemporalRun: (
     agentRun: Record<string, unknown>,
@@ -906,7 +907,12 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
             },
           )
         } else if (runtimeType === 'custom') {
-          newRuntimeRef = await submitCustomRun(agentRun, implResource, memory)
+          newRuntimeRef = await submitCustomRun(
+            agentRun,
+            implResource,
+            memory,
+            systemPromptResolution.resolvedSystemPrompt,
+          )
         } else if (runtimeType === 'temporal') {
           newRuntimeRef = await submitTemporalRun(
             agentRun,
@@ -916,7 +922,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
             memory,
             vcsContext,
             resolvedParameters,
-            systemPromptResolution.systemPrompt,
+            systemPromptResolution.resolvedSystemPrompt,
           )
         } else {
           throw new Error(`unknown runtime type: ${runtimeType}`)

--- a/services/jangar/src/server/agents-controller/implementation-contract.ts
+++ b/services/jangar/src/server/agents-controller/implementation-contract.ts
@@ -129,6 +129,7 @@ export const createImplementationContractTools = (resolveParam: ResolveParam) =>
       if (typeof value !== 'string') continue
       const trimmed = value.trim()
       if (!trimmed) continue
+      if (key.trim().toLowerCase() === 'prompt') continue
       metadata[key] = trimmed
     }
 
@@ -141,7 +142,6 @@ export const createImplementationContractTools = (resolveParam: ResolveParam) =>
     const resolvedIssueTitle = metadata.issueTitle ?? resolveParam(parameters, ['issueTitle'])
     const resolvedIssueBody = metadata.issueBody ?? resolveParam(parameters, ['issueBody'])
     const resolvedIssueUrl = metadata.issueUrl ?? resolveParam(parameters, ['issueUrl'])
-    const resolvedPrompt = metadata.prompt ?? resolveParam(parameters, ['prompt'])
     const base = metadata.base ?? resolveParam(parameters, ['base'])
     const head = metadata.head ?? resolveParam(parameters, ['head'])
     const stage = metadata.stage ?? resolveParam(parameters, ['stage'])
@@ -168,7 +168,7 @@ export const createImplementationContractTools = (resolveParam: ResolveParam) =>
     const renderedText = renderParameterTemplate(text, templateContext)
     const issueTitle = renderParameterTemplate(resolvedIssueTitle || renderedSummary, templateContext)
     const issueBody = renderParameterTemplate(resolvedIssueBody || renderedText, templateContext)
-    const prompt = renderParameterTemplate(resolvedPrompt || renderedText || renderedSummary, templateContext)
+    const prompt = renderedText || renderedSummary
 
     setMetadataIfMissing(metadata, 'issueTitle', issueTitle)
     setMetadataIfMissing(metadata, 'issueBody', issueBody)

--- a/services/jangar/src/server/agents-controller/system-prompt-policy.ts
+++ b/services/jangar/src/server/agents-controller/system-prompt-policy.ts
@@ -1,0 +1,78 @@
+import { Effect } from 'effect'
+import { createActor, createMachine } from 'xstate'
+
+type SystemPromptPolicyInput = {
+  hasRunOverride: boolean
+  hasDefaultRef: boolean
+  hasDefaultInline: boolean
+}
+
+type AllowedSystemPromptPolicy = {
+  ok: true
+  candidateOrder: Array<'ref' | 'inline'>
+}
+
+type RejectedSystemPromptPolicy = {
+  ok: false
+  reason: 'SystemPromptOverrideNotAllowed' | 'MissingSystemPromptConfiguration'
+  message: string
+}
+
+export type SystemPromptPolicyDecision = AllowedSystemPromptPolicy | RejectedSystemPromptPolicy
+
+const createSystemPromptPolicyMachine = (input: SystemPromptPolicyInput) =>
+  createMachine({
+    id: 'systemPromptPolicy',
+    initial: 'evaluate',
+    states: {
+      evaluate: {
+        always: [
+          { guard: () => input.hasRunOverride, target: 'rejectedOverride' },
+          { guard: () => input.hasDefaultRef, target: 'allowedRefFirst' },
+          { guard: () => input.hasDefaultInline, target: 'allowedInlineOnly' },
+          { target: 'rejectedMissing' },
+        ],
+      },
+      allowedRefFirst: { type: 'final' },
+      allowedInlineOnly: { type: 'final' },
+      rejectedOverride: { type: 'final' },
+      rejectedMissing: { type: 'final' },
+    },
+  })
+
+export const evaluateSystemPromptPolicy = (input: SystemPromptPolicyInput) =>
+  Effect.sync<SystemPromptPolicyDecision>(() => {
+    const actor = createActor(createSystemPromptPolicyMachine(input))
+    actor.start()
+    const snapshot = actor.getSnapshot()
+
+    if (snapshot.matches('rejectedOverride')) {
+      return {
+        ok: false,
+        reason: 'SystemPromptOverrideNotAllowed',
+        message:
+          'AgentRun-level systemPrompt/systemPromptRef overrides are not allowed; configure Agent.spec.defaults instead',
+      }
+    }
+
+    if (snapshot.matches('rejectedMissing')) {
+      return {
+        ok: false,
+        reason: 'MissingSystemPromptConfiguration',
+        message: 'Agent.spec.defaults.systemPrompt or Agent.spec.defaults.systemPromptRef is required',
+      }
+    }
+
+    if (snapshot.matches('allowedRefFirst')) {
+      const candidateOrder: Array<'ref' | 'inline'> = input.hasDefaultInline ? ['ref', 'inline'] : ['ref']
+      return {
+        ok: true,
+        candidateOrder,
+      }
+    }
+
+    return {
+      ok: true,
+      candidateOrder: ['inline'],
+    }
+  })

--- a/services/jangar/src/server/agents-controller/system-prompt.ts
+++ b/services/jangar/src/server/agents-controller/system-prompt.ts
@@ -1,6 +1,8 @@
 import { asRecord, asString, readNested } from '~/server/primitives-http'
+import { Effect } from 'effect'
 
 import { isNonBlankString, sha256Hex } from './template-hash'
+import { evaluateSystemPromptPolicy } from './system-prompt-policy'
 
 export const SYSTEM_PROMPT_INLINE_MAX_LENGTH = 16_384
 
@@ -57,12 +59,20 @@ export const resolveSystemPrompt = async (options: {
   const defaults = asRecord(readNested(options.agent, ['spec', 'defaults'])) ?? {}
   const maxInlineLength = options.maxInlineLength ?? SYSTEM_PROMPT_INLINE_MAX_LENGTH
 
-  const candidates: Array<{ type: 'ref'; raw: unknown } | { type: 'inline'; raw: unknown }> = [
-    { type: 'ref', raw: spec.systemPromptRef },
-    { type: 'inline', raw: spec.systemPrompt },
-    { type: 'ref', raw: defaults.systemPromptRef },
-    { type: 'inline', raw: defaults.systemPrompt },
-  ]
+  const policy = Effect.runSync(
+    evaluateSystemPromptPolicy({
+      hasRunOverride: spec.systemPrompt != null || spec.systemPromptRef != null,
+      hasDefaultRef: defaults.systemPromptRef != null,
+      hasDefaultInline: defaults.systemPrompt != null,
+    }),
+  )
+  if (!policy.ok) {
+    return policy
+  }
+
+  const candidates: Array<{ type: 'ref'; raw: unknown } | { type: 'inline'; raw: unknown }> = policy.candidateOrder.map(
+    (type) => (type === 'ref' ? { type, raw: defaults.systemPromptRef } : { type, raw: defaults.systemPrompt }),
+  )
 
   for (const candidate of candidates) {
     if (candidate.raw == null) continue
@@ -89,6 +99,7 @@ export const resolveSystemPrompt = async (options: {
         systemPrompt: value,
         systemPromptRef: null,
         systemPromptHash: sha256Hex(value),
+        resolvedSystemPrompt: value,
       }
     }
 
@@ -153,13 +164,13 @@ export const resolveSystemPrompt = async (options: {
       systemPrompt: null,
       systemPromptRef: ref,
       systemPromptHash: sha256Hex(contents),
+      resolvedSystemPrompt: contents,
     }
   }
 
   return {
-    ok: true as const,
-    systemPrompt: null,
-    systemPromptRef: null,
-    systemPromptHash: null,
+    ok: false as const,
+    reason: 'MissingSystemPromptConfiguration',
+    message: 'Agent.spec.defaults.systemPrompt or Agent.spec.defaults.systemPromptRef is required',
   }
 }

--- a/services/jangar/src/server/agents-controller/temporal-runtime.ts
+++ b/services/jangar/src/server/agents-controller/temporal-runtime.ts
@@ -73,17 +73,30 @@ export const createTemporalRuntimeTools = (deps: TemporalRuntimeDependencies) =>
     agentRun: Record<string, unknown>,
     implementation: Record<string, unknown>,
     memory: Record<string, unknown> | null,
+    systemPrompt?: string | null,
   ) => {
     const runtimeConfig = asRecord(readNested(agentRun, ['spec', 'runtime', 'config'])) ?? {}
     const endpoint = asString(runtimeConfig.endpoint)
     if (!endpoint) {
       throw new Error('spec.runtime.config.endpoint is required for custom runtime')
     }
-    const payload = runtimeConfig.payload ?? {
+    const payloadBase = runtimeConfig.payload ?? {
       agentRun,
       implementation,
       memory,
     }
+    const payload =
+      typeof systemPrompt === 'string' && systemPrompt.trim().length > 0
+        ? payloadBase && typeof payloadBase === 'object' && !Array.isArray(payloadBase)
+          ? {
+              ...(payloadBase as Record<string, unknown>),
+              systemPrompt,
+            }
+          : {
+              payload: payloadBase,
+              systemPrompt,
+            }
+        : payloadBase
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/services/jangar/src/server/agents-controller/workflow.ts
+++ b/services/jangar/src/server/agents-controller/workflow.ts
@@ -4,6 +4,7 @@ import { parseBooleanEnv, parseNumberEnv, parseOptionalNumber } from './env-conf
 
 const PARAMETERS_MAX_ENTRIES = 100
 const PARAMETERS_MAX_VALUE_BYTES = 2048
+const FORBIDDEN_PARAMETER_KEYS = new Set(['prompt'])
 
 const WORKFLOW_LOOPS_ENABLED_ENV = 'JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED'
 const WORKFLOW_LOOP_MAX_ITERATIONS_ENV = 'JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOP_MAX_ITERATIONS'
@@ -137,6 +138,14 @@ export const validateParameters = (params: Record<string, unknown>) => {
     }
   }
   for (const [key, value] of entries) {
+    const normalizedKey = key.trim().toLowerCase()
+    if (FORBIDDEN_PARAMETER_KEYS.has(normalizedKey)) {
+      return {
+        ok: false as const,
+        reason: 'ForbiddenParameterKey',
+        message: `spec.parameters.${key} is not allowed; use ImplementationSpec.spec.text`,
+      }
+    }
     if (typeof value !== 'string') {
       return {
         ok: false as const,


### PR DESCRIPTION
## Summary

- Enforce AgentRun prompt policy so run-level `spec.systemPrompt`/`spec.systemPromptRef` overrides are rejected in API/controller and system prompts resolve only from `Agent.spec.defaults`.
- Remove prompt override paths by rejecting `spec.parameters.prompt` and `workflow.steps[].parameters.prompt` in route validation, workflow validation, CRD schema, and Go API types.
- Keep ImplementationSpec text as the implementation todo payload source and prevent `prompt` parameter metadata from overriding implementation contract prompt text.
- Add `system-prompt-policy` logic implemented with XState + Effect and expand regression coverage across controller, API primitives, and codex implementation runner tests.
- Update agents chart/docs/runbooks to document runner-image entry points, prompt precedence policy, and the no-override contract for AgentRuns.

## Related Issues

None

## Testing

- `bun --cwd services/jangar test src/server/__tests__/agents-controller-system-prompt-policy.test.ts src/server/__tests__/agents-controller-system-prompt.test.ts src/server/__tests__/agents-controller-implementation-contract.test.ts src/server/__tests__/primitives-endpoints.test.ts src/server/__tests__/agents-controller.test.ts`
- `bun --cwd services/jangar test scripts/codex/lib/__tests__/pull-request-policy.test.ts scripts/codex/__tests__/codex-implement.test.ts`
- `go test ./services/jangar/api/...`

## Screenshots (if applicable)

N/A

## Breaking Changes

- AgentRun submissions that set `spec.systemPrompt`, `spec.systemPromptRef`, `spec.parameters.prompt`, or `workflow.steps[].parameters.prompt` are now rejected.
- Required migration: move system prompt configuration to `Agent.spec.defaults.systemPrompt` or `Agent.spec.defaults.systemPromptRef`, and keep implementation work instructions in `ImplementationSpec.spec.text`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
