### PR TITLE
fix(argocd): align agents chart pin with rendered chart version

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -42,5 +42,5 @@ helmCharts:
     releaseName: agents
     namespace: agents
     valuesFile: values.yaml
-    version: 0.9.1
+    version: 0.9.4
     includeCRDs: true


### PR DESCRIPTION
## Summary

- Updated `argocd/applications/agents/kustomization.yaml` Helm chart pin from `0.9.1` to `0.9.4`.
- Aligned ArgoCD chart resolution with the in-repo `charts/agents` version to avoid stale CRD rendering.
- Unblocked `agents` app sync attempts that were failing on an outdated CRD CEL validation rule.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
