### PR TITLE
docs(jangar): assess control-plane reliability gaps in discover

### DIFF
--- a/docs/agents/designs/jangar-control-plane-operability-reliability-assessment.md
+++ b/docs/agents/designs/jangar-control-plane-operability-reliability-assessment.md
@@ -1,137 +1,168 @@
-# Jangar Control Plane Operability and Reliability Assessment (Plan Stage)
+# Jangar Control Plane Operability and Reliability Assessment (Discover Stage)
 
-Status: Draft (2026-03-04)
+Status: In Review (2026-03-04)
 
 ## Executive summary
 
-The control plane read surface is healthy enough for baseline requests, and cache freshness signals were already introduced on core resource APIs, but production operations are still blind to high-frequency failures in swarm job execution and cache-watch health. This assessment proposes a first-stage design change: extend operator-facing control-plane observability through a deterministic, low-cardinality reliability surface that unifies schedule/job status with existing control-plane status output.
+The control-plane read surface is healthy enough for baseline requests, and cache freshness signals already exist on core resource APIs, but operations are still blind to recurring schedule/job rollout failures. This stage captures evidence across cluster/source/database surfaces and records one prioritized design change: add a controlled rollout reliability envelope to the control-plane status API while keeping request-level fallback safety.
+
+The chosen design surfaces burst and trend failure signals without adding new write paths, and keeps payload size and blast radius bounded.
 
 ## Assessment context
 
-- Cluster scope: `jangar` control plane via `jangar` namespace in `agents`.
-- Swarm scope: `jangar-control-plane`.
-- Stage: `plan`.
+- Cluster scope: `jangar` control-plane-related workloads in namespace `agents`.
+- Swarm scope: `jangar-control-plane` (`discover`, with `implement` and `verify` adjacent stages).
+- Objective stage: `discover`.
+- Base/branch: `main` → `codex/swarm-jangar-control-plane-discover`.
 
 ## Source assessment
 
 ### Current strengths
 
 - Control-plane cache read paths are implemented in cache store and route handlers with freshness metadata.
-- Route-level tests validate cache freshness behavior and fallback semantics for `resource`, `resources`, and `summary` endpoints.
-- Control-plane status surface already emits controller/runtime/database/grpc health fields.
+- Route-level tests validate cache freshness and fallback semantics for `/api/agents/control-plane/resource`, `/api/agents/control-plane/resources`, and `/api/agents/control-plane/summary`.
+- Control-plane status surface already emits controller/runtime/database/grpc/watch reliability fields.
 
-### High-risk modules
+### Source-based risk index (top)
 
-- `services/jangar/src/server/control-plane-cache.ts`:
-  - Watches resource objects and updates `agents_control_plane.resources_current`.
-  - Failure modes are logged per object but do not expose aggregate health for operators.
-- `services/jangar/src/server/control-plane-status.ts`:
-  - Strong for component health, weak for job/workflow health and rollout impact.
-- `services/jangar/src/server/control-plane-cache-store.ts` / migrations:
-  - Handles upsert/listing and timestamp metadata, but no direct lag/error telemetry stream.
+- `services/jangar/src/server/control-plane-status.ts`
+  - High: no explicit job rollout health summary (backoff count, active run count, top failure reasons).
+  - Medium: `watch_reliability` aggregates watch behavior but does not map to schedule/job rollout operations used by operator triage.
+- `services/jangar/src/server/control-plane-watch-reliability.ts`
+  - Medium: good signal for stream health but separate from deployment/run failure diagnostics.
+- `services/jangar/src/server/control-plane-cache.ts`
+  - Low/medium: resilient fallback behavior avoids outages but can hide prolonged divergence without explicit rollout telemetry.
 
 ### Test coverage and gaps
 
-- Covered:
-  - Freshness + stale-read fallback logic for `/api/agents/control-plane/resource` and `/api/agents/control-plane/resources`.
-  - Summary fallback paths with mixed cache/live data in `/api/agents/control-plane/summary`.
-  - gRPC status socket reachability tests.
-- Gaps:
-  - No unit/integration coverage for cache-watch lag, watch restart frequency, or job backoff state.
-  - No test covers control-plane status endpoint enrichment with job/failure rollup data.
+Covered:
 
-### Source-based risk notes
+- Resource cache freshness + fallback in `resource`, `resources`, and `summary` routes.
+- Control-plane status assembly with degraded component tracking.
+- Watch reliability unit tests covering errors and restarts.
 
-- `startControlPlaneCache()` can silently recover from watch failures, reducing immediate crash risk but also removing high-signal telemetry for repeatable cache divergence.
-- Existing route handlers avoid hard failures via fallback-to-live logic, which is robust for availability but can mask recurring staleness under backoff conditions.
+Gaps:
+
+- No tests for rollout/job failure rollups or status surface health mapping.
+- No end-to-end path test that combines Kubernetes rollout signals with status decomposition.
+
+### Source proposal implication
+
+- Keep control-plane status as the primary operator surface in discover stage.
+- Add a bounded `status.workflows` block and explicit `degraded_components` entry (`workflows`) only when thresholds are crossed.
 
 ## Database/data assessment
 
 ### Data model quality
 
