### PR TITLE
feat(jangar): add control-plane watch reliability status envelope

### DIFF
--- a/docs/agents/designs/jangar-control-plane-watch-reliability-envelope.md
+++ b/docs/agents/designs/jangar-control-plane-watch-reliability-envelope.md
@@ -1,0 +1,72 @@
+# Jangar Control Plane Watch Reliability Envelope (Design)
+
+Status: Discover (2026-03-04)
+
+## Summary
+
+This design captures operationally relevant watch-layer reliability signals and surfaces them in
+`/api/agents/control-plane/status` so operators can distinguish a healthy control plane from one that is repeatedly
+restarting or erroring watches. The implementation reuses the existing in-process watch machinery and keeps the payload
+compatible with current control-plane status consumers while extending it with a bounded reliability envelope.
+
+## Objectives
+
+- Preserve existing status behavior for controllers, runtime adapters, DB, and gRPC.
+- Add a deterministic, low-cardinality watch reliability signal (`watch_reliability`) to status responses.
+- Keep risk low: no cluster mutation; no schema migrations; failure in status enrichment never blocks status endpoint responses.
+
+## Problem statement
+
+Cluster events show transient pod-level readiness churn and watch-activity failures (for example, multi-attach retries and
+watch-close events), but those signals were previously only available via manual `kubectl get events`, making them
+reactive and non-actionable during sustained incidents.
+
+Control-plane code currently increments global kube-watch counters for events, errors, and restarts, but there was no single
+service-level rollup tied to the operator-facing status surface.
+
+## Proposed design
+
+- Add `services/jangar/src/server/control-plane-watch-reliability.ts` as an in-memory collector:
+  - Tracks per `(resource, namespace)` watch events, errors, and restarts.
+  - Applies a rolling window (default 15 minutes) and drops observations outside the window.
+  - Exposes:
+    - `status` (`healthy|degraded|unknown`)
+    - `window_minutes`
+    - `observed_streams`
+    - `total_events`
+    - `total_errors`
+    - `total_restarts`
+    - `streams` top offenders (bounded).
+- Wire `startResourceWatch()` to record reliability observations in parallel with existing metric counters.
+- Extend `ControlPlaneStatus` with `watch_reliability` and include `watch_reliability` in degraded-component calculations when
+  the watch envelope is degraded.
+- Show watch reliability in the control-plane UI panel, with concise stream-level detail.
+
+## Configuration
+
+- `JANGAR_CONTROL_PLANE_WATCH_HEALTH_WINDOW_MINUTES` (default: `15`)
+- `JANGAR_CONTROL_PLANE_WATCH_HEALTH_STREAM_LIMIT` (default: `20`)
+
+## Alternatives considered
+
+- A) Keep current status payload unchanged and rely solely on manual event review.
+  - Pros: zero implementation and rollout risk.
+  - Cons: no operator-facing reliability signal for sustained watch issues.
+- B) Add a brand-new `/api/agents/control-plane/watch-health` endpoint.
+  - Pros: specialized interface for watch metrics and alerting.
+  - Cons: requires new client work, increased discoverability burden, and duplicated rendering in UI.
+- C) (Selected) Add `watch_reliability` to existing status envelope.
+  - Pros: immediate visibility in already used panel; minimal client/API surface changes; incremental rollout risk.
+  - Cons: status consumers that do not expect the field will ignore it, but new schema is additive.
+
+## Validation plan
+
+- Unit tests for watch reliability collector.
+- Existing kube-watch tests remain aligned and continue verifying event/error/restart recording.
+- Control-plane-status unit tests verify degraded-component propagation (`watch_reliability`).
+- Manual smoke: exercise a short-lived watch error in staging and confirm status stream/reporting changes within the window.
+
+## Rollout notes
+
+- This is an additive code-only change; no database migration required.
+- In degraded mode, status now reports watch failures without failing control-plane status endpoint execution.

