### PR TITLE
fix(jangar): improve torghut dropdown legibility

### DIFF
--- a/services/jangar/src/components/__tests__/torghut-visuals-controls.test.tsx
+++ b/services/jangar/src/components/__tests__/torghut-visuals-controls.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TorghutVisualsControls } from '@/components/torghut-visuals-controls'
+
+describe('TorghutVisualsControls', () => {
+  it('uses themed select triggers instead of native select elements', () => {
+    const { container } = render(
+      <TorghutVisualsControls
+        symbols={['AAPL', 'MSFT']}
+        selectedSymbol="MSFT"
+        onSymbolChange={vi.fn()}
+        rangeOptions={[
+          { id: '15m', label: 'Last 15m', seconds: 900 },
+          { id: '1h', label: 'Last 1h', seconds: 3600 },
+        ]}
+        range={{ id: '1h', label: 'Last 1h', seconds: 3600 }}
+        onRangeChange={vi.fn()}
+        resolutionOptions={[
+          { id: '15s', label: '15s', seconds: 15 },
+          { id: '1m', label: '1m', seconds: 60 },
+        ]}
+        resolution={{ id: '15s', label: '15s', seconds: 15 }}
+        onResolutionChange={vi.fn()}
+        indicators={{ ema: true, boll: true, vwap: false, macd: false, rsi: false }}
+        onIndicatorToggle={vi.fn()}
+        onRefresh={vi.fn()}
+        isRefreshing={false}
+        queryLimit={240}
+        maxPoints={2000}
+      />,
+    )
+
+    expect(container.querySelectorAll('select')).toHaveLength(0)
+    expect(screen.getAllByRole('combobox')).toHaveLength(3)
+    expect(screen.getByText('MSFT')).toBeTruthy()
+    expect(screen.getByText('1h')).toBeTruthy()
+    expect(screen.getByText('15s')).toBeTruthy()
+  })
+})

--- a/services/jangar/src/components/torghut-visuals-controls.tsx
+++ b/services/jangar/src/components/torghut-visuals-controls.tsx
@@ -1,9 +1,14 @@
-import { Button } from '@proompteng/design/ui'
+import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@proompteng/design/ui'
 import { cn } from '@/lib/utils'
 import type { IndicatorState, RangeOption, ResolutionOption } from './torghut-visuals-types'
 
