### PR TITLE
feat(torghut): add schema drift diagnostics to readiness checks

### DIFF
--- a/docs/torghut/design-system/v6/23-readiness-schema-drift-diagnostics-2026-03-04.md
+++ b/docs/torghut/design-system/v6/23-readiness-schema-drift-diagnostics-2026-03-04.md
@@ -1,0 +1,57 @@
+# 23. Readiness Schema Drift Diagnostics for Deployment Stability (2026-03-04)
+
+## Summary
+
+`torghut` currently reports readiness health as boolean pass/fail for schema readiness in `/readyz` and `/db-check`, but operators cannot quickly distinguish migration drift types when failures occur. When rollout probes flap, teams lose time reconstructing whether a failure is due to missing expected Alembic heads, unexpected extra heads, or a configuration bypass in single-account mode. This proposal adds deterministic schema-drift diagnostics to both readiness and db-check responses.
+
+## Problem
+
+From current cluster observations, `torghut` shows repeated probe failures during revisions (`Readiness probe failed`, `Liveness probe failed`, `503`, and private service endpoint churn) while the rollout path still needs to preserve quick root-cause signals. In production debugging, a single boolean `schema_current` can hide the actual contract mismatch shape, making it harder to know whether failures are transient, pending migration, or drift.
+
+## Decision
+
+Emit and propagate structured migration-contract diagnostics from `check_schema_current` and `_evaluate_database_contract` into:
+
+- `services/torghut/app/db.py`
+  - Extend schema-check return with deterministic drift fields:
+    - `schema_missing_heads`
+    - `schema_unexpected_heads`
+    - `schema_head_count_expected`
+    - `schema_head_count_current`
+    - `schema_head_delta_count`
+- `services/torghut/app/main.py`
+  - Include the above fields in `/readyz` dependency payload under `dependencies.database`.
+  - Include the same fields in `/db-check` diagnostic detail payload.
+  - Add `account_scope_warnings` when account-scope checks are intentionally bypassed because `trading_multi_account_enabled=false`.
+
+## Alternatives Considered
+
+- Option A: Keep current boolean-only schema contract outputs.
+  - Pros: minimal surface area.
+  - Cons: continues to force human investigation during rollout by requiring log correlation for every failure.
+- Option B: Add external log enrichment and rely on migration/job logs only.
+  - Pros: no API shape changes.
+  - Cons: not available in every readiness consumer path and still delayed by log aggregation.
+- Option C (selected): Add schema-drift fields directly in contract payloads.
+  - Pros: fastest operator path to root-cause, zero extra dependency, additive contract change.
+  - Cons: increases payload size and requires endpoint contract test updates.
+
+## Tradeoffs and Risks
+
+- Increased contract payload size is small and additive; clients should ignore unknown fields.
+- Diff fields are computed from Alembic head sets, not migration history semantics; they indicate drift shape, not operational severity.
+- In single-account mode, bypassed account-scope checks remain possible by design and now emit explicit warnings to prevent silent assumptions.
+
+## Validation
+
+- Added/updated tests in `services/torghut/tests/test_db.py`:
+  - schema drift signal assertions for `check_schema_current`.
+- Added/updated tests in `services/torghut/tests/test_trading_api.py`:
+  - `/db-check` now asserts `schema_missing_heads`, `schema_unexpected_heads`, and head-count diagnostics.
+  - `/readyz` failure path asserts schema drift fields in `dependencies.database`.
+  - Single-account mode verifies explicit account-scope bypass warnings are visible.
+
+## Rollback
+
+- Remove the new diagnostic fields from `_readiness_dependency_checks`, `_evaluate_database_contract`, and `/db-check` payload assembly while retaining existing schema boolean checks.
+- Keep compatibility with schema contract helpers and existing DB checks if diagnostic fields are no longer needed.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -55,6 +55,7 @@ This pack is positioned as the next architecture layer above:
 20. `20-trading-allocator-config-surface-hardening-2026-03-04.md`
 21. `21-schema-fingerprint-and-freshness-for-database-readiness-2026-03-04.md`
 22. `22-trading-readiness-dependency-freshness-cache-2026-03-04.md`
