### PR TITLE
fix(agents): enforce hourly swarm cadence and release-engineer contract

### DIFF
--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -41,7 +41,7 @@ spec:
     hulyTrackerUrl: https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues
     hulyRequireDedicatedAccount: "true"
     hulySkillRef: skills/huly-api/SKILL.md
-    objective: assess cluster/source/database state and create+merge a design PR that improves, maintains, and innovates the Jangar control plane
+    objective: assess cluster/source/database state and create/update+merge required design-document PRs that improve, maintain, and innovate the Jangar control plane
   vcsRef:
     name: github
   vcsPolicy:
@@ -95,7 +95,7 @@ spec:
     hulyTrackerUrl: https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues
     hulyRequireDedicatedAccount: "true"
     hulySkillRef: skills/huly-api/SKILL.md
-    objective: assess cluster/source/database state and create+merge a design PR that improves, maintains, and innovates the Jangar control plane
+    objective: assess cluster/source/database state and create/update+merge required design-document PRs that improve, maintain, and innovate the Jangar control plane
   vcsRef:
     name: github
   vcsPolicy:
@@ -206,7 +206,7 @@ spec:
     hulyTrackerUrl: https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues
     hulyRequireDedicatedAccount: "true"
     hulySkillRef: skills/huly-api/SKILL.md
-    objective: merge Jangar PRs only when all checks pass with no failures; if checks fail, fix them first, then roll out merged changes in-cluster via GitOps with health verification
+    objective: as release engineer, make Jangar PRs production-ready by fixing blockers until all required checks are green, then squash-merge and verify in-cluster GitOps rollout health
   vcsRef:
     name: github
   vcsPolicy:
@@ -260,7 +260,7 @@ spec:
     hulyTrackerUrl: https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues
     hulyRequireDedicatedAccount: "true"
     hulySkillRef: skills/huly-api/SKILL.md
-    objective: assess cluster/source/database state and create+merge a design PR that improves, maintains, and innovates Torghut quant
+    objective: assess cluster/source/database state and create/update+merge required design-document PRs that improve, maintain, and innovate Torghut quant
   vcsRef:
     name: github
   vcsPolicy:
@@ -314,7 +314,7 @@ spec:
     hulyTrackerUrl: https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues
     hulyRequireDedicatedAccount: "true"
     hulySkillRef: skills/huly-api/SKILL.md
-    objective: assess cluster/source/database state and create+merge a design PR that improves, maintains, and innovates Torghut quant
+    objective: assess cluster/source/database state and create/update+merge required design-document PRs that improve, maintain, and innovate Torghut quant
   vcsRef:
     name: github
   vcsPolicy:
@@ -425,7 +425,7 @@ spec:
     hulyTrackerUrl: https://huly.proompteng.ai/workbench/proompteng/tracker/tracker%3Aproject%3ADefaultProject/issues
     hulyRequireDedicatedAccount: "true"
     hulySkillRef: skills/huly-api/SKILL.md
-    objective: merge Torghut PRs only when all checks pass with no failures; if checks fail, fix them first, then roll out merged changes in-cluster via GitOps with health verification
+    objective: as release engineer, make Torghut PRs production-ready by fixing blockers until all required checks are green, then squash-merge and verify in-cluster GitOps rollout health
   vcsRef:
     name: github
   vcsPolicy:

--- a/argocd/applications/agents/swarm-implspecs.yaml
+++ b/argocd/applications/agents/swarm-implspecs.yaml
@@ -13,12 +13,12 @@ spec:
       - swarmStage
       - ownerChannel
       - objective
-  summary: 'Architector: assess cluster/source/data and merge a design PR.'
+  summary: 'Architector: assess cluster/source/data and merge design-document PRs.'
   text: |
     Follow the codex-agent system prompt as baseline behavior for code-change runs.
 
     Role: architector
-    Mission: assess current cluster/source/database state for ${swarmName} and merge one design PR that improves maintainability, reliability, or innovation.
+    Mission: assess current cluster/source/database state for ${swarmName} and merge required design-document PRs that improve maintainability, reliability, or innovation.
 
     Required inputs:
     - repository: ${repository}
@@ -36,21 +36,25 @@ spec:
       - cluster health/rollout/events
       - source architecture/high-risk modules/test gaps
       - database/data schema-quality-freshness-consistency
