### PR TITLE
fix(torghut): surface rejection alert state

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1473,6 +1473,10 @@ class Settings(BaseSettings):
         default=0.5,
         alias="LLM_DSPY_LIVE_RUNTIME_BLOCK_QTY_MULTIPLIER",
     )
+    llm_dspy_runtime_fallback_alert_ratio: float = Field(
+        default=0.01,
+        alias="LLM_DSPY_RUNTIME_FALLBACK_ALERT_RATIO",
+    )
     llm_dspy_compile_metrics_policy_ref: str = Field(
         default="config/trading/llm/dspy-metrics.yaml",
         alias="LLM_DSPY_COMPILE_METRICS_POLICY_REF",

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1269,6 +1269,9 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
     llm_evaluation = _load_llm_evaluation(session)
     tca_summary = _load_tca_summary(session)
     control_plane_contract = _build_control_plane_contract(state)
+    market_context_status = scheduler.market_context_status()
+    shorting_metadata_status = scheduler.shorting_metadata_status()
+    rejection_alert_status = scheduler.rejection_alert_status()
     return {
         "enabled": settings.trading_enabled,
         "autonomy_enabled": settings.trading_autonomy_enabled,
@@ -1330,22 +1333,33 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
             "signal_lag_alert_threshold_seconds": settings.trading_signal_stale_lag_alert_seconds,
             "signal_continuity_recovery_cycles": settings.trading_signal_continuity_recovery_cycles,
         },
-        "market_context": {
-            "required": settings.trading_market_context_required,
-            "fail_mode": settings.trading_market_context_fail_mode,
-            "allow_degraded_last_good": settings.trading_market_context_allow_degraded_last_good,
-            "min_quality": settings.trading_market_context_min_quality,
-            "max_staleness_seconds": settings.trading_market_context_max_staleness_seconds,
-            "fundamentals_degraded_max_staleness_seconds": settings.trading_market_context_fundamentals_degraded_max_staleness_seconds,
-            "news_degraded_max_staleness_seconds": settings.trading_market_context_news_degraded_max_staleness_seconds,
-        },
-        "shorting_metadata": scheduler.shorting_metadata_status(),
+        "market_context": market_context_status,
+        "shorting_metadata": shorting_metadata_status,
         "rejections": {
             "policy_veto_total": state.metrics.llm_policy_veto_total,
             "runtime_fallback_total": state.metrics.llm_runtime_fallback_total,
             "market_context_block_total": state.metrics.llm_market_context_block_total,
             "pre_llm_capacity_reject_total": state.metrics.pre_llm_capacity_reject_total,
             "pre_llm_qty_below_min_total": state.metrics.pre_llm_qty_below_min_total,
+            "runtime_fallback_ratio": rejection_alert_status[
+                "runtime_fallback_ratio"
+            ],
+            "runtime_fallback_alert_ratio_threshold": rejection_alert_status[
+                "runtime_fallback_alert_ratio_threshold"
+            ],
+            "runtime_fallback_alert_active": rejection_alert_status[
+                "runtime_fallback_alert_active"
+            ],
+        },
+        "alerts": {
+            "market_context_alert_active": market_context_status["alert_active"],
+            "market_context_alert_reason": market_context_status["alert_reason"],
+            "runtime_fallback_alert_active": rejection_alert_status[
+                "runtime_fallback_alert_active"
+            ],
+            "shorting_metadata_alert_active": rejection_alert_status[
+                "shorting_metadata_alert_active"
+            ],
         },
         "rollback": {
             "emergency_stop_active": state.emergency_stop_active,
@@ -1595,11 +1609,35 @@ def prometheus_metrics(session: Session = Depends(get_session)) -> Response:
         scheduler = TradingScheduler()
         app.state.trading_scheduler = scheduler
     metrics = scheduler.state.metrics
+    market_context_status = scheduler.market_context_status()
+    shorting_metadata_status = scheduler.shorting_metadata_status()
+    rejection_alert_status = scheduler.rejection_alert_status()
     payload = render_trading_metrics(
         {
             **metrics.__dict__,
             "tca_summary": _load_tca_summary(session),
             "route_provenance": _load_route_provenance_summary(session),
+            "market_context_alert_active": int(
+                bool(market_context_status.get("alert_active"))
+            ),
+            "market_context_last_freshness_seconds": _safe_int(
+                market_context_status.get("last_freshness_seconds")
+            ),
+            "market_context_last_quality_score": _safe_float(
+                market_context_status.get("last_quality_score")
+            ),
+            "llm_runtime_fallback_ratio": _safe_float(
+                rejection_alert_status.get("runtime_fallback_ratio")
+            ),
+            "llm_runtime_fallback_alert_active": int(
+                bool(rejection_alert_status.get("runtime_fallback_alert_active"))
+            ),
+            "shorting_metadata_account_ready": int(
+                shorting_metadata_status.get("account_ready") is True
+            ),
+            "shorting_metadata_alert_active": int(
+                bool(rejection_alert_status.get("shorting_metadata_alert_active"))
+            ),
         }
     )
     return Response(content=payload, media_type="text/plain; version=0.0.4")
@@ -2602,6 +2640,14 @@ def _safe_int(value: object) -> int:
     if isinstance(value, float):
         return int(value)
     return 0
+
+
+def _safe_float(value: object) -> float:
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    return 0.0
 
 
 def _load_llm_evaluation(session: Session) -> dict[str, object]:

--- a/services/torghut/app/metrics.py
+++ b/services/torghut/app/metrics.py
@@ -347,6 +347,34 @@ _DIRECT_GAUGES: dict[str, tuple[str, str]] = {
         "torghut_trading_feature_duplicate_ratio",
         "Duplicate event ratio in the latest ingest batch.",
     ),
+    "market_context_alert_active": (
+        "torghut_trading_market_context_alert_active",
+        "Whether a market-context alert is currently active (1=yes, 0=no).",
+    ),
+    "market_context_last_freshness_seconds": (
+        "torghut_trading_market_context_last_freshness_seconds",
+        "Freshness in seconds of the last observed market-context bundle.",
+    ),
+    "market_context_last_quality_score": (
+        "torghut_trading_market_context_last_quality_score",
+        "Quality score of the last observed market-context bundle.",
+    ),
+    "llm_runtime_fallback_ratio": (
+        "torghut_trading_llm_runtime_fallback_ratio",
+        "Ratio of LLM runtime fallbacks to total LLM requests.",
+    ),
+    "llm_runtime_fallback_alert_active": (
+        "torghut_trading_llm_runtime_fallback_alert_active",
+        "Whether the LLM runtime fallback alert threshold is currently breached (1=yes, 0=no).",
+    ),
+    "shorting_metadata_account_ready": (
+        "torghut_trading_shorting_metadata_account_ready",
+        "Whether cached account shorting metadata is currently ready (1=yes, 0=no).",
+    ),
+    "shorting_metadata_alert_active": (
+        "torghut_trading_shorting_metadata_alert_active",
+        "Whether shorting metadata readiness is currently alerting during market hours (1=yes, 0=no).",
+    ),
 }
 
 _AUTONOMY_WINDOW_GAUGES: dict[str, tuple[str, str]] = {

--- a/services/torghut/app/trading/market_context.py
+++ b/services/torghut/app/trading/market_context.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import dataclass
 from http.client import HTTPConnection, HTTPSConnection
 from typing import Any, Optional, cast
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 from ..config import settings
 from .llm.schema import MarketContextBundle
@@ -144,6 +145,7 @@ class MarketContextClient:
     def __init__(self) -> None:
         self._base_url = (settings.trading_market_context_url or "").strip()
         self._timeout_seconds = max(settings.trading_market_context_timeout_seconds, 1)
+        self._health_cache: dict[str, tuple[float, dict[str, Any]]] = {}
 
     def fetch(self, symbol: str) -> Optional[MarketContextBundle]:
         if not self._base_url:
@@ -176,6 +178,52 @@ class MarketContextClient:
         if not isinstance(context, dict):
             raise RuntimeError("market_context_missing_context")
         return MarketContextBundle.model_validate(context)
+
+    def fetch_health(self, symbol: str) -> Optional[dict[str, Any]]:
+        if not self._base_url:
+            return None
+        cache_key = symbol.strip().upper() or "default"
+        now = time.monotonic()
+        cached = self._health_cache.get(cache_key)
+        if cached is not None and now - cached[0] <= 15.0:
+            return dict(cached[1])
+
+        health_url = self._derive_health_url()
+        query = urlencode({"symbol": symbol})
+        delimiter = "&" if "?" in health_url else "?"
+        request_url = f"{health_url}{delimiter}{query}"
+        request = _HttpRequest(
+            full_url=request_url,
+            method="GET",
+            headers={"accept": "application/json"},
+        )
+        payload = ""
+        with urlopen(request, self._timeout_seconds) as response:
+            raw_status = getattr(response, "status", 200)
+            status = raw_status if isinstance(raw_status, int) else 200
+            if status < 200 or status >= 300:
+                raise RuntimeError(f"market_context_health_http_{status}")
+            payload = response.read().decode("utf-8")
+        data = json.loads(payload)
+        if not isinstance(data, dict):
+            raise RuntimeError("market_context_health_invalid_payload")
+        payload_dict = cast(dict[str, Any], data)
+        if payload_dict.get("ok") is not True:
+            message = payload_dict.get("message") or "market_context_health_failed"
+            raise RuntimeError(str(message))
+        health = payload_dict.get("health")
+        if not isinstance(health, dict):
+            raise RuntimeError("market_context_health_missing_health")
+        health_dict = cast(dict[str, Any], health)
+        self._health_cache[cache_key] = (now, health_dict)
+        return dict(health_dict)
+
+    def _derive_health_url(self) -> str:
+        parsed = urlsplit(self._base_url)
+        path = parsed.path.rstrip("/")
+        if not path.endswith("/health"):
+            path = f"{path}/health"
+        return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
 
 def evaluate_market_context(bundle: Optional[MarketContextBundle]) -> MarketContextStatus:

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -1069,6 +1069,22 @@ class TradingState:
     signal_continuity_alert_started_at: Optional[datetime] = None
     signal_continuity_alert_last_seen_at: Optional[datetime] = None
     signal_continuity_recovery_streak: int = 0
+    last_market_context_symbol: Optional[str] = None
+    last_market_context_checked_at: Optional[datetime] = None
+    last_market_context_as_of: Optional[datetime] = None
+    last_market_context_freshness_seconds: Optional[int] = None
+    last_market_context_quality_score: Optional[float] = None
+    last_market_context_domain_states: dict[str, str] = field(
+        default_factory=lambda: cast(dict[str, str], {})
+    )
+    last_market_context_risk_flags: list[str] = field(
+        default_factory=lambda: cast(list[str], [])
+    )
+    last_market_context_allow_llm: Optional[bool] = None
+    last_market_context_reason: Optional[str] = None
+    last_market_context_fetch_error: Optional[str] = None
+    market_context_alert_active: bool = False
+    market_context_alert_reason: Optional[str] = None
     autonomy_no_signal_streak: int = 0
     last_evidence_continuity_report: Optional[dict[str, Any]] = None
     autonomy_failure_streak: int = 0
@@ -3424,6 +3440,11 @@ class TradingPipeline:
         market_context, market_context_error = self._fetch_market_context(
             decision.symbol
         )
+        self._record_market_context_observation(
+            symbol=decision.symbol,
+            market_context=market_context,
+            market_context_error=market_context_error,
+        )
         if market_context_error is not None:
             self.state.metrics.llm_market_context_error_total += 1
 
@@ -3591,6 +3612,67 @@ class TradingPipeline:
                 }
             },
             policy_resolution=policy_resolution,
