### PR TITLE
docs(architecture): add torghut quant architecture contracts

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -155,6 +155,7 @@ For env and gRPC source-of-truth changes in this branch:
 - [designs/controller-failed-reconcile-events.md](designs/controller-failed-reconcile-events.md)
 - [designs/jangar-control-plane-operability-reliability-assessment.md](designs/jangar-control-plane-operability-reliability-assessment.md)
 - [designs/jangar-control-plane-capability-admission-failure-budgets-and-rollout-rings-2026-03-06.md](designs/jangar-control-plane-capability-admission-failure-budgets-and-rollout-rings-2026-03-06.md)
+- [designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md](designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md)
 - [designs/controller-finalizer-conventions.md](designs/controller-finalizer-conventions.md)
 - [designs/controller-kubectl-version-compat.md](designs/controller-kubectl-version-compat.md)
 - [designs/controller-namespace-scope-parse-validate.md](designs/controller-namespace-scope-parse-validate.md)

--- a/docs/agents/designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md
+++ b/docs/agents/designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md
@@ -1,0 +1,343 @@
+# Jangar Control Plane Admission Quorum and Rollout Circuit Breaker (2026-03-06)
+
+Status: Proposed
+
+## Summary
+
+Jangar currently detects some runtime failures only after a stage Job has already been created, and the primary
+control-plane health surface still overweights current replica counts versus recent crash-loop, probe-failure, and
+preflight-failure history. The result is avoidable churn: stage runs burn retry budget on configuration or provider
+errors that were knowable in advance, while rollout health can look green during a short-lived recovery window.
+
+This design adds two system-level controls:
+
+1. an admission quorum that classifies and blocks preflightable failures before Job creation, and
+2. a rollout circuit breaker that treats recent restart/probe-failure history as first-class rollout health.
+
+The intent is explicit failure-mode reduction and safer rollout behavior for the Jangar control plane.
+
+## Assessment context
+
+- Cluster scope: `agents` and `jangar` namespaces.
+- Source scope: `services/jangar/**`, `argocd/applications/agents/**`.
+- Database scope: Jangar status-owned migration consistency only; direct SQL was not required for the selected change.
+- Time of live evidence capture: `2026-03-06 05:09 UTC` through `2026-03-06 05:32 UTC`.
+
+## Live evidence
+
+### Cluster and rollout evidence
+
+- `kubectl -n agents get pods -o wide` at `2026-03-06 05:31 UTC` showed:
+  - `agents-55496fc7c7-zm6sv` in `CrashLoopBackOff`
+  - `agents-controllers-*` healthy
+  - many recent `jangar-control-plane-*` and `torghut-quant-*` stage pods in `Error`
+- `kubectl -n agents get events --sort-by=.lastTimestamp | tail -n 120` showed:
+  - repeated `Liveness probe failed` and `BackOff` events for `pod/agents-55496fc7c7-zm6sv`
+  - repeated `BackoffLimitExceeded` for stage Jobs
+  - fresh `torghut-market-context-*` batch failures
+- `kubectl -n jangar get events --sort-by=.lastTimestamp | tail -n 120` showed:
+  - rollout-time `Readiness probe failed` on `pod/jangar-*`
+  - `Multi-Attach error` events for both `jangar` and `jangar-worker` PVC-backed rollouts
+- `curl http://agents.agents.svc.cluster.local/health` and `/ready` both returned `200` during the same window, even
+  while the backing pod was still cycling through probe failures.
+- `curl http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status` returned:
+  - `rollout_health.status=healthy`
+  - `workflows.recent_failed_jobs=0`
+  - `workflows.backoff_limit_exceeded_jobs=0`
+  - despite the concurrent pod and Job failure evidence above.
+
+### Runtime failure evidence
+
+- `kubectl -n agents logs jangar-control-plane-plan-sched-6wfn5-step-1-attempt-1-rhw2t`:
+  - failed with `Quota exceeded. Check your plan and billing details.`
+- `kubectl -n agents logs torghut-quant-discover-sched-f72cz-step-1-attempt-1-lff7w`:
+  - failed with `Unsupported value: 'xhigh' is not supported ... reasoning.effort`
+- `kubectl -n agents logs torghut-market-context-news-batch-template-job-mvxds`:
+  - failed with `Missing repository metadata in event payload`
+- `kubectl -n agents logs agents-55496fc7c7-zm6sv --previous`:
+  - showed repeated Postgres connect timeouts before process exit.
+
+### Source evidence
+
+- `services/jangar/src/server/control-plane-status.ts`
+  - `buildRolloutHealth(...)` models current deployment state only.
+  - `resolveWorkflowsReliabilityStatus(...)` catches Kubernetes list failures and returns bounded zero counters.
+  - namespace degradation only keys off current status objects, not recent restart/probe-failure windows.
+- `services/jangar/src/server/__tests__/control-plane-status.test.ts`
+  - includes `keeps control-plane status healthy when workflow list lookup fails`, which currently codifies
+    healthy-zero behavior when workflow collection is blind.
+- `services/jangar/scripts/codex/codex-implement.ts`
+  - already classifies transient provider throttling/quota failures and already throws on missing repository metadata.
+  - this logic runs after a Job exists, so the cluster still pays the full scheduling/startup/backoff cost.
+- `argocd/applications/agents/codex-spark-agentprovider.yaml`
+  - pins `model_reasoning_effort = "xhigh"`.
+- `argocd/applications/agents/torghut-market-context-agentprovider.yaml`
+  - also pins `model_reasoning_effort = "xhigh"` while the runtime logs show at least one active model lane rejecting it.
+
+### Database/data evidence
+
+- `curl http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status`
+  reported `database.status=healthy` and `migration_consistency.status=healthy`.
+- The selected change is not DB-schema-driven; database impact is on admission/rollout metadata emitted through status.
+
+## Problem statement
+
+Jangar currently has three separate truths for the same failure window:
+
+1. cluster events show pods and stage Jobs failing,
+2. per-run logs show provider quota, model capability mismatch, and missing metadata errors, and
+3. the primary control-plane status surface can still look healthy enough to keep scheduling.
+
+This is not just an observability gap. It increases failure volume and widens rollout blast radius:
+
+- configuration and metadata errors are discovered too late,
+- provider quota and capability errors consume retries instead of being delayed or rerouted,
+- rollout evaluation lacks restart-history context, and
+- operators cannot tell whether "healthy now" means "stable" or merely "briefly responding."
+
+## Alternatives considered
+
+### Option A: Improve status payload only
+
+- Pros: smallest code change, low rollout risk.
+- Cons: keeps avoidable failed Jobs and does not reduce failure volume.
+
+### Option B: Rely on existing per-run provider fallback only
+
+- Pros: reuses `codex-implement.ts` fallback logic.
+- Cons: fallback is post-dispatch, does not catch capability mismatch or missing metadata early, and still burns Job
+  retries plus cluster churn.
+
+### Option C: Selected, admission quorum plus rollout circuit breaker
+
+- Pros: reduces failures before dispatch, aligns status with recent rollout reality, and gives deployers a clean
+  rollback trigger.
+- Cons: requires additive status contract work plus controller/runtime template changes.
+
+## Decision
+
+Adopt an additive two-layer resilience envelope:
+
+1. `admission_quorum`
+   - a pre-dispatch check executed by the controller before stage Job creation.
+2. `rollout_circuit_breaker`
+   - a status and rollout gate that treats recent restart/probe-failure history as deploy health, not just
+     instantaneous readiness.
+
+The design deliberately builds on existing Jangar strengths:
+
+- keep `codex-implement.ts` as the final runtime fallback and error-classification authority,
+- keep status payloads additive and bounded,
+- keep rollout logic non-blocking when Kubernetes reads are partially restricted,
+- but stop treating runtime-discoverable failures as acceptable steady-state noise.
+
+## Selected architecture
+
+### 1. Admission quorum
+
+Before the controller creates a stage Job, it must evaluate a bounded preflight contract and emit one decision:
+
+- `allow`
+- `delay`
+- `block`
+
+Required preflight checks:
+
+1. provider capability
+   - confirm requested model supports configured reasoning effort and other required knobs
+2. provider capacity
+   - inspect recent quota/rate-limit failures for the same provider/model lane
+3. event payload completeness
+   - repository, issue number, stage, and required swarm metadata present
+4. collaboration prerequisites
+   - required Huly credentials/channel contract resolvable for the stage
+5. rollout breaker state
+   - if the deployment is inside a recent instability window, delay new stage dispatches
+
+Required classification codes:
+
+- `provider_capability_mismatch`
+- `provider_quota_exhausted`
+- `provider_rate_limited`
+- `missing_repository_metadata`
+- `missing_stage_metadata`
+- `huly_access_unavailable`
+- `rollout_circuit_open`
+- `unknown_preflight_error`
+
+`allow` creates the Job normally.
+
+`delay` requeues without consuming a Job attempt and records the next eligible retry time.
+
+`block` marks the stage outcome as failed-fast without creating a Job and increments a control-plane admission metric.
+
+### 2. Capability registry
+
+Move provider capability knowledge from scattered config and log parsing into a controller-readable registry.
+
+Minimum fields:
+
+- `provider`
+- `model`
+- `supported_reasoning_efforts`
+- `max_parallel_sessions`
+- `fallback_provider_chain`
+- `fallback_model_chain`
+- `requires_repository_metadata`
+- `requires_issue_number`
+
+This registry should become the source of truth used by:
+
+- schedule admission,
+- runtime fallback selection,
+- and deploy-time validation of `AgentProvider` configs.
+
+### 3. Rollout circuit breaker
+
+Extend rollout health from current deployment shape to recent rollout behavior.
+
+Additive status fields:
+
+- `restart_churn_window_minutes`
+- `recent_container_restarts`
+- `recent_probe_failures`
+- `recent_admission_blocks`
+- `recent_admission_delays`
+- `recent_preflight_failure_reasons`
+- `circuit_open`
+- `circuit_reason`
+
+Circuit-open rules:
+
+- open if the control-plane deployment has more than `N` restarts in the last `M` minutes,
+- open if probe failures continue after a rollout begins,
+- open if admission failures cross a configured rate threshold during rollout,
+- close only after a restart-free and probe-clean soak window.
+
+### 4. Status semantics
+
+`/api/agents/control-plane/status` must distinguish:
+
+- `healthy`: stable now and stable over the configured observation window
+- `degraded`: currently serving, but recent rollout/admission history indicates risk
+- `unknown`: cluster read is incomplete; no healthy-zero fallback when evidence is missing
+
+This replaces the current "healthy because counters are zero" bias during collection failures.
+
+### 5. Safer rollout behavior
+
+Use the circuit breaker as the deploy-time go/no-go gate:
+
+1. roll out one canary replica,
+2. observe admission and restart behavior for a soak window,
+3. widen only when:
+   - no restart churn beyond threshold,
+   - no probe-failure burst,
+   - no repeated `provider_capability_mismatch`,
+   - no sustained quota-driven `delay` backlog,
+4. otherwise halt and roll back.
+
+## Implementation scope
+
+Primary code/config surfaces:
+
+- `services/jangar/src/server/control-plane-status.ts`
+- `services/jangar/src/server/__tests__/control-plane-status.test.ts`
+- `services/jangar/src/server/supporting-primitives-controller.ts`
+- `services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`
+- `services/jangar/scripts/codex/codex-implement.ts`
+- `services/jangar/scripts/codex/__tests__/codex-implement.test.ts`
+- `argocd/applications/agents/codex-spark-agentprovider.yaml`
+- `argocd/applications/agents/torghut-market-context-agentprovider.yaml`
+
+Recommended implementation slices:
+
+1. Status contract
+   - add admission and restart-window fields
+   - degrade on workflow/admission collection blindness
+2. Controller preflight
+   - evaluate capability, metadata, Huly, and rollout breaker before Job creation
+3. Capability registry
+   - centralize supported reasoning-effort metadata and fallback chain defaults
+4. Rollout breaker
+   - derive recent restart/probe-failure health from pod conditions and events
+5. Config validation
+   - fail CI/GitOps validation when provider config requests unsupported reasoning effort
+
+## Validation gates
+
+### Engineer acceptance gates
+
+1. Unit tests prove `provider_capability_mismatch` and `missing_repository_metadata` are blocked before Job creation.
+2. Unit tests prove quota/rate-limit conditions return `delay`, not immediate failed Job creation.
+3. Status tests prove collection failures report `unknown` or `degraded`, never healthy-zero.
+4. Rollout-health tests prove restart churn and probe-failure history open the circuit.
+5. Config validation catches unsupported `model_reasoning_effort` at review time.
+
+### Deployer acceptance gates
+
+1. During canary rollout, `circuit_open=false` for a full soak window.
+2. `recent_container_restarts=0` and `recent_probe_failures=0` for the active deployment set.
+3. `recent_admission_blocks` is zero for capability/metadata classes after config promotion.
+4. No new stage Jobs are created while the circuit is open.
+5. Control-plane status and cluster events agree on whether the system is degraded.
+
+## Rollout plan
+
+1. Ship status contract first, additive only.
+2. Enable admission quorum in observe-only mode:
+   - log classifications
+   - do not block yet
+3. Turn on `block` for metadata and capability mismatches.
+4. Turn on `delay` for quota/rate-limit failures once fallback policy is validated.
+5. Enable rollout circuit breaker gating for the `agents` deployment.
+6. Extend the same contract to `jangar` and `jangar-worker` after one clean rollout window.
+
+## Rollback plan
+
+If rollout blocks healthy traffic or classification is too aggressive:
+
+1. disable admission enforcement and revert to observe-only mode,
+2. keep additive status fields but mark circuit state informational,
+3. revert provider capability validation changes if a safe registry is not ready,
+4. retain runtime fallback inside `codex-implement.ts` so stage execution still has a last-resort recovery path.
+
+## Risks and mitigations
+
+- Risk: overly strict capability registry blocks a valid model lane.
+  - Mitigation: observe-only warmup plus explicit allowlist overrides.
+- Risk: event-based restart history is noisy under RBAC constraints.
+  - Mitigation: combine pod restart counts, probe failures, and current deployment state; degrade to `unknown` when data is partial.
+- Risk: quota-driven `delay` creates a hidden backlog.
+  - Mitigation: expose queue age, delayed-stage count, and provider-specific delay reasons in status.
+
+## Relationship to existing designs
+
+This document extends, rather than replaces:
+
+- `docs/agents/designs/jangar-control-plane-capability-admission-failure-budgets-and-rollout-rings-2026-03-06.md`
+- `docs/agents/designs/jangar-control-plane-rollout-health-envelope.md`
+- `docs/agents/designs/jangar-control-plane-stage-outcome-confidence-and-quota-resilience.md`
+- `docs/agents/designs/jangar-control-plane-watch-reliability-envelope.md`
+- `docs/agents/designs/chart-deployment-strategy-rollingupdate.md`
+
+## Engineer handoff
+
+Implement the admission quorum before changing rollout automation. The fastest path is:
+
+1. status contract and tests,
+2. preflight classification in the controller,
+3. capability registry and config validation,
+4. rollout circuit breaker,
+5. deploy-time soak policy.
+
+Do not ship rollout gating without the new status fields and tests; operators need the explainability first.
+
+## Deployer handoff
+
+Treat this as a safety feature, not a throughput feature. Promotion is successful only when:
+
+- canary stays restart-free,
+- admission decisions match observed failure classes,
+- quota/capability failures become `delay` or `block` events instead of failed Jobs,
+- and `/api/agents/control-plane/status` no longer reports healthy when the rollout window is unstable.

