### PR TITLE
feat(torghut): cache readiness dependency checks with freshness metadata

### DIFF
--- a/docs/torghut/design-system/v6/22-trading-readiness-dependency-freshness-cache-2026-03-04.md
+++ b/docs/torghut/design-system/v6/22-trading-readiness-dependency-freshness-cache-2026-03-04.md
@@ -1,0 +1,71 @@
+# 22. Trading Readiness Dependency Freshness Cache (2026-03-04)
+
+## Context
+
+Torghut readiness probes have historically mixed fast liveness checks with repeated dependency checks from `/readyz` and `/trading/health`. The service has external dependency checks in the readiness path:
+
+- Postgres ping (`_check_postgres`)
+- ClickHouse HTTP `/` probe (`_check_clickhouse`)
+- Alpaca account/accounting check (`_check_alpaca`)
+- Optional schema/account-scope contract checks for `/readyz` (`_evaluate_database_contract`)
+
+Cluster rollout evidence for `torghut-00042` shows repeated probe failures and unstable transitions (`Liveness probe failed` and `Readiness probe failed`), consistent with a heavy per-request readiness contract during startup or transient dependency jitter.
+
+## Problem
+
+The readiness handler currently executes all expensive dependency checks synchronously for each request. This increases tail-latency variance and amplifies transient dependency jitter into K8s/Knative readiness churn.
+
+## Decision
+
+Introduce a bounded TTL in-memory readiness dependency cache used by the shared readiness payload path.
+
+1. Add configurable cache controls in `services/torghut/app/config.py`:
+- `TRADING_READINESS_DEPENDENCY_CACHE_ENABLED`
+- `TRADING_READINESS_DEPENDENCY_CACHE_TTL_SECONDS`
+
+2. Add caching helper helpers in `services/torghut/app/main.py`:
+- `_readiness_dependency_cache_key`
+- `_readiness_dependency_checks`
+- `_readiness_dependency_snapshot`
+
+3. Keep the existing `/readyz` semantics for contract shape and status mapping while adding metadata under `dependencies.readiness_cache`:
+- `cache_used`
+- `cache_ttl_seconds`
+- `checked_at`
+
+4. Add regression tests in `services/torghut/tests/test_trading_api.py` for:
+- cache hit (single invocation across repeated `/readyz` calls)
+- stale refresh (forced cache age beyond TTL triggers new dependency checks)
+
+## Alternatives Considered
+
+1. Keep current synchronous checks (status quo)
+- Pros: behavior is straightforward and always freshest.
+- Cons: unchanged probe churn and no suppression of transient dependency flaps.
+
+2. Reduce dependency timeouts only
+- Pros: easier and smaller diff.
+- Cons: still executes full dependency suite each probe and remains sensitive to traffic bursts.
+
+3. Cache dependency checks with bounded TTL (selected)
+- Pros: reduces readiness-probe amplification, adds deterministic freshness metadata, keeps fail-closed behavior when stale checks degrade.
+- Cons: introduces up to TTL of stale readiness reporting and requires cache-control tuning.
+
+## Tradeoffs and Risks
+
+- Freshness vs stability: TTL smoothing can delay detection of newly introduced dependency issues by up to configured TTL.
+- Memory scope: cache is process-local and resets on pod restart, which is acceptable for transient probe behavior.
+- Observability: cache metadata in payload allows operators to reason about health sample age, but existing clients must ignore the new field.
+
+## Verification Matrix
+
+- `services/torghut/tests/test_trading_api.py::TestTradingApi::test_readyz_reuses_dependency_checks_within_cache_ttl`
+  - validates cache hit behavior and `dependencies.readiness_cache.cache_used`.
+- `services/torghut/tests/test_trading_api.py::TestTradingApi::test_readyz_refreshes_dependency_checks_after_cache_ttl`
+  - validates cache expiry path and refreshed dependency evaluation.
+- Existing checks for `/readyz` success/failure paths continue to exercise dependency contract behavior for both schema and account-scope checks.
+
+## Rollback Plan
+
+- Disable caching with `TRADING_READINESS_DEPENDENCY_CACHE_ENABLED=false` and keep schema checks in place.
+- If needed, set `TRADING_READINESS_DEPENDENCY_CACHE_TTL_SECONDS=0` to force synchronous checks while keeping rollout changes unchanged.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -7,7 +7,7 @@
 - Maturity: `production-quality design pack`
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Completed` (program closure passed against all v6/13 definition-of-done criteria on `2026-03-03`)
-- Implementation status (strict): `Implemented=14`, `Partial=0`, `Planned=1` of 15
+- Implementation status (strict): `Implemented=15`, `Partial=0`, `Planned=1` of 16
 - Evidence: `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence sync: `14-legacy-gap-disposition-map-2026-03-03.md` (signed v4/v5 disposition completeness)
 - Rollout status: v6 pack controls are represented by merged runtime/control-plane closure phases in `main` (`#3921` through `#3960`).
