### PR TITLE
fix(jangar): restore swarm codex production path

### DIFF
--- a/argocd/applications/agents/codex-secretbinding.yaml
+++ b/argocd/applications/agents/codex-secretbinding.yaml
@@ -9,6 +9,8 @@ spec:
     - kind: Agent
       name: codex-spark-agent
     - kind: Agent
+      name: codex-spark-smoke-agent
+    - kind: Agent
       name: codex-spark-review
   allowedSecrets:
     - github-token

--- a/argocd/applications/agents/codex-spark-smoke-agent-system-prompt-configmap.yaml
+++ b/argocd/applications/agents/codex-spark-smoke-agent-system-prompt-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: codex-spark-smoke-agent-system-prompt
+data:
+  system-prompt.md: |-
+    Execute a read-only Codex runtime smoke validation.
+
+    Requirements:
+    - Do not modify repository state, branches, commits, pull requests, issues, Huly artifacts, or cluster resources.
+    - Verify that the configured Codex provider, model, auth secret, and runner image can start successfully.
+    - Write a short success note to `/workspace/.agentrun/smoke/result.md`.
+    - If startup fails, exit with the exact auth/model/runtime error.
+    - Finish after the smoke note is written. Do not continue into implementation work.

--- a/argocd/applications/agents/codex-spark-smoke-agent.yaml
+++ b/argocd/applications/agents/codex-spark-smoke-agent.yaml
@@ -1,0 +1,12 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: Agent
+metadata:
+  name: codex-spark-smoke-agent
+spec:
+  providerRef:
+    name: codex-spark
+  defaults:
+    systemPromptRef:
+      kind: ConfigMap
+      name: codex-spark-smoke-agent-system-prompt
+      key: system-prompt.md

--- a/argocd/applications/agents/codex-spark-smoke-implspec.yaml
+++ b/argocd/applications/agents/codex-spark-smoke-implspec.yaml
@@ -1,0 +1,30 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: codex-spark-smoke-implspec
+  namespace: agents
+spec:
+  contract:
+    requiredKeys:
+      - repository
+      - base
+      - head
+      - objective
+  summary: 'Read-only Codex runtime smoke check.'
+  text: |
+    Run a read-only Codex startup smoke for ${repository} on ${head} from ${base}.
+
+    Goal:
+    - verify the configured provider, model, auth secret, and runner image can execute one no-op task successfully.
+
+    Constraints:
+    - Do not change files.
+    - Do not commit, push, open a PR, or post external updates.
+    - Keep the run short and deterministic.
+
+    Deliverables:
+    - `/workspace/.agentrun/smoke/result.md` containing:
+      - startup status
+      - resolved repository/base/head
+      - resolved stage
+      - one-line confirmation that no repo or external side effects were performed

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -13,6 +13,9 @@ resources:
   - codex-spark-review-agentprovider.yaml
   - codex-agent.yaml
   - codex-spark-agent.yaml
+  - codex-spark-smoke-agent.yaml
+  - codex-spark-smoke-agent-system-prompt-configmap.yaml
+  - codex-spark-smoke-implspec.yaml
   - codex-whitepaper-secretbinding.yaml
   - codex-whitepaper-agent.yaml
   - codex-agentprovider.yaml

--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -31,7 +31,7 @@ spec:
     swarmAgentIdentity: architector-jangar-discover
     swarmHumanName: architector
     swarmTeamName: Jangar Engineering
-    ownerChannel: http://transactor.huly.svc.cluster.local
+    ownerChannel: swarm://owner/platform
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
     hulyProject: DefaultProject
@@ -85,7 +85,7 @@ spec:
     swarmAgentIdentity: architector-jangar-plan
     swarmHumanName: architector
     swarmTeamName: Jangar Engineering
-    ownerChannel: http://transactor.huly.svc.cluster.local
+    ownerChannel: swarm://owner/platform
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
     hulyProject: DefaultProject
@@ -143,7 +143,7 @@ spec:
     swarmHumanName: engineer
     swarmTeamName: Jangar Engineering
     objective: grab the system design document, implement high-quality engineering changes, update impacted documentation, and deliver a production-ready PR
-    ownerChannel: http://transactor.huly.svc.cluster.local
+    ownerChannel: swarm://owner/platform
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
     hulyProject: DefaultProject
@@ -196,7 +196,7 @@ spec:
     swarmAgentIdentity: deployer-jangar-verify
     swarmHumanName: deployer
     swarmTeamName: Jangar Engineering
-    ownerChannel: http://transactor.huly.svc.cluster.local
+    ownerChannel: swarm://owner/platform
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
     hulyProject: DefaultProject
@@ -250,7 +250,7 @@ spec:
     swarmAgentIdentity: architector-torghut-discover
     swarmHumanName: architector
     swarmTeamName: Torghut Traders
-    ownerChannel: http://transactor.huly.svc.cluster.local
+    ownerChannel: swarm://owner/trading
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
     hulyProject: DefaultProject
@@ -304,7 +304,7 @@ spec:
     swarmAgentIdentity: architector-torghut-plan
     swarmHumanName: architector
     swarmTeamName: Torghut Traders
-    ownerChannel: http://transactor.huly.svc.cluster.local
+    ownerChannel: swarm://owner/trading
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
     hulyProject: DefaultProject
@@ -362,7 +362,7 @@ spec:
     swarmHumanName: engineer
     swarmTeamName: Torghut Traders
     objective: grab the system design document, implement high-quality engineering changes, update impacted documentation, and deliver a production-ready PR
-    ownerChannel: http://transactor.huly.svc.cluster.local
+    ownerChannel: swarm://owner/trading
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
     hulyProject: DefaultProject
@@ -415,7 +415,7 @@ spec:
     swarmAgentIdentity: deployer-torghut-verify
     swarmHumanName: deployer
     swarmTeamName: Torghut Traders
-    ownerChannel: http://transactor.huly.svc.cluster.local
+    ownerChannel: swarm://owner/trading
     hulyApiBaseUrl: http://transactor.huly.svc.cluster.local
     hulyWorkspace: proompteng
     hulyProject: DefaultProject

--- a/argocd/applications/agents/swarm-implspecs.yaml
+++ b/argocd/applications/agents/swarm-implspecs.yaml
@@ -32,7 +32,7 @@ spec:
     - swarmName: ${swarmName}
     - swarmStage: ${swarmStage} (discover | plan)
     - objective: ${objective}
-    - ownerChannel: ${ownerChannel}
+    - ownerChannel (conversation URI): ${ownerChannel}
 
     Execution loop (run in order):
     1) Confirm objective/scope and success metrics from runtime inputs.
@@ -123,7 +123,7 @@ spec:
     - head: ${head}
     - swarmName: ${swarmName}
     - objective: ${objective}
-    - ownerChannel: ${ownerChannel}
+    - ownerChannel (conversation URI): ${ownerChannel}
 
     Optional cross-swarm requirement inputs:
     - swarmRequirementId
@@ -208,7 +208,7 @@ spec:
     - head: ${head}
     - swarmName: ${swarmName}
     - objective: ${objective}
