### PR TITLE
chore(jangar): promote image 9f306ea4

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 68317cc1
-  digest: sha256:46e180cb6bdde28ed6277bae9af8d5af2e27b7f9501c8dc3829eccadae79146d
+  tag: 9f306ea4
+  digest: sha256:10787a512cfadcbdd084e0c2814e0e5fc2ae5322b2289e85e5624cd93f2d45fb
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 68317cc1
-    digest: sha256:4030695814825b79f2c148d7c376e4f242ecb34f18e7509b2179b8cd3854af39
+    tag: 9f306ea4
+    digest: sha256:892e9edcdea8bed8c262649b65409c681da3c74af4b994bf9f4be8ba22abab3f
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 68317cc1
-    digest: sha256:46e180cb6bdde28ed6277bae9af8d5af2e27b7f9501c8dc3829eccadae79146d
+    tag: 9f306ea4
+    digest: sha256:10787a512cfadcbdd084e0c2814e0e5fc2ae5322b2289e85e5624cd93f2d45fb
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T10:10:26Z"
+    deploy.knative.dev/rollout: "2026-03-06T23:10:22Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T10:10:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-06T23:10:22Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "68317cc1"
-    digest: sha256:46e180cb6bdde28ed6277bae9af8d5af2e27b7f9501c8dc3829eccadae79146d
+    newTag: "9f306ea4"
+    digest: sha256:10787a512cfadcbdd084e0c2814e0e5fc2ae5322b2289e85e5624cd93f2d45fb


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `9f306ea4f32ef540ce44f9a224a050a65ca8786a`
- Image tag: `9f306ea4`
- Image digest: `sha256:10787a512cfadcbdd084e0c2814e0e5fc2ae5322b2289e85e5624cd93f2d45fb`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`