+        )
+
+    def _record_market_context_observation(
+        self,
+        *,
+        symbol: str,
+        market_context: Optional[MarketContextBundle],
+        market_context_error: Optional[str],
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        self.state.last_market_context_symbol = symbol
+        self.state.last_market_context_checked_at = now
+        self.state.last_market_context_fetch_error = market_context_error
+        if market_context is None:
+            self.state.last_market_context_as_of = None
+            self.state.last_market_context_freshness_seconds = None
+            self.state.last_market_context_quality_score = None
+            self.state.last_market_context_domain_states = {}
+            self.state.last_market_context_risk_flags = []
+            allow_llm = not settings.trading_market_context_required
+            reason = (
+                market_context_error
+                or (
+                    "market_context_required_missing"
+                    if settings.trading_market_context_required
+                    else None
+                )
+            )
+            self.state.last_market_context_allow_llm = allow_llm
+            self.state.last_market_context_reason = reason
+            self.state.market_context_alert_active = market_context_error is not None or (
+                settings.trading_market_context_required and not allow_llm
+            )
+            self.state.market_context_alert_reason = reason
+            return
+
+        market_context_status = evaluate_market_context(market_context)
+        as_of = market_context.as_of_utc
+        self.state.last_market_context_as_of = as_of
+        self.state.last_market_context_freshness_seconds = int(
+            market_context.freshness_seconds
+        )
+        self.state.last_market_context_quality_score = float(
+            market_context.quality_score
+        )
+        self.state.last_market_context_domain_states = {
+            "technicals": market_context.domains.technicals.state,
+            "fundamentals": market_context.domains.fundamentals.state,
+            "news": market_context.domains.news.state,
+            "regime": market_context.domains.regime.state,
+        }
+        self.state.last_market_context_risk_flags = list(market_context.risk_flags)
+        self.state.last_market_context_allow_llm = market_context_status.allow_llm
+        self.state.last_market_context_reason = (
+            market_context_error or market_context_status.reason
+        )
+        self.state.market_context_alert_active = market_context_error is not None or (
+            not market_context_status.allow_llm
+        )
+        self.state.market_context_alert_reason = (
+            market_context_error or market_context_status.reason
         )
 
     def _record_llm_verdict_counter(self, verdict: str) -> None:
@@ -3874,6 +3956,24 @@ class TradingPipeline:
         }
         if response_payload_extra:
             response_payload.update(response_payload_extra)
