### PR TITLE
chore(torghut): promote image 005ab2bc

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc325015c159b1cbd74da789489ea2750c777e6b71ab0a6c60c2f76b808a315d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad2ab354bd0be3a8652036dca10087d56c87077e7b2283ee7adbb3e9d84949a
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-06T06:23:06Z"
+        client.knative.dev/updateTimestamp: "2026-03-06T06:48:49Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc325015c159b1cbd74da789489ea2750c777e6b71ab0a6c60c2f76b808a315d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6ad2ab354bd0be3a8652036dca10087d56c87077e7b2283ee7adbb3e9d84949a
           ports:
             - name: http1
               containerPort: 8181
@@ -434,9 +434,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-333-gfab5cdf4
+              value: v0.562.0-337-g005ab2bc
             - name: TORGHUT_COMMIT
-              value: fab5cdf4b2af94568ba232be9cc180355c1ba814
+              value: 005ab2bc7638975923d33c7f07ba2333715a81ef
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `005ab2bc7638975923d33c7f07ba2333715a81ef`
- Image tag: `005ab2bc`
- Image digest: `sha256:6ad2ab354bd0be3a8652036dca10087d56c87077e7b2283ee7adbb3e9d84949a`