+23. `23-readiness-schema-drift-diagnostics-2026-03-04.md`
 
 ## Recommended Build Order
 
@@ -81,6 +82,7 @@ This pack is positioned as the next architecture layer above:
 20. `20-trading-allocator-config-surface-hardening-2026-03-04.md`
 21. `21-schema-fingerprint-and-freshness-for-database-readiness-2026-03-04.md`
 22. `22-trading-readiness-dependency-freshness-cache-2026-03-04.md`
+23. `23-readiness-schema-drift-diagnostics-2026-03-04.md`
 
 ## Why This Sequence
 

--- a/services/torghut/app/db.py
+++ b/services/torghut/app/db.py
@@ -304,4 +304,10 @@ def check_schema_current(session: Session) -> dict[str, object]:
         "current_heads": current_heads,
         "expected_heads": list(expected_heads),
         "expected_heads_signature": _schema_heads_signature(expected_heads),
+        "schema_missing_heads": sorted(expected_heads_set - current_heads_set),
+        "schema_unexpected_heads": sorted(current_heads_set - expected_heads_set),
+        "schema_head_count_expected": len(expected_heads),
+        "schema_head_count_current": len(current_heads),
+        "schema_head_delta_count": len(expected_heads_set - current_heads_set)
+        + len(current_heads_set - expected_heads_set),
     }

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -325,10 +325,31 @@ def _readiness_dependency_checks(
             "schema_current": bool(database_contract.get("schema_current")),
             "schema_current_heads": database_contract.get("schema_current_heads"),
             "expected_heads": database_contract.get("expected_heads"),
+            "schema_missing_heads": database_contract.get(
+                "schema_missing_heads",
+                [],
+            ),
+            "schema_unexpected_heads": database_contract.get(
+                "schema_unexpected_heads",
+                [],
+            ),
+            "schema_head_count_expected": database_contract.get(
+                "schema_head_count_expected",
+            ),
+            "schema_head_count_current": database_contract.get(
+                "schema_head_count_current",
+            ),
+            "schema_head_delta_count": database_contract.get(
+                "schema_head_delta_count",
+            ),
             "schema_head_signature": database_contract.get("schema_head_signature"),
             "checked_at": database_contract.get("checked_at"),
             "account_scope_ready": bool(database_contract.get("account_scope_ready")),
             "account_scope_errors": database_contract.get("account_scope_errors", []),
+            "account_scope_warnings": database_contract.get(
+                "account_scope_warnings",
+                [],
+            ),
         }
 
     return dependencies, datetime.now(timezone.utc)
@@ -591,9 +612,13 @@ def _evaluate_database_contract(session: Session) -> dict[str, object]:
         }
 
     account_scope_checks = dict(account_scope_status)
+    account_scope_warnings: list[str] = []
     if not settings.trading_multi_account_enabled:
         account_scope_checks["account_scope_ready"] = True
         account_scope_checks["account_scope_errors"] = []
+        account_scope_warnings.append(
+            "account scope checks are bypassed when trading_multi_account_enabled is false"
+        )
 
     schema_current = bool(schema_status.get("schema_current"))
     account_scope_ready = bool(account_scope_checks.get("account_scope_ready"))
@@ -602,6 +627,11 @@ def _evaluate_database_contract(session: Session) -> dict[str, object]:
         "schema_current": schema_current,
         "schema_current_heads": schema_status.get("current_heads", []),
         "expected_heads": schema_status.get("expected_heads", []),
+        "schema_missing_heads": schema_status.get("schema_missing_heads", []),
+        "schema_unexpected_heads": schema_status.get("schema_unexpected_heads", []),
+        "schema_head_count_expected": schema_status.get("schema_head_count_expected"),
+        "schema_head_count_current": schema_status.get("schema_head_count_current"),
+        "schema_head_delta_count": schema_status.get("schema_head_delta_count"),
         "schema_head_signature": schema_status.get(
             "expected_heads_signature",
             schema_status.get("schema_head_signature"),
@@ -609,6 +639,7 @@ def _evaluate_database_contract(session: Session) -> dict[str, object]:
         "checked_at": checked_at,
         "account_scope_ready": account_scope_ready,
         "account_scope_errors": account_scope_checks.get("account_scope_errors", []),
+        "account_scope_warnings": account_scope_warnings,
     }
 
 
