### PR TITLE
chore(jangar): promote image a9cf41e1

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: bc56d588
-  digest: sha256:484fa974af912022ae7fb275e9288f8350aad472382f7688f2b615477957f45c
+  tag: a9cf41e1
+  digest: sha256:7ce5d3540ac2ee60f1a67a0b8d00cb8a4a5e28f3814180b14667e8178efdf5f4
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: bc56d588
-    digest: sha256:3ab79bea09eb3786826c932a7ba562fc44579fe0c2f84e24535814d476c7f648
+    tag: a9cf41e1
+    digest: sha256:41bcf75cd3432169af4ae37b219c71d04b580d0d157c508ea332eed2399fed94
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: bc56d588
-    digest: sha256:484fa974af912022ae7fb275e9288f8350aad472382f7688f2b615477957f45c
+    tag: a9cf41e1
+    digest: sha256:7ce5d3540ac2ee60f1a67a0b8d00cb8a4a5e28f3814180b14667e8178efdf5f4
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T05:36:19Z"
+    deploy.knative.dev/rollout: "2026-03-06T05:55:23Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T05:36:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T05:55:23Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "bc56d588"
-    digest: sha256:484fa974af912022ae7fb275e9288f8350aad472382f7688f2b615477957f45c
+    newTag: "a9cf41e1"
+    digest: sha256:7ce5d3540ac2ee60f1a67a0b8d00cb8a4a5e28f3814180b14667e8178efdf5f4


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a9cf41e12d4111f959aa62490312fd2b7e72bf38`
- Image tag: `a9cf41e1`
- Image digest: `sha256:7ce5d3540ac2ee60f1a67a0b8d00cb8a4a5e28f3814180b14667e8178efdf5f4`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`