### PR TITLE
chore(torghut): promote image 38d2b571

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f6b6da2f4b5d85ce83ee2f86b4a2e8143943c561e5863514d8c13a22016c1b3f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1cf5008bda3ba18c6e8af8839df7906141c9dc5c25d7846c7afddb7b07e5536b
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T00:33:41Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T04:30:07Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f6b6da2f4b5d85ce83ee2f86b4a2e8143943c561e5863514d8c13a22016c1b3f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1cf5008bda3ba18c6e8af8839df7906141c9dc5c25d7846c7afddb7b07e5536b
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-373-gb977fd86
+              value: v0.562.0-376-g38d2b571
             - name: TORGHUT_COMMIT
-              value: b977fd86e9ced9af2a6aa1880fe88be2dfe86ff1
+              value: 38d2b5715a4f9a700c9516337d43d0b450f52dff
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `38d2b5715a4f9a700c9516337d43d0b450f52dff`
- Image tag: `38d2b571`
- Image digest: `sha256:1cf5008bda3ba18c6e8af8839df7906141c9dc5c25d7846c7afddb7b07e5536b`