### PR TITLE
fix(torghut): use numeric knative probe ports

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -427,18 +427,18 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http1
+              port: 8181
           startupProbe:
             httpGet:
               path: /healthz
-              port: http1
+              port: 8181
             failureThreshold: 18
             periodSeconds: 5
             timeoutSeconds: 2
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http1
+              port: 8181
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## Summary

- Fix Torghut Knative health probes to use numeric port `8181` for liveness/startup/readiness.
- Resolve kubelet startup-probe failures (`strconv.Atoi: parsing "http1"`) caused by mismatched named port references.
- Keep probe path on `/healthz` so new revisions can become Ready and receive traffic.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applications/torghut/knative-service.yaml`
- Live verification (post-apply): latest Torghut revision reached Ready with `/healthz` probe responses 200.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
