### PR TITLE
fix(torghut): widen forecast calibration freshness window

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: TRADING_FORECAST_REGISTRY_REFRESH_SECONDS
               value: "30"
             - name: TRADING_FORECAST_CALIBRATION_STALE_AFTER_SECONDS
-              value: "86400"
+              value: "604800"
             - name: TRADING_FORECAST_SERVICE_TIMEOUT_SECONDS
               value: "5"
           volumeMounts:


### PR DESCRIPTION
## Summary

- widen the `torghut-forecast` calibration freshness window from one day to seven days
- prevent the bootstrap registry from flipping forecast authority to blocked after the UTC date boundary
- keep the live forecast service healthy until a real calibration refresh pipeline is producing newer registry entries

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build argocd/applications/torghut-forecast >/tmp/torghut-forecast.kustomize.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
