### PR TITLE
fix(agents): use a valid Argo hook image

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -19,6 +19,9 @@ runner:
     digest: sha256:a5e6619500fb97a49e5c4a403f74bbd00fae006e57ad01b70e5fbca02956d2af
 argocdHooks:
   enabled: true
+  image:
+    repository: alpine/k8s
+    tag: 1.30.11
   smoke:
     agentRun:
       apiVersion: agents.proompteng.ai/v1alpha1

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -450,8 +450,8 @@ argocdHooks:
     preSync: '-1'
     postSync: '1'
   image:
-    repository: bitnami/kubectl
-    tag: '1.30.1'
+    repository: alpine/k8s
+    tag: 1.30.11
     pullPolicy: IfNotPresent
   preSync:
     enabled: true


### PR DESCRIPTION
## Summary

- replace the broken Argo hook helper image with `alpine/k8s:1.30.11`, which is pullable and includes both `kubectl` and `sh`
- set the production `agents` overlay to pin the same hook image explicitly instead of inheriting the chart default
- prevent the swarm smoke cleanup and smoke-run hook jobs from blocking future `agents` syncs on an invalid image tag

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-kustomize-hotfix.yaml`
- `docker manifest inspect alpine/k8s:1.30.11`
- `docker run --rm alpine/k8s:1.30.11 sh -c 'command -v sh >/dev/null && command -v kubectl >/dev/null && echo alpine-k8s-shell-ok'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
