### PR TITLE
chore(jangar): promote image 68317cc1

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 5bc19d80
-  digest: sha256:27d4a5e44a64aed89aea7474ca5b068500bf72d961af7aa1630e85fe8d08c2bc
+  tag: 68317cc1
+  digest: sha256:46e180cb6bdde28ed6277bae9af8d5af2e27b7f9501c8dc3829eccadae79146d
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 5bc19d80
-    digest: sha256:8e8a0b5c04528fdaa8fb0ff1706a74bc91d490dda97f3e8967cc38c0be014683
+    tag: 68317cc1
+    digest: sha256:4030695814825b79f2c148d7c376e4f242ecb34f18e7509b2179b8cd3854af39
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 5bc19d80
-    digest: sha256:27d4a5e44a64aed89aea7474ca5b068500bf72d961af7aa1630e85fe8d08c2bc
+    tag: 68317cc1
+    digest: sha256:46e180cb6bdde28ed6277bae9af8d5af2e27b7f9501c8dc3829eccadae79146d
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T09:55:32Z"
+    deploy.knative.dev/rollout: "2026-03-06T10:10:26Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T09:55:32Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T10:10:26Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "5bc19d80"
-    digest: sha256:27d4a5e44a64aed89aea7474ca5b068500bf72d961af7aa1630e85fe8d08c2bc
+    newTag: "68317cc1"
+    digest: sha256:46e180cb6bdde28ed6277bae9af8d5af2e27b7f9501c8dc3829eccadae79146d


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `68317cc18d7c19e2a9321f658286fd4b2c2bc0e6`
- Image tag: `68317cc1`
- Image digest: `sha256:46e180cb6bdde28ed6277bae9af8d5af2e27b7f9501c8dc3829eccadae79146d`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`