--- a/docs/torghut/design-system/v6/28-hypothesis-led-alpha-readiness-and-profit-circuit-2026-03-06.md
+++ b/docs/torghut/design-system/v6/28-hypothesis-led-alpha-readiness-and-profit-circuit-2026-03-06.md
@@ -1,0 +1,331 @@
+# 28. Hypothesis-Led Alpha Readiness and Profit Circuit for `torghut` Quant Profitability (2026-03-06)
+
+## Status
+
+- Date: `2026-03-06`
+- Maturity: `architecture decision + implementation contract`
+- Scope: `torghut` live autonomy, alpha admission, execution quality, and promotion governance
+- Owners: `torghut`, `jangar`, `agents`, `observability`
+- Primary objective: convert a runtime-healthy but alpha-inert live system into a hypothesis-driven trading system that only scales capital when signal freshness, feature evidence, and post-cost profitability are all proven.
+
+## Executive Summary
+
+The current `torghut` deployment is healthy enough to stay online, but it is not operating as a trustworthy profit engine.
+
+Read-only live evidence from `2026-03-06` shows:
+
+- `/trading/status`: `enabled=true`, `autonomy_enabled=true`, `mode=live`, `running=true`, but `autonomy.runs_total=0`, `signals_total=0`, and `no_signal_streak=8`.
+- `/trading/status`: `signal_continuity.alert_reason=cursor_ahead_of_stream`, `signal_lag_seconds~=27038`, `feature_batch_rows_total=0`, `drift_detection_checks_total=0`, `evidence_continuity_checks_total=0`.
+- `/trading/status`: `tca.order_count=259`, `avg_abs_slippage_bps~=28.6612`, with the last computation at `2026-03-05T21:15:17Z`.
+- Service logs repeatedly report `Signal continuity observed as expected staleness reason=cursor_tail_stable` and `Signal lag threshold exceeded outside market session; suppressing emergency stop`.
+- `/db-check`: `ok=true`, `schema_current=true`, and both expected heads are present, so the blocking gap is not basic schema freshness.
+
+This creates a dangerous operating shape:
+
+1. the service can stay green while the alpha path produces no trusted signals;
+2. the execution loop can still incur costs and slippage without a measurable profit thesis;
+3. the drift and evidence guardrails already exist in source but are not part of a hard promotion contract.
+
+This design extends the live hypothesis ledger architecture in `27-live-hypothesis-ledger-and-capital-allocation-contract-2026-03-06.md` with the runtime contract that decides whether a strategy lane is blocked, shadow-only, canary-live, or scaled-live.
+
+## Problem Statement
+
+The current runtime optimizes for service availability and deterministic safety, but profitability requires a different contract: every live lane must prove that it has current data, valid features, recent evidence continuity, bounded slippage, and positive post-cost expectancy before it consumes meaningful capital.
+
+Today the gaps are structural rather than cosmetic:
+
+- `services/torghut/app/trading/scheduler.py` already tracks `feature_batch_rows_total`, `drift_detection_checks_total`, `evidence_continuity_checks_total`, `signal_lag_seconds`, and `no_signal_streak`, but those values do not determine a hard lane state.
+- `services/torghut/app/main.py` surfaces a useful control-plane contract, but the contract does not declare whether any alpha lane is actually trade-ready.
+- `services/jangar/src/server/control-plane-status.ts` can report healthy status even when recent job failures and crash loops are visible elsewhere, which means dependency truth is not strict enough for capital promotion.
+- The system measures execution quality through TCA, but there is no first-class link between slippage budgets and capital scaling.
+
+## Objectives
+
+1. Make alpha readiness explicit and machine-evaluable instead of inferred from partial health signals.
+2. Attach every live trading decision to a declared, measurable hypothesis with entry criteria, expected edge, and rollback thresholds.
+3. Prevent capital scale-up when data freshness, feature coverage, or evidence continuity are degraded even if the process itself is running.
+4. Couple execution quality and realized post-cost outcomes to promotion and demotion decisions.
+5. Reuse the Jangar resilience lane so upstream quota, rollout, and dependency degradation can automatically push Torghut back to shadow mode.
+
+## Non-goals
+
+- This document does not relax deterministic risk controls or emergency stop semantics.
+- This document does not claim deterministic profitability for every session.
+- This document does not require immediate introduction of new model families before the readiness and profit circuit exists.
+
+## Alternatives Considered
+
+### 1. Tune the existing live strategy in place
+
+- Pros: fastest path to another rollout.
+- Cons: still leaves no durable contract for why a strategy deserves capital; likely repeats the same blind spots with different thresholds.
+
+### 2. Expand the feature/model stack first
+
+- Pros: ambitious research surface and potentially higher upside.
+- Cons: current evidence already shows the system lacks a reliable admission contract; expanding complexity first increases failure modes before the control plane can judge readiness.
+
+### 3. Add a hypothesis-led readiness and profit circuit first (selected)
+
+- Pros: makes profitability testable, ties promotion to post-cost evidence, and turns current freshness/drift/evidence signals into enforceable state.
+- Cons: requires new manifest/config surfaces, new status payloads, and stricter deployer gates before capital can be scaled.
+
+## Selected Architecture
+
+### 1. Introduce a versioned hypothesis registry
+
+Each autonomous or operator-promoted lane must reference a versioned hypothesis manifest stored in source control and loaded by `torghut` at startup.
+
+The manifest contract should include at least:
+
+- `hypothesis_id`
+- `lane_id`
+- `strategy_family`
+- `market_regimes`
+- `required_feature_sets`
+- `required_dependency_capabilities`
+- `expected_gross_edge_bps`
+- `max_allowed_slippage_bps`
+- `min_sample_count_for_live_canary`
+- `min_sample_count_for_scale_up`
+- `max_rolling_drawdown_bps`
+- `rollback_triggers`
+- `promotion_gates`
+
+The registry becomes the source of truth for whether a decision is part of:
+
+- `blocked`
+- `shadow`
+- `canary_live`
+- `scaled_live`
+
+No lane is allowed to skip directly from design to scaled live operation.
+
+### 2. Compile alpha readiness from live runtime signals
+
+Add an alpha readiness compiler inside the scheduler/control-plane path that converts existing runtime metrics into a strict lane-state decision.
+
+The readiness compiler must evaluate:
+
+- signal continuity:
+  - `signal_lag_seconds`
+  - `no_signal_streak`
+  - `signal_continuity_alert_reason`
+- feature quality:
+  - `feature_batch_rows_total`
+  - feature freshness and required columns per hypothesis
+- evidence continuity:
+  - recent `evidence_continuity_checks_total`
+  - `last_evidence_continuity_report`
+- drift governance:
+  - recent drift checks and active drift action
+- execution quality:
+  - rolling TCA, realized spread/slippage, reject mix
+- dependency quorum:
+  - Jangar control-plane capabilities and market-context freshness
+
+The compiler should produce a per-hypothesis state object:
+
+- `state`: `blocked | shadow | canary_live | scaled_live`
+- `reasons`: atomic blocking or degrading reasons
+- `last_verified_at`
+- `capital_multiplier`
+- `promotion_eligible`
+- `rollback_required`
+
+If `feature_batch_rows_total == 0`, `evidence_continuity_checks_total == 0`, or `drift_detection_checks_total == 0` for the relevant lookback window, the lane cannot be `canary_live` or `scaled_live`.
+
+### 3. Add a profit circuit that gates capital by post-cost evidence
+
+Add a profit circuit controller on top of the readiness compiler. The controller must use realized performance and TCA to determine capital stage.
+
+Capital stages:
+
+1. `shadow`
+2. `0.10x canary`
+3. `0.25x canary`
+4. `0.50x live`
+5. `1.00x live`
+
+Promotion requires all of:
+
+- readiness compiler state is healthy for the hypothesis;
+- rolling realized expectancy after costs is positive;
+- rolling average absolute slippage is within hypothesis budget;
+- reject mix does not show dependency or policy path regressions;
+- market-session evidence count exceeds the hypothesis minimum sample count.
+
+Automatic demotion is triggered by any of:
+
+- rolling expectancy after costs below zero for the configured window;
+- average absolute slippage above hypothesis budget for two consecutive windows;
+- continuity alert becomes actionable during market session;
+- Jangar dependency quorum returns `delay` or `block`;
+- drift governance returns `degrade`, `abstain`, or `fail` for the active route.
+
+### 4. Split the system into shadow evidence and capital-consuming lanes
+
+Today the runtime can be "live" while the alpha engine is effectively inert. The new design separates:
+
+- `shadow evidence lane`: always captures candidate trades, features, and post-trade counterfactual outcomes;
+- `capital lane`: allowed to place live risk only when the readiness compiler and profit circuit both approve.
+
+This separation allows Torghut to keep learning when live capital is blocked, instead of conflating operational uptime with trading readiness.
+
+### 5. Reuse Jangar admission quorum as a dependency gate
+
+The Jangar design in `docs/agents/designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md` should become an upstream dependency contract for Torghut.
+
+Torghut must consume dependency state as:
+
+- `allow`: normal readiness evaluation may continue.
+- `delay`: shadow-only mode; live capital promotion blocked.
+- `block`: emergency demotion to `shadow` and cancellation of promotion attempts.
+
+This is required because current evidence shows provider quota exhaustion and agent-provider configuration errors can occur while high-level status remains misleadingly healthy.
+
+## Initial Hypothesis Set
+
+The first implementation should not attempt unlimited strategy breadth. Start with three explicit hypotheses:
+
+### `H-CONT-01`
+
+- Description: regime-aligned intraday continuation on liquid symbols using the existing signal feed plus TCA-aware execution policy.
+- Initial state: `shadow`
+- Entry contract: `signal_lag_seconds <= 90` during market hours, fresh universe, feature rows present, evidence continuity checked in the last 30 minutes.
+- Promotion contract: `>= 40` market-session samples, post-cost expectancy `> 6 bps`, average absolute slippage `<= 12 bps`.
+- Rollback triggers: expectancy `<= 0`, slippage `> 15 bps`, or continuity alert becomes actionable.
+
+### `H-REV-01`
+
+- Description: event reversion after a fresh market-context shock with confirmation from Jangar.
+- Initial state: `shadow`
+- Entry contract: `market-context` freshness `<= 120s`, dependency quorum `allow`, and no missing repository or provider metadata.
+- Promotion contract: `>= 30` samples, post-cost expectancy `> 8 bps`, and false-positive rate below the configured threshold.
+- Rollback triggers: market-context freshness breach, dependency quorum `delay` or `block`, or repeated stale context incidents.
+
+### `H-MICRO-01`
+
+- Description: microstructure-informed breakout lane with adaptive execution and a tighter slippage budget.
+- Initial state: `blocked` until features exist
+- Entry contract: order-book or liquidity features present with `>= 95%` coverage, drift governance active, and shadow counterfactual logs complete.
+- Promotion contract: `>= 60` samples, post-cost expectancy `> 10 bps`, average absolute slippage `<= 8 bps`.
+- Rollback triggers: feature coverage drop, drift gate `degrade` or `fail`, or slippage above budget.
+
+The architecture is intentionally ambitious: it preserves the current live continuation path as one candidate, adds an event-driven profit hypothesis, and reserves a higher-upside microstructure lane that cannot leave `blocked` until its data contract exists.
+
+## Implementation Scope
+
+### `torghut`
+
+Required code paths:
+
+- `services/torghut/app/config.py`
+  - define hypothesis manifest path, readiness windows, and profit circuit thresholds.
+- `services/torghut/app/trading/scheduler.py`
+  - compile readiness state, enforce stage transitions, and publish per-hypothesis status.
+- `services/torghut/app/trading/ingest.py`
+  - expose freshness and coverage diagnostics required by the readiness compiler.
+- `services/torghut/app/trading/tca.py`
+  - provide rolling slippage/expectancy inputs aligned to hypothesis windows.
+- `services/torghut/app/main.py`
+  - expose `hypotheses`, `readiness`, `capital_stage`, and `promotion_blockers` in `/trading/status`, `/trading/health`, and `/metrics`.
+- `services/torghut/tests/`
+  - add regression coverage for promotion, demotion, and shadow-only enforcement.
+
+### `jangar`
+
+Required code paths:
+
+- `services/jangar/src/server/control-plane-status.ts`
+  - emit dependency quorum state that reflects recent rollout failures, crash loops, provider throttles, and disabled controllers truthfully.
+- `services/jangar/src/server/__tests__/control-plane-status.test.ts`
+  - replace the current "healthy on workflow lookup failure" expectation with explicit degraded behavior when evidence is incomplete or stale.
+
+### Config and artifact surfaces
+
+Add source-controlled manifests for each hypothesis, stored alongside other trading runtime configuration, so deployers can diff the exact business logic being promoted.
+
+## Validation and Acceptance Gates
+
+### Engineer handoff gates
+
+The engineer stage is complete only when all are true:
+
+1. `torghut` exposes a per-hypothesis readiness payload in `/trading/status`.
+2. A hypothesis without fresh features, evidence continuity, and drift checks is forced to `shadow` or `blocked`.
+3. The capital multiplier is derived from realized post-cost metrics rather than a static environment flag.
+4. Unit and integration tests cover:
+   - readiness compiler state transitions,
+   - Jangar dependency quorum ingestion,
+   - profit circuit promotion and demotion,
+   - hypothesis manifest validation,
+   - shadow-only behavior for missing feature coverage.
+5. The implementation includes a reproducible query or report for per-hypothesis expectancy, slippage, and drawdown windows.
+
+### Deployer handoff gates
+
+The deployer stage is complete only when all are true:
+
+1. Jangar dependency quorum is `allow` for the required capabilities for one full market session before any capital promotion.
+2. `H-CONT-01` remains in `shadow` until:
+   - `signal_lag_seconds <= 90` during market hours for the promotion window,
+   - `feature_batch_rows_total > 0`,
+   - `drift_detection_checks_total > 0`,
+   - `evidence_continuity_checks_total > 0`.
+3. No hypothesis is promoted above `0.25x canary` without documented evidence that post-cost expectancy stayed positive for the configured sample window.
+4. Any continuity alert, quota degradation, or slippage budget breach triggers immediate demotion to `shadow` and review before re-promotion.
+5. Rollout notes record the hypothesis IDs, capital stage changes, sample counts, and the exact rollback condition that would reverse the promotion.
+
+## Rollout Plan
+
+### Phase 0: observability and manifest introduction
+
+- Add hypothesis manifests, readiness compiler outputs, and metrics without changing live capital allocation.
+- Keep all hypotheses in `shadow` or `blocked`.
+
+### Phase 1: shadow evidence proving
+
+- Run `H-CONT-01` and `H-REV-01` in shadow for at least one full trading week.
+- Record per-hypothesis signal counts, expectancy, slippage, and blocker reasons.
+
+### Phase 2: constrained canary
+
+- Promote only `H-CONT-01` to `0.10x` then `0.25x` canary if all promotion gates hold.
+- Keep `H-REV-01` shadow-only until Jangar market-context jobs and dependency quorum stop showing metadata/configuration failures.
+
+### Phase 3: scaled capital
+
+- Only hypotheses with repeated positive post-cost evidence and bounded slippage can graduate to `0.50x` and `1.00x`.
+- `H-MICRO-01` stays `blocked` until its feature coverage contract is implemented and validated.
+
+## Rollback Plan
+
+Rollback is operationally simple:
+
+- demote any hypothesis to `shadow`;
+- set global live capital multiplier to zero if dependency quorum is `block`;
+- preserve shadow evidence collection during rollback to avoid losing learning windows;
+- revert the hypothesis manifest version if the issue is contract/configuration induced rather than market-regime induced.
+
+The deployer should never need to disable the entire service merely because a single hypothesis fails readiness or profit gates.
+
+## Risks and Open Questions
+
+- The current live environment already shows a mismatch between service uptime and trading readiness; if the new readiness payload is not adopted as the promotion truth, operators may continue to over-trust the old status.
+- `H-REV-01` depends on Jangar market-context reliability, and recent agent logs show template jobs failing due to missing repository metadata. That dependency must be corrected before event-driven lanes can consume capital.
+- `H-MICRO-01` is intentionally blocked by missing feature coverage; treating it as live-ready early would recreate the same "healthy but unproven" pattern at higher complexity.
+- The first implementation must choose windows carefully so it does not overfit recent low-signal periods; all thresholds should be backed by forward-only evaluation and revisited after the first shadow week.
+
+## Relationship to Existing Documents
+
+This document extends, not replaces:
+
+- `08-profitability-research-validation-execution-governance-system.md`
+- `15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`
+- `27-live-hypothesis-ledger-and-capital-allocation-contract-2026-03-06.md`
+- `19-jangar-symbol-dependency-freshness-and-readiness-guard.md`
+- `22-trading-readiness-dependency-freshness-cache-2026-03-04.md`
+- `26-database-migration-lineage-and-readiness-contract-2026-03-05.md`
+
+The new contribution is the missing profit architecture layer: a formal contract that binds alpha hypotheses, dependency truth, feature freshness, and post-cost outcomes into a single promotion system.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -59,6 +59,7 @@ This pack is positioned as the next architecture layer above:
 25. `23-trading-startup-readiness-warmup-2026-03-04.md`
 26. `26-database-migration-lineage-and-readiness-contract-2026-03-05.md`
 27. `27-live-hypothesis-ledger-and-capital-allocation-contract-2026-03-06.md`
