### PR TITLE
feat(torghut): add dependency-aware /readyz for readiness probes

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -424,7 +424,7 @@ spec:
               port: http1
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http1
           resources:
             requests:

--- a/docs/torghut/design-system/v6/18-trading-readiness-and-rollout-stability-2026-03-04.md
+++ b/docs/torghut/design-system/v6/18-trading-readiness-and-rollout-stability-2026-03-04.md
@@ -1,0 +1,55 @@
+# 17. Trading Readiness and Rollout Stability Through Dependency-aware `/readyz` (2026-03-04)
+
+## Context
+
+- Rollout events observed repeated readiness/liveness instability on `torghut` pods:
+  - `Readiness probe failed: ...:8012/` timeouts.
+  - `Liveness probe failed: GET ...:8181/healthz` connection-refused.
+- The service already exposes a dependency-aware `/trading/health` endpoint but Knative routes both liveness and readiness probes to `/healthz`, which only returns static `{"status":"ok","service":"torghut"}`.
+- Source and architecture review also found duplicated allocator configuration aliases in `services/torghut/app/config.py`, a future maintainability hazard that is noted for later cleanup.
+
+## Design Decision
+
+Introduce `/readyz` as a reusable, dependency-aware readiness contract and map Knative `readinessProbe` to this endpoint while keeping `/healthz` unchanged for liveness.
+
+### Implementation
+
+1. Add shared helper:
+  - `services/torghut/app/main.py: _evaluate_trading_health_payload(session)`
+  - Centralizes scheduler/dependency evaluation currently in `/trading/health`.
+2. Add endpoint:
+  - `GET /readyz` (same payload and 503/200 status behavior as `/trading/health`).
+3. Update Knative readiness probe:
+  - `services/torghut/argocd/applications/torghut/knative-service.yaml`
+  - `readinessProbe.httpGet.path: /readyz`.
+4. Add regression tests:
+  - `services/torghut/tests/test_trading_api.py`
+  - covers `/readyz` success and dependency-failure behavior.
+
+## Alternatives Considered
+
+- **Option A (Selected): Add `/readyz` and keep `/healthz` unchanged**
+  - Pros: minimal surface area, preserves existing liveness contract, reduces blast radius for rollouts.
+  - Cons: `/trading/health` and `/readyz` remain duplicate outputs; can be merged later.
+- **Option B: Promote `/trading/health` to readiness and drop `/readyz`**
+  - Pros: zero new endpoint.
+  - Cons: semantically couples public trading-health API with K8s probe contract and increases accidental API change risk.
+- **Option C: Keep current probe target**
+  - Pros: no manifest changes.
+  - Cons: no improvement to readiness signal quality and no reduction in rollout flaps.
+
+## Tradeoffs
+
+- Readiness now depends on dependency checks (Postgres/ClickHouse/Alpaca + scheduler state), which is safer for rollout but can fail readiness under transient upstream outages.
+- Liveness remains low-fidelity by design, so container restarts are still guarded by separate kubelet policies and do not depend on external systems.
+
+## Acceptance Criteria
+
+- Kubernetes readiness transitions to healthy only when `/readyz` returns 200.
+- `/readyz` returns the same dependency status shape and status-code semantics currently used by `/trading/health`.
+- Unit tests cover both healthy and degraded readiness conditions.
+
+## Rollback Plan
+
+- Revert only `argocd/applications/torghut/knative-service.yaml` readiness path to `/healthz`.
+- Optionally keep `/readyz` endpoint and tests in place as a no-op diagnostic route if probe behavior must be stabilized quickly.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -47,7 +47,9 @@ This pack is positioned as the next architecture layer above:
 13. `13-production-gap-closure-master-plan-2026-03-03.md`
 14. `14-legacy-gap-disposition-map-2026-03-03.md`
 15. `15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`
-16. `17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md`
+16. `16-dspy-llm-live-gate-root-cause-and-rollout-2026-03-04.md`
+17. `17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md`
+18. `18-trading-readiness-and-rollout-stability-2026-03-04.md`
 
 ## Recommended Build Order
 
@@ -66,7 +68,9 @@ This pack is positioned as the next architecture layer above:
 13. `13-production-gap-closure-master-plan-2026-03-03.md`
 14. `14-legacy-gap-disposition-map-2026-03-03.md`
 15. `15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`
-16. `17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md`
+16. `16-dspy-llm-live-gate-root-cause-and-rollout-2026-03-04.md`
+17. `17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md`
+18. `18-trading-readiness-and-rollout-stability-2026-03-04.md`
 
 ## Why This Sequence
 

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -271,6 +271,64 @@ def healthz() -> dict[str, str]:
     return {"status": "ok", "service": "torghut"}
 
 
