### PR TITLE
chore(jangar): promote image c55d0c94

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 6dbe344d
-  digest: sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af
+  tag: c55d0c94
+  digest: sha256:ba6fda8f75cdebcd9c6fae1dfee8a77067e6d11432491c94be0a7ffebf1380f3
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 6dbe344d
-    digest: sha256:a6e4564f8cbfdcbfb91ef70e6c523945cdfa3ffdd235f441fca4e918f59d2c5f
+    tag: c55d0c94
+    digest: sha256:fb150742819466012b619a496ae0ce51bbb5cebabd20d1e0173d3093fa3fd2e0
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 6dbe344d
-    digest: sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af
+    tag: c55d0c94
+    digest: sha256:ba6fda8f75cdebcd9c6fae1dfee8a77067e6d11432491c94be0a7ffebf1380f3
 argocdHooks:
   enabled: true
   smoke:
@@ -47,7 +47,8 @@ argocdHooks:
           head: codex/swarm-smoke
           issueNumber: swarm-codex-smoke
           issueTitle: Codex Spark smoke validation
-          objective: verify api-backed codex auth, provider startup, and the promoted runner image without VCS or external side effects
+          objective: verify api-backed codex auth, provider startup, and the promoted runner image without VCS or external side
+            effects
         vcsRef:
           name: github
         vcsPolicy:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-05T23:11:17Z"
+    deploy.knative.dev/rollout: "2026-03-06T01:52:44Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-05T23:11:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T01:52:44Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "6dbe344d"
-    digest: sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af
+    newTag: "c55d0c94"
+    digest: sha256:ba6fda8f75cdebcd9c6fae1dfee8a77067e6d11432491c94be0a7ffebf1380f3


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c55d0c949f9ca3e66b2f4c9c576c548f15a4a9dd`
- Image tag: `c55d0c94`
- Image digest: `sha256:ba6fda8f75cdebcd9c6fae1dfee8a77067e6d11432491c94be0a7ffebf1380f3`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`