### PR TITLE
chore(jangar): promote image bcbe332f

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a3826d58
-  digest: sha256:15530bc1043f0d51df2e358fded58a6d1d6a1a79b2289e02a65494af7f3461cb
+  tag: bcbe332f
+  digest: sha256:6df893661fdb35ae037707b710de0e747bef45f8ac9019a2b78e273da5fd8386
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a3826d58
-    digest: sha256:d2a8133500180a1102fda6ca67cc7d50fba464c8ef58d90c2c39357a068af16c
+    tag: bcbe332f
+    digest: sha256:4a622d6e573fa4b66f8014ce6944b9dbf883c050304dce9b1019b396e94688eb
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a3826d58
-    digest: sha256:15530bc1043f0d51df2e358fded58a6d1d6a1a79b2289e02a65494af7f3461cb
+    tag: bcbe332f
+    digest: sha256:6df893661fdb35ae037707b710de0e747bef45f8ac9019a2b78e273da5fd8386
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T08:35:32Z"
+    deploy.knative.dev/rollout: "2026-03-06T09:06:12Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T08:35:32Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T09:06:12Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a3826d58"
-    digest: sha256:15530bc1043f0d51df2e358fded58a6d1d6a1a79b2289e02a65494af7f3461cb
+    newTag: "bcbe332f"
+    digest: sha256:6df893661fdb35ae037707b710de0e747bef45f8ac9019a2b78e273da5fd8386


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `bcbe332fb2a5c75e78b84c461185f01bf90da671`
- Image tag: `bcbe332f`
- Image digest: `sha256:6df893661fdb35ae037707b710de0e747bef45f8ac9019a2b78e273da5fd8386`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`