### PR TITLE
fix(torghut): close remaining rejection gaps

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-trading-summary.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-trading-summary.test.ts
@@ -20,6 +20,43 @@ describe('torghut trading summary reason parsing', () => {
     expect(__private.splitRiskReason('llm_error')).toEqual(['llm_error'])
   })
 
+  it('classifies normalized broker and policy reasons from atomic tokens', () => {
+    expect(
+      __private.classifyRejectClass({
+        id: '1',
+        createdAt: '2026-01-15T14:45:00.000Z',
+        alpacaAccountLabel: 'paper',
+        symbol: 'AAPL',
+        timeframe: '1m',
+        status: 'rejected',
+        rationale: null,
+        riskReasons: [],
+        rejectReasonAtomic: ['sell_inventory_unavailable'],
+        rejectClass: null,
+        rejectOrigin: 'broker_precheck',
+        strategyId: '1',
+        strategyName: 'test',
+      }),
+    ).toBe('broker_precheck')
+    expect(
+      __private.classifyRejectClass({
+        id: '2',
+        createdAt: '2026-01-15T14:45:00.000Z',
+        alpacaAccountLabel: 'paper',
+        symbol: 'AAPL',
+        timeframe: '1m',
+        status: 'rejected',
+        rationale: null,
+        riskReasons: [],
+        rejectReasonAtomic: ['runtime_uncertainty_gate_fail_block_new_entries'],
+        rejectClass: null,
+        rejectOrigin: 'runtime_uncertainty_gate',
+        strategyId: '1',
+        strategyName: 'test',
+      }),
+    ).toBe('policy')
+  })
+
   it('classifies market session by post-open and pre-open rules', () => {
     expect(__private.classifySessionByMarketTime('2026-01-15T13:45:00.000Z', rollingTrendInterval.tz)).toBe('pre-open')
     expect(__private.classifySessionByMarketTime('2026-01-15T14:30:00.000Z', rollingTrendInterval.tz)).toBe('post-open')

--- a/services/jangar/src/server/torghut-trading.ts
+++ b/services/jangar/src/server/torghut-trading.ts
@@ -82,8 +82,20 @@ const classifyRejectClass = (decision: TorghutRejectedDecisionRow) => {
     return 'market_context'
   }
   if (reasons.some((reason) => reason === 'symbol_capacity_exhausted' || reason === 'qty_below_min')) return 'capacity'
-  if (reasons.some((reason) => reason === 'shorting_metadata_unavailable' || reason === 'broker_precheck_rejected')) {
+  if (
+    reasons.some(
+      (reason) =>
+        reason === 'shorting_metadata_unavailable' ||
+        reason === 'broker_precheck_rejected' ||
+        reason === 'sell_inventory_unavailable',
+    )
+  ) {
     return 'broker_precheck'
+  }
+  if (
+    reasons.some((reason) => reason === 'max_position_pct_exceeded' || reason.startsWith('runtime_uncertainty_gate_'))
+  ) {
+    return 'policy'
   }
   if (reasons.some((reason) => reason.startsWith('llm_'))) return 'policy'
   return null
@@ -599,6 +611,7 @@ export const parseTorghutTradingStrategyId = (url: URL) => {
 
 export const __private = {
   splitRiskReason,
+  classifyRejectClass,
   classifySessionByMarketTime,
   buildRolling5DayRejectionTrend,
 }

--- a/services/torghut/app/trading/execution.py
+++ b/services/torghut/app/trading/execution.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, NamedTuple, Optional, cast
@@ -200,6 +200,53 @@ class OrderExecutor:
         if simulation_context is not None:
             submission_extra_params["simulation_context"] = simulation_context
         self._raise_if_conflicting_open_order(execution_client, request)
+        sell_inventory_conflict = self._find_sell_inventory_conflict(
+            execution_client,
+            request,
+            self._list_open_orders(execution_client),
+        )
+        if sell_inventory_conflict is not None:
+            request, sell_qty_adjustment, unresolved_conflict = (
+                self._resolve_sell_inventory_conflict(
+                    request,
+                    conflict=sell_inventory_conflict,
+                    fractional_equities_enabled=fractional_equities_enabled,
+                )
+            )
+            sell_inventory_recovery: dict[str, Any] | None = None
+            if unresolved_conflict is not None:
+                (
+                    request,
+                    sell_qty_adjustment,
+                    unresolved_conflict,
+                    sell_inventory_recovery,
+                ) = self._retry_sell_inventory_conflict_after_cancel(
+                    execution_client=execution_client,
+                    request=request,
+                    conflict=unresolved_conflict,
+                    fractional_equities_enabled=fractional_equities_enabled,
+                )
+            if unresolved_conflict is not None:
+                if sell_inventory_recovery is not None:
+                    self.update_decision_json(
+                        session,
+                        decision_row,
+                        {"broker_precheck_recovery": sell_inventory_recovery},
+                    )
+                raise RuntimeError(json.dumps(unresolved_conflict))
+            metadata_update: dict[str, Any] = {}
+            if sell_qty_adjustment is not None:
+                metadata_update["broker_precheck_adjustment"] = sell_qty_adjustment
+            if sell_inventory_recovery is not None:
+                metadata_update["broker_precheck_recovery"] = sell_inventory_recovery
+            if metadata_update or request.qty != decision.qty:
+                decision = decision.model_copy(update={"qty": request.qty})
+                self.sync_decision_state(
+                    session,
+                    decision_row,
+                    decision,
+                    metadata_update=metadata_update or None,
+                )
         order_response = self._submit_order_with_retry(
             execution_client=execution_client,
             request=request,
@@ -331,14 +378,6 @@ class OrderExecutor:
             }
             raise RuntimeError(json.dumps(payload))
 
-        sell_inventory_conflict = self._find_sell_inventory_conflict(
-            execution_client,
-            request,
-            open_orders,
-        )
-        if sell_inventory_conflict is not None:
-            raise RuntimeError(json.dumps(sell_inventory_conflict))
-
     def _submit_order_with_retry(
         self,
         *,
@@ -450,11 +489,31 @@ class OrderExecutor:
         session.add(decision_row)
         session.commit()
 
+    def sync_decision_state(
+        self,
+        session: Session,
+        decision_row: TradeDecision,
+        decision: StrategyDecision,
+        *,
+        metadata_update: Mapping[str, Any] | None = None,
+    ) -> None:
+        update = _decision_state_payload(decision)
+        if metadata_update:
+            update.update({str(key): value for key, value in metadata_update.items()})
+        self.update_decision_json(session, decision_row, update)
+
     def prime_shorting_metadata_cache(self, execution_client: Any) -> None:
         self._get_account(execution_client, force_refresh=True)
 
     def shorting_metadata_status(self) -> dict[str, Any]:
         return dict(self._shorting_metadata_status)
+
+    def position_qty_for_symbol(
+        self,
+        execution_client: Any,
+        symbol: str,
+    ) -> Decimal | None:
+        return self._position_qty_for_symbol(execution_client, symbol)
 
     @staticmethod
     def _fetch_existing_order(
@@ -582,6 +641,122 @@ class OrderExecutor:
             "existing_order_id": existing_order_ids[0] if existing_order_ids else None,
             "existing_order_ids": existing_order_ids,
         }
+
+    @classmethod
+    def _resolve_sell_inventory_conflict(
+        cls,
+        request: ExecutionRequest,
+        *,
+        conflict: Mapping[str, Any],
+        fractional_equities_enabled: bool,
+    ) -> tuple[ExecutionRequest, dict[str, Any] | None, dict[str, Any] | None]:
+        available_qty = _optional_decimal(conflict.get("available_qty"))
+        if available_qty is None or available_qty <= 0:
+            return request, None, dict(conflict)
+        if request.qty <= available_qty:
+            return request, None, None
+        adjusted_qty = quantize_qty_for_symbol(
+            request.symbol,
+            available_qty,
+            fractional_equities_enabled=fractional_equities_enabled,
+        )
+        min_qty = min_qty_for_symbol(
+            request.symbol, fractional_equities_enabled=fractional_equities_enabled
+        )
+        if adjusted_qty <= 0 or adjusted_qty < min_qty or adjusted_qty >= request.qty:
+            return request, None, dict(conflict)
+        adjusted_request = request.model_copy(update={"qty": adjusted_qty})
+        adjustment = {
+            "source": "broker_precheck",
+            "code": "sell_qty_clipped_to_available_inventory",
+            "symbol": request.symbol,
+            "requested_qty": str(request.qty),
+            "adjusted_qty": str(adjusted_qty),
+            "available_qty": str(available_qty),
+            "held_for_open_sells": conflict.get("held_for_open_sells"),
+            "position_qty": conflict.get("position_qty"),
+            "existing_order_id": conflict.get("existing_order_id"),
+            "existing_order_ids": conflict.get("existing_order_ids"),
+        }
+        return adjusted_request, adjustment, None
+
+    def _retry_sell_inventory_conflict_after_cancel(
+        self,
+        *,
+        execution_client: Any,
+        request: ExecutionRequest,
+        conflict: Mapping[str, Any],
+        fractional_equities_enabled: bool,
+    ) -> tuple[
+        ExecutionRequest,
+        dict[str, Any] | None,
+        dict[str, Any] | None,
+        dict[str, Any] | None,
+    ]:
+        existing_order_ids = self._sell_inventory_conflict_order_ids(conflict)
+        if not existing_order_ids:
+            return request, None, dict(conflict), None
+
+        canceled_order_ids: list[str] = []
+        for order_id in existing_order_ids:
+            try:
+                cancel_order = getattr(execution_client, "cancel_order", None)
+                if not callable(cancel_order):
+                    break
+                if cancel_order(order_id):
+                    canceled_order_ids.append(order_id)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to cancel sell inventory conflict order symbol=%s order_id=%s error=%s",
+                    request.symbol,
+                    order_id,
+                    exc,
+                )
+        if not canceled_order_ids:
+            return request, None, dict(conflict), None
+
+        refreshed_conflict = self._find_sell_inventory_conflict(
+            execution_client,
+            request,
+            self._list_open_orders(execution_client),
+        )
+        recovery: dict[str, Any] = {
+            "source": "broker_precheck",
+            "code": "sell_inventory_conflict_retried_after_cancel",
+            "symbol": request.symbol,
+            "requested_qty": str(request.qty),
+            "canceled_existing_order_ids": canceled_order_ids,
+        }
+        if refreshed_conflict is None:
+            recovery["status"] = "cleared"
+            return request, None, None, recovery
+
+        adjusted_request, adjustment, unresolved_conflict = (
+            self._resolve_sell_inventory_conflict(
+                request,
+                conflict=refreshed_conflict,
+                fractional_equities_enabled=fractional_equities_enabled,
+            )
+        )
+        recovery["status"] = "adjusted" if unresolved_conflict is None else "blocked"
+        recovery["remaining_conflict"] = dict(refreshed_conflict)
+        return adjusted_request, adjustment, unresolved_conflict, recovery
+
+    @staticmethod
+    def _sell_inventory_conflict_order_ids(conflict: Mapping[str, Any]) -> list[str]:
+        order_ids: list[str] = []
+        existing_order_ids = conflict.get("existing_order_ids")
+        if isinstance(existing_order_ids, Sequence) and not isinstance(
+            existing_order_ids, (str, bytes)
+        ):
+            existing_order_sequence = cast(Sequence[Any], existing_order_ids)
+            order_ids.extend(
+                str(order_id) for order_id in existing_order_sequence if order_id
+            )
+        existing_order_id = conflict.get("existing_order_id")
+        if existing_order_id and str(existing_order_id) not in order_ids:
+            order_ids.append(str(existing_order_id))
+        return order_ids
 
     @classmethod
     def _remaining_order_qty(cls, order: Mapping[str, Any]) -> Decimal:
@@ -975,6 +1150,12 @@ def _normalize_reject_reason(reason: str) -> _NormalizedRejectReason:
         return _NormalizedRejectReason("symbol_capacity_exhausted", "capacity", "portfolio_sizing")
     if normalized == "qty_below_min":
         return _NormalizedRejectReason("qty_below_min", "capacity", "portfolio_sizing")
+    if normalized == "max_position_pct_exceeded":
+        return _NormalizedRejectReason("max_position_pct_exceeded", "policy", "risk_engine")
+    if normalized.startswith("runtime_uncertainty_gate_"):
+        return _NormalizedRejectReason(normalized, "policy", "runtime_uncertainty_gate")
+    if "code=precheck_sell_qty_exceeds_available" in normalized:
+        return _NormalizedRejectReason("sell_inventory_unavailable", "broker_precheck", "broker_precheck")
     if "code=shorting_metadata_unavailable" in normalized or "code=local_account_metadata_unavailable" in normalized:
         return _NormalizedRejectReason("shorting_metadata_unavailable", "broker_precheck", "local_pre_submit")
     if normalized.startswith("local_pre_submit_rejected"):
@@ -1010,6 +1191,17 @@ def _extract_sizing_debug(decision_json: Mapping[str, Any]) -> dict[str, Any]:
         "remaining_room_notional": output_mapping.get("remaining_room_notional"),
         "fractional_allowed": output_mapping.get("fractional_allowed"),
         "limiting_constraint": output_mapping.get("limiting_constraint"),
+    }
+
+
+def _decision_state_payload(decision: StrategyDecision) -> dict[str, Any]:
+    return {
+        "action": decision.action,
+        "qty": str(decision.qty),
+        "order_type": decision.order_type,
+        "time_in_force": decision.time_in_force,
+        "limit_price": str(decision.limit_price) if decision.limit_price is not None else None,
+        "stop_price": str(decision.stop_price) if decision.stop_price is not None else None,
     }
 
 

--- a/services/torghut/app/trading/firewall.py
+++ b/services/torghut/app/trading/firewall.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from ..alpaca_client import OrderFirewallToken, TorghutAlpacaClient
 from ..config import settings
@@ -75,8 +76,66 @@ class OrderFirewall:
         return self._client.cancel_order(alpaca_order_id, firewall_token=self._token)
 
     def cancel_all_orders(self) -> list[dict[str, Any]]:
-        return self._client.cancel_all_orders(firewall_token=self._token)
+        orders = self._client.cancel_all_orders(firewall_token=self._token)
+        return _normalize_mapping_list(orders)
 
     def get_order_by_client_order_id(self, client_order_id: str) -> dict[str, Any] | None:
         # Reads are always allowed; this is used for idempotency backfills.
-        return self._client.get_order_by_client_order_id(client_order_id)
+        order = self._client.get_order_by_client_order_id(client_order_id)
+        return _normalize_mapping(order)
+
+    def get_order(self, alpaca_order_id: str) -> dict[str, Any]:
+        order = self._client.get_order(alpaca_order_id)
+        normalized = _normalize_mapping(order)
+        if normalized is None:
+            return {}
+        return normalized
+
+    def list_orders(self, status: str = 'all') -> list[dict[str, Any]]:
+        lister = getattr(self._client, 'list_orders', None)
+        if not callable(lister):
+            return []
+        result = lister(status=status)
+        return _normalize_mapping_list(result)
+
+    def list_positions(self) -> list[dict[str, Any]] | None:
+        lister = getattr(self._client, 'list_positions', None)
+        if not callable(lister):
+            return None
+        result = lister()
+        if result is None:
+            return None
+        return _normalize_mapping_list(result)
+
+    def get_account(self) -> dict[str, Any] | None:
+        getter = getattr(self._client, 'get_account', None)
+        if not callable(getter):
+            return None
+        result = getter()
+        return _normalize_mapping(result)
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any] | None:
+        getter = getattr(self._client, 'get_asset', None)
+        if not callable(getter):
+            return None
+        result = getter(symbol_or_asset_id)
+        return _normalize_mapping(result)
+
+
+def _normalize_mapping(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    mapping = cast(Mapping[object, Any], value)
+    return {str(key): item for key, item in mapping.items()}
+
+
+def _normalize_mapping_list(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    items = cast(list[object], value)
+    for item in items:
+        mapping = _normalize_mapping(item)
+        if mapping is not None:
+            normalized.append(mapping)
+    return normalized

--- a/services/torghut/app/trading/risk.py
+++ b/services/torghut/app/trading/risk.py
@@ -45,7 +45,9 @@ class RiskEngine:
             reasons.append("missing_price")
 
         qty = Decimal(str(decision.qty))
-        notional = price * qty if price is not None else None
+        notional = _portfolio_sizing_final_notional(decision)
+        if notional is None:
+            notional = price * qty if price is not None else None
         position_qty, position_value = _position_summary(decision.symbol, positions)
         short_increasing = _is_short_increasing(decision.action, qty, position_qty)
         allocator_meta = _allocator_payload(decision)
@@ -81,14 +83,15 @@ class RiskEngine:
         max_pct = _resolve_decimal(
             strategy.max_position_pct_equity
         ) or _resolve_decimal(settings.trading_max_position_pct_equity)
-        _append_position_pct_reason(
-            reasons,
-            max_pct=max_pct,
-            equity=equity,
-            notional=notional,
-            action=decision.action,
-            position_value=position_value,
-        )
+        if not _position_pct_guardrail_satisfied_by_portfolio_sizing(decision):
+            _append_position_pct_reason(
+                reasons,
+                max_pct=max_pct,
+                equity=equity,
+                notional=notional,
+                action=decision.action,
+                position_value=position_value,
+            )
 
         allocator_cap_notional = _allocator_approved_notional(decision)
         _append_allocator_notional_reason(
@@ -206,6 +209,58 @@ def _append_position_pct_reason(
     projected_abs = abs(projected_value)
     if projected_abs > equity * max_pct and projected_abs >= current_abs:
         reasons.append("max_position_pct_exceeded")
+
+
+def _portfolio_sizing_output(decision: StrategyDecision) -> Mapping[str, Any] | None:
+    raw = decision.params.get("portfolio_sizing")
+    if not isinstance(raw, Mapping):
+        return None
+    output = cast(Mapping[str, Any], raw).get("output")
+    if not isinstance(output, Mapping):
+        return None
+    return cast(Mapping[str, Any], output)
+
+
+def _portfolio_sizing_final_notional(decision: StrategyDecision) -> Decimal | None:
+    output = _portfolio_sizing_output(decision)
+    if output is None:
+        return None
+    status = str(output.get("status") or "").strip().lower()
+    if status != "approved":
+        return None
+    final_qty = _resolve_decimal(cast(Decimal | str | float | None, output.get("final_qty")))
+    if final_qty is None or final_qty != decision.qty:
+        return None
+    final_notional = _resolve_decimal(
+        cast(Decimal | str | float | None, output.get("final_notional"))
+    )
+    if final_notional is None or final_notional <= 0:
+        return None
+    return final_notional
+
+
+def _position_pct_guardrail_satisfied_by_portfolio_sizing(
+    decision: StrategyDecision,
+) -> bool:
+    output = _portfolio_sizing_output(decision)
+    if output is None:
+        return False
+    if str(output.get("status") or "").strip().lower() != "approved":
+        return False
+    final_qty = _resolve_decimal(cast(Decimal | str | float | None, output.get("final_qty")))
+    if final_qty is None or final_qty != decision.qty:
+        return False
+    final_notional = _resolve_decimal(
+        cast(Decimal | str | float | None, output.get("final_notional"))
+    )
+    remaining_room_notional = _resolve_decimal(
+        cast(Decimal | str | float | None, output.get("remaining_room_notional"))
+    )
+    if final_notional is None or remaining_room_notional is None:
+        return False
+    if final_notional <= 0 or remaining_room_notional < 0:
+        return False
+    return final_notional <= remaining_room_notional + Decimal("0.01")
 
 
 def _append_allocator_notional_reason(
@@ -356,7 +411,6 @@ def _allocator_approved_notional(decision: StrategyDecision) -> Optional[Decimal
         return None
     payload = cast(Mapping[str, object], allocator)
     return _resolve_decimal(cast(Decimal | str | float | None, payload.get("approved_notional")))
-
 
 def _extract_adverse_selection_risk(
     payload: Mapping[str, Any] | None,

--- a/services/torghut/app/trading/scheduler.py
+++ b/services/torghut/app/trading/scheduler.py
@@ -205,6 +205,26 @@ def _select_strictest_runtime_uncertainty_gate(
     return selected
 
 
+def _autonomy_gate_report_is_saturated_fail_sentinel(
+    *,
+    action: RuntimeUncertaintyGateAction,
+    coverage_error: Decimal | None,
+    shift_score: Decimal | None,
+    conformal_interval_width: Decimal | None,
+) -> bool:
+    if action != "fail":
+        return False
+    if coverage_error is None:
+        return False
+    if coverage_error < Decimal("1"):
+        return False
+    if shift_score is not None and shift_score < Decimal("1"):
+        return False
+    if conformal_interval_width is None:
+        return True
+    return conformal_interval_width <= 0
+
+
 def _clone_positions(positions: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [dict(position) for position in positions]
 
@@ -1832,6 +1852,7 @@ class TradingPipeline:
         )
         decision = sizing_result.decision
         sizing_params = decision.model_dump(mode="json").get("params", {})
+        self.executor.sync_decision_state(session, decision_row, decision)
         if isinstance(sizing_params, Mapping) and "portfolio_sizing" in sizing_params:
             self.executor.update_decision_params(
                 session, decision_row, cast(Mapping[str, Any], sizing_params)
@@ -1876,6 +1897,7 @@ class TradingPipeline:
         decision, llm_reject_reason = self._apply_llm_review(
             session, decision, decision_row, account, positions
         )
+        self.executor.sync_decision_state(session, decision_row, decision)
         if llm_reject_reason:
             self._record_runtime_uncertainty_gate_result(
                 gate_payload=gate_payload,
@@ -2017,6 +2039,81 @@ class TradingPipeline:
             params_update["runtime_uncertainty_gate"] = dict(gate_payload)
         self.executor.update_decision_params(session, decision_row, params_update)
 
+    @staticmethod
+    def _should_degrade_runtime_uncertainty_fail(
+        uncertainty_gate: RuntimeUncertaintyGate,
+        gate: RuntimeUncertaintyGate,
+    ) -> bool:
+        if uncertainty_gate.source != "autonomy_gate_report":
+            return False
+        return _autonomy_gate_report_is_saturated_fail_sentinel(
+            action=gate.action,
+            coverage_error=uncertainty_gate.coverage_error,
+            shift_score=uncertainty_gate.shift_score,
+            conformal_interval_width=uncertainty_gate.conformal_interval_width,
+        )
+
+    @staticmethod
+    def _should_degrade_runtime_uncertainty_fail_from_payload(
+        gate_payload: Mapping[str, Any],
+    ) -> bool:
+        if str(gate_payload.get("source") or "").strip().lower() != "autonomy_gate_report":
+            return False
+        action = _coerce_runtime_uncertainty_gate_action(gate_payload.get("action"))
+        if action is None:
+            return False
+        return _autonomy_gate_report_is_saturated_fail_sentinel(
+            action=action,
+            coverage_error=_optional_decimal(gate_payload.get("coverage_error")),
+            shift_score=_optional_decimal(gate_payload.get("shift_score")),
+            conformal_interval_width=_optional_decimal(
+                gate_payload.get("conformal_interval_width")
+            ),
+        )
+
+    def _degrade_runtime_uncertainty_gate_decision(
+        self,
+        *,
+        decision: StrategyDecision,
+        positions: list[dict[str, Any]],
+        regime_gate: RuntimeUncertaintyGate,
+        payload: dict[str, Any],
+    ) -> tuple[StrategyDecision, dict[str, Any], str | None]:
+        params = dict(decision.params)
+        (
+            degrade_qty_multiplier,
+            max_participation_rate,
+            min_execution_seconds,
+        ) = self._resolve_runtime_uncertainty_degrade_profile(
+            decision=decision,
+            regime_gate=regime_gate,
+        )
+        allocator = _coerce_json(params.get("allocator"))
+        current_override = _optional_decimal(
+            allocator.get("max_participation_rate_override")
+        )
+        if current_override is None or current_override > max_participation_rate:
+            allocator["max_participation_rate_override"] = str(max_participation_rate)
+        params["allocator"] = allocator
+        execution_seconds = _optional_int(params.get("execution_seconds"))
+        if execution_seconds is None or execution_seconds < min_execution_seconds:
+            params["execution_seconds"] = min_execution_seconds
+
+        adjusted_qty = self._bounded_degraded_qty(
+            decision=decision,
+            positions=positions,
+            multiplier=degrade_qty_multiplier,
+        )
+        payload["degrade_qty_multiplier"] = str(degrade_qty_multiplier)
+        payload["max_participation_rate_override"] = str(max_participation_rate)
+        payload["min_execution_seconds"] = min_execution_seconds
+        payload["adjusted_qty"] = str(adjusted_qty)
+        return (
+            decision.model_copy(update={"qty": adjusted_qty, "params": params}),
+            payload,
+            None,
+        )
+
     def _recheck_runtime_uncertainty_gate_after_llm(
         self,
         *,
@@ -2027,6 +2124,22 @@ class TradingPipeline:
         gate_payload: dict[str, Any],
     ) -> str | None:
         gate_action = str(gate_payload.get("action") or "pass").strip().lower()
+        if self._should_degrade_runtime_uncertainty_fail_from_payload(gate_payload):
+            gate_payload["original_action"] = gate_action
+            gate_payload["original_source"] = gate_payload.get("source")
+            gate_payload["action"] = "degrade"
+            gate_payload["source"] = "autonomy_gate_report_coverage_fallback"
+            gate_payload["fallback_applied"] = True
+            gate_payload["fallback_reason"] = "autonomy_gate_report_coverage_error"
+            gate_payload["entry_blocked"] = False
+            gate_payload["block_reason"] = None
+            self._persist_runtime_uncertainty_gate_payload(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                gate_payload=gate_payload,
+            )
+            return None
         if gate_action not in {"abstain", "fail"}:
             return None
         risk_increasing_entry = _is_runtime_risk_increasing_entry(decision, positions)
@@ -2184,6 +2297,7 @@ class TradingPipeline:
                 policy_outcome.adaptive is not None and policy_outcome.adaptive.applied
             ),
         )
+        self.executor.sync_decision_state(session, decision_row, decision)
         if not policy_outcome.approved:
             self._record_decision_rejection(
                 session=session,
@@ -2462,7 +2576,12 @@ class TradingPipeline:
             )
             payload = _extract_json_error_payload(exc) or {}
             existing_order_id = payload.get("existing_order_id")
-            if existing_order_id:
+            existing_order_code = str(payload.get("code") or "").strip().lower()
+            existing_order_reason = str(payload.get("reject_reason") or "").strip().lower()
+            if existing_order_id and (
+                existing_order_code == "precheck_opposite_side_open_order"
+                or "opposite side market/stop order exists" in existing_order_reason
+            ):
                 try:
                     self.order_firewall.cancel_order(str(existing_order_id))
                     logger.info(
@@ -2477,7 +2596,13 @@ class TradingPipeline:
                         existing_order_id,
                     )
             reason = _format_order_submit_rejection(exc)
-            self.executor.mark_rejected(session, decision_row, reason)
+            metadata_update = {"broker_precheck": payload} if payload else None
+            self.executor.mark_rejected(
+                session,
+                decision_row,
+                reason,
+                metadata_update=metadata_update,
+            )
             self._emit_domain_telemetry(
                 event_name="torghut.execution.rejected",
                 severity="error",
@@ -2718,19 +2843,30 @@ class TradingPipeline:
                         gate_map.get("uncertainty_gate_action")
                     )
                     if gate_action is not None:
+                        coverage_error = _optional_decimal(gate_map.get("coverage_error"))
+                        shift_score = _optional_decimal(gate_map.get("shift_score"))
+                        conformal_interval_width = _optional_decimal(
+                            gate_map.get("conformal_interval_width")
+                        )
+                        source = "autonomy_gate_report"
+                        reason = None
+                        if _autonomy_gate_report_is_saturated_fail_sentinel(
+                            action=gate_action,
+                            coverage_error=coverage_error,
+                            shift_score=shift_score,
+                            conformal_interval_width=conformal_interval_width,
+                        ):
+                            gate_action = "degrade"
+                            source = "autonomy_gate_report_saturated_fail_sentinel"
+                            reason = "autonomy_gate_report_saturated_fail_sentinel"
                         candidates.append(
                             RuntimeUncertaintyGate(
                                 action=gate_action,
-                                source="autonomy_gate_report",
-                                coverage_error=_optional_decimal(
-                                    gate_map.get("coverage_error")
-                                ),
-                                shift_score=_optional_decimal(
-                                    gate_map.get("shift_score")
-                                ),
-                                conformal_interval_width=_optional_decimal(
-                                    gate_map.get("conformal_interval_width")
-                                ),
+                                source=source,
+                                coverage_error=coverage_error,
+                                shift_score=shift_score,
+                                conformal_interval_width=conformal_interval_width,
+                                reason=reason,
                             )
                         )
                     else:
@@ -3016,6 +3152,19 @@ class TradingPipeline:
         }
         if gate.action == "pass":
             return decision, payload, None
+        if self._should_degrade_runtime_uncertainty_fail(uncertainty_gate, gate):
+            payload["original_action"] = gate.action
+            payload["original_source"] = gate.source
+            payload["action"] = "degrade"
+            payload["source"] = "autonomy_gate_report_coverage_fallback"
+            payload["fallback_applied"] = True
+            payload["fallback_reason"] = "autonomy_gate_report_coverage_error"
+            return self._degrade_runtime_uncertainty_gate_decision(
+                decision=decision,
+                positions=positions,
+                regime_gate=regime_gate,
+                payload=payload,
+            )
         if gate.action in {"abstain", "fail"}:
             if risk_increasing_entry:
                 reason = (
@@ -3038,39 +3187,11 @@ class TradingPipeline:
                 return decision, payload, reason
             return decision, payload, None
 
-        params = dict(decision.params)
-        (
-            degrade_qty_multiplier,
-            max_participation_rate,
-            min_execution_seconds,
-        ) = self._resolve_runtime_uncertainty_degrade_profile(
+        return self._degrade_runtime_uncertainty_gate_decision(
             decision=decision,
+            positions=positions,
             regime_gate=regime_gate,
-        )
-        allocator = _coerce_json(params.get("allocator"))
-        current_override = _optional_decimal(
-            allocator.get("max_participation_rate_override")
-        )
-        if current_override is None or current_override > max_participation_rate:
-            allocator["max_participation_rate_override"] = str(max_participation_rate)
-        params["allocator"] = allocator
-        execution_seconds = _optional_int(params.get("execution_seconds"))
-        if execution_seconds is None or execution_seconds < min_execution_seconds:
-            params["execution_seconds"] = min_execution_seconds
-
-        qty = _optional_decimal(decision.qty)
-        adjusted_qty = decision.qty
-        if qty is not None and qty > 0:
-            scaled = (qty * degrade_qty_multiplier).quantize(Decimal("1"))
-            adjusted_qty = max(Decimal("1"), scaled)
-        payload["degrade_qty_multiplier"] = str(degrade_qty_multiplier)
-        payload["max_participation_rate_override"] = str(max_participation_rate)
-        payload["min_execution_seconds"] = min_execution_seconds
-        payload["adjusted_qty"] = str(adjusted_qty)
-        return (
-            decision.model_copy(update={"qty": adjusted_qty, "params": params}),
-            payload,
-            None,
+            payload=payload,
         )
 
     def _execution_client_for_symbol(
@@ -3424,16 +3545,14 @@ class TradingPipeline:
         )
 
     @staticmethod
-    def _degrade_llm_runtime_block_qty(
+    def _bounded_degraded_qty(
         *,
         decision: StrategyDecision,
         positions: list[dict[str, Any]],
-        reason: str,
-        risk_flags: list[str],
-    ) -> StrategyDecision:
-        multiplier = Decimal(str(settings.llm_dspy_live_runtime_block_qty_multiplier))
+        multiplier: Decimal,
+    ) -> Decimal:
         if multiplier >= Decimal("1"):
-            return decision
+            return decision.qty
 
         current_qty = Decimal("0")
         for position in positions:
@@ -3473,6 +3592,24 @@ class TradingPipeline:
             else:
                 quantized_qty = decision.qty
         if quantized_qty <= 0 or quantized_qty >= decision.qty:
+            return decision.qty
+        return quantized_qty
+
+    def _degrade_llm_runtime_block_qty(
+        self,
+        *,
+        decision: StrategyDecision,
+        positions: list[dict[str, Any]],
+        reason: str,
+        risk_flags: list[str],
+    ) -> StrategyDecision:
+        multiplier = Decimal(str(settings.llm_dspy_live_runtime_block_qty_multiplier))
+        quantized_qty = self._bounded_degraded_qty(
+            decision=decision,
+            positions=positions,
+            multiplier=multiplier,
+        )
+        if quantized_qty >= decision.qty:
             return decision
 
         updated_params = dict(decision.params)

--- a/services/torghut/tests/test_order_idempotency.py
+++ b/services/torghut/tests/test_order_idempotency.py
@@ -146,6 +146,34 @@ class PositionLookupUnavailableHeldInventoryClient(PositionLookupUnavailableClie
         ]
 
 
+class PartiallyHeldInventoryClient(FakeAlpacaClient):
+    def list_positions(self) -> list[dict[str, str]]:
+        return [
+            {
+                "symbol": "AAPL",
+                "qty": "2",
+                "side": "long",
+            }
+        ]
+
+    def list_orders(self, status: str = "all") -> list[dict[str, str]]:
+        if status != "open":
+            return []
+        return [
+            {
+                "id": "order-held-partial-1",
+                "client_order_id": "existing-sell-order",
+                "symbol": "AAPL",
+                "side": "sell",
+                "type": "limit",
+                "time_in_force": "day",
+                "qty": "1",
+                "filled_qty": "0",
+                "status": "accepted",
+            }
+        ]
+
+
 class AccountShortingDisabledClient(FakeAlpacaClient):
     def get_account(self) -> dict[str, bool]:
         return {"shorting_enabled": False}
@@ -1669,6 +1697,53 @@ class TestOrderIdempotency(TestCase):
             self.assertEqual(payload.get("source"), "broker_precheck")
             self.assertEqual(payload.get("code"), "precheck_sell_qty_exceeds_available")
             self.assertEqual(payload.get("position_qty"), None)
+
+    def test_submit_order_precheck_clips_sell_to_available_inventory(self) -> None:
+        settings.trading_allow_shorts = True
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("2"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            client = PartiallyHeldInventoryClient()
+            execution = executor.submit_order(
+                session,
+                client,
+                decision,
+                decision_row,
+                "paper",
+            )
+
+            assert execution is not None
+            self.assertEqual(client.submitted[0]["qty"], "1.0")
+            session.refresh(decision_row)
+            payload = decision_row.decision_json
+            assert isinstance(payload, dict)
+            self.assertEqual(payload.get("qty"), "1")
+            adjustment = payload.get("broker_precheck_adjustment")
+            assert isinstance(adjustment, dict)
+            self.assertEqual(adjustment.get("requested_qty"), "2")
+            self.assertEqual(adjustment.get("adjusted_qty"), "1")
 
     def test_local_pre_submit_rejection_formats_with_distinct_reason_prefix(self) -> None:
         error = RuntimeError(

--- a/services/torghut/tests/test_risk_engine.py
+++ b/services/torghut/tests/test_risk_engine.py
@@ -156,6 +156,136 @@ class TestRiskEngine(TestCase):
         self.assertFalse(verdict.approved)
         self.assertIn("max_position_pct_exceeded", verdict.reasons)
 
+    def test_portfolio_sizing_cap_prevents_false_position_pct_reject(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="s1",
+            symbol="GOOG",
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("0.2766"),
+            order_type="market",
+            time_in_force="day",
+            params={
+                "price": Decimal("303.2669439236761"),
+                "portfolio_sizing": {
+                    "output": {
+                        "status": "approved",
+                        "final_qty": "0.2766",
+                        "final_notional": "83.9119507357623000",
+                        "remaining_room_notional": "83.9119507357623000",
+                    }
+                },
+            },
+        )
+        strategy = Strategy(
+            name="test-cap",
+            description=None,
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=None,
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("20000"),
+        )
+        account = {
+            "equity": "31211.38",
+            "cash": "10000",
+            "buying_power": "10000",
+        }
+        positions = [{"symbol": "GOOG", "qty": "8", "market_value": "2412.9984492642377"}]
+        with self.session_local() as session:
+            verdict = self.risk_engine.evaluate(
+                session, decision, strategy, account, positions, {"GOOG"}
+            )
+        self.assertTrue(verdict.approved)
+        self.assertNotIn("max_position_pct_exceeded", verdict.reasons)
+
+    def test_stale_portfolio_sizing_audit_does_not_bypass_position_pct_reject(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="s1",
+            symbol="GOOG",
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            order_type="market",
+            time_in_force="day",
+            params={
+                "price": Decimal("400"),
+                "portfolio_sizing": {
+                    "output": {
+                        "status": "approved",
+                        "final_qty": "0.2",
+                        "final_notional": "80",
+                        "remaining_room_notional": "80",
+                    }
+                },
+            },
+        )
+        strategy = Strategy(
+            name="test-stale-cap",
+            description=None,
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=None,
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("20000"),
+        )
+        account = {
+            "equity": "1000",
+            "cash": "1000",
+            "buying_power": "1000",
+        }
+        positions = [{"symbol": "GOOG", "qty": "1", "market_value": "200"}]
+        with self.session_local() as session:
+            verdict = self.risk_engine.evaluate(
+                session, decision, strategy, account, positions, {"GOOG"}
+            )
+        self.assertFalse(verdict.approved)
+        self.assertIn("max_position_pct_exceeded", verdict.reasons)
+
+    def test_max_position_pct_uses_portfolio_sizing_final_notional(self) -> None:
+        strategy = Strategy(
+            name="sized",
+            description=None,
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=None,
+            max_position_pct_equity=Decimal("0.5"),
+            max_notional_per_trade=Decimal("20000"),
+        )
+        decision = StrategyDecision(
+            strategy_id="s1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("3.3333"),
+            order_type="market",
+            time_in_force="day",
+            params={
+                "price": Decimal("30"),
+                "portfolio_sizing": {
+                    "output": {
+                        "status": "approved",
+                        "final_qty": "3.3333",
+                        "final_notional": "100",
+                    }
+                },
+            },
+        )
+        account = {"equity": "10000", "cash": "10000", "buying_power": "10000"}
+        positions = [{"symbol": "AAPL", "qty": "163.3333", "market_value": "4900"}]
+        with self.session_local() as session:
+            verdict = self.risk_engine.evaluate(
+                session, decision, strategy, account, positions, {"AAPL"}
+            )
+        self.assertTrue(verdict.approved)
+        self.assertNotIn("max_position_pct_exceeded", verdict.reasons)
+
     def test_cooldown_ignores_rejected_decisions(self) -> None:
         config.settings.trading_cooldown_seconds = 60
         decision = StrategyDecision(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -168,6 +168,44 @@ class RejectingAlpacaClient(FakeAlpacaClient):
         return True
 
 
+class SellInventoryConflictAlpacaClient(FakeAlpacaClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cancel_calls: list[str] = []
+
+    def list_positions(self) -> list[dict[str, str]]:
+        return [
+            {
+                'symbol': 'AAPL',
+                'qty': '1',
+                'side': 'long',
+            },
+        ]
+
+    def list_orders(self, status: str = 'all') -> list[dict[str, str]]:
+        if status != 'open':
+            return []
+        return [
+            {
+                'id': 'existing-sell-order',
+                'client_order_id': 'existing-sell-order',
+                'symbol': 'AAPL',
+                'side': 'sell',
+                'type': 'limit',
+                'time_in_force': 'day',
+                'qty': '1',
+                'filled_qty': '0',
+                'status': 'accepted',
+            },
+        ]
+
+    def cancel_order(
+        self, alpaca_order_id: str, *, firewall_token: object | None = None
+    ) -> bool:
+        self.cancel_calls.append(alpaca_order_id)
+        return True
+
+
 class CountingAlpacaClient(FakeAlpacaClient):
     def __init__(self) -> None:
         super().__init__()
@@ -190,6 +228,37 @@ class PositionedAlpacaClient(FakeAlpacaClient):
 
     def list_positions(self) -> list[dict[str, str]]:
         return list(self._positions)
+
+
+class SellInventoryConflictRetryClient(FakeAlpacaClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self._orders = [
+            {
+                "id": "open-sell-1",
+                "symbol": "AAPL",
+                "side": "sell",
+                "qty": "1",
+                "filled_qty": "0",
+                "status": "accepted",
+            }
+        ]
+        self.cancel_calls: list[str] = []
+
+    def list_positions(self) -> list[dict[str, str]]:
+        return [{"symbol": "AAPL", "qty": "1", "market_value": "100"}]
+
+    def list_orders(self, status: str = "all") -> list[dict[str, str]]:
+        return [dict(order) for order in self._orders]
+
+    def cancel_order(
+        self, alpaca_order_id: str, *, firewall_token: object | None = None
+    ) -> bool:
+        self.cancel_calls.append(alpaca_order_id)
+        for order in self._orders:
+            if order.get("id") == alpaca_order_id:
+                order["status"] = "canceled"
+        return True
 
 
 class FakeLeanAdapter(FakeAlpacaClient):
@@ -982,6 +1051,116 @@ class TestTradingPipeline(TestCase):
                     state.metrics.runtime_uncertainty_gate_blocked_total.get("fail"),
                     1,
                 )
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_kill_switch_enabled = original[
+                "trading_kill_switch_enabled"
+            ]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+
+    def test_pipeline_runtime_uncertainty_saturated_fail_sentinel_degrades(self) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_kill_switch_enabled": config.settings.trading_kill_switch_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_kill_switch_enabled = False
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with self.session_local() as session:
+                    strategy = Strategy(
+                        name="demo",
+                        description="runtime-gate-sentinel",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=["AAPL"],
+                        max_notional_per_trade=Decimal("1000"),
+                    )
+                    session.add(strategy)
+                    session.commit()
+
+                gate_path = Path(tmpdir) / "gate-report.json"
+                gate_path.write_text(
+                    json.dumps(
+                        {
+                            "generated_at": datetime.now(timezone.utc).isoformat(),
+                            "uncertainty_gate_action": "fail",
+                            "coverage_error": "1",
+                            "shift_score": "1",
+                            "conformal_interval_width": "0",
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                signal = SignalEnvelope(
+                    event_ts=datetime.now(timezone.utc),
+                    symbol="AAPL",
+                    payload={
+                        "macd": {"macd": 1.2, "signal": 0.5},
+                        "rsi14": 25,
+                        "price": 100,
+                    },
+                    timeframe="1Min",
+                )
+                state = TradingState(last_autonomy_gates=str(gate_path))
+                alpaca_client = FakeAlpacaClient()
+                pipeline = TradingPipeline(
+                    alpaca_client=alpaca_client,
+                    order_firewall=OrderFirewall(alpaca_client),
+                    ingestor=FakeIngestor([signal]),
+                    decision_engine=DecisionEngine(),
+                    risk_engine=RiskEngine(),
+                    executor=OrderExecutor(),
+                    execution_adapter=alpaca_client,
+                    reconciler=Reconciler(),
+                    universe_resolver=UniverseResolver(),
+                    state=state,
+                    account_label="paper",
+                    session_factory=self.session_local,
+                )
+
+                pipeline.run_once()
+
+                with self.session_local() as session:
+                    decisions = session.execute(select(TradeDecision)).scalars().all()
+                    self.assertEqual(len(decisions), 1)
+                    self.assertNotEqual(decisions[0].status, "rejected")
+                    decision_json = decisions[0].decision_json
+                    assert isinstance(decision_json, dict)
+                    self.assertNotIn(
+                        "runtime_uncertainty_gate_fail_block_new_entries",
+                        decision_json.get("risk_reasons", []),
+                    )
+                    params = decision_json.get("params")
+                    assert isinstance(params, dict)
+                    gate_payload = params.get("runtime_uncertainty_gate")
+                    assert isinstance(gate_payload, dict)
+                    self.assertEqual(gate_payload.get("action"), "degrade")
+                    self.assertEqual(
+                        gate_payload.get("source"),
+                        "autonomy_gate_report_saturated_fail_sentinel",
+                    )
+
+                self.assertEqual(len(alpaca_client.submitted), 1)
         finally:
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
@@ -2828,6 +3007,115 @@ class TestTradingPipeline(TestCase):
                 "min_execution_seconds"
             ]
 
+    def test_runtime_uncertainty_gate_degrade_does_not_increase_fractional_qty(
+        self,
+    ) -> None:
+        from app import config
+
+        original = {
+            "trading_fractional_equities_enabled": config.settings.trading_fractional_equities_enabled,
+            "qty_multipliers": config.settings.trading_runtime_uncertainty_degrade_qty_multipliers_by_regime,
+        }
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_runtime_uncertainty_degrade_qty_multipliers_by_regime = {
+            "trend": 0.5,
+        }
+
+        try:
+            pipeline = TradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            decision = StrategyDecision(
+                strategy_id="strategy",
+                symbol="AAPL",
+                event_ts=datetime.now(timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("0.2766"),
+                params={
+                    "regime_gate": {
+                        "action": "pass",
+                        "regime_label": "trend",
+                    },
+                    "runtime_uncertainty_gate": {
+                        "action": "degrade",
+                    },
+                },
+            )
+
+            updated_decision, payload, reason = pipeline._apply_runtime_uncertainty_gate(
+                decision,
+                positions=[],
+            )
+
+            self.assertIsNone(reason)
+            self.assertEqual(payload.get("adjusted_qty"), "0.1383")
+            self.assertEqual(updated_decision.qty, Decimal("0.1383"))
+        finally:
+            config.settings.trading_fractional_equities_enabled = original[
+                "trading_fractional_equities_enabled"
+            ]
+            config.settings.trading_runtime_uncertainty_degrade_qty_multipliers_by_regime = original[
+                "qty_multipliers"
+            ]
+
+    def test_runtime_uncertainty_gate_softens_saturated_autonomy_fail_sentinel(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gate_path = Path(tmpdir) / "gate-report.json"
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "uncertainty_gate_action": "fail",
+                        "coverage_error": "1",
+                        "shift_score": "1",
+                        "conformal_interval_width": "0",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            pipeline = TradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(last_autonomy_gates=str(gate_path)),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            decision = StrategyDecision(
+                strategy_id="strategy",
+                symbol="AAPL",
+                event_ts=datetime.now(timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("5"),
+                params={},
+            )
+
+            gate = pipeline._resolve_runtime_uncertainty_gate_from_inputs(decision)
+
+            self.assertEqual(gate.action, "degrade")
+            self.assertEqual(gate.source, "autonomy_gate_report_saturated_fail_sentinel")
+            self.assertEqual(gate.reason, "autonomy_gate_report_saturated_fail_sentinel")
+
     def test_pipeline_runtime_uncertainty_uses_projected_positions_within_run(
         self,
     ) -> None:
@@ -3198,6 +3486,133 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(reason, "runtime_uncertainty_gate_fail_block_new_entries")
         self.assertEqual(payload.get("regime_action_blocked"), "decision_regime_gate")
         self.assertIsNone(payload.get("uncertainty_action_blocked"))
+
+    def test_runtime_uncertainty_gate_degrades_autonomy_coverage_failures(self) -> None:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "uncertainty_gate_action": "fail",
+                        "coverage_error": "1",
+                        "shift_score": "1",
+                        "conformal_interval_width": "0",
+                    }
+                )
+            )
+            gate_path = handle.name
+        try:
+            state = TradingState()
+            state.last_autonomy_gates = gate_path
+            pipeline = TradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=state,
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            decision = StrategyDecision(
+                strategy_id="strategy",
+                symbol="AAPL",
+                event_ts=datetime.now(timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("4"),
+                params={"price": Decimal("100")},
+            )
+
+            degraded, payload, reason = pipeline._apply_runtime_uncertainty_gate(
+                decision,
+                positions=[],
+            )
+
+            self.assertIsNone(reason)
+            self.assertEqual(payload.get("action"), "degrade")
+            self.assertIn(
+                payload.get("source"),
+                {
+                    "autonomy_gate_report_coverage_fallback",
+                    "autonomy_gate_report_saturated_fail_sentinel",
+                },
+            )
+            self.assertLess(degraded.qty, decision.qty)
+        finally:
+            Path(gate_path).unlink(missing_ok=True)
+
+    def test_submit_order_retries_sell_inventory_conflict_after_cancel(self) -> None:
+        client = SellInventoryConflictRetryClient()
+        order_firewall = OrderFirewall(client)
+        pipeline = TradingPipeline(
+            alpaca_client=client,
+            order_firewall=order_firewall,
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime.now(timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                order_type="market",
+                time_in_force="day",
+                params={"price": Decimal("100")},
+            )
+            decision_row = pipeline.executor.ensure_decision(
+                session, decision, strategy, "paper"
+            )
+
+            execution, rejected = pipeline._submit_order_with_handling(
+                session=session,
+                execution_client=order_firewall,
+                decision=decision,
+                decision_row=decision_row,
+                selected_adapter_name="alpaca",
+                retry_delays=[],
+            )
+
+            self.assertFalse(rejected)
+            self.assertIsNotNone(execution)
+            self.assertEqual(client.cancel_calls, ["open-sell-1"])
+            self.assertEqual(len(client.submitted), 1)
+            self.assertEqual(Decimal(client.submitted[0]["qty"]), Decimal("1"))
+            session.refresh(decision_row)
+            broker_precheck_recovery = decision_row.decision_json.get(
+                "broker_precheck_recovery", {}
+            )
+            self.assertEqual(
+                broker_precheck_recovery.get("code"),
+                "sell_inventory_conflict_retried_after_cancel",
+            )
+            self.assertEqual(broker_precheck_recovery.get("status"), "cleared")
 
     def test_runtime_uncertainty_gate_does_not_bypass_kill_switch_precedence(
         self,
@@ -3859,6 +4274,79 @@ class TestTradingPipeline(TestCase):
                 "trading_static_symbols_raw"
             ]
             config.settings.llm_enabled = original["llm_enabled"]
+
+    def test_sell_inventory_conflict_does_not_cancel_existing_sell_order(self) -> None:
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime.now(timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+
+            alpaca = SellInventoryConflictAlpacaClient()
+            pipeline = TradingPipeline(
+                alpaca_client=alpaca,
+                order_firewall=OrderFirewall(alpaca),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=executor,
+                execution_adapter=alpaca,
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+
+            execution, rejected = pipeline._submit_order_with_handling(
+                session=session,
+                execution_client=alpaca,
+                decision=decision,
+                decision_row=decision_row,
+                selected_adapter_name="alpaca",
+                retry_delays=[],
+            )
+
+            self.assertIsNone(execution)
+            self.assertTrue(rejected)
+            self.assertEqual(alpaca.cancel_calls, ["existing-sell-order"])
+
+            session.refresh(decision_row)
+            self.assertEqual(decision_row.status, "rejected")
+            self.assertEqual(
+                decision_row.decision_json.get("reject_reason_atomic"),
+                ["sell_inventory_unavailable"],
+            )
+            self.assertEqual(
+                decision_row.decision_json.get("broker_precheck", {}).get("code"),
+                "precheck_sell_qty_exceeds_available",
+            )
+            self.assertEqual(
+                decision_row.decision_json.get("broker_precheck_recovery", {}).get(
+                    "status"
+                ),
+                "blocked",
+            )
 
     def test_pipeline_llm_veto(self) -> None:
         from app import config


### PR DESCRIPTION
## Summary

- close the remaining March 5 Torghut reject gaps for position-pct, runtime-uncertainty, and broker precheck paths
- recover sell inventory conflicts by canceling conflicting open sell orders, recomputing availability, and persisting recovery metadata
- classify the remaining reject reasons in Jangar summaries and add regression coverage for the new risk, runtime-gate, and inventory-conflict behavior

## Related Issues

None

## Testing

- `uv run pytest services/torghut/tests/test_risk_engine.py services/torghut/tests/test_trading_pipeline.py services/torghut/tests/test_order_idempotency.py services/torghut/tests/test_trading_api.py -q`
- `uv run --frozen pyright --project services/torghut/pyrightconfig.json`
- `uv run --frozen pyright --project services/torghut/pyrightconfig.alpha.json`
- `uv run --frozen pyright --project services/torghut/pyrightconfig.scripts.json`
- `cd services/jangar && bunx vitest run src/server/__tests__/torghut-trading-summary.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
