### PR TITLE
feat(trading): add startup readiness grace and startup probe

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -422,6 +422,13 @@ spec:
             httpGet:
               path: /healthz
               port: http1
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http1
+            failureThreshold: 18
+            periodSeconds: 5
+            timeoutSeconds: 2
           readinessProbe:
             httpGet:
               path: /readyz

--- a/docs/torghut/design-system/v6/23-trading-startup-readiness-warmup-2026-03-04.md
+++ b/docs/torghut/design-system/v6/23-trading-startup-readiness-warmup-2026-03-04.md
@@ -1,0 +1,60 @@
+# 23. Trading Startup Readiness Warmup and Rollout Stability (2026-03-04)
+
+## Context
+
+- Torghut Knative revisions (`torghut-00042` -> `torghut-00044`) repeatedly enter startup churn with probe failures, including:
+  - `Liveness probe failed.../healthz` (connection refused / timeout).
+  - `Readiness probe failed.../readyz` with HTTP 503.
+- Readiness currently marks scheduler failures hard as soon as `TradingScheduler.state.running` is false, even while startup tasks are still initializing.
+- Existing manifests lacked a startup probe; startup failures can therefore be interpreted by kubelet before the service establishes readiness criteria.
+
+## Problem
+
+Current readiness behavior can restart containers during benign startup latency by requiring immediate readiness. During initialization, dependency contracts and first scheduler warmup work can produce temporary `503` responses, which contributes to unstable revisions and repeated startup loops.
+
+## Decision
+
+Apply a bounded startup grace in readiness and add a Knative `startupProbe`:
+
+1. Add scheduler startup tracking state (`startup_started_at`) in `services/torghut/app/trading/scheduler.py`.
+2. Update readiness evaluation in `services/torghut/app/main.py`:
+   - If trading is enabled and scheduler is not yet `running`, allow `readyz` to remain optimistic inside `TRADING_STARTUP_READINESS_GRACE_SECONDS`.
+   - After grace expires, readiness returns 503 as before unless dependencies are healthy and scheduler is running.
+3. Add startup readiness probe configuration to `argocd/applications/torghut/knative-service.yaml`:
+   - `/readyz` startup probe with a small retry window before kubelet marks the pod unhealthy.
+4. Add regression tests in `services/torghut/tests/test_trading_api.py` for startup grace pass/fail paths.
+
+## Alternatives Considered
+
+1. **Startup-probe-only change** (selected as insufficient)
+   - Pros: simple manifest-only change.
+   - Cons: still returns `503` readiness during benign startup windows and can trigger unnecessary cold restarts in tight restart budgets.
+
+2. **Liveness/readiness probe delay-only tuning**
+   - Pros: low code risk.
+   - Cons: delays failure discovery for true dependency regressions and does not encode application startup intent.
+
+3. **Startup grace + startup probe** (selected)
+   - Pros: combines explicit startup allowance with readiness semantics tied to process lifecycle.
+   - Cons: introduces bounded period where readiness may stay non-strict during bootstrap.
+
+## Tradeoffs
+
+- **Stability gain:** reduces false-negative readiness during initialization and protects startup progress from minor bootstrap transients.
+- **Risk window:** readiness may stay accepting for up to `TRADING_STARTUP_READINESS_GRACE_SECONDS` even before first full scheduler loop cycle.
+- **Mitigation:** keep grace short and conservative, and maintain dependency checks in readiness after startup grace expires.
+
+## Rollback Plan
+
+- Set `TRADING_STARTUP_READINESS_GRACE_SECONDS=0` to disable startup optimism.
+- Remove the Knative `startupProbe` if rollout behavior regresses.
+- Revert this file and commit if readiness semantics need to be strict during bootstrap in future.
+
+## Verification
+
+- `services/torghut/app/main.py::_evaluate_trading_health_payload` updated to use warmup allowance with structured scheduler metadata.
+- `services/torghut/app/trading/scheduler.py` now tracks startup timing and flips running state at loop entry.
+- `services/torghut/tests/test_trading_api.py`
+  - `test_readyz_allows_startup_grace_window`
+  - `test_readyz_rejects_after_startup_grace_expires`
+- `argocd/applications/torghut/knative-service.yaml` startupProbe added for `/readyz`.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -56,6 +56,7 @@ This pack is positioned as the next architecture layer above:
 21. `21-schema-fingerprint-and-freshness-for-database-readiness-2026-03-04.md`
 22. `22-trading-readiness-dependency-freshness-cache-2026-03-04.md`
 23. `23-readiness-schema-drift-diagnostics-2026-03-04.md`
+24. `23-trading-startup-readiness-warmup-2026-03-04.md`
 
 ## Recommended Build Order
 
