### PR TITLE
chore(torghut): promote image c0289612

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f3df8ce0229757e2219c5ecb566b749aa2f92a0830f8dd447ca8f3ec723d63e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:2822b4648fc70e8638afdcb3ad4318d328eae07c67595ea84522c346dc4340fe
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-05T05:13:15Z"
+        client.knative.dev/updateTimestamp: "2026-03-05T22:18:43Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f3df8ce0229757e2219c5ecb566b749aa2f92a0830f8dd447ca8f3ec723d63e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:2822b4648fc70e8638afdcb3ad4318d328eae07c67595ea84522c346dc4340fe
           ports:
             - name: http1
               containerPort: 8181
@@ -424,9 +424,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-282-gacbb4997
+              value: v0.562.0-300-gc0289612
             - name: TORGHUT_COMMIT
-              value: acbb4997de0772916afaec22fd876db8848f341e
+              value: c02896125580cc37e01dd31ee5892615c9376aab
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `c02896125580cc37e01dd31ee5892615c9376aab`
- Image tag: `c0289612`
- Image digest: `sha256:2822b4648fc70e8638afdcb3ad4318d328eae07c67595ea84522c346dc4340fe`