### PR TITLE
fix(torghut): validate forecast module in image build

### DIFF
--- a/services/torghut/Dockerfile
+++ b/services/torghut/Dockerfile
@@ -2,6 +2,7 @@
 # check=error=true
 
 ARG PYTHON_VERSION=3.11
+ARG TORGHUT_COMMIT=unknown
 
 FROM python:${PYTHON_VERSION}-slim AS builder
 
@@ -22,8 +23,10 @@ RUN apt-get update \
 
 COPY pyproject.toml uv.lock README.md ./
 COPY alembic.ini ./
+ARG TORGHUT_COMMIT
 COPY app ./app
 COPY migrations ./migrations
+RUN test -f /app/app/forecast_service.py
 RUN /opt/venv/bin/uv sync --frozen --no-dev
 
 
@@ -54,11 +57,13 @@ RUN apt-get update \
 
 COPY --from=builder /opt/venv /opt/venv
 COPY alembic.ini ./
+ARG TORGHUT_COMMIT
 COPY app ./app
 COPY config ./config
 COPY migrations ./migrations
 COPY scripts ./scripts
 COPY README.md .
+RUN test -f /app/app/forecast_service.py
 
 RUN groupadd --system torghut && useradd --system --create-home --gid torghut torghut
 USER torghut


### PR DESCRIPTION
## Summary

- add a commit-scoped cache-busting `ARG` to the Torghut Dockerfile build stages
- fail the image build if `/app/app/forecast_service.py` is missing from the builder or runtime image
- prevent the newly merged `torghut-forecast` rollout from silently publishing an image that cannot import `app.forecast_service`

## Related Issues

None

## Testing

- `docker build -f services/torghut/Dockerfile services/torghut --build-arg TORGHUT_COMMIT=local-test -t torghut:forecast-fix-test`
- `docker run --rm torghut:forecast-fix-test python -c 'import app.forecast_service as m; print(m.__file__)'`
- `kubectl logs -n torghut pod/torghut-forecast-57766dcfb6-scqtl --previous`
- `kubectl run -n torghut torghut-forecast-debug --restart=Never --rm -i --image=registry.ide-newton.ts.net/lab/torghut@sha256:073dcbf3ea4875f9201d57ecce97ffdc70e130bdac5ca7ea4880277b9b9a86fa --command -- python -c 'import os,sys; print(os.getcwd()); print(sys.path); import app.forecast_service as m; print(m.__file__)'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
