### PR TITLE
chore(torghut): promote image f0570875

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8bf5f0e864003a99da1ec663780a431834d2e69221527117e32b3bc3714b5d42
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5563a1531e5619f907f32201cec67abca69069a97bba949628932dabab48d407
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-06T05:45:27Z"
+        client.knative.dev/updateTimestamp: "2026-03-06T06:01:34Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8bf5f0e864003a99da1ec663780a431834d2e69221527117e32b3bc3714b5d42
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5563a1531e5619f907f32201cec67abca69069a97bba949628932dabab48d407
           ports:
             - name: http1
               containerPort: 8181
@@ -430,9 +430,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-326-ga9cf41e1
+              value: v0.562.0-331-gf0570875
             - name: TORGHUT_COMMIT
-              value: a9cf41e12d4111f959aa62490312fd2b7e72bf38
+              value: f05708755910183d8d108a5b6a23a028f02881fb
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `f05708755910183d8d108a5b6a23a028f02881fb`
- Image tag: `f0570875`
- Image digest: `sha256:5563a1531e5619f907f32201cec67abca69069a97bba949628932dabab48d407`