### PR TITLE
fix(agents): declare agentrun status reason and message

### DIFF
--- a/charts/agents/crds/agents.proompteng.ai_agentruns.yaml
+++ b/charts/agents/crds/agents.proompteng.ai_agentruns.yaml
@@ -583,6 +583,8 @@ spec:
                 type: integer
               phase:
                 type: string
+              reason:
+                type: string
               runtimeRef:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
@@ -592,6 +594,8 @@ spec:
                 type: string
               startedAt:
                 format: date-time
+                type: string
+              message:
                 type: string
               systemPromptHash:
                 type: string


### PR DESCRIPTION
## Summary

- add `status.reason` and `status.message` to the `AgentRun` CRD schema
- align the CRD with the controller status fields already written during workflow failures
- unblock server-side status apply for live `AgentRun` reconciliation and smoke runs

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-kustomize-schema-fix.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
