### PR TITLE
chore(jangar): promote image 6f7bb43d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f4c2ade8
-  digest: sha256:89932b3c1e805cdc9c2b05ed00a0bd4a3a7dc3e0c1df15cdab75de423f80305e
+  tag: 6f7bb43d
+  digest: sha256:641c80ec9e0e35ddbe5b9544e57b2a50fb0821c1055a5ecf87c1c01e86382ea1
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f4c2ade8
-    digest: sha256:b0e2cee88204cfc0d16af0b7ae8ac5f1495388f0dd83b947e459186579e9402d
+    tag: 6f7bb43d
+    digest: sha256:f6dfefb0166cbd5a2a99630172e2aa30df9ae558c1d9765497012e40f399eef7
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f4c2ade8
-    digest: sha256:89932b3c1e805cdc9c2b05ed00a0bd4a3a7dc3e0c1df15cdab75de423f80305e
+    tag: 6f7bb43d
+    digest: sha256:641c80ec9e0e35ddbe5b9544e57b2a50fb0821c1055a5ecf87c1c01e86382ea1
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-05T06:44:19Z"
+    deploy.knative.dev/rollout: "2026-03-05T07:37:12Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-05T06:44:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-05T07:37:12Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f4c2ade8"
-    digest: sha256:89932b3c1e805cdc9c2b05ed00a0bd4a3a7dc3e0c1df15cdab75de423f80305e
+    newTag: "6f7bb43d"
+    digest: sha256:641c80ec9e0e35ddbe5b9544e57b2a50fb0821c1055a5ecf87c1c01e86382ea1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `6f7bb43d66b8ca106de49ce968be428264259a78`
- Image tag: `6f7bb43d`
- Image digest: `sha256:641c80ec9e0e35ddbe5b9544e57b2a50fb0821c1055a5ecf87c1c01e86382ea1`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`