@@ -649,10 +680,25 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
             "current_heads": database_contract.get("schema_current_heads"),
             "expected_heads": database_contract.get("expected_heads"),
             "schema_head_signature": database_contract.get("schema_head_signature"),
+            "schema_missing_heads": database_contract.get("schema_missing_heads", []),
+            "schema_unexpected_heads": database_contract.get("schema_unexpected_heads", []),
+            "schema_head_count_expected": database_contract.get(
+                "schema_head_count_expected",
+            ),
+            "schema_head_count_current": database_contract.get(
+                "schema_head_count_current",
+            ),
+            "schema_head_delta_count": database_contract.get(
+                "schema_head_delta_count",
+            ),
         }
         account_scope_status = {
             "account_scope_ready": bool(database_contract.get("account_scope_ready")),
             "account_scope_errors": database_contract.get("account_scope_errors", []),
+            "account_scope_warnings": database_contract.get(
+                "account_scope_warnings",
+                [],
+            ),
         }
     except SQLAlchemyError as exc:
         raise HTTPException(status_code=503, detail="database unavailable") from exc
@@ -665,8 +711,14 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
             detail={
                 "error": database_contract.get("error"),
                 "schema_current": False,
+                "schema_missing_heads": database_contract.get("schema_missing_heads", []),
+                "schema_unexpected_heads": database_contract.get("schema_unexpected_heads", []),
                 "checked_at": database_contract.get("checked_at"),
                 "account_scope_ready": account_scope_status.get("account_scope_ready"),
+                "account_scope_warnings": account_scope_status.get(
+                    "account_scope_warnings",
+                    [],
+                ),
             },
         )
 
@@ -676,6 +728,17 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
             detail={
                 "error": "database schema mismatch",
                 "checked_at": database_contract.get("checked_at"),
+                "schema_missing_heads": database_contract.get("schema_missing_heads", []),
+                "schema_unexpected_heads": database_contract.get("schema_unexpected_heads", []),
+                "schema_head_count_expected": database_contract.get(
+                    "schema_head_count_expected",
+                ),
+                "schema_head_count_current": database_contract.get(
+                    "schema_head_count_current",
+                ),
+                "schema_head_delta_count": database_contract.get(
+                    "schema_head_delta_count",
+                ),
                 **schema_status,
             },
         )
@@ -688,6 +751,10 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
                 "error": "database account scope schema mismatch",
                 "checked_at": database_contract.get("checked_at"),
                 "schema_head_signature": database_contract.get("schema_head_signature"),
+                "account_scope_warnings": database_contract.get(
+                    "account_scope_warnings",
+                    [],
+                ),
                 **account_scope_status,
             },
         )

--- a/services/torghut/tests/test_db.py
+++ b/services/torghut/tests/test_db.py
@@ -110,6 +110,11 @@ class TestDbSchemaCurrent(TestCase):
             status["expected_heads_signature"],
             hashlib.sha256("0011_demo_alpha,0012_demo_beta".encode("utf-8")).hexdigest(),
         )
+        self.assertEqual(status["schema_missing_heads"], ["0012_demo_beta"])
+        self.assertEqual(status["schema_unexpected_heads"], ["0012_demo_gamma"])
+        self.assertEqual(status["schema_head_count_expected"], 2)
+        self.assertEqual(status["schema_head_count_current"], 3)
+        self.assertEqual(status["schema_head_delta_count"], 2)
 
     def test_expected_schema_heads_cached(self) -> None:
         app_db._get_expected_schema_heads.cache_clear()

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -194,6 +194,11 @@ class TestTradingApi(TestCase):
             "current_heads": ["0011_execution_tca_simulator_divergence"],
             "expected_heads": ["0011_execution_tca_simulator_divergence"],
             "schema_head_signature": "7f8e4d0",
+            "schema_missing_heads": [],
+            "schema_unexpected_heads": [],
+            "schema_head_count_expected": 1,
+            "schema_head_count_current": 1,
+            "schema_head_delta_count": 0,
         },
     )
     @patch(
@@ -213,6 +218,11 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["current_heads"], payload["expected_heads"])
         self.assertTrue(payload["account_scope_ready"])
         self.assertEqual(payload["schema_head_signature"], "7f8e4d0")
