### PR TITLE
chore(jangar): promote image 0b24cee1

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c55d0c94
-  digest: sha256:ba6fda8f75cdebcd9c6fae1dfee8a77067e6d11432491c94be0a7ffebf1380f3
+  tag: 0b24cee1
+  digest: sha256:d8bc546d4774fa773d9bf8939519e78d44a64ac4d2b66b2546549a3a76bdc0b2
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c55d0c94
-    digest: sha256:fb150742819466012b619a496ae0ce51bbb5cebabd20d1e0173d3093fa3fd2e0
+    tag: 0b24cee1
+    digest: sha256:9f9430a33c6633533be9b1f223a377e31eec339c2cdc24b994d7d1f60504d9ab
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c55d0c94
-    digest: sha256:ba6fda8f75cdebcd9c6fae1dfee8a77067e6d11432491c94be0a7ffebf1380f3
+    tag: 0b24cee1
+    digest: sha256:d8bc546d4774fa773d9bf8939519e78d44a64ac4d2b66b2546549a3a76bdc0b2
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T01:52:44Z"
+    deploy.knative.dev/rollout: "2026-03-06T02:37:28Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T01:52:44Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T02:37:28Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c55d0c94"
-    digest: sha256:ba6fda8f75cdebcd9c6fae1dfee8a77067e6d11432491c94be0a7ffebf1380f3
+    newTag: "0b24cee1"
+    digest: sha256:d8bc546d4774fa773d9bf8939519e78d44a64ac4d2b66b2546549a3a76bdc0b2


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `0b24cee175c637eff22080d97958f6f1a251fc53`
- Image tag: `0b24cee1`
- Image digest: `sha256:d8bc546d4774fa773d9bf8939519e78d44a64ac4d2b66b2546549a3a76bdc0b2`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`