### PR TITLE
chore(jangar): promote image 56d1ddd2

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f7f3eb92
-  digest: sha256:1876e7ba8824cf875013a9ea69972f1a1e52f4748f3c9e9e2f421a18fb2e8605
+  tag: 56d1ddd2
+  digest: sha256:3be29de89fb1f4205011449a6620692f492f94470ca78147b3e94f9a676b96fd
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f7f3eb92
-    digest: sha256:27994e04b2569ed3203b28a786cb61fde49079a7c15a35e4ce67b8f5795074cc
+    tag: 56d1ddd2
+    digest: sha256:522d35673657c07a3ddb3cf15c3223947abddb1537fed7dea79c072a580c7ee0
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f7f3eb92
-    digest: sha256:1876e7ba8824cf875013a9ea69972f1a1e52f4748f3c9e9e2f421a18fb2e8605
+    tag: 56d1ddd2
+    digest: sha256:3be29de89fb1f4205011449a6620692f492f94470ca78147b3e94f9a676b96fd
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T06:54:21Z"
+    deploy.knative.dev/rollout: "2026-03-06T07:12:11Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T06:54:21Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T07:12:11Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f7f3eb92"
-    digest: sha256:1876e7ba8824cf875013a9ea69972f1a1e52f4748f3c9e9e2f421a18fb2e8605
+    newTag: "56d1ddd2"
+    digest: sha256:3be29de89fb1f4205011449a6620692f492f94470ca78147b3e94f9a676b96fd


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `56d1ddd253ad25102c31a34b6a0e5647f033b388`
- Image tag: `56d1ddd2`
- Image digest: `sha256:3be29de89fb1f4205011449a6620692f492f94470ca78147b3e94f9a676b96fd`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`