### PR TITLE
chore(jangar): promote image bc56d588

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: da3f2955
-  digest: sha256:4b9714ef502e5b33f672e4bfa385b95a73bee521e92a4e2a830d19f49c1c6ba0
+  tag: bc56d588
+  digest: sha256:484fa974af912022ae7fb275e9288f8350aad472382f7688f2b615477957f45c
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: da3f2955
-    digest: sha256:27bcf9890bf639db682132eb5c34d534a23c7aa66deee1d04031bc98ecee1e93
+    tag: bc56d588
+    digest: sha256:3ab79bea09eb3786826c932a7ba562fc44579fe0c2f84e24535814d476c7f648
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: da3f2955
-    digest: sha256:4b9714ef502e5b33f672e4bfa385b95a73bee521e92a4e2a830d19f49c1c6ba0
+    tag: bc56d588
+    digest: sha256:484fa974af912022ae7fb275e9288f8350aad472382f7688f2b615477957f45c
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T05:02:03Z"
+    deploy.knative.dev/rollout: "2026-03-06T05:36:19Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T05:02:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T05:36:19Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "da3f2955"
-    digest: sha256:4b9714ef502e5b33f672e4bfa385b95a73bee521e92a4e2a830d19f49c1c6ba0
+    newTag: "bc56d588"
+    digest: sha256:484fa974af912022ae7fb275e9288f8350aad472382f7688f2b615477957f45c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `bc56d588417ba5554ee87a6afcf42f3f771b16bf`
- Image tag: `bc56d588`
- Image digest: `sha256:484fa974af912022ae7fb275e9288f8350aad472382f7688f2b615477957f45c`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`