### PR TITLE
chore(torghut): promote image 56deb647

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:77850cb550ef7078ffe70dc4be5a4552daaeda9d197ad56dc594c898c3a5947f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7d08d523d3455fba1ddce88b4c1a6167ac95a170f40b650c75208721e8ad99d7
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-04T08:16:58Z"
+        client.knative.dev/updateTimestamp: "2026-03-05T01:23:42Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:6bf54586aab618047fd10613e591e1b90b4f9cd8335b96112d36030e5ee863b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7d08d523d3455fba1ddce88b4c1a6167ac95a170f40b650c75208721e8ad99d7
           ports:
             - name: http1
               containerPort: 8181
@@ -418,9 +418,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-219-gf4510305
+              value: v0.562.0-276-g56deb647
             - name: TORGHUT_COMMIT
-              value: f45103058baf1b47917c057f7c0b3fa8b5d227b0
+              value: 56deb647f72878f43b3ca7c66b222cade109cbd0
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `56deb647f72878f43b3ca7c66b222cade109cbd0`
- Image tag: `56deb647`
- Image digest: `sha256:7d08d523d3455fba1ddce88b4c1a6167ac95a170f40b650c75208721e8ad99d7`