### PR TITLE
chore(jangar): promote image 6bbb235b

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: d93c2164
-  digest: sha256:ca14d8b4797188dcbc64e105df985ec38e18736aab659545aee377b4fadcf808
+  tag: 6bbb235b
+  digest: sha256:6fafe739b6c479baed03df6345d124591e2f72ca606613f916e6b4cbda84d930
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: d93c2164
-    digest: sha256:529f7d2d9ddd0a730013c245cacc557a3d83923741981dd31663658017b0e693
+    tag: 6bbb235b
+    digest: sha256:6510203be94e02751fd0df8de03e7da37ff8962e2f91e8f71b3c48d8e390b497
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: d93c2164
-    digest: sha256:ca14d8b4797188dcbc64e105df985ec38e18736aab659545aee377b4fadcf808
+    tag: 6bbb235b
+    digest: sha256:6fafe739b6c479baed03df6345d124591e2f72ca606613f916e6b4cbda84d930
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-05T05:23:25Z"
+    deploy.knative.dev/rollout: "2026-03-05T05:43:38Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-05T05:23:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-05T05:43:38Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "d93c2164"
-    digest: sha256:ca14d8b4797188dcbc64e105df985ec38e18736aab659545aee377b4fadcf808
+    newTag: "6bbb235b"
+    digest: sha256:6fafe739b6c479baed03df6345d124591e2f72ca606613f916e6b4cbda84d930


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `6bbb235bbc4282bf6c54c42adfeb1e35441c0258`
- Image tag: `6bbb235b`
- Image digest: `sha256:6fafe739b6c479baed03df6345d124591e2f72ca606613f916e6b4cbda84d930`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`