### PR TITLE
fix(argocd): unblock agents sync by deduplicating queue env

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -30,7 +30,6 @@ controllers:
       JANGAR_WHITEPAPER_FINALIZE_ENABLED: "true"
       JANGAR_WHITEPAPER_FINALIZE_BASE_URL: http://torghut.torghut.svc.cluster.local
       JANGAR_WHITEPAPER_FINALIZE_USE_SERVICE_ACCOUNT_TOKEN: "true"
-      JANGAR_AGENTS_CONTROLLER_QUEUE_REPO: "200"
 resources:
   requests:
     cpu: 200m
@@ -40,6 +39,8 @@ controller:
     - agents
   concurrency:
     perAgent: 10
+  queue:
+    perRepo: 200
   jobTtlSeconds: 86400
   jobTtlSecondsAfterFinished: 86400
   logRetentionSeconds: 604800


### PR DESCRIPTION
## Summary

- Removed `JANGAR_AGENTS_CONTROLLER_QUEUE_REPO` from `controllers.env.vars` in agents GitOps values.
- Set queue override through the typed chart key `controller.queue.perRepo: 200` instead of raw env injection.
- Eliminated duplicate env-key rendering that caused Argo CD `ComparisonError` and blocked `agents` app sync.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
