### PR TITLE
fix(agents): require engineer doc updates and unblock app sync

### DIFF
--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -43,4 +43,4 @@ helmCharts:
     namespace: agents
     valuesFile: values.yaml
     version: 0.9.4
-    includeCRDs: true
+    includeCRDs: false

--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -142,7 +142,7 @@ spec:
     swarmAgentIdentity: engineer-jangar-implement
     swarmHumanName: engineer
     swarmTeamName: Jangar Engineering
-    objective: grab the system design document, implement high-quality engineering changes, and deliver a production-ready PR
+    objective: grab the system design document, implement high-quality engineering changes, update impacted documentation, and deliver a production-ready PR
     ownerChannel: http://transactor.huly.svc.cluster.local
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
@@ -361,7 +361,7 @@ spec:
     swarmAgentIdentity: engineer-torghut-implement
     swarmHumanName: engineer
     swarmTeamName: Torghut Traders
-    objective: grab the system design document, implement high-quality engineering changes, and deliver a production-ready PR
+    objective: grab the system design document, implement high-quality engineering changes, update impacted documentation, and deliver a production-ready PR
     ownerChannel: http://transactor.huly.svc.cluster.local
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng


### PR DESCRIPTION
## Summary

- Updated both swarm `engineer` objectives to explicitly require documentation updates alongside implementation changes.
- Set `includeCRDs: false` for the agents Helm chart in Argo app kustomization.
- Prevented the known invalid AgentRun CRD CEL rule from blocking app sync while keeping existing CRDs in-cluster.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
