### PR TITLE
chore(jangar): promote image da3f2955

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 14f42bed
-  digest: sha256:2f012ad7f34291d164a6ea7486dc7c981fe68f865ff50939f22060ec8754ea48
+  tag: da3f2955
+  digest: sha256:4b9714ef502e5b33f672e4bfa385b95a73bee521e92a4e2a830d19f49c1c6ba0
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 14f42bed
-    digest: sha256:15b943a0a98ba0a851a0da127921da39af796a17de53866e94b0e791be3ec3ea
+    tag: da3f2955
+    digest: sha256:27bcf9890bf639db682132eb5c34d534a23c7aa66deee1d04031bc98ecee1e93
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 14f42bed
-    digest: sha256:2f012ad7f34291d164a6ea7486dc7c981fe68f865ff50939f22060ec8754ea48
+    tag: da3f2955
+    digest: sha256:4b9714ef502e5b33f672e4bfa385b95a73bee521e92a4e2a830d19f49c1c6ba0
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T04:49:01Z"
+    deploy.knative.dev/rollout: "2026-03-06T05:02:03Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T04:49:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T05:02:03Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "14f42bed"
-    digest: sha256:2f012ad7f34291d164a6ea7486dc7c981fe68f865ff50939f22060ec8754ea48
+    newTag: "da3f2955"
+    digest: sha256:4b9714ef502e5b33f672e4bfa385b95a73bee521e92a4e2a830d19f49c1c6ba0


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `da3f2955a2f9eeffe845baee13e2316304bcf540`
- Image tag: `da3f2955`
- Image digest: `sha256:4b9714ef502e5b33f672e4bfa385b95a73bee521e92a4e2a830d19f49c1c6ba0`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`