### PR TITLE
fix(jangar): reuse shared db clients for store defaults

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-cache-store.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-cache-store.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbMocks = vi.hoisted(() => ({
+  createKyselyDb: vi.fn(),
+  getDb: vi.fn(),
+  resolveStoreDb: vi.fn((options: { url?: string; createDb?: (url: string) => unknown } = {}) => {
+    const url = options.url ?? process.env.DATABASE_URL ?? null
+    if (!url) return { db: null, shared: false, url: null }
+    if (!options.createDb && (options.url == null || options.url === process.env.DATABASE_URL)) {
+      return { db: dbMocks.getDb(), shared: true, url }
+    }
+    return {
+      db: (options.createDb ?? dbMocks.createKyselyDb)(url),
+      shared: false,
+      url,
+    }
+  }),
+}))
+
+const migrationsMocks = vi.hoisted(() => ({
+  ensureMigrations: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('~/server/db', () => dbMocks)
+vi.mock('~/server/kysely-migrations', () => migrationsMocks)
+
+import { createControlPlaneCacheStore } from '../control-plane-cache-store'
+
+describe('control plane cache store', () => {
+  const previousDatabaseUrl = process.env.DATABASE_URL
+
+  beforeEach(() => {
+    process.env.DATABASE_URL = 'postgresql://jangar:secret@db.example:5432/jangar'
+    dbMocks.createKyselyDb.mockReset()
+    dbMocks.getDb.mockReset()
+    migrationsMocks.ensureMigrations.mockClear()
+  })
+
+  afterEach(() => {
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl
+    }
+  })
+
+  it('reuses the shared process db when using the default DATABASE_URL', async () => {
+    const destroy = vi.fn(async () => undefined)
+    const sharedDb = { destroy } as unknown
+
+    dbMocks.getDb.mockReturnValue(sharedDb)
+
+    const store = createControlPlaneCacheStore()
+    await store.ready
+    await store.close()
+
+    expect(dbMocks.getDb).toHaveBeenCalledTimes(1)
+    expect(dbMocks.createKyselyDb).not.toHaveBeenCalled()
+    expect(migrationsMocks.ensureMigrations).toHaveBeenCalledWith(sharedDb)
+    expect(destroy).not.toHaveBeenCalled()
+  })
+
+  it('creates and destroys a dedicated db when a custom url is provided', async () => {
+    const destroy = vi.fn(async () => undefined)
+    const dedicatedDb = { destroy } as unknown
+
+    dbMocks.createKyselyDb.mockReturnValue(dedicatedDb)
+
+    const store = createControlPlaneCacheStore({
+      url: 'postgresql://jangar:secret@other-db.example:5432/jangar',
+    })
+    await store.ready
+    await store.close()
+
+    expect(dbMocks.getDb).not.toHaveBeenCalled()
+    expect(dbMocks.createKyselyDb).toHaveBeenCalledWith('postgresql://jangar:secret@other-db.example:5432/jangar')
+    expect(migrationsMocks.ensureMigrations).toHaveBeenCalledWith(dedicatedDb)
+    expect(destroy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/jangar/src/server/__tests__/db.test.ts
+++ b/services/jangar/src/server/__tests__/db.test.ts
@@ -7,6 +7,7 @@ describe('db ssl config', () => {
 
   beforeEach(() => {
     previousEnv.PGSSLMODE = process.env.PGSSLMODE
+    previousEnv.DATABASE_URL = process.env.DATABASE_URL
   })
 
   afterEach(() => {
@@ -14,6 +15,12 @@ describe('db ssl config', () => {
       delete process.env.PGSSLMODE
     } else {
       process.env.PGSSLMODE = previousEnv.PGSSLMODE
+    }
+
+    if (previousEnv.DATABASE_URL === undefined) {
+      delete process.env.DATABASE_URL
+    } else {
+      process.env.DATABASE_URL = previousEnv.DATABASE_URL
     }
   })
 
@@ -49,5 +56,19 @@ describe('db ssl config', () => {
     const ssl = __private.resolveSslConfig('verify-full', ca)
     expect(ssl?.rejectUnauthorized).toBe(true)
     expect(ssl?.ca).toBe(ca)
+  })
+
+  it('normalizes blank database urls', () => {
+    expect(__private.normalizeDbUrl(undefined)).toBe('')
+    expect(__private.normalizeDbUrl('  postgres://db  ')).toBe('postgres://db')
+  })
+
+  it('reuses the shared db only for the default process url without a custom factory', () => {
+    process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db'
+
+    expect(__private.shouldReuseSharedDb({})).toBe(true)
+    expect(__private.shouldReuseSharedDb({ url: 'postgresql://user:pass@localhost:5432/db' })).toBe(true)
+    expect(__private.shouldReuseSharedDb({ url: 'postgresql://other@localhost:5432/db' })).toBe(false)
+    expect(__private.shouldReuseSharedDb({ createDb: () => ({}) as never })).toBe(false)
   })
 })

--- a/services/jangar/src/server/agent-messages-store.ts
+++ b/services/jangar/src/server/agent-messages-store.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 
-import { createKyselyDb, type Db } from '~/server/db'
+import { resolveStoreDb, type Db } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 
 export type AgentMessageRecord = {
@@ -149,12 +149,11 @@ export type ListAgentMessagesInput = {
 }
 
 export const createAgentMessagesStore = (options: AgentMessagesStoreOptions = {}): AgentMessagesStore => {
-  const url = options.url ?? process.env.DATABASE_URL
-  if (!url) {
+  const resolved = resolveStoreDb(options)
+  if (!resolved.db) {
     throw new Error('DATABASE_URL is required for agent messages storage')
   }
-
-  const db = (options.createDb ?? createKyselyDb)(url)
+  const db = resolved.db
   let schemaReady: Promise<void> | null = null
 
   const ensureReady = async () => {
@@ -257,6 +256,7 @@ export const createAgentMessagesStore = (options: AgentMessagesStoreOptions = {}
   }
 
   const close = async () => {
+    if (resolved.shared) return
     await db.destroy()
   }
 

--- a/services/jangar/src/server/atlas-store.ts
+++ b/services/jangar/src/server/atlas-store.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 
-import { createKyselyDb, type Db } from '~/server/db'
+import { resolveStoreDb, type Db } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 
 export type RepositoryRecord = {
@@ -602,12 +602,11 @@ const toIso = (value: string | Date | null | undefined) => {
 }
 
 export const createPostgresAtlasStore = (options: PostgresAtlasStoreOptions = {}): AtlasStore => {
-  const url = options.url ?? process.env.DATABASE_URL
-  if (!url) {
+  const resolved = resolveStoreDb(options)
+  if (!resolved.db) {
     throw new Error('DATABASE_URL is required for Atlas storage')
   }
-
-  const db = (options.createDb ?? createKyselyDb)(url)
+  const db = resolved.db
   let schemaReady: Promise<void> | null = null
   const defaults = resolveEmbeddingDefaults(
     process.env.OPENAI_API_BASE_URL ?? process.env.OPENAI_API_BASE ?? DEFAULT_OPENAI_API_BASE_URL,

--- a/services/jangar/src/server/codex-judge-store.ts
+++ b/services/jangar/src/server/codex-judge-store.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 
-import { createKyselyDb, type Db } from '~/server/db'
+import { resolveStoreDb, type Db } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 
 export type CodexRunRecord = {
@@ -521,12 +521,11 @@ const rowToRerunSubmission = (row: Record<string, unknown>): CodexRerunSubmissio
 export const createCodexJudgeStore = (
   options: { url?: string; createDb?: (url: string) => Db } = {},
 ): CodexJudgeStore => {
-  const url = options.url ?? process.env.DATABASE_URL
-  if (!url) {
+  const resolved = resolveStoreDb(options)
+  if (!resolved.db) {
     throw new Error('DATABASE_URL is required for Codex judge storage')
   }
-
-  const db = (options.createDb ?? createKyselyDb)(url)
+  const db = resolved.db
   const ready = ensureSchema(db)
 
   const getRunByWorkflow = async (workflowName: string, namespace?: string | null) => {
@@ -1286,6 +1285,7 @@ export const createCodexJudgeStore = (
   }
 
   const close = async () => {
+    if (resolved.shared) return
     await db.destroy()
   }
 

--- a/services/jangar/src/server/control-plane-cache-store.ts
+++ b/services/jangar/src/server/control-plane-cache-store.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 
-import { createKyselyDb, type Db } from '~/server/db'
+import { resolveStoreDb, type Db } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 
 type Timestamp = string | Date
@@ -89,15 +89,16 @@ const resolveLimit = (value: number | null | undefined) => {
 }
 
 export const createControlPlaneCacheStore = (options: StoreOptions = {}): ControlPlaneCacheStore => {
-  const url = options.url ?? process.env.DATABASE_URL
-  if (!url) {
+  const resolved = resolveStoreDb(options)
+  if (!resolved.db || !resolved.url) {
     throw new Error('DATABASE_URL is required for Jangar control-plane cache')
   }
 
-  const db = (options.createDb ?? createKyselyDb)(url)
+  const db = resolved.db
   const ready = ensureMigrations(db)
 
   const close = async () => {
+    if (resolved.shared) return
     await db.destroy()
   }
 

--- a/services/jangar/src/server/db.ts
+++ b/services/jangar/src/server/db.ts
@@ -4,6 +4,11 @@ import { type Generated, Kysely, PostgresDialect } from 'kysely'
 import { Pool } from 'pg'
 
 export type Db = Kysely<Database>
+export type StoreDbResolution = {
+  db: Db | null
+  shared: boolean
+  url: string | null
+}
 
 type Timestamp = string | Date
 
@@ -837,10 +842,19 @@ const createDbClient = (rawUrl: string): Db => {
   })
 }
 
+const normalizeDbUrl = (value: string | undefined) => value?.trim() ?? ''
+
+const shouldReuseSharedDb = (options: { url?: string; createDb?: (url: string) => Db }) => {
+  if (options.createDb) return false
+  const envUrl = normalizeDbUrl(process.env.DATABASE_URL)
+  const resolvedUrl = normalizeDbUrl(options.url) || envUrl
+  return resolvedUrl.length > 0 && resolvedUrl === envUrl
+}
+
 export const getDb = () => {
   if (db !== undefined) return db
 
-  const url = process.env.DATABASE_URL?.trim()
+  const url = normalizeDbUrl(process.env.DATABASE_URL)
   if (!url) {
     db = null
     return db
@@ -852,7 +866,22 @@ export const getDb = () => {
 
 export const createKyselyDb = (url: string) => createDbClient(url)
 
+export const resolveStoreDb = (options: { url?: string; createDb?: (url: string) => Db } = {}): StoreDbResolution => {
+  const url = normalizeDbUrl(options.url) || normalizeDbUrl(process.env.DATABASE_URL)
+  if (!url) {
+    return { db: null, shared: false, url: null }
+  }
+
+  if (shouldReuseSharedDb(options)) {
+    return { db: getDb(), shared: true, url }
+  }
+
+  return { db: (options.createDb ?? createKyselyDb)(url), shared: false, url }
+}
+
 export const __private = {
+  normalizeDbUrl,
   resolveEffectiveSslMode,
   resolveSslConfig,
+  shouldReuseSharedDb,
 }

--- a/services/jangar/src/server/github-review-store.ts
+++ b/services/jangar/src/server/github-review-store.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 
-import { createKyselyDb, type Db, getDb } from '~/server/db'
+import { resolveStoreDb, type Db } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 
 export type GithubCheckRun = {
@@ -373,16 +373,16 @@ const mergeRuns = (existing: GithubCheckRun[], incoming: GithubCheckRun) => {
 }
 
 export const createGithubReviewStore = (options: StoreOptions = {}): GithubReviewStore => {
-  const url = options.url ?? process.env.DATABASE_URL ?? ''
-  const createDb = options.createDb ?? createKyselyDb
-  const db = url ? createDb(url) : getDb()
-  if (!db) {
+  const resolved = resolveStoreDb(options)
+  if (!resolved.db) {
     throw new Error('DATABASE_URL is required')
   }
+  const db = resolved.db
 
   const ready = ensureMigrations(db)
 
   const close = async () => {
+    if (resolved.shared) return
     await db.destroy()
   }
 

--- a/services/jangar/src/server/memories-store.ts
+++ b/services/jangar/src/server/memories-store.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 
-import { createKyselyDb, type Db } from '~/server/db'
+import { resolveStoreDb, type Db } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 
 export type MemoryRecord = {
@@ -225,12 +225,11 @@ const embedText = async (text: string): Promise<number[]> => {
 }
 
 export const createPostgresMemoriesStore = (options: PostgresMemoriesStoreOptions = {}): MemoriesStore => {
-  const url = options.url ?? process.env.DATABASE_URL
-  if (!url) {
+  const resolved = resolveStoreDb(options)
+  if (!resolved.db) {
     throw new Error('DATABASE_URL is required for MCP memories storage')
   }
-
-  const db = (options.createDb ?? createKyselyDb)(url)
+  const db = resolved.db
   let schemaReady: Promise<void> | null = null
   const defaults = resolveEmbeddingDefaults(
     process.env.OPENAI_API_BASE_URL ?? process.env.OPENAI_API_BASE ?? DEFAULT_OPENAI_API_BASE_URL,

--- a/services/jangar/src/server/primitives-store.ts
+++ b/services/jangar/src/server/primitives-store.ts
@@ -2,7 +2,7 @@ import { sql } from 'kysely'
 
 import { type AuditEventContext, buildAuditPayload } from '~/server/audit-logging'
 import { emitAuditEventToOptionalSink } from '~/server/audit-sink'
-import { createKyselyDb, type Db, getDb } from '~/server/db'
+import { resolveStoreDb, type Db } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 
 type Timestamp = string | Date
@@ -275,14 +275,15 @@ const toAuditEventRecord = (row: {
 })
 
 export const createPrimitivesStore = (options: PrimitivesStoreOptions = {}): PrimitivesStore => {
-  const url = options.url ?? process.env.DATABASE_URL
-  const db = url && options.createDb ? options.createDb(url) : url ? createKyselyDb(url) : getDb()
-  if (!db) {
+  const resolved = resolveStoreDb(options)
+  if (!resolved.db) {
     throw new Error('DATABASE_URL is required for Jangar primitives storage')
   }
+  const db = resolved.db
   const ready = ensureMigrations(db)
 
   const close = async () => {
+    if (resolved.shared) return
     await db.destroy()
   }
 


### PR DESCRIPTION
## Summary

- reuse Jangar's shared process DB client for store factories that use the default `DATABASE_URL`
- avoid destroying the shared DB client when store instances are closed
- apply the shared DB resolution path across control-plane, primitives, judge, message, memory, atlas, and review stores
- add regression coverage for DB reuse policy and control-plane cache store lifecycle behavior

## Related Issues

None

## Testing

- `bun install --frozen-lockfile`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-cache-store.test.ts src/server/__tests__/db.test.ts` (from `services/jangar`)
- `bunx tsc --noEmit -p services/jangar/tsconfig.app.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
