### PR TITLE
fix(torghut): disable trading lane to restore service readiness

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -74,7 +74,7 @@ spec:
             - name: CLICKHOUSE_TIMEOUT_SECONDS
               value: "10"
             - name: TRADING_ENABLED
-              value: "true"
+              value: "false"
             - name: TRADING_KILL_SWITCH_ENABLED
               value: "true"
             - name: TRADING_FEATURE_FLAGS_ENABLED


### PR DESCRIPTION
## Summary

- Set `TRADING_ENABLED` to `"false"` in Torghut Knative service desired manifest.
- Keep `TRADING_KILL_SWITCH_ENABLED` enabled from the prior hotfix while trading pipeline is unstable.
- Restore service readiness/health by preventing startup background trading and reconcile loops from exhausting SQLAlchemy pool.

## Related Issues

None

## Testing

- `kubectl logs -n torghut deploy/torghut-00045-deployment -c user-container --tail=250` (confirmed reconcile lane still fails with `sqlalchemy.exc.TimeoutError` while kill switch alone is enabled)
- `kubectl get application torghut -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.sync.revision}{"\n"}'`
- `kubectl get ksvc torghut -n torghut -o jsonpath='{.status.latestCreatedRevisionName} {.status.latestReadyRevisionName}{"\n"}'`

## Screenshots (if applicable)

N/A

## Breaking Changes

Trading is intentionally disabled for Torghut until the DB/session pool regression is fixed and validated.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
