### PR TITLE
fix(torghut): enforce startup shorts policy and expose shorts metric

### DIFF
--- a/services/torghut/app/metrics.py
+++ b/services/torghut/app/metrics.py
@@ -304,6 +304,10 @@ _SERVICE_LABEL_GAUGES: dict[str, tuple[str, str]] = {
         "torghut_trading_signal_lag_seconds",
         "Latest signal ingestion lag in seconds.",
     ),
+    "trading_shorts_enabled": (
+        "torghut_trading_shorts_enabled",
+        "Whether shorting is currently enabled in runtime configuration.",
+    ),
     "no_signal_streak": (
         "torghut_trading_no_signal_streak",
         "Consecutive no-signal autonomy cycles.",

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -131,8 +131,7 @@ def _merge_emergency_stop_reasons(raw_reasons: Sequence[str]) -> list[str]:
 
 def _is_recoverable_emergency_stop_reason(reason: str) -> bool:
     return any(
-        reason.startswith(prefix)
-        for prefix in _RECOVERABLE_EMERGENCY_STOP_PREFIXES
+        reason.startswith(prefix) for prefix in _RECOVERABLE_EMERGENCY_STOP_PREFIXES
     )
 
 
@@ -140,6 +139,7 @@ def _coerce_recovery_reason_sequence(raw_reasons: Sequence[str] | None) -> list[
     if not raw_reasons:
         return []
     return _merge_emergency_stop_reasons(raw_reasons)
+
 
 _RUNTIME_UNCERTAINTY_DEGRADE_QTY_MULTIPLIER = Decimal("0.50")
 _RUNTIME_UNCERTAINTY_DEGRADE_MAX_PARTICIPATION_RATE = Decimal("0.05")
@@ -207,6 +207,7 @@ def _select_strictest_runtime_uncertainty_gate(
 
 def _clone_positions(positions: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [dict(position) for position in positions]
+
 
 def _normalize_reason_metric(reason: str | None) -> str:
     normalized = reason.strip() if isinstance(reason, str) else ""
@@ -422,6 +423,7 @@ class TradingMetrics:
     )
     no_signal_streak: int = 0
     market_session_open: int = 0
+    trading_shorts_enabled: int = 0
     signal_continuity_actionable: int = 0
     signal_continuity_alert_active: int = 0
     signal_continuity_alert_recovery_streak: int = 0
@@ -2878,7 +2880,9 @@ class TradingPipeline:
         )
         decimal_degrade_threshold = Decimal(str(degrade_threshold))
         decimal_abstain_threshold = Decimal(str(abstain_threshold))
-        return max(decimal_degrade_threshold, decimal_abstain_threshold), decimal_abstain_threshold
+        return max(
+            decimal_degrade_threshold, decimal_abstain_threshold
+        ), decimal_abstain_threshold
 
     def _apply_runtime_uncertainty_gate(
         self,
@@ -4768,6 +4772,42 @@ class TradingScheduler:
         lane = settings.trading_accounts[0]
         return self._build_pipeline_for_account(lane)
 
+    @staticmethod
+    def _coerce_boolean_env_value(env_name: str, value: str) -> bool:
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "t", "yes", "on", "y"}:
+            return True
+        if normalized in {"0", "false", "f", "no", "off", "n"}:
+            return False
+        raise ValueError(
+            f"{env_name} has invalid boolean value: {value!r}; expected one of "
+            "1, true, false, 0, on, off, yes, no"
+        )
+
+    def _assert_trading_shorts_startup_policy(self) -> None:
+        env_name = "TRADING_ALLOW_SHORTS"
+        raw_env_value = os.getenv(env_name)
+        if raw_env_value is None:
+            raise RuntimeError(
+                f"{env_name} must be explicitly set before scheduler startup"
+            )
+
+        configured_env_value = self._coerce_boolean_env_value(env_name, raw_env_value)
+        configured_setting = bool(settings.trading_allow_shorts)
+        if configured_env_value != configured_setting:
+            raise RuntimeError(
+                f"{env_name} resolved to {configured_env_value} but settings value is "
+                f"{configured_setting}; expected a single source of truth"
+            )
+
+        logger.info(
+            "Startup short policy explicit: %s=%s (declared=%s)",
+            env_name,
+            configured_setting,
+            raw_env_value,
+        )
+        self.state.metrics.trading_shorts_enabled = 1 if configured_setting else 0
+
     def _drift_thresholds(self) -> DriftThresholds:
         return DriftThresholds(
             max_required_null_rate=Decimal(
@@ -5149,7 +5189,9 @@ class TradingScheduler:
         ]
         if recoverable_current_reasons:
             self.state.emergency_stop_recovery_streak = 0
-            refreshed = ";".join(_merge_emergency_stop_reasons(recoverable_current_reasons))
+            refreshed = ";".join(
+                _merge_emergency_stop_reasons(recoverable_current_reasons)
+            )
             if refreshed and refreshed != self.state.emergency_stop_reason:
                 self.state.emergency_stop_reason = refreshed
             return
@@ -5232,7 +5274,9 @@ class TradingScheduler:
         self.state.emergency_stop_triggered_at = now
         self.state.emergency_stop_resolved_at = None
         self.state.emergency_stop_recovery_streak = 0
-        self.state.emergency_stop_reason = ";".join(_merge_emergency_stop_reasons(reasons))
+        self.state.emergency_stop_reason = ";".join(
+            _merge_emergency_stop_reasons(reasons)
+        )
         self.state.metrics.signal_continuity_breach_total += 1
         self.state.last_error = (
             f"emergency_stop_triggered reasons={self.state.emergency_stop_reason}"
@@ -5375,6 +5419,7 @@ class TradingScheduler:
     async def start(self) -> None:
         if self._task:
             return
+        self._assert_trading_shorts_startup_policy()
         if not self._pipelines:
             lanes = settings.trading_accounts
             self._pipelines = [self._build_pipeline_for_account(lane) for lane in lanes]

--- a/services/torghut/tests/test_metrics.py
+++ b/services/torghut/tests/test_metrics.py
@@ -561,3 +561,15 @@ class TestTradingMetrics(TestCase):
             'torghut_trading_decision_regime_resolution_fallback_total{reason="hmm_unknown"} 2',
             payload,
         )
+
+    def test_trading_shorts_enabled_metric_is_exported(self) -> None:
+        metrics = TradingMetrics()
+        metrics.trading_shorts_enabled = 1
+
+        payload = render_trading_metrics(metrics.__dict__)
+
+        self.assertIn(
+            'torghut_trading_shorts_enabled{service="torghut"} 1',
+            payload,
+        )
+        self.assertIn("# TYPE torghut_trading_shorts_enabled gauge", payload)

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 import json
 import tempfile
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
 
 from app import config
 from app.trading.scheduler import (
@@ -22,13 +24,13 @@ class _OrderFirewallStub:
     def status(self) -> object:
         class _Status:
             kill_switch_enabled = False
-            reason = 'ok'
+            reason = "ok"
 
         return _Status()
 
     def cancel_all_orders(self) -> list[dict[str, object]]:
         self.cancel_all_calls += 1
-        return [{'id': 'o-1'}]
+        return [{"id": "o-1"}]
 
 
 class _PipelineStub:
@@ -39,47 +41,57 @@ class _PipelineStub:
 class TestTradingSchedulerSafety(TestCase):
     def setUp(self) -> None:
         self._snapshot = {
-            'trading_autonomy_artifact_dir': config.settings.trading_autonomy_artifact_dir,
-            'trading_emergency_stop_enabled': config.settings.trading_emergency_stop_enabled,
-            'trading_emergency_stop_recovery_cycles': config.settings.trading_emergency_stop_recovery_cycles,
-            'trading_rollback_signal_lag_seconds_limit': config.settings.trading_rollback_signal_lag_seconds_limit,
-            'trading_rollback_fallback_ratio_limit': config.settings.trading_rollback_fallback_ratio_limit,
-            'trading_rollback_autonomy_failure_streak_limit': config.settings.trading_rollback_autonomy_failure_streak_limit,
-            'trading_rollback_max_drawdown_limit': config.settings.trading_rollback_max_drawdown_limit,
-            'trading_signal_staleness_alert_critical_reasons_raw': (
+            "trading_autonomy_artifact_dir": config.settings.trading_autonomy_artifact_dir,
+            "trading_emergency_stop_enabled": config.settings.trading_emergency_stop_enabled,
+            "trading_allow_shorts": config.settings.trading_allow_shorts,
+            "trading_emergency_stop_recovery_cycles": config.settings.trading_emergency_stop_recovery_cycles,
+            "trading_rollback_signal_lag_seconds_limit": config.settings.trading_rollback_signal_lag_seconds_limit,
+            "trading_rollback_fallback_ratio_limit": config.settings.trading_rollback_fallback_ratio_limit,
+            "trading_rollback_autonomy_failure_streak_limit": config.settings.trading_rollback_autonomy_failure_streak_limit,
+            "trading_rollback_max_drawdown_limit": config.settings.trading_rollback_max_drawdown_limit,
+            "trading_signal_staleness_alert_critical_reasons_raw": (
                 config.settings.trading_signal_staleness_alert_critical_reasons_raw
             ),
-            'trading_rollback_signal_staleness_alert_streak_limit': (
+            "trading_rollback_signal_staleness_alert_streak_limit": (
                 config.settings.trading_rollback_signal_staleness_alert_streak_limit
             ),
-            'trading_signal_market_closed_expected_reasons_raw': (
+            "trading_signal_market_closed_expected_reasons_raw": (
                 config.settings.trading_signal_market_closed_expected_reasons_raw
             ),
         }
 
     def tearDown(self) -> None:
-        config.settings.trading_autonomy_artifact_dir = self._snapshot['trading_autonomy_artifact_dir']
-        config.settings.trading_emergency_stop_enabled = self._snapshot['trading_emergency_stop_enabled']
+        config.settings.trading_autonomy_artifact_dir = self._snapshot[
+            "trading_autonomy_artifact_dir"
+        ]
+        config.settings.trading_emergency_stop_enabled = self._snapshot[
+            "trading_emergency_stop_enabled"
+        ]
+        config.settings.trading_allow_shorts = self._snapshot["trading_allow_shorts"]
         config.settings.trading_emergency_stop_recovery_cycles = self._snapshot[
-            'trading_emergency_stop_recovery_cycles'
+            "trading_emergency_stop_recovery_cycles"
         ]
         config.settings.trading_rollback_signal_lag_seconds_limit = self._snapshot[
-            'trading_rollback_signal_lag_seconds_limit'
+            "trading_rollback_signal_lag_seconds_limit"
         ]
-        config.settings.trading_rollback_fallback_ratio_limit = self._snapshot['trading_rollback_fallback_ratio_limit']
+        config.settings.trading_rollback_fallback_ratio_limit = self._snapshot[
+            "trading_rollback_fallback_ratio_limit"
+        ]
         config.settings.trading_rollback_autonomy_failure_streak_limit = self._snapshot[
-            'trading_rollback_autonomy_failure_streak_limit'
+            "trading_rollback_autonomy_failure_streak_limit"
         ]
-        config.settings.trading_rollback_max_drawdown_limit = self._snapshot['trading_rollback_max_drawdown_limit']
-        config.settings.trading_signal_staleness_alert_critical_reasons_raw = self._snapshot[
-            'trading_signal_staleness_alert_critical_reasons_raw'
+        config.settings.trading_rollback_max_drawdown_limit = self._snapshot[
+            "trading_rollback_max_drawdown_limit"
         ]
-        config.settings.trading_rollback_signal_staleness_alert_streak_limit = self._snapshot[
-            'trading_rollback_signal_staleness_alert_streak_limit'
-        ]
-        config.settings.trading_signal_market_closed_expected_reasons_raw = self._snapshot[
-            'trading_signal_market_closed_expected_reasons_raw'
-        ]
+        config.settings.trading_signal_staleness_alert_critical_reasons_raw = (
+            self._snapshot["trading_signal_staleness_alert_critical_reasons_raw"]
+        )
+        config.settings.trading_rollback_signal_staleness_alert_streak_limit = (
+            self._snapshot["trading_rollback_signal_staleness_alert_streak_limit"]
+        )
+        config.settings.trading_signal_market_closed_expected_reasons_raw = (
+            self._snapshot["trading_signal_market_closed_expected_reasons_raw"]
+        )
 
     def test_emergency_stop_triggers_on_signal_lag(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -95,12 +107,14 @@ class TestTradingSchedulerSafety(TestCase):
 
             self.assertTrue(scheduler.state.emergency_stop_active)
             self.assertEqual(scheduler.state.rollback_incidents_total, 1)
-            self.assertIn('signal_lag_exceeded', scheduler.state.emergency_stop_reason or '')
+            self.assertIn(
+                "signal_lag_exceeded", scheduler.state.emergency_stop_reason or ""
+            )
             self.assertEqual(scheduler._pipeline.order_firewall.cancel_all_calls, 1)  # type: ignore[union-attr]
-            evidence_path = Path(scheduler.state.rollback_incident_evidence_path or '')
+            evidence_path = Path(scheduler.state.rollback_incident_evidence_path or "")
             self.assertTrue(evidence_path.exists())
-            payload = json.loads(evidence_path.read_text(encoding='utf-8'))
-            self.assertEqual(payload['signal_lag_seconds'], 7)
+            payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["signal_lag_seconds"], 7)
 
     def test_signal_lag_does_not_trigger_when_market_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -141,7 +155,9 @@ class TestTradingSchedulerSafety(TestCase):
             self.assertFalse(scheduler.state.emergency_stop_active)
             self.assertEqual(scheduler.state.rollback_incidents_total, 0)
 
-    def test_freshness_emergency_stop_auto_clears_after_recovery_hysteresis(self) -> None:
+    def test_freshness_emergency_stop_auto_clears_after_recovery_hysteresis(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
@@ -176,7 +192,7 @@ class TestTradingSchedulerSafety(TestCase):
             scheduler = TradingScheduler()
             scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
             scheduler.state.emergency_stop_active = True
-            scheduler.state.emergency_stop_reason = 'max_drawdown_exceeded:0.1200'
+            scheduler.state.emergency_stop_reason = "max_drawdown_exceeded:0.1200"
             scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
             scheduler.state.metrics.signal_lag_seconds = 0
 
@@ -185,15 +201,17 @@ class TestTradingSchedulerSafety(TestCase):
             self.assertTrue(scheduler.state.emergency_stop_active)
             self.assertEqual(
                 scheduler.state.emergency_stop_reason,
-                'max_drawdown_exceeded:0.1200',
+                "max_drawdown_exceeded:0.1200",
             )
             self.assertEqual(scheduler.state.emergency_stop_recovery_streak, 0)
             self.assertIsNone(scheduler.state.emergency_stop_resolved_at)
 
     def test_emergency_stop_triggers_on_drawdown_from_gate_report(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            gate_path = Path(tmpdir) / 'gate.json'
-            gate_path.write_text(json.dumps({'metrics': {'max_drawdown': '0.12'}}), encoding='utf-8')
+            gate_path = Path(tmpdir) / "gate.json"
+            gate_path.write_text(
+                json.dumps({"metrics": {"max_drawdown": "0.12"}}), encoding="utf-8"
+            )
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
             config.settings.trading_rollback_max_drawdown_limit = 0.08
@@ -204,7 +222,9 @@ class TestTradingSchedulerSafety(TestCase):
             scheduler._evaluate_safety_controls()
 
             self.assertTrue(scheduler.state.emergency_stop_active)
-            self.assertIn('max_drawdown_exceeded', scheduler.state.emergency_stop_reason or '')
+            self.assertIn(
+                "max_drawdown_exceeded", scheduler.state.emergency_stop_reason or ""
+            )
 
     def test_disabled_emergency_stop_clears_latched_state(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -213,7 +233,7 @@ class TestTradingSchedulerSafety(TestCase):
             scheduler = TradingScheduler()
             scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
             scheduler.state.emergency_stop_active = True
-            scheduler.state.emergency_stop_reason = 'signal_lag_exceeded:1234'
+            scheduler.state.emergency_stop_reason = "signal_lag_exceeded:1234"
             scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
             scheduler.state.metrics.signal_lag_seconds = 9999
 
@@ -258,7 +278,9 @@ class TestTradingSchedulerSafety(TestCase):
             _is_recoverable_emergency_stop_reason("max_drawdown_exceeded:0.10")
         )
 
-    def test_split_emergency_stop_reasons_ignores_duplicates_and_whitespace(self) -> None:
+    def test_split_emergency_stop_reasons_ignores_duplicates_and_whitespace(
+        self,
+    ) -> None:
         self.assertEqual(
             _split_emergency_stop_reasons(
                 " signal_lag_exceeded:10 ;signal_lag_exceeded:10;; max_drawdown_exceeded:0.1000 ;  "
@@ -266,7 +288,9 @@ class TestTradingSchedulerSafety(TestCase):
             ["signal_lag_exceeded:10", "max_drawdown_exceeded:0.1000"],
         )
 
-    def test_emergency_stop_recovery_canonicalizes_and_merges_nonrecoverable_reasons(self) -> None:
+    def test_emergency_stop_recovery_canonicalizes_and_merges_nonrecoverable_reasons(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
@@ -280,16 +304,14 @@ class TestTradingSchedulerSafety(TestCase):
             )
             scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
             scheduler.state.metrics.signal_lag_seconds = 0
-            scheduler._collect_emergency_stop_reasons = (
-                lambda: (
-                    [
-                        " signal_lag_exceeded:7 ",
-                        "max_drawdown_exceeded:0.1100",
-                        "signal_lag_exceeded:7",
-                    ],
-                    0.0,
-                    None,
-                )
+            scheduler._collect_emergency_stop_reasons = lambda: (
+                [
+                    " signal_lag_exceeded:7 ",
+                    "max_drawdown_exceeded:0.1100",
+                    "signal_lag_exceeded:7",
+                ],
+                0.0,
+                None,
             )
 
             scheduler._evaluate_safety_controls()
@@ -301,3 +323,20 @@ class TestTradingSchedulerSafety(TestCase):
                 "signal_lag_exceeded:7;"
                 "max_drawdown_exceeded:0.1100",
             )
+
+    def test_startup_shorts_policy_requires_explicit_environment(self) -> None:
+        config.settings.trading_allow_shorts = True
+        with patch.dict(os.environ, {}, clear=True):
+            scheduler = TradingScheduler()
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "TRADING_ALLOW_SHORTS",
+            ):
+                scheduler._assert_trading_shorts_startup_policy()
+
+    def test_startup_shorts_policy_metric_tracks_declared_setting(self) -> None:
+        config.settings.trading_allow_shorts = False
+        with patch.dict(os.environ, {"TRADING_ALLOW_SHORTS": "0"}):
+            scheduler = TradingScheduler()
+            scheduler._assert_trading_shorts_startup_policy()
+            self.assertEqual(scheduler.state.metrics.trading_shorts_enabled, 0)


### PR DESCRIPTION
## Summary

- Added startup short-policy enforcement in torghut scheduler initialization (`services/torghut/app/trading/scheduler.py`): scheduler now fails fast when `TRADING_ALLOW_SHORTS` is not explicitly set in process environment, asserts exact parity with runtime `trading_allow_shorts` setting, logs an explicit startup declaration, and updates a runtime metric value.
- Added a new Prometheus mapping for `trading_shorts_enabled` under `torghut_trading_shorts_enabled` in `services/torghut/app/metrics.py` and documented what the gauge reports.
- Added regression tests in `services/torghut/tests/test_trading_scheduler_safety.py` and `services/torghut/tests/test_metrics.py` to cover required-env enforcement, metric value emission, and declared startup setting behavior.

## Related Issues

- Governing design: `docs/torghut/design-system/v6/15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md` (Workstream 3: Shorts Safety and Configuration Drift Guard)
- Mission provenance: Huly issue `TSK-106` (issue identifier from upserted mission artifact) / mission `swarm-torghut-quant`

## Testing

- `python3 -m ruff check services/torghut/app/metrics.py services/torghut/app/trading/scheduler.py services/torghut/tests/test_metrics.py services/torghut/tests/test_trading_scheduler_safety.py`
- `python3 -m ruff format --check services/torghut/app/metrics.py services/torghut/app/trading/scheduler.py services/torghut/tests/test_metrics.py services/torghut/tests/test_trading_scheduler_safety.py`
- `cd /workspace/lab/services/torghut && python3 -m pytest tests/test_metrics.py tests/test_trading_scheduler_safety.py`
- `cd /workspace/lab/services/torghut && python3 -m pyright --project pyrightconfig.json`
- `cd /workspace/lab/services/torghut && python3 -m pyright --project pyrightconfig.alpha.json`
- `cd /workspace/lab/services/torghut && python3 -m pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None.

## Risk Notes

- If scheduler startup is launched with a stale or absent `TRADING_ALLOW_SHORTS` environment variable, startup will fail fast instead of continuing silently with inconsistent assumptions.
- Environments that pass inconsistent casing/formatting strings for the flag are now rejected unless the value can be safely coerced via an explicit boolean mapping.

## Rollback Path

- Revert the scheduler and metric commits on `codex/swarm-torghut-quant` and re-run the validation commands above.
- In service deployment, disable this branch's changes by reverting the release reference for `services/torghut` to the previous known-good commit/image.
