### PR TITLE
feat(jangar): add control-plane cache freshness contract

### DIFF
--- a/docs/agents/designs/control-plane-cache-freshness-contract.md
+++ b/docs/agents/designs/control-plane-cache-freshness-contract.md
@@ -1,0 +1,91 @@
+# Control Plane Cache Freshness Contract
+
+Status: Draft (2026-03-04)
+
+Docs index: [README](../README.md)
+
+## Current State
+
+- `/api/agents/control-plane/resource` and `/api/agents/control-plane/resources` can read from `agents_control_plane.resources_current` when `JANGAR_CONTROL_PLANE_CACHE_ENABLED` is on.
+- Cache responses currently return only the snapshot JSON document with no freshness metadata.
+- If the database cache lags, operators cannot distinguish a stale hit from a current hit.
+- Cache stale behavior is implicit; there is no explicit policy for when stale records should be rejected.
+
+## Problem
+
+- High-confidence control-plane operations (resource fetch/list) can return silently stale state.
+- Incident triage is harder because API consumers see unexpected drift without signal.
+- `agents_control_plane.resources_current` has no explicit freshness contract surfaced to HTTP clients, so clients cannot decide whether to accept cache data or force live reads.
+
+## Goals
+
+- Provide deterministic cache freshness metadata for GET/list control-plane routes.
+- Keep cache as default read path while allowing strict deployments to require live reads.
+- Ensure no change in default runtime behavior without explicit configuration.
+
+## Design
+
+- Add `services/jangar/src/server/control-plane-cache-freshness.ts` with:
+  - cache window configuration via `JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS` (seconds),
+  - stale-policy configuration via `JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE` (default `true`),
+  - shared freshness evaluation helper and response serialization helper.
+- Extend cache store reads to return timestamp metadata (`last_seen_at`, `updated_at`, `resource_updated_at`) with every resource row:
+  - `services/jangar/src/server/control-plane-cache-store.ts`
+- Update API handlers:
+  - `/api/agents/control-plane/resource`:
+    - return `cache` metadata when serving cached records;
+    - if stale and strict mode disabled (`ALLOW_STALE=false`), fall back to Kubernetes live read.
+  - `/api/agents/control-plane/resources`:
+    - evaluate stale state per cached row;
+    - return aggregate cache metadata (`stale_count`, `oldest_age_seconds`) when cached data is used;
+    - if strict mode is disabled and any row is stale, fall back to live list.
+- Add regression tests for cache freshness and strict fallback:
+  - `services/jangar/src/server/__tests__/agents-control-plane-resource.test.ts`
+  - `services/jangar/src/server/__tests__/agents-control-plane-resources.test.ts`
+
+## Alternatives and tradeoffs
+
+- A) Serve stale cache only (current behavior).  
+  - Pro: no extra DB/Kubernetes roundtrips.  
+  - Con: no freshness signal; stale drift remains invisible.
+- B) Always serve cache with explicit metadata (chosen).  
+  - Pro: preserves throughput, surfaces freshness risk, easy rollback via env toggle.  
+  - Con: stale data still possible when `ALLOW_STALE=true`; requires consumers to use metadata.
+- C) Always require live Kubernetes read when stale.  
+  - Pro: strongest freshness guarantee.  
+  - Con: higher control-plane API latency during watch lag/failures.
+- D) Add a separate "cache refresh required" endpoint and two-phase reads.  
+  - Pro: clear operator control.  
+  - Con: extra API surface and client complexity.
+
+## Source and migration considerations
+
+- Database schema is unchanged; freshness uses existing `last_seen_at`.
+- `services/jangar/src/server/migrations/20260205_agents_control_plane_cache.ts` already persists `last_seen_at` and can support this contract without migration.
+- No generated file changes required.
+
+## Risks
+
+- Clients that expect untyped response shape might treat the additional `cache` field as unknown but should ignore it.
+- Strict mode (`ALLOW_STALE=false`) can increase response latency if cache rows are behind.
+- If cluster clocks are skewed, freshness age calculations may be noisy.
+
+## Validation
+
+- Confirm stale records include `cache.stale=true` and configured age thresholds in response payload.
+- Verify `ALLOW_STALE=false` forces live reads when cached records are stale.
+- Confirm list endpoint returns cache metadata and fallback to live list when configured.
+- Confirm no production behavior change for default configuration except added metadata.
+
+## Handoff Appendix (Repo + Chart + Cluster)
+
+### Source of truth
+
+- Control-plane API routes: `services/jangar/src/routes/api/agents/control-plane/resource.ts`, `services/jangar/src/routes/api/agents/control-plane/resources.ts`
+- Cache store + freshness: `services/jangar/src/server/control-plane-cache-store.ts`, `services/jangar/src/server/control-plane-cache-freshness.ts`
+- Tests: `services/jangar/src/server/__tests__/agents-control-plane-resource.test.ts`, `services/jangar/src/server/__tests__/agents-control-plane-resources.test.ts`
+
+### Handoff notes
+
+- Rollout path: merge into `main` and validate via standard CI checks.
+- If freshness signaling is needed downstream, update UI or clients to read `cache.stale` and `cache.age_seconds`.

