### PR TITLE
fix(agents): bump chart version to 0.9.6

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/proompteng/charts/tree/main/charts/agents
 sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
-version: 0.9.5
+version: 0.9.6
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:


### PR DESCRIPTION
## Summary

- bump `charts/agents/Chart.yaml` from `0.9.5` to `0.9.6`
- match the already-merged chart content changes so `agents-sync` can publish a new OCI artifact
- keep the change isolated to chart packaging metadata with no runtime behavior changes

## Related Issues

None

## Testing

- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
