### PR TITLE
chore(jangar): promote image fab5cdf4

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a9cf41e1
-  digest: sha256:7ce5d3540ac2ee60f1a67a0b8d00cb8a4a5e28f3814180b14667e8178efdf5f4
+  tag: fab5cdf4
+  digest: sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a9cf41e1
-    digest: sha256:41bcf75cd3432169af4ae37b219c71d04b580d0d157c508ea332eed2399fed94
+    tag: fab5cdf4
+    digest: sha256:3fa01ed3ee4665b98c6a1d149582ec3513f34a76325f8400ad2a1a027619cb2c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a9cf41e1
-    digest: sha256:7ce5d3540ac2ee60f1a67a0b8d00cb8a4a5e28f3814180b14667e8178efdf5f4
+    tag: fab5cdf4
+    digest: sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T05:55:23Z"
+    deploy.knative.dev/rollout: "2026-03-06T06:29:39Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T05:55:23Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T06:29:39Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a9cf41e1"
-    digest: sha256:7ce5d3540ac2ee60f1a67a0b8d00cb8a4a5e28f3814180b14667e8178efdf5f4
+    newTag: "fab5cdf4"
+    digest: sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `fab5cdf4b2af94568ba232be9cc180355c1ba814`
- Image tag: `fab5cdf4`
- Image digest: `sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`