### PR TITLE
fix(torghut): enable trading kill switch to recover service health

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -76,7 +76,7 @@ spec:
             - name: TRADING_ENABLED
               value: "true"
             - name: TRADING_KILL_SWITCH_ENABLED
-              value: "false"
+              value: "true"
             - name: TRADING_FEATURE_FLAGS_ENABLED
               value: "false"
             - name: TRADING_FEATURE_FLAGS_URL


### PR DESCRIPTION
## Summary

- Set `TRADING_KILL_SWITCH_ENABLED` to `"true"` in Torghut Knative service desired manifest.
- Prevent Torghut startup crash loop caused by trading lane DB pool exhaustion in current image revision.
- Keep GitOps desired state aligned with emergency-safe runtime until a code-level pool fix lands.

## Related Issues

None

## Testing

- `kubectl logs -n torghut deploy/torghut-00044-deployment -c user-container --tail=250` (confirmed repeated `sqlalchemy.exc.TimeoutError` crash path with kill switch disabled before fix)
- `kubectl patch ksvc torghut -n torghut --type='json' -p='[{"op":"replace","path":"/spec/template/spec/containers/0/env/13/value","value":"true"}]'` (validated kill switch setting produces a new revision)
- `kubectl get application torghut -n argocd -o jsonpath='{.status.sync.status} {.status.health.status}{"\n"}'` (used for sync/health convergence verification loop)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
