### PR TITLE
fix(torghut): tolerate bounded stale readiness cache on /readyz

### DIFF
--- a/docs/torghut/design-system/v6/26-readyz-stale-cache-readiness-stability-2026-03-05.md
+++ b/docs/torghut/design-system/v6/26-readyz-stale-cache-readiness-stability-2026-03-05.md
@@ -1,0 +1,89 @@
+# ADR-026: /readyz stale-cache tolerance for rollout stability
+
+## Summary
+
+This ADR documents a readiness-plane improvement for `torghut` that keeps `/readyz` probe responses stable when dependency checks are healthy-but-late, without weakening overall production readiness controls.
+
+- Status: Approved for discover-stage implementation
+- Date: 2026-03-05
+- Swarm: torghut-quant (discover)
+- Owner: architector
+- Related issue: `swarm-torghut-quant-discover`
+
+## Problem
+
+`/readyz` currently re-evaluates dependency checks whenever cache TTL has expired. The endpoint includes:
+
+- PostgreSQL connectivity check
+- ClickHouse health probe
+- Alpaca account endpoint check
+- Database schema/account-scope contract check
+
+Even with cache enabled (`TRADING_READINESS_DEPENDENCY_CACHE_TTL_SECONDS=8`), probe-driven traffic can still become sensitive to transient dependency latency:
+
+- Kubernetes probe timeout is ~1 second in rollout manifests.
+- A valid dependency state can become stale just after TTL expiry and force full re-checks.
+- Transient or delayed responses can mark readiness degraded even when state is recoverably stable.
+
+This produces false-negative flaps and extends startup/redeployment loops.
+
+## Design options considered
+
+### Option A (status quo)
+
+- Keep strict `/readyz` checks as-is.
+- Pros: strongest freshness guarantees.
+- Cons: higher sensitivity to short transient latency at probe cadence.
+
+### Option B (selected)
+
+- Add bounded stale-cache acceptance on `/readyz` only:
+  - add `TRADING_READINESS_DEPENDENCY_CACHE_STALE_TOLERANCE_SECONDS`.
+  - when cache age is beyond TTL but within TTL + tolerance, return the cached state and mark it as stale.
+  - expose `cache_stale` + `cache_age_seconds` in payload.
+  - keep `/trading/health` on strict behavior (no stale acceptance).
+- Pros: improves rollout probe stability while preserving non-probe enforcement surface.
+- Cons: `/readyz` may report slightly stale signals for the tolerance window.
+
+### Option C
+
+- Increase probe timeouts in Knative/Service manifest to fully avoid false negatives.
+- Pros: improves signal freshness window.
+- Cons: changes control plane behavior more broadly and can slow failure detection globally.
+
+### Option D
+
+- Remove database checks from `/readyz` and keep only lightweight health checks.
+- Pros: maximum readiness liveness.
+- Cons: reduces deployment guardrails for schema drift and account-scope invariants.
+
+## Decision
+
+Select Option B.
+
+`/readyz` is for rollout readiness and has a distinct SLO from `/trading/health`, which remains strict and includes full synchronous evaluation. The selected option balances rollout stability with safety by making freshness degradations explicit in the payload.
+
+## Implementation changes
+
+1. Add `TRADING_READINESS_DEPENDENCY_CACHE_STALE_TOLERANCE_SECONDS` to settings with default `20`.
+2. Extend readiness dependency snapshot logic to permit stale-cache reuse when:
+   - cache is older than TTL,
+   - within TTL + tolerance window,
+   - endpoint is `/readyz` (`allow_stale_dependency_cache=True`).
+3. Include `readiness_cache.cache_stale`, `cache_age_seconds`, and tolerance in `/readyz` payload.
+4. Keep `/trading/health` using strict snapshot behavior.
+
+## Test plan and evidence
+
+- Add regression tests:
+  - `/readyz` reuses stale cache inside tolerance and emits `cache_stale=true`.
+  - `/readyz` refreshes after hard TTL when stale exceeds tolerance.
+  - `/trading/health` remains strict and refreshes stale cache immediately.
+
+## Risks and mitigations
+
+- Risk: readiness could stay green briefly while dependency state changed.
+  - Mitigation: tolerance is bounded and explicitly visible in payload.
+  - Mitigation: `/trading/health` still validates synchronously and will surface degradation.
+- Risk: operational confusion around cache age fields in observability dashboards.
+  - Mitigation: include concrete fields in contract and update runbook references if needed.

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1264,6 +1264,14 @@ class Settings(BaseSettings):
             "force synchronous checks on every request."
         ),
     )