+def _evaluate_trading_health_payload(
+    session: Session,
+) -> tuple[dict[str, object], int]:
+    """Build shared trading health payload and status code."""
+
+    scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
+    if scheduler is None:
+        scheduler = TradingScheduler()
+        app.state.trading_scheduler = scheduler
+
+    scheduler_ok = True
+    scheduler_detail = "ok"
+    if settings.trading_enabled and not scheduler.state.running:
+        scheduler_ok = False
+        if scheduler.state.last_run_at is None:
+            scheduler_detail = "trading loop not started"
+        else:
+            scheduler_detail = "trading loop not running"
+
+    postgres_status = _check_postgres(session)
+    if settings.trading_enabled:
+        clickhouse_status = _check_clickhouse()
+        alpaca_status = _check_alpaca()
+    else:
+        clickhouse_status = {"ok": True, "detail": "skipped (trading disabled)"}
+        alpaca_status = {"ok": True, "detail": "skipped (trading disabled)"}
+
+    dependencies = {
+        "postgres": postgres_status,
+        "clickhouse": clickhouse_status,
+        "alpaca": alpaca_status,
+    }
+
+    overall_ok = scheduler_ok and all(dep["ok"] for dep in dependencies.values())
+    status = "ok" if overall_ok else "degraded"
+    status_code = 200 if overall_ok else 503
+
+    return (
+        {
+            "status": status,
+            "scheduler": {"ok": scheduler_ok, "detail": scheduler_detail},
+            "dependencies": dependencies,
+        },
+        status_code,
+    )
+
+
+@app.get("/readyz")
+def readyz(session: Session = Depends(get_session)) -> JSONResponse:
+    """Readiness endpoint with dependency-aware status for rollout safety."""
+
+    payload, status_code = _evaluate_trading_health_payload(session)
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonable_encoder(payload),
+    )
+
+
 @app.get("/")
 def root() -> dict[str, str]:
     """Surface service identity and build metadata."""
@@ -1240,43 +1298,7 @@ def trading_tca(
 def trading_health(session: Session = Depends(get_session)) -> JSONResponse:
     """Trading loop health including dependency readiness."""
 
-    scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
-    if scheduler is None:
-        scheduler = TradingScheduler()
-        app.state.trading_scheduler = scheduler
-    scheduler_ok = True
-    scheduler_detail = "ok"
-    if settings.trading_enabled and not scheduler.state.running:
-        scheduler_ok = False
-        if scheduler.state.last_run_at is None:
-            scheduler_detail = "trading loop not started"
-        else:
-            scheduler_detail = "trading loop not running"
-
-    postgres_status = _check_postgres(session)
-    if settings.trading_enabled:
-        clickhouse_status = _check_clickhouse()
-        alpaca_status = _check_alpaca()
-    else:
-        clickhouse_status = {"ok": True, "detail": "skipped (trading disabled)"}
-        alpaca_status = {"ok": True, "detail": "skipped (trading disabled)"}
-
-    dependencies = {
-        "postgres": postgres_status,
-        "clickhouse": clickhouse_status,
-        "alpaca": alpaca_status,
-    }
-
-    overall_ok = scheduler_ok and all(dep["ok"] for dep in dependencies.values())
-    status = "ok" if overall_ok else "degraded"
-
-    payload = {
-        "status": status,
-        "scheduler": {"ok": scheduler_ok, "detail": scheduler_detail},
-        "dependencies": dependencies,
-    }
-
-    status_code = 200 if overall_ok else 503
+    payload, status_code = _evaluate_trading_health_payload(session)
     return JSONResponse(status_code=status_code, content=jsonable_encoder(payload))
 
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -373,6 +373,49 @@ class TestTradingApi(TestCase):
         finally:
             settings.trading_enabled = original
 
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
+    def test_readyz_returns_200_when_dependencies_are_healthy(
+        self, _mock_clickhouse: object, _mock_alpaca: object
+    ) -> None:
+        original = settings.trading_enabled
+        settings.trading_enabled = True
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = True
+            scheduler.state.last_run_at = datetime.now(timezone.utc)
+            app.state.trading_scheduler = scheduler
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["status"], "ok")
+            self.assertTrue(payload["dependencies"]["postgres"]["ok"])
+            self.assertTrue(payload["dependencies"]["clickhouse"]["ok"])
+            self.assertTrue(payload["dependencies"]["alpaca"]["ok"])
+        finally:
+            settings.trading_enabled = original
+
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_postgres", return_value={"ok": False, "detail": "down"})
+    def test_readyz_returns_503_when_dependency_degraded(
+        self, _mock_postgres: object, _mock_alpaca: object
+    ) -> None:
+        original = settings.trading_enabled
+        settings.trading_enabled = True
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = True
+            scheduler.state.last_run_at = datetime.now(timezone.utc)
+            app.state.trading_scheduler = scheduler
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 503)
+            payload = response.json()
+            self.assertEqual(payload["status"], "degraded")
+            self.assertFalse(payload["dependencies"]["postgres"]["ok"])
+            self.assertEqual(payload["dependencies"]["postgres"]["detail"], "down")
+        finally:
+            settings.trading_enabled = original
+
     def test_trading_status_includes_llm_evaluation(self) -> None:
         response = self.client.get("/trading/status")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary

- Added a shared health evaluation helper in `services/torghut/app/main.py` and introduced `GET /readyz` as a dependency-aware readiness endpoint for rollout-safe probes.
- Wired Knative `readinessProbe` to `readyz` while preserving `/healthz` as liveness-only.
- Added regression coverage in `services/torghut/tests/test_trading_api.py` for readiness healthy/degraded paths and added a v6 design ADR plus index entry for rollout stability.

## Related Issues

- N/A

## Testing

- `cd services/torghut && pyright --project pyrightconfig.json`
- `cd services/torghut && pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && python3 -m pytest tests/test_trading_api.py -k readyz`
- `cd services/torghut && ruff check app/main.py tests/test_trading_api.py`

## Breaking Changes

- None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is omitted because this change is backend and cluster-manifest focused.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
