### PR TITLE
chore(jangar): promote image c0289612

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 897e176c
-  digest: sha256:41a32b6c467914545bdcc859bce09ddf995b278226ea07cabd665814cf196e8f
+  tag: c0289612
+  digest: sha256:497350d08dc9f4835050cdf4275d6729851c14bddf074e88736fb7ce9d1cc43d
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 897e176c
-    digest: sha256:94b929377a46a26a25f92621a76f4eb52a0eb0f340f1ee95f9cb5dd9b5f5c9cf
+    tag: c0289612
+    digest: sha256:dc6f4d194d2cc9eb3884f5d73d7b3e9dc163cdb2c06e5fdd003911849ce9ecc3
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 897e176c
-    digest: sha256:41a32b6c467914545bdcc859bce09ddf995b278226ea07cabd665814cf196e8f
+    tag: c0289612
+    digest: sha256:497350d08dc9f4835050cdf4275d6729851c14bddf074e88736fb7ce9d1cc43d
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-05T08:07:50Z"
+    deploy.knative.dev/rollout: "2026-03-05T22:23:32Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-05T08:07:50Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-05T22:23:32Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "897e176c"
-    digest: sha256:41a32b6c467914545bdcc859bce09ddf995b278226ea07cabd665814cf196e8f
+    newTag: "c0289612"
+    digest: sha256:497350d08dc9f4835050cdf4275d6729851c14bddf074e88736fb7ce9d1cc43d


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c02896125580cc37e01dd31ee5892615c9376aab`
- Image tag: `c0289612`
- Image digest: `sha256:497350d08dc9f4835050cdf4275d6729851c14bddf074e88736fb7ce9d1cc43d`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`