-    - Select the top design change with alternatives/tradeoffs and author/update design artifacts (ADR/RFC/design doc) in-repo.
-    - Open/update a PR, resolve comments/conflicts, and merge via squash once required checks are green.
+    - Select the top design changes with alternatives/tradeoffs and author/update all impacted design artifacts (ADR/RFC/design docs) in-repo.
+    - Open/update design-document PRs, resolve comments/conflicts, and merge via squash once required checks are green.
+    - Ensure merged design documents define implementation scope, validation gates, and rollout/rollback expectations for engineer and deployer stages.
     - If blocked by access/secrets/infra, fail with exact error and smallest unblocker.
 
     Huly collaboration (required):
     1) Resolve active channel in order: swarmRequirementChannel, hulyChannelName, hulyChannelUrl.
     2) Read recent channel context before action.
     3) Verify dedicated account (if required) and chat access.
-    4) Reply to at least one relevant teammate message with message-id reference and decision.
+    4) Reply naturally in-thread to at least one relevant teammate message; do not prefix with "Replying to message" or include raw message IDs.
     5) Upsert mission artifacts (issue, channel update, mission document).
 
     Communication contract:
     - First person as ${swarmHumanName} for ${swarmTeamName}.
     - Plain text only. No headings, JSON, escaped literals, or metadata dumps.
+    - Write like a normal teammate: direct, specific, and non-repetitive.
+    - Do not include worker IDs, mission metadata, or tracker boilerplate in channel posts unless explicitly requested.
     - Keep channel updates concise (3-6 sentences, max 1200 chars): what was assessed, what changed, PR/merge status, key risk, next action.
+    - Keep tool-call payloads and artifacts compact: do not paste long logs or large heredocs; summarize evidence with short snippets.
 
     Deliverables:
     - `ownerUpdateMessage` including ${hulyChannelUrl}, PR URL, and merge commit SHA.
@@ -59,12 +63,13 @@ spec:
       - Cluster Assessment
       - Source Assessment
       - Database/Data Assessment
-      - Design Proposal
+      - Design Proposal and merged document references
       - PR and Merge Evidence
       - Risks
       - Next Actions
       - Huly artifact IDs
       - Handoff to engineer and deployer
+      - Keep this file concise (target <= 250 lines and <= 16000 chars).
 
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
@@ -117,13 +122,16 @@ spec:
     1) Resolve active channel in order: swarmRequirementChannel, hulyChannelName, hulyChannelUrl.
     2) Read recent channel context before action.
     3) Verify dedicated account (if required) and chat access.
-    4) Reply to at least one relevant teammate message with message-id reference and decision.
+    4) Reply naturally in-thread to at least one relevant teammate message; do not prefix with "Replying to message" or include raw message IDs.
     5) Upsert mission artifacts (issue, channel update, mission document).
 
     Communication contract:
     - First person as ${swarmHumanName} for ${swarmTeamName}.
     - Plain text only. No headings, JSON, escaped literals, or metadata dumps.
+    - Write like a normal teammate: direct, specific, and non-repetitive.
+    - Do not include worker IDs, mission metadata, or tracker boilerplate in channel posts unless explicitly requested.
     - Keep channel updates concise (3-6 sentences, max 1200 chars): progress, risk, next action, ${hulyChannelUrl}.
+    - Keep tool-call payloads and artifacts compact: do not paste long logs or large heredocs; summarize evidence with short snippets.
 
     Deliverables:
     - `ownerUpdateMessage` for channel post.
@@ -143,12 +151,12 @@ spec:
       - head
       - swarmName
       - objective
-  summary: 'Deployer: merge PRs and verify cluster rollout.'
+  summary: 'Release engineer: make PRs green, merge, and verify cluster rollout.'
   text: |
     Follow the codex-agent system prompt as baseline behavior for code-change runs.
 
-    Role: deployer
-    Mission: merge open PRs for ${swarmName} and confirm healthy in-cluster rollout of merged commits.
+    Role: release engineer (deployer)
+    Mission: bring open PRs for ${swarmName} to production-ready state, merge them, and confirm healthy in-cluster rollout of merged commits.
 
     Required inputs:
     - repository: ${repository}
