### PR TITLE
fix(agents): use promoted runner for swarms

### DIFF
--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -12,8 +12,6 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  workload:
-    image: registry.ide-newton.ts.net/lab/jangar:fab5cdf4@sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   ttlSecondsAfterFinished: 43200
   workflow:
     steps:
@@ -70,8 +68,6 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  workload:
-    image: registry.ide-newton.ts.net/lab/jangar:fab5cdf4@sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   ttlSecondsAfterFinished: 43200
   workflow:
     steps:
@@ -128,8 +124,6 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  workload:
-    image: registry.ide-newton.ts.net/lab/jangar:fab5cdf4@sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   ttlSecondsAfterFinished: 172800
   workflow:
     steps:
@@ -189,8 +183,6 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  workload:
-    image: registry.ide-newton.ts.net/lab/jangar:fab5cdf4@sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   ttlSecondsAfterFinished: 43200
   workflow:
     steps:
@@ -247,8 +239,6 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  workload:
-    image: registry.ide-newton.ts.net/lab/jangar:fab5cdf4@sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   ttlSecondsAfterFinished: 43200
   workflow:
     steps:
@@ -305,8 +295,6 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  workload:
-    image: registry.ide-newton.ts.net/lab/jangar:fab5cdf4@sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   ttlSecondsAfterFinished: 43200
   workflow:
     steps:
@@ -363,8 +351,6 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  workload:
-    image: registry.ide-newton.ts.net/lab/jangar:fab5cdf4@sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   ttlSecondsAfterFinished: 172800
   workflow:
     steps:
@@ -424,8 +410,6 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  workload:
-    image: registry.ide-newton.ts.net/lab/jangar:fab5cdf4@sha256:1db0eb6d389b94bd34f4be2f1f7574c11219742d63d17d363851e0ee6c197195
   ttlSecondsAfterFinished: 43200
   workflow:
     steps:

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -3362,6 +3362,7 @@ describe('agents controller reconcileAgentRun', () => {
     const steps = Array.isArray(workflow.steps) ? (workflow.steps as Record<string, unknown>[]) : []
     expect(steps[0]?.phase).toBe('Running')
     expect(steps[0]?.message).toBe('Waiting for job to be created')
+    expect(typeof steps[0]?.jobObservedAt).toBe('string')
   })
 
   it('warns when workflow jobs disappear after observation', async () => {

--- a/services/jangar/src/server/agents-controller/workflow-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/workflow-reconciler.ts
@@ -801,6 +801,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         const job = prefetchedJobForTimeout ?? (await kube.get('job', jobName, jobNamespace))
         if (!job) {
           if (!stepStatus.jobObservedAt) {
+            stepStatus.jobObservedAt = deps.nowIso()
             setWorkflowStepPhase(stepStatus, 'Running', 'Waiting for job to be created')
             runtimeRefUpdate = buildRuntimeRef('workflow', jobName, jobNamespace, {
               runName,


### PR DESCRIPTION
## Summary

- remove the hardcoded stale `jangar:fab5cdf4` workload image from swarm AgentRun templates so scheduled swarm jobs use the promoted runner image from controller defaults
- record `jobObservedAt` the first time a workflow step is waiting on a missing child Job so deleted smoke/runtime Jobs cannot leave workflow steps stuck in `Running` forever
- add regression coverage for the missing-job workflow path in the agents controller tests

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/agents-controller.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
