### PR TITLE
chore(jangar): promote image 5bc19d80

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: bcbe332f
-  digest: sha256:6df893661fdb35ae037707b710de0e747bef45f8ac9019a2b78e273da5fd8386
+  tag: 5bc19d80
+  digest: sha256:27d4a5e44a64aed89aea7474ca5b068500bf72d961af7aa1630e85fe8d08c2bc
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: bcbe332f
-    digest: sha256:4a622d6e573fa4b66f8014ce6944b9dbf883c050304dce9b1019b396e94688eb
+    tag: 5bc19d80
+    digest: sha256:8e8a0b5c04528fdaa8fb0ff1706a74bc91d490dda97f3e8967cc38c0be014683
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: bcbe332f
-    digest: sha256:6df893661fdb35ae037707b710de0e747bef45f8ac9019a2b78e273da5fd8386
+    tag: 5bc19d80
+    digest: sha256:27d4a5e44a64aed89aea7474ca5b068500bf72d961af7aa1630e85fe8d08c2bc
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T09:06:12Z"
+    deploy.knative.dev/rollout: "2026-03-06T09:55:32Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T09:06:12Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T09:55:32Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "bcbe332f"
-    digest: sha256:6df893661fdb35ae037707b710de0e747bef45f8ac9019a2b78e273da5fd8386
+    newTag: "5bc19d80"
+    digest: sha256:27d4a5e44a64aed89aea7474ca5b068500bf72d961af7aa1630e85fe8d08c2bc


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `5bc19d808c60253355d82ab214e7f527a2ae01d6`
- Image tag: `5bc19d80`
- Image digest: `sha256:27d4a5e44a64aed89aea7474ca5b068500bf72d961af7aa1630e85fe8d08c2bc`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`