### PR TITLE
chore(torghut): promote image d9682b9a

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e1dcbb33c1addc4eff52e9ab45f704219004183a3121f93f3a523b55c1e5f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6dbeec91ac77a7bf49723c4f105c1a04f366b0f0dcf4cefa783a99e16820912
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-06T07:06:28Z"
+        client.knative.dev/updateTimestamp: "2026-03-06T09:51:12Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e1dcbb33c1addc4eff52e9ab45f704219004183a3121f93f3a523b55c1e5f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6dbeec91ac77a7bf49723c4f105c1a04f366b0f0dcf4cefa783a99e16820912
           ports:
             - name: http1
               containerPort: 8181
@@ -440,9 +440,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-341-g56d1ddd2
+              value: v0.562.0-359-gd9682b9a
             - name: TORGHUT_COMMIT
-              value: 56d1ddd253ad25102c31a34b6a0e5647f033b388
+              value: d9682b9ab73adb2139ebadebdde1ba393e83129c
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `d9682b9ab73adb2139ebadebdde1ba393e83129c`
- Image tag: `d9682b9a`
- Image digest: `sha256:c6dbeec91ac77a7bf49723c4f105c1a04f366b0f0dcf4cefa783a99e16820912`