### PR TITLE
chore(jangar): promote image 8ea175db

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 22dd66d2
-  digest: sha256:bdb4b42b498660d95b9b3d20df80a6d3efddb58ee5ab7a101664143e372c4045
+  tag: 8ea175db
+  digest: sha256:044d4430d03389a6fb95b31f091fad5586197823a753cb57a1a4f3c047382913
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 22dd66d2
-    digest: sha256:a8d520093b672a99e0881444e330c7d001769d1148bfa06aeaaa802d6c6c7793
+    tag: 8ea175db
+    digest: sha256:7648369f56b15a8cf414680ff93d1aa18cdab4600c63089cbce4e8b883e7eff9
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 22dd66d2
-    digest: sha256:bdb4b42b498660d95b9b3d20df80a6d3efddb58ee5ab7a101664143e372c4045
+    tag: 8ea175db
+    digest: sha256:044d4430d03389a6fb95b31f091fad5586197823a753cb57a1a4f3c047382913
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-04T07:59:08Z"
+    deploy.knative.dev/rollout: "2026-03-04T12:48:19Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-04T07:59:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-04T12:48:19Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "22dd66d2"
-    digest: sha256:bdb4b42b498660d95b9b3d20df80a6d3efddb58ee5ab7a101664143e372c4045
+    newTag: "8ea175db"
+    digest: sha256:044d4430d03389a6fb95b31f091fad5586197823a753cb57a1a4f3c047382913


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `8ea175dbf3ef10862c24c33cf76a349cd2b3c9bb`
- Image tag: `8ea175db`
- Image digest: `sha256:044d4430d03389a6fb95b31f091fad5586197823a753cb57a1a4f3c047382913`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`