### PR TITLE
fix(torghut): restore revision readiness with healthz probes

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -430,14 +430,14 @@ spec:
               port: http1
           startupProbe:
             httpGet:
-              path: /readyz
+              path: /healthz
               port: http1
             failureThreshold: 18
             periodSeconds: 5
             timeoutSeconds: 2
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: /healthz
               port: http1
           resources:
             requests:


### PR DESCRIPTION
## Summary

- Fix Torghut Knative startup/readiness probes to use `/healthz` instead of `/readyz`.
- Resolve rollout blocker where new revisions were stuck NotReady because `/readyz` returned 404 in the current runtime image.
- Preserve existing liveness probe behavior (already `/healthz`) for consistent health semantics.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applications/torghut/knative-service.yaml`
- Post-merge live check planned: verify latest Torghut revision becomes Ready and receives traffic.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