-- `services/jangar/src/server/migrations/20260205_agents_control_plane_cache.ts` defines:
-  - schema `agents_control_plane.resources_current`
-  - `last_seen_at` as `TIMESTAMPTZ NOT NULL DEFAULT now()`
-  - source-of-truth indexes for by-kind/namespace/time and `deleted_at` filtering.
-- `services/jangar/src/server/db.ts` exposes the same shape as a first-class typed table contract.
+- `services/jangar/src/server/migrations/20260205_agents_control_plane_cache.ts` defines table `agents_control_plane.resources_current` with:
+  - `last_seen_at` freshness timestamps.
+  - namespace/kind/time indexes.
+  - `deleted_at` filters for soft-deletion behavior.
+- `services/jangar/src/server/db.ts` exposes typed contracts for that table.
 
-### Freshness/consistency
+### Freshness/consistency observations
 
-- Freshness metadata is computed at read time, with no dedicated DB field for stale threshold violations.
-- The table does not persist structured lag/health deltas over time, so operators cannot trend drift without external scraping.
-- Current query model (`listResources`) is optimized for namespace/kind retrieval with indexes, and supports fallback decisions based on timestamps.
+- Freshness metadata is computed at read-time; there is no dedicated persisted schema for job rollout lag/trend, only resource cache state.
+- Repeated operational failures do not currently persist as structured rollout telemetry in DB.
+- As a result, operators have to combine status health with cluster events/logs to infer rollout drift.
 
-### Data-quality observations
+### Data-quality posture
 
-- Multiple job execution failures do not currently mutate cache state directly; observability is only implicit through log and Kubernetes events.
-- Without explicit rollout/job health in control-plane status, cluster and data views are split: API health can be green while schedule steps show repeated backoff events.
+- Control-plane resource contract quality is good for current API responses.
+- Rollout-operability quality is incomplete for this stage (no explicit historical failure trend persistence).
+
+## Cluster assessment
+
+### Rollout and health snapshot
+
+Observed read-only signals:
+
+- `kubectl -n agents get swarm jangar-control-plane -o yaml`:
+  - swarm is `Active`, `Ready=True`.
+  - requirements show queued/dispatched/pending activity and one blocked requirement.
+  - recent 24h counts were observed (`missions24h=23`, `discoveries24h=3`).
+  - `autonomousSuccessRate24h` was ~`0.0909`.
+- `kubectl -n agents get jobs | rg jangar-control-plane` and `get events --field-selector reason=BackoffLimitExceeded` show recurring job-step failures in control-plane and torghut stages.
+- `kubectl -n agents get cronjobs | rg jangar-control-plane` lists active cron schedules at 30m cadence.
+- Direct `kubectl -n agents auth can-i` and operation probes show:
+  - pod and service-account reads are possible.
+  - deployments/crd/metrics reads remain RBAC-limited in this runner.
+
+### Reliability signal interpretation
+
+- Event backoff patterns are visible in cluster events and indicate repeated schedule/job execution churn.
+- Control-plane status API currently does not include this failure rollup today.
+- This is a reliable design target because it closes the visibility gap with minimum API change.
 
 ## Problem statement
 
-The control plane can report controller/runtime/database health while the same window contains multiple BackoffLimitExceeded job events and long-running failed schedule attempts. This prevents reliable maintenance decisions and delays incident triage.
-
-Recent commands observed:
-
-- `kubectl -n agents get jobs | wc -l` and job event output show repeated `BackoffLimitExceeded` entries.
-- `kubectl -n agents get events --field-selector reason=BackoffLimitExceeded` shows multiple active swarm-related failures in the same control-plane time window.
-- Swarm scheduling remains Active for all stages, but job-level execution health is not surfaced in `/api/agents/control-plane/status`.
+The control plane can report controller/runtime/database status while this window still contains repeated schedule/job failures. This weakens operator confidence and extends mean-time-to-awareness.
 
 ## Design proposal
 
 ### Top design change (chosen)
 
-Add a control-plane reliability envelope to status output, using existing cache and Kubernetes read paths:
+Add a bounded `workflows` reliability block into `GET /api/agents/control-plane/status`:
 
-- Introduce a small `workflows` block in `services/jangar/src/server/control-plane-status.ts`:
-  - `active_job_runs`
-  - `recent_failed_jobs`
-  - `backoff_limit_exceeded_jobs`
-  - `window_minutes` (configurable)
-  - optional `top_failure_reasons`
-- Add a lightweight adapter that queries jobs using the same service credentials as other control-plane operations and filters by:
-  - label patterns used by schedule jobs for `jangar-control-plane` and optional `torghut-quant`
-  - optional namespace scoping from `JANGAR_AGENTS_CONTROLLER_NAMESPACES`.
-- Return `status.runtime` degraded if backoff counts exceed configured thresholds, but never fail control-plane requests.
-- Keep defaults conservative (`window_minutes` default 15, warn at first repeated failure, degrade at sustained threshold).
+- `status: healthy | degraded | unknown`
+- `window_minutes` (configurable)
+- `active_job_runs`
+- `recent_failed_jobs`
+- `backoff_limit_exceeded_jobs`
+- `top_failure_reasons`
+
+Implementation intent:
+
+- Add a small adapter in `services/jangar/src/server/` that queries cluster jobs/events via the existing Kubernetes command execution path and returns deterministic counters.
+- Degrade `status.runtime` (via `degraded_components`) when sustained threshold breaches are hit.
+- Never fail status endpoint on adapter errors; emit `workflows.status=degraded` and include reason tags.
 
 ### Alternatives considered
 
