### PR TITLE
chore(jangar): promote image d93c2164

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "95735e00"
-  digest: sha256:2dab4eb41fac6e3e583a543732e9460528e0aef33d7213a6d3eb86f716f1176f
+  tag: d93c2164
+  digest: sha256:ca14d8b4797188dcbc64e105df985ec38e18736aab659545aee377b4fadcf808
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: "95735e00"
-    digest: sha256:6930632624820101b861033f94017ff0c93fb4a0b8bcd5b8253c12573fa7c72a
+    tag: d93c2164
+    digest: sha256:529f7d2d9ddd0a730013c245cacc557a3d83923741981dd31663658017b0e693
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: "95735e00"
-    digest: sha256:2dab4eb41fac6e3e583a543732e9460528e0aef33d7213a6d3eb86f716f1176f
+    tag: d93c2164
+    digest: sha256:ca14d8b4797188dcbc64e105df985ec38e18736aab659545aee377b4fadcf808
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-04T23:17:15Z"
+    deploy.knative.dev/rollout: "2026-03-05T05:23:25Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-04T23:17:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-05T05:23:25Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "95735e00"
-    digest: sha256:2dab4eb41fac6e3e583a543732e9460528e0aef33d7213a6d3eb86f716f1176f
+    newTag: "d93c2164"
+    digest: sha256:ca14d8b4797188dcbc64e105df985ec38e18736aab659545aee377b4fadcf808


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `d93c2164bcc9eca0c00b7462746bb4b96b0d4e0d`
- Image tag: `d93c2164`
- Image digest: `sha256:ca14d8b4797188dcbc64e105df985ec38e18736aab659545aee377b4fadcf808`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`