### PR TITLE
chore(jangar): promote image c172f603

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: ec98653e
-  digest: sha256:d0931bae1ee361cfc986df25b02f58faf34bf04d3a9b1051caf761037863f84e
+  tag: c172f603
+  digest: sha256:1d898658baf4b11b8e565dbc92049204f9e39c6d51e05b461f749a7ca54f4a71
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: ec98653e
-    digest: sha256:f2ee1ca6a71b72e69bcbd0bba2cdde3b9167e6d2b9f8a474685fe9f94966721f
+    tag: c172f603
+    digest: sha256:ab25dd3aad0f1d98cb34a225875251f5d27705cf43b4eea80ec6b2877704fe82
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: ec98653e
-    digest: sha256:d0931bae1ee361cfc986df25b02f58faf34bf04d3a9b1051caf761037863f84e
+    tag: c172f603
+    digest: sha256:1d898658baf4b11b8e565dbc92049204f9e39c6d51e05b461f749a7ca54f4a71
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T08:01:14Z"
+    deploy.knative.dev/rollout: "2026-03-06T08:02:17Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T08:01:14Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T08:02:17Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "ec98653e"
-    digest: sha256:d0931bae1ee361cfc986df25b02f58faf34bf04d3a9b1051caf761037863f84e
+    newTag: "c172f603"
+    digest: sha256:1d898658baf4b11b8e565dbc92049204f9e39c6d51e05b461f749a7ca54f4a71


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c172f60325389587b379f8ef8140c9965aaad6b5`
- Image tag: `c172f603`
- Image digest: `sha256:1d898658baf4b11b8e565dbc92049204f9e39c6d51e05b461f749a7ca54f4a71`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`