### PR TITLE
fix(jangar): surface workflow data confidence in control-plane status

### DIFF
--- a/docs/agents/designs/jangar-control-plane-stage-outcome-confidence-and-quota-resilience.md
+++ b/docs/agents/designs/jangar-control-plane-stage-outcome-confidence-and-quota-resilience.md
@@ -1,6 +1,6 @@
 # Jangar Control Plane Stage Outcome Confidence and Quota Resilience
 
-Status: Proposed (2026-03-05)
+Status: In Progress (2026-03-06)
 
 ## Summary
 
@@ -8,6 +8,39 @@ Current `jangar-control-plane` stage schedules can report `Active/Ready` while s
 `BackoffLimitExceeded`, and discover/plan/verify failures do not contribute to the existing swarm freeze trigger.
 This proposal introduces a unified stage outcome confidence model and quota-aware failure policy so that control-plane
 status reflects execution truth, not only schedule liveness.
+
+## Implementation update (2026-03-06)
+
+This iteration implements the highest-priority runtime slice: stop reporting workflow reliability as implicitly healthy
+when Kubernetes workflow collection fails.
+
+Shipped in this slice:
+
+- `workflows.data_confidence` (`high|degraded|unknown`) in `/api/agents/control-plane/status`.
+- Explicit workflow collection telemetry:
+  - `workflows.collection_errors`
+  - `workflows.collected_namespaces`
+  - `workflows.target_namespaces`
+  - `workflows.message`
+- Namespace degradation wiring for workflow blind spots:
+  - `workflows` is degraded when confidence is not `high`.
+  - `runtime:workflows` is degraded when confidence is `unknown`.
+- UI surfacing for workflow data confidence and collection coverage.
+- Regression tests updated to require degraded status when workflow list lookup fails.
+
+Remaining design slices from this document:
+
+- Stage-level counters and confidence by discover/plan/implement/verify.
+- Freeze trigger expansion from implement-only to all enabled stages.
+- Quota/capacity-specific classification (`ModelCapacityExceeded`) and provider fallback policy metadata.
+
+Rollback path for this slice:
+
+- Revert the workflow confidence fields and namespace degradation wiring in:
+  - `services/jangar/src/server/control-plane-status.ts`
+  - `services/jangar/src/data/agents-control-plane.ts`
+  - `services/jangar/src/components/agents-control-plane-status.tsx`
+- Restore prior test expectations in `services/jangar/src/server/__tests__/control-plane-status.test.ts`.
 
 ## Assessment context
 

--- a/services/jangar/src/components/__tests__/agents-control-plane-status.test.tsx
+++ b/services/jangar/src/components/__tests__/agents-control-plane-status.test.tsx
@@ -38,6 +38,11 @@ const baseStatus: ControlPlaneStatus = {
     active_job_runs: 1,
     recent_failed_jobs: 2,
     backoff_limit_exceeded_jobs: 1,
+    data_confidence: 'high',
+    collection_errors: 0,
+    collected_namespaces: 1,
+    target_namespaces: 1,
+    message: '',
     top_failure_reasons: [
       { reason: 'BackoffLimitExceeded', count: 2 },
       { reason: 'ImagePullBackOff', count: 1 },
@@ -100,6 +105,7 @@ describe('ControlPlaneStatusPanel', () => {
     const normalizedHtml = html.replace(/<!-- -->/g, '')
 
     expect(normalizedHtml).toContain('Top failure reasons: BackoffLimitExceeded (2), ImagePullBackOff (1)')
+    expect(normalizedHtml).toContain('Data confidence: high')
     expect(normalizedHtml).not.toContain('Top failure reasons: [object Object], [object Object]')
   })
 })

