### PR TITLE
chore(jangar): promote image ec98653e

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 56d1ddd2
-  digest: sha256:3be29de89fb1f4205011449a6620692f492f94470ca78147b3e94f9a676b96fd
+  tag: ec98653e
+  digest: sha256:d0931bae1ee361cfc986df25b02f58faf34bf04d3a9b1051caf761037863f84e
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 56d1ddd2
-    digest: sha256:522d35673657c07a3ddb3cf15c3223947abddb1537fed7dea79c072a580c7ee0
+    tag: ec98653e
+    digest: sha256:f2ee1ca6a71b72e69bcbd0bba2cdde3b9167e6d2b9f8a474685fe9f94966721f
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 56d1ddd2
-    digest: sha256:3be29de89fb1f4205011449a6620692f492f94470ca78147b3e94f9a676b96fd
+    tag: ec98653e
+    digest: sha256:d0931bae1ee361cfc986df25b02f58faf34bf04d3a9b1051caf761037863f84e
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T07:12:11Z"
+    deploy.knative.dev/rollout: "2026-03-06T08:01:14Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T07:12:11Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T08:01:14Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "56d1ddd2"
-    digest: sha256:3be29de89fb1f4205011449a6620692f492f94470ca78147b3e94f9a676b96fd
+    newTag: "ec98653e"
+    digest: sha256:d0931bae1ee361cfc986df25b02f58faf34bf04d3a9b1051caf761037863f84e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `ec98653eea3fc0e9e9b70e54471114ed73a4b0de`
- Image tag: `ec98653e`
- Image digest: `sha256:d0931bae1ee361cfc986df25b02f58faf34bf04d3a9b1051caf761037863f84e`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`