### PR TITLE
chore(jangar): promote image f7f3eb92

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: fab5cdf4
-  digest: sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
+  tag: f7f3eb92
+  digest: sha256:1876e7ba8824cf875013a9ea69972f1a1e52f4748f3c9e9e2f421a18fb2e8605
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: fab5cdf4
-    digest: sha256:3fa01ed3ee4665b98c6a1d149582ec3513f34a76325f8400ad2a1a027619cb2c
+    tag: f7f3eb92
+    digest: sha256:27994e04b2569ed3203b28a786cb61fde49079a7c15a35e4ce67b8f5795074cc
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: fab5cdf4
-    digest: sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
+    tag: f7f3eb92
+    digest: sha256:1876e7ba8824cf875013a9ea69972f1a1e52f4748f3c9e9e2f421a18fb2e8605
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T06:29:39Z"
+    deploy.knative.dev/rollout: "2026-03-06T06:54:21Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T06:29:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T06:54:21Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "fab5cdf4"
-    digest: sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
+    newTag: "f7f3eb92"
+    digest: sha256:1876e7ba8824cf875013a9ea69972f1a1e52f4748f3c9e9e2f421a18fb2e8605


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f7f3eb9266cf5365e046119916a99102fcade3b4`
- Image tag: `f7f3eb92`
- Image digest: `sha256:1876e7ba8824cf875013a9ea69972f1a1e52f4748f3c9e9e2f421a18fb2e8605`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`