### PR TITLE
feat(jangar): add control-plane migration consistency status

### DIFF
--- a/docs/agents/designs/jangar-control-plane-migration-consistency-status.md
+++ b/docs/agents/designs/jangar-control-plane-migration-consistency-status.md
@@ -1,0 +1,94 @@
+# Jangar Control Plane Migration Consistency Status
+
+Status: Draft (2026-03-04)
+
+Docs index: [README](../README.md)
+
+## Summary
+
+This design defines a control-plane status signal for DB migration consistency so operators can detect schema drift before it impacts runtime behavior. It complements the existing workflow reliability status surface by adding a `migration_consistency` block under `database` in `/api/agents/control-plane/status`.
+
+The design is low-risk because it does not block startup, does not write to the database, and reuses the existing migration registry source and typed DB access layer.
+
+## Problem
+
+Current status checks confirm DB connectivity but do not validate the health of migration state. A deployment can:
+
+- report DB as healthy while migrations are missing in production,
+- report DB as healthy while older migration files are no longer applied,
+- or diverge from declared migration files due to accidental file omissions.
+
+This blind spot delays detection of schema incompatibilities and makes rollout incidents less debuggable.
+
+## Context and current behavior
+
+- `services/jangar/src/server/kysely-migrations.ts` maintains explicit migration registration.
+- `services/jangar/src/server/control-plane-status.ts` validates DB connectivity and latency but does not compare schema history against registration.
+- UI surfaces and API consumers use `DatabaseStatus` from `services/jangar/src/data/agents-control-plane.ts`.
+- There is existing migration-coverage work in progress around status reporting and workflow reliability.
+
+## Alternatives and tradeoffs
+
+1. Startup-only migration enforcement
+   - Fail startup when `registered !== applied`.
+   - Pros: strongest immediate safety; prevents operations under mismatched schema.
+   - Cons: higher blast radius and lower resilience during partial upgrades or one-off reconciliation windows.
+
+2. CI-only registry parity checks only
+   - Add/extend test coverage in CI to assert migration files and registry entries match.
+   - Pros: cheap and deterministic; catches some classes of drift in merge checks.
+   - Cons: blind to runtime-environment drift and does not provide operator-facing signal.
+
+3. Runtime status-consistency signal (selected)
+   - Add bounded, non-blocking status read path with `database.migration_consistency`.
+   - Pros: immediate operational visibility from existing control-plane tooling; supports de-noised response playbooks and rollback gating.
+   - Cons: requires extra DB read in status endpoint and can surface false-positive noise if migration tracking tables are intentionally transient during custom maintenance tasks.
+
+## Design decision
+
+Choose option 3 (runtime status-consistency signal).
+
+- Keep migration check behavior non-blocking and additive:
+  - when table is missing, return degraded `migration_consistency` with explicit message,
+  - when drift is detected, mark database status degraded and expose `unapplied_count`, `unexpected_count`, and migration lists.
+- Preserve current status contract by preserving existing fields and adding nested `database.migration_consistency`.
+- Keep rollout compatibility: unknown connection state remains unchanged and still reported as DB degraded.
+
+## Proposed implementation
+
+- Add deterministic migration table discovery in `services/jangar/src/server/control-plane-status.ts`:
+  - `kysely_migration` primary candidate, with fallback to `kysely_migrations`.
+- Compare registered migration list (`getRegisteredMigrationNames`) with applied names read from the resolved table.
+- Surface:
+  - `registered_count`
+  - `applied_count`
+  - `unapplied_count`
+  - `unexpected_count`
+  - `latest_registered`
+  - `latest_applied`
+  - `missing_migrations`
+  - `unexpected_migrations`
+  - `message`
+  - `status` (`healthy`/`degraded`/`unknown`)
+- Extend `DatabaseStatus` in `services/jangar/src/data/agents-control-plane.ts` and update control-plane status tests.
+- Keep `control-plane-status` response deterministic with bounded payload and no throw-through.
+
+## Validation
+
+- Unit test in `services/jangar/src/server/__tests__/control-plane-status.test.ts`:
+  - healthy baseline with full consistency,
+  - degraded when migration drift exists (`unapplied_count > 0`),
+  - degraded when query failures occur.
+- Keep formatting/lint checks for touched TypeScript paths.
+
+## Risk controls
+
+- If migration tracking table names change again, detection will report as degraded unknown to avoid false healthy signals.
+- If this causes noisy status churn during controlled maintenance, reduce query window by gating with dedicated env flags before adding any blocking behavior in a follow-up change.
+
+## Rollout plan
+
+1. Merge as plan-stage design + implementation.
+2. Monitor `/api/agents/control-plane/status` migration_consistency fields during next rollout.
+3. Escalate to startup gate only if frequent mismatches indicate recurring deployment breakage.
+