+        decision_metadata_update: dict[str, Any] = {}
+        if response_payload_extra:
+            llm_runtime_payload = response_payload_extra.get("llm_runtime")
+            if isinstance(llm_runtime_payload, Mapping):
+                decision_metadata_update["llm_runtime"] = dict(
+                    cast(Mapping[str, Any], llm_runtime_payload)
+                )
+            market_context_payload = response_payload_extra.get("market_context")
+            if isinstance(market_context_payload, Mapping):
+                decision_metadata_update["market_context"] = dict(
+                    cast(Mapping[str, Any], market_context_payload)
+                )
+        if decision_metadata_update:
+            self.executor.update_decision_json(
+                session,
+                decision_row,
+                decision_metadata_update,
+            )
         response_payload["request_hash"] = _hash_payload(request_payload)
         response_payload["response_hash"] = _hash_payload(response_payload)
         self._persist_llm_review(
@@ -4810,9 +4910,13 @@ class TradingScheduler:
 
     def llm_status(self) -> dict[str, object]:
         circuit_snapshot = None
-        if self._pipeline and self._pipeline.llm_review_engine:
+        pipeline = self._pipeline
+        llm_review_engine = (
+            getattr(pipeline, "llm_review_engine", None) if pipeline is not None else None
+        )
+        if llm_review_engine:
             circuit_snapshot = (
-                self._pipeline.llm_review_engine.circuit_breaker.snapshot()
+                llm_review_engine.circuit_breaker.snapshot()
             )
         guardrails = evaluate_llm_guardrails()
         policy_resolution = _build_llm_policy_resolution(
@@ -4837,6 +4941,9 @@ class TradingScheduler:
             ),
             "policy_veto_total": self.state.metrics.llm_policy_veto_total,
             "runtime_fallback_total": self.state.metrics.llm_runtime_fallback_total,
+            "runtime_fallback_ratio": self.rejection_alert_status()[
+                "runtime_fallback_ratio"
+            ],
             "dspy_live_runtime_block_fail_mode": settings.llm_dspy_live_runtime_block_fail_mode,
             "dspy_live_runtime_block_qty_multiplier": settings.llm_dspy_live_runtime_block_qty_multiplier,
             "circuit": circuit_snapshot,
@@ -4850,13 +4957,93 @@ class TradingScheduler:
         }
 
     def shorting_metadata_status(self) -> dict[str, object]:
-        executor = self._pipeline.executor if self._pipeline is not None else None
+        pipeline = self._pipeline
+        executor = getattr(pipeline, "executor", None) if pipeline is not None else None
+        alert_active = False
+        if self.state.market_session_open is True:
+            raw_status = None
+            if isinstance(executor, OrderExecutor):
+                raw_status = executor.shorting_metadata_status()
+            account_ready = raw_status.get("account_ready") if isinstance(raw_status, Mapping) else None
+            alert_active = account_ready is False
         if isinstance(executor, OrderExecutor):
-            return cast(dict[str, object], executor.shorting_metadata_status())
+            status = cast(dict[str, object], executor.shorting_metadata_status())
+            status["alert_active"] = alert_active
+            return status
         return {
             "account_ready": None,
             "last_refresh_at": None,
             "last_error": None,
+            "alert_active": False,
+        }
+
+    def market_context_status(self) -> dict[str, object]:
+        health: dict[str, Any] | None = None
+        health_error: str | None = None
+        pipeline = self._pipeline
+        market_context_client = (
+            getattr(pipeline, "market_context_client", None)
+            if pipeline is not None
+            else None
+        )
+        if not isinstance(market_context_client, MarketContextClient):
+            market_context_client = MarketContextClient()
+        if self.state.last_market_context_symbol:
+            try:
+                health = market_context_client.fetch_health(
+                    self.state.last_market_context_symbol
+                )
+            except Exception as exc:
+                health_error = str(exc)
+        return {
+            "required": settings.trading_market_context_required,
+            "fail_mode": settings.trading_market_context_fail_mode,
+            "allow_degraded_last_good": settings.trading_market_context_allow_degraded_last_good,
+            "min_quality": settings.trading_market_context_min_quality,
+            "max_staleness_seconds": settings.trading_market_context_max_staleness_seconds,
+            "fundamentals_degraded_max_staleness_seconds": settings.trading_market_context_fundamentals_degraded_max_staleness_seconds,
+            "news_degraded_max_staleness_seconds": settings.trading_market_context_news_degraded_max_staleness_seconds,
+            "last_symbol": self.state.last_market_context_symbol,
+            "last_checked_at": self.state.last_market_context_checked_at,
+            "last_as_of": self.state.last_market_context_as_of,
+            "last_freshness_seconds": self.state.last_market_context_freshness_seconds,
+            "last_quality_score": self.state.last_market_context_quality_score,
+            "last_domain_states": dict(self.state.last_market_context_domain_states),
+            "last_risk_flags": list(self.state.last_market_context_risk_flags),
+            "last_allow_llm": self.state.last_market_context_allow_llm,
+            "last_reason": self.state.last_market_context_reason,
+            "last_fetch_error": self.state.last_market_context_fetch_error,
+            "reason_total": dict(self.state.metrics.llm_market_context_reason_total),
+            "shadow_total": dict(self.state.metrics.llm_market_context_shadow_total),
+            "alert_active": self.state.market_context_alert_active,
+            "alert_reason": self.state.market_context_alert_reason,
+            "health": health,
+            "health_error": health_error,
+        }
+
+    def rejection_alert_status(self) -> dict[str, object]:
+        llm_requests_total = max(0, int(self.state.metrics.llm_requests_total))
+        runtime_fallback_total = max(
+            0, int(self.state.metrics.llm_runtime_fallback_total)
+        )
+        runtime_fallback_ratio = (
+            float(runtime_fallback_total) / float(llm_requests_total)
+            if llm_requests_total > 0
+            else 0.0
+        )
+        runtime_fallback_alert_active = (
+            llm_requests_total > 0
+            and runtime_fallback_ratio
+            > settings.llm_dspy_runtime_fallback_alert_ratio
+        )
+        shorting_status = self.shorting_metadata_status()
+        return {
+            "runtime_fallback_ratio": runtime_fallback_ratio,
+            "runtime_fallback_alert_ratio_threshold": settings.llm_dspy_runtime_fallback_alert_ratio,
+            "runtime_fallback_alert_active": runtime_fallback_alert_active,
+            "shorting_metadata_alert_active": bool(
+                shorting_status.get("alert_active", False)
+            ),
         }
 
     def _build_pipeline_for_account(self, lane: TradingAccountLane) -> TradingPipeline:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1255,9 +1255,28 @@ class TestTradingApi(TestCase):
             scheduler = TradingScheduler()
             scheduler.state.metrics.llm_policy_veto_total = 3
             scheduler.state.metrics.llm_runtime_fallback_total = 5