+    trading_readiness_dependency_cache_stale_tolerance_seconds: int = Field(
+        default=20,
+        alias="TRADING_READINESS_DEPENDENCY_CACHE_STALE_TOLERANCE_SECONDS",
+        description=(
+            "Additional seconds allowed to reuse stale readiness dependency cache "
+            "on /readyz requests before a hard refresh is forced."
+        ),
+    )
     trading_startup_readiness_grace_seconds: int = Field(
         default=45,
         alias="TRADING_STARTUP_READINESS_GRACE_SECONDS",
@@ -1886,6 +1894,13 @@ class Settings(BaseSettings):
             (
                 self.trading_planned_decision_timeout_seconds,
                 "TRADING_PLANNED_DECISION_TIMEOUT_SECONDS must be >= 0",
+            ),
+            (
+                self.trading_readiness_dependency_cache_stale_tolerance_seconds,
+                (
+                    "TRADING_READINESS_DEPENDENCY_CACHE_STALE_TOLERANCE_SECONDS "
+                    "must be >= 0"
+                ),
             ),
         ]
         for value, message in checks:

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -359,6 +359,7 @@ def _readiness_dependency_snapshot(
     session: Session,
     *,
     include_database_contract: bool,
+    allow_stale_dependency_cache: bool = False,
 ) -> tuple[dict[str, object], datetime, bool]:
     if (
         not settings.trading_readiness_dependency_cache_enabled
@@ -373,6 +374,10 @@ def _readiness_dependency_snapshot(
     cache_ttl = timedelta(
         seconds=settings.trading_readiness_dependency_cache_ttl_seconds
     )
+    stale_tolerance = max(
+        0,
+        int(settings.trading_readiness_dependency_cache_stale_tolerance_seconds),
+    )
     now = datetime.now(timezone.utc)
     cache_key = _readiness_dependency_cache_key(include_database_contract)
 
@@ -380,7 +385,18 @@ def _readiness_dependency_snapshot(
         cache_entry = _TRADING_DEPENDENCY_HEALTH_CACHE.get(cache_key)
         if cache_entry:
             cache_checked_at = cast(datetime, cache_entry["checked_at"])
-            if now - cache_checked_at < cache_ttl:
+            cache_age = now - cache_checked_at
+            if cache_age < cache_ttl:
+                return (
+                    cast(dict[str, object], cache_entry["dependencies"]),
+                    cache_checked_at,
+                    True,
+                )
+            if (
+                allow_stale_dependency_cache
+                and stale_tolerance > 0
+                and cache_age <= cache_ttl + timedelta(seconds=stale_tolerance)
+            ):
                 return (
                     cast(dict[str, object], cache_entry["dependencies"]),
                     cache_checked_at,
@@ -403,6 +419,7 @@ def _evaluate_trading_health_payload(
     session: Session,
     *,
     include_database_contract: bool = False,
+    allow_stale_dependency_cache: bool = False,
 ) -> tuple[dict[str, object], int]:
     """Build shared trading health payload and status code."""
 
@@ -447,12 +464,25 @@ def _evaluate_trading_health_payload(
         scheduler_payload["startup_readiness_grace_seconds"] = startup_grace_seconds
         scheduler_payload["startup_readiness_grace_active"] = in_startup_grace
 
+    now = datetime.now(timezone.utc)
     dependencies, checked_at, cache_used = _readiness_dependency_snapshot(
         session,
         include_database_contract=include_database_contract,
+        allow_stale_dependency_cache=allow_stale_dependency_cache,
     )
     dependencies = dict(dependencies)
     dependencies["universe"] = _evaluate_universe_dependency(scheduler)
+    cache_age_seconds = (
+        (now - checked_at).total_seconds() if checked_at else 0.0
+    )
+    cache_age_seconds = (
+        0.0 if cache_age_seconds < 0 else round(cache_age_seconds, 3)
+    )
+    cache_stale = (
+        cache_used
+        and cache_age_seconds
+        > settings.trading_readiness_dependency_cache_ttl_seconds
+    )
     dependency_statuses = [
         cast(dict[str, object], checks).get("ok", True)
         for name, checks in dependencies.items()
@@ -461,7 +491,10 @@ def _evaluate_trading_health_payload(
     dependencies["readiness_cache"] = {
         "checked_at": checked_at.isoformat(),
         "cache_ttl_seconds": settings.trading_readiness_dependency_cache_ttl_seconds,
+        "cache_stale_tolerance_seconds": settings.trading_readiness_dependency_cache_stale_tolerance_seconds,
         "cache_used": cache_used,
+        "cache_age_seconds": cache_age_seconds,
+        "cache_stale": cache_stale,
     }
 
     overall_ok = scheduler_ok and all(bool(dep) for dep in dependency_statuses)
@@ -680,6 +713,7 @@ def readyz(session: Session = Depends(get_session)) -> JSONResponse:
     payload, status_code = _evaluate_trading_health_payload(
         session,
         include_database_contract=True,
+        allow_stale_dependency_cache=True,
     )
     return JSONResponse(
         status_code=status_code,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -761,9 +761,141 @@ class TestTradingApi(TestCase):
             self.assertIn("checked_at", payload["dependencies"]["database"])
             self.assertIn("readiness_cache", payload["dependencies"])
             self.assertIn("cache_used", payload["dependencies"]["readiness_cache"])
+            self.assertFalse(payload["dependencies"]["readiness_cache"]["cache_stale"])
         finally:
             settings.trading_enabled = original
             settings.trading_universe_source = original_source
+
+    @patch(
+        "app.main._evaluate_database_contract",
+        return_value={
+            "ok": True,
+            "schema_current": True,
+            "schema_current_heads": ["0011_execution_tca_simulator_divergence"],
+            "expected_heads": ["0011_execution_tca_simulator_divergence"],
+            "schema_head_signature": "7f8e4d0",
+            "checked_at": "2026-03-04T00:00:00+00:00",
+            "account_scope_ready": True,
+            "account_scope_errors": [],
+        },
+    )
+    @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    def test_readyz_reuses_stale_dependency_cache_within_stale_tolerance(
+        self,
+        _mock_alpaca: object,
+        _mock_clickhouse: object,
+        _mock_postgres: object,
+        _mock_contract: object,
+    ) -> None:
+        original = settings.trading_enabled
+        original_cache_enabled = settings.trading_readiness_dependency_cache_enabled
+        original_cache_ttl = settings.trading_readiness_dependency_cache_ttl_seconds
+        original_stale_tolerance = (
+            settings.trading_readiness_dependency_cache_stale_tolerance_seconds
+        )
+        settings.trading_enabled = True
+        settings.trading_readiness_dependency_cache_enabled = True
+        settings.trading_readiness_dependency_cache_ttl_seconds = 8
+        settings.trading_readiness_dependency_cache_stale_tolerance_seconds = 20
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = True
+            scheduler.state.last_run_at = datetime.now(timezone.utc)
+            app.state.trading_scheduler = scheduler
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 200)
+            cache_key = _readiness_dependency_cache_key(include_database_contract=True)
+            _TRADING_DEPENDENCY_HEALTH_CACHE[cache_key]["checked_at"] = datetime.now(
+                timezone.utc
+            ) - timedelta(seconds=22)
+            response = self.client.get("/readyz")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(_mock_postgres.call_count, 1)
+            self.assertEqual(_mock_clickhouse.call_count, 1)
+            self.assertEqual(_mock_alpaca.call_count, 1)
+            payload = response.json()
+            cache = payload["dependencies"]["readiness_cache"]
+            self.assertTrue(cache["cache_used"])
+            self.assertTrue(cache["cache_stale"])
+            self.assertGreater(cache["cache_age_seconds"], 8)
+            self.assertLessEqual(cache["cache_age_seconds"], 28)
+        finally:
+            settings.trading_enabled = original
+            settings.trading_readiness_dependency_cache_enabled = original_cache_enabled
+            settings.trading_readiness_dependency_cache_ttl_seconds = original_cache_ttl
+            settings.trading_readiness_dependency_cache_stale_tolerance_seconds = (
+                original_stale_tolerance
+            )
+            _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
+
+    @patch(
+        "app.main._evaluate_database_contract",
+        return_value={
+            "ok": True,
+            "schema_current": True,
+            "schema_current_heads": ["0011_execution_tca_simulator_divergence"],
+            "expected_heads": ["0011_execution_tca_simulator_divergence"],
+            "schema_head_signature": "7f8e4d0",
+            "checked_at": "2026-03-04T00:00:00+00:00",
+            "account_scope_ready": True,
+            "account_scope_errors": [],
+        },
+    )
+    @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
+    @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
+    def test_trading_health_refreshes_stale_readiness_cache_without_tolerance(
+        self,
+        _mock_alpaca: object,
+        _mock_clickhouse: object,
+        _mock_postgres: object,
+        _mock_contract: object,
+    ) -> None:
+        original = settings.trading_enabled
+        original_cache_enabled = settings.trading_readiness_dependency_cache_enabled
+        original_cache_ttl = settings.trading_readiness_dependency_cache_ttl_seconds
+        original_stale_tolerance = (
+            settings.trading_readiness_dependency_cache_stale_tolerance_seconds
+        )
+        original_source = settings.trading_universe_source
+        settings.trading_enabled = True
+        settings.trading_readiness_dependency_cache_enabled = True
+        settings.trading_readiness_dependency_cache_ttl_seconds = 8
+        settings.trading_readiness_dependency_cache_stale_tolerance_seconds = 20
+        settings.trading_universe_source = "jangar"
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = True
+            scheduler.state.last_run_at = datetime.now(timezone.utc)
+            scheduler.state.universe_source_status = "ok"
+            scheduler.state.universe_source_reason = "jangar_fetch_ok"
+            scheduler.state.universe_symbols_count = 2
+            scheduler.state.universe_cache_age_seconds = 0
+            app.state.trading_scheduler = scheduler
+            response = self.client.get("/trading/health")
+            self.assertEqual(response.status_code, 200)
+            cache_key = _readiness_dependency_cache_key(include_database_contract=False)
+            _TRADING_DEPENDENCY_HEALTH_CACHE[cache_key]["checked_at"] = datetime.now(
+                timezone.utc
+            ) - timedelta(seconds=30)
+            response = self.client.get("/trading/health")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(_mock_postgres.call_count, 2)
+            self.assertEqual(_mock_clickhouse.call_count, 2)
+            self.assertEqual(_mock_alpaca.call_count, 2)
+            payload = response.json()
+            self.assertFalse(payload["dependencies"]["readiness_cache"]["cache_stale"])
+        finally:
+            settings.trading_enabled = original
+            settings.trading_readiness_dependency_cache_enabled = original_cache_enabled
+            settings.trading_readiness_dependency_cache_ttl_seconds = original_cache_ttl
+            settings.trading_readiness_dependency_cache_stale_tolerance_seconds = (
+                original_stale_tolerance
+            )
+            settings.trading_universe_source = original_source
+            _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
 
     @patch(
         "app.main._evaluate_database_contract",


### PR DESCRIPTION
## Summary

- Added a bounded stale-cache tolerance path for `readyz` dependency checks in `services/torghut/app/main.py` so probe traffic can reuse near-fresh dependency state during rollout jitter without weakening strict health enforcement.
- Added `TRADING_READINESS_DEPENDENCY_CACHE_STALE_TOLERANCE_SECONDS` and non-negative validation in `services/torghut/app/config.py`, with cache metadata (`cache_age_seconds`, `cache_stale`, `cache_stale_tolerance_seconds`) returned in readiness payloads.
- Added regression coverage in `services/torghut/tests/test_trading_api.py` for `/readyz` stale-cache reuse and `/trading/health` strict refresh behavior, and authored an ADR for design alternatives in `docs/torghut/design-system/v6/26-readyz-stale-cache-readiness-stability-2026-03-05.md`.

## Related Issues

None

## Testing

- `cd /workspace/lab && bunx oxfmt --check services/torghut/app/config.py services/torghut/app/main.py services/torghut/tests/test_trading_api.py docs/torghut/design-system/v6/26-readyz-stale-cache-readiness-stability-2026-03-05.md`
- `cd /workspace/lab/services/torghut && source .venv/bin/activate && pytest tests/test_trading_api.py -q`
- `cd /workspace/lab/services/torghut && source .venv/bin/activate && pyright --project pyrightconfig.json`
- `cd /workspace/lab/services/torghut && source .venv/bin/activate && pyright --project pyrightconfig.scripts.json`
- `cd /workspace/lab/services/torghut && source .venv/bin/activate && pyright --project pyrightconfig.alpha.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
