### PR TITLE
refactor(torghut): canonicalize allocator config surface

### DIFF
--- a/docs/torghut/design-system/v6/20-trading-allocator-config-surface-hardening-2026-03-04.md
+++ b/docs/torghut/design-system/v6/20-trading-allocator-config-surface-hardening-2026-03-04.md
@@ -35,6 +35,10 @@ Adopt one canonical allocator config surface while keeping backward-compatible e
   - Pros: reduces future config drift, preserves existing deployments, and makes a single allocator path enforceable.
   - Cons: requires one-time code+test update and explicit upgrade note in release docs.
 
+4. Add field-level schema linting to detect duplicate env aliases at startup (rejected)
+   - Pros: gives runtime early warning when duplicate env definitions reappear or alias mappings drift.
+   - Cons: adds complexity in settings bootstrap and does not prevent duplicate fields without additional migration burden.
+
 ## Implementation
 
 1. `services/torghut/app/config.py`
@@ -59,6 +63,14 @@ Adopt one canonical allocator config surface while keeping backward-compatible e
 
 - Risk: if a deployment depends on both alias families in different services, only merge-time precedence applies via environment resolution order; behavior remains explicit and backward-compatible.
 - Rollback: revert this PR and redeploy the previous image if unexpected alias behavior is observed.
+
+## Discovery-Run Verification Updates (2026-03-04)
+
+- Added regression test `TestSettings::test_allocator_surface_uses_canonical_field_names` to catch reintroduction of removed duplicate model fields and enforce canonical aliases.
+- Updated source-of-truth assessment confirms:
+  - Canonical settings field `trading_allocator_symbol_correlation_groups` with legacy alias support.
+  - Canonical settings field `trading_allocator_correlation_group_caps` with legacy alias support.
+  - Canonical allocator budget maps (`trading_allocator_strategy_notional_caps`, `trading_allocator_symbol_notional_caps`) remain unchanged and are normalized through a single path.
 
 ## Relation to Objective
 

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -962,16 +962,6 @@ class Settings(BaseSettings):
         alias="TRADING_ALLOCATOR_MAX_SYMBOL_NOTIONAL",
         description="Allocator pre-risk concentration cap as absolute notional per symbol (optional).",
     )
-    trading_allocator_strategy_notional_caps: dict[str, float] = Field(
-        default_factory=dict,
-        alias="TRADING_ALLOCATOR_STRATEGY_NOTIONAL_CAPS",
-        description="Strategy->notional budget caps applied by allocator before risk checks (JSON object).",
-    )
-    trading_allocator_symbol_notional_caps: dict[str, float] = Field(
-        default_factory=dict,
-        alias="TRADING_ALLOCATOR_SYMBOL_NOTIONAL_CAPS",
-        description="Symbol->notional concentration caps applied by allocator before risk checks (JSON object).",
-    )
     trading_allocator_symbol_correlation_groups: dict[str, str] = Field(
         default_factory=dict,
         alias="TRADING_ALLOCATOR_SYMBOL_CORRELATION_GROUPS",

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -455,6 +455,33 @@ class TestConfig(TestCase):
             {"megacap": 3000.0},
         )
 
+    def test_allocator_surface_uses_canonical_field_names(self) -> None:
+        model_fields = set(Settings.model_fields.keys())
+        self.assertIn(
+            "trading_allocator_symbol_correlation_groups",
+            model_fields,
+        )
+        self.assertIn(
+            "trading_allocator_correlation_group_caps",
+            model_fields,
+        )
+        self.assertIn(
+            "trading_allocator_strategy_notional_caps",
+            model_fields,
+        )
+        self.assertIn(
+            "trading_allocator_symbol_notional_caps",
+            model_fields,
+        )
+        self.assertNotIn(
+            "trading_allocator_correlation_symbol_groups",
+            model_fields,
+        )
+        self.assertNotIn(
+            "trading_allocator_correlation_group_notional_caps",
+            model_fields,
+        )
+
     def test_legacy_allocator_aliases_are_supported(self) -> None:
         settings = Settings(
             TRADING_UNIVERSE_SOURCE="static",


### PR DESCRIPTION
## Summary
- Canonicalized the Torghut allocator config surface to avoid duplicated settings fields for allocator correlation maps.
- Kept backward-compatible legacy aliases via `AliasChoices` while making canonical keys the active source-of-truth.
- Added a regression test asserting canonical `Settings.model_fields` surface and updated design-system documentation.

## Related Issues
- Huly: `TSK-122` (`swarm-torghut-quant-discover`)

## Testing
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app tests`
- `uv run --frozen python -m unittest tests.test_config`

## Screenshots (if applicable)
N/A

## Breaking Changes
- None. Legacy aliases are preserved to avoid rollout migration risk.

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
