### PR TITLE
fix(torghut): use daily forecast readiness window

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: TRADING_FORECAST_REGISTRY_REFRESH_SECONDS
               value: "30"
             - name: TRADING_FORECAST_CALIBRATION_STALE_AFTER_SECONDS
-              value: "3600"
+              value: "86400"
             - name: TRADING_FORECAST_SERVICE_TIMEOUT_SECONDS
               value: "5"
           volumeMounts:


### PR DESCRIPTION
## Summary

- change `torghut-forecast` calibration staleness from one hour to one day
- align readiness with the daily bootstrap calibration registry currently shipped via GitOps
- keep forecast readiness healthy without weakening promotion-time authority checks

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build argocd/applications/torghut-forecast >/tmp/torghut-forecast.kustomize.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
