### PR TITLE
fix(agents): restore gpt-5.4 codex provider pins

### DIFF
--- a/argocd/applications/agents/codex-agentprovider.yaml
+++ b/argocd/applications/agents/codex-agentprovider.yaml
@@ -11,7 +11,7 @@ spec:
   inputFiles:
     - path: /root/.codex/config.toml
       content: |-
-        model = "gpt-5-codex"
+        model = "gpt-5.4"
         model_reasoning_summary = "detailed"
         model_reasoning_effort = "high"
         model_verbosity = "medium"

--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -12,7 +12,7 @@ spec:
   inputFiles:
     - path: /root/.codex/config.toml
       content: |-
-        model = "gpt-5-codex"
+        model = "gpt-5.4"
         model_reasoning_summary = "none"
         model_reasoning_effort = "xhigh"
         model_verbosity = "medium"

--- a/argocd/applications/agents/codex-spark-review-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-review-agentprovider.yaml
@@ -56,7 +56,7 @@ spec:
   inputFiles:
     - path: /root/.codex/config.toml
       content: |-
-        model = "gpt-5-codex"
+        model = "gpt-5.4"
         model_reasoning_summary = "none"
         model_reasoning_effort = "xhigh"
         model_verbosity = "medium"

--- a/argocd/applications/agents/torghut-market-context-agentprovider.yaml
+++ b/argocd/applications/agents/torghut-market-context-agentprovider.yaml
@@ -9,7 +9,7 @@ spec:
     CODEX_LOG_LEVEL: info
     NATS_URL: nats://nats.nats.svc.cluster.local:4222
     AGENT_PROVIDER_PATH: /root/.codex/provider-torghut-market-context.json
-    CODEX_MARKET_CONTEXT_PROVIDER_CHAIN: codex-spark:gpt-5-codex
+    CODEX_MARKET_CONTEXT_PROVIDER_CHAIN: codex-spark:gpt-5.4
     CODEX_MARKET_CONTEXT_ATTEMPT_TIMEOUT_SECONDS: "600"
     CODEX_MARKET_CONTEXT_OVERALL_TIMEOUT_SECONDS: "1200"
     CODEX_MARKET_CONTEXT_PROGRESS_TIMEOUT_SECONDS: "10"
@@ -20,7 +20,7 @@ spec:
   inputFiles:
     - path: /root/.codex/config.toml
       content: |-
-        model = "gpt-5-codex"
+        model = "gpt-5.4"
         model_reasoning_summary = "none"
         model_reasoning_effort = "xhigh"
         model_verbosity = "medium"
@@ -214,7 +214,7 @@ spec:
             model = (model or provider).strip()
             if provider:
               providers.append((provider, model))
-          return providers or [('codex-spark', 'gpt-5-codex')]
+          return providers or [('codex-spark', 'gpt-5.4')]
 
         def _read_json(path: Path) -> dict:
           payload = json.loads(path.read_text(encoding='utf-8'))

--- a/services/jangar/scripts/codex-config-container.toml
+++ b/services/jangar/scripts/codex-config-container.toml
@@ -1,4 +1,4 @@
-model = "gpt-5-codex"
+model = "gpt-5.4"
 model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
 model_verbosity = "medium"


### PR DESCRIPTION
## Summary

- restore the autonomous Codex provider configs to `gpt-5.4`
- remove the unintended `gpt-5-codex` fallback from the Torghut market-context provider chain
- keep the `auth.json` contract repair intact while reverting the bad model drift from `#4090`

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-gpt54-render.yaml`
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.4 -C /tmp 'Reply with OK only.'`
- `kubectl get agentprovider -n agents codex codex-spark codex-spark-review torghut-market-context -o yaml | rg -n 'model = |CODEX_MARKET_CONTEXT_PROVIDER_CHAIN|type: Ready|status: "?True"?'`
- `kubectl get swarm -n agents jangar-control-plane torghut-quant -o json | jq -r '.items[] | [.metadata.name, .status.phase, ((.status.conditions // [])[]? | select(.type=="Ready") | .status)] | @tsv'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