@@ -54,6 +54,7 @@ This pack is positioned as the next architecture layer above:
 20. `19-jangar-symbol-dependency-freshness-and-readiness-guard.md`
 20. `20-trading-allocator-config-surface-hardening-2026-03-04.md`
 21. `21-schema-fingerprint-and-freshness-for-database-readiness-2026-03-04.md`
+22. `22-trading-readiness-dependency-freshness-cache-2026-03-04.md`
 
 ## Recommended Build Order
 
@@ -79,6 +80,7 @@ This pack is positioned as the next architecture layer above:
 20. `19-jangar-symbol-dependency-freshness-and-readiness-guard.md`
 20. `20-trading-allocator-config-surface-hardening-2026-03-04.md`
 21. `21-schema-fingerprint-and-freshness-for-database-readiness-2026-03-04.md`
+22. `22-trading-readiness-dependency-freshness-cache-2026-03-04.md`
 
 ## Why This Sequence
 

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1227,6 +1227,22 @@ class Settings(BaseSettings):
             "TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS", "CLICKHOUSE_TIMEOUT_SECONDS"
         ),
     )
+    trading_readiness_dependency_cache_enabled: bool = Field(
+        default=True,
+        alias="TRADING_READINESS_DEPENDENCY_CACHE_ENABLED",
+        description=(
+            "Cache readiness dependency checks for probe stability while avoiding constant "
+            "dependency calls under high probe frequency."
+        ),
+    )
+    trading_readiness_dependency_cache_ttl_seconds: int = Field(
+        default=8,
+        alias="TRADING_READINESS_DEPENDENCY_CACHE_TTL_SECONDS",
+        description=(
+            "Maximum cache age for readiness dependency checks (in seconds). Set to 0 to "
+            "force synchronous checks on every request."
+        ),
+    )
 
     # Jangar gateway (recommended for LLM calls in-cluster).
     jangar_base_url: Optional[str] = Field(default=None, alias="JANGAR_BASE_URL")
@@ -1651,15 +1667,14 @@ class Settings(BaseSettings):
                     f"TRADING_ALLOCATOR_CORRELATION_GROUP_CAPS[{key}] must be >= 0"
                 )
             normalized_correlation_caps[normalized_key] = value
-        self.trading_allocator_correlation_group_caps = (
-            normalized_correlation_caps
-        )
+        self.trading_allocator_correlation_group_caps = normalized_correlation_caps
 
     def _normalize_runtime_regime_confidence_thresholds_by_entropy_band(self) -> None:
         normalized: dict[str, tuple[float, float]] = {}
-        for key, thresholds in (
-            self.trading_runtime_regime_confidence_thresholds_by_entropy_band.items()
-        ):
+        for (
+            key,
+            thresholds,
+        ) in self.trading_runtime_regime_confidence_thresholds_by_entropy_band.items():
             normalized_key = str(key).strip().lower()
             if not normalized_key:
                 continue
@@ -1853,9 +1868,10 @@ class Settings(BaseSettings):
                 )
 
     def _validate_runtime_regime_confidence_thresholds_by_entropy_band(self) -> None:
-        for entropy_band, thresholds in (
-            self.trading_runtime_regime_confidence_thresholds_by_entropy_band.items()
-        ):
+        for (
+            entropy_band,
+            thresholds,
+        ) in self.trading_runtime_regime_confidence_thresholds_by_entropy_band.items():
             if len(thresholds) != 2:
                 raise ValueError(
                     "TRADING_RUNTIME_REGIME_CONFIDENCE_THRESHOLDS_BY_ENTROPY_BAND"

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from http.client import HTTPConnection, HTTPSConnection
 from pathlib import Path
+from threading import Lock
 from typing import Any, cast
 from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.encoders import jsonable_encoder
@@ -63,6 +64,8 @@ RUNTIME_PROFITABILITY_LOOKBACK_HOURS = 72
 RUNTIME_PROFITABILITY_SCHEMA_VERSION = "torghut.runtime-profitability.v1"
 LEAN_LANE_MANAGER = LeanLaneManager()
 WHITEPAPER_WORKFLOW = WhitepaperWorkflowService()
+_TRADING_DEPENDENCY_HEALTH_CACHE_LOCK = Lock()
+_TRADING_DEPENDENCY_HEALTH_CACHE: dict[str, dict[str, object]] = {}
 
 
 def _extract_bearer_token(authorization_header: str | None) -> str | None:
@@ -119,20 +122,28 @@ def _register_whitepaper_inngest_routes(app: FastAPI) -> inngest.Inngest | None:
             signing_key=_env_or_none("INNGEST_SIGNING_KEY"),
         )
     except Exception as exc:  # pragma: no cover - configuration/runtime dependent
