### PR TITLE
fix(agents): use existing workspace for smoke runs

### DIFF
--- a/argocd/applications/agents/codex-spark-smoke-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-smoke-agentprovider.yaml
@@ -103,7 +103,7 @@ spec:
         local config_file
         config_file="$(rewrite_config "$model")"
         export CODEX_CONFIG="$config_file"
-        if codex exec --skip-git-repo-check -C /workspace/lab < "$PROMPT_FILE" >"$LOG_PATH" 2>&1; then
+        if codex exec --skip-git-repo-check -C /workspace < "$PROMPT_FILE" >"$LOG_PATH" 2>&1; then
           rm -f "$config_file"
           return 0
         fi


### PR DESCRIPTION
## Summary

- point the smoke provider at `/workspace` instead of the nonexistent `/workspace/lab`
- fix the live PostSync smoke failure that currently exits with `No such file or directory (os error 2)` before Codex can start
- keep the change scoped to the smoke hook path only

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `git diff --check`
- live validation: reproduced the smoke failure in `codex-spark-smoke` and verified the broken path in the rendered Job spec

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