-const selectClassName =
-  'border-input focus-visible:border-ring focus-visible:ring-ring/50 rounded-none border bg-transparent px-2.5 py-1 text-xs text-foreground focus-visible:ring-1 outline-none'
+const selectTriggerClassName =
+  'h-auto w-full rounded-none border border-input bg-transparent px-2.5 py-1 text-xs text-foreground shadow-none hover:bg-accent/10 focus-visible:ring-1'
+
+const selectContentClassName =
+  'rounded-none border border-border bg-popover/95 p-1 text-popover-foreground backdrop-blur-sm'
+
+const selectItemClassName = 'rounded-none'
 
 type TorghutVisualsControlsProps = {
   symbols: string[]
@@ -68,58 +73,77 @@ export function TorghutVisualsControls({
           <label className="text-xs font-medium text-muted-foreground" htmlFor="torghut-symbol">
             Symbol
           </label>
-          <select
-            id="torghut-symbol"
-            className={cn(selectClassName, 'w-full')}
-            value={selectedSymbol}
-            onChange={(event) => onSymbolChange(event.target.value)}
+          <Select
+            value={selectedSymbol || undefined}
+            onValueChange={(value) => {
+              if (value) onSymbolChange(value)
+            }}
             disabled={disabled || symbols.length === 0}
           >
-            {symbols.length === 0 ? <option value="">No symbols enabled</option> : null}
-            {symbols.map((symbol) => (
-              <option key={symbol} value={symbol}>
-                {symbol}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger id="torghut-symbol" className={selectTriggerClassName}>
+              <SelectValue placeholder={symbols.length === 0 ? 'No symbols enabled' : 'Select symbol'} />
+            </SelectTrigger>
+            <SelectContent align="start" className={selectContentClassName}>
+              {symbols.length === 0 ? (
+                <SelectItem value="none" disabled className={selectItemClassName}>
+                  No symbols enabled
+                </SelectItem>
+              ) : null}
+              {symbols.map((symbol) => (
+                <SelectItem key={symbol} value={symbol} className={selectItemClassName}>
+                  {symbol}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         <div className="space-y-1">
           <label className="text-xs font-medium text-muted-foreground" htmlFor="torghut-range">
             Time range
           </label>
-          <select
-            id="torghut-range"
-            className={cn(selectClassName, 'w-full')}
+          <Select
             value={range.id}
-            onChange={(event) => onRangeChange(event.target.value)}
+            onValueChange={(value) => {
+              if (value) onRangeChange(value)
+            }}
             disabled={disabled}
           >
-            {rangeOptions.map((option) => (
-              <option key={option.id} value={option.id}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger id="torghut-range" className={selectTriggerClassName}>
+              <SelectValue placeholder="Select time range" />
+            </SelectTrigger>
+            <SelectContent align="start" className={selectContentClassName}>
+              {rangeOptions.map((option) => (
+                <SelectItem key={option.id} value={option.id} className={selectItemClassName}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         <div className="space-y-1">
           <label className="text-xs font-medium text-muted-foreground" htmlFor="torghut-resolution">
             Resolution
           </label>
-          <select
-            id="torghut-resolution"
-            className={cn(selectClassName, 'w-full')}
+          <Select
             value={resolution.id}
-            onChange={(event) => onResolutionChange(event.target.value)}
+            onValueChange={(value) => {
+              if (value) onResolutionChange(value)
+            }}
             disabled={disabled}
           >
-            {resolutionOptions.map((option) => (
-              <option key={option.id} value={option.id}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger id="torghut-resolution" className={selectTriggerClassName}>
+              <SelectValue placeholder="Select resolution" />
+            </SelectTrigger>
+            <SelectContent align="start" className={selectContentClassName}>
+              {resolutionOptions.map((option) => (
+                <SelectItem key={option.id} value={option.id} className={selectItemClassName}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 

--- a/services/jangar/src/styles.css
+++ b/services/jangar/src/styles.css
@@ -61,9 +61,19 @@
     outline-offset: 2px;
   }
 
-  /* Preserve native option contrast across Chromium dark-theme dropdown renderers. */
+  /*
+   * Native dropdown menus in Jangar render via the OS/browser picker UI.
+   * Keep them in dark mode so menu chrome and inherited option text stay legible.
+   */
   select {
-    color-scheme: light;
+    color-scheme: dark;
+  }
+
+  select,
+  option,
+  optgroup {
+    color: var(--popover-foreground);
+    background-color: var(--popover);
   }
 }
 

--- a/services/jangar/tests/ui-pages.e2e.ts
+++ b/services/jangar/tests/ui-pages.e2e.ts
@@ -33,6 +33,10 @@ test.describe('ui pages', () => {
   test('torghut symbols', async ({ page }) => {
     await page.goto('/torghut/symbols')
     await expect(page.getByRole('heading', { name: 'Symbols', level: 1 })).toBeVisible()
+    const assetClassSelect = page.locator('#torghut-symbol-asset-class')
+    await expect(assetClassSelect).toBeVisible()
+    const colorScheme = await assetClassSelect.evaluate((element) => getComputedStyle(element).colorScheme)
+    expect(colorScheme).toContain('dark')
   })
 
   test('torghut charts', async ({ page }) => {
@@ -40,7 +44,7 @@ test.describe('ui pages', () => {
     await expect(page.getByRole('heading', { name: 'Charts', level: 1 })).toBeVisible()
     const symbolSelect = page.locator('#torghut-symbol')
     await expect(symbolSelect).toBeVisible()
-    const colorScheme = await symbolSelect.evaluate((element) => getComputedStyle(element).colorScheme)
-    expect(colorScheme).toContain('light')
+    const tagName = await symbolSelect.evaluate((element) => element.tagName)
+    expect(tagName).toBe('BUTTON')
   })
 })


### PR DESCRIPTION
## Summary

- Replace Torghut charts native dropdowns with the shared themed select component.
- Keep remaining native Jangar selects on a dark color scheme so option menus stay legible.
- Add focused unit and Playwright coverage for the Torghut dropdown surfaces.

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run src/components/__tests__/torghut-visuals-controls.test.tsx`
- `cd services/jangar && node node_modules/@playwright/test/cli.js test tests/ui-pages.e2e.ts -g "torghut (symbols|charts)"`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