-    - ownerChannel: ${ownerChannel}
+    - ownerChannel (conversation URI): ${ownerChannel}
 
     Execution loop (run in order):
     1) Enumerate open PRs and select unblock-first/high-impact items.

--- a/argocd/applications/agents/swarm-instances.yaml
+++ b/argocd/applications/agents/swarm-instances.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   owner:
     id: platform-owner
-    channel: http://transactor.huly.svc.cluster.local
+    channel: swarm://owner/platform
   domains:
     - platform-reliability
     - platform-evolution
@@ -79,7 +79,7 @@ metadata:
 spec:
   owner:
     id: trading-owner
-    channel: http://transactor.huly.svc.cluster.local
+    channel: swarm://owner/trading
   domains:
     - quant-research
     - autonomous-trading

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -17,6 +17,45 @@ runner:
     repository: registry.ide-newton.ts.net/lab/jangar
     tag: 6dbe344d
     digest: sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af
+argocdHooks:
+  enabled: true
+  smoke:
+    agentRun:
+      apiVersion: agents.proompteng.ai/v1alpha1
+      kind: AgentRun
+      metadata:
+        name: codex-spark-smoke
+      spec:
+        agentRef:
+          name: codex-spark-smoke-agent
+        implementationSpecRef:
+          name: codex-spark-smoke-implspec
+        runtime:
+          type: workflow
+          config:
+            serviceAccountName: agents-sa
+        ttlSecondsAfterFinished: 1800
+        workflow:
+          steps:
+            - name: smoke
+              timeoutSeconds: 900
+              parameters:
+                stage: implementation
+        parameters:
+          repository: proompteng/lab
+          base: main
+          head: codex/swarm-smoke
+          issueNumber: swarm-codex-smoke
+          issueTitle: Codex Spark smoke validation
+          objective: verify api-backed codex auth, provider startup, and the promoted runner image without VCS or external side effects
+        vcsRef:
+          name: github
+        vcsPolicy:
+          required: true
+          mode: read-write
+        secrets:
+          - github-token
+          - codex-auth
 controllers:
   enabled: true
   replicaCount: 2

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -461,6 +461,10 @@ Example:
 helm upgrade agents charts/agents --namespace agents --reuse-values   --set controller.authSecret.name=codex-auth   --set controller.authSecret.key=auth.json
 ```
 
+`codex-auth` is the mounted autonomous Codex auth contract for production runners. This chart only references the
+Secret name/key and mount path; the actual secret payload is managed outside these manifests and must use API-backed
+credentials rather than ChatGPT-account auth.
+
 ### Admission control policy
 
 Use admission policy values to reject unsafe AgentRuns before submission. Rejections surface as `InvalidSpec`.
@@ -507,6 +511,9 @@ Effective `JANGAR_AGENT_RUNNER_IMAGE` precedence in rendered Deployments:
 1. `env.vars.JANGAR_AGENT_RUNNER_IMAGE` (explicit operator override)
 2. `runner.image.*`
 3. `runtime.agentRunnerImage`
+
+For GitOps-managed production rollouts, treat `runner.image.*` as the authoritative promoted tag+digest pin for Codex
+runner jobs. Promote validated image pairs there and keep controller/runtime consumers in lockstep.
 
 ### Agent comms subjects (optional)
 

--- a/charts/agents/examples/swarm-jangar-control-plane.yaml
+++ b/charts/agents/examples/swarm-jangar-control-plane.yaml
@@ -15,6 +15,7 @@ spec:
     - autonomously construct and expand internal platform capabilities
   mode: lights-out
   timezone: UTC
+  # Example/demo cadence. The production overlay runs all stages hourly.
   cadence:
     discoverEvery: 5m
     planEvery: 10m

--- a/charts/agents/examples/swarm-torghut-quant.yaml
+++ b/charts/agents/examples/swarm-torghut-quant.yaml
@@ -15,6 +15,7 @@ spec:
     - optimize risk-adjusted outcomes under strict drawdown policy
   mode: lights-out
   timezone: UTC
+  # Example/demo cadence. The production overlay runs all stages hourly.
   cadence:
     discoverEvery: 1m
     planEvery: 5m

--- a/charts/agents/templates/argocd-hooks.yaml
+++ b/charts/agents/templates/argocd-hooks.yaml
@@ -41,8 +41,8 @@ spec:
               kubectl -n "{{ $namespace }}" delete jobs -l "{{ $labelSelector }}" --ignore-not-found
               kubectl -n "{{ $namespace }}" delete configmaps -l "{{ $labelSelector }}" --ignore-not-found
               {{- end }}
-{{- end }}
-{{- if and .Values.argocdHooks.postSync.enabled $smokeName (gt (len .Values.argocdHooks.smoke.agentRun) 0) -}}
+{{ end }}
+{{ if and .Values.argocdHooks.postSync.enabled $smokeName (gt (len .Values.argocdHooks.smoke.agentRun) 0) -}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -1191,6 +1191,5 @@
       },
       "additionalProperties": false
     }
-  },
-  "allOf": []
+  }
 }

--- a/docs/agents/designs/gitops-argocd-hooks.md
+++ b/docs/agents/designs/gitops-argocd-hooks.md
@@ -7,7 +7,8 @@ Docs index: [README](../README.md)
 ## Current State
 
 - Chart: argocdHooks templates support PreSync cleanup and PostSync smoke AgentRun.
-- Cluster: argocd app values do not enable argocdHooks; no hook jobs present.
+- Cluster: the `agents` production overlay now enables a PostSync Codex smoke AgentRun to validate provider startup
+  before normal swarm cadence resumes.
 - Kustomize renders the chart with includeCRDs: true.
 
 ## Problem
@@ -56,6 +57,8 @@ GitOps deployments need deterministic pre/post-sync behavior.
 
 - Exercise the primary flow and confirm expected status, logs, or metrics.
 - Confirm no regression in existing workflows, CI checks, or chart rendering.
+- For the production overlay, confirm the PostSync smoke AgentRun reaches `Succeeded` and that its logs do not contain
+  ChatGPT auth-mode, quota-limit, or unknown-model failures.
 
 ## Acceptance Criteria
 

--- a/docs/agents/designs/jangar-swarm-intelligence-owner-serving.md
+++ b/docs/agents/designs/jangar-swarm-intelligence-owner-serving.md
@@ -87,7 +87,7 @@ Group/version/kind:
 ### `spec` (required fields)
 
 - `owner.id`: stable owner identity for accountability and routing.
-- `owner.channel`: primary conversation channel.
+- `owner.channel`: primary conversation channel URI, not a transport base URL.
 - `domains[]`: mission domains (for example `platform-reliability`, `quant-strategy`, `docs-automation`).
 - `objectives[]`: outcome statements (not task lists).
 - `mode`: `assisted` or `lights-out`.
@@ -534,6 +534,7 @@ spec:
     - continuously improve reliability and operational quality for managed services
     - continuously improve risk-adjusted outcomes under strict policy limits
   mode: lights-out
+  # Example/demo cadence. The production overlay runs all stages hourly.
   cadence:
     discoverEvery: 1m
     planEvery: 5m
@@ -595,6 +596,7 @@ spec:
     - continuously discover and implement control-plane improvements
     - autonomously construct and expand internal platform capabilities
   mode: lights-out
+  # Example/demo cadence. The production overlay runs all stages hourly.
   cadence:
     discoverEvery: 5m
     planEvery: 10m
@@ -624,6 +626,7 @@ spec:
     - continuously discover and implement alpha/risk improvements
     - optimize risk-adjusted outcomes under strict drawdown policy
   mode: lights-out
+  # Example/demo cadence. The production overlay runs all stages hourly.
   cadence:
     discoverEvery: 1m
     planEvery: 5m

--- a/docs/agents/swarm-end-to-end-runbook.md
+++ b/docs/agents/swarm-end-to-end-runbook.md
@@ -36,6 +36,9 @@ Channel selection is dynamic at runtime:
 2. `hulyChannelName`.
 3. `hulyChannelUrl`.
 
+`owner.channel` remains a logical conversation URI for swarm ownership and routing. Huly transport uses explicit
+`hulyApiBaseUrl` wiring and must not be inferred from `owner.channel`.
+
 ## Execution Loop
 
 ```mermaid