-- A) Keep status endpoint unchanged and rely on manual `kubectl get events` inspection (current state).
-  - Lowest risk and implementation cost.
-  - Highest mean-time-to-awareness during sustained failures.
-- B) Add a dedicated `/api/agents/control-plane/health` endpoint for job/reporting only.
-  - Clear separation of concerns and less payload coupling.
-  - Requires additional client changes and potential UI duplication.
-- C) Add control-plane metrics first, then status reporting (hybrid).
-  - Better long-term scalability and alerting, but no immediate operator visibility in current CLI/UI surfaces.
-- Chosen approach: **A+B hybrid with status-first minimal payload**.
-  - Immediate maintainability gain: same endpoint surfaces degraded rollup and failure patterns.
-  - Minimal downstream impact and lower rollout risk than a brand-new endpoint.
-  - Can be evolved later into dedicated metrics consumers.
+- A) Keep status unchanged and rely on manual `kubectl get events`.
+  - Low implementation risk, lower operator value.
+  - Rejected because high mean-time-to-awareness and repeated triage friction.
+- B) Add dedicated `/api/agents/control-plane/health` endpoint only.
+  - Clean split but requires additional client/UI adoption and migration.
+  - Deferred to follow-up stage.
+- C) Add rollout metrics first, then status later.
+  - Strong long-term analytics path.
+  - Delays immediate discover usability for operators.
+- D) Status-first envelope with deterministic workflow summary (chosen).
+  - Fastest operator gain.
+  - Minimal downstream surface change.
+  - Safe migration path to metrics consumers.
 
-### Design requirements
+### Design requirements for implementation
 
-- Keep payload deterministic and capped.
-- Do not fail `GET /api/agents/control-plane/status` if Kubernetes job list calls fail.
-- Expose explicit `degraded_components` entry for `workflows` when threshold crossed.
+- Bounded payload and deterministic sort order.
+- Status requests must remain queryable if Kubernetes queries fail.
+- `status.runtime` and `namespaces[].degraded_components` should include `workflows` when reliability is degraded.
+- Defaults to conservative thresholds and explicit environment variable overrides.
 
-### Rollout and validation
+### Rollout plan (if/when implementation is added)
 
-1. Design-only PR in `docs/agents/designs`.
-2. If implemented in follow-up stage:
-   - add config and tests for status adapter behavior;
-   - add smoke check with one failing job pattern and one healthy pattern;
-   - document remediation steps in handoff runbooks.
+1. Add runtime adapter + status typing + unit tests.
+2. Add or update status tests for degraded/unknown cases.
+3. Extend docs and handoff runbooks with failure thresholds.
+4. Add rollout verification check to this runbook family.
+5. Move to plan stage with metrics-backed follow-up once this endpoint is stable.
 
 ## Handoff appendix
 
 - Source of truth in this stage:
   - `services/jangar/src/server/control-plane-status.ts`
   - `services/jangar/src/server/control-plane-cache.ts`
+  - `services/jangar/src/server/control-plane-watch-reliability.ts`
   - `services/jangar/src/server/control-plane-cache-store.ts`
-  - `services/jangar/src/server/db.ts`
   - `services/jangar/src/server/migrations/20260205_agents_control_plane_cache.ts`
-  - `services/jangar/src/server/__tests__/agents-control-plane-resource.test.ts`
-  - `services/jangar/src/server/__tests__/agents-control-plane-resources.test.ts`
-  - `services/jangar/src/server/__tests__/agents-control-plane-summary.test.ts`
+  - `services/jangar/src/server/db.ts`
   - `services/jangar/src/server/__tests__/control-plane-status.test.ts`
+  - `services/jangar/src/server/__tests__/control-plane-watch-reliability.test.ts`
+  - `docs/agents/designs/jangar-control-plane-operability-reliability-assessment.md`
+
+## PR and merge evidence (discover stage)
+
+- A design-only discover PR will carry this decision and evidence for merge.
+- Required follow-up checks are expected for changed files and repository CI profile.


### PR DESCRIPTION
## Summary

- Updated `docs/agents/designs/jangar-control-plane-operability-reliability-assessment.md` with a discover-stage control-plane reliability assessment across cluster, source, and database surfaces.
- Documented explicit rollout cluster evidence (BackoffLimitExceeded patterns, swarm state, RBAC scope limits) and formalized the top design direction for status-level workflow reliability visibility.
- Added prioritized alternatives and tradeoffs with a chosen status-first bounded rollout health design for the next implementation stage.

## Related Issues

- None.

## Testing

- `bun run --filter @proompteng/jangar lint`

## Breaking Changes

- None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Documentation and follow-ups are updated or tracked.
