### PR TITLE
fix(argocd): ignore forgejo runner restart drift

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -500,6 +500,18 @@ spec:
             - .spec.template.spec.restartPolicy
             - .spec.template.spec.schedulerName
             - .spec.template.spec.volumes[].configMap.defaultMode
+        - kind: StatefulSet
+          group: apps
+          namespace: forgejo-runners
+          name: forgejo-runners-amd64
+          jqPathExpressions:
+            - '.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]'
+        - kind: StatefulSet
+          group: apps
+          namespace: forgejo-runners
+          name: forgejo-runners-arm64
+          jqPathExpressions:
+            - '.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]'
         - kind: Service
           group: serving.knative.dev
           namespace: graf


### PR DESCRIPTION
## Summary

- add Argo CD ignore rules for the manual `kubectl.kubernetes.io/restartedAt` annotation on `forgejo-runners-amd64`
- add the same ignore rule for `forgejo-runners-arm64`
- keep the `forgejo-runners` app from remaining `OutOfSync` after manual rollout restarts without masking broader drift

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl get application -n argocd forgejo-runners -o yaml`
- `kubectl get statefulset -n forgejo-runners`
- `kubectl logs -n forgejo-runners statefulset/forgejo-runners-amd64 -c runner --tail=50`
- `kubectl logs -n forgejo-runners statefulset/forgejo-runners-arm64 -c runner --tail=30`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