--- a/services/jangar/src/data/agents-control-plane.ts
+++ b/services/jangar/src/data/agents-control-plane.ts
@@ -131,12 +131,27 @@ export type WorkflowReliabilityStatus = {
   message: string
 }
 
+export type DatabaseMigrationConsistency = {
+  status: 'healthy' | 'degraded' | 'unknown'
+  migration_table: string | null
+  registered_count: number
+  applied_count: number
+  unapplied_count: number
+  unexpected_count: number
+  latest_registered: string | null
+  latest_applied: string | null
+  missing_migrations: string[]
+  unexpected_migrations: string[]
+  message: string
+}
+
 export type DatabaseStatus = {
   configured: boolean
   connected: boolean
   status: 'healthy' | 'degraded' | 'disabled'
   message: string
   latency_ms: number
+  migration_consistency: DatabaseMigrationConsistency
 }
 
 export type GrpcStatus = {

--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -12,6 +12,21 @@ const healthyController = {
 }
 const now = () => new Date('2026-01-20T00:00:00Z')
 
+const makeMigrationConsistency = (overrides: Record<string, unknown> = {}) => ({
+  status: 'healthy' as const,
+  migration_table: 'kysely_migration',
+  registered_count: 18,
+  applied_count: 18,
+  unapplied_count: 0,
+  unexpected_count: 0,
+  latest_registered: '20260304_jangar_github_worktree_refresh_state',
+  latest_applied: '20260304_jangar_github_worktree_refresh_state',
+  missing_migrations: [] as string[],
+  unexpected_migrations: [] as string[],
+  message: 'migration registry and database are synchronized',
+  ...overrides,
+})
+
 const createKubeList = (jobs: unknown[]) => ({
   list: async () => ({ items: jobs }) as Record<string, unknown>,
 })
@@ -132,6 +147,7 @@ describe('control-plane status', () => {
           status: 'healthy',
           message: '',
           latency_ms: 4,
+          migration_consistency: makeMigrationConsistency(),
         }),
         getWatchReliabilitySummary: () => watchReliabilityHealthy,
       },
@@ -189,6 +205,17 @@ describe('control-plane status', () => {
           status: 'disabled',
           message: 'DATABASE_URL not set',
           latency_ms: 0,
+          migration_consistency: makeMigrationConsistency({
+            status: 'degraded',
+            migration_table: null,
+            registered_count: 0,
+            applied_count: 0,
+            unapplied_count: 0,
+            unexpected_count: 0,
+            latest_registered: null,
+            latest_applied: null,
+            message: 'DATABASE_URL not set',
+          }),
         }),
         getWatchReliabilitySummary: () => watchReliabilityDegraded,
       },
@@ -234,6 +261,7 @@ describe('control-plane status', () => {
           status: 'healthy',
           message: '',
           latency_ms: 4,
+          migration_consistency: makeMigrationConsistency(),
         }),
         kube: createKubeList([
           createBackoffJob(
@@ -284,6 +312,7 @@ describe('control-plane status', () => {
           status: 'healthy',
           message: '',
           latency_ms: 4,
+          migration_consistency: makeMigrationConsistency(),
         }),
         kube: failingKubeList,
       },
@@ -292,5 +321,53 @@ describe('control-plane status', () => {
     expect(status.workflows.status).toBe('unknown')
     expect(status.workflows.message).toContain('kubernetes query failed')
     expect(status.namespaces[0]?.degraded_components).not.toContain('workflows')
+  })
+
+  it('marks database component as degraded when migration drift is detected', async () => {
+    const status = await buildControlPlaneStatus(
+      {
+        namespace: 'agents',
+        grpc: {
+          enabled: true,
+          address: '127.0.0.1:50051',
+          status: 'healthy',
+          message: '',
+        },
+      },
+      {
+        now,
+        getAgentsControllerHealth: () => healthyController,
+        getSupportingControllerHealth: () => healthyController,
+        getOrchestrationControllerHealth: () => healthyController,
+        resolveTemporalAdapter: async () => ({
+          name: 'temporal',
+          available: true,
+          status: 'configured',
+          message: '',
+          endpoint: 'temporal:7233',
+        }),
+        checkDatabase: async () => ({
+          configured: true,
+          connected: true,
+          status: 'degraded',
+          message: '2 registered migrations not applied',
+          latency_ms: 4,
+          migration_consistency: makeMigrationConsistency({
+            status: 'degraded',
+            message: '2 registered migrations not applied',
+            unapplied_count: 2,
+            missing_migrations: ['20260305_new_migration', '20260306_followup_migration'],
+            unexpected_count: 0,
+            unexpected_migrations: [],
+          }),
+        }),
+        kube: createKubeList([createActiveJob()]),
+        getWatchReliabilitySummary: () => watchReliabilityHealthy,
+      },
+    )
+
+    expect(status.namespaces[0]?.degraded_components).toContain('database')
+    expect(status.database.status).toBe('degraded')
+    expect(status.database.migration_consistency.unapplied_count).toBe(2)
   })
 })

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -2,7 +2,8 @@ import { loadTemporalConfig } from '@proompteng/temporal-bun-sdk'
 import { sql } from 'kysely'
 
 import { getAgentsControllerHealth } from '~/server/agents-controller'