--- a/services/jangar/src/components/agents-control-plane-status.tsx
+++ b/services/jangar/src/components/agents-control-plane-status.tsx
@@ -127,6 +127,36 @@ export const ControlPlaneStatusPanel = ({
         </div>
 
         <div className="space-y-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Watch reliability
+          </div>
+          <div className="rounded-none border p-2 border-border/60 bg-muted/30 space-y-1">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="font-medium text-foreground">Kubernetes watch health</span>
+              <StatusBadge label={status.watch_reliability.status} />
+            </div>
+            <div className="text-muted-foreground">
+              Window: {status.watch_reliability.window_minutes}m · Streams: {status.watch_reliability.observed_streams}
+            </div>
+            <div className="text-muted-foreground">
+              Events: {renderSummaryValue(status.watch_reliability.total_events)} · Errors:{' '}
+              {renderSummaryValue(status.watch_reliability.total_errors)} · Restarts:{' '}
+              {renderSummaryValue(status.watch_reliability.total_restarts)}
+            </div>
+            {status.watch_reliability.streams.length > 0 ? (
+              <ul className="space-y-1 pt-1 text-muted-foreground">
+                {status.watch_reliability.streams.map((entry) => (
+                  <li key={`${entry.resource}:${entry.namespace}`} className="text-[11px]">
+                    {entry.resource}/{entry.namespace}: events {entry.events} · errors {entry.errors} · restarts{' '}
+                    {entry.restarts}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="space-y-2">
           <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Dependencies</div>
           <div className="grid gap-2 sm:grid-cols-2">
             <div className="rounded-none border p-2 border-border/60 bg-muted/30 space-y-1">

--- a/services/jangar/src/data/agents-control-plane.ts
+++ b/services/jangar/src/data/agents-control-plane.ts
@@ -131,6 +131,25 @@ export type GrpcStatus = {
   message: string
 }
 
+export type ControlPlaneWatchReliabilityStream = {
+  resource: string
+  namespace: string
+  events: number
+  errors: number
+  restarts: number
+  last_seen_at: string
+}
+
+export type ControlPlaneWatchReliability = {
+  status: 'healthy' | 'degraded' | 'unknown'
+  window_minutes: number
+  observed_streams: number
+  total_events: number
+  total_errors: number
+  total_restarts: number
+  streams: ControlPlaneWatchReliabilityStream[]
+}
+
 export type NamespaceStatus = {
   namespace: string
   status: 'healthy' | 'degraded'
@@ -156,6 +175,7 @@ export type ControlPlaneStatus = {
   runtime_adapters: RuntimeAdapterStatus[]
   database: DatabaseStatus
   grpc: GrpcStatus
+  watch_reliability: ControlPlaneWatchReliability
   namespaces: NamespaceStatus[]
 }
 

--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -11,6 +11,60 @@ const healthyController = {
   lastCheckedAt: '2026-01-20T00:00:00Z',
 }
 
+const watchReliabilityHealthy = {
+  status: 'healthy' as const,
+  window_minutes: 15,
+  observed_streams: 2,
+  total_events: 14,
+  total_errors: 0,
+  total_restarts: 0,
+  streams: [
+    {
+      resource: 'agents',
+      namespace: 'agents',
+      events: 10,
+      errors: 0,
+      restarts: 0,
+      last_seen_at: '2026-01-20T00:00:00Z',
+    },
+    {
+      resource: 'agentruns',
+      namespace: 'agents',
+      events: 4,
+      errors: 0,
+      restarts: 0,
+      last_seen_at: '2026-01-20T00:00:00Z',
+    },
+  ],
+}
+
+const watchReliabilityDegraded = {
+  status: 'degraded' as const,
+  window_minutes: 15,
+  observed_streams: 2,
+  total_events: 3,
+  total_errors: 2,
+  total_restarts: 1,
+  streams: [
+    {
+      resource: 'agents',
+      namespace: 'agents',
+      events: 2,
+      errors: 1,
+      restarts: 1,
+      last_seen_at: '2026-01-20T00:00:00Z',
+    },
+    {
+      resource: 'jobs',
+      namespace: 'agents',
+      events: 1,
+      errors: 1,
+      restarts: 0,
+      last_seen_at: '2026-01-20T00:00:00Z',
+    },
+  ],
+}
+
 describe('control-plane status', () => {
   it('returns healthy summary when components are healthy', async () => {
     const status = await buildControlPlaneStatus(
@@ -42,6 +96,7 @@ describe('control-plane status', () => {
           message: '',
           latency_ms: 4,
         }),
+        getWatchReliabilitySummary: () => watchReliabilityHealthy,
       },
     )
 
@@ -51,6 +106,8 @@ describe('control-plane status', () => {
     expect(status.namespaces).toHaveLength(1)
     expect(status.namespaces[0]?.status).toBe('healthy')
     expect(status.namespaces[0]?.degraded_components ?? []).toHaveLength(0)
+    expect(status.watch_reliability).toEqual(watchReliabilityHealthy)
+    expect(status.watch_reliability.streams).toHaveLength(2)
   })
 
   it('marks degraded components when controllers or database fail', async () => {
@@ -92,6 +149,7 @@ describe('control-plane status', () => {
           message: 'DATABASE_URL not set',
           latency_ms: 0,
         }),
+        getWatchReliabilitySummary: () => watchReliabilityDegraded,
       },
     )
 
@@ -100,6 +158,9 @@ describe('control-plane status', () => {
     expect(degraded).toContain('agents-controller')
     expect(degraded).toContain('runtime:temporal')
     expect(degraded).toContain('database')
+    expect(degraded).toContain('watch_reliability')
     expect(degraded).not.toContain('grpc')
+    expect(status.watch_reliability.status).toBe('degraded')
+    expect(status.watch_reliability.total_errors).toBe(2)
   })
 })

--- a/services/jangar/src/server/__tests__/control-plane-watch-reliability.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-watch-reliability.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearWatchReliabilityState,
+  getWatchReliabilitySummary,
+  recordWatchReliabilityError,
+  recordWatchReliabilityEvent,
+  recordWatchReliabilityRestart,
+} from '~/server/control-plane-watch-reliability'
+
+const withEnv = <T>(updates: Record<string, string | undefined>, fn: () => T): T => {
+  const backup = { ...process.env }
+  Object.entries(updates).forEach(([key, value]) => {
+    if (value == null) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  })
+  try {
+    return fn()
+  } finally {
+    process.env = backup
+  }
+}
+
+describe('control-plane watch reliability', () => {
+  beforeEach(() => {
+    clearWatchReliabilityState()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-20T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns degraded state when errors occur in the configured window', () => {
+    recordWatchReliabilityEvent({ resource: 'AgentRun', namespace: 'agents' })
+    recordWatchReliabilityEvent({ resource: 'AgentRun', namespace: 'agents' })
+    recordWatchReliabilityError({ resource: 'Agent', namespace: 'agents' })
+
+    const summary = getWatchReliabilitySummary()
+    expect(summary.status).toBe('degraded')
+    expect(summary.total_events).toBe(2)
+    expect(summary.total_errors).toBe(1)
+    expect(summary.total_restarts).toBe(0)
+    expect(summary.streams).toHaveLength(2)
+    expect(summary.streams[0]).toMatchObject({ resource: 'Agent', namespace: 'agents', errors: 1, events: 0 })
+    expect(summary.streams[1]).toMatchObject({ resource: 'AgentRun', namespace: 'agents', events: 2, errors: 0 })
+  })
+
+  it('returns unknown when no stream activity exists in the window', () => {
+    const summary = getWatchReliabilitySummary()
+    expect(summary.status).toBe('unknown')
+    expect(summary.total_events).toBe(0)
+    expect(summary.total_errors).toBe(0)
+    expect(summary.total_restarts).toBe(0)
+    expect(summary.streams).toHaveLength(0)
+  })
+
+  it('expires observations outside the configured window', () => {
+    withEnv({ JANGAR_CONTROL_PLANE_WATCH_HEALTH_WINDOW_MINUTES: '5' }, () => {
+      recordWatchReliabilityError({ resource: 'Agent', namespace: 'agents' })
+      vi.advanceTimersByTime(6 * 60 * 1000)
+      const summary = getWatchReliabilitySummary()
+      expect(summary.status).toBe('unknown')
+      expect(summary.total_errors).toBe(0)
+      expect(summary.streams).toHaveLength(0)
+    })
+  })
+
+  it('includes restarts in status and degraded detection', () => {
+    recordWatchReliabilityRestart({ resource: 'Workflow', namespace: 'agents' })
+    const summary = getWatchReliabilitySummary()
+    expect(summary.status).toBe('degraded')
+    expect(summary.total_restarts).toBe(1)
+    expect(summary.streams[0]).toMatchObject({ resource: 'Workflow', namespace: 'agents', restarts: 1 })
+  })
+})

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -6,6 +6,10 @@ import { getDb } from '~/server/db'
 import { getLeaderElectionStatus } from '~/server/leader-election'
 import { getOrchestrationControllerHealth } from '~/server/orchestration-controller'
 import { getSupportingControllerHealth } from '~/server/supporting-primitives-controller'
+import {
+  getWatchReliabilitySummary,
+  type ControlPlaneWatchReliabilitySummary,
+} from '~/server/control-plane-watch-reliability'
 
 const DEFAULT_TEMPORAL_HOST = 'temporal-frontend.temporal.svc.cluster.local'
 const DEFAULT_TEMPORAL_PORT = 7233
@@ -54,6 +58,16 @@ export type NamespaceStatus = {
   degraded_components: string[]
 }
 
+export type ControlPlaneWatchReliability = {
+  status: ControlPlaneWatchReliabilitySummary['status']
+  window_minutes: number
+  observed_streams: number
+  total_events: number
+  total_errors: number
+  total_restarts: number
+  streams: ControlPlaneWatchReliabilitySummary['streams']
+}
+
 export type ControlPlaneStatus = {
   service: string
   generated_at: string
@@ -73,6 +87,7 @@ export type ControlPlaneStatus = {
   runtime_adapters: RuntimeAdapterStatus[]
   database: DatabaseStatus
   grpc: GrpcStatus
+  watch_reliability: ControlPlaneWatchReliability
   namespaces: NamespaceStatus[]
 }
 
@@ -89,6 +104,7 @@ export type ControlPlaneStatusDeps = {
   getOrchestrationControllerHealth?: () => ControllerHealth
   resolveTemporalAdapter?: () => Promise<RuntimeAdapterStatus>
   checkDatabase?: () => Promise<DatabaseStatus>
+  getWatchReliabilitySummary?: () => ControlPlaneWatchReliabilitySummary
 }
 
 const normalizeMessage = (value: unknown) => (value instanceof Error ? value.message : String(value))
@@ -284,6 +300,7 @@ export const buildControlPlaneStatus = async (
 
   const database = await (deps.checkDatabase ?? checkDatabase)()
   const grpcStatus = options.grpc
+  const watchReliability = (deps.getWatchReliabilitySummary ?? getWatchReliabilitySummary)()
 
   const degradedComponents = [
     ...controllers
@@ -292,6 +309,7 @@ export const buildControlPlaneStatus = async (
     ...runtimeAdapters.filter((adapter) => adapter.status === 'degraded').map((adapter) => `runtime:${adapter.name}`),
     ...(database.status === 'healthy' ? [] : ['database']),
     ...(grpcStatus.enabled && grpcStatus.status !== 'healthy' ? ['grpc'] : []),
+    ...(watchReliability.status === 'degraded' ? ['watch_reliability'] : []),
   ]
 
   const now = (deps.now ?? (() => new Date()))()
@@ -316,6 +334,15 @@ export const buildControlPlaneStatus = async (
     runtime_adapters: runtimeAdapters,
     database,
     grpc: grpcStatus,
+    watch_reliability: {
+      status: watchReliability.status,
+      window_minutes: watchReliability.window_minutes,
+      observed_streams: watchReliability.observed_streams,
+      total_events: watchReliability.total_events,
+      total_errors: watchReliability.total_errors,
+      total_restarts: watchReliability.total_restarts,
+      streams: watchReliability.streams,
+    },
     namespaces: [
       {
         namespace: options.namespace,

--- a/services/jangar/src/server/control-plane-watch-reliability.ts
+++ b/services/jangar/src/server/control-plane-watch-reliability.ts
@@ -1,0 +1,180 @@
+type ControlPlaneWatchReliabilityStream = {
+  resource: string
+  namespace: string
+  events: number
+  errors: number
+  restarts: number
+  last_seen_at: string
+}
+
+export type ControlPlaneWatchReliabilitySummary = {
+  status: 'healthy' | 'degraded' | 'unknown'
+  window_minutes: number
+  observed_streams: number
+  total_events: number
+  total_errors: number
+  total_restarts: number
+  streams: ControlPlaneWatchReliabilityStream[]
+}
+
+type WatchEventType = 'event' | 'error' | 'restart'
+
+type WatchStreamState = {
+  events: number[]
+  errors: number[]
+  restarts: number[]
+  lastSeenAt: number
+  resource: string
+  namespace: string
+}
+
+const DEFAULT_WINDOW_MINUTES = 15
+const DEFAULT_STREAM_LIMIT = 20
+const MAX_RECORDED_STREAMS = 200
+const TOP_STREAM_LIMIT = 10
+const MINUTE_MS = 60_000
+
+const normalize = (value: string) => {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : 'unknown'
+}
+
+const resolveWindowMinutes = () => {
+  const raw = process.env.JANGAR_CONTROL_PLANE_WATCH_HEALTH_WINDOW_MINUTES?.trim()
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_WINDOW_MINUTES
+  return Math.min(Math.max(Math.floor(parsed), 1), 24 * 60)
+}
+
+const resolveStreamLimit = () => {
+  const raw = process.env.JANGAR_CONTROL_PLANE_WATCH_HEALTH_STREAM_LIMIT?.trim()
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_STREAM_LIMIT
+  return Math.min(Math.max(Math.floor(parsed), 1), MAX_RECORDED_STREAMS)
+}
+
+const windowStartMs = (now: number, windowMinutes: number) => now - windowMinutes * MINUTE_MS
+
+const prune = (values: number[], cutoffMs: number) => {
+  while (values.length > 0 && values[0] < cutoffMs) {
+    values.shift()
+  }
+}
+
+const streamStore = new Map<string, WatchStreamState>()
+const makeStreamKey = (resource: string, namespace: string) => `${normalize(resource)}||${normalize(namespace)}`
+
+const readStreamState = (resource: string, namespace: string) => {
+  const normalizedResource = normalize(resource)
+  const normalizedNamespace = normalize(namespace)
+  const key = makeStreamKey(normalizedResource, normalizedNamespace)
+  let state = streamStore.get(key)
+  if (!state) {
+    state = {
+      events: [],
+      errors: [],
+      restarts: [],
+      lastSeenAt: Date.now(),
+      resource: normalizedResource,
+      namespace: normalizedNamespace,
+    }
+    streamStore.set(key, state)
+  }
+  if (streamStore.size > MAX_RECORDED_STREAMS) {
+    const oldest = [...streamStore.entries()].sort((a, b) => a[1].lastSeenAt - b[1].lastSeenAt)[0]
+    if (oldest) {
+      streamStore.delete(oldest[0])
+    }
+  }
+  return state
+}
+
+const record = (eventType: WatchEventType, input: { resource: string; namespace: string }) => {
+  const now = Date.now()
+  const state = readStreamState(input.resource, input.namespace)
+  state.lastSeenAt = now
+  if (eventType === 'event') {
+    state.events.push(now)
+  } else if (eventType === 'error') {
+    state.errors.push(now)
+  } else {
+    state.restarts.push(now)
+  }
+}
+
+export const recordWatchReliabilityEvent = (input: { resource: string; namespace: string }) => {
+  record('event', input)
+}
+
+export const recordWatchReliabilityError = (input: { resource: string; namespace: string }) => {
+  record('error', input)
+}
+
+export const recordWatchReliabilityRestart = (input: { resource: string; namespace: string }) => {
+  record('restart', input)
+}
+
+export const getWatchReliabilitySummary = (): ControlPlaneWatchReliabilitySummary => {
+  const now = Date.now()
+  const windowMinutes = resolveWindowMinutes()
+  const cutoffMs = windowStartMs(now, windowMinutes)
+  const observedStreams = new Array<ControlPlaneWatchReliabilityStream>()
+
+  let totalEvents = 0
+  let totalErrors = 0
+  let totalRestarts = 0
+
+  for (const [key, state] of streamStore.entries()) {
+    prune(state.events, cutoffMs)
+    prune(state.errors, cutoffMs)
+    prune(state.restarts, cutoffMs)
+
+    const hasRecentActivity =
+      state.events.length > 0 || state.errors.length > 0 || state.restarts.length > 0 || state.lastSeenAt >= cutoffMs
+
+    if (!hasRecentActivity) {
+      streamStore.delete(key)
+      continue
+    }
+
+    const events = state.events.length
+    const errors = state.errors.length
+    const restarts = state.restarts.length
+    observedStreams.push({
+      resource: state.resource,
+      namespace: state.namespace,
+      events,
+      errors,
+      restarts,
+      last_seen_at: new Date(state.lastSeenAt).toISOString(),
+    })
+
+    totalEvents += events
+    totalErrors += errors
+    totalRestarts += restarts
+  }
+
+  const streamLimit = resolveStreamLimit()
+  observedStreams.sort((a, b) => {
+    const delta = b.errors + b.restarts - (a.errors + a.restarts)
+    if (delta !== 0) return delta
+    return b.events - a.events
+  })
+  const topStreams = observedStreams.slice(0, Math.min(streamLimit, TOP_STREAM_LIMIT))
+
+  const status = totalErrors > 0 || totalRestarts > 0 ? 'degraded' : observedStreams.length > 0 ? 'healthy' : 'unknown'
+
+  return {
+    status,
+    window_minutes: windowMinutes,
+    observed_streams: observedStreams.length,
+    total_events: totalEvents,
+    total_errors: totalErrors,
+    total_restarts: totalRestarts,
+    streams: topStreams,
+  }
+}
+
+export const clearWatchReliabilityState = () => {
+  streamStore.clear()
+}

--- a/services/jangar/src/server/kube-watch.ts
+++ b/services/jangar/src/server/kube-watch.ts
@@ -1,5 +1,10 @@
 import { spawn } from 'node:child_process'
 import { recordKubeWatchError, recordKubeWatchEvent, recordKubeWatchRestart } from '~/server/metrics'
+import {
+  recordWatchReliabilityError,
+  recordWatchReliabilityEvent,
+  recordWatchReliabilityRestart,
+} from '~/server/control-plane-watch-reliability'
 
 type WatchEvent = {
   type?: string
@@ -108,6 +113,10 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
       restartTimer = null
       start()
     }, restartDelayMs)
+    recordWatchReliabilityRestart({
+      resource: normalizedResource,
+      namespace: normalizedNamespace,
+    })
   }
 
   const start = () => {
@@ -142,6 +151,10 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
           namespace: normalizedNamespace,
           type: eventType,
         })
+        recordWatchReliabilityEvent({
+          resource: normalizedResource,
+          namespace: normalizedNamespace,
+        })
         void onEvent(payload)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
@@ -149,6 +162,10 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
           resource: normalizedResource,
           namespace: normalizedNamespace,
           reason: 'parse_error',
+        })
+        recordWatchReliabilityError({
+          resource: normalizedResource,
+          namespace: normalizedNamespace,
         })
         onError?.(new Error(`${logPrefix} failed to parse watch event: ${message}`))
       }
@@ -175,6 +192,10 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
             namespace: normalizedNamespace,
             reason: 'stderr_message',
           })
+          recordWatchReliabilityError({
+            resource: normalizedResource,
+            namespace: normalizedNamespace,
+          })
           onError?.(new Error(`${logPrefix} ${resource} (${namespace}) stderr: ${message}`))
         }
       })
@@ -184,6 +205,10 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
         namespace: normalizedNamespace,
         reason: 'stderr_unavailable',
       })
+      recordWatchReliabilityError({
+        resource: normalizedResource,
+        namespace: normalizedNamespace,
+      })
       onError?.(new Error(`${logPrefix} ${resource} (${namespace}) stderr unavailable`))
     }
     child.on('error', (error) => {
@@ -191,6 +216,10 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
         resource: normalizedResource,
         namespace: normalizedNamespace,
         reason: 'spawn_error',
+      })
+      recordWatchReliabilityError({
+        resource: normalizedResource,
+        namespace: normalizedNamespace,
       })
       onError?.(error instanceof Error ? error : new Error(String(error)))
       scheduleRestart('spawn_error')
