### PR TITLE
fix(jangar): unblock market context run lifecycle

### DIFF
--- a/argocd/applications/agents/torghut-market-context-agentprovider.yaml
+++ b/argocd/applications/agents/torghut-market-context-agentprovider.yaml
@@ -194,6 +194,8 @@ spec:
         import urllib.request
         from pathlib import Path
 
+        DEFAULT_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+
         def _parse_positive_int(value: str | None, fallback: int) -> int:
           try:
             parsed = int((value or '').strip())
@@ -262,9 +264,26 @@ spec:
             return payload.strip()
           return fallback
 
+        def _load_bearer_token() -> str | None:
+          token_path = (os.environ.get('CODEX_MARKET_CONTEXT_TOKEN_PATH') or DEFAULT_TOKEN_PATH).strip()
+          if not token_path:
+            return None
+          try:
+            token = Path(token_path).read_text(encoding='utf-8').strip()
+          except OSError:
+            return None
+          return token or None
+
         def _post_json(url: str, payload: dict, timeout_seconds: int) -> tuple[int, object | None]:
           body = json.dumps(payload).encode('utf-8')
-          request = urllib.request.Request(url, data=body, headers={'content-type': 'application/json'})
+          headers = {
+            'accept': 'application/json',
+            'content-type': 'application/json',
+          }
+          token = _load_bearer_token()
+          if token:
+            headers['authorization'] = f'Bearer {token}'
+          request = urllib.request.Request(url, data=body, headers=headers)
           try:
             with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
               return response.getcode() or 200, _parse_json_bytes(response.read())

--- a/services/jangar/src/server/__tests__/agents-controller-implementation-contract.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller-implementation-contract.test.ts
@@ -87,6 +87,27 @@ describe('agents controller implementation-contract module', () => {
     expect(context.payload.issueTitle).toBe('Compile proompteng/lab')
   })
 
+  it('preserves unknown shell placeholders while interpolating known parameters', () => {
+    const implementation = {
+      source: {
+        provider: 'github',
+      },
+      text: 'SCRIPT_ROOT=/root/.codex && test -f "${SCRIPT_ROOT}/run.py" && echo ${symbol}',
+      contract: {
+        requiredKeys: ['symbol'],
+      },
+    }
+
+    const parameters = {
+      symbol: 'AAPL',
+    }
+
+    const context = buildEventContext(implementation, parameters)
+    expect(context.missingRequiredKeys).toEqual([])
+    expect(context.payload.prompt).toBe('SCRIPT_ROOT=/root/.codex && test -f "${SCRIPT_ROOT}/run.py" && echo AAPL')
+    expect(context.payload.issueBody).toBe('SCRIPT_ROOT=/root/.codex && test -f "${SCRIPT_ROOT}/run.py" && echo AAPL')
+  })
+
   it('falls back to github external id when repository metadata is missing', () => {
     const implementation = {
       source: {

--- a/services/jangar/src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts
@@ -1,0 +1,17 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+describe('torghut market-context AgentProvider manifest', () => {
+  it('uses a bearer token for lifecycle start/progress requests', async () => {
+    const manifest = await readFile(
+      resolve(process.cwd(), '..', '..', 'argocd/applications/agents/torghut-market-context-agentprovider.yaml'),
+      'utf8',
+    )
+
+    expect(manifest).toContain("DEFAULT_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'")
+    expect(manifest).toContain('token = _load_bearer_token()')
+    expect(manifest).toContain("headers['authorization'] = f'Bearer {token}'")
+  })
+})

--- a/services/jangar/src/server/agents-controller/implementation-contract.ts
+++ b/services/jangar/src/server/agents-controller/implementation-contract.ts
@@ -88,8 +88,9 @@ const renderParameterTemplate = (template: string, context: Record<string, unkno
   const rendered = renderTemplate(template, context)
   return rendered.replace(/\$\{\s*([^}]+)\s*\}/g, (_match, rawPath) => {
     const path = String(rawPath).trim()
-    if (!path) return ''
+    if (!path) return _match
     const value = resolvePath(context, path) ?? context[path]
+    if (value == null) return _match
     return stringifyTemplateValue(value)
   })
 }


### PR DESCRIPTION
## Summary

- add bearer-token auth to the market-context provider wrapper so `runs/start` and `runs/progress` are accepted by Jangar
- preserve unknown shell-style placeholders like `${SCRIPT_ROOT}` when rendering implementation prompts while still interpolating known parameters
- add regressions for the implementation-contract placeholder handling and the live AgentProvider manifest auth behavior

## Related Issues

None

## Testing

- `bun run --cwd services/jangar test -- src/server/__tests__/agents-controller-implementation-contract.test.ts src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts`
- `bun run --cwd services/jangar tsc`
- `python3 - <<'PY'`
  `import yaml, pathlib`
  `path = pathlib.Path('argocd/applications/agents/torghut-market-context-agentprovider.yaml')`
  `list(yaml.safe_load_all(path.read_text()))`
  `print('yaml ok')`
  `PY`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
