### PR TITLE
chore(jangar): promote image aa1a943c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 0b24cee1
-  digest: sha256:d8bc546d4774fa773d9bf8939519e78d44a64ac4d2b66b2546549a3a76bdc0b2
+  tag: aa1a943c
+  digest: sha256:6f437d370832cb3bb8cec5e8451fa8098b33ef1eef13ba512b4b576b0c49899d
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 0b24cee1
-    digest: sha256:9f9430a33c6633533be9b1f223a377e31eec339c2cdc24b994d7d1f60504d9ab
+    tag: aa1a943c
+    digest: sha256:f457c81b5cdd5b1a8636cc2bf9161099436906456a26e9f4995e945b5ebfb0c9
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 0b24cee1
-    digest: sha256:d8bc546d4774fa773d9bf8939519e78d44a64ac4d2b66b2546549a3a76bdc0b2
+    tag: aa1a943c
+    digest: sha256:6f437d370832cb3bb8cec5e8451fa8098b33ef1eef13ba512b4b576b0c49899d
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T02:37:28Z"
+    deploy.knative.dev/rollout: "2026-03-06T03:22:58Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T02:37:28Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T03:22:58Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "0b24cee1"
-    digest: sha256:d8bc546d4774fa773d9bf8939519e78d44a64ac4d2b66b2546549a3a76bdc0b2
+    newTag: "aa1a943c"
+    digest: sha256:6f437d370832cb3bb8cec5e8451fa8098b33ef1eef13ba512b4b576b0c49899d


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `aa1a943c26856bfecc93b75c77c10b54eec23599`
- Image tag: `aa1a943c`
- Image digest: `sha256:6f437d370832cb3bb8cec5e8451fa8098b33ef1eef13ba512b4b576b0c49899d`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`