-        logger.warning("Failed to initialize Inngest client for whitepaper workflow: %s", exc)
+        logger.warning(
+            "Failed to initialize Inngest client for whitepaper workflow: %s", exc
+        )
         app.state.whitepaper_inngest_registered = False
         WHITEPAPER_WORKFLOW.set_inngest_client(None)
         return None
 
     requested_event_name = (
-        _env_or_none("WHITEPAPER_INNGEST_EVENT_NAME") or "torghut/whitepaper.analysis.requested"
+        _env_or_none("WHITEPAPER_INNGEST_EVENT_NAME")
+        or "torghut/whitepaper.analysis.requested"
     )
-    requested_fn_id = _env_or_none("WHITEPAPER_INNGEST_FUNCTION_ID") or "torghut-whitepaper-analysis-v1"
+    requested_fn_id = (
+        _env_or_none("WHITEPAPER_INNGEST_FUNCTION_ID")
+        or "torghut-whitepaper-analysis-v1"
+    )
     finalized_event_name = (
-        _env_or_none("WHITEPAPER_INNGEST_FINALIZED_EVENT_NAME") or "torghut/whitepaper.analysis.finalized"
+        _env_or_none("WHITEPAPER_INNGEST_FINALIZED_EVENT_NAME")
+        or "torghut/whitepaper.analysis.finalized"
     )
     finalized_fn_id = (
-        _env_or_none("WHITEPAPER_INNGEST_FINALIZE_FUNCTION_ID") or "torghut-whitepaper-synthesis-index-v1"
+        _env_or_none("WHITEPAPER_INNGEST_FINALIZE_FUNCTION_ID")
+        or "torghut-whitepaper-synthesis-index-v1"
     )
 
     @client.create_function(
@@ -156,7 +167,9 @@ def _register_whitepaper_inngest_routes(app: FastAPI) -> inngest.Inngest | None:
                 return result
             except Exception:
                 session.rollback()
-                logger.exception("Inngest requested whitepaper run failed for run_id=%s", run_id)
+                logger.exception(
+                    "Inngest requested whitepaper run failed for run_id=%s", run_id
+                )
                 raise
 
     @client.create_function(
@@ -169,7 +182,11 @@ def _register_whitepaper_inngest_routes(app: FastAPI) -> inngest.Inngest | None:
         if not run_id:
             raise ValueError("run_id_required")
         if not whitepaper_semantic_indexing_enabled():
-            return {"run_id": run_id, "skipped": True, "reason": "semantic_indexing_disabled"}
+            return {
+                "run_id": run_id,
+                "skipped": True,
+                "reason": "semantic_indexing_disabled",
+            }
         with SessionLocal() as session:
             try:
                 result = WHITEPAPER_WORKFLOW.index_synthesis_semantic_content(
@@ -180,7 +197,9 @@ def _register_whitepaper_inngest_routes(app: FastAPI) -> inngest.Inngest | None:
                 return result
             except Exception:
                 session.rollback()
-                logger.exception("Inngest finalized whitepaper indexing failed for run_id=%s", run_id)
+                logger.exception(
+                    "Inngest finalized whitepaper indexing failed for run_id=%s", run_id
+                )
                 raise
 
     try:
@@ -271,6 +290,94 @@ def healthz() -> dict[str, str]:
     return {"status": "ok", "service": "torghut"}
 
 
+def _readiness_dependency_cache_key(include_database_contract: bool) -> str:
+    trading_mode = int(settings.trading_enabled)
+    cache_mode = int(settings.trading_readiness_dependency_cache_enabled)
+    return f"readyz:{trading_mode}:{cache_mode}:{int(include_database_contract)}"
+
+
+def _readiness_dependency_checks(
+    session: Session,
+    *,
+    include_database_contract: bool,
+) -> tuple[dict[str, object], datetime]:
+    postgres_status = _check_postgres(session)
+    if settings.trading_enabled:
+        clickhouse_status = _check_clickhouse()
+        alpaca_status = _check_alpaca()
+    else:
+        clickhouse_status = {"ok": True, "detail": "skipped (trading disabled)"}
+        alpaca_status = {"ok": True, "detail": "skipped (trading disabled)"}
+
+    dependencies: dict[str, object] = {
+        "postgres": postgres_status,
+        "clickhouse": clickhouse_status,
+        "alpaca": alpaca_status,
+    }
+
+    if include_database_contract:
+        database_contract = _evaluate_database_contract(session)
+        dependencies["database"] = {
+            "ok": bool(database_contract.get("ok")),
+            "detail": "ok"
+            if bool(database_contract.get("ok"))
+            else "database contract failed",
+            "schema_current": bool(database_contract.get("schema_current")),
+            "schema_current_heads": database_contract.get("schema_current_heads"),
+            "expected_heads": database_contract.get("expected_heads"),
+            "schema_head_signature": database_contract.get("schema_head_signature"),
+            "checked_at": database_contract.get("checked_at"),
+            "account_scope_ready": bool(database_contract.get("account_scope_ready")),
+            "account_scope_errors": database_contract.get("account_scope_errors", []),
+        }
+
+    return dependencies, datetime.now(timezone.utc)
+
+
+def _readiness_dependency_snapshot(
+    session: Session,
+    *,
+    include_database_contract: bool,
+) -> tuple[dict[str, object], datetime, bool]:
+    if (
+        not settings.trading_readiness_dependency_cache_enabled
+        or settings.trading_readiness_dependency_cache_ttl_seconds <= 0
+    ):
+        dependencies, checked_at = _readiness_dependency_checks(
+            session,
+            include_database_contract=include_database_contract,
+        )
+        return dependencies, checked_at, False
+
+    cache_ttl = timedelta(
+        seconds=settings.trading_readiness_dependency_cache_ttl_seconds
+    )
+    now = datetime.now(timezone.utc)
+    cache_key = _readiness_dependency_cache_key(include_database_contract)
+
+    with _TRADING_DEPENDENCY_HEALTH_CACHE_LOCK:
+        cache_entry = _TRADING_DEPENDENCY_HEALTH_CACHE.get(cache_key)
+        if cache_entry:
+            cache_checked_at = cast(datetime, cache_entry["checked_at"])
+            if now - cache_checked_at < cache_ttl:
+                return (
+                    cast(dict[str, object], cache_entry["dependencies"]),
+                    cache_checked_at,
+                    True,
+                )
+
+    dependencies, checked_at = _readiness_dependency_checks(
+        session,
+        include_database_contract=include_database_contract,
+    )
+    with _TRADING_DEPENDENCY_HEALTH_CACHE_LOCK:
+        _TRADING_DEPENDENCY_HEALTH_CACHE[cache_key] = {
+            "checked_at": checked_at,
+            "dependencies": dependencies,
+        }
+    return dependencies, checked_at, False
+
+
 def _evaluate_trading_health_payload(
     session: Session,
     *,
@@ -292,37 +399,23 @@ def _evaluate_trading_health_payload(
         else:
             scheduler_detail = "trading loop not running"
 
-    postgres_status = _check_postgres(session)
-    if settings.trading_enabled:
-        clickhouse_status = _check_clickhouse()
-        alpaca_status = _check_alpaca()
-    else:
-        clickhouse_status = {"ok": True, "detail": "skipped (trading disabled)"}
-        alpaca_status = {"ok": True, "detail": "skipped (trading disabled)"}
-
-    dependencies = {
-        "postgres": postgres_status,
-        "clickhouse": clickhouse_status,
-        "alpaca": alpaca_status,
+    dependencies, checked_at, cache_used = _readiness_dependency_snapshot(
+        session,
+        include_database_contract=include_database_contract,
+    )
+    dependencies = dict(dependencies)
+    dependency_statuses = [
+        cast(dict[str, object], checks).get("ok", True)
+        for name, checks in dependencies.items()
+        if name != "readiness_cache"
+    ]
+    dependencies["readiness_cache"] = {
+        "checked_at": checked_at.isoformat(),
+        "cache_ttl_seconds": settings.trading_readiness_dependency_cache_ttl_seconds,
+        "cache_used": cache_used,
     }
 
-    if include_database_contract:
-        database_contract = _evaluate_database_contract(session)
-        dependencies["database"] = {
-            "ok": bool(database_contract.get("ok")),
-            "detail": "ok" if bool(database_contract.get("ok")) else "database contract failed",
-            "schema_current": bool(database_contract.get("schema_current")),
-            "schema_current_heads": database_contract.get("schema_current_heads"),
-            "expected_heads": database_contract.get("expected_heads"),
-            "schema_head_signature": database_contract.get("schema_head_signature"),
-            "checked_at": database_contract.get("checked_at"),
-            "account_scope_ready": bool(
-                database_contract.get("account_scope_ready")
-            ),
-            "account_scope_errors": database_contract.get("account_scope_errors", []),
-        }
-
-    overall_ok = scheduler_ok and all(dep["ok"] for dep in dependencies.values())
+    overall_ok = scheduler_ok and all(bool(dep) for dep in dependency_statuses)
     status = "ok" if overall_ok else "degraded"
     status_code = 200 if overall_ok else 503
 
@@ -426,9 +519,7 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
             "schema_current": bool(database_contract.get("schema_current")),
             "current_heads": database_contract.get("schema_current_heads"),
             "expected_heads": database_contract.get("expected_heads"),
-            "schema_head_signature": database_contract.get(
-                "schema_head_signature"
-            ),
+            "schema_head_signature": database_contract.get("schema_head_signature"),
         }
         account_scope_status = {
             "account_scope_ready": bool(database_contract.get("account_scope_ready")),
@@ -500,7 +591,9 @@ def whitepaper_status() -> dict[str, object]:
         "workflow_enabled": whitepaper_workflow_enabled(),
         "kafka_enabled": whitepaper_kafka_enabled(),
         "inngest_enabled": whitepaper_inngest_enabled(),
-        "inngest_registered": bool(getattr(app.state, "whitepaper_inngest_registered", False)),
+        "inngest_registered": bool(
+            getattr(app.state, "whitepaper_inngest_registered", False)
+        ),
         "inngest_event_name": os.getenv(
             "WHITEPAPER_INNGEST_EVENT_NAME",
             "torghut/whitepaper.analysis.requested",
@@ -637,14 +730,28 @@ def approve_whitepaper_for_engineering(
 
     _require_whitepaper_control_token(request)
 
-    approved_by = str(payload.get("approved_by") or payload.get("approvedBy") or "").strip()
-    approval_reason = str(payload.get("approval_reason") or payload.get("approvalReason") or "").strip()
-    approval_source = str(payload.get("approval_source") or payload.get("approvalSource") or "jangar_ui").strip()
-    target_scope = str(payload.get("target_scope") or payload.get("targetScope") or "").strip() or None
+    approved_by = str(
+        payload.get("approved_by") or payload.get("approvedBy") or ""
+    ).strip()
+    approval_reason = str(
+        payload.get("approval_reason") or payload.get("approvalReason") or ""
+    ).strip()
+    approval_source = str(
+        payload.get("approval_source") or payload.get("approvalSource") or "jangar_ui"
+    ).strip()
+    target_scope = (
+        str(payload.get("target_scope") or payload.get("targetScope") or "").strip()
+        or None
+    )
     repository = str(payload.get("repository") or "").strip() or None
     base = str(payload.get("base") or "").strip() or None
     head = str(payload.get("head") or "").strip() or None
-    rollout_profile = str(payload.get("rollout_profile") or payload.get("rolloutProfile") or "").strip() or None
+    rollout_profile = (
+        str(
+            payload.get("rollout_profile") or payload.get("rolloutProfile") or ""
+        ).strip()
+        or None
+    )
 
     try:
         result = WHITEPAPER_WORKFLOW.approve_for_engineering(
@@ -667,7 +774,9 @@ def approve_whitepaper_for_engineering(
     except Exception as exc:
         session.rollback()
         logger.exception("Whitepaper manual approval failed for run_id=%s", run_id)
-        raise HTTPException(status_code=500, detail=f"whitepaper_manual_approval_failed:{exc}") from exc
+        raise HTTPException(
+            status_code=500, detail=f"whitepaper_manual_approval_failed:{exc}"
+        ) from exc
     session.commit()
     return cast(dict[str, object], result)
 
@@ -695,11 +804,15 @@ def get_whitepaper_run(
         .first()
     )
 
-    pr_rows = session.execute(
-        select(WhitepaperDesignPullRequest)
-        .where(WhitepaperDesignPullRequest.analysis_run_id == row.id)
-        .order_by(WhitepaperDesignPullRequest.attempt.asc())
-    ).scalars().all()
+    pr_rows = (
+        session.execute(
+            select(WhitepaperDesignPullRequest)
+            .where(WhitepaperDesignPullRequest.analysis_run_id == row.id)
+            .order_by(WhitepaperDesignPullRequest.attempt.asc())
+        )
+        .scalars()
+        .all()
+    )
     trigger_row = session.execute(
         select(WhitepaperEngineeringTrigger).where(
             WhitepaperEngineeringTrigger.analysis_run_id == row.id
@@ -707,11 +820,15 @@ def get_whitepaper_run(
     ).scalar_one_or_none()
     rollout_rows: Sequence[WhitepaperRolloutTransition] = []
     if trigger_row is not None:
-        rollout_rows = session.execute(
-            select(WhitepaperRolloutTransition)
-            .where(WhitepaperRolloutTransition.trigger_id == trigger_row.id)
-            .order_by(WhitepaperRolloutTransition.created_at.asc())
-        ).scalars().all()
+        rollout_rows = (
+            session.execute(
+                select(WhitepaperRolloutTransition)
+                .where(WhitepaperRolloutTransition.trigger_id == trigger_row.id)
+                .order_by(WhitepaperRolloutTransition.created_at.asc())
+            )
+            .scalars()
+            .all()
+        )
 
     return jsonable_encoder(
         {
@@ -826,7 +943,9 @@ def search_whitepapers(
     """Hybrid semantic + lexical whitepaper search over indexed chunks."""
 
     if not whitepaper_semantic_indexing_enabled():
-        raise HTTPException(status_code=409, detail="whitepaper_semantic_search_disabled")
+        raise HTTPException(
+            status_code=409, detail="whitepaper_semantic_search_disabled"
+        )
 
     normalized_scope = scope.strip().lower()
     if normalized_scope not in {"all", "full_text", "synthesis"}:
@@ -846,7 +965,9 @@ def search_whitepapers(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         logger.exception("Whitepaper search failed")
-        raise HTTPException(status_code=500, detail=f"whitepaper_search_failed:{exc}") from exc
+        raise HTTPException(
+            status_code=500, detail=f"whitepaper_search_failed:{exc}"
+        ) from exc
 
     return cast(dict[str, object], jsonable_encoder(result))
 
@@ -1948,9 +2069,8 @@ def _load_runtime_profitability_gate_rollback_attribution(
     actuation_gates = _to_str_map(actuation_payload.get("gates"))
     actuation_root = _to_str_map(actuation_payload)
     actuation_audit = _to_str_map(actuation_payload.get("audit"))
-    actuation_readiness = _to_str_map(
-        actuation_audit.get("rollback_readiness_readout")
-    )
+    actuation_readiness = _to_str_map(actuation_audit.get("rollback_readiness_readout"))
+
     def _optional_trace_id(value: object) -> str | None:
         if value is None:
             return None
@@ -1993,8 +2113,9 @@ def _load_runtime_profitability_gate_rollback_attribution(
     return {
         "gate_report_artifact": gate_artifact_path or None,
         "gate_report_run_id": (
-            str(actuation_payload.get("run_id") or gate_payload.get("run_id") or "")
-            .strip()
+            str(
+                actuation_payload.get("run_id") or gate_payload.get("run_id") or ""
+            ).strip()
             or None
         ),
         "gate_report_trace_id": (
@@ -2027,7 +2148,8 @@ def _load_runtime_profitability_gate_rollback_attribution(
             "artifact_path": actuation_artifact_path or None,
             "actuation_allowed": bool(actuation_root.get("actuation_allowed")),
             "recommendation_trace_id": (
-                str(actuation_gates.get("recommendation_trace_id") or "").strip() or None
+                str(actuation_gates.get("recommendation_trace_id") or "").strip()
+                or None
             ),
             "gate_report_trace_id": (
                 str(actuation_gates.get("gate_report_trace_id") or "").strip() or None

--- a/services/torghut/app/trading/execution_adapters.py
+++ b/services/torghut/app/trading/execution_adapters.py
@@ -295,7 +295,9 @@ class SimulationExecutionAdapter:
             return None
 
         try:
-            producer = KafkaProducer(
+            return cast(
+                Any,
+                KafkaProducer(
                 bootstrap_servers=[item.strip() for item in bootstrap_servers.split(',') if item.strip()],
                 value_serializer=None,
                 key_serializer=None,
@@ -303,8 +305,8 @@ class SimulationExecutionAdapter:
                 request_timeout_ms=2_000,
                 max_block_ms=2_000,
                 **self._kafka_security_kwargs,
+                ),
             )
-            return producer
         except Exception as exc:  # pragma: no cover - environment-dependent
             self._producer_init_error = f'kafka_producer_init_failed:{exc}'
             logger.warning(

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -204,17 +204,20 @@ class OrderFeedIngestor:
         except Exception as exc:  # pragma: no cover - import guarded at runtime
             raise RuntimeError('kafka-python dependency is required for order-feed ingestion') from exc
 
-        return KafkaConsumer(
-            *settings.trading_order_feed_topics,
-            bootstrap_servers=settings.trading_order_feed_bootstrap_server_list,
-            group_id=settings.trading_order_feed_group_id,
-            client_id=settings.trading_order_feed_client_id,
-            enable_auto_commit=False,
-            auto_offset_reset=settings.trading_order_feed_auto_offset_reset,
-            consumer_timeout_ms=max(settings.trading_order_feed_poll_ms, 1000),
-            value_deserializer=None,
-            key_deserializer=None,
-            **settings.trading_order_feed_kafka_security_kwargs,
+        return cast(
+            Any,
+            KafkaConsumer(
+                *settings.trading_order_feed_topics,
+                bootstrap_servers=settings.trading_order_feed_bootstrap_server_list,
+                group_id=settings.trading_order_feed_group_id,
+                client_id=settings.trading_order_feed_client_id,
+                enable_auto_commit=False,
+                auto_offset_reset=settings.trading_order_feed_auto_offset_reset,
+                consumer_timeout_ms=max(settings.trading_order_feed_poll_ms, 1000),
+                value_deserializer=None,
+                key_deserializer=None,
+                **settings.trading_order_feed_kafka_security_kwargs,
+            ),
         )
 
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -15,7 +15,12 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.db import get_session
-from app.main import _assert_dspy_cutover_migration_guard, app
+from app.main import (
+    _TRADING_DEPENDENCY_HEALTH_CACHE,
+    _assert_dspy_cutover_migration_guard,
+    _readiness_dependency_cache_key,
+    app,
+)
 from app.trading.scheduler import TradingScheduler
 from app.config import settings
 from app.models import (
@@ -30,6 +35,7 @@ from app.models import (
 
 class TestTradingApi(TestCase):
     def setUp(self) -> None:
+        _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
         engine = create_engine(
             "sqlite+pysqlite:///:memory:",
             future=True,
@@ -139,6 +145,7 @@ class TestTradingApi(TestCase):
             session.commit()
 
     def tearDown(self) -> None:
+        _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
         app.dependency_overrides.clear()
 
     def test_trading_decisions_endpoint(self) -> None:
@@ -148,7 +155,9 @@ class TestTradingApi(TestCase):
         self.assertEqual(len(payload), 1)
         self.assertEqual(payload[0]["symbol"], "AAPL")
 
-    def test_dspy_cutover_migration_guard_assertion_raises_for_legacy_toggles(self) -> None:
+    def test_dspy_cutover_migration_guard_assertion_raises_for_legacy_toggles(
+        self,
+    ) -> None:
         original_runtime_mode = settings.llm_dspy_runtime_mode
         original_fail_mode_enforcement = settings.llm_fail_mode_enforcement
         original_fail_mode = settings.llm_fail_mode
@@ -382,6 +391,112 @@ class TestTradingApi(TestCase):
         finally:
             settings.trading_enabled = original
 
+    @patch(
+        "app.main._evaluate_database_contract",
+        return_value={
+            "ok": True,
+            "schema_current": True,
+            "schema_current_heads": ["0011_execution_tca_simulator_divergence"],
+            "expected_heads": ["0011_execution_tca_simulator_divergence"],
+            "schema_head_signature": "7f8e4d0",
+            "checked_at": "2026-03-04T00:00:00+00:00",
+            "account_scope_ready": True,
+            "account_scope_errors": [],
+        },
+    )
+    @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    def test_readyz_reuses_dependency_checks_within_cache_ttl(
+        self,
+        _mock_alpaca: object,
+        _mock_clickhouse: object,
+        _mock_postgres: object,
+        _mock_contract: object,
+    ) -> None:
+        original = settings.trading_enabled
+        original_cache_enabled = settings.trading_readiness_dependency_cache_enabled
+        original_cache_ttl = settings.trading_readiness_dependency_cache_ttl_seconds
+        settings.trading_enabled = True
+        settings.trading_readiness_dependency_cache_enabled = True
+        settings.trading_readiness_dependency_cache_ttl_seconds = 8
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = True
+            scheduler.state.last_run_at = datetime.now(timezone.utc)
+            app.state.trading_scheduler = scheduler
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 200)
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(_mock_postgres.call_count, 1)
+            self.assertEqual(_mock_clickhouse.call_count, 1)
+            self.assertEqual(_mock_alpaca.call_count, 1)
+            payload = response.json()
+            self.assertEqual(
+                payload["dependencies"]["readiness_cache"]["cache_used"], True
+            )
+            self.assertIn("checked_at", payload["dependencies"]["readiness_cache"])
+        finally:
+            settings.trading_enabled = original
+            settings.trading_readiness_dependency_cache_enabled = original_cache_enabled
+            settings.trading_readiness_dependency_cache_ttl_seconds = original_cache_ttl
+
+    @patch(
+        "app.main._evaluate_database_contract",
+        return_value={
+            "ok": True,
+            "schema_current": True,
+            "schema_current_heads": ["0011_execution_tca_simulator_divergence"],
+            "expected_heads": ["0011_execution_tca_simulator_divergence"],
+            "schema_head_signature": "7f8e4d0",
+            "checked_at": "2026-03-04T00:00:00+00:00",
+            "account_scope_ready": True,
+            "account_scope_errors": [],
+        },
+    )
+    @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    def test_readyz_refreshes_dependency_checks_after_cache_ttl(
+        self,
+        _mock_alpaca: object,
+        _mock_clickhouse: object,
+        _mock_postgres: object,
+        _mock_contract: object,
+    ) -> None:
+        original = settings.trading_enabled
+        original_cache_enabled = settings.trading_readiness_dependency_cache_enabled
+        original_cache_ttl = settings.trading_readiness_dependency_cache_ttl_seconds
+        settings.trading_enabled = True
+        settings.trading_readiness_dependency_cache_enabled = True
+        settings.trading_readiness_dependency_cache_ttl_seconds = 8
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = True
+            scheduler.state.last_run_at = datetime.now(timezone.utc)
+            app.state.trading_scheduler = scheduler
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 200)
+
+            cache_key = _readiness_dependency_cache_key(include_database_contract=True)
+            _TRADING_DEPENDENCY_HEALTH_CACHE[cache_key]["checked_at"] = datetime.now(
+                timezone.utc
+            ) - timedelta(seconds=120)
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(_mock_postgres.call_count, 2)
+            self.assertEqual(_mock_clickhouse.call_count, 2)
+            self.assertEqual(_mock_alpaca.call_count, 2)
+            payload = response.json()
+            self.assertEqual(
+                payload["dependencies"]["readiness_cache"]["cache_used"], False
+            )
+        finally:
+            settings.trading_enabled = original
+            settings.trading_readiness_dependency_cache_enabled = original_cache_enabled
+            settings.trading_readiness_dependency_cache_ttl_seconds = original_cache_ttl
+
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": False, "detail": "down"})
     @patch(
@@ -460,6 +575,8 @@ class TestTradingApi(TestCase):
                 payload["dependencies"]["database"]["schema_head_signature"], "7f8e4d0"
             )
             self.assertIn("checked_at", payload["dependencies"]["database"])
+            self.assertIn("readiness_cache", payload["dependencies"])
+            self.assertIn("cache_used", payload["dependencies"]["readiness_cache"])
         finally:
             settings.trading_enabled = original
 
@@ -595,7 +712,10 @@ class TestTradingApi(TestCase):
                 payload["dependencies"]["database"]["schema_current"], True
             )
             self.assertFalse(payload["dependencies"]["database"]["account_scope_ready"])
-            self.assertIn("legacy unique index detected", payload["dependencies"]["database"]["account_scope_errors"][0])
+            self.assertIn(
+                "legacy unique index detected",
+                payload["dependencies"]["database"]["account_scope_errors"][0],
+            )
             self.assertEqual(
                 payload["dependencies"]["database"]["schema_head_signature"], "7f8e4d0"
             )


### PR DESCRIPTION
## Summary
- Added configurable in-process readiness dependency caching for Torghut probe endpoints to improve rollout stability under high probe frequency.
- Added bounded freshness metadata to readiness responses (`dependencies.readiness_cache`) and preserved existing readiness schema behavior for trading scheduler, postgres, clickhouse, alpaca, and optional database contract checks.
- Added regression tests for cache reuse and TTL expiry behavior on `/readyz`, plus updated readiness payload assertions in existing database-related checks.
- Added ADR `22-trading-readiness-dependency-freshness-cache-2026-03-04.md` and updated v6 design index ordering.

## Related Issues
- Huly issue: c40d7c5452758d5d6b4d8e5d

## Testing
- `cd /workspace/lab/services/torghut && source .venv/bin/activate && ruff check app/config.py app/main.py app/trading/execution_adapters.py app/trading/order_feed.py tests/test_trading_api.py`
- `cd /workspace/lab/services/torghut && source .venv/bin/activate && python -m pytest tests/test_trading_api.py -q`
- `bunx pyright --project services/torghut/pyrightconfig.json`
- `bunx pyright --project services/torghut/pyrightconfig.alpha.json`
- `bunx pyright --project services/torghut/pyrightconfig.scripts.json`

## Breaking Changes
- None.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