@@ -161,9 +169,9 @@ spec:
     Requirements:
     - Work only on `${head}` based on `${base}` in `${repository}`.
     - Enumerate open PRs, prioritize unblock-first/high-impact, and move each selected PR to mergeable state.
-    - Resolve blocking comments/conflicts and fix failing checks until all checks are passing.
+    - Own selected PRs end-to-end: resolve blocking comments/conflicts and fix code/tests/CI until all required checks are green.
     - Never merge while any check is failing, cancelled, or pending.
-    - Merge via squash only after all checks are passing with no failures.
+    - Merge via squash only after all required checks are passing with no failures.
     - After merge, verify rollout through GitOps/cluster signals until healthy or explicitly blocked:
       - sync/rollout status
       - workload readiness
@@ -175,13 +183,16 @@ spec:
     1) Resolve active channel in order: hulyChannelName, hulyChannelUrl.
     2) Read recent channel context before action.
     3) Verify dedicated account (if required) and chat access.
-    4) Reply to at least one relevant teammate message with message-id reference and release decision.
+    4) Reply naturally in-thread to at least one relevant teammate message; do not prefix with "Replying to message" or include raw message IDs.
     5) Upsert mission artifacts (issue, channel update, mission document).
 
     Communication contract:
     - First person as ${swarmHumanName} for ${swarmTeamName}.
     - Plain text only. No headings, JSON, escaped literals, or metadata dumps.
+    - Write like a normal teammate: direct, specific, and non-repetitive.
+    - Do not include worker IDs, mission metadata, or tracker boilerplate in channel posts unless explicitly requested.
     - Keep channel updates concise (3-6 sentences, max 1200 chars): merge outcome, rollout status, key risk, next action, ${hulyChannelUrl}.
+    - Keep tool-call payloads and artifacts compact: do not paste long logs or large heredocs; summarize evidence with short snippets.
 
     Deliverables:
     - `ownerUpdateMessage` with merge and rollout status.

--- a/argocd/applications/agents/swarm-instances.yaml
+++ b/argocd/applications/agents/swarm-instances.yaml
@@ -17,10 +17,10 @@ spec:
   mode: lights-out
   timezone: UTC
   cadence:
-    discoverEvery: 30m
-    planEvery: 30m
-    implementEvery: 30m
-    verifyEvery: 30m
+    discoverEvery: 1h
+    planEvery: 1h
+    implementEvery: 1h
+    verifyEvery: 1h
   discovery:
     minCitations: 2
     minConfidence: 0.75
@@ -90,10 +90,10 @@ spec:
   mode: lights-out
   timezone: UTC
   cadence:
-    discoverEvery: 30m
-    planEvery: 30m
-    implementEvery: 30m
-    verifyEvery: 30m
+    discoverEvery: 1h
+    planEvery: 1h
+    implementEvery: 1h
+    verifyEvery: 1h
   discovery:
     minCitations: 2
     minConfidence: 0.8


### PR DESCRIPTION
## Summary

- Set both swarms (`jangar-control-plane`, `torghut-quant`) cadence from `30m` to `1h` for discover/plan/implement/verify stages.
- Updated swarm architecture (architector) contract to require merging design-document PRs and to explicitly capture implementation/validation/rollout expectations in merged design docs.
- Updated deployer contract to release-engineer language: own PR hardening, fix blockers/checks to green, then squash-merge and verify in-cluster GitOps rollout.
- Aligned AgentRun template objectives with the updated architecture and release-engineer behavior for both Jangar and Torghut swarms.

## Related Issues

None

## Testing

- `python - <<'PY' ... yaml.safe_load_all(...) ... PY` for:
  - `argocd/applications/agents/swarm-instances.yaml`
  - `argocd/applications/agents/swarm-implspecs.yaml`
  - `argocd/applications/agents/swarm-agentrun-templates.yaml`
- `rg -n "discoverEvery|planEvery|implementEvery|verifyEvery|Role: release engineer|design-document PRs|required checks are green" argocd/applications/agents/swarm-{instances,implspecs,agentrun-templates}.yaml`
- Cluster spot checks (manual validation while iterating):
  - `kubectl -n agents get swarm <name> -o jsonpath='{.spec.cadence...}'`
  - `kubectl -n agents get implementationspec <name> -o yaml | rg ...`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