+        self.assertEqual(payload["schema_missing_heads"], [])
+        self.assertEqual(payload["schema_unexpected_heads"], [])
+        self.assertEqual(payload["schema_head_count_expected"], 1)
+        self.assertEqual(payload["schema_head_count_current"], 1)
+        self.assertEqual(payload["schema_head_delta_count"], 0)
         self.assertIn("checked_at", payload)
 
     @patch(
@@ -225,6 +235,14 @@ class TestTradingApi(TestCase):
                 "0011_execution_tca_simulator_divergence",
             ],
             "schema_head_signature": "7f8e4d0",
+            "schema_missing_heads": [
+                "0011_autonomy_lifecycle_and_promotion_audit",
+                "0011_execution_tca_simulator_divergence",
+            ],
+            "schema_unexpected_heads": ["0010_execution_provenance_and_governance_trace"],
+            "schema_head_count_expected": 2,
+            "schema_head_count_current": 1,
+            "schema_head_delta_count": 3,
         },
     )
     @patch(
@@ -241,6 +259,20 @@ class TestTradingApi(TestCase):
         payload = response.json()
         self.assertEqual(payload["detail"]["error"], "database schema mismatch")
         self.assertFalse(payload["detail"]["schema_current"])
+        self.assertEqual(
+            payload["detail"]["schema_missing_heads"],
+            [
+                "0011_autonomy_lifecycle_and_promotion_audit",
+                "0011_execution_tca_simulator_divergence",
+            ],
+        )
+        self.assertEqual(
+            payload["detail"]["schema_unexpected_heads"],
+            ["0010_execution_provenance_and_governance_trace"],
+        )
+        self.assertEqual(payload["detail"]["schema_head_count_expected"], 2)
+        self.assertEqual(payload["detail"]["schema_head_count_current"], 1)
+        self.assertEqual(payload["detail"]["schema_head_delta_count"], 3)
         self.assertEqual(payload["detail"]["schema_head_signature"], "7f8e4d0")
         self.assertIn("checked_at", payload["detail"])
 
@@ -251,6 +283,11 @@ class TestTradingApi(TestCase):
             "current_heads": ["0011_execution_tca_simulator_divergence"],
             "expected_heads": ["0011_execution_tca_simulator_divergence"],
             "schema_head_signature": "7f8e4d0",
+            "schema_missing_heads": [],
+            "schema_unexpected_heads": [],
+            "schema_head_count_expected": 1,
+            "schema_head_count_current": 1,
+            "schema_head_delta_count": 0,
         },
     )
     def test_db_check_enforces_account_scope_when_multi_account_enabled(
@@ -289,6 +326,11 @@ class TestTradingApi(TestCase):
             "current_heads": ["0011_execution_tca_simulator_divergence"],
             "expected_heads": ["0011_execution_tca_simulator_divergence"],
             "schema_head_signature": "7f8e4d0",
+            "schema_missing_heads": [],
+            "schema_unexpected_heads": [],
+            "schema_head_count_expected": 1,
+            "schema_head_count_current": 1,
+            "schema_head_delta_count": 0,
         },
     )
     def test_db_check_allows_account_scope_issues_when_multi_account_disabled(
@@ -313,6 +355,16 @@ class TestTradingApi(TestCase):
         payload = response.json()
         self.assertTrue(payload["ok"])
         self.assertEqual(payload["account_scope_ready"], True)
+        self.assertIn(
+            "account_scope_warnings",
+            payload["account_scope_checks"],
+        )
+        self.assertEqual(
+            payload["account_scope_checks"]["account_scope_warnings"],
+            [
+                "account scope checks are bypassed when trading_multi_account_enabled is false"
+            ],
+        )
         self.assertEqual(payload["schema_head_signature"], "7f8e4d0")
         self.assertIn("checked_at", payload)
 
@@ -715,6 +767,11 @@ class TestTradingApi(TestCase):
             "current_heads": ["0010_execution_provenance_and_governance_trace"],
             "expected_heads": ["0011_autonomy_lifecycle_and_promotion_audit"],
             "schema_head_signature": "7f8e4d0",
+            "schema_missing_heads": ["0011_autonomy_lifecycle_and_promotion_audit"],
+            "schema_unexpected_heads": ["0010_execution_provenance_and_governance_trace"],
+            "schema_head_count_expected": 1,
+            "schema_head_count_current": 1,
+            "schema_head_delta_count": 2,
         },
     )
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
@@ -745,9 +802,83 @@ class TestTradingApi(TestCase):
                 payload["dependencies"]["database"]["account_scope_errors"], []
             )
             self.assertEqual(
+                payload["dependencies"]["database"]["schema_missing_heads"],
+                ["0011_autonomy_lifecycle_and_promotion_audit"],
+            )
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_unexpected_heads"],
+                ["0010_execution_provenance_and_governance_trace"],
+            )
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_head_count_expected"], 1
+            )
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_head_count_current"], 1
+            )
+            self.assertEqual(payload["dependencies"]["database"]["schema_head_delta_count"], 2)
+            self.assertEqual(
                 payload["dependencies"]["database"]["schema_head_signature"], "7f8e4d0"
             )
             self.assertIn("checked_at", payload["dependencies"]["database"])