--- a/services/jangar/src/components/agents-control-plane-status.tsx
+++ b/services/jangar/src/components/agents-control-plane-status.tsx
@@ -175,6 +175,17 @@ export const ControlPlaneStatusPanel = ({
               <span>Backoff limit exceeded: {renderSummaryValue(status.workflows.backoff_limit_exceeded_jobs)}</span>
               <span>Window: {renderSummaryValue(status.workflows.window_minutes)}m</span>
             </div>
+            <div className="flex flex-wrap gap-4">
+              <span>Data confidence: {renderSummaryValue(status.workflows.data_confidence)}</span>
+              <span>
+                Namespace coverage: {renderSummaryValue(status.workflows.collected_namespaces)}/
+                {renderSummaryValue(status.workflows.target_namespaces)}
+              </span>
+              <span>Collection errors: {renderSummaryValue(status.workflows.collection_errors)}</span>
+            </div>
+            {status.workflows.message ? (
+              <div className="text-muted-foreground">Collection status: {status.workflows.message}</div>
+            ) : null}
             <div className="text-muted-foreground">
               Top failure reasons:{' '}
               {status.workflows.top_failure_reasons.length > 0

--- a/services/jangar/src/data/agents-control-plane.ts
+++ b/services/jangar/src/data/agents-control-plane.ts
@@ -121,6 +121,8 @@ export type WorkflowFailureReason = {
   count: number
 }
 
+export type WorkflowDataConfidence = 'high' | 'degraded' | 'unknown'
+
 export type DatabaseMigrationConsistency = {
   status: 'healthy' | 'degraded' | 'unknown'
   migration_table: string | null
@@ -150,6 +152,11 @@ export type WorkflowsReliabilityStatus = {
   backoff_limit_exceeded_jobs: number
   window_minutes: number
   top_failure_reasons: WorkflowFailureReason[]
+  data_confidence: WorkflowDataConfidence
+  collection_errors: number
+  collected_namespaces: number
+  target_namespaces: number
+  message: string
 }
 
 export type DeploymentRolloutStatus = {

--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -61,6 +61,11 @@ const buildWorkflowsReliabilityStatus = (
   backoff_limit_exceeded_jobs: 0,
   window_minutes: 15,
   top_failure_reasons: [],
+  data_confidence: 'high',
+  collection_errors: 0,
+  collected_namespaces: 1,
+  target_namespaces: 1,
+  message: '',
   ...overrides,
 })
 
@@ -207,6 +212,11 @@ describe('control-plane status', () => {
       backoff_limit_exceeded_jobs: 0,
       window_minutes: 15,
       top_failure_reasons: [],
+      data_confidence: 'high',
+      collection_errors: 0,
+      collected_namespaces: 1,
+      target_namespaces: 1,
+      message: '',
     })
     expect(status.namespaces).toHaveLength(1)
     expect(status.namespaces[0]?.status).toBe('healthy')
@@ -334,7 +344,7 @@ describe('control-plane status', () => {
     expect(status.namespaces[0]?.degraded_components ?? []).not.toContain('runtime:workflows')
   })
 
-  it('keeps control-plane status healthy when workflow list lookup fails', async () => {
+  it('marks workflow confidence unknown when workflow list lookup fails', async () => {
     kubeClientMocks.createKubernetesClient.mockReturnValue({
       list: vi.fn(async () => {
         throw new Error('simulated kubernetes failure')
@@ -377,9 +387,16 @@ describe('control-plane status', () => {
       backoff_limit_exceeded_jobs: 0,
       window_minutes: 15,
       top_failure_reasons: [],
+      data_confidence: 'unknown',
+      collection_errors: 1,
+      collected_namespaces: 0,
+      target_namespaces: 1,
+      message:
+        'workflow reliability unavailable (1/1 namespace queries failed); sample errors: agents: simulated kubernetes failure',
     })
-    expect(status.namespaces[0]?.status).toBe('healthy')
-    expect(status.namespaces[0]?.degraded_components ?? []).toHaveLength(0)
+    expect(status.namespaces[0]?.status).toBe('degraded')
+    expect(status.namespaces[0]?.degraded_components ?? []).toContain('workflows')
+    expect(status.namespaces[0]?.degraded_components ?? []).toContain('runtime:workflows')
   })
 
   it('throws when kubernetes client creation fails', async () => {

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -28,6 +28,7 @@ const DEFAULT_WORKFLOWS_WARNING_BACKOFF_THRESHOLD = 2
 const DEFAULT_WORKFLOWS_DEGRADED_BACKOFF_THRESHOLD = 3
 const DEFAULT_ROLLOUT_DEPLOYMENTS = ['agents']
 const MAX_TOP_FAILURE_REASONS = 5
+const MAX_WORKFLOW_COLLECTION_ERROR_SAMPLE = 3
 const MIN_WINDOW_MINUTES = 1
 const MAX_WINDOW_MINUTES = 24 * 60
 
@@ -700,6 +701,9 @@ const resolveWorkflowsReliabilityStatus = async ({
   let recentFailedJobs = 0
   let backoffLimitExceededJobs = 0
   const reasonsMap = new Map<string, number>()
+  let collectionErrors = 0
+  let collectedNamespaces = 0
+  const collectionErrorMessages: string[] = []
 
   const uniqueNamespaces = uniqueStrings(namespaces)
   const uniqueSwarms = uniqueStrings(swarms)
@@ -716,6 +720,7 @@ const resolveWorkflowsReliabilityStatus = async ({
     try {
       const jobsPayload = await kube.list(WORKFLOW_JOB_RESOURCE, currentNamespace, labelSelector)
       const jobs = parseItems(jobsPayload)
+      collectedNamespaces += 1
 
       for (const job of jobs) {
         const metadata = asRecord(job.metadata) ?? {}
@@ -792,8 +797,11 @@ const resolveWorkflowsReliabilityStatus = async ({
         }
       }
     } catch (error) {
+      collectionErrors += 1
+      const errorMessage = normalizeMessage(error)
+      collectionErrorMessages.push(`${currentNamespace}: ${errorMessage}`)
       console.warn(
-        `[jangar] failed to collect workflow reliability metrics for namespace ${currentNamespace}: ${normalizeMessage(error)}`,
+        `[jangar] failed to collect workflow reliability metrics for namespace ${currentNamespace}: ${errorMessage}`,
       )
     }
   }
@@ -806,6 +814,23 @@ const resolveWorkflowsReliabilityStatus = async ({
     .slice(0, MAX_TOP_FAILURE_REASONS)
     .map(([reason, count]) => ({ reason, count }))
 
+  const targetNamespaces = namespaceScope.length
+  const dataConfidence: WorkflowsReliabilityStatus['data_confidence'] =
+    collectionErrors === 0 ? 'high' : collectedNamespaces === 0 ? 'unknown' : 'degraded'
+  const collectionMessage =
+    dataConfidence === 'high'
+      ? ''
+      : [
+          dataConfidence === 'unknown'
+            ? `workflow reliability unavailable (${collectionErrors}/${targetNamespaces} namespace queries failed)`
+            : `workflow reliability partially unavailable (${collectionErrors}/${targetNamespaces} namespace queries failed)`,
+          collectionErrorMessages.length > 0
+            ? `sample errors: ${collectionErrorMessages.slice(0, MAX_WORKFLOW_COLLECTION_ERROR_SAMPLE).join(' | ')}`
+            : '',
+        ]
+          .filter((value) => value.length > 0)
+          .join('; ')
+
   // Keep payload bounded and deterministic.
   return {
     active_job_runs: activeJobRuns,
@@ -813,6 +838,11 @@ const resolveWorkflowsReliabilityStatus = async ({
     backoff_limit_exceeded_jobs: backoffLimitExceededJobs,
     window_minutes: windowMinutes,
     top_failure_reasons: topFailureReasons,
+    data_confidence: dataConfidence,
+    collection_errors: collectionErrors,
+    collected_namespaces: collectedNamespaces,
+    target_namespaces: targetNamespaces,
+    message: collectionMessage,
   }
 }
 
@@ -895,6 +925,9 @@ export const buildControlPlaneStatus = async (
     kube: createKubernetesClient(),
   })
 
+  const isWorkflowsDataUnknown = workflows.data_confidence === 'unknown'
+  const isWorkflowsDataDegraded = workflows.data_confidence === 'degraded'
+  const isWorkflowsDataUnavailable = isWorkflowsDataUnknown || isWorkflowsDataDegraded
   const isWorkflowsWarning = workflows.backoff_limit_exceeded_jobs >= warningBackoffThreshold
   const isWorkflowsDegraded = workflows.backoff_limit_exceeded_jobs >= degradedBackoffThreshold
 
@@ -908,8 +941,8 @@ export const buildControlPlaneStatus = async (
     ...(database.status === 'healthy' ? [] : ['database']),
     ...(grpcStatus.enabled && grpcStatus.status !== 'healthy' ? ['grpc'] : []),
     ...(watchReliability.status === 'degraded' ? ['watch_reliability'] : []),
-    ...(isWorkflowsWarning || isWorkflowsDegraded ? ['workflows'] : []),
-    ...(isWorkflowsDegraded ? ['runtime:workflows'] : []),
+    ...(isWorkflowsDataUnavailable || isWorkflowsWarning || isWorkflowsDegraded ? ['workflows'] : []),
+    ...(isWorkflowsDataUnknown || isWorkflowsDegraded ? ['runtime:workflows'] : []),
     ...(rolloutHealth.status === 'degraded' ? ['rollout_health'] : []),
   ]
 


### PR DESCRIPTION
## Summary

- Added explicit workflow reliability data-confidence contract fields to control-plane status: `data_confidence`, `collection_errors`, `collected_namespaces`, `target_namespaces`, and `message`.
- Updated workflow reliability aggregation to downgrade confidence when Kubernetes workflow collection fails, rather than silently returning healthy-looking zero counters.
- Wired namespace degradation to workflow confidence gaps (`workflows` for degraded/unknown confidence and `runtime:workflows` for unknown confidence) and surfaced the new confidence/coverage details in the control-plane UI.
- Updated regression coverage for control-plane status and UI, and updated the governing design doc with implementation status, shipped scope, remaining slices, and rollback guidance.

## Related Issues

None. Runtime objective provenance is from swarm mission payload (`ownerChannel: swarm://owner/platform`) and the design artifact below.

## Provenance

- Governing design artifact: `docs/agents/designs/jangar-control-plane-stage-outcome-confidence-and-quota-resilience.md`
- Runtime requirement signal used for this slice: design evidence showing workflow list lookup failures currently surfacing as healthy reliability counters, plus active jangar-control-plane mission objective to close runtime reliability gaps.

## Testing

- `bun run --filter @proompteng/jangar lint` (pass)
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-status.test.ts src/components/__tests__/agents-control-plane-status.test.tsx` (pass)
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/control-plane-status.test.ts src/components/__tests__/agents-control-plane-status.test.tsx` (pretest wrapper fails due existing `@proompteng/temporal-bun-sdk build` argument-forwarding issue; underlying targeted vitest run passes)

## CI Evidence

- `Lint commit messages` ✅
- `Validate PR title` ✅
- `check_changed_files` ✅
- `validate` (agents-ci) ✅
- `integration` (agents-ci) ✅
- `lint-and-typecheck / run` (jangar-ci) ✅

## Breaking Changes

None.

## Risks

- API payload is additive, but strict consumers that assert exact workflow object keys may need updates.
- New degradation behavior can increase alerting sensitivity when Kubernetes query access intermittently fails.

## Rollback Path

- Revert commit `07be46da` to restore prior workflow reliability shape and degradation behavior.
- If partial rollback is required, revert workflow-confidence logic and fields in:
  - `services/jangar/src/server/control-plane-status.ts`
  - `services/jangar/src/data/agents-control-plane.ts`
  - `services/jangar/src/components/agents-control-plane-status.tsx`
  - `services/jangar/src/server/__tests__/control-plane-status.test.ts`

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
