### PR TITLE
chore(torghut): promote image 520b91ae

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ed936c6d5d5263aa170f97d37ce866a26316ab74bd313d941ae302fb43f65277
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e3dbf0a63c694367d9a067325eab6ce4a9b906e2c8576ddd6dff049c2c4669ea
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T05:16:12Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T05:59:13Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ed936c6d5d5263aa170f97d37ce866a26316ab74bd313d941ae302fb43f65277
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e3dbf0a63c694367d9a067325eab6ce4a9b906e2c8576ddd6dff049c2c4669ea
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-378-gb7f73bf3
+              value: v0.562.0-382-g520b91ae
             - name: TORGHUT_COMMIT
-              value: b7f73bf315a7d9797048c7eb262d7da522fae6ad
+              value: 520b91aedb40d01574364233286d2d4bc64dd881
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `520b91aedb40d01574364233286d2d4bc64dd881`
- Image tag: `520b91ae`
- Image digest: `sha256:e3dbf0a63c694367d9a067325eab6ce4a9b906e2c8576ddd6dff049c2c4669ea`