+        finally:
+            settings.trading_enabled = original
+
+    @patch("app.main._evaluate_database_contract")
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
+    def test_readyz_surface_schema_head_drift_fields(
+        self,
+        _mock_postgres: object,
+        _mock_clickhouse: object,
+        _mock_alpaca: object,
+        _mock_contract: object,
+    ) -> None:
+        original = settings.trading_enabled
+        settings.trading_enabled = True
+        try:
+            app.state.trading_scheduler = TradingScheduler()
+            app.state.trading_scheduler.state.running = True
+            app.state.trading_scheduler.state.last_run_at = datetime.now(timezone.utc)
+            _mock_contract.return_value = {
+                "ok": False,
+                "schema_current": False,
+                "schema_current_heads": ["0012_demo_beta"],
+                "expected_heads": ["0011_demo_alpha"],
+                "schema_missing_heads": ["0011_demo_alpha"],
+                "schema_unexpected_heads": ["0012_demo_beta"],
+                "schema_head_count_expected": 1,
+                "schema_head_count_current": 1,
+                "schema_head_delta_count": 2,
+                "schema_head_signature": "sig-20260304",
+                "checked_at": "2026-03-04T00:00:00+00:00",
+                "account_scope_ready": True,
+                "account_scope_errors": [],
+                "account_scope_warnings": [],
+            }
+            response = self.client.get("/readyz")
+
+            self.assertEqual(response.status_code, 503)
+            payload = response.json()
+            self.assertEqual(payload["status"], "degraded")
+            self.assertFalse(payload["dependencies"]["database"]["ok"])
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_missing_heads"],
+                ["0011_demo_alpha"],
+            )
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_unexpected_heads"],
+                ["0012_demo_beta"],
+            )
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_head_count_expected"],
+                1,
+            )
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_head_count_current"],
+                1,
+            )
+            self.assertEqual(payload["dependencies"]["database"]["schema_head_delta_count"], 2)
         finally:
             settings.trading_enabled = original
 


### PR DESCRIPTION
## Summary

- Add explicit schema drift diagnostics to Torghut readiness (`/readyz`) and database check (`/db-check`) payloads by reporting missing heads, unexpected heads, and head-count deltas.
- Preserve existing boolean readiness semantics while surfacing account-scope bypass warnings when `trading_multi_account_enabled` is disabled.
- Add regression coverage in `services/torghut/tests/test_db.py` and `services/torghut/tests/test_trading_api.py` for new drift fields and warning behavior.
- Add design decision document `docs/torghut/design-system/v6/23-readiness-schema-drift-diagnostics-2026-03-04.md` and update design index references.

## Related Issues

N/A

## Testing

- `python3 -m pip install --upgrade pip`
- `python3 -m pip install uv`
- `cd services/torghut && uv lock --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen python -m unittest discover -s tests -p "test_*.py"`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Breaking Changes section is handled.
- [x] Documentation, release notes, and follow-ups are updated.