@@ -83,6 +84,7 @@ This pack is positioned as the next architecture layer above:
 21. `21-schema-fingerprint-and-freshness-for-database-readiness-2026-03-04.md`
 22. `22-trading-readiness-dependency-freshness-cache-2026-03-04.md`
 23. `23-readiness-schema-drift-diagnostics-2026-03-04.md`
+24. `23-trading-startup-readiness-warmup-2026-03-04.md`
 
 ## Why This Sequence
 

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1246,6 +1246,14 @@ class Settings(BaseSettings):
             "force synchronous checks on every request."
         ),
     )
+    trading_startup_readiness_grace_seconds: int = Field(
+        default=45,
+        alias="TRADING_STARTUP_READINESS_GRACE_SECONDS",
+        description=(
+            "Grace window (in seconds) where startup delay is allowed while "
+            "readiness remains optimistic during scheduler startup initialization."
+        ),
+    )
 
     # Jangar gateway (recommended for LLM calls in-cluster).
     jangar_base_url: Optional[str] = Field(default=None, alias="JANGAR_BASE_URL")

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -413,12 +413,39 @@ def _evaluate_trading_health_payload(
 
     scheduler_ok = True
     scheduler_detail = "ok"
+
+    startup_grace_seconds = max(0, settings.trading_startup_readiness_grace_seconds)
+    in_startup_grace = False
+    startup_started_at = scheduler.state.startup_started_at
     if settings.trading_enabled and not scheduler.state.running:
-        scheduler_ok = False
-        if scheduler.state.last_run_at is None:
-            scheduler_detail = "trading loop not started"
+        if (
+            startup_started_at is not None
+            and startup_grace_seconds > 0
+            and datetime.now(timezone.utc) - startup_started_at
+            <= timedelta(seconds=startup_grace_seconds)
+        ):
+            in_startup_grace = True
+            scheduler_ok = True
+            scheduler_detail = (
+                f"trading loop starting (within {startup_grace_seconds}s readiness grace)"
+            )
         else:
-            scheduler_detail = "trading loop not running"
+            scheduler_ok = False
+            scheduler_detail = (
+                "trading loop not started"
+                if scheduler.state.last_run_at is None
+                else "trading loop not running"
+            )
+
+    scheduler_payload: dict[str, object] = {
+        "ok": scheduler_ok,
+        "detail": scheduler_detail,
+        "running": scheduler.state.running,
+    }
+    if startup_started_at is not None:
+        scheduler_payload["startup_started_at"] = startup_started_at.isoformat()
+        scheduler_payload["startup_readiness_grace_seconds"] = startup_grace_seconds
+        scheduler_payload["startup_readiness_grace_active"] = in_startup_grace
 
     dependencies, checked_at, cache_used = _readiness_dependency_snapshot(
         session,
@@ -444,7 +471,7 @@ def _evaluate_trading_health_payload(
     return (
         {
             "status": status,
-            "scheduler": {"ok": scheduler_ok, "detail": scheduler_detail},
+            "scheduler": scheduler_payload,
             "dependencies": dependencies,
         },
         status_code,

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -1029,6 +1029,7 @@ class TradingMetrics:
 @dataclass
 class TradingState:
     running: bool = False
+    startup_started_at: Optional[datetime] = None
     last_run_at: Optional[datetime] = None
     last_reconcile_at: Optional[datetime] = None
     last_error: Optional[str] = None
@@ -5425,7 +5426,8 @@ class TradingScheduler:
             self._pipelines = [self._build_pipeline_for_account(lane) for lane in lanes]
             self._pipeline = self._pipelines[0] if self._pipelines else None
         self._stop_event.clear()
-        self.state.running = True
+        self.state.startup_started_at = datetime.now(timezone.utc)
+        self.state.running = False
         self._task = asyncio.create_task(self._run_loop())
 
     async def stop(self) -> None:
@@ -5438,6 +5440,7 @@ class TradingScheduler:
         except asyncio.CancelledError:
             pass
         self._task = None
+        self.state.startup_started_at = None
         self.state.running = False
         active_pipelines = self._pipelines or (
             [self._pipeline] if self._pipeline is not None else []
@@ -5448,6 +5451,7 @@ class TradingScheduler:
         self._pipeline = None
 
     async def _run_loop(self) -> None:
+        self.state.running = True
         poll_interval = settings.trading_poll_ms / 1000
         reconcile_interval = settings.trading_reconcile_ms / 1000
         autonomy_interval = max(30, settings.trading_autonomy_interval_seconds)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -711,6 +711,106 @@ class TestTradingApi(TestCase):
             settings.trading_enabled = original
             settings.trading_universe_source = original_source
 
+    @patch(
+        "app.main._evaluate_database_contract",
+        return_value={
+            "ok": True,
+            "schema_current": True,
+            "schema_current_heads": ["0011_execution_tca_simulator_divergence"],
+            "expected_heads": ["0011_execution_tca_simulator_divergence"],
+            "schema_head_signature": "7f8e4d0",
+            "checked_at": "2026-03-04T00:00:00+00:00",
+            "account_scope_ready": True,
+            "account_scope_errors": [],
+        },
+    )
+    @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    def test_readyz_allows_startup_grace_window(
+        self,
+        _mock_alpaca: object,
+        _mock_clickhouse: object,
+        _mock_postgres: object,
+        _mock_contract: object,
+    ) -> None:
+        original = settings.trading_enabled
+        original_source = settings.trading_universe_source
+        original_grace = settings.trading_startup_readiness_grace_seconds
+        settings.trading_enabled = True
+        settings.trading_universe_source = "jangar"
+        settings.trading_startup_readiness_grace_seconds = 45
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = False
+            scheduler.state.startup_started_at = datetime.now(timezone.utc)
+            scheduler.state.universe_source_status = "ok"
+            scheduler.state.universe_source_reason = "jangar_fetch_ok"
+            scheduler.state.universe_symbols_count = 2
+            scheduler.state.universe_cache_age_seconds = 0
+            app.state.trading_scheduler = scheduler
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["status"], "ok")
+            self.assertTrue(payload["scheduler"]["ok"])
+            self.assertIn("readiness grace", payload["scheduler"]["detail"])
+            self.assertTrue(payload["scheduler"]["startup_readiness_grace_active"])
+        finally:
+            settings.trading_enabled = original
+            settings.trading_universe_source = original_source
+            settings.trading_startup_readiness_grace_seconds = original_grace
+            _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
+
+    @patch(
+        "app.main._evaluate_database_contract",
+        return_value={
+            "ok": True,
+            "schema_current": True,
+            "schema_current_heads": ["0011_execution_tca_simulator_divergence"],
+            "expected_heads": ["0011_execution_tca_simulator_divergence"],
+            "schema_head_signature": "7f8e4d0",
+            "checked_at": "2026-03-04T00:00:00+00:00",
+            "account_scope_ready": True,
+            "account_scope_errors": [],
+        },
+    )
+    @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    def test_readyz_rejects_after_startup_grace_expires(
+        self,
+        _mock_alpaca: object,
+        _mock_clickhouse: object,
+        _mock_postgres: object,
+        _mock_contract: object,
+    ) -> None:
+        original = settings.trading_enabled
+        original_source = settings.trading_universe_source
+        original_grace = settings.trading_startup_readiness_grace_seconds
+        settings.trading_enabled = True
+        settings.trading_universe_source = "jangar"
+        settings.trading_startup_readiness_grace_seconds = 30
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = False
+            scheduler.state.startup_started_at = datetime.now(timezone.utc) - timedelta(
+                seconds=61
+            )
+            app.state.trading_scheduler = scheduler
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 503)
+            payload = response.json()
+            self.assertEqual(payload["status"], "degraded")
+            self.assertFalse(payload["scheduler"]["ok"])
+            self.assertIn("trading loop", payload["scheduler"]["detail"])
+            self.assertFalse(payload["scheduler"]["startup_readiness_grace_active"])
+        finally:
+            settings.trading_enabled = original
+            settings.trading_universe_source = original_source
+            settings.trading_startup_readiness_grace_seconds = original_grace
+            _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
+
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_postgres", return_value={"ok": False, "detail": "down"})
     @patch(


### PR DESCRIPTION
## Summary

- Add startup readiness warmup handling in scheduler state (`startup_started_at`) and make `/readyz` tolerant during bounded startup warmup in `services/torghut/app/main.py`.
- Add startup probe and readiness metadata in the torghut Knative service manifest to reduce false startup churn (`argocd/applications/torghut/knative-service.yaml`).
- Add regression coverage for startup-readiness grace allow/deny behavior in `services/torghut/tests/test_trading_api.py` and document the design in v6 docs.

## Related Issues

- TSK-139

## Testing

- `cd services/torghut && source /tmp/torghut-tools/bin/activate && uv sync --frozen --extra dev --python 3.12`
- `.venv/bin/python -m pytest tests/test_trading_api.py`
- `.venv/bin/ruff check app/main.py app/trading/scheduler.py tests/test_trading_api.py app/config.py`
- `.venv/bin/pyright --project pyrightconfig.json`
- `.venv/bin/pyright --project pyrightconfig.alpha.json`
- `.venv/bin/pyright --project pyrightconfig.scripts.json`
- `.venv/bin/alembic heads`

## Breaking Changes

- None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
