### PR TITLE
chore(jangar): promote image 6dbe344d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c0289612
-  digest: sha256:497350d08dc9f4835050cdf4275d6729851c14bddf074e88736fb7ce9d1cc43d
+  tag: 6dbe344d
+  digest: sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c0289612
-    digest: sha256:dc6f4d194d2cc9eb3884f5d73d7b3e9dc163cdb2c06e5fdd003911849ce9ecc3
+    tag: 6dbe344d
+    digest: sha256:a6e4564f8cbfdcbfb91ef70e6c523945cdfa3ffdd235f441fca4e918f59d2c5f
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c0289612
-    digest: sha256:497350d08dc9f4835050cdf4275d6729851c14bddf074e88736fb7ce9d1cc43d
+    tag: 6dbe344d
+    digest: sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af
 controllers:
   enabled: true
   replicaCount: 2

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-05T22:23:32Z"
+    deploy.knative.dev/rollout: "2026-03-05T23:11:17Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-05T22:23:32Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-05T23:11:17Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c0289612"
-    digest: sha256:497350d08dc9f4835050cdf4275d6729851c14bddf074e88736fb7ce9d1cc43d
+    newTag: "6dbe344d"
+    digest: sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `6dbe344d1af67c41ccc5d37127ec94c76c5fecd7`
- Image tag: `6dbe344d`
- Image digest: `sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`