@@ -202,6 +231,10 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
           resource: normalizedResource,
           namespace: normalizedNamespace,
           reason: `close_${String(code ?? 'unknown')}`,
+        })
+        recordWatchReliabilityError({
+          resource: normalizedResource,
+          namespace: normalizedNamespace,
         })
         onError?.(new Error(`${logPrefix} ${resource} (${namespace}) closed with code ${code ?? 'unknown'}`))
       }


### PR DESCRIPTION
## Summary

- Add an in-memory Kubernetes watch reliability collector (`control-plane-watch-reliability.ts`) that tracks per `(resource, namespace)` events, errors, and restarts with a configurable rolling window.
- Wire watch reliability tracking into `startResourceWatch()` and surface a new `watch_reliability` status envelope via `/api/agents/control-plane/status`.
- Include watch reliability in degraded status propagation and render a new control-plane UI section in `ControlPlaneStatusPanel`.
- Add regression coverage for collector behavior and status propagation.
- Add a design document and complete discover mission evidence in `/workspace/.agentrun/swarm/jangar-control-plane-discover.md`.

## Related Issues

- TSK-133 (`7b24428471f4e8d0e1f25a43`)

## Testing

- `cd services/jangar && bun run lint`
- `cd services/jangar && bun run lint:oxlint`
- `cd /workspace/lab && bunx oxfmt --check src/server/control-plane-watch-reliability.ts src/server/kube-watch.ts src/server/control-plane-status.ts src/server/__tests__/control-plane-status.test.ts src/server/__tests__/control-plane-watch-reliability.test.ts src/data/agents-control-plane.ts src/components/agents-control-plane-status.tsx`
- `cd /workspace/lab/services/jangar && bunx vitest run src/server/__tests__/control-plane-status.test.ts src/server/__tests__/control-plane-watch-reliability.test.ts src/server/__tests__/kube-watch.test.ts`

## Screenshots

- N/A

## Breaking Changes

- None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
