### PR TITLE
fix(torghut): normalize emergency-stop reason handling

### DIFF
--- a/docs/torghut/design-system/v6/17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md
+++ b/docs/torghut/design-system/v6/17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md
@@ -1,0 +1,78 @@
+# Emergency Stop Reason Normalization and Recovery Stability
+
+## Status
+
+- Type: ADR/design proposal
+- Date: `2026-03-04`
+- Source of truth: `services/torghut/app/trading/scheduler.py`
+- Scope: torghut safety controls and emergency-stop signal handling
+- Evidence basis: cluster rollout events, scheduler safety state machine, and targeted regression tests
+
+## Objective
+
+Reduce operational noise and improve recovery determinism by making emergency-stop reason strings canonicalized, deduplicated, and order-stable without changing existing emergency stop semantics.
+
+## Problem
+
+`TradingScheduler` stores emergency-stop reasons as semicolon-delimited free-form strings and then recomputes these lists during recovery.
+
+Observed risks:
+- duplicate reasons can be appended repeatedly after recoverable/nonrecoverable transitions,
+- whitespace and malformed fragments can survive through reason parsing,
+- repeated set sorting can change ordering between incidents and make incident evidence harder to compare,
+- duplicate or messy reason strings can amplify false-change alerts in evidence review.
+
+## Design decision
+
+Implement a single canonicalization path for emergency-stop reason handling.
+
+1) Parse and normalize all semicolon-delimited reason strings through a shared helper.
+2) Deduplicate by first-seen order while trimming whitespace.
+3) Reuse that normalized representation in both trigger and recovery paths.
+
+This keeps behavior identical from a control perspective (emergency stop still engages whenever reasons are present) while making reason bookkeeping deterministic and cleaner.
+
+## Alternatives considered
+
+### Option A: Keep current behavior unchanged
+- Pros: zero code movement and zero regression risk.
+- Cons: keeps flaky reason ordering and duplicate history across retries, which complicates post-incident comparisons and escalation heuristics.
+
+### Option B: Sort unique reasons in recovery and trigger paths
+- Pros: deterministic ordering regardless of source order.
+- Cons: lexical ordering hides causal sequence, which makes operator-readable incident trails harder to infer at glance.
+
+### Option C: Introduce structured reason objects (id/type/severity metadata) in DB + runtime
+- Pros: future extensibility and stronger typing.
+- Cons: larger schema/runtime surface and migration cost not proportional to current objective.
+
+### Selected: Option C avoided, Option B avoided, implemented Option D (shared canonical list helper)
+- Canonicalization with dedupe by first-seen order is minimal, safe, and solves the highest-risk operational ambiguity.
+
+## Implementation
+
+- Added `app.trading.scheduler._merge_emergency_stop_reasons`.
+- Updated `_split_emergency_stop_reasons` to use the canonical merge helper.
+- Updated `_evaluate_emergency_stop_recovery`:
+  - merge latched + current non-recoverable reasons without duplicate loss,
+  - refresh recoverable reason set without duplicate or whitespace artifacts.
+- Updated `_trigger_emergency_stop` to store canonicalized reason strings.
+- Added regression tests:
+  - `test_split_emergency_stop_reasons_ignores_duplicates_and_whitespace`
+  - `test_emergency_stop_recovery_canonicalizes_and_merges_nonrecoverable_reasons`
+
+## Risk and impact
+
+- Risk: whitespace trimming and dedupe may collapse reasons that relied on leading/trailing spaces for local distinction. No code path intentionally encodes semantic differences this way.
+- Risk: unchanged reasons still remain semicolon strings; richer schema evolution remains future work.
+
+## Rollout and verification
+
+- Unit tests for scheduler safety now encode the new behavior.
+- Runtime verification remains read-only during this mission: compare `/trading/status` and rollback incident evidence before/after deployments for reduced reason churn and stable ordering.
+
+## Exit criteria
+
+- New helper and reason-path updates are merged.
+- Regression tests cover normalization and recovery merge behavior.
+- Design and mission artifacts include rationale, alternatives, and handoff notes.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -47,6 +47,7 @@ This pack is positioned as the next architecture layer above:
 13. `13-production-gap-closure-master-plan-2026-03-03.md`
 14. `14-legacy-gap-disposition-map-2026-03-03.md`
 15. `15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`
+16. `17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md`
 
 ## Recommended Build Order
 
@@ -65,6 +66,7 @@ This pack is positioned as the next architecture layer above:
 13. `13-production-gap-closure-master-plan-2026-03-03.md`
 14. `14-legacy-gap-disposition-map-2026-03-03.md`
 15. `15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`
+16. `17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md`
 
 ## Why This Sequence
 

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -173,8 +173,21 @@ def _clone_positions(positions: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def _split_emergency_stop_reasons(raw: str | None) -> list[str]:
     if not raw:
         return []
-    parts = [part.strip() for part in raw.split(";")]
-    return [part for part in parts if part]
+    return _merge_emergency_stop_reasons(raw.split(";"))
+
+
+def _merge_emergency_stop_reasons(reason_groups: Sequence[str]) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for reason in reason_groups:
+        normalized = reason.strip()
+        if not normalized:
+            continue
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        merged.append(normalized)
+    return merged
 
 
 def _is_recoverable_emergency_stop_reason(reason: str) -> bool:
@@ -5103,8 +5116,8 @@ class TradingScheduler:
             if not _is_recoverable_emergency_stop_reason(reason)
         ]
         if nonrecoverable_current_reasons:
-            merged_reasons = sorted(
-                set(latched_reasons + nonrecoverable_current_reasons)
+            merged_reasons = _merge_emergency_stop_reasons(
+                latched_reasons + nonrecoverable_current_reasons
             )
             self.state.emergency_stop_reason = ";".join(merged_reasons)
             self.state.emergency_stop_recovery_streak = 0
@@ -5121,7 +5134,7 @@ class TradingScheduler:
         ]
         if recoverable_current_reasons:
             self.state.emergency_stop_recovery_streak = 0
-            refreshed = ";".join(sorted(set(recoverable_current_reasons)))
+            refreshed = ";".join(_merge_emergency_stop_reasons(recoverable_current_reasons))
             if refreshed and refreshed != self.state.emergency_stop_reason:
                 self.state.emergency_stop_reason = refreshed
             return
@@ -5204,7 +5217,7 @@ class TradingScheduler:
         self.state.emergency_stop_triggered_at = now
         self.state.emergency_stop_resolved_at = None
         self.state.emergency_stop_recovery_streak = 0
-        self.state.emergency_stop_reason = ";".join(reasons)
+        self.state.emergency_stop_reason = ";".join(_merge_emergency_stop_reasons(reasons))
         self.state.metrics.signal_continuity_breach_total += 1
         self.state.last_error = (
             f"emergency_stop_triggered reasons={self.state.emergency_stop_reason}"

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest import TestCase
 
 from app import config
-from app.trading.scheduler import TradingScheduler
+from app.trading.scheduler import TradingScheduler, _split_emergency_stop_reasons
 
 
 class _OrderFirewallStub:
@@ -218,3 +218,47 @@ class TestTradingSchedulerSafety(TestCase):
             self.assertIsNone(scheduler.state.emergency_stop_reason)
             self.assertIsNone(scheduler.state.emergency_stop_triggered_at)
             self.assertEqual(scheduler._pipeline.order_firewall.cancel_all_calls, 0)  # type: ignore[union-attr]
+
+    def test_split_emergency_stop_reasons_ignores_duplicates_and_whitespace(self) -> None:
+        self.assertEqual(
+            _split_emergency_stop_reasons(
+                " signal_lag_exceeded:10 ;signal_lag_exceeded:10;; max_drawdown_exceeded:0.1000 ;  "
+            ),
+            ["signal_lag_exceeded:10", "max_drawdown_exceeded:0.1000"],
+        )
+
+    def test_emergency_stop_recovery_canonicalizes_and_merges_nonrecoverable_reasons(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.settings.trading_autonomy_artifact_dir = tmpdir
+            config.settings.trading_emergency_stop_enabled = True
+            config.settings.trading_emergency_stop_recovery_cycles = 1
+            scheduler = TradingScheduler()
+            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
+            scheduler.state.emergency_stop_active = True
+            scheduler.state.emergency_stop_reason = (
+                " signal_staleness_streak_exceeded:no_signals_in_window ;"
+                "signal_lag_exceeded:7; signal_lag_exceeded:7; "
+            )
+            scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
+            scheduler.state.metrics.signal_lag_seconds = 0
+            scheduler._collect_emergency_stop_reasons = (
+                lambda: (
+                    [
+                        " signal_lag_exceeded:7 ",
+                        "max_drawdown_exceeded:0.1100",
+                        "signal_lag_exceeded:7",
+                    ],
+                    0.0,
+                    None,
+                )
+            )
+
+            scheduler._evaluate_safety_controls()
+
+            self.assertTrue(scheduler.state.emergency_stop_active)
+            self.assertEqual(
+                scheduler.state.emergency_stop_reason,
+                "signal_staleness_streak_exceeded:no_signals_in_window;"
+                "signal_lag_exceeded:7;"
+                "max_drawdown_exceeded:0.1100",
+            )


### PR DESCRIPTION
## Summary

- Added canonical emergency-stop reason normalization and deduplication in `services/torghut/app/trading/scheduler.py` via shared `_merge_emergency_stop_reasons`.
- Applied the normalization helper in parsing, trigger, and recovery paths to make emergency-stop reason trails stable and avoid duplicate reason churn.
- Added regression coverage in `services/torghut/tests/test_trading_scheduler_safety.py` for whitespace/duplicate reason parsing and non-recoverable reason merge behavior.
- Added a new Torghut design artifact: `docs/torghut/design-system/v6/17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md` and referenced it from the v6 design index.

## Related Issues

- `TSK-84` (mission-backed design issue)

## Testing

- `python3 -m pytest services/torghut/tests/test_trading_scheduler_safety.py services/torghut/tests/test_db.py -q` (failed: host environment missing pytest)
- `python3 -m venv /tmp/torghut-venv && /tmp/torghut-venv/bin/pip install -q fastapi uvicorn[standard] pydantic pydantic-settings sqlalchemy psycopg-binary psycopg numpy pandas openai dspy-ai kafka-python lz4 alembic pyyaml inngest pytz alpaca-py`
- `python3 -m pip install -q pytest` (failed in host environment: externally-managed, Python policy prevents global install)
- `cd /workspace/lab && /tmp/torghut-venv/bin/python -m pytest services/torghut/tests/test_trading_scheduler_safety.py services/torghut/tests/test_db.py -q`
- `/tmp/torghut-venv/bin/python -m ruff check services/torghut/app/trading/scheduler.py services/torghut/tests/test_trading_scheduler_safety.py`
- `/tmp/torghut-venv/bin/pyright --project pyrightconfig.json`
- `/tmp/torghut-venv/bin/pyright --project pyrightconfig.alpha.json` (baseline unresolved import/type failures in unrelated modules under current environment)
- `/tmp/torghut-venv/bin/pyright --project pyrightconfig.scripts.json` (baseline unresolved import/type failures in unrelated scripts)

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