@@ -90,6 +93,18 @@ Expected:
 - `agents` app is `Synced` and `Healthy`.
 - `jangar-control-plane` and `torghut-quant` swarms are `Active` and `Ready=True`.
 - All stage schedules are `Active`.
+
+### 2a. Post-sync smoke
+
+```bash
+kubectl -n agents get agentrun codex-spark-smoke -o json | jq '{phase:.status.phase,reason:.status.reason,message:.status.message}'
+kubectl -n agents logs job/$(kubectl -n agents get job -l agents.proompteng.ai/agent-run=codex-spark-smoke -o jsonpath='{.items[0].metadata.name}') --tail=200
+```
+
+Expected:
+
+- `phase` is `Succeeded`.
+- No ChatGPT auth-mode, usage-limit, or unknown-model errors appear in the job logs.
 
 ### 3. Cross-swarm handoff proof
 
@@ -147,18 +162,10 @@ Expected evidence:
 - `upsert-mission` called with explicit `--message`.
 - Returned Huly artifact ids (`issueId`, `documentId`, `messageId`).
 
-## Current Known State (2026-03-02)
+## Current Known State
 
-- `agents` Argo CD app: `Synced` + `Healthy` on revision `d455ba84e1e80c3f04a4c7e736a5c26dc59018c1`.
-- Both swarms: `Active` + `Ready=True`.
-- Cross-swarm handoff run observed: `jangar-control-plane-torghut-quant-req-00gbjlqs-1-n2l4r` (active).
-- Post-merge channel-behavior probe run succeeded:
-  `e2e-jangar-verify-human-msg-1772441402`.
-- Probe logs confirm required interaction contract:
-  - `list-channel-messages` executed before mission decisions.
-  - `verify-chat-access` executed with explicit worker-authored `--message`.
-  - `upsert-mission` executed with explicit worker-authored `--message`.
-  - Huly artifact ids returned (`issueId`, `documentId`, `messageId`).
+Check live cluster state before using this runbook. Swarm readiness, freeze status, and smoke outcomes are operational
+signals, not static documentation.
 
 ## Failure Criteria
 

--- a/services/jangar/Dockerfile.codex
+++ b/services/jangar/Dockerfile.codex
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.6
-FROM ghcr.io/openai/codex-universal:latest
+FROM ghcr.io/openai/codex-universal@sha256:956c2e7dd1590fc12763f172579d777464312006b9fa1f6405f5f1b78b8ea2dc
 
 ARG ARGO_VERSION=v3.6.3
 ARG KUBECONFORM_VERSION=v0.6.7
@@ -7,7 +7,7 @@ ARG NATSCLI_VERSION=v0.3.0
 ARG TARGETARCH=arm64
 ARG TEMPORAL_VERSION=v1.5.1
 ARG CODEX_AUTH_CHECKSUM=unspecified
-ARG CODEX_VERSION=latest
+ARG CODEX_VERSION=0.106.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
     WORKSPACE=/workspace \

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -2045,4 +2045,35 @@ exit 1
     expect(runCodexSessionMock).toHaveBeenCalledTimes(2)
     expect(process.env.CODEX_MODEL).toBe('codex')
   }, 40_000)
