### PR TITLE
chore(jangar): promote image a3826d58

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c172f603
-  digest: sha256:1d898658baf4b11b8e565dbc92049204f9e39c6d51e05b461f749a7ca54f4a71
+  tag: a3826d58
+  digest: sha256:15530bc1043f0d51df2e358fded58a6d1d6a1a79b2289e02a65494af7f3461cb
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c172f603
-    digest: sha256:ab25dd3aad0f1d98cb34a225875251f5d27705cf43b4eea80ec6b2877704fe82
+    tag: a3826d58
+    digest: sha256:d2a8133500180a1102fda6ca67cc7d50fba464c8ef58d90c2c39357a068af16c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c172f603
-    digest: sha256:1d898658baf4b11b8e565dbc92049204f9e39c6d51e05b461f749a7ca54f4a71
+    tag: a3826d58
+    digest: sha256:15530bc1043f0d51df2e358fded58a6d1d6a1a79b2289e02a65494af7f3461cb
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T08:02:17Z"
+    deploy.knative.dev/rollout: "2026-03-06T08:35:32Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T08:02:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T08:35:32Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c172f603"
-    digest: sha256:1d898658baf4b11b8e565dbc92049204f9e39c6d51e05b461f749a7ca54f4a71
+    newTag: "a3826d58"
+    digest: sha256:15530bc1043f0d51df2e358fded58a6d1d6a1a79b2289e02a65494af7f3461cb


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a3826d58dc4595c8426010c62729b49c10db0d8f`
- Image tag: `a3826d58`
- Image digest: `sha256:15530bc1043f0d51df2e358fded58a6d1d6a1a79b2289e02a65494af7f3461cb`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`