### PR TITLE
chore(jangar): promote image 7fd72577

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 16cca3db
-  digest: sha256:cfd2b827d75cc0e914d076b9379fe013819dbd61ac619a117acadf4dbf3d8c90
+  tag: 7fd72577
+  digest: sha256:fbe30aae26b24378926ba23b79d77cd0a5f985d3b78e69fb1d4b01e76928e888
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 16cca3db
-    digest: sha256:7d1899ec6f0cd464f64e233fcbb812fec0c011a81712b4fec1baafc17ec1a600
+    tag: 7fd72577
+    digest: sha256:e8eb1eeaaa434af410b16187ab74cdffedcc9665f5b35f93fc8dcba99a57ae49
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 16cca3db
-    digest: sha256:cfd2b827d75cc0e914d076b9379fe013819dbd61ac619a117acadf4dbf3d8c90
+    tag: 7fd72577
+    digest: sha256:fbe30aae26b24378926ba23b79d77cd0a5f985d3b78e69fb1d4b01e76928e888
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-04T07:19:59Z"
+    deploy.knative.dev/rollout: "2026-03-04T07:54:06Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-04T07:19:59Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-04T07:54:06Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "16cca3db"
-    digest: sha256:cfd2b827d75cc0e914d076b9379fe013819dbd61ac619a117acadf4dbf3d8c90
+    newTag: "7fd72577"
+    digest: sha256:fbe30aae26b24378926ba23b79d77cd0a5f985d3b78e69fb1d4b01e76928e888


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `7fd725779e14953822afe916d335503eb63fb587`
- Image tag: `7fd72577`
- Image digest: `sha256:fbe30aae26b24378926ba23b79d77cd0a5f985d3b78e69fb1d4b01e76928e888`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`