+28. `28-hypothesis-led-alpha-readiness-and-profit-circuit-2026-03-06.md`
 
 ## Recommended Build Order
 
@@ -89,6 +90,7 @@ This pack is positioned as the next architecture layer above:
 25. `23-trading-startup-readiness-warmup-2026-03-04.md`
 26. `26-database-migration-lineage-and-readiness-contract-2026-03-05.md`
 27. `27-live-hypothesis-ledger-and-capital-allocation-contract-2026-03-06.md`
+28. `28-hypothesis-led-alpha-readiness-and-profit-circuit-2026-03-06.md`
 
 ## Why This Sequence
 
@@ -101,3 +103,4 @@ This pack is positioned as the next architecture layer above:
 - Production rollout and governance closes with explicit SLO, rollback, and incident controls.
 - Live profitability must ultimately be governed by a database-backed hypothesis ledger, not only by static artifacts.
 - PostHog observability design is sequenced late to instrument stable runtime paths and avoid telemetry contract churn.
+- The hypothesis-led alpha readiness and profit circuit closes the remaining gap between runtime health and capital promotion, ensuring profitable scale-up is evidence-backed instead of inferred from process uptime.


### PR DESCRIPTION
## Summary

- add a Jangar architecture design for admission quorum and rollout circuit breaking based on live cluster failure evidence
- add a Torghut architecture design for hypothesis-led alpha readiness and profit-governed capital promotion
- update the Agents and Torghut design indexes so the new architecture artifacts are part of the in-repo source of truth

## Related Issues

None

## Testing

- `bunx oxfmt --check docs/agents/README.md docs/agents/designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/27-hypothesis-led-alpha-readiness-and-profit-circuit-2026-03-06.md`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
