### PR TITLE
chore(jangar): promote image 14f42bed

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: aa1a943c
-  digest: sha256:6f437d370832cb3bb8cec5e8451fa8098b33ef1eef13ba512b4b576b0c49899d
+  tag: 14f42bed
+  digest: sha256:2f012ad7f34291d164a6ea7486dc7c981fe68f865ff50939f22060ec8754ea48
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: aa1a943c
-    digest: sha256:f457c81b5cdd5b1a8636cc2bf9161099436906456a26e9f4995e945b5ebfb0c9
+    tag: 14f42bed
+    digest: sha256:15b943a0a98ba0a851a0da127921da39af796a17de53866e94b0e791be3ec3ea
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: aa1a943c
-    digest: sha256:6f437d370832cb3bb8cec5e8451fa8098b33ef1eef13ba512b4b576b0c49899d
+    tag: 14f42bed
+    digest: sha256:2f012ad7f34291d164a6ea7486dc7c981fe68f865ff50939f22060ec8754ea48
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T03:22:58Z"
+    deploy.knative.dev/rollout: "2026-03-06T04:49:01Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T03:22:58Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T04:49:01Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "aa1a943c"
-    digest: sha256:6f437d370832cb3bb8cec5e8451fa8098b33ef1eef13ba512b4b576b0c49899d
+    newTag: "14f42bed"
+    digest: sha256:2f012ad7f34291d164a6ea7486dc7c981fe68f865ff50939f22060ec8754ea48


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `14f42bedf4bc2ba980a9e61f0dd544e0ee340085`
- Image tag: `14f42bed`
- Image digest: `sha256:2f012ad7f34291d164a6ea7486dc7c981fe68f865ff50939f22060ec8754ea48`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`