### PR TITLE
chore(jangar): promote image f4c2ade8

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 6bbb235b
-  digest: sha256:6fafe739b6c479baed03df6345d124591e2f72ca606613f916e6b4cbda84d930
+  tag: f4c2ade8
+  digest: sha256:89932b3c1e805cdc9c2b05ed00a0bd4a3a7dc3e0c1df15cdab75de423f80305e
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 6bbb235b
-    digest: sha256:6510203be94e02751fd0df8de03e7da37ff8962e2f91e8f71b3c48d8e390b497
+    tag: f4c2ade8
+    digest: sha256:b0e2cee88204cfc0d16af0b7ae8ac5f1495388f0dd83b947e459186579e9402d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 6bbb235b
-    digest: sha256:6fafe739b6c479baed03df6345d124591e2f72ca606613f916e6b4cbda84d930
+    tag: f4c2ade8
+    digest: sha256:89932b3c1e805cdc9c2b05ed00a0bd4a3a7dc3e0c1df15cdab75de423f80305e
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-05T05:43:38Z"
+    deploy.knative.dev/rollout: "2026-03-05T06:44:19Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-05T05:43:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-05T06:44:19Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "6bbb235b"
-    digest: sha256:6fafe739b6c479baed03df6345d124591e2f72ca606613f916e6b4cbda84d930
+    newTag: "f4c2ade8"
+    digest: sha256:89932b3c1e805cdc9c2b05ed00a0bd4a3a7dc3e0c1df15cdab75de423f80305e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f4c2ade8b18fc59d10f52ceca2c09d39a9b1ab06`
- Image tag: `f4c2ade8`
- Image digest: `sha256:89932b3c1e805cdc9c2b05ed00a0bd4a3a7dc3e0c1df15cdab75de423f80305e`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`