### PR TITLE
feat(jangar): add torghut rejection reporting splits

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-trading-summary.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-trading-summary.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import { __private } from '../torghut-trading'
 
+const rollingTrendInterval = {
+  tz: 'America/New_York',
+  startUtc: '2026-01-15T05:00:00.000Z',
+  endUtc: '2026-01-16T05:00:00.000Z',
+}
+
 describe('torghut trading summary reason parsing', () => {
   it('splits semicolon-delimited risk reasons into individual tokens', () => {
     expect(__private.splitRiskReason('shorts_not_allowed;symbol_capacity_exhausted')).toEqual([
@@ -12,5 +18,74 @@ describe('torghut trading summary reason parsing', () => {
 
   it('keeps single reasons unchanged', () => {
     expect(__private.splitRiskReason('llm_error')).toEqual(['llm_error'])
+  })
+
+  it('classifies market session by post-open and pre-open rules', () => {
+    expect(__private.classifySessionByMarketTime('2026-01-15T13:45:00.000Z', rollingTrendInterval.tz)).toBe('pre-open')
+    expect(__private.classifySessionByMarketTime('2026-01-15T14:30:00.000Z', rollingTrendInterval.tz)).toBe('post-open')
+    expect(__private.classifySessionByMarketTime('2026-01-15T18:00:00.000Z', rollingTrendInterval.tz)).toBe('post-open')
+  })
+
+  it('builds a bounded 5-day rejection trend with per-day session split', () => {
+    const trend = __private.buildRolling5DayRejectionTrend(
+      [
+        {
+          id: '1',
+          createdAt: '2026-01-11T14:10:00.000Z',
+          alpacaAccountLabel: 'paper',
+          symbol: 'ABC',
+          timeframe: '1m',
+          status: 'rejected',
+          rationale: null,
+          riskReasons: ['shorts_not_allowed;llm_error'],
+          strategyId: '1',
+          strategyName: 'test',
+        },
+        {
+          id: '2',
+          createdAt: '2026-01-12T14:45:00.000Z',
+          alpacaAccountLabel: 'paper',
+          symbol: 'ABC',
+          timeframe: '1m',
+          status: 'rejected',
+          rationale: null,
+          riskReasons: ['qty_below_min'],
+          strategyId: '1',
+          strategyName: 'test',
+        },
+        {
+          id: '3',
+          createdAt: '2026-01-10T14:40:00.000Z',
+          alpacaAccountLabel: 'paper',
+          symbol: 'ABC',
+          timeframe: '1m',
+          status: 'rejected',
+          rationale: null,
+          riskReasons: ['llm_error'],
+          strategyId: '1',
+          strategyName: 'test',
+        },
+      ],
+      rollingTrendInterval,
+    )
+
+    expect(trend.byDay).toHaveLength(2)
+    expect(trend.byDay[0]).toEqual({
+      day: '2026-01-11',
+      rejectedCount: 1,
+      preOpenCount: 1,
+      postOpenCount: 0,
+      topReasons: [
+        { reason: 'shorts_not_allowed', count: 1 },
+        { reason: 'llm_error', count: 1 },
+      ],
+    })
+    expect(trend.byDay[1]).toEqual({
+      day: '2026-01-12',
+      rejectedCount: 1,
+      preOpenCount: 0,
+      postOpenCount: 1,
+      topReasons: [{ reason: 'qty_below_min', count: 1 }],
+    })
   })
 })

--- a/services/jangar/src/server/torghut-trading.ts
+++ b/services/jangar/src/server/torghut-trading.ts
@@ -267,6 +267,26 @@ export type TorghutTradingSummary = {
   rejections: {
     rejectedCount: number
     topReasons: { reason: string; count: number }[]
+    sessionSplit: {
+      preOpenCount: number
+      postOpenCount: number
+    }
+    perAccountSplit: {
+      alpacaAccountLabel: string
+      preOpenCount: number
+      postOpenCount: number
+    }[]
+    rolling5DayTrend: {
+      windowStartUtc: string
+      windowEndUtc: string
+      byDay: {
+        day: string
+        rejectedCount: number
+        preOpenCount: number
+        postOpenCount: number
+        topReasons: { reason: string; count: number }[]
+      }[]
+    }
   }
   equity: {
     available: boolean
@@ -278,13 +298,132 @@ export type TorghutTradingSummary = {
   }
 }
 
+const MARKET_OPEN_HOUR = 9
+const MARKET_OPEN_MINUTE = 30
+
+type SessionBucket = {
+  rejectedCount: number
+  preOpenCount: number
+  postOpenCount: number
+  reasonCounts: Map<string, number>
+}
+
+const toMarketParts = (value: string, tz: string) => {
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return null
+
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(date)
+
+  const record: Record<string, string> = {}
+  for (const part of parts) {
+    if (part.type !== 'literal') record[part.type] = part.value
+  }
+
+  const year = Number.parseInt(record.year ?? '', 10)
+  const month = Number.parseInt(record.month ?? '', 10)
+  const day = Number.parseInt(record.day ?? '', 10)
+  const hour = Number.parseInt(record.hour ?? '', 10)
+  const minute = Number.parseInt(record.minute ?? '', 10)
+  if (![year, month, day, hour, minute].every((value) => Number.isFinite(value))) return null
+
+  return {
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    key: `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`,
+  }
+}
+
+const classifySessionByMarketTime = (createdAt: string, tz: string): 'pre-open' | 'post-open' => {
+  const marketParts = toMarketParts(createdAt, tz)
+  if (!marketParts) return 'pre-open'
+  if (marketParts.hour > MARKET_OPEN_HOUR) return 'post-open'
+  if (marketParts.hour < MARKET_OPEN_HOUR) return 'pre-open'
+  return marketParts.minute >= MARKET_OPEN_MINUTE ? 'post-open' : 'pre-open'
+}
+
+const formatSessionReasonTop = (bucket: SessionBucket, limit = 12) =>
+  [...bucket.reasonCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([reason, count]) => ({ reason, count }))
+
+const addReasonCounts = (bucket: SessionBucket, decision: TorghutRejectedDecisionRow) => {
+  for (const reason of decision.riskReasons) {
+    for (const key of splitRiskReason(reason)) {
+      bucket.reasonCounts.set(key, (bucket.reasonCounts.get(key) ?? 0) + 1)
+    }
+  }
+}
+
+const shiftUtcDayWindowStart = (value: string, dayOffset: number) =>
+  new Date(Date.parse(value) - dayOffset * 24 * 60 * 60 * 1000).toISOString()
+
+const buildRolling5DayRejectionTrend = (
+  decisions: TorghutRejectedDecisionRow[],
+  interval: { tz: string; startUtc: string; endUtc: string },
+) => {
+  const windowStartUtc = shiftUtcDayWindowStart(interval.startUtc, 4)
+  const byDay = new Map<string, SessionBucket>()
+
+  for (const decision of decisions) {
+    if (decision.createdAt < windowStartUtc || decision.createdAt >= interval.endUtc) continue
+
+    const marketParts = toMarketParts(decision.createdAt, interval.tz)
+    if (!marketParts) continue
+
+    const bucket = byDay.get(marketParts.key) ?? {
+      rejectedCount: 0,
+      preOpenCount: 0,
+      postOpenCount: 0,
+      reasonCounts: new Map(),
+    }
+    bucket.rejectedCount += 1
+    const session = classifySessionByMarketTime(decision.createdAt, interval.tz)
+    if (session === 'pre-open') {
+      bucket.preOpenCount += 1
+    } else {
+      bucket.postOpenCount += 1
+    }
+    addReasonCounts(bucket, decision)
+    byDay.set(marketParts.key, bucket)
+  }
+
+  const days = [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .slice(-5)
+    .map(([day, bucket]) => ({
+      day,
+      rejectedCount: bucket.rejectedCount,
+      preOpenCount: bucket.preOpenCount,
+      postOpenCount: bucket.postOpenCount,
+      topReasons: formatSessionReasonTop(bucket, 6),
+    }))
+
+  return {
+    windowStartUtc,
+    windowEndUtc: interval.endUtc,
+    byDay: days,
+  }
+}
+
 export const buildTorghutTradingSummary = async (params: {
   pool: Pool
   interval: { tz: string; day: string; startUtc: string; endUtc: string }
   strategyId?: string | null
 }) => {
   const strategyId = params.strategyId ?? null
-  const [executions, rejections, strategies, snapshots] = await Promise.all([
+  const [executions, rejections, rollingRejections, strategies, snapshots] = await Promise.all([
     listTorghutTradingFilledExecutions({
       pool: params.pool,
       startUtc: params.interval.startUtc,
@@ -298,6 +437,13 @@ export const buildTorghutTradingSummary = async (params: {
       endUtc: params.interval.endUtc,
       strategyId,
       limit: 2000,
+    }),
+    listTorghutTradingRejectedDecisions({
+      pool: params.pool,
+      startUtc: shiftUtcDayWindowStart(params.interval.startUtc, 4),
+      endUtc: params.interval.endUtc,
+      strategyId,
+      limit: 5000,
     }),
     listTorghutTradingStrategies({ pool: params.pool, limit: 500 }),
     listTorghutTradingPositionSnapshots({
@@ -318,13 +464,41 @@ export const buildTorghutTradingSummary = async (params: {
   const pnl = computeRealizedPnlAverageCostLongOnly(executions)
 
   const reasonsCount = new Map<string, number>()
+  const sessionSplit = {
+    preOpenCount: 0,
+    postOpenCount: 0,
+  }
+  const byAccountSplit = new Map<
+    string,
+    {
+      alpacaAccountLabel: string
+      preOpenCount: number
+      postOpenCount: number
+    }
+  >()
+
   for (const decision of rejections) {
+    const session = classifySessionByMarketTime(decision.createdAt, params.interval.tz)
+    if (session === 'pre-open') sessionSplit.preOpenCount += 1
+    else sessionSplit.postOpenCount += 1
+
+    const byAccount = byAccountSplit.get(decision.alpacaAccountLabel) ?? {
+      alpacaAccountLabel: decision.alpacaAccountLabel,
+      preOpenCount: 0,
+      postOpenCount: 0,
+    }
+    if (session === 'pre-open') byAccount.preOpenCount += 1
+    else byAccount.postOpenCount += 1
+    byAccountSplit.set(decision.alpacaAccountLabel, byAccount)
+
     for (const reason of decision.riskReasons) {
       for (const key of splitRiskReason(reason)) {
         reasonsCount.set(key, (reasonsCount.get(key) ?? 0) + 1)
       }
     }
   }
+
+  const rollingTrend = buildRolling5DayRejectionTrend(rollingRejections, params.interval)
   const topReasons = [...reasonsCount.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, 12)
@@ -367,6 +541,15 @@ export const buildTorghutTradingSummary = async (params: {
     rejections: {
       rejectedCount: rejections.length,
       topReasons,
+      sessionSplit,
+      perAccountSplit: [...byAccountSplit.values()].sort((a, b) =>
+        a.alpacaAccountLabel.localeCompare(b.alpacaAccountLabel),
+      ),
+      rolling5DayTrend: {
+        windowStartUtc: rollingTrend.windowStartUtc,
+        windowEndUtc: rollingTrend.windowEndUtc,
+        byDay: rollingTrend.byDay,
+      },
     },
     equity: {
       available: equityByAccount.length > 0,
@@ -385,4 +568,6 @@ export const parseTorghutTradingStrategyId = (url: URL) => {
 
 export const __private = {
   splitRiskReason,
+  classifySessionByMarketTime,
+  buildRolling5DayRejectionTrend,
 }


### PR DESCRIPTION
## Summary

- Added rejection reason normalization for Jangar Torghut summary reporting by splitting semicolon-delimited `risk_reasons` into atomic reasons.
- Added summary aggregates required by Workstream 4 in `docs/torghut/design-system/v6/15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`: pre-open/post-open session split, per-account split, and 5-day rolling trend with per-day top reasons.
- Added regression coverage in `services/jangar/src/server/__tests__/torghut-trading-summary.test.ts` for reason splitting and trend bucketing behavior.

## Related Issues

- Governing design document: `docs/torghut/design-system/v6/15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md` (Workstream 4: Jangar Summary Normalization and Operator Truth).
- Requirement provenance: `TSK-79` (`swarm-torghut-quant`) mission artifact.

## Testing

- `bun run --cwd services/jangar lint`
- `bunx oxfmt --check services/jangar/src/server/torghut-trading.ts services/jangar/src/server/__tests__/torghut-trading-summary.test.ts`
- `bun run --cwd services/jangar lint:oxlint`
- `bun run --cwd services/jangar lint:oxlint:type`
- `bun run --cwd services/jangar test src/server/__tests__/torghut-trading-summary.test.ts`

## Risks / Rollback Path

- Design risk: semicolon-normalized split behavior could alter downstream interpretation of historical rejection reason displays; this is backward compatible in storage (only read/aggregation path).
- Rollback path: Revert this PR and redeploy prior `services/jangar` image to restore prior summary behavior; no schema migration required.

## Screenshots

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