+
+  it('does not inject a default CODEX_MODEL when provider config is the source of truth', async () => {
+    delete process.env.CODEX_MODEL
+    delete process.env.CODEX_MODEL_FALLBACKS
+
+    runCodexSessionMock.mockImplementationOnce(async () => {
+      expect(process.env.CODEX_MODEL).toBeUndefined()
+      return {
+        agentMessages: ['done'],
+        sessionId: 'provider-model-session',
+        exitCode: 0,
+        forcedTermination: false,
+      }
+    })
+
+    const result = await runCodexImplementation(eventPath)
+    expect(result.sessionId).toBe('provider-model-session')
+    expect(process.env.CODEX_MODEL).toBeUndefined()
+  })
+
+  it('does not enable implicit fallback models when CODEX_MODEL_FALLBACKS is unset', async () => {
+    process.env.CODEX_MODEL = 'gpt-5.3-codex-spark'
+    delete process.env.CODEX_MODEL_FALLBACKS
+    process.env.CODEX_MAX_SESSION_ATTEMPTS = '2'
+
+    runCodexSessionMock.mockRejectedValueOnce(new Error('429 rate limit exceeded for gpt-5.3-codex-spark'))
+
+    await expect(runCodexImplementation(eventPath)).rejects.toThrow('429 rate limit exceeded for gpt-5.3-codex-spark')
+    expect(runCodexSessionMock).toHaveBeenCalledTimes(1)
+    expect(process.env.CODEX_MODEL).toBe('gpt-5.3-codex-spark')
+  })
 })

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -3235,10 +3235,6 @@ export const runCodexImplementation = async (eventPath: string) => {
   exportScalarEventParametersToEnv(event)
 
   process.env.CODEX_STAGE = stage
-  const configuredModel = normalizeOptionalString(sanitizeNullableString(process.env.CODEX_MODEL))
-  if (!configuredModel) {
-    process.env.CODEX_MODEL = 'codex-spark'
-  }
   process.env.RUST_LOG = process.env.RUST_LOG ?? 'codex_core=info,codex_exec=info'
   process.env.RUST_BACKTRACE = process.env.RUST_BACKTRACE ?? '1'
 
@@ -3511,10 +3507,10 @@ export const runCodexImplementation = async (eventPath: string) => {
 
     const maxSessionAttempts = parsePositiveIntEnv(process.env.CODEX_MAX_SESSION_ATTEMPTS, 3)
     let sessionResult: RunCodexSessionResult = { agentMessages: [], sessionId: undefined, exitCode: 0 }
-    const primaryModel = process.env.CODEX_MODEL?.trim() || 'codex-spark'
-    const modelFallbackQueue = parseModelCandidates(
-      process.env.CODEX_MODEL_FALLBACKS ?? (primaryModel === 'codex-spark' ? 'codex' : ''),
-    ).filter((candidate) => candidate !== primaryModel)
+    const primaryModel = normalizeOptionalString(sanitizeNullableString(process.env.CODEX_MODEL))
+    const modelFallbackQueue = parseModelCandidates(process.env.CODEX_MODEL_FALLBACKS ?? '').filter(
+      (candidate) => candidate !== primaryModel,
+    )
     const runSession = async (sessionPrompt: string) => {
       return await runCodexSession({
         stage: stage as Parameters<typeof runCodexSession>[0]['stage'],

--- a/services/jangar/src/server/__tests__/agents-controller-resource-reconcilers.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller-resource-reconcilers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { createResourceReconcilers } from '~/server/agents-controller/resource-reconcilers'
+import { validateAutonomousCodexAuthSecret } from '~/server/agents-controller/policy'
 
 const makeDeps = () => {
   const setStatus = vi.fn<
@@ -17,11 +18,21 @@ const makeDeps = () => {
       if (typeof value === 'string' && value.trim()) return value.trim()
       return null
     },
+    resolveAuthSecretConfig: () => ({ name: 'codex-auth', key: 'auth.json', mountPath: '/root/.codex' }),
+    resolveSecretValue: (secret: Record<string, unknown>, key: string) => {
+      const data = (secret.data as Record<string, unknown> | undefined) ?? {}
+      const stringData = (secret.stringData as Record<string, unknown> | undefined) ?? {}
+      const raw = stringData[key] ?? data[key]
+      if (typeof raw !== 'string') return null
+      if (key in stringData) return raw
+      return Buffer.from(raw, 'base64').toString('utf8')
+    },
     secretHasKey: (secret: Record<string, unknown>, key: string) => {
       const data = (secret.data as Record<string, unknown> | undefined) ?? {}
       const stringData = (secret.stringData as Record<string, unknown> | undefined) ?? {}
       return key in data || key in stringData
     },
+    validateAutonomousCodexAuthSecret,
   }
   return { deps, setStatus }
 }
@@ -90,6 +101,71 @@ describe('agents controller resource reconcilers module', () => {
       expect.arrayContaining([
         expect.objectContaining({ type: 'Unreachable', status: 'True', reason: 'SecretNotFound' }),
       ]),
+    )
+  })
+
+  it('marks autonomous codex providers not ready when auth secret uses chatgpt mode', async () => {
+    const { deps, setStatus } = makeDeps()
+    const { reconcileAgentProvider } = createResourceReconcilers(deps)
+
+    await reconcileAgentProvider(
+      {
+        get: vi.fn(async () => ({
+          data: {
+            'auth.json': Buffer.from(JSON.stringify({ auth_mode: 'chatgpt' })).toString('base64'),
+          },
+        })),
+      },
+      {
+        metadata: { generation: 1, namespace: 'agents' },
+        spec: {
+          binary: '/usr/local/bin/agent-runner',
+          envTemplate: {
+            AGENT_PROVIDER_PATH: '/root/.codex/provider-codex-spark.json',
+          },
+        },
+      },
+    )
+
+    const [, , status] = setStatus.mock.calls[0]
+    expect(status.conditions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'Ready', status: 'False', reason: 'UnsupportedAuthMode' }),
+      ]),
+    )
+  })
+
+  it('marks autonomous codex providers ready when auth secret is API-backed', async () => {
+    const { deps, setStatus } = makeDeps()
+    const { reconcileAgentProvider } = createResourceReconcilers(deps)
+
+    await reconcileAgentProvider(
+      {
+        get: vi.fn(async () => ({
+          data: {
+            'auth.json': Buffer.from(
+              JSON.stringify({
+                auth_mode: 'api_key',
+                OPENAI_API_KEY: 'test-key',
+              }),
+            ).toString('base64'),
+          },
+        })),
+      },
+      {
+        metadata: { generation: 1, namespace: 'agents' },
+        spec: {
+          binary: '/usr/local/bin/agent-runner',
+          envTemplate: {
+            AGENT_PROVIDER_PATH: '/root/.codex/provider-codex-spark.json',
+          },
+        },
+      },
+    )
+
+    const [, , status] = setStatus.mock.calls[0]
+    expect(status.conditions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'Ready', status: 'True', reason: 'ValidSpec' })]),
     )
   })
 })

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -3494,6 +3494,133 @@ describe('agents controller reconcileAgentRun', () => {
     expect(thirdSteps[0]?.phase).toBe('Running')
   })
 
