### PR TITLE
chore(jangar): promote image 22dd66d2

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7fd72577
-  digest: sha256:fbe30aae26b24378926ba23b79d77cd0a5f985d3b78e69fb1d4b01e76928e888
+  tag: 22dd66d2
+  digest: sha256:bdb4b42b498660d95b9b3d20df80a6d3efddb58ee5ab7a101664143e372c4045
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7fd72577
-    digest: sha256:e8eb1eeaaa434af410b16187ab74cdffedcc9665f5b35f93fc8dcba99a57ae49
+    tag: 22dd66d2
+    digest: sha256:a8d520093b672a99e0881444e330c7d001769d1148bfa06aeaaa802d6c6c7793
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7fd72577
-    digest: sha256:fbe30aae26b24378926ba23b79d77cd0a5f985d3b78e69fb1d4b01e76928e888
+    tag: 22dd66d2
+    digest: sha256:bdb4b42b498660d95b9b3d20df80a6d3efddb58ee5ab7a101664143e372c4045
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-04T07:54:06Z"
+    deploy.knative.dev/rollout: "2026-03-04T07:59:08Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-04T07:54:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-04T07:59:08Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "7fd72577"
-    digest: sha256:fbe30aae26b24378926ba23b79d77cd0a5f985d3b78e69fb1d4b01e76928e888
+    newTag: "22dd66d2"
+    digest: sha256:bdb4b42b498660d95b9b3d20df80a6d3efddb58ee5ab7a101664143e372c4045


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `22dd66d2ab4fcaeea3b945e6c85667e14c5b3c5d`
- Image tag: `22dd66d2`
- Image digest: `sha256:bdb4b42b498660d95b9b3d20df80a6d3efddb58ee5ab7a101664143e372c4045`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`