### PR TITLE
fix(torghut): align lean runner jangar settings

### DIFF
--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -38,6 +38,26 @@ spec:
           env:
             - name: APP_ENV
               value: prod
+            - name: TRADING_UNIVERSE_SOURCE
+              value: jangar
+            - name: TRADING_UNIVERSE_REQUIRE_NON_EMPTY_JANGAR
+              value: "true"
+            - name: TRADING_UNIVERSE_STATIC_FALLBACK_ENABLED
+              value: "true"
+            - name: TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS
+              value: AAPL,AMAT,AMD,AVGO,GOOG,INTC,META,MSFT,NVDA,QQQ,SPY,TSLA
+            - name: TRADING_UNIVERSE_MAX_STALE_SECONDS
+              value: "900"
+            - name: JANGAR_SYMBOLS_URL
+              value: http://jangar.jangar.svc.cluster.local/api/torghut/symbols?assetClass=equity
+            - name: JANGAR_BASE_URL
+              value: http://jangar.jangar.svc.cluster.local
+            - name: JANGAR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: jangar-api-key
+                  key: key
+                  optional: true
             - name: TRADING_MODE
               value: live
             - name: TRADING_LIVE_ENABLED


### PR DESCRIPTION
## Summary

- add the Jangar universe settings to `torghut-lean-runner`
- match the runtime assumptions already used by the main Torghut service
- unblock lean-runner startup under the newer Torghut image validation rules

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build argocd/applications/torghut >/tmp/torghut.kustomize.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