+            scheduler.state.metrics.llm_requests_total = 100
             scheduler.state.metrics.llm_market_context_block_total = 7
             scheduler.state.metrics.pre_llm_capacity_reject_total = 11
             scheduler.state.metrics.pre_llm_qty_below_min_total = 13
+            scheduler.state.market_session_open = True
+            scheduler.state.last_market_context_symbol = "AAPL"
+            scheduler.state.last_market_context_checked_at = datetime(
+                2026, 3, 5, 15, 30, tzinfo=timezone.utc
+            )
+            scheduler.state.last_market_context_freshness_seconds = 120
+            scheduler.state.last_market_context_quality_score = 0.92
+            scheduler.state.last_market_context_domain_states = {
+                "technicals": "ok",
+                "fundamentals": "stale",
+                "news": "ok",
+                "regime": "ok",
+            }
+            scheduler.state.last_market_context_risk_flags = ["fundamentals_stale"]
+            scheduler.state.last_market_context_allow_llm = False
+            scheduler.state.last_market_context_reason = "market_context_stale"
+            scheduler.state.market_context_alert_active = True
+            scheduler.state.market_context_alert_reason = "market_context_stale"
             executor = OrderExecutor()
             executor._shorting_metadata_status.update(  # noqa: SLF001
                 {
@@ -1278,16 +1297,28 @@ class TestTradingApi(TestCase):
             payload = response.json()
             self.assertEqual(payload["market_context"]["fail_mode"], "shadow_only")
             self.assertFalse(payload["market_context"]["required"])
+            self.assertEqual(payload["market_context"]["last_symbol"], "AAPL")
+            self.assertEqual(payload["market_context"]["last_reason"], "market_context_stale")
+            self.assertTrue(payload["market_context"]["alert_active"])
             self.assertEqual(payload["rejections"]["policy_veto_total"], 3)
             self.assertEqual(payload["rejections"]["runtime_fallback_total"], 5)
+            self.assertAlmostEqual(payload["rejections"]["runtime_fallback_ratio"], 0.05)
+            self.assertEqual(
+                payload["rejections"]["runtime_fallback_alert_ratio_threshold"], 0.01
+            )
+            self.assertTrue(payload["rejections"]["runtime_fallback_alert_active"])
             self.assertEqual(payload["rejections"]["market_context_block_total"], 7)
             self.assertEqual(payload["rejections"]["pre_llm_capacity_reject_total"], 11)
             self.assertEqual(payload["rejections"]["pre_llm_qty_below_min_total"], 13)
             self.assertFalse(payload["shorting_metadata"]["account_ready"])
+            self.assertTrue(payload["shorting_metadata"]["alert_active"])
             self.assertEqual(
                 payload["shorting_metadata"]["last_error"],
                 "account lookup unavailable",
             )
+            self.assertTrue(payload["alerts"]["market_context_alert_active"])
+            self.assertTrue(payload["alerts"]["runtime_fallback_alert_active"])
+            self.assertTrue(payload["alerts"]["shorting_metadata_alert_active"])
         finally:
             if original_scheduler is None:
                 if hasattr(app.state, "trading_scheduler"):
@@ -1340,6 +1371,8 @@ class TestTradingApi(TestCase):
                 'torghut_trading_execution_advisor_fallback_total{reason="advisor_disabled"} 1',
                 metrics_payload,
             )
+            self.assertIn("torghut_trading_llm_runtime_fallback_ratio", metrics_payload)
+            self.assertIn("torghut_trading_market_context_alert_active", metrics_payload)
         finally:
             if original_scheduler is None:
                 del app.state.trading_scheduler

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4978,8 +4978,10 @@ class TestTradingPipeline(TestCase):
 
             with self.session_local() as session:
                 reviews = session.execute(select(LLMDecisionReview)).scalars().all()
+                decisions = session.execute(select(TradeDecision)).scalars().all()
                 executions = session.execute(select(Execution)).scalars().all()
                 self.assertEqual(len(reviews), 1)
+                self.assertEqual(len(decisions), 1)
                 self.assertEqual(reviews[0].verdict, "error")
                 self.assertEqual(reviews[0].response_json.get("fallback"), "veto")
                 self.assertEqual(
@@ -4987,6 +4989,10 @@ class TestTradingPipeline(TestCase):
                 )
                 self.assertEqual(
                     reviews[0].response_json.get("llm_runtime", {}).get("subtype"),
+                    "dspy_live_runtime_gate",
+                )
+                self.assertEqual(
+                    decisions[0].decision_json.get("llm_runtime", {}).get("subtype"),
                     "dspy_live_runtime_gate",
                 )
                 self.assertEqual(len(executions), 0)
@@ -6459,6 +6465,10 @@ class TestTradingPipeline(TestCase):
                 self.assertEqual(reviews[0].verdict, "error")
                 self.assertEqual(
                     reviews[0].response_json.get("error"),
+                    "market_context_fetch_error",
+                )
+                self.assertEqual(
+                    decisions[0].decision_json.get("market_context", {}).get("reason"),
                     "market_context_fetch_error",
                 )
                 policy_resolution = reviews[0].response_json.get("policy_resolution")


### PR DESCRIPTION
## Summary

- persist `llm_runtime` and `market_context` metadata into `decision_json` for runtime-block and market-context unavailable paths so downstream diagnostics are not limited to `LLMDecisionReview`
- expose live rejection-alert posture in Torghut status and Prometheus, including runtime fallback ratio/threshold breaches, market-context alert state, and shorting-metadata readiness alerts during market hours
- add Jangar market-context health lookups to the runtime status surface and extend Torghut tests to cover the new decision metadata and operator-facing alert fields

## Related Issues

Follow-up to #4099

## Testing

- `cd services/torghut && uv run pytest tests/test_trading_pipeline.py tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
