### PR TITLE
fix(agents): require fully green checks before deployer merge

### DIFF
--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -206,7 +206,7 @@ spec:
     hulyTrackerUrl: https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues
     hulyRequireDedicatedAccount: "true"
     hulySkillRef: skills/huly-api/SKILL.md
-    objective: merge production-ready Jangar PRs and roll out the merged changes in-cluster via GitOps with health verification
+    objective: merge Jangar PRs only when all required checks pass with no failures; if checks fail, fix them first, then roll out merged changes in-cluster via GitOps with health verification
   vcsRef:
     name: github
   vcsPolicy:
@@ -425,7 +425,7 @@ spec:
     hulyTrackerUrl: https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues
     hulyRequireDedicatedAccount: "true"
     hulySkillRef: skills/huly-api/SKILL.md
-    objective: merge production-ready Torghut PRs and roll out the merged changes in-cluster via GitOps with health verification
+    objective: merge Torghut PRs only when all required checks pass with no failures; if checks fail, fix them first, then roll out merged changes in-cluster via GitOps with health verification
   vcsRef:
     name: github
   vcsPolicy:

--- a/argocd/applications/agents/swarm-implspecs.yaml
+++ b/argocd/applications/agents/swarm-implspecs.yaml
@@ -161,8 +161,9 @@ spec:
     Requirements:
     - Work only on `${head}` based on `${base}` in `${repository}`.
     - Enumerate open PRs, prioritize unblock-first/high-impact, and move each selected PR to mergeable state.
-    - Resolve blocking comments/conflicts and keep required checks green.
-    - Merge via squash when gates are satisfied.
+    - Resolve blocking comments/conflicts and fix failing required checks until every required check is passing.
+    - Never merge while any required check is failing, cancelled, or pending.
+    - Merge via squash only after all required checks are passing with no failures.
     - After merge, verify rollout through GitOps/cluster signals until healthy or explicitly blocked:
       - sync/rollout status
       - workload readiness


### PR DESCRIPTION
## Summary

- Tightened `swarm-deployer-v1` requirements so deployers must fix failing required checks before merge.
- Added an explicit no-merge rule while any required check is failing, cancelled, or pending.
- Updated both verify template objectives (Jangar and Torghut) to require all checks passing with no failures before merge.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
