### PR TITLE
feat(argocd): add forgejo app with cnpg postgres and ssh ingress

### DIFF
--- a/argocd/applications/forgejo/README.md
+++ b/argocd/applications/forgejo/README.md
@@ -1,0 +1,28 @@
+# Forgejo Argo CD App
+
+This app deploys [Forgejo](https://forgejo.org/) using the official OCI Helm chart:
+
+- Chart: `oci://code.forgejo.org/forgejo-helm/forgejo`
+- Chart version: `16.2.0`
+- App version: `14.0.2`
+
+## Current profile
+
+- Single-pod baseline (`replicaCount: 1`)
+- Persistent storage enabled (`50Gi`) on `rook-ceph-block`
+- External Postgres on CNPG (`forgejo-db`, `10Gi` on `rook-ceph-block`)
+- Traefik ingress enabled for `git.proompteng.ai`
+- SSH service exposed as `LoadBalancer` on port `22`
+- Public user registration disabled
+- Admin user: `kalmyk` (password generated into `forgejo-admin` secret)
+
+## Notes from upstream docs
+
+- The chart defaults to SQLite for simple installs, but this app is configured to use CNPG Postgres.
+- Forgejo upstream recommends external PostgreSQL/MySQL for long-term multi-user installations.
+- For medium/large workloads, external Redis/Valkey is recommended for session/cache/queue workloads.
+
+References:
+
+- https://forgejo.org/docs/latest/
+- https://artifacthub.io/packages/helm/forgejo-helm/forgejo

--- a/argocd/applications/forgejo/kustomization.yaml
+++ b/argocd/applications/forgejo/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: forgejo
+resources:
+  - postgres-cluster.yaml
+helmCharts:
+  - name: forgejo
+    repo: oci://code.forgejo.org/forgejo-helm
+    version: 16.2.0
+    releaseName: forgejo
+    namespace: forgejo
+    valuesFile: values.yaml

--- a/argocd/applications/forgejo/postgres-cluster.yaml
+++ b/argocd/applications/forgejo/postgres-cluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: forgejo-db
+  namespace: forgejo
+spec:
+  instances: 1
+  primaryUpdateStrategy: unsupervised
+  storage:
+    storageClass: rook-ceph-block
+    size: 10Gi
+  bootstrap:
+    initdb:
+      database: forgejo
+      owner: forgejo
+      encoding: 'UTF8'
+      dataChecksums: true
+  monitoring:
+    enablePodMonitor: true
+# CNPG emits application credentials in `forgejo-db-app` (uri, user, password, host, port, dbname)

--- a/argocd/applications/forgejo/values.yaml
+++ b/argocd/applications/forgejo/values.yaml
@@ -1,0 +1,56 @@
+# Single-pod Forgejo with CNPG Postgres + PVC.
+# For medium/large instances, add external Redis/Valkey for session/cache/queue.
+replicaCount: 1
+
+persistence:
+  enabled: true
+  size: 50Gi
+  storageClass: rook-ceph-block
+
+ingress:
+  enabled: true
+  className: traefik
+  hosts:
+    - host: git.proompteng.ai
+      paths:
+        - path: /
+          pathType: Prefix
+          port: http
+  tls:
+    - hosts:
+        - git.proompteng.ai
+
+service:
+  ssh:
+    type: LoadBalancer
+    annotations:
+      metallb.io/address-pool: metallb-ip-pool
+      metallb.io/allow-shared-ip: ingress-edge
+
+gitea:
+  admin:
+    username: kalmyk
+    passwordMode: initialOnlyNoReset
+  config:
+    server:
+      ROOT_URL: https://git.proompteng.ai
+      DOMAIN: git.proompteng.ai
+      SSH_DOMAIN: git.proompteng.ai
+      SSH_PORT: 22
+    database:
+      DB_TYPE: postgres
+      HOST: forgejo-db-rw:5432
+      NAME: forgejo
+      USER: forgejo
+      SSL_MODE: disable
+    service:
+      DISABLE_REGISTRATION: true
+  additionalConfigFromEnvs:
+    - name: FORGEJO__DATABASE__PASSWD
+      valueFrom:
+        secretKeyRef:
+          name: forgejo-db-app
+          key: password
+
+test:
+  enabled: false

--- a/argocd/applications/traefik/values.yaml
+++ b/argocd/applications/traefik/values.yaml
@@ -5,6 +5,7 @@ service:
   type: LoadBalancer
   annotations:
     metallb.io/address-pool: metallb-ip-pool
+    metallb.io/allow-shared-ip: ingress-edge
 
 ingressClass:
   enabled: true

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -79,6 +79,13 @@ spec:
                   argocd.argoproj.io/sync-wave: "6"
                 automation: manual
                 enabled: "false"
+              - name: forgejo
+                path: argocd/applications/forgejo
+                namespace: forgejo
+                annotations:
+                  argocd.argoproj.io/sync-wave: "6"
+                automation: manual
+                enabled: "true"
               - name: kitty-krew
                 path: argocd/applications/kitty-krew
                 namespace: kitty-krew


### PR DESCRIPTION
## Summary

- Added a new Forgejo Argo CD application under `argocd/applications/forgejo` using the official OCI Helm chart (`forgejo-helm/forgejo` v16.2.0).
- Configured Forgejo with Traefik ingress at `git.proompteng.ai`, SSH LoadBalancer exposure, Ceph-backed persistent storage (`50Gi`), and admin bootstrap user `kalmyk`.
- Added CNPG Postgres (`forgejo-db`) and wired Forgejo to use external Postgres credentials from CNPG secret `forgejo-db-app`.
- Registered Forgejo in `argocd/applicationsets/product.yaml` so Argo CD manages it in the `forgejo` namespace.
- Added MetalLB shared-IP annotation in Traefik service values to support same-host web (`443`) and SSH (`22`) routing.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/forgejo`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/traefik`
- `kubectl -n forgejo wait --for=condition=Ready cluster.postgresql.cnpg.io/forgejo-db --timeout=300s`
- `kubectl -n forgejo rollout status deploy/forgejo --timeout=300s`
- `kubectl -n forgejo get svc forgejo-http forgejo-ssh -o wide` (verified `forgejo-ssh` external IP allocated)
- `kubectl -n forgejo exec deploy/forgejo -- sh -c "grep -E '^(DB_TYPE|HOST|NAME|USER|SSL_MODE)\s*=' /data/gitea/conf/app.ini"` (verified `DB_TYPE=postgres`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
