### PR TITLE
fix(jangar): keep swarm freeze status valid after unfreeze

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -2315,7 +2315,18 @@ describe('supporting primitives controller', () => {
     const finalStatusCall = applyStatus.mock.calls.at(-1)
     const finalStatus = (finalStatusCall?.[0] as { status?: Record<string, unknown> } | undefined)?.status ?? {}
     expect(finalStatus.phase).toBe('Active')
-    expect(finalStatus.freeze).toBeUndefined()
+    expect(finalStatus.freeze).toMatchObject({
+      reason: 'NotFrozen',
+      threshold: 2,
+      durationMs: 60 * 60 * 1000,
+      evidence: {
+        triggeringRuns: [],
+        stageStaleness: [],
+        triggers: [],
+      },
+    })
+    expect(finalStatus.freeze).toHaveProperty('until')
+    expect(finalStatus.freeze).toHaveProperty('enteredAt')
   })
 
   it('chunks unfreeze timers so long freeze durations wait the full expiry time', async () => {
@@ -2391,7 +2402,18 @@ describe('supporting primitives controller', () => {
     const finalStatusCall = applyStatus.mock.calls.at(-1)
     const finalStatus = (finalStatusCall?.[0] as { status?: Record<string, unknown> } | undefined)?.status ?? {}
     expect(finalStatus.phase).toBe('Active')
-    expect(finalStatus.freeze).toBeUndefined()
+    expect(finalStatus.freeze).toMatchObject({
+      reason: 'NotFrozen',
+      threshold: 2,
+      durationMs: 60 * 60 * 1000,
+      evidence: {
+        triggeringRuns: [],
+        stageStaleness: [],
+        triggers: [],
+      },
+    })
+    expect(finalStatus.freeze).toHaveProperty('until')
+    expect(finalStatus.freeze).toHaveProperty('enteredAt')
   })
 
   it('uses different schedule names for long swarms with identical prefixes', async () => {

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -2424,6 +2424,8 @@ const reconcileSwarm = async (
     }
   }
 
+  const inactiveFreezeUntil = freezeUntil ?? existingFreezeUntil ?? nowIso()
+  const inactiveFreezeEnteredAt = freezeEnteredAt ?? existingFreezeEnteredAt ?? nowIso()
   let conditions = conditionsBase
   if (freezeActive) {
     if (freezeUntil) {
@@ -2462,6 +2464,23 @@ const reconcileSwarm = async (
       reason: 'NotFrozen',
       message: 'swarm operating normally',
     })
+    // Keep a concrete object here so server-side apply updates the existing freeze status
+    // instead of attempting to delete it with null values that violate the CRD schema.
+    nextStatus.freeze = {
+      reason: 'NotFrozen',
+      until: inactiveFreezeUntil,
+      consecutiveFailures,
+      threshold: freezeAfterFailures,
+      enteredAt: inactiveFreezeEnteredAt,
+      durationMs: freezeDurationMs,
+      evidence: {
+        triggeringRuns: freezeFailureEvidence,
+        recentRunWindowMs: freezeAfterFailures * freezeDurationMs,
+        freezeWindowStartedAt: failureWindowStartMs === null ? null : new Date(failureWindowStartMs).toISOString(),
+        stageStaleness: staleStageSignals,
+        triggers: freezeTriggerReasons,
+      },
+    }
   }
 
   if (requirementStats.invalidChannel > 0) {


### PR DESCRIPTION
## Summary

- keep `Swarm.status.freeze` as a concrete object after unfreeze so server-side apply does not send schema-invalid `null` removals
- preserve `freeze.evidence` on active swarms with `reason: NotFrozen` so freeze status remains actionable and CRD-compatible
- update swarm unfreeze regression tests to assert the active-state freeze payload shape

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/supporting-primitives-controller.test.ts`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