+  it('propagates failed workflow job reason and message onto AgentRun status', async () => {
+    const jobStatuses = new Map<string, Record<string, unknown>>()
+    const apply = vi.fn(async (resource: Record<string, unknown>) => {
+      const metadata = (resource.metadata ?? {}) as Record<string, unknown>
+      const uid = metadata.uid ?? `uid-${String(resource.kind ?? 'resource').toLowerCase()}`
+      const applied = { ...resource, metadata: { ...metadata, uid } }
+      if (resource.kind === 'Job') {
+        const name = (resource.metadata as Record<string, unknown> | undefined)?.name as string | undefined
+        if (name) {
+          jobStatuses.set(name, applied)
+        }
+      }
+      return applied
+    })
+    const kube = buildKube({
+      apply,
+      get: vi.fn(async (resource: string, name: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        if (resource === 'job') {
+          return jobStatuses.get(name) ?? null
+        }
+        return null
+      }),
+    })
+
+    const agentRun = buildAgentRun({
+      spec: {
+        agentRef: { name: 'agent-1' },
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'workflow', config: {} },
+        workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
+        workflow: {
+          steps: [{ name: 'deploy-step', retries: 0 }],
+        },
+      },
+    })
+
+    await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
+
+    const firstStatus = getLastStatus(kube)
+    const firstWorkflow = firstStatus.workflow as Record<string, unknown>
+    const firstStep = ((firstWorkflow.steps as Record<string, unknown>[]) ?? [])[0] ?? {}
+    const firstJobName = (firstStep.jobRef as Record<string, unknown> | undefined)?.name as string | undefined
+    jobStatuses.set(firstJobName ?? '', {
+      ...jobStatuses.get(firstJobName ?? ''),
+      status: {
+        failed: 1,
+        conditions: [
+          {
+            type: 'Failed',
+            status: 'True',
+            reason: 'BackoffLimitExceeded',
+            message: 'container exited with code 17',
+          },
+        ],
+      },
+    })
+
+    await __test.reconcileAgentRun(
+      kube as never,
+      { ...agentRun, status: firstStatus },
+      'agents',
+      [],
+      [],
+      defaultConcurrency,
+      buildInFlight(),
+      0,
+    )
+
+    const failedStatus = getLastStatus(kube)
+    expect(failedStatus.phase).toBe('Failed')
+    expect(failedStatus.reason).toBe('BackoffLimitExceeded')
+    expect(failedStatus.message).toBe('workflow step deploy-step: container exited with code 17')
+    const failedWorkflow = failedStatus.workflow as Record<string, unknown>
+    const failedStep = ((failedWorkflow.steps as Record<string, unknown>[]) ?? [])[0] ?? {}
+    expect(failedStep.message).toBe('container exited with code 17')
+  })
+
+  it('propagates failed job reason and message onto AgentRun status', async () => {
+    const kube = buildKube({
+      get: vi.fn(async (resource: string, name: string) => {
+        if (resource === 'job' && name === 'job-1') {
+          return {
+            metadata: { name: 'job-1', namespace: 'agents' },
+            status: {
+              failed: 1,
+              conditions: [
+                {
+                  type: 'Failed',
+                  status: 'True',
+                  reason: 'DeadlineExceeded',
+                  message: 'job exceeded active deadline',
+                },
+              ],
+            },
+          }
+        }
+        return null
+      }),
+    })
+
+    const agentRun = buildAgentRun({
+      status: {
+        phase: 'Running',
+        runtimeRef: { type: 'job', name: 'job-1', namespace: 'agents' },
+      },
+    })
+
+    await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
+
+    const status = getLastStatus(kube)
+    expect(status.phase).toBe('Failed')
+    expect(status.reason).toBe('DeadlineExceeded')
+    expect(status.message).toBe('job exceeded active deadline')
+  })
+
   it('fails workflow steps when timeout is exceeded', async () => {
     const apply = vi.fn(async (resource: Record<string, unknown>) => {
       const metadata = (resource.metadata ?? {}) as Record<string, unknown>

--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -568,7 +568,7 @@ describe('supporting primitives controller', () => {
     expect(status.stageStates).toBeTruthy()
   })
 
-  it('derives transactor huly api base url from front owner channel', async () => {
+  it('does not derive huly api base url from owner channel transport-like values', async () => {
     const applyStatus = vi.fn().mockResolvedValue({})
     const apply = vi.fn().mockResolvedValue({})
     const get = vi.fn().mockResolvedValue({
@@ -617,7 +617,7 @@ describe('supporting primitives controller', () => {
       .find((payload) => payload.kind === 'Schedule') as { metadata?: Record<string, unknown> } | undefined
     expect(schedulePayload).toBeDefined()
     const annotations = (schedulePayload?.metadata?.annotations ?? {}) as Record<string, string>
-    expect(annotations['swarm.proompteng.ai/huly-base-url']).toBe('http://transactor.huly.svc.cluster.local')
+    expect(annotations['swarm.proompteng.ai/huly-base-url']).toBe('https://huly.proompteng.ai')
   })
 
   it('dispatches Huly requirement signals into implement runs', async () => {
@@ -1779,6 +1779,110 @@ describe('supporting primitives controller', () => {
     const status = (firstStatusCall?.[0] as { status?: Record<string, unknown> } | undefined)?.status ?? {}
     expect(status.phase).toBe('Frozen')
     expect(status.freeze).toBeTruthy()
+  })
+
+  it('includes nested workflow failure detail in freeze evidence when top-level status is empty', async () => {
+    const applyStatus = vi.fn().mockResolvedValue({})
+    const apply = vi.fn().mockResolvedValue({})
+    const get = vi.fn().mockResolvedValue(null)
+    const list = vi.fn(async (resource: string) => {
+      if (resource === RESOURCE_MAP.AgentRun) {
+        return {
+          items: [
+            {
+              metadata: {
+                name: 'run-2',
+                creationTimestamp: '2026-01-20T00:01:00Z',
+                labels: {
+                  'swarm.proompteng.ai/name': 'torghut-quant',
+                  'swarm.proompteng.ai/stage': 'implement',
+                },
+              },
+              status: {
+                phase: 'Failed',
+                workflow: {
+                  steps: [
+                    {
+                      name: 'deploy-step',
+                      phase: 'Failed',
+                      message: 'workflow step deploy-step: container exited with code 17',
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              metadata: {
+                name: 'run-1',
+                creationTimestamp: '2026-01-20T00:00:00Z',
+                labels: {
+                  'swarm.proompteng.ai/name': 'torghut-quant',
+                  'swarm.proompteng.ai/stage': 'implement',
+                },
+              },
+              status: {
+                phase: 'Failed',
+                workflow: {
+                  steps: [
+                    {
+                      name: 'deploy-step',
+                      phase: 'Failed',
+                      message: 'workflow step deploy-step: container exited with code 17',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        }
+      }
+      if (resource === RESOURCE_MAP.OrchestrationRun) {
+        return { items: [] }
+      }
+      return { items: [] }
+    })
+    const deleteFn = vi.fn().mockResolvedValue(null)
+    const kube = { applyStatus, apply, get, list, delete: deleteFn } as unknown as KubernetesClient
+
+    const swarm = {
+      apiVersion: 'swarm.proompteng.ai/v1alpha1',
+      kind: 'Swarm',
+      metadata: { name: 'torghut-quant', namespace: 'agents', generation: 1, uid: 'swarm-uid' },
+      spec: {
+        owner: { id: 'trading-owner', channel: 'swarm://owner/trading' },
+        domains: ['autonomous-trading'],
+        objectives: ['improve risk-adjusted return'],
+        mode: 'lights-out',
+        cadence: {
+          discoverEvery: '1m',
+          planEvery: '5m',
+          implementEvery: '15m',
+          verifyEvery: '1m',
+        },
+        discovery: { sources: [{ name: 'market-feed' }] },
+        delivery: { deploymentTargets: ['torghut'] },
+        risk: { freezeAfterFailures: 2, freezeDuration: '60m' },
+        execution: {
+          discover: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          plan: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          implement: { targetRef: { kind: 'OrchestrationRun', name: 'orchestrationrun-sample' } },
+          verify: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+        },
+      },
+    }
+
+    await __test__.reconcileSwarm(kube, swarm, 'agents')
+
+    const firstStatusCall = applyStatus.mock.calls[0]
+    const status = (firstStatusCall?.[0] as { status?: Record<string, unknown> } | undefined)?.status ?? {}
+    expect(status.freeze).toMatchObject({
+      reason: 'ConsecutiveFailures',
+      evidence: {
+        triggeringRuns: expect.arrayContaining([
+          expect.objectContaining({ reason: 'workflow step deploy-step: container exited with code 17' }),
+        ]),
+      },
+    })
   })
 
   it('freezes when consecutive timed-out implement failures remain active', async () => {

--- a/services/jangar/src/server/agents-controller/agent-run-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/agent-run-reconciler.ts
@@ -6,6 +6,7 @@ import type { createPrimitivesStore } from '~/server/primitives-store'
 import { type Condition, upsertCondition } from './conditions'
 import { parseStringList } from './env-config'
 import { hashAgentRunImmutableSpec } from './immutable-spec'
+import { extractJobFailureDetail } from './job-status'
 import { resolveMemory } from './namespace-state'
 import { normalizeLabelMap, validateAuthSecretPolicy, validateImagePolicy, validateLabelPolicy } from './policy'
 import {
@@ -1005,6 +1006,8 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
         await setStatus(kube, agentRun, {
           observedGeneration,
           phase: 'Succeeded',
+          reason: undefined,
+          message: undefined,
           startedAt: asString(jobStatus.startTime) ?? asString(status.startedAt) ?? undefined,
           finishedAt: asString(jobStatus.completionTime) ?? nowIso(),
           runtimeRef,
@@ -1013,14 +1016,21 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
         })
         await applyJobTtlAfterStatus(kube, job, asString(runtimeRef.namespace) ?? namespace, runtimeConfig)
       } else if (failed > 0 && isJobFailed(job)) {
+        const failureDetail = extractJobFailureDetail(job, {
+          reason: 'JobFailed',
+          message: `job ${asString(runtimeRef.name) ?? 'unknown'} failed`,
+        })
         const updated = upsertCondition(conditions, {
           type: 'Failed',
           status: 'True',
-          reason: 'JobFailed',
+          reason: failureDetail.reason,
+          message: failureDetail.message,
         })
         await setStatus(kube, agentRun, {
           observedGeneration,
           phase: 'Failed',
+          reason: failureDetail.reason,
+          message: failureDetail.message,
           finishedAt: nowIso(),
           runtimeRef,
           conditions: updated,
@@ -1031,6 +1041,8 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
         await setStatus(kube, agentRun, {
           observedGeneration,
           phase: 'Running',
+          reason: undefined,
+          message: undefined,
           startedAt: asString(status.startedAt) ?? nowIso(),
           runtimeRef: {
             ...runtimeRef,

--- a/services/jangar/src/server/agents-controller/index.ts
+++ b/services/jangar/src/server/agents-controller/index.ts
@@ -53,11 +53,14 @@ import {
   clearGithubAppTokenCache,
   fetchGithubAppToken,
   parseIntOrString,
+  resolveAuthSecretConfig,
+  resolveSecretValue,
   resolveVcsContext,
   resolveVcsPrRateLimits,
   secretHasKey,
 } from './vcs-context'
 import { createWorkflowReconciler } from './workflow-reconciler'
+import { validateAutonomousCodexAuthSecret } from './policy'
 
 const DEFAULT_NAMESPACES = ['agents']
 const DEFAULT_AGENTRUN_RETENTION_SECONDS = 30 * 24 * 60 * 60
@@ -674,7 +677,10 @@ const {
   resolveVcsAuthMethod,
   validateVcsAuthConfig,
   parseIntOrString,
+  resolveAuthSecretConfig,
+  resolveSecretValue,
   secretHasKey,
+  validateAutonomousCodexAuthSecret,
 })
 
 const buildConditions = (resource: Record<string, unknown>) =>

--- a/services/jangar/src/server/agents-controller/job-status.ts
+++ b/services/jangar/src/server/agents-controller/job-status.ts
@@ -1,0 +1,30 @@
+import { asRecord, asString } from '~/server/primitives-http'
+
+type FailureFallback = {
+  reason: string
+  message: string
+}
+
+export const extractJobFailureDetail = (job: Record<string, unknown>, fallback: FailureFallback) => {
+  const status = asRecord(job.status) ?? {}
+  const conditions = Array.isArray(status.conditions) ? status.conditions : []
+  for (let index = conditions.length - 1; index >= 0; index -= 1) {
+    const condition = asRecord(conditions[index])
+    if (!condition) continue
+    if (asString(condition.type) !== 'Failed' || asString(condition.status) !== 'True') continue
+    const reason = asString(condition.reason) ?? fallback.reason
+    const message = asString(condition.message) ?? asString(condition.reason) ?? fallback.message
+    return { reason, message }
+  }
+
+  const statusReason = asString(status.reason)
+  const statusMessage = asString(status.message)
+  if (statusReason || statusMessage) {
+    return {
+      reason: statusReason ?? fallback.reason,
+      message: statusMessage ?? statusReason ?? fallback.message,
+    }
+  }
+
+  return fallback
+}

--- a/services/jangar/src/server/agents-controller/policy.ts
+++ b/services/jangar/src/server/agents-controller/policy.ts
@@ -1,3 +1,5 @@
+import { asRecord, asString, readNested } from '~/server/primitives-http'
+
 import { parseEnvStringList } from './env-config'
 
 export type ImagePolicyCandidate = {
@@ -7,6 +9,56 @@ export type ImagePolicyCandidate = {
 
 type AuthSecretLike = {
   name: string
+  key?: string
+}
+
+const CODEX_API_AUTH_MODES = new Set(['api', 'api_key', 'openai_api'])
+
+const normalizeOptionalString = (value: unknown) => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const findStringByKey = (value: unknown, keys: Set<string>, depth = 0): string | null => {
+  if (depth > 6 || value === null || value === undefined) return null
+  if (typeof value === 'string') {
+    return normalizeOptionalString(value)
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = findStringByKey(entry, keys, depth + 1)
+      if (found) return found
+    }
+    return null
+  }
+  if (typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  for (const [key, entry] of Object.entries(record)) {
+    if (keys.has(key)) {
+      const found = normalizeOptionalString(entry)
+      if (found) return found
+    }
+  }
+  for (const entry of Object.values(record)) {
+    const found = findStringByKey(entry, keys, depth + 1)
+    if (found) return found
+  }
+  return null
+}
+
+export const isAutonomousCodexProvider = (provider: Record<string, unknown>) => {
+  const spec = asRecord(provider.spec) ?? provider
+  const binary = asString(spec.binary) ?? ''
+  const envTemplate = asRecord(spec.envTemplate) ?? {}
+  const inputFiles = Array.isArray(spec.inputFiles) ? spec.inputFiles : []
+  const providerPath = asString(envTemplate.AGENT_PROVIDER_PATH) ?? ''
+  if (binary.includes('codex')) return true
+  if (binary.includes('agent-runner') && providerPath.startsWith('/root/.codex/provider-')) return true
+  return inputFiles.some((entry) => {
+    const path = asString(readNested(entry, ['path'])) ?? ''
+    return path.startsWith('/root/.codex/')
+  })
 }
 
 const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -113,5 +165,85 @@ export const validateAuthSecretPolicy = (allowedSecrets: string[], authSecret: A
       message: `auth secret ${authSecret.name} is not allowlisted by the Agent`,
     }
   }
+  return { ok: true as const }
+}
+
+export const validateAutonomousCodexAuthSecret = (input: {
+  provider: Record<string, unknown>
+  authSecret: AuthSecretLike | null
+  secret: Record<string, unknown> | null
+  secretValue: string | null
+}) => {
+  if (!isAutonomousCodexProvider(input.provider)) {
+    return { ok: true as const }
+  }
+  if (!input.authSecret) {
+    return {
+      ok: false as const,
+      reason: 'MissingAuthSecretConfig',
+      message: 'autonomous Codex providers require JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_* configuration',
+    }
+  }
+  if (!input.secret) {
+    return {
+      ok: false as const,
+      reason: 'AuthSecretNotFound',
+      message: `auth secret ${input.authSecret.name} not found`,
+    }
+  }
+  const secretValue = normalizeOptionalString(input.secretValue)
+  if (!secretValue) {
+    return {
+      ok: false as const,
+      reason: 'InvalidAuthSecret',
+      message: `auth secret ${input.authSecret.name} key ${input.authSecret.key ?? 'auth.json'} is empty`,
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(secretValue)
+  } catch (error) {
+    return {
+      ok: false as const,
+      reason: 'InvalidAuthSecret',
+      message: `auth secret ${input.authSecret.name} contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+
+  const record = asRecord(parsed)
+  if (!record) {
+    return {
+      ok: false as const,
+      reason: 'InvalidAuthSecret',
+      message: `auth secret ${input.authSecret.name} must contain a JSON object`,
+    }
+  }
+
+  const authMode = normalizeOptionalString(record.auth_mode)?.toLowerCase() ?? null
+  if (authMode === 'chatgpt') {
+    return {
+      ok: false as const,
+      reason: 'UnsupportedAuthMode',
+      message: `auth secret ${input.authSecret.name} uses unsupported chatgpt auth_mode; autonomous Codex providers require API-backed credentials`,
+    }
+  }
+  if (authMode && !CODEX_API_AUTH_MODES.has(authMode)) {
+    return {
+      ok: false as const,
+      reason: 'UnsupportedAuthMode',
+      message: `auth secret ${input.authSecret.name} uses unsupported auth_mode ${authMode}; expected API-backed credentials`,
+    }
+  }
+
+  const apiKey = findStringByKey(record, new Set(['OPENAI_API_KEY', 'openai_api_key', 'apiKey', 'api_key']))
+  if (!apiKey) {
+    return {
+      ok: false as const,
+      reason: 'MissingOpenAIApiKey',
+      message: `auth secret ${input.authSecret.name} must include OPENAI_API_KEY for autonomous Codex providers`,
+    }
+  }
+
   return { ok: true as const }
 }

--- a/services/jangar/src/server/agents-controller/resource-reconcilers.ts
+++ b/services/jangar/src/server/agents-controller/resource-reconcilers.ts
@@ -25,7 +25,15 @@ export const createResourceReconcilers = (deps: {
   resolveVcsAuthMethod: (auth: Record<string, unknown>) => string
   validateVcsAuthConfig: (providerType: string, auth: Record<string, unknown>) => VcsAuthValidation
   parseIntOrString: (value: unknown) => string | null
+  resolveAuthSecretConfig: () => { name: string; key: string; mountPath: string } | null
+  resolveSecretValue: (secret: Record<string, unknown>, key: string) => string | null
   secretHasKey: (secret: Record<string, unknown>, key: string) => boolean
+  validateAutonomousCodexAuthSecret: (input: {
+    provider: Record<string, unknown>
+    authSecret: { name: string; key?: string } | null
+    secret: Record<string, unknown> | null
+    secretValue: string | null
+  }) => { ok: boolean; reason?: string; message?: string }
 }) => {
   const buildConditions = (resource: Record<string, unknown>) =>
     normalizeConditions(readNested(resource, ['status', 'conditions']))
@@ -58,7 +66,17 @@ export const createResourceReconcilers = (deps: {
           message: `agent provider ${providerName} not found`,
         })
       } else {
-        updated = upsertCondition(updated, { type: 'Ready', status: 'True', reason: 'ValidSpec' })
+        const providerReady = buildConditions(provider).find((condition) => condition.type === 'Ready')
+        if (providerReady?.status === 'False') {
+          updated = upsertCondition(updated, {
+            type: 'Ready',
+            status: 'False',
+            reason: 'ProviderNotReady',
+            message: providerReady.message || `agent provider ${providerName} is not ready`,
+          })
+        } else {
+          updated = upsertCondition(updated, { type: 'Ready', status: 'True', reason: 'ValidSpec' })
+        }
       }
     }
 
@@ -85,6 +103,7 @@ export const createResourceReconcilers = (deps: {
     const spec = asRecord(provider.spec) ?? {}
     const conditions = buildConditions(provider)
     const binary = asString(spec.binary)
+    const namespace = asString(readNested(provider, ['metadata', 'namespace'])) ?? 'default'
     let updated = conditions
     if (!binary) {
       updated = upsertCondition(updated, {
@@ -94,7 +113,34 @@ export const createResourceReconcilers = (deps: {
         message: 'spec.binary is required',
       })
     } else {
-      updated = upsertCondition(updated, { type: 'Ready', status: 'True', reason: 'ValidSpec' })
+      const authSecret = deps.resolveAuthSecretConfig()
+      const secret = authSecret ? await (kube as KubeClient).get('secret', authSecret.name, namespace) : null
+      const secretValue = authSecret && secret ? deps.resolveSecretValue(secret, authSecret.key) : null
+      const authValidation = deps.validateAutonomousCodexAuthSecret({
+        provider,
+        authSecret,
+        secret,
+        secretValue,
+      })
+      if (!authValidation.ok) {
+        const conditionType = authValidation.reason === 'AuthSecretNotFound' ? 'Unreachable' : 'InvalidSpec'
+        updated = upsertCondition(updated, {
+          type: conditionType,
+          status: 'True',
+          reason: authValidation.reason ?? 'InvalidAuthSecret',
+          message: authValidation.message ?? 'autonomous Codex auth validation failed',
+        })
+        updated = upsertCondition(updated, {
+          type: 'Ready',
+          status: 'False',
+          reason: authValidation.reason ?? 'InvalidAuthSecret',
+          message: authValidation.message ?? 'autonomous Codex auth validation failed',
+        })
+      } else {
+        updated = upsertCondition(updated, { type: 'InvalidSpec', status: 'False', reason: 'ValidSpec', message: '' })
+        updated = upsertCondition(updated, { type: 'Unreachable', status: 'False', reason: 'Reachable', message: '' })
+        updated = upsertCondition(updated, { type: 'Ready', status: 'True', reason: 'ValidSpec' })
+      }
     }
     await deps.setStatus(kube, provider, {
       observedGeneration: asRecord(provider.metadata)?.generation ?? 0,

--- a/services/jangar/src/server/agents-controller/workflow-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/workflow-reconciler.ts
@@ -6,6 +6,7 @@ import { type createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-k
 import { type Condition, upsertCondition } from './conditions'
 import { parseStringList } from './env-config'
 import { hashAgentRunImmutableSpec } from './immutable-spec'
+import { extractJobFailureDetail } from './job-status'
 import { resolveMemory } from './namespace-state'
 import { type ImagePolicyCandidate, validateAuthSecretPolicy, validateImagePolicy } from './policy'
 import { resolveImplementation, resolveParameters } from './run-utils'
@@ -521,12 +522,15 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
       const maxAttempts = stepSpec.retries + 1
 
       if (stepStatus.phase === 'Failed') {
+        const persistedFailureMessage = asString(stepStatus.message) ?? 'workflow step failed'
         if (loopStatus && !loopStatus.stopReason) {
           loopStatus.stopReason = 'LoopIterationFailed'
         }
         workflowFailure = {
           reason: 'WorkflowStepFailed',
-          message: `workflow step ${stepSpec.name} failed`,
+          message: persistedFailureMessage.startsWith('workflow step')
+            ? persistedFailureMessage
+            : `workflow step ${stepSpec.name}: ${persistedFailureMessage}`,
         }
         break
       }
@@ -980,8 +984,16 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
           continue
         }
         if (failed > 0 && deps.isJobFailed(job)) {
+          const failureDetail = extractJobFailureDetail(job, {
+            reason: 'WorkflowStepFailed',
+            message: `workflow step ${stepSpec.name} failed`,
+          })
           if (stepStatus.attempt < maxAttempts) {
-            setWorkflowStepPhase(stepStatus, 'Retrying', 'Step failed; retrying')
+            const retryMessage =
+              failureDetail.message === `workflow step ${stepSpec.name} failed`
+                ? 'Step failed; retrying'
+                : `${failureDetail.message}; retrying`
+            setWorkflowStepPhase(stepStatus, 'Retrying', retryMessage)
             stepStatus.finishedAt = deps.nowIso()
             stepStatus.nextRetryAt =
               stepSpec.retryBackoffSeconds > 0
@@ -993,7 +1005,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
                 attempts: stepStatus.attempt,
                 startedAt: stepStatus.startedAt,
                 finishedAt: stepStatus.finishedAt,
-                message: 'Step failed; retrying',
+                message: retryMessage,
                 jobRef: stepStatus.jobRef,
               })
             }
@@ -1001,7 +1013,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
             workflowRunning = true
             break
           }
-          setWorkflowStepPhase(stepStatus, 'Failed', 'Step failed')
+          setWorkflowStepPhase(stepStatus, 'Failed', failureDetail.message)
           stepStatus.finishedAt = deps.nowIso()
           if (loopStatus) {
             upsertWorkflowLoopIteration(loopStatus, iterationIndex, {
@@ -1009,15 +1021,15 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
               attempts: stepStatus.attempt,
               startedAt: stepStatus.startedAt,
               finishedAt: stepStatus.finishedAt,
-              message: 'Step failed',
+              message: failureDetail.message,
               jobRef: stepStatus.jobRef,
             })
             loopStatus.stopReason = 'LoopIterationFailed'
           }
           completedJobs.push({ job, namespace: jobNamespace })
           workflowFailure = {
-            reason: 'WorkflowStepFailed',
-            message: `workflow step ${stepSpec.name} failed`,
+            reason: failureDetail.reason,
+            message: `workflow step ${stepSpec.name}: ${failureDetail.message}`,
           }
           break
         }
@@ -1046,6 +1058,8 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Failed',
+        reason: workflowFailure.reason,
+        message: workflowFailure.message,
         finishedAt: deps.nowIso(),
         runtimeRef: runtimeRefUpdate ?? parseRuntimeRef(status.runtimeRef) ?? undefined,
         workflow: workflowStatus,
@@ -1071,6 +1085,8 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Succeeded',
+        reason: undefined,
+        message: undefined,
         finishedAt: deps.nowIso(),
         runtimeRef: runtimeRefUpdate ?? parseRuntimeRef(status.runtimeRef) ?? undefined,
         workflow: workflowStatus,
@@ -1094,6 +1110,8 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Running',
+        reason: undefined,
+        message: undefined,
         startedAt: asString(status.startedAt) ?? deps.nowIso(),
         runtimeRef: runtimeRefUpdate ?? parseRuntimeRef(status.runtimeRef) ?? undefined,
         workflow: workflowStatus,

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -928,9 +928,7 @@ const resolveSwarmHulyIntegration = (
   const integrations = asRecord(spec.integrations) ?? {}
   const huly = asRecord(integrations.huly) ?? {}
   const authSecretRef = asRecord(huly.authSecretRef) ?? {}
-  const ownerChannel = asString(owner.channel)
-  const baseUrl =
-    normalizeHulyBaseUrl(asString(huly.baseUrl)) || normalizeHulyBaseUrl(ownerChannel) || SWARM_DEFAULT_HULY_BASE_URL
+  const baseUrl = normalizeHulyBaseUrl(asString(huly.baseUrl)) || SWARM_DEFAULT_HULY_BASE_URL
   // Avoid implicit global secret fallback; swarm runs should use explicit per-swarm auth secret refs.
   const secretName = asString(authSecretRef.name)?.trim() ?? ''
   const workspace = asString(huly.workspace)?.trim() || undefined
@@ -1260,8 +1258,26 @@ const collectRecentFailureRuns = (resources: Record<string, unknown>[], limit = 
     const phase = (asString(readNested(resource, ['status', 'phase'])) ?? '').toLowerCase()
     const timestamp = getRunTimestamp(resource)
     const conclusion = asString(readNested(resource, ['status', 'conclusion']))
+    const failedCondition = (
+      Array.isArray(readNested(resource, ['status', 'conditions']))
+        ? (readNested(resource, ['status', 'conditions']) as unknown[])
+        : []
+    )
+      .map((entry) => asRecord(entry))
+      .find((condition) => asString(condition?.type) === 'Failed' && asString(condition?.status) === 'True')
+    const failedStep = (
+      Array.isArray(readNested(resource, ['status', 'workflow', 'steps']))
+        ? (readNested(resource, ['status', 'workflow', 'steps']) as unknown[])
+        : []
+    )
+      .map((entry) => asRecord(entry))
+      .find((step) => asString(step?.phase) === 'Failed')
     const reason =
-      asString(readNested(resource, ['status', 'message'])) ?? asString(readNested(resource, ['status', 'reason']))
+      asString(readNested(resource, ['status', 'message'])) ??
+      asString(readNested(resource, ['status', 'reason'])) ??
+      asString(failedCondition?.message) ??
+      asString(failedCondition?.reason) ??
+      asString(failedStep?.message)
     return {
       name,
       namespace,


### PR DESCRIPTION
## Summary

- restore autonomous swarm Codex execution by pinning the runtime, removing implicit model aliasing, and rejecting ChatGPT-mode auth for autonomous providers
- propagate real job and workflow failure reasons into AgentRun and swarm freeze status so production freezes are actionable
- add a dedicated Codex Spark smoke Agent/ImplementationSpec plus Argo hook wiring, and fix the chart hook render path so `kustomize --enable-helm` stays valid
- align swarm owner channel manifests and docs with the conversation-URI contract rather than Huly transport URLs

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `bunx vitest run --config vitest.config.ts scripts/codex/__tests__/codex-implement.test.ts src/server/__tests__/agents-controller-resource-reconcilers.test.ts src/server/__tests__/supporting-primitives-controller.test.ts src/server/__tests__/agents-controller.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-kustomize.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

- `codex-auth` for autonomous Codex providers must now be API-backed; ChatGPT-mode auth is rejected by the controller.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