-import { getDb } from '~/server/db'
+import { getDb, type Db } from '~/server/db'
+import { getRegisteredMigrationNames } from '~/server/kysely-migrations'
 import { getLeaderElectionStatus } from '~/server/leader-election'
 import { getOrchestrationControllerHealth } from '~/server/orchestration-controller'
 import { getSupportingControllerHealth } from '~/server/supporting-primitives-controller'
@@ -48,7 +49,22 @@ export type DatabaseStatus = {
   status: 'healthy' | 'degraded' | 'disabled'
   message: string
   latency_ms: number
+  migration_consistency: {
+    status: 'healthy' | 'degraded' | 'unknown'
+    migration_table: string | null
+    registered_count: number
+    applied_count: number
+    unapplied_count: number
+    unexpected_count: number
+    latest_registered: string | null
+    latest_applied: string | null
+    missing_migrations: string[]
+    unexpected_migrations: string[]
+    message: string
+  }
 }
+
+type DatabaseMigrationConsistency = DatabaseStatus['migration_consistency']
 
 export type GrpcStatus = {
   enabled: boolean
@@ -138,6 +154,7 @@ const asString = (value: unknown): string | null => {
   const normalized = normalizeText(value)
   return normalized.length > 0 ? normalized : null
 }
+const dedupeSorted = (items: string[]) => [...new Set(items)].sort()
 const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : [])
 const asNumber = (value: unknown, fallback: number): number => {
   if (typeof value === 'number' && Number.isFinite(value)) return value
@@ -193,6 +210,104 @@ const toTopFailureReasons = (entries: Map<string, number>) =>
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .slice(0, WORKFLOW_WINDOW_REASON_LIMIT)
     .map(([reason, count]) => ({ reason, count }))
+
+const MIGRATION_TABLE_CANDIDATES = ['kysely_migration', 'kysely_migrations'] as const
+
+const buildDatabaseMigrationConsistencyUnknown = (message: string): DatabaseMigrationConsistency => ({
+  status: 'unknown',
+  migration_table: null,
+  registered_count: 0,
+  applied_count: 0,
+  unapplied_count: 0,
+  unexpected_count: 0,
+  latest_registered: null,
+  latest_applied: null,
+  missing_migrations: [],
+  unexpected_migrations: [],
+  message,
+})
+
+const checkMigrationTable = async (db: Db): Promise<string | null> => {
+  const checkExists = async (table: (typeof MIGRATION_TABLE_CANDIDATES)[number]) => {
+    const response = await sql<{ exists: boolean }>`
+      SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = ${table}
+      ) AS exists
+    `.execute(db)
+    const row = response.rows[0]
+    return row?.exists === true ? table : null
+  }
+
+  for (const table of MIGRATION_TABLE_CANDIDATES) {
+    const migrationTable = await checkExists(table)
+    if (migrationTable) {
+      return migrationTable
+    }
+  }
+
+  return null
+}
+
+const readAppliedMigrations = async (db: Db, migrationTable: string) => {
+  const response = await sql<{
+    name: string | null
+  }>`SELECT name FROM ${sql.ref(migrationTable)} ORDER BY name`.execute(db)
+  return dedupeSorted(response.rows.map((row) => asString(row.name)).filter(Boolean) as string[])
+}
+
+const buildDatabaseMigrationConsistency = async (db: Db): Promise<DatabaseMigrationConsistency> => {
+  const registered = dedupeSorted(getRegisteredMigrationNames())
+  const latestRegistered = registered.at(-1) ?? null
+
+  const migrationTable = await checkMigrationTable(db)
+  if (!migrationTable) {
+    return {
+      ...buildDatabaseMigrationConsistencyUnknown('kysely migration table not found'),
+      status: 'degraded' as const,
+      registered_count: registered.length,
+      latest_registered: latestRegistered,
+    }
+  }
+
+  const applied = await readAppliedMigrations(db, migrationTable)
+  const appliedSet = new Set(applied)
+  const registeredSet = new Set(registered)
+
+  const missingMigrations = registered.filter((migration) => !appliedSet.has(migration))
+  const unexpectedMigrations = applied.filter((migration) => !registeredSet.has(migration))
+  const status: DatabaseMigrationConsistency['status'] =
+    missingMigrations.length === 0 && unexpectedMigrations.length === 0 ? 'healthy' : 'degraded'
+
+  const messageParts = []
+  if (status === 'healthy') {
+    messageParts.push('migration registry and database are synchronized')
+  } else {
+    if (missingMigrations.length > 0) {
+      messageParts.push(`${missingMigrations.length} registered migrations not applied`)
+    }
+    if (unexpectedMigrations.length > 0) {
+      messageParts.push(`${unexpectedMigrations.length} migrations applied but unregistered`)
+    }
+  }
+  const latestApplied = applied.at(-1) ?? null
+
+  return {
+    status,
+    migration_table: migrationTable,
+    registered_count: registered.length,
+    applied_count: applied.length,
+    unapplied_count: missingMigrations.length,
+    unexpected_count: unexpectedMigrations.length,
+    latest_registered: latestRegistered,
+    latest_applied: latestApplied,
+    missing_migrations: missingMigrations,
+    unexpected_migrations: unexpectedMigrations,
+    message: messageParts.join('; '),
+  }
+}
 
 const buildWorkflowReliability = async (deps: {
   now: Date
@@ -391,18 +506,22 @@ const checkDatabase = async (): Promise<DatabaseStatus> => {
       status: 'disabled',
       message: 'DATABASE_URL not set',
       latency_ms: 0,
+      migration_consistency: buildDatabaseMigrationConsistencyUnknown('DATABASE_URL not set'),
     }
   }
 
   const start = Date.now()
   try {
     await sql`select 1`.execute(db)
+    const migration_consistency = await buildDatabaseMigrationConsistency(db)
+
     return {
       configured: true,
       connected: true,
-      status: 'healthy',
-      message: '',
+      status: migration_consistency.status === 'healthy' ? 'healthy' : 'degraded',
+      message: migration_consistency.message,
       latency_ms: Math.max(0, Date.now() - start),
+      migration_consistency,
     }
   } catch (error) {
     return {
@@ -411,6 +530,10 @@ const checkDatabase = async (): Promise<DatabaseStatus> => {
       status: 'degraded',
       message: normalizeMessage(error),
       latency_ms: Math.max(0, Date.now() - start),
+      migration_consistency: {
+        ...buildDatabaseMigrationConsistencyUnknown(normalizeMessage(error)),
+        registered_count: getRegisteredMigrationNames().length,
+      },
     }
   }
 }

--- a/services/jangar/src/server/kysely-migrations.ts
+++ b/services/jangar/src/server/kysely-migrations.ts
@@ -59,6 +59,8 @@ const migrations: MigrationMap = {
   '20260304_jangar_github_worktree_refresh_state': jangarGithubWorktreeRefreshStateMigration,
 }
 
+export const getRegisteredMigrationNames = () => Object.keys(migrations).sort()
+
 const migrationProvider = new StaticMigrationProvider(migrations)
 const migrationPromises = new WeakMap<Db, Promise<void>>()
 
@@ -125,5 +127,5 @@ export const ensureMigrations = async (db: Db) => {
 }
 
 export const __test__ = {
-  getRegisteredMigrations: () => Object.keys(migrations).sort(),
+  getRegisteredMigrations: getRegisteredMigrationNames,
 }


### PR DESCRIPTION
## Summary
- Add DB migration consistency visibility to `services/jangar` control-plane status endpoint.
- Extend status schema with `database.migration_consistency` including drift metrics, table discovery, and consistency health.
- Add ADR/doc design artifact and unit test coverage for migration-consistency reporting states.

## Related Issues
- https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues/TSK-158
- [huly issue #158](https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues)

## Testing
- `bun run --filter @proompteng/jangar lint`
- `bunx oxfmt services/jangar/src/server/control-plane-status.ts services/jangar/src/data/agents-control-plane.ts services/jangar/src/server/__tests__/control-plane-status.test.ts services/jangar/src/server/kysely-migrations.ts`
- `bunx oxlint --config .oxlintrc.json --type-aware services/jangar/src/server/control-plane-status.ts services/jangar/src/data/agents-control-plane.ts services/jangar/src/server/__tests__/control-plane-status.test.ts services/jangar/src/server/kysely-migrations.ts`
- `bun run --filter @proompteng/jangar tsc` (currently fails in repository baseline due pre-existing temporal/module/type issues in unrelated workspace files)
- `cd services/jangar && bunx vitest run -c vitest.config.ts src/server/__tests__/control-plane-status.test.ts`

## Screenshots (if applicable)
N/A

## Breaking Changes
- N/A

## Checklist
- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