--- a/services/jangar/src/routes/api/agents/control-plane/resource.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/resource.ts
@@ -14,6 +14,11 @@ import {
 import { createKubernetesClient } from '~/server/primitives-kube'
 import { createPrimitivesStore } from '~/server/primitives-store'
 import { createKubectlWatchStream } from '~/server/primitives-watch'
+import {
+  buildCacheFreshnessState,
+  cacheStateToResponse,
+  resolveCacheFreshnessConfig,
+} from '~/server/control-plane-cache-freshness'
 
 export const Route = createFileRoute('/api/agents/control-plane/resource')({
   server: {
@@ -44,6 +49,11 @@ export const getPrimitiveResource = async (
   const kube = deps.kubeClient ?? createKubernetesClient()
   const stream = url.searchParams.get('stream') === 'true' || url.searchParams.get('stream') === '1'
 
+  const resolveCacheEnabled = () => {
+    const cacheFlag = (process.env.JANGAR_CONTROL_PLANE_CACHE_ENABLED ?? '').trim().toLowerCase()
+    return cacheFlag === '1' || cacheFlag === 'true' || cacheFlag === 'yes' || cacheFlag === 'on'
+  }
+
   try {
     if (stream) {
       const args = ['get', resolved.resource, name, '-n', namespace, '-o', 'json', '--watch', '--output-watch-events']
@@ -70,8 +80,7 @@ export const getPrimitiveResource = async (
       })
     }
 
-    const cacheFlag = (process.env.JANGAR_CONTROL_PLANE_CACHE_ENABLED ?? '').trim().toLowerCase()
-    const cacheEnabled = cacheFlag === '1' || cacheFlag === 'true' || cacheFlag === 'yes' || cacheFlag === 'on'
+    const cacheEnabled = resolveCacheEnabled()
     const cacheKinds = new Set([
       'Agent',
       'AgentRun',
@@ -84,12 +93,25 @@ export const getPrimitiveResource = async (
     if (cacheEnabled && cacheKinds.has(resolved.kind)) {
       const cluster = (process.env.JANGAR_CONTROL_PLANE_CACHE_CLUSTER ?? 'default').trim() || 'default'
       let store: ReturnType<typeof createControlPlaneCacheStore> | null = null
+      const cacheConfig = resolveCacheFreshnessConfig()
+      const cacheCheckedAt = new Date()
       try {
         store = createControlPlaneCacheStore()
         await store.ready
         const cached = await store.getResource({ cluster, kind: resolved.kind, namespace, name })
         if (cached) {
-          return okResponse({ ok: true, kind: resolved.kind, namespace, resource: cached })
+          const freshness = buildCacheFreshnessState(cached.lastSeenAt, cacheCheckedAt, cacheConfig)
+          if (!freshness.isFresh && !cacheConfig.allowStale) {
+            // Explicitly require live reads when cache data is stale and stale reads are disabled.
+          } else {
+            return okResponse({
+              ok: true,
+              kind: resolved.kind,
+              namespace,
+              resource: cached.resource,
+              cache: cacheStateToResponse(freshness),
+            })
+          }
         }
       } catch {
         // Fall back to kubectl get for transient DB issues.

--- a/services/jangar/src/routes/api/agents/control-plane/resources.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/resources.ts
@@ -4,6 +4,11 @@ import { resolvePrimitiveKind } from '~/server/primitives-control-plane'
 import { asRecord, asString, errorResponse, normalizeNamespace, okResponse } from '~/server/primitives-http'
 import { createKubernetesClient } from '~/server/primitives-kube'
 import { createKubectlWatchStream } from '~/server/primitives-watch'
+import {
+  buildCacheFreshnessState,
+  cacheStateToResponse,
+  resolveCacheFreshnessConfig,
+} from '~/server/control-plane-cache-freshness'
 
 export const Route = createFileRoute('/api/agents/control-plane/resources')({
   server: {
@@ -145,6 +150,8 @@ export const listPrimitiveResources = async (
 
     if (canUseCache) {
       const cluster = (process.env.JANGAR_CONTROL_PLANE_CACHE_CLUSTER ?? 'default').trim() || 'default'
+      const cacheCheckedAt = new Date()
+      const cacheConfig = resolveCacheFreshnessConfig()
       let store: ReturnType<typeof createControlPlaneCacheStore> | null = null
       try {
         store = createControlPlaneCacheStore()
@@ -158,13 +165,36 @@ export const listPrimitiveResources = async (
           runtime,
           limit,
         })
-        return okResponse({
-          ok: true,
-          kind: resolved.kind,
-          namespace,
-          total: result.total,
-          items: result.items,
-        })
+        const freshnessStates = result.items.map((item) =>
+          buildCacheFreshnessState(item.lastSeenAt, cacheCheckedAt, cacheConfig),
+        )
+        const staleCount = freshnessStates.filter((state) => state.isStale).length
+        if (staleCount > 0 && !cacheConfig.allowStale) {
+          // Explicitly require live reads when cached list has stale rows and stale reads are disabled.
+        } else {
+          const oldestAgeSeconds = freshnessStates.reduce((max, state) => {
+            if (state.ageSeconds == null) return max
+            return Math.max(max, state.ageSeconds)
+          }, 0)
+          const representative = freshnessStates[0] ?? buildCacheFreshnessState(null, cacheCheckedAt, cacheConfig)
+          return okResponse({
+            ok: true,
+            kind: resolved.kind,
+            namespace,
+            total: result.total,
+            items: result.items.map((item) => item.resource),
+            cache: {
+              ...cacheStateToResponse({
+                ...representative,
+                isFresh: staleCount === 0,
+                isStale: staleCount > 0,
+                stale: staleCount > 0,
+              }),
+              stale_count: staleCount,
+              oldest_age_seconds: oldestAgeSeconds,
+            },
+          })
+        }
       } catch {
         // Fall back to kubectl list for unsupported selectors / transient DB issues.
       } finally {

--- a/services/jangar/src/server/__tests__/agents-control-plane-resource.test.ts
+++ b/services/jangar/src/server/__tests__/agents-control-plane-resource.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const cacheStoreMocks = vi.hoisted(() => ({
+  createControlPlaneCacheStore: vi.fn(),
+}))
+
+const kubeClientMocks = vi.hoisted(() => ({
+  createKubernetesClient: vi.fn(),
+}))
+
+vi.mock('~/server/control-plane-cache-store', () => cacheStoreMocks)
+vi.mock('~/server/primitives-kube', async () => {
+  const actual = await vi.importActual<typeof import('~/server/primitives-kube')>('~/server/primitives-kube')
+  return {
+    ...actual,
+    createKubernetesClient: kubeClientMocks.createKubernetesClient,
+  }
+})
+
+import { getPrimitiveResource } from '~/routes/api/agents/control-plane/resource'
+
+const cacheResource = (name: string, lastSeenAt: string) => ({
+  resource: {
+    apiVersion: 'agents.proompteng.ai/v1alpha1',
+    kind: 'Agent',
+    metadata: { name },
+    spec: {},
+    status: {},
+  },
+  lastSeenAt,
+  updatedAt: lastSeenAt,
+  resourceUpdatedAt: lastSeenAt,
+})
+
+describe('agents control-plane resource route', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    delete process.env.JANGAR_CONTROL_PLANE_CACHE_ENABLED
+    delete process.env.JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS
+    delete process.env.JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE
+  })
+
+  it('returns cached resource with freshness metadata when cache is fresh', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-20T00:00:10Z'))
+
+    process.env.JANGAR_CONTROL_PLANE_CACHE_ENABLED = '1'
+    process.env.JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS = '60'
+    process.env.JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE = '1'
+
+    const cachedStore = {
+      ready: Promise.resolve(),
+      close: vi.fn(async () => undefined),
+      getDbNow: vi.fn(async () => new Date()),
+      upsertResource: vi.fn(),
+      markDeleted: vi.fn(),
+      markNotSeenSince: vi.fn(),
+      getResource: vi.fn(async () => cacheResource('agent-a', '2026-01-20T00:00:08Z')),
+      listResources: vi.fn(),
+    }
+    cacheStoreMocks.createControlPlaneCacheStore.mockReturnValue(cachedStore)
+    const kube = {
+      get: vi.fn(async () => ({ status: 'miss', metadata: { name: 'agent-a' } })),
+    }
+    kubeClientMocks.createKubernetesClient.mockReturnValue(kube)
+
+    const response = await getPrimitiveResource(
+      new Request('http://localhost/api/agents/control-plane/resource?kind=Agent&name=agent-a&namespace=agents'),
+      { kubeClient: kube },
+    )
+
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.ok).toBe(true)
+    expect(payload.kind).toBe('Agent')
+    expect(payload.cache).toMatchObject({
+      source: 'control-plane-cache',
+      stale: false,
+      fresh: true,
+      max_age_seconds: 60,
+    })
+    expect(payload.resource).toMatchObject({ apiVersion: 'agents.proompteng.ai/v1alpha1', kind: 'Agent' })
+  })
+
+  it('falls back to Kubernetes when cached resource is stale and stale reads are disabled', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-20T00:02:00Z'))
+
+    process.env.JANGAR_CONTROL_PLANE_CACHE_ENABLED = '1'
+    process.env.JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS = '30'
+    process.env.JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE = 'false'
+
+    const cachedStore = {
+      ready: Promise.resolve(),
+      close: vi.fn(async () => undefined),
+      getDbNow: vi.fn(async () => new Date()),
+      upsertResource: vi.fn(),
+      markDeleted: vi.fn(),
+      markNotSeenSince: vi.fn(),
+      getResource: vi.fn(async () => cacheResource('agent-a', '2026-01-20T00:01:00Z')),
+      listResources: vi.fn(),
+    }
+    cacheStoreMocks.createControlPlaneCacheStore.mockReturnValue(cachedStore)
+    const kube = {
+      get: vi.fn(async () => ({
+        apiVersion: 'agents.proompteng.ai/v1alpha1',
+        kind: 'Agent',
+        metadata: { name: 'agent-a' },
+        spec: {},
+        status: {},
+      })),
+    }
+    kubeClientMocks.createKubernetesClient.mockReturnValue(kube)
+
+    const response = await getPrimitiveResource(
+      new Request('http://localhost/api/agents/control-plane/resource?kind=Agent&name=agent-a&namespace=agents'),
+      { kubeClient: kube },
+    )
+
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.ok).toBe(true)
+    expect(payload.kind).toBe('Agent')
+    expect(payload.resource).toMatchObject({ apiVersion: 'agents.proompteng.ai/v1alpha1' })
+    expect(payload).not.toHaveProperty('cache')
+    expect(kube.get).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/jangar/src/server/__tests__/agents-control-plane-resources.test.ts
+++ b/services/jangar/src/server/__tests__/agents-control-plane-resources.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const cacheStoreMocks = vi.hoisted(() => ({
+  createControlPlaneCacheStore: vi.fn(),
+}))
+
+const kubeClientMocks = vi.hoisted(() => ({
+  createKubernetesClient: vi.fn(),
+}))
+
+vi.mock('~/server/control-plane-cache-store', () => cacheStoreMocks)
+vi.mock('~/server/primitives-kube', async () => {
+  const actual = await vi.importActual<typeof import('~/server/primitives-kube')>('~/server/primitives-kube')
+  return {
+    ...actual,
+    createKubernetesClient: kubeClientMocks.createKubernetesClient,
+  }
+})
+
+import { listPrimitiveResources } from '~/routes/api/agents/control-plane/resources'
+
+const cacheResource = (name: string, lastSeenAt: string) => ({
+  resource: {
+    apiVersion: 'agents.proompteng.ai/v1alpha1',
+    kind: 'Agent',
+    metadata: { name },
+    spec: {},
+    status: {},
+  },
+  lastSeenAt,
+  updatedAt: lastSeenAt,
+  resourceUpdatedAt: lastSeenAt,
+})
+
+describe('agents control-plane resources route', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    delete process.env.JANGAR_CONTROL_PLANE_CACHE_ENABLED
+    delete process.env.JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS
+    delete process.env.JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE
+  })
+
+  it('returns cached list with freshness metadata when cache is fresh', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-20T00:00:40Z'))
+
+    process.env.JANGAR_CONTROL_PLANE_CACHE_ENABLED = 'on'
+    process.env.JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS = '60'
+    process.env.JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE = '1'
+
+    const cachedStore = {
+      ready: Promise.resolve(),
+      close: vi.fn(async () => undefined),
+      getDbNow: vi.fn(async () => new Date()),
+      upsertResource: vi.fn(),
+      markDeleted: vi.fn(),
+      markNotSeenSince: vi.fn(),
+      getResource: vi.fn(),
+      listResources: vi.fn(async () => ({
+        total: 2,
+        items: [cacheResource('agent-a', '2026-01-20T00:00:20Z'), cacheResource('agent-b', '2026-01-20T00:00:30Z')],
+      })),
+    }
+    cacheStoreMocks.createControlPlaneCacheStore.mockReturnValue(cachedStore)
+    const kube = {
+      list: vi.fn(async () => ({ items: [] })),
+    }
+    kubeClientMocks.createKubernetesClient.mockReturnValue(kube)
+
+    const response = await listPrimitiveResources(
+      new Request('http://localhost/api/agents/control-plane/resources?kind=Agent&namespace=agents'),
+      { kubeClient: kube },
+    )
+
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.ok).toBe(true)
+    expect(payload.kind).toBe('Agent')
+    expect(payload.total).toBe(2)
+    expect(payload.cache).toMatchObject({ source: 'control-plane-cache', stale: false, stale_count: 0 })
+    expect(Array.isArray(payload.items)).toBe(true)
+    expect(kube.list).not.toHaveBeenCalled()
+  })
+
+  it('falls back to Kubernetes list when cache has stale rows and stale reads are disabled', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-20T00:03:00Z'))
+
+    process.env.JANGAR_CONTROL_PLANE_CACHE_ENABLED = 'on'
+    process.env.JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS = '60'
+    process.env.JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE = 'false'
+
+    const cachedStore = {
+      ready: Promise.resolve(),
+      close: vi.fn(async () => undefined),
+      getDbNow: vi.fn(async () => new Date()),
+      upsertResource: vi.fn(),
+      markDeleted: vi.fn(),
+      markNotSeenSince: vi.fn(),
+      getResource: vi.fn(),
+      listResources: vi.fn(async () => ({
+        total: 1,
+        items: [cacheResource('agent-a', '2026-01-20T00:01:00Z')],
+      })),
+    }
+    cacheStoreMocks.createControlPlaneCacheStore.mockReturnValue(cachedStore)
+    const kube = {
+      list: vi.fn(async () => ({
+        items: [{ kind: 'Agent', metadata: { name: 'agent-live' }, spec: {}, status: {} }],
+      })),
+    }
+    kubeClientMocks.createKubernetesClient.mockReturnValue(kube)
+
+    const response = await listPrimitiveResources(
+      new Request('http://localhost/api/agents/control-plane/resources?kind=Agent&namespace=agents'),
+      { kubeClient: kube },
+    )
+
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.ok).toBe(true)
+    expect(payload.cache).toBeUndefined()
+    expect(payload.total).toBe(1)
+    expect(Array.isArray(payload.items)).toBe(true)
+    expect((payload.items as Array<Record<string, unknown>>)[0]?.metadata?.name).toBe('agent-live')
+    expect(kube.list).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/jangar/src/server/control-plane-cache-freshness.ts
+++ b/services/jangar/src/server/control-plane-cache-freshness.ts
@@ -1,0 +1,93 @@
+const CACHE_STALE_SECONDS_DEFAULT = 120
+const CACHE_BOOL_TRUE = new Set(['1', 'true', 'yes', 'on', 'enabled'])
+
+type TimestampValue = string | Date | null | undefined
+
+export type CacheFreshnessConfig = {
+  maxAgeSeconds: number
+  allowStale: boolean
+}
+
+export type CacheFreshnessState = {
+  isFresh: boolean
+  isStale: boolean
+  stale: boolean
+  maxAgeSeconds: number
+  asOf: string | null
+  checkedAt: string
+  ageSeconds: number | null
+}
+
+const parseBoolean = (value: string | undefined) => {
+  if (!value) return null
+  return CACHE_BOOL_TRUE.has(value.trim().toLowerCase())
+}
+
+const parsePositiveSeconds = (value: string | undefined, fallback: number) => {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value.trim(), 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  return parsed
+}
+
+const parseTimestamp = (value: TimestampValue) => {
+  if (!value) return null
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value
+  if (value instanceof Date) return null
+  const normalized = new Date(value)
+  if (Number.isNaN(normalized.getTime())) return null
+  return normalized
+}
+
+export const resolveCacheFreshnessConfig = (): CacheFreshnessConfig => ({
+  maxAgeSeconds: parsePositiveSeconds(
+    process.env.JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS,
+    CACHE_STALE_SECONDS_DEFAULT,
+  ),
+  allowStale: parseBoolean(process.env.JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE) ?? true,
+})
+
+export const buildCacheFreshnessState = (
+  lastSeenAt: TimestampValue,
+  checkedAt = new Date(),
+  config: CacheFreshnessConfig = resolveCacheFreshnessConfig(),
+): CacheFreshnessState => {
+  const parsed = parseTimestamp(lastSeenAt)
+  const maxAgeMs = config.maxAgeSeconds * 1000
+  const checkedIso = checkedAt.toISOString()
+  if (!parsed) {
+    return {
+      isFresh: false,
+      isStale: true,
+      stale: true,
+      maxAgeSeconds: config.maxAgeSeconds,
+      asOf: null,
+      checkedAt: checkedIso,
+      ageSeconds: null,
+    }
+  }
+
+  const ageMs = checkedAt.getTime() - parsed.getTime()
+  const ageSeconds = ageMs > 0 ? Math.floor(ageMs / 1000) : 0
+
+  const isFresh = ageMs >= 0 && ageMs <= maxAgeMs
+  return {
+    isFresh,
+    isStale: !isFresh,
+    stale: !isFresh,
+    maxAgeSeconds: config.maxAgeSeconds,
+    asOf: parsed.toISOString(),
+    checkedAt: checkedIso,
+    ageSeconds,
+  }
+}
+
+export const cacheStateToResponse = (state: CacheFreshnessState) => ({
+  source: 'control-plane-cache',
+  age_seconds: state.ageSeconds,
+  max_age_seconds: state.maxAgeSeconds,
+  as_of: state.asOf,
+  checked_at: state.checkedAt,
+  stale: state.stale,
+  fresh: state.isFresh,
+})

--- a/services/jangar/src/server/control-plane-cache-store.ts
+++ b/services/jangar/src/server/control-plane-cache-store.ts
@@ -20,6 +20,13 @@ export type ControlPlaneCacheResource = {
   status: Record<string, unknown>
 }
 
+export type ControlPlaneCacheResourceRow = {
+  resource: ControlPlaneCacheResource
+  lastSeenAt: Timestamp | null
+  updatedAt: Timestamp | null
+  resourceUpdatedAt: Timestamp | null
+}
+
 export type UpsertControlPlaneCacheResourceInput = {
   key: ControlPlaneCacheKey
   uid: string | null
@@ -59,9 +66,9 @@ export type ControlPlaneCacheStore = {
   upsertResource: (input: UpsertControlPlaneCacheResourceInput) => Promise<void>
   markDeleted: (key: ControlPlaneCacheKey) => Promise<void>
   markNotSeenSince: (input: { cluster: string; kind: string; namespace: string; since: Timestamp }) => Promise<void>
-  getResource: (key: ControlPlaneCacheKey) => Promise<ControlPlaneCacheResource | null>
+  getResource: (key: ControlPlaneCacheKey) => Promise<ControlPlaneCacheResourceRow | null>
   listResources: (input: ListControlPlaneCacheResourcesInput) => Promise<{
-    items: ControlPlaneCacheResource[]
+    items: ControlPlaneCacheResourceRow[]
     total: number
   }>
 }
@@ -203,7 +210,7 @@ export const createControlPlaneCacheStore = (options: StoreOptions = {}): Contro
     await ready
     const row = await db
       .selectFrom('agents_control_plane.resources_current')
-      .select(['resource'])
+      .select(['resource', 'last_seen_at', 'updated_at', 'resource_updated_at'])
       .where('cluster', '=', key.cluster)
       .where('kind', '=', key.kind)
       .where('namespace', '=', key.namespace)
@@ -211,7 +218,12 @@ export const createControlPlaneCacheStore = (options: StoreOptions = {}): Contro
       .where('deleted_at', 'is', null)
       .executeTakeFirst()
     if (!row) return null
-    return row.resource as unknown as ControlPlaneCacheResource
+    return {
+      resource: row.resource as unknown as ControlPlaneCacheResource,
+      lastSeenAt: row.last_seen_at,
+      updatedAt: row.updated_at,
+      resourceUpdatedAt: row.resource_updated_at,
+    }
   }
 
   const listResources: ControlPlaneCacheStore['listResources'] = async (input) => {
@@ -244,7 +256,10 @@ export const createControlPlaneCacheStore = (options: StoreOptions = {}): Contro
     const [{ count }] = await base.select((eb) => eb.fn.countAll<string>().as('count')).execute()
     const total = Number.parseInt(count ?? '0', 10) || 0
 
-    let list = base.select(['resource']).orderBy('resource_updated_at', 'desc').orderBy('name', 'asc')
+    let list = base
+      .select(['resource', 'last_seen_at', 'updated_at', 'resource_updated_at'])
+      .orderBy('resource_updated_at', 'desc')
+      .orderBy('name', 'asc')
 
     if (limit) {
       list = list.limit(limit)
@@ -253,7 +268,12 @@ export const createControlPlaneCacheStore = (options: StoreOptions = {}): Contro
     const rows = await list.execute()
     return {
       total,
-      items: rows.map((row) => row.resource as unknown as ControlPlaneCacheResource),
+      items: rows.map((row) => ({
+        resource: row.resource as unknown as ControlPlaneCacheResource,
+        lastSeenAt: row.last_seen_at,
+        updatedAt: row.updated_at,
+        resourceUpdatedAt: row.resource_updated_at,
+      })),
     }
   }
 


### PR DESCRIPTION
## Summary

- Add explicit cache freshness evaluation and contract metadata for control-plane resource endpoints.
- Extend cache store reads to carry freshness timestamps (`last_seen_at`, `updated_at`, `resource_updated_at`) so API handlers can classify stale data.
- Add regression tests for fresh cache responses and strict stale fallback behavior to Kubernetes live reads.

## Related Issues

- TSK-90 (design-and-implementation mission issue)

## Testing

- `bun run --filter @proompteng/jangar lint`
- `bunx oxfmt --write services/jangar/src/routes/api/agents/control-plane/resource.ts services/jangar/src/routes/api/agents/control-plane/resources.ts services/jangar/src/server/__tests__/agents-control-plane-resource.test.ts services/jangar/src/server/__tests__/agents-control-plane-resources.test.ts services/jangar/src/server/control-plane-cache-freshness.ts`
- `bun run --filter @proompteng/jangar lint` (post-format)
- `cd services/jangar && bunx oxlint --config ../../.oxlintrc.json src/routes/api/agents/control-plane/resource.ts src/routes/api/agents/control-plane/resources.ts src/server/control-plane-cache-store.ts src/server/control-plane-cache-freshness.ts src/server/__tests__/agents-control-plane-resource.test.ts src/server/__tests__/agents-control-plane-resources.test.ts`
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/agents-control-plane-resource.test.ts src/server/__tests__/agents-control-plane-resources.test.ts` *(blocked in this environment: `vitest`/`tsc` pretest toolchain missing; execution deferred to CI)*

## Breaking Changes

None.

