### PR TITLE
chore(jangar): promote image 897e176c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 6f7bb43d
-  digest: sha256:641c80ec9e0e35ddbe5b9544e57b2a50fb0821c1055a5ecf87c1c01e86382ea1
+  tag: 897e176c
+  digest: sha256:41a32b6c467914545bdcc859bce09ddf995b278226ea07cabd665814cf196e8f
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 6f7bb43d
-    digest: sha256:f6dfefb0166cbd5a2a99630172e2aa30df9ae558c1d9765497012e40f399eef7
+    tag: 897e176c
+    digest: sha256:94b929377a46a26a25f92621a76f4eb52a0eb0f340f1ee95f9cb5dd9b5f5c9cf
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 6f7bb43d
-    digest: sha256:641c80ec9e0e35ddbe5b9544e57b2a50fb0821c1055a5ecf87c1c01e86382ea1
+    tag: 897e176c
+    digest: sha256:41a32b6c467914545bdcc859bce09ddf995b278226ea07cabd665814cf196e8f
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-05T07:37:12Z"
+    deploy.knative.dev/rollout: "2026-03-05T08:07:50Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-05T07:37:12Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-05T08:07:50Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "6f7bb43d"
-    digest: sha256:641c80ec9e0e35ddbe5b9544e57b2a50fb0821c1055a5ecf87c1c01e86382ea1
+    newTag: "897e176c"
+    digest: sha256:41a32b6c467914545bdcc859bce09ddf995b278226ea07cabd665814cf196e8f


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `897e176c15a9a0243fcb3a3b58dd198098f670a5`
- Image tag: `897e176c`
- Image digest: `sha256:41a32b6c467914545bdcc859bce09ddf995b278226ea07cabd665814